### PR TITLE
Reformat ADRs 001-008 into the standard ADR format

### DIFF
--- a/planning/adr/adr-001-markdown-first.md
+++ b/planning/adr/adr-001-markdown-first.md
@@ -1,8 +1,21 @@
-**ADR-001 Markdown First**
+# ADR-001 Markdown First
 
-Decision: Markdown is the canonical source format.
+## Status
 
-Why:
+Accepted
+
+## Context
+
+RAC needs a single canonical source format for requirements and other artifacts.
+
+## Decision
+
+Markdown is the canonical source format.
+
+## Consequences
+
+### Positive
+
 - Human-readable
 - Git-friendly
 - Tool-independent

--- a/planning/adr/adr-002-ai-optional.md
+++ b/planning/adr/adr-002-ai-optional.md
@@ -1,7 +1,21 @@
-ADR-002 AI Optional
-Decision:
+# ADR-002 AI Optional
+
+## Status
+
+Accepted
+
+## Context
+
+RAC should be useful on its own, with AI as an enhancement rather than a dependency.
+
+## Decision
+
 RAC must provide value without AI.
-Why:
-Lower complexity
-Easier testing
-Works offline
+
+## Consequences
+
+### Positive
+
+- Lower complexity
+- Easier testing
+- Works offline

--- a/planning/adr/adr-003-structured-outputs-first.md
+++ b/planning/adr/adr-003-structured-outputs-first.md
@@ -1,9 +1,22 @@
-ADR-003 Structured Outputs First
-Decision:
+# ADR-003 Structured Outputs First
+
+## Status
+
+Accepted
+
+## Context
+
+RAC commands need to be consumable by scripts, SDKs, and future integrations — not just humans.
+
+## Decision
+
 Every command returns typed result models.
-Why:
-JSON
-SDK
-MCP
-CI
-all become trivial.
+
+## Consequences
+
+### Positive
+
+- JSON output becomes trivial
+- SDK usage becomes trivial
+- MCP integration becomes trivial
+- CI integration becomes trivial

--- a/planning/adr/adr-004-artifact-model.md
+++ b/planning/adr/adr-004-artifact-model.md
@@ -1,10 +1,24 @@
-ADR-004 Artifact Model
-Decision:
-RAC analyzes artifacts rather than documents.
-Future artifacts:
-Requirement
-Decision
-Roadmap
-Prompt
-Meeting
-This ADR is the bridge to v0.5+.
+# ADR-004 Artifact Model
+
+## Status
+
+Accepted
+
+## Context
+
+Not all documents are the same kind of knowledge. RAC needs a model that can grow beyond requirements.
+
+## Decision
+
+RAC analyzes typed artifacts rather than generic documents. Planned artifact types include Requirement, Decision, Roadmap, Prompt, and Meeting.
+
+## Consequences
+
+### Positive
+
+- Provides the bridge to v0.5+ artifact types
+- Each artifact type can have its own structure and validation
+
+### Negative
+
+- More modeling work as new artifact types are added

--- a/planning/adr/adr-005-cli-first.md
+++ b/planning/adr/adr-005-cli-first.md
@@ -1,11 +1,30 @@
-ADR-005 CLI First
-Decision:
-CLI is the primary interface.
-Not:
-Web app
-SaaS
-Browser extension
-Why:
-Fastest path to value
-Easy automation
-Easy AI integration later
+# ADR-005 CLI First
+
+## Status
+
+Accepted
+
+## Context
+
+RAC needs a primary interface that ships quickly and automates well.
+
+## Decision
+
+The CLI is the primary interface.
+
+## Alternatives Considered
+
+### Web app / SaaS / Browser extension
+
+Cons:
+- Slower path to value
+- Harder to automate
+- Heavier infrastructure
+
+## Consequences
+
+### Positive
+
+- Fastest path to value
+- Easy automation
+- Easy AI integration later

--- a/planning/adr/adr-006-ingest-over-rewrite.md
+++ b/planning/adr/adr-006-ingest-over-rewrite.md
@@ -1,9 +1,20 @@
-ADR-007 Ingestion Over Rewrite
-Decision:
-Users should not have to rewrite existing documents.
-Why:
-People already have:
-PDFs
-Word docs
-Notion exports
-RAC should adapt to them.
+# ADR-006 Ingestion Over Rewrite
+
+## Status
+
+Accepted
+
+## Context
+
+People already have product knowledge in PDFs, Word docs, and Notion exports.
+
+## Decision
+
+Users should not have to rewrite existing documents; RAC should adapt to them via ingestion.
+
+## Consequences
+
+### Positive
+
+- Lower barrier to adoption
+- RAC meets users where their knowledge already lives

--- a/planning/adr/adr-007-json-contract-stability.md
+++ b/planning/adr/adr-007-json-contract-stability.md
@@ -1,17 +1,23 @@
-ADR-006 JSON Contract Stability
-Decision: JSON outputs are public APIs.
-Meaning:
+# ADR-007 JSON Contract Stability
 
-{
-  "features": 12
-}
+## Status
 
-shouldn't randomly become:
+Accepted
 
-{
-  "feature_count": 12
-}
+## Context
 
-without versioning.
+RAC's JSON output is consumed by scripts and will be consumed by future MCP integrations.
 
-This matters enormously for future MCP integrations.
+## Decision
+
+JSON outputs are treated as public APIs. Field names (for example `features`) will not change to alternatives (for example `feature_count`) without explicit versioning.
+
+## Consequences
+
+### Positive
+
+- Stable contract for scripts and MCP integrations
+
+### Negative
+
+- Schema changes require a versioning strategy

--- a/planning/adr/adr-008-agent-ready-architecture.md
+++ b/planning/adr/adr-008-agent-ready-architecture.md
@@ -1,15 +1,40 @@
-ADR-009 AI-Assisted Development
-Decision
-When using AI coding agents:
-Accepted ADRs are considered architectural constraints.
-Agents should consult ADRs before significant changes.
-Conflicts should result in a proposed ADR rather than silent implementation.
-ADRs outweigh README examples when there is disagreement.
-Consequences
-Positive:
-Consistent architecture
-Less drift between contributors
-Better onboarding for humans and agents
-Negative:
-Slightly slower implementation
-More ADR maintenance
+# ADR-008 Agent Ready Architecture
+
+## Status
+
+Accepted
+
+## Context
+
+Future versions of RAC may be used by Claude, Codex, Cursor, and other AI systems.
+
+The architecture should avoid coupling business logic to the CLI.
+
+## Decision
+
+All RAC capabilities will be implemented in reusable service layers.
+
+The CLI will be a thin wrapper around those services.
+
+## Alternatives Considered
+
+### CLI-only Architecture
+
+Pros:
+- Simpler initially
+
+Cons:
+- Difficult to expose as SDK or MCP server
+
+## Consequences
+
+### Positive
+
+- Easy MCP support
+- Easy SDK support
+- Easier testing
+
+### Negative
+
+- Slightly more abstraction
+- Additional project structure


### PR DESCRIPTION
Convert the terse ADR outlines into the same structure used by adr-009/010/011: # title, ## Status, ## Context, ## Decision, (## Alternatives Considered), and ## Consequences. Content preserved; structure added so 'rac inspect' classifies them as Decision artifacts (previously Unknown).

- Trust filenames for the swapped numbers: 006 = Ingestion Over Rewrite, 007 = JSON Contract Stability.
- adr-008 becomes Agent Ready Architecture (the AI-Assisted Development content already lives, properly formatted, in adr-009).