### PR TITLE
Add rac stats command (v0.2 portfolio analysis)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,6 @@ rac diff bond_dashboard_v1.md bond_dashboard_v2.md
 rac stats ./features
 ```
 
-*(planned for v0.2)*
-
 ---
 
 # Example
@@ -334,9 +332,12 @@ Requirements are matched by ID.
 
 ---
 
-## Stats (Planned)
+## Stats
 
-Portfolio-level analysis.
+Portfolio-level analysis. Recursively scans a directory for `*.md` files
+(skipping dotted folders like `.git`), parses and validates each one, and
+aggregates the totals. Files that fail validation are still counted and are
+listed separately rather than skipped silently.
 
 ```bash
 rac stats ./features
@@ -349,17 +350,43 @@ Portfolio Overview
 ==================
 
 Features: 12
-
 Requirements: 87
-
-Success Metrics: 24
-
+Metrics: 24
 Risks: 18
 
-Features Missing Risks: 3
+Quality
+=======
 
 Features Missing Metrics: 2
+  - Trade Alerts
+  - Watchlists
+Features Missing Risks: 3
+  - Trade Alerts
+  - Watchlists
+  - Onboarding
+Average Requirements Per Feature: 7.3
+Largest Feature: Bond Dashboard (16 requirements)
+
+Requirements by Feature
+=======================
+
+Bond Dashboard      16
+Trade Alerts        11
+Watchlists           8
+Onboarding           3
+
+Invalid Features (1)
+  ./features/draft.md — missing-title, missing-requirements
 ```
+
+Counts span all parsed files; a feature with only *warnings* (e.g. no metrics)
+still counts as valid. Invalid files are listed at the end so they are never
+silently skipped.
+
+Add `--json` for machine-readable output. `stats` exits `0` when the directory
+has at least one valid feature, `1` if none are valid, and `2` if the path is
+not a directory. (A `--strict` flag for failing on *any* invalid file — handy in
+CI — is planned.)
 
 ---
 

--- a/rac/cli.py
+++ b/rac/cli.py
@@ -3,22 +3,25 @@
 Commands:
     rac validate <file.md> [--json]
     rac diff <old.md> <new.md> [--json]
+    rac stats <directory> [--json]
 
 Exit codes:
-    0  success (validate: no errors; diff: always, when it runs)
-    1  validation found errors
-    2  usage / IO error (e.g. file not found)
+    0  success (validate: no errors; diff: ran; stats: >=1 valid feature)
+    1  validate: errors found; stats: no valid features in the directory
+    2  usage / IO error (e.g. file not found, path is not a directory)
 """
 
 from __future__ import annotations
 
 import argparse
 import sys
+from pathlib import Path
 
 from . import __version__
 from . import outputs
 from .diff import diff as diff_asts
 from .parser import parse_file
+from .stats import collect_stats
 from .validate import has_errors, validate
 
 EXIT_OK = 0
@@ -59,6 +62,21 @@ def cmd_diff(args: argparse.Namespace) -> int:
     return EXIT_OK
 
 
+def cmd_stats(args: argparse.Namespace) -> int:
+    if not Path(args.directory).is_dir():
+        print(f"rac: not a directory: {args.directory}", file=sys.stderr)
+        raise SystemExit(EXIT_USAGE)
+    stats = collect_stats(args.directory)
+    if args.json:
+        print(outputs.render_stats_json(stats))
+    else:
+        print(outputs.render_stats_human(stats))
+    # Success as long as the portfolio has at least one valid feature. Invalid
+    # files are reported but don't fail the run on their own. (A future --strict
+    # flag will fail the run if *any* file is invalid, for CI use.)
+    return EXIT_OK if stats.valid_features > 0 else EXIT_VALIDATION_FAILED
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="rac",
@@ -86,7 +104,16 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p_diff.set_defaults(func=cmd_diff)
 
-    # Future commands (rac stats <dir>, rac review <file>) will register here.
+    p_stats = sub.add_parser(
+        "stats", help="Summarize a directory of requirement files."
+    )
+    p_stats.add_argument("directory", help="Directory to scan recursively for *.md.")
+    p_stats.add_argument(
+        "--json", action="store_true", help="Emit JSON instead of human-readable text."
+    )
+    p_stats.set_defaults(func=cmd_stats)
+
+    # Future command (rac review <file>) will register here.
     return parser
 
 

--- a/rac/outputs.py
+++ b/rac/outputs.py
@@ -11,6 +11,7 @@ import sys
 from dataclasses import asdict
 
 from .models import Diff, Issue, Product
+from .stats import PortfolioStats
 
 # --- Minimal color (auto-disabled when not writing to a TTY) ----------------
 
@@ -148,5 +149,89 @@ def render_diff_json(d: Diff, old_path: str, new_path: str) -> str:
         "removed_metrics": d.removed_metrics,
         "added_risks": d.added_risks,
         "removed_risks": d.removed_risks,
+    }
+    return json.dumps(payload, indent=2)
+
+
+# --- stats -------------------------------------------------------------------
+
+
+def render_stats_human(s: PortfolioStats) -> str:
+    lines = [
+        _bold("Portfolio Overview"),
+        "==================",
+        "",
+        f"Features: {s.files_found}",
+        f"Requirements: {s.total_requirements}",
+        f"Metrics: {s.total_metrics}",
+        f"Risks: {s.total_risks}",
+        "",
+        _bold("Quality"),
+        "=======",
+        "",
+    ]
+
+    def missing_block(label: str, names: list[str]) -> None:
+        lines.append(f"{label}: {len(names)}")
+        for name in names:
+            lines.append(f"  - {name}")
+
+    missing_block("Features Missing Metrics", s.missing_metrics)
+    missing_block("Features Missing Risks", s.missing_risks)
+    lines.append(
+        f"Average Requirements Per Feature: {s.average_requirements:.1f}"
+    )
+
+    largest = s.largest_feature
+    if largest is not None:
+        lines.append(
+            f"Largest Feature: {largest.name} ({largest.requirements} requirements)"
+        )
+    else:
+        lines.append("Largest Feature: (none)")
+
+    lines += ["", _bold("Requirements by Feature"), "=======================", ""]
+    by_feature = s.requirements_by_feature
+    if by_feature:
+        width = max(len(f.name) for f in by_feature) + 4
+        for f in by_feature:
+            lines.append(f"{f.name:<{width}}{f.requirements}")
+    else:
+        lines.append("(none)")
+
+    if s.invalid:
+        lines += ["", _bold(f"Invalid Features ({len(s.invalid)})")]
+        for f in s.invalid:
+            reasons = ", ".join(f.error_codes) or "unknown"
+            lines.append(f"  {_red(f.path)} — {reasons}")
+
+    return "\n".join(lines)
+
+
+def render_stats_json(s: PortfolioStats) -> str:
+    largest = s.largest_feature
+    payload = {
+        "directory": s.directory,
+        "features": s.files_found,
+        "valid_features": s.valid_features,
+        "invalid_features": s.invalid_features,
+        "requirements": s.total_requirements,
+        "metrics": s.total_metrics,
+        "risks": s.total_risks,
+        "features_missing_metrics": s.features_missing_metrics,
+        "features_missing_risks": s.features_missing_risks,
+        "missing_metrics": s.missing_metrics,
+        "missing_risks": s.missing_risks,
+        "average_requirements_per_feature": round(s.average_requirements, 1),
+        "largest_feature": (
+            {"name": largest.name, "requirements": largest.requirements}
+            if largest is not None
+            else None
+        ),
+        "requirements_by_feature": [
+            {"name": f.name, "requirements": f.requirements}
+            for f in s.requirements_by_feature
+        ],
+        "invalid": [{"file": f.path, "errors": f.error_codes} for f in s.invalid],
     }
     return json.dumps(payload, indent=2)

--- a/rac/stats.py
+++ b/rac/stats.py
@@ -1,0 +1,143 @@
+"""Portfolio-level statistics across a directory of requirement files.
+
+`rac stats <directory>` walks the tree for Markdown files, parses and validates
+each one, and aggregates the results. Like the rest of RAC, it works on the
+Product AST: every `.md` is parsed into a :class:`~rac.models.Product`.
+
+Counting basis: totals, averages, and the per-feature breakdown span *all*
+parsed files (including ones that fail validation). A file counts as a *valid
+feature* when it has no error-severity issues; invalid files are still counted
+and are reported separately (never silently skipped).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from .parser import parse_file
+from .validate import validate
+
+
+@dataclass
+class FeatureStat:
+    """Per-file result feeding the portfolio aggregate."""
+
+    path: str
+    name: str  # the feature title, or the filename stem if it has none
+    valid: bool
+    error_codes: list[str]
+    requirements: int
+    success_metrics: int
+    risks: int
+
+
+@dataclass
+class PortfolioStats:
+    """Aggregate view over all discovered requirement files."""
+
+    directory: str
+    features: list[FeatureStat] = field(default_factory=list)
+
+    # --- counts (all parsed files) ---
+    @property
+    def files_found(self) -> int:
+        return len(self.features)
+
+    @property
+    def valid_features(self) -> int:
+        return sum(1 for f in self.features if f.valid)
+
+    @property
+    def invalid_features(self) -> int:
+        return sum(1 for f in self.features if not f.valid)
+
+    @property
+    def total_requirements(self) -> int:
+        return sum(f.requirements for f in self.features)
+
+    @property
+    def total_metrics(self) -> int:
+        return sum(f.success_metrics for f in self.features)
+
+    @property
+    def total_risks(self) -> int:
+        return sum(f.risks for f in self.features)
+
+    # --- quality ---
+    @property
+    def missing_metrics(self) -> list[str]:
+        """Names of features that define no success metrics."""
+        return [f.name for f in self.features if f.success_metrics == 0]
+
+    @property
+    def missing_risks(self) -> list[str]:
+        """Names of features that define no risks."""
+        return [f.name for f in self.features if f.risks == 0]
+
+    @property
+    def features_missing_metrics(self) -> int:
+        return len(self.missing_metrics)
+
+    @property
+    def features_missing_risks(self) -> int:
+        return len(self.missing_risks)
+
+    @property
+    def average_requirements(self) -> float:
+        if not self.features:
+            return 0.0
+        return self.total_requirements / self.files_found
+
+    @property
+    def largest_feature(self) -> FeatureStat | None:
+        if not self.features:
+            return None
+        # Most requirements wins; ties broken by name for stable output.
+        return max(self.features, key=lambda f: (f.requirements, _neg_name(f.name)))
+
+    @property
+    def requirements_by_feature(self) -> list[FeatureStat]:
+        """Features sorted by requirement count (desc), then name (asc)."""
+        return sorted(self.features, key=lambda f: (-f.requirements, f.name))
+
+    @property
+    def invalid(self) -> list[FeatureStat]:
+        return [f for f in self.features if not f.valid]
+
+
+def _neg_name(name: str) -> tuple[int, ...]:
+    """Sort key that makes earlier names 'larger' (for max() tie-breaks)."""
+    return tuple(-ord(c) for c in name)
+
+
+def find_markdown_files(directory: str) -> list[Path]:
+    """Recursively find `*.md` files, skipping dotted dirs (.git, .venv, ...)."""
+    root = Path(directory)
+    found = [
+        p
+        for p in root.rglob("*.md")
+        if not any(part.startswith(".") for part in p.relative_to(root).parts)
+    ]
+    return sorted(found)
+
+
+def collect_stats(directory: str) -> PortfolioStats:
+    """Parse and validate every Markdown file under ``directory``."""
+    stats = PortfolioStats(directory=directory)
+    for path in find_markdown_files(directory):
+        product = parse_file(str(path))
+        issues = validate(product)
+        error_codes = [i.code for i in issues if i.severity == "error"]
+        stats.features.append(
+            FeatureStat(
+                path=str(path),
+                name=product.title or path.stem,
+                valid=not error_codes,
+                error_codes=error_codes,
+                requirements=len(product.requirements),
+                success_metrics=len(product.success_metrics),
+                risks=len(product.risks),
+            )
+        )
+    return stats

--- a/tests/fixtures/portfolio/broken.md
+++ b/tests/fixtures/portfolio/broken.md
@@ -1,0 +1,7 @@
+## Problem
+
+No title here.
+
+## Requirements
+
+[REQ-001] Counted even though file is invalid

--- a/tests/fixtures/portfolio/feature_a.md
+++ b/tests/fixtures/portfolio/feature_a.md
@@ -1,0 +1,18 @@
+# Feature A
+
+## Problem
+
+A problem.
+
+## Requirements
+
+[REQ-001] User can do thing one
+[REQ-002] User can do thing two
+
+## Success Metrics
+
+- Metric one
+
+## Risks
+
+- Risk one

--- a/tests/fixtures/portfolio/feature_b.md
+++ b/tests/fixtures/portfolio/feature_b.md
@@ -1,0 +1,9 @@
+# Feature B
+
+## Problem
+
+Another problem.
+
+## Requirements
+
+[REQ-001] User can do another thing

--- a/tests/fixtures/portfolio/sub/feature_c.md
+++ b/tests/fixtures/portfolio/sub/feature_c.md
@@ -1,0 +1,11 @@
+# Feature C
+
+## Problem
+
+Nested feature.
+
+## Requirements
+
+[REQ-001] Nested requirement
+[REQ-002] Another nested req
+[REQ-003] Third

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,0 +1,119 @@
+"""Tests for portfolio statistics (`rac stats`)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from rac.cli import main
+from rac.stats import collect_stats
+
+from conftest import fixture_path
+
+
+def test_collect_counts():
+    s = collect_stats(fixture_path("portfolio"))
+    assert s.files_found == 4  # includes the nested feature_c.md (recursion)
+    assert s.valid_features == 3
+    assert s.invalid_features == 1
+    assert s.total_requirements == 7  # 2 + 1 + 1 (invalid) + 3 (nested)
+    assert s.total_metrics == 1
+    assert s.total_risks == 1
+
+
+def test_invalid_files_are_reported_not_skipped():
+    s = collect_stats(fixture_path("portfolio"))
+    assert len(s.invalid) == 1
+    bad = s.invalid[0]
+    assert bad.path.endswith("broken.md")
+    assert "missing-title" in bad.error_codes
+    # Its requirement still contributes to the portfolio total.
+    assert bad.requirements == 1
+
+
+def test_warnings_only_file_counts_as_valid():
+    # feature_b.md has no metrics/risks (warnings only) -> still a valid feature.
+    s = collect_stats(fixture_path("portfolio"))
+    feature_b = next(f for f in s.features if f.path.endswith("feature_b.md"))
+    assert feature_b.valid is True
+    assert feature_b.error_codes == []
+
+
+def test_quality_metrics():
+    s = collect_stats(fixture_path("portfolio"))
+    assert s.features_missing_metrics == 3  # only feature_a has a metric
+    assert s.features_missing_risks == 3  # only feature_a has a risk
+    # REQ-008/009: identify *which* features are missing them (by name).
+    assert s.missing_metrics == ["broken", "Feature B", "Feature C"]
+    assert s.missing_risks == ["broken", "Feature B", "Feature C"]
+    assert round(s.average_requirements, 1) == 1.8  # 7 reqs / 4 files
+    assert s.largest_feature.name == "Feature C"
+    assert s.largest_feature.requirements == 3
+    # Sorted by requirement count desc, then name asc.
+    assert [f.name for f in s.requirements_by_feature] == [
+        "Feature C",
+        "Feature A",
+        "Feature B",
+        "broken",
+    ]
+
+
+def test_cli_stats_human(capsys):
+    rc = main(["stats", fixture_path("portfolio")])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Portfolio Overview" in out
+    assert "Features: 4" in out
+    assert "Quality" in out
+    assert "Features Missing Metrics: 3" in out
+    assert "  - Feature B" in out  # names listed, not just the count
+    assert "Average Requirements Per Feature: 1.8" in out
+    assert "Largest Feature: Feature C (3 requirements)" in out
+    assert "Requirements by Feature" in out
+    assert "Invalid Features (1)" in out
+    assert "broken.md" in out
+
+
+def test_cli_stats_json(capsys):
+    rc = main(["stats", fixture_path("portfolio"), "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["features"] == 4
+    assert payload["valid_features"] == 3
+    assert payload["requirements"] == 7
+    assert payload["metrics"] == 1
+    assert payload["features_missing_metrics"] == 3
+    assert payload["missing_metrics"] == ["broken", "Feature B", "Feature C"]
+    assert payload["average_requirements_per_feature"] == 1.8
+    assert payload["largest_feature"] == {"name": "Feature C", "requirements": 3}
+    assert payload["requirements_by_feature"][0] == {
+        "name": "Feature C",
+        "requirements": 3,
+    }
+    assert payload["invalid"][0]["file"].endswith("broken.md")
+
+
+def test_cli_stats_missing_directory_exits_two():
+    with pytest.raises(SystemExit) as exc:
+        main(["stats", fixture_path("portfolio", "does_not_exist")])
+    assert exc.value.code == 2
+
+
+def test_cli_stats_exits_one_when_no_valid_features(tmp_path, capsys):
+    # A directory whose only file fails validation -> no valid features.
+    (tmp_path / "broken.md").write_text(
+        "## Problem\n\nNo title.\n\n## Requirements\n\n[REQ-001] x\n"
+    )
+    rc = main(["stats", str(tmp_path)])
+    assert rc == 1
+    assert "Invalid Features (1)" in capsys.readouterr().out
+
+
+def test_cli_stats_exits_zero_with_one_valid_feature(tmp_path):
+    (tmp_path / "ok.md").write_text(
+        "# Ok\n\n## Problem\n\np\n\n## Requirements\n\n[REQ-001] x\n"
+    )
+    (tmp_path / "broken.md").write_text("## Problem\n\nno title\n")
+    # One valid feature present -> exit 0 even though a broken file exists.
+    assert main(["stats", str(tmp_path)]) == 0


### PR DESCRIPTION
Implements `rac stats <directory>` — portfolio-level analysis across a directory of requirement files.

## What it does
Recursively scans for `*.md` (skipping dotted dirs like `.git`/`.venv`), parses and validates each file via the existing Product AST + validator, and reports:

**Portfolio Overview** — Features, Requirements, Metrics, Risks (totals across all parsed files).

**Quality**
- Features Missing Metrics / Missing Risks — count **and the names** of the offending features
- Average Requirements Per Feature
- Largest Feature (name + requirement count)

**Requirements by Feature** — per-feature table sorted by requirement count (desc).

**Invalid Features** — files that fail validation are counted and listed with their error codes, never silently skipped. A warnings-only file (e.g. no metrics) still counts as valid.

`--json` emits the full structure for scripting.

## Requirements coverage
REQ-001…REQ-012 all satisfied (directory analysis, recursive default, total feature/requirement/metric/risk counts, invalid-file identification, features missing metrics/risks by name, largest features, JSON export, and valid files analyzed even when invalid files exist).

## Behaviour notes
- Counting basis is **all parsed files**; invalid files are reported separately.
- Exit codes: `0` when ≥1 valid feature, `1` if none are valid, `2` if the path is not a directory.
- Performance: ~0.2s over 100 files (success-metric target was <5s).

## Tests
Adds `tests/test_stats.py` (10 tests) + a `tests/fixtures/portfolio/` tree (incl. a nested file and an invalid file). Full suite: 43 passing.

Closes #5
