### PR TITLE
Add pytest suite and fixtures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,18 @@
+"""Shared pytest fixtures: paths to the Markdown fixture files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+@pytest.fixture
+def fixtures_dir() -> Path:
+    return FIXTURES
+
+
+def fixture_path(*parts: str) -> str:
+    return str(FIXTURES.joinpath(*parts))

--- a/tests/fixtures/diff/new.md
+++ b/tests/fixtures/diff/new.md
@@ -1,0 +1,21 @@
+# Notifications
+
+## Problem
+
+Users miss important account events.
+
+## Requirements
+
+[REQ-001] User can receive email on password change
+[REQ-002] User can receive email or SMS on new login
+[REQ-004] User can choose a daily digest instead of instant emails
+
+## Success Metrics
+
+- 90% of password-change emails are delivered
+- Digest opt-in rate above 20%
+
+## Risks
+
+- Email volume could trigger spam filters
+- SMS delivery adds per-message cost

--- a/tests/fixtures/diff/old.md
+++ b/tests/fixtures/diff/old.md
@@ -1,0 +1,20 @@
+# Notifications
+
+## Problem
+
+Users miss important account events.
+
+## Requirements
+
+[REQ-001] User can receive email on password change
+[REQ-002] User can receive email on new login
+[REQ-003] User can mute all notifications
+
+## Success Metrics
+
+- 90% of password-change emails are delivered
+- Open rate above 40%
+
+## Risks
+
+- Email volume could trigger spam filters

--- a/tests/fixtures/invalid/duplicate_ids.md
+++ b/tests/fixtures/invalid/duplicate_ids.md
@@ -1,0 +1,10 @@
+# Duplicate IDs
+
+## Problem
+
+A problem statement.
+
+## Requirements
+
+[REQ-001] User can do the first thing
+[REQ-001] User can do a different thing with the same ID

--- a/tests/fixtures/invalid/empty_req_text.md
+++ b/tests/fixtures/invalid/empty_req_text.md
@@ -1,0 +1,9 @@
+# Empty Requirement Text
+
+## Problem
+
+A problem statement.
+
+## Requirements
+
+[REQ-001]

--- a/tests/fixtures/invalid/malformed_id.md
+++ b/tests/fixtures/invalid/malformed_id.md
@@ -1,0 +1,9 @@
+# Malformed ID
+
+## Problem
+
+A problem statement.
+
+## Requirements
+
+[REQ-1A] User can do the thing

--- a/tests/fixtures/invalid/missing_id.md
+++ b/tests/fixtures/invalid/missing_id.md
@@ -1,0 +1,9 @@
+# Missing ID
+
+## Problem
+
+A problem statement.
+
+## Requirements
+
+User can do the thing but this line has no ID

--- a/tests/fixtures/invalid/missing_problem.md
+++ b/tests/fixtures/invalid/missing_problem.md
@@ -1,0 +1,5 @@
+# No Problem Here
+
+## Requirements
+
+[REQ-001] User can do the thing

--- a/tests/fixtures/invalid/missing_requirements.md
+++ b/tests/fixtures/invalid/missing_requirements.md
@@ -1,0 +1,5 @@
+# No Requirements Section
+
+## Problem
+
+There is a problem but no requirements section follows.

--- a/tests/fixtures/invalid/missing_title.md
+++ b/tests/fixtures/invalid/missing_title.md
@@ -1,0 +1,7 @@
+## Problem
+
+No title heading above this section.
+
+## Requirements
+
+[REQ-001] User can do the thing

--- a/tests/fixtures/invalid/multiple_titles.md
+++ b/tests/fixtures/invalid/multiple_titles.md
@@ -1,0 +1,11 @@
+# First Title
+
+## Problem
+
+A problem statement.
+
+## Requirements
+
+[REQ-001] User can do the thing
+
+# Second Title

--- a/tests/fixtures/valid/bullet_requirements.md
+++ b/tests/fixtures/valid/bullet_requirements.md
@@ -1,0 +1,18 @@
+# Bulk Actions
+
+## Problem
+
+Editing items one at a time is slow for power users.
+
+## Requirements
+
+- [REQ-001] User can select multiple items with a checkbox
+- [REQ-002] User can delete all selected items at once
+
+## Success Metrics
+
+- Time to clear a list drops by half
+
+## Risks
+
+- Accidental bulk deletes are hard to undo

--- a/tests/fixtures/valid/feature.md
+++ b/tests/fixtures/valid/feature.md
@@ -1,0 +1,18 @@
+# Search Filters
+
+## Problem
+
+Users cannot narrow large result sets, so they abandon search.
+
+## Requirements
+
+[REQ-001] User can filter results by category
+[REQ-002] User can combine multiple filters at once
+
+## Success Metrics
+
+- Median results-per-search drops below 20
+
+## Risks
+
+- Filter combinations could produce confusing empty states

--- a/tests/fixtures/valid/minimal.md
+++ b/tests/fixtures/valid/minimal.md
@@ -1,0 +1,9 @@
+# Minimal Feature
+
+## Problem
+
+A short problem statement.
+
+## Requirements
+
+[REQ-001] User can do the one important thing

--- a/tests/fixtures/valid/warnings.md
+++ b/tests/fixtures/valid/warnings.md
@@ -1,0 +1,11 @@
+# Warning Cases
+
+## Problem
+
+A problem statement.
+
+## Requirements
+
+[REQ-001] System can support multiple providers
+[REQ-002] User can view their data
+[REQ-003] User can view their data

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,65 @@
+"""Tests for the CLI: exit codes and JSON output."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from rac.cli import main
+
+from conftest import fixture_path
+
+
+def test_validate_valid_exits_zero(capsys):
+    rc = main(["validate", fixture_path("valid", "feature.md")])
+    assert rc == 0
+    assert "PASS" in capsys.readouterr().out
+
+
+def test_validate_invalid_exits_one(capsys):
+    rc = main(["validate", fixture_path("invalid", "duplicate_ids.md")])
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "FAIL" in out
+    assert "duplicate-req-id" in out
+
+
+def test_validate_missing_file_exits_two():
+    with pytest.raises(SystemExit) as exc:
+        main(["validate", fixture_path("valid", "does_not_exist.md")])
+    assert exc.value.code == 2
+
+
+def test_validate_json_shape(capsys):
+    rc = main(["validate", fixture_path("invalid", "malformed_id.md"), "--json"])
+    assert rc == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["valid"] is False
+    assert {"file", "valid", "errors", "warnings"} <= payload.keys()
+    assert any(e["code"] == "malformed-req-id" for e in payload["errors"])
+
+
+def test_diff_exits_zero_and_reports(capsys):
+    rc = main(["diff", fixture_path("diff", "old.md"), fixture_path("diff", "new.md")])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Added Requirements" in out
+    assert "REQ-004" in out
+    assert "Before:" in out and "After:" in out  # modified-requirement format
+
+
+def test_diff_json_shape(capsys):
+    rc = main(
+        [
+            "diff",
+            fixture_path("diff", "old.md"),
+            fixture_path("diff", "new.md"),
+            "--json",
+        ]
+    )
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert [r["id"] for r in payload["added_requirements"]] == ["REQ-004"]
+    assert [r["id"] for r in payload["removed_requirements"]] == ["REQ-003"]
+    assert [c["id"] for c in payload["modified_requirements"]] == ["REQ-002"]

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1,0 +1,60 @@
+"""Tests for AST-level diffing."""
+
+from __future__ import annotations
+
+from rac.diff import diff
+from rac.parser import parse_file
+
+from conftest import fixture_path
+
+
+def make_diff():
+    old = parse_file(fixture_path("diff", "old.md"))
+    new = parse_file(fixture_path("diff", "new.md"))
+    return diff(old, new)
+
+
+def test_added_requirements():
+    d = make_diff()
+    assert [r.id for r in d.added_requirements] == ["REQ-004"]
+
+
+def test_removed_requirements():
+    d = make_diff()
+    assert [r.id for r in d.removed_requirements] == ["REQ-003"]
+
+
+def test_modified_requirements():
+    d = make_diff()
+    assert [c.id for c in d.modified_requirements] == ["REQ-002"]
+    change = d.modified_requirements[0]
+    assert "or SMS" in change.new_text
+    assert "or SMS" not in change.old_text
+
+
+def test_unchanged_requirements_are_omitted():
+    d = make_diff()
+    touched = (
+        {r.id for r in d.added_requirements}
+        | {r.id for r in d.removed_requirements}
+        | {c.id for c in d.modified_requirements}
+    )
+    assert "REQ-001" not in touched  # identical in both versions
+
+
+def test_metric_changes():
+    d = make_diff()
+    assert d.added_metrics == ["Digest opt-in rate above 20%"]
+    assert d.removed_metrics == ["Open rate above 40%"]
+
+
+def test_risk_changes():
+    d = make_diff()
+    assert d.added_risks == ["SMS delivery adds per-message cost"]
+    assert d.removed_risks == []
+
+
+def test_identical_files_have_empty_diff():
+    a = parse_file(fixture_path("diff", "old.md"))
+    b = parse_file(fixture_path("diff", "old.md"))
+    assert diff(a, b).is_empty()

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,69 @@
+"""Tests for the Markdown -> Product AST parser."""
+
+from __future__ import annotations
+
+from rac.parser import parse, parse_file
+
+from conftest import fixture_path
+
+
+def test_parses_basic_structure():
+    p = parse_file(fixture_path("valid", "feature.md"))
+    assert p.title == "Search Filters"
+    assert "narrow large result sets" in p.problem
+    assert [r.id for r in p.requirements] == ["REQ-001", "REQ-002"]
+    assert p.success_metrics == ["Median results-per-search drops below 20"]
+    assert p.risks == ["Filter combinations could produce confusing empty states"]
+    assert p.has_problem_section and p.has_requirements_section
+    assert p.has_metrics_section and p.has_risks_section
+
+
+def test_headings_are_case_insensitive_and_trimmed():
+    text = "# T\n\n##   problem  \n\nbody\n\n##\tREQUIREMENTS\n\n[REQ-001] do it\n"
+    p = parse(text)
+    assert p.has_problem_section
+    assert p.has_requirements_section
+    assert [r.id for r in p.requirements] == ["REQ-001"]
+
+
+def test_requirement_ids_preserved_exactly():
+    text = "# T\n\n## Problem\n\nx\n\n## Requirements\n\n[REQ-007] keep zero padding\n"
+    p = parse(text)
+    assert p.requirements[0].id == "REQ-007"
+
+
+def test_line_numbers_are_tracked():
+    p = parse_file(fixture_path("valid", "feature.md"))
+    # Requirements start on line 9 in the fixture.
+    assert p.requirements[0].line == 9
+    assert p.requirements[1].line == 10
+
+
+def test_bullet_and_plain_requirements_both_parse():
+    bullets = parse_file(fixture_path("valid", "bullet_requirements.md"))
+    assert [r.id for r in bullets.requirements] == ["REQ-001", "REQ-002"]
+
+
+def test_malformed_lines_are_captured_not_dropped():
+    text = (
+        "# T\n\n## Problem\n\nx\n\n## Requirements\n\n"
+        "[REQ-1A] bad id\n"
+        "no id at all\n"
+        "[REQ-002]\n"
+    )
+    p = parse(text)
+    assert p.requirements == []
+    kinds = {(m.bad_id, m.empty_text) for m in p.malformed_requirements}
+    assert ("REQ-1A", False) in kinds  # malformed id
+    assert (None, False) in kinds  # missing id
+    assert ("REQ-002", True) in kinds  # empty text
+
+
+def test_absent_vs_empty_problem():
+    absent = parse("# T\n\n## Requirements\n\n[REQ-001] x\n")
+    assert absent.problem is None
+    assert not absent.has_problem_section
+
+    empty = parse("# T\n\n## Problem\n\n## Requirements\n\n[REQ-001] x\n")
+    assert empty.has_problem_section
+    assert empty.problem == ""

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,0 +1,99 @@
+"""Tests for the validation rules."""
+
+from __future__ import annotations
+
+from rac.parser import parse, parse_file
+from rac.validate import has_errors, validate
+
+from conftest import fixture_path
+
+
+def codes(issues):
+    return {i.code for i in issues}
+
+
+def validate_fixture(*parts):
+    return validate(parse_file(fixture_path(*parts)))
+
+
+def test_valid_file_has_no_errors():
+    issues = validate_fixture("valid", "feature.md")
+    assert not has_errors(issues)
+    assert codes(issues) == set()  # fully clean: no warnings either
+
+
+def test_minimal_file_is_valid_but_warns_on_optional_sections():
+    issues = validate_fixture("valid", "minimal.md")
+    assert not has_errors(issues)
+    assert "missing-success-metrics" in codes(issues)
+    assert "missing-risks" in codes(issues)
+
+
+def test_missing_title():
+    assert "missing-title" in codes(validate_fixture("invalid", "missing_title.md"))
+
+
+def test_multiple_titles():
+    issues = validate_fixture("invalid", "multiple_titles.md")
+    assert "multiple-titles" in codes(issues)
+    assert has_errors(issues)
+    # One error regardless of count, pointing at the first extra title.
+    extra = [i for i in issues if i.code == "multiple-titles"]
+    assert len(extra) == 1
+    assert extra[0].line == 11
+
+
+def test_multiple_titles_reports_single_error_for_many():
+    text = "# One\n\n## Problem\n\nx\n\n## Requirements\n\n[REQ-001] do it\n\n# Two\n\n# Three\n"
+    issues = validate(parse(text))
+    assert sum(1 for i in issues if i.code == "multiple-titles") == 1
+
+
+def test_missing_problem():
+    assert "missing-problem" in codes(validate_fixture("invalid", "missing_problem.md"))
+
+
+def test_missing_requirements():
+    assert "missing-requirements" in codes(
+        validate_fixture("invalid", "missing_requirements.md")
+    )
+
+
+def test_malformed_id():
+    issues = validate_fixture("invalid", "malformed_id.md")
+    assert "malformed-req-id" in codes(issues)
+    assert has_errors(issues)
+
+
+def test_missing_id():
+    assert "req-missing-id" in codes(validate_fixture("invalid", "missing_id.md"))
+
+
+def test_empty_req_text():
+    assert "empty-req-text" in codes(validate_fixture("invalid", "empty_req_text.md"))
+
+
+def test_duplicate_id():
+    issues = validate_fixture("invalid", "duplicate_ids.md")
+    assert "duplicate-req-id" in codes(issues)
+    # Reported once even though the ID appears twice.
+    assert sum(1 for i in issues if i.code == "duplicate-req-id") == 1
+
+
+def test_warnings_fixture_flags_ambiguous_verb_and_duplicate_text():
+    issues = validate_fixture("valid", "warnings.md")
+    assert not has_errors(issues)
+    assert "ambiguous-verb" in codes(issues)
+    assert "duplicate-req-text" in codes(issues)
+
+
+def test_empty_problem_warning():
+    issues = validate(parse("# T\n\n## Problem\n\n## Requirements\n\n[REQ-001] x\n"))
+    assert "empty-problem" in codes(issues)
+
+
+def test_too_many_requirements_warning():
+    reqs = "\n".join(f"[REQ-{i:03d}] requirement number {i}" for i in range(1, 60))
+    text = f"# T\n\n## Problem\n\nx\n\n## Requirements\n\n{reqs}\n"
+    issues = validate(parse(text))
+    assert "too-many-requirements" in codes(issues)


### PR DESCRIPTION
Adds the initial test suite for RAC v0.1. No changes to package code - 34 tests only. 

Fixtures live under `tests/fixtures/{valid,invalid,diff}`; shared paths in `conftest.py`.

Run with `pip install -e ".[dev]" && pytest -q`.