### PR TITLE
Reformat roadmap specs into valid RAC format

### DIFF
--- a/planning/roadmap/v0.2-stats.md
+++ b/planning/roadmap/v0.2-stats.md
@@ -1,4 +1,6 @@
-**Problem**
+# v0.2 Portfolio Stats
+
+## Problem
 
 RAC can currently validate and diff individual requirement files.
 
@@ -6,29 +8,29 @@ However, Product Managers typically manage portfolios of features rather than in
 
 There is currently no way to understand the overall health, size, quality, or complexity of a collection of requirements.
 
-**Requirements**
+## Requirements
 
-	•	[REQ-001] User can analyze a directory of requirement files
-	•	[REQ-002] Directory scanning is recursive by default
-	•	[REQ-003] User can view total feature count
-	•	[REQ-004] User can view total requirement count
-	•	[REQ-005] User can view total metric count
-	•	[REQ-006] User can view total risk count
-	•	[REQ-007] User can identify invalid files
-	•	[REQ-008] User can identify features missing metrics
-	•	[REQ-009] User can identify features missing risks
-	•	[REQ-010] User can view largest features by requirement count
-	•	[REQ-011] User can export results as JSON
-	•	[REQ-012] Valid files are analyzed even when invalid files exist
+[REQ-001] User can analyze a directory of requirement files
+[REQ-002] Directory scanning is recursive by default
+[REQ-003] User can view total feature count
+[REQ-004] User can view total requirement count
+[REQ-005] User can view total metric count
+[REQ-006] User can view total risk count
+[REQ-007] User can identify invalid files
+[REQ-008] User can identify features missing metrics
+[REQ-009] User can identify features missing risks
+[REQ-010] User can view largest features by requirement count
+[REQ-011] User can export results as JSON
+[REQ-012] Valid files are analyzed even when invalid files exist
 
-**Success Metrics**
+## Success Metrics
 
-	•	Stats command executes against 100 files in under 5 seconds
-	•	Stats command used against RAC roadmap repository
-	•	JSON output successfully consumed by another script
+- Stats command executes against 100 files in under 5 seconds
+- Stats command used against RAC roadmap repository
+- JSON output successfully consumed by another script
 
-**Risks**
+## Risks
 
-	•	Recursive scanning may impact performance
-	•	Large repositories may produce noisy output
-	•	Invalid files may skew statistics if not handled consistently
+- Recursive scanning may impact performance
+- Large repositories may produce noisy output
+- Invalid files may skew statistics if not handled consistently

--- a/planning/roadmap/v0.3-ingest.md
+++ b/planning/roadmap/v0.3-ingest.md
@@ -1,31 +1,37 @@
-**Problem**
+# v0.3 Knowledge Ingestion
+
+## Problem
 
 Most product knowledge already exists in:
-	•	DOCX files
-	•	PDFs
-	•	HTML exports
-	•	Existing Markdown
+
+- DOCX files
+- PDFs
+- HTML exports
+- Existing Markdown
 
 Users should not be required to manually rewrite documentation into RAC format before receiving value.
 
-**Requirements**
-	•	[REQ-001] User can ingest DOCX files
-	•	[REQ-002] User can ingest PDF files
-	•	[REQ-003] User can ingest HTML files
-	•	[REQ-004] User can ingest Markdown files
-	•	[REQ-005] RAC uses MarkItDown as the default conversion engine
-	•	[REQ-006] User can generate normalized Markdown output
-	•	[REQ-007] User can generate RAC-compliant Markdown output
-	•	[REQ-008] User can preview generated content before saving
-	•	[REQ-009] User can overwrite existing files with confirmation
-	•	[REQ-010] Conversion failures are clearly reported
+## Requirements
 
-**Success Metrics**
-	•	Successful conversion of 10 real-world documents
-	•	Less than 5 minutes required to onboard an existing project
-	•	At least 80% of generated output requires minimal manual cleanup
+[REQ-001] User can ingest DOCX files
+[REQ-002] User can ingest PDF files
+[REQ-003] User can ingest HTML files
+[REQ-004] User can ingest Markdown files
+[REQ-005] RAC uses MarkItDown as the default conversion engine
+[REQ-006] User can generate normalized Markdown output
+[REQ-007] User can generate RAC-compliant Markdown output
+[REQ-008] User can preview generated content before saving
+[REQ-009] User can overwrite existing files with confirmation
+[REQ-010] Conversion failures are clearly reported
 
-**Risks**
-	•	Source documents may be poorly structured
-	•	PDF extraction quality may vary significantly
-	•	Generated Markdown may not fully match RAC conventions
+## Success Metrics
+
+- Successful conversion of 10 real-world documents
+- Less than 5 minutes required to onboard an existing project
+- At least 80% of generated output requires minimal manual cleanup
+
+## Risks
+
+- Source documents may be poorly structured
+- PDF extraction quality may vary significantly
+- Generated Markdown may not fully match RAC conventions

--- a/planning/roadmap/v0.4-inspect.md
+++ b/planning/roadmap/v0.4-inspect.md
@@ -1,29 +1,34 @@
-**Problem**
+# v0.4 Artifact Inspection
+
+## Problem
 
 Not all documents represent the same type of knowledge.
 
 Before validation or analysis can occur, RAC should understand what type of artifact it is examining.
 
-**Requirements**
-	•	[REQ-001] User can inspect a file
-	•	[REQ-002] RAC attempts to classify artifact type
-	•	[REQ-003] RAC reports classification confidence
-	•	[REQ-004] RAC identifies missing sections
-	•	[REQ-005] RAC identifies unexpected sections
-	•	[REQ-006] RAC displays artifact health summary
-	•	[REQ-007] RAC supports Requirement artifacts
-	•	[REQ-008] RAC supports Decision artifacts
-	•	[REQ-009] RAC supports Roadmap artifacts
-	•	[REQ-010] RAC supports Prompt artifacts
-	•	[REQ-011] RAC supports Meeting artifacts
-	•	[REQ-012] Output is available as JSON
+## Requirements
 
-**Success Metrics**
-	•	Artifact classification accuracy exceeds 90% on sample repository
-	•	Inspection completes in under 2 seconds for standard files
-	•	Users can identify document quality issues without opening the file
+[REQ-001] User can inspect a file
+[REQ-002] RAC attempts to classify artifact type
+[REQ-003] RAC reports classification confidence
+[REQ-004] RAC identifies missing sections
+[REQ-005] RAC identifies unexpected sections
+[REQ-006] RAC displays artifact health summary
+[REQ-007] RAC supports Requirement artifacts
+[REQ-008] RAC supports Decision artifacts
+[REQ-009] RAC supports Roadmap artifacts
+[REQ-010] RAC supports Prompt artifacts
+[REQ-011] RAC supports Meeting artifacts
+[REQ-012] Output is available as JSON
 
-**Risks**
-	•	Similar artifact types may be difficult to distinguish
-	•	Classification rules may become overly complex
-	•	Confidence scoring may be difficult to explain
+## Success Metrics
+
+- Artifact classification accuracy exceeds 90% on sample repository
+- Inspection completes in under 2 seconds for standard files
+- Users can identify document quality issues without opening the file
+
+## Risks
+
+- Similar artifact types may be difficult to distinguish
+- Classification rules may become overly complex
+- Confidence scoring may be difficult to explain

--- a/planning/roadmap/v0.5-decisions.md
+++ b/planning/roadmap/v0.5-decisions.md
@@ -1,27 +1,32 @@
-**Problem**
+# v0.5 Decisions As Code
+
+## Problem
 
 Important product and engineering decisions are often lost in meetings, chats, and documents.
 
 Teams struggle to understand why decisions were made and what trade-offs were considered.
 
-**Requirements**
-	•	[REQ-001] RAC supports Decision artifacts
-	•	[REQ-002] User can validate decision documents
-	•	[REQ-003] User can diff decision versions
-	•	[REQ-004] User can analyze decision repositories
-	•	[REQ-005] Decision documents contain Context section
-	•	[REQ-006] Decision documents contain Decision section
-	•	[REQ-007] Decision documents contain Consequences section
-	•	[REQ-008] User can identify superseded decisions
-	•	[REQ-009] User can categorize decisions
-	•	[REQ-010] User can export decision statistics
+## Requirements
 
-**Success Metrics**
-	•	RAC roadmap decisions are tracked using Decision artifacts
-	•	At least 20 decisions stored in repository
-	•	Users can locate decision rationale within 60 seconds
+[REQ-001] RAC supports Decision artifacts
+[REQ-002] User can validate decision documents
+[REQ-003] User can diff decision versions
+[REQ-004] User can analyze decision repositories
+[REQ-005] Decision documents contain Context section
+[REQ-006] Decision documents contain Decision section
+[REQ-007] Decision documents contain Consequences section
+[REQ-008] User can identify superseded decisions
+[REQ-009] User can categorize decisions
+[REQ-010] User can export decision statistics
 
-**Risks**
-	•	Teams may not consistently record decisions
-	•	Decision quality may vary significantly
-	•	Categorization may become inconsistent
+## Success Metrics
+
+- RAC roadmap decisions are tracked using Decision artifacts
+- At least 20 decisions stored in repository
+- Users can locate decision rationale within 60 seconds
+
+## Risks
+
+- Teams may not consistently record decisions
+- Decision quality may vary significantly
+- Categorization may become inconsistent

--- a/planning/roadmap/v0.6-roadmaps.md
+++ b/planning/roadmap/v0.6-roadmaps.md
@@ -1,28 +1,33 @@
-**Problem**
+# v0.6 Roadmaps As Code
+
+## Problem
 
 Roadmaps often focus on outputs rather than outcomes.
 
 Planning quality is difficult to assess and compare.
 
-**Requirements**
-	•	[REQ-001] RAC supports Roadmap artifacts
-	•	[REQ-002] User can validate roadmap documents
-	•	[REQ-003] Roadmaps contain desired outcomes
-	•	[REQ-004] Roadmaps contain initiatives
-	•	[REQ-005] Roadmaps support owners
-	•	[REQ-006] Roadmaps support timelines
-	•	[REQ-007] Roadmaps support success measures
-	•	[REQ-008] User can identify initiatives missing outcomes
-	•	[REQ-009] User can identify initiatives missing owners
-	•	[REQ-010] User can identify initiatives missing success measures
-	•	[REQ-011] User can analyze roadmap repositories
+## Requirements
 
-**Success Metrics**
-	•	All RAC roadmap items tracked using roadmap artifacts
-	•	Validation identifies incomplete roadmap items
-	•	Roadmap reviews become faster and more consistent
+[REQ-001] RAC supports Roadmap artifacts
+[REQ-002] User can validate roadmap documents
+[REQ-003] Roadmaps contain desired outcomes
+[REQ-004] Roadmaps contain initiatives
+[REQ-005] Roadmaps support owners
+[REQ-006] Roadmaps support timelines
+[REQ-007] Roadmaps support success measures
+[REQ-008] User can identify initiatives missing outcomes
+[REQ-009] User can identify initiatives missing owners
+[REQ-010] User can identify initiatives missing success measures
+[REQ-011] User can analyze roadmap repositories
 
-**Risks**
-	•	Roadmap formats vary significantly across organizations
-	•	Validation rules may become opinionated
-	•	Outcomes may be difficult to standardize
+## Success Metrics
+
+- All RAC roadmap items tracked using roadmap artifacts
+- Validation identifies incomplete roadmap items
+- Roadmap reviews become faster and more consistent
+
+## Risks
+
+- Roadmap formats vary significantly across organizations
+- Validation rules may become opinionated
+- Outcomes may be difficult to standardize

--- a/planning/roadmap/v0.7-prompts.md
+++ b/planning/roadmap/v0.7-prompts.md
@@ -1,28 +1,33 @@
-**Problem**
+# v0.7 Prompts As Code
+
+## Problem
 
 AI prompts are increasingly important knowledge assets.
 
 Prompt quality is difficult to assess, compare, and maintain.
 
-**Requirements**
-	•	[REQ-001] RAC supports Prompt artifacts
-	•	[REQ-002] User can validate prompt documents
-	•	[REQ-003] Prompts contain objective section
-	•	[REQ-004] Prompts contain input specification
-	•	[REQ-005] Prompts contain output specification
-	•	[REQ-006] Prompts support examples
-	•	[REQ-007] User can identify missing examples
-	•	[REQ-008] User can identify ambiguous instructions
-	•	[REQ-009] User can identify missing output definitions
-	•	[REQ-010] User can compare prompt versions
-	•	[REQ-011] User can analyze prompt repositories
+## Requirements
 
-**Success Metrics**
-	•	Prompt validation used on real-world AI workflows
-	•	Validation identifies quality issues before deployment
-	•	Prompt changes become easier to review and understand
+[REQ-001] RAC supports Prompt artifacts
+[REQ-002] User can validate prompt documents
+[REQ-003] Prompts contain objective section
+[REQ-004] Prompts contain input specification
+[REQ-005] Prompts contain output specification
+[REQ-006] Prompts support examples
+[REQ-007] User can identify missing examples
+[REQ-008] User can identify ambiguous instructions
+[REQ-009] User can identify missing output definitions
+[REQ-010] User can compare prompt versions
+[REQ-011] User can analyze prompt repositories
 
-**Risks**
-	•	Prompt engineering practices evolve rapidly
-	•	Prompt quality can be subjective
-	•	Different AI providers may require different structures
+## Success Metrics
+
+- Prompt validation used on real-world AI workflows
+- Validation identifies quality issues before deployment
+- Prompt changes become easier to review and understand
+
+## Risks
+
+- Prompt engineering practices evolve rapidly
+- Prompt quality can be subjective
+- Different AI providers may require different structures


### PR DESCRIPTION
Makes `planning/roadmap/*.md` conform to RAC's own format so they parse as valid features — dogfooding `rac stats` against the roadmap (a v0.2 success metric).

## Why
Running `rac stats planning/` flagged all roadmap files as invalid with 0 requirements. They used bold pseudo-headings (`**Problem**`) and bullet-char lines (`•⇥[REQ-001] …`), which RAC doesn't recognize — it keys off `##` headings and `[REQ-NNN]` line starts.

## What changed (6 files)
For each `planning/roadmap/*.md`:
- Added a top-level `# Title` (e.g. `# v0.2 Portfolio Stats`).
- `**Problem**` / `**Requirements**` / `**Success Metrics**` / `**Risks**` → `##` headings.
- `•⇥[REQ-NNN] …` → `[REQ-NNN] …`.
- Metric/risk bullets normalized to `- ` Markdown lists.

No wording changes — structure only.

## Result
`rac stats planning/roadmap` now reports real data:

```
Features: 6
Requirements: 66
Metrics: 18
Risks: 18
Features Missing Metrics: 0
Features Missing Risks: 0
Average Requirements Per Feature: 11.0
Largest Feature: v0.2 Portfolio Stats (12 requirements)
```

All 6 validate cleanly (`rac validate` exit 0).

## Out of scope
`planning/adr/*` and `planning/future/*` are different artifact types (decisions / future sketches), not features — intentionally left unchanged.