### PR TITLE
v0.4.1 - Expand inspect to directories, verbose, and synonyms

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,6 +468,55 @@ anything that doesn't fit well is reported as **Unknown** (a valid, successful
 result — not an error). `--json` emits `{ type, confidence, present_sections,
 missing_sections }`.
 
+### Inspect a directory
+
+Point `inspect` at a directory to get a summary across many files (recursive by
+default; `--top-level` limits it to the directory's own files):
+
+```bash
+rac inspect planning/
+rac inspect planning/ --top-level
+rac inspect planning/ --json        # versioned summary + per-file array
+```
+
+```text
+Files Inspected: 23
+
+Requirements: 7
+Decisions: 3
+Unknown: 13
+```
+
+### Explain a classification (`--verbose`)
+
+```bash
+rac inspect bond-dashboard.md --verbose
+```
+
+```text
+Artifact Type: Requirement
+Confidence: 71%
+
+Required Matches:
+  ✓ Problem
+  ✓ Requirements
+
+Recommended Matches:
+  ✓ Success Metrics
+
+Missing:
+  ✗ Risks
+  ✗ Assumptions
+
+Score: 2 + 0.5 × 1 = 2.5 / 3.5 = 0.71
+```
+
+### Synonyms
+
+Common heading variants are recognized automatically (case-insensitive,
+deterministic) — e.g. `Success Criteria` and `KPIs` both count as Success Metrics,
+and `Alternatives` counts as Alternatives Considered.
+
 `inspect` exits `0` for any completed inspection (including Unknown) and `2` for
 usage errors (file not found, or a non-Markdown file — convert it with
 `rac ingest` first).

--- a/planning/roadmap/v0.4.1-expansion.md
+++ b/planning/roadmap/v0.4.1-expansion.md
@@ -1,0 +1,42 @@
+# v0.4.1 Inspection Expansion
+
+## Problem
+
+v0.4.0 inspects individual Markdown files.
+
+As repositories grow, users need visibility across collections of artifacts rather than one file at a time, along with more transparency into how a file was classified.
+
+RAC should support inspecting directories, explaining classifications, and tolerating common heading variants — while remaining purely observational.
+
+## Requirements
+
+[REQ-001] User can inspect a directory
+[REQ-002] Directory inspection summarizes detected artifact types
+[REQ-003] Directory inspection reports the total files inspected
+[REQ-004] Unknown artifacts are included in summary results
+[REQ-005] Directory inspection is recursive by default
+[REQ-006] User can limit inspection to top-level files
+[REQ-007] Directory inspection supports JSON output
+[REQ-008] JSON output includes artifact counts by type
+[REQ-009] User can request verbose single-file inspection
+[REQ-010] Verbose output shows matched and missing sections
+[REQ-011] Verbose output shows the confidence calculation
+[REQ-012] RAC supports artifact-specific heading synonyms
+[REQ-013] Synonym matching is deterministic and case-insensitive
+
+## Success Metrics
+
+- Repository inspection correctly classifies well-formed artifacts
+- Inspection remains deterministic and explainable
+- JSON output supports future automation workflows
+
+## Risks
+
+- Large repositories may impact performance
+- Synonym matching may introduce ambiguity
+- Classification confidence may require tuning
+
+## Assumptions
+
+- No new artifact types are introduced in this release
+- Inspection remains observational; improvement guidance is a later release

--- a/rac/artifacts.py
+++ b/rac/artifacts.py
@@ -28,9 +28,11 @@ class ArtifactSpec:
     display: str  # human label, e.g. "Requirement"
     required: tuple[str, ...]  # normalized section names that define the type
     recommended: tuple[str, ...] = ()  # expected-but-optional sections
-    # Optional aliases: alternate normalized headings that map onto a canonical
-    # section name (e.g. "alternatives" -> "alternatives considered").
-    aliases: dict[str, str] = field(default_factory=dict)
+    # Synonyms: alternate normalized headings that map onto a canonical section
+    # name (e.g. "success criteria" -> "success metrics"). Applied before
+    # matching, so synonyms contribute to confidence. Matching is deterministic
+    # (dict lookup) and case-insensitive (headings are normalized first).
+    synonyms: dict[str, str] = field(default_factory=dict)
 
     @property
     def expected(self) -> tuple[str, ...]:
@@ -44,12 +46,20 @@ ARTIFACT_SPECS: tuple[ArtifactSpec, ...] = (
         display="Requirement",
         required=("problem", "requirements"),
         recommended=("success metrics", "risks", "assumptions"),
+        synonyms={
+            "success criteria": "success metrics",
+            "kpis": "success metrics",
+            "kpi": "success metrics",
+        },
     ),
     ArtifactSpec(
         name="decision",
         display="Decision",
         required=("context", "decision", "consequences"),
         recommended=("status", "alternatives considered"),
-        aliases={"alternatives": "alternatives considered"},
+        synonyms={
+            "alternatives": "alternatives considered",
+            "options considered": "alternatives considered",
+        },
     ),
 )

--- a/rac/cli.py
+++ b/rac/cli.py
@@ -24,7 +24,12 @@ from . import __version__
 from . import outputs
 from .diff import diff as diff_asts
 from .ingest import ConversionError, UnsupportedDocument, ingest
-from .inspect import inspect_text
+from .inspect import (
+    classify,
+    extract_sections,
+    inspect_directory,
+    inspect_text,
+)
 from .parser import parse_file
 from .stats import collect_stats
 from .validate import has_errors, validate
@@ -145,11 +150,25 @@ def _read_inspect_input(target: str) -> str:
 
 
 def cmd_inspect(args: argparse.Namespace) -> int:
-    result = inspect_text(_read_inspect_input(args.file))
-    if args.json:
-        print(outputs.render_inspect_json(result))
+    # Directory? Aggregate per-file results into type counts.
+    if args.file != "-" and Path(args.file).is_dir():
+        recursive = not args.top_level
+        result = inspect_directory(args.file, recursive=recursive)
+        if args.json:
+            print(outputs.render_dir_inspect_json(result))
+        else:
+            print(outputs.render_dir_inspect_human(result))
+        return EXIT_OK
+
+    # Single file (or stdin).
+    text = _read_inspect_input(args.file)
+    if args.verbose and not args.json:
+        sections = extract_sections(text)
+        print(outputs.render_inspect_verbose(classify(sections), sections))
+    elif args.json:
+        print(outputs.render_inspect_json(inspect_text(text)))
     else:
-        print(outputs.render_inspect_human(result))
+        print(outputs.render_inspect_human(inspect_text(text)))
     # A completed inspection always succeeds — Unknown is a valid outcome.
     return EXIT_OK
 
@@ -234,10 +253,26 @@ def build_parser() -> argparse.ArgumentParser:
         parents=[version_parent],
     )
     p_inspect.add_argument(
-        "file", help="Path to a Markdown file, or '-' to read from stdin."
+        "file",
+        help="A Markdown file, a directory, or '-' to read from stdin.",
     )
     p_inspect.add_argument(
         "--json", action="store_true", help="Emit JSON instead of human-readable text."
+    )
+    p_inspect.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Show the classification breakdown and score (single file only).",
+    )
+    p_inspect.add_argument(
+        "--top-level",
+        action="store_true",
+        help="When inspecting a directory, only its top-level files (no recursion).",
+    )
+    p_inspect.add_argument(
+        "--recursive",
+        action="store_true",
+        help="Recurse into subdirectories (the default; accepted for clarity).",
     )
     p_inspect.set_defaults(func=cmd_inspect)
 

--- a/rac/inspect.py
+++ b/rac/inspect.py
@@ -1,10 +1,11 @@
-"""Artifact inspection — classify a Markdown document and report its structure.
+"""Artifact inspection — classify Markdown documents and report their structure.
 
 `rac inspect <file>` answers, for a single document: *what kind of artifact is
 this, how confident are we, and which expected sections are present / missing?*
-It is strictly observational — it never modifies content and never recommends
-changes (that is v0.5 `improve`'s job). Classification is a pure heuristic over
-the document's ``##`` section headings (ADR-002: AI-optional); it consumes the
+`rac inspect <dir>` aggregates that across a directory into type counts. It is
+strictly observational — it never modifies content and never recommends changes
+(that is a future `improve` command's job). Classification is a pure heuristic
+over the document's ``##`` section headings (ADR-002: AI-optional), consuming the
 shared schemas in :mod:`rac.artifacts`.
 """
 
@@ -16,6 +17,7 @@ from markdown_it import MarkdownIt
 
 from .artifacts import ARTIFACT_SPECS
 from .parser import _normalize_heading
+from .stats import find_markdown_files
 
 # Below this best-fit score, the document is reported as Unknown rather than
 # forced into a type. Unknown is a valid, successful outcome — not an error.
@@ -31,17 +33,29 @@ class DocumentSections:
 
 
 @dataclass
-class InspectionResult:
-    """Typed inspection result (ADR-003).
+class TypeScore:
+    """How well a document fits one artifact type — the explainable breakdown."""
 
-    Section names are stored normalized (e.g. ``"success metrics"``); the
-    renderers format them for display/JSON. ``to_dict`` is the JSON contract and
-    is intentionally additive-friendly — future keys (e.g. ``schema_version``)
-    can be added without breaking existing consumers.
+    name: str
+    display: str
+    matched_required: list[str]
+    matched_recommended: list[str]
+    missing: list[str]
+    points: float  # matched_required + 0.5 * matched_recommended
+    ceiling: float  # |required| + 0.5 * |recommended|
+    fit: float  # points / ceiling, 0.0 – 1.0 (unrounded)
+
+
+@dataclass
+class InspectionResult:
+    """Typed single-file inspection result (ADR-003).
+
+    Section names are stored normalized (e.g. ``"success metrics"``); renderers
+    format them. ``to_dict`` is the JSON contract and is additive-friendly.
     """
 
     type: str  # artifact name, or "unknown"
-    confidence: float  # 0.0 – 1.0
+    confidence: float  # 0.0 – 1.0 (rounded to 2dp)
     present_sections: list[str]
     missing_sections: list[str]
 
@@ -52,6 +66,41 @@ class InspectionResult:
             "present_sections": [_snake(s) for s in self.present_sections],
             "missing_sections": [_snake(s) for s in self.missing_sections],
         }
+
+
+@dataclass
+class FileInspection:
+    """One file's result inside a directory inspection (flat — path/type/conf)."""
+
+    path: str
+    type: str
+    confidence: float
+
+
+@dataclass
+class DirectoryInspection:
+    """Aggregated inspection across a directory of Markdown files."""
+
+    directory: str
+    recursive: bool
+    files: list[FileInspection]
+
+    @property
+    def total_files(self) -> int:
+        return len(self.files)
+
+    @property
+    def counts(self) -> dict[str, int]:
+        # Known types first (in ARTIFACT_SPECS order), then unknown.
+        counts = {spec.name: 0 for spec in ARTIFACT_SPECS}
+        counts["unknown"] = 0
+        for f in self.files:
+            counts[f.type] = counts.get(f.type, 0) + 1
+        return counts
+
+    @property
+    def unknown_count(self) -> int:
+        return self.counts.get("unknown", 0)
 
 
 def _snake(section: str) -> str:
@@ -74,42 +123,57 @@ def extract_sections(text: str) -> DocumentSections:
     return DocumentSections(title=title, headings=headings)
 
 
+def score_artifacts(sections: DocumentSections) -> list[TypeScore]:
+    """Score the document against every artifact type, best fit first.
+
+    Synonyms (e.g. "success criteria" -> "success metrics") are applied before
+    matching, so they contribute to the score deterministically.
+    """
+    scores: list[TypeScore] = []
+    for spec in ARTIFACT_SPECS:
+        mapped = {spec.synonyms.get(h, h) for h in sections.headings}
+        matched_required = [s for s in spec.required if s in mapped]
+        matched_recommended = [s for s in spec.recommended if s in mapped]
+        missing = [s for s in spec.expected if s not in mapped]
+        points = len(matched_required) + 0.5 * len(matched_recommended)
+        ceiling = len(spec.required) + 0.5 * len(spec.recommended)
+        fit = points / ceiling if ceiling else 0.0
+        scores.append(
+            TypeScore(
+                name=spec.name,
+                display=spec.display,
+                matched_required=matched_required,
+                matched_recommended=matched_recommended,
+                missing=missing,
+                points=points,
+                ceiling=ceiling,
+                fit=fit,
+            )
+        )
+    # Best fit first; ties broken by more required matches, then ARTIFACT_SPECS
+    # order (stable sort preserves it).
+    scores.sort(key=lambda t: (t.fit, len(t.matched_required)), reverse=True)
+    return scores
+
+
 def classify(sections: DocumentSections) -> InspectionResult:
     """Pick the best-fit artifact type for ``sections`` (or Unknown)."""
-    best_spec = None
-    best_fit = 0.0
-    best_required_hits = -1
+    scores = score_artifacts(sections)
+    best = scores[0] if scores else None
 
-    for spec in ARTIFACT_SPECS:
-        mapped = {spec.aliases.get(h, h) for h in sections.headings}
-        required_hits = sum(1 for s in spec.required if s in mapped)
-        recommended_hits = sum(1 for s in spec.recommended if s in mapped)
-        raw = required_hits + 0.5 * recommended_hits
-        ceiling = len(spec.required) + 0.5 * len(spec.recommended)
-        fit = raw / ceiling if ceiling else 0.0
-        # Highest fit wins; ties broken by more required matches, then by the
-        # order of ARTIFACT_SPECS (we only replace on a strict improvement).
-        if (fit, required_hits) > (best_fit, best_required_hits):
-            best_fit, best_required_hits, best_spec = fit, required_hits, spec
-
-    confidence = round(best_fit, 2)
-
-    if best_spec is None or best_fit < CONFIDENCE_THRESHOLD or best_required_hits == 0:
+    if best is None or best.fit < CONFIDENCE_THRESHOLD or not best.matched_required:
         return InspectionResult(
             type="unknown",
-            confidence=confidence,
+            confidence=round(best.fit, 2) if best else 0.0,
             present_sections=list(sections.headings),
             missing_sections=[],
         )
 
-    mapped = {best_spec.aliases.get(h, h) for h in sections.headings}
-    present = [s for s in best_spec.expected if s in mapped]
-    missing = [s for s in best_spec.expected if s not in mapped]
     return InspectionResult(
-        type=best_spec.name,
-        confidence=confidence,
-        present_sections=present,
-        missing_sections=missing,
+        type=best.name,
+        confidence=round(best.fit, 2),
+        present_sections=best.matched_required + best.matched_recommended,
+        missing_sections=best.missing,
     )
 
 
@@ -120,3 +184,14 @@ def inspect_text(text: str) -> InspectionResult:
 def inspect_file(path: str) -> InspectionResult:
     with open(path, encoding="utf-8") as fh:
         return inspect_text(fh.read())
+
+
+def inspect_directory(directory: str, recursive: bool = True) -> DirectoryInspection:
+    """Inspect every Markdown file under ``directory`` and aggregate the types."""
+    files = []
+    for path in find_markdown_files(directory, recursive=recursive):
+        result = inspect_file(str(path))
+        files.append(
+            FileInspection(path=str(path), type=result.type, confidence=result.confidence)
+        )
+    return DirectoryInspection(directory=directory, recursive=recursive, files=files)

--- a/rac/outputs.py
+++ b/rac/outputs.py
@@ -10,8 +10,15 @@ import json
 import sys
 from dataclasses import asdict
 
+from .artifacts import ARTIFACT_SPECS
 from .ingest import IngestResult
-from .inspect import InspectionResult
+from .inspect import (
+    CONFIDENCE_THRESHOLD,
+    DirectoryInspection,
+    DocumentSections,
+    InspectionResult,
+    score_artifacts,
+)
 from .models import Diff, Issue, Product
 from .stats import PortfolioStats
 
@@ -261,6 +268,78 @@ def render_inspect_human(result: InspectionResult) -> str:
 
 def render_inspect_json(result: InspectionResult) -> str:
     return json.dumps(result.to_dict(), indent=2)
+
+
+def render_inspect_verbose(result: InspectionResult, sections: DocumentSections) -> str:
+    """Explainable single-file output: matches, misses, and the score math."""
+    chosen = next(
+        (s for s in score_artifacts(sections) if s.name == result.type), None
+    )
+    if chosen is None:  # Unknown — explain via the closest candidate
+        scores = score_artifacts(sections)
+        chosen = scores[0] if scores else None
+
+    lines = [
+        _bold(f"Artifact Type: {result.type.title()}"),
+        f"Confidence: {result.confidence:.0%}",
+    ]
+    if chosen is None:
+        return "\n".join(lines)
+    if result.type == "unknown":
+        lines.append(f"Closest match: {chosen.display}")
+
+    def block(title: str, names: list[str]) -> None:
+        lines.extend(["", _bold(title)])
+        if names:
+            lines.extend(_green(f"  ✓ {s.title()}") for s in names)
+        else:
+            lines.append("  (none)")
+
+    block("Required Matches:", chosen.matched_required)
+    block("Recommended Matches:", chosen.matched_recommended)
+    if chosen.missing:
+        lines.extend(["", _bold("Missing:")])
+        lines.extend(_red(f"  ✗ {s.title()}") for s in chosen.missing)
+
+    req, rec = len(chosen.matched_required), len(chosen.matched_recommended)
+    lines.extend(
+        [
+            "",
+            _bold("Score:")
+            + f" {req} + 0.5 × {rec} = {chosen.points:g} / {chosen.ceiling:g}"
+            + f" = {round(chosen.fit, 2)}",
+        ]
+    )
+    if result.type == "unknown":
+        lines.append(f"(below the {CONFIDENCE_THRESHOLD:.0%} threshold → Unknown)")
+    return "\n".join(lines)
+
+
+def render_dir_inspect_human(d: DirectoryInspection) -> str:
+    counts = d.counts
+    lines = [_bold(f"Files Inspected: {d.total_files}"), ""]
+    for spec in ARTIFACT_SPECS:
+        lines.append(f"{spec.display}s: {counts.get(spec.name, 0)}")
+    lines.append(f"Unknown: {counts.get('unknown', 0)}")
+    return "\n".join(lines)
+
+
+def render_dir_inspect_json(d: DirectoryInspection) -> str:
+    payload = {
+        "schema_version": "1",
+        "directory": d.directory,
+        "recursive": d.recursive,
+        "summary": {
+            "total_files": d.total_files,
+            "counts": d.counts,
+            "unknown": d.unknown_count,
+        },
+        "files": [
+            {"path": f.path, "type": f.type, "confidence": f.confidence}
+            for f in d.files
+        ],
+    }
+    return json.dumps(payload, indent=2)
 
 
 # --- ingest ------------------------------------------------------------------

--- a/rac/stats.py
+++ b/rac/stats.py
@@ -111,12 +111,17 @@ def _neg_name(name: str) -> tuple[int, ...]:
     return tuple(-ord(c) for c in name)
 
 
-def find_markdown_files(directory: str) -> list[Path]:
-    """Recursively find `*.md` files, skipping dotted dirs (.git, .venv, ...)."""
+def find_markdown_files(directory: str, recursive: bool = True) -> list[Path]:
+    """Find `*.md` files, skipping dotted dirs (.git, .venv, ...).
+
+    Recursive by default (used by `stats` and `inspect`); pass ``recursive=False``
+    to look only at files directly inside ``directory``.
+    """
     root = Path(directory)
+    glob = root.rglob if recursive else root.glob
     found = [
         p
-        for p in root.rglob("*.md")
+        for p in glob("*.md")
         if not any(part.startswith(".") for part in p.relative_to(root).parts)
     ]
     return sorted(found)

--- a/tests/fixtures/inspect/nested/another_requirement.md
+++ b/tests/fixtures/inspect/nested/another_requirement.md
@@ -1,0 +1,9 @@
+# Nested Feature
+
+## Problem
+
+A requirement file inside a subdirectory, used to test recursive inspection.
+
+## Requirements
+
+[REQ-001] Recursive inspection finds nested files

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -14,8 +14,10 @@ from rac.inspect import (
     CONFIDENCE_THRESHOLD,
     classify,
     extract_sections,
+    inspect_directory,
     inspect_file,
     inspect_text,
+    score_artifacts,
 )
 
 from conftest import fixture_path
@@ -82,6 +84,109 @@ def test_dogfood_repo_artifacts():
     roadmap = REPO_ROOT / "planning/roadmap/v0.4-inspect.md"
     assert inspect_file(str(adr)).type == "decision"
     assert inspect_file(str(roadmap)).type == "requirement"
+
+
+# --- synonyms ---------------------------------------------------------------
+
+
+def test_synonym_counts_as_canonical_section():
+    # "## Success Criteria" should satisfy the requirement's success-metrics slot.
+    text = (
+        "# Feature\n\n## Problem\n\np\n\n## Requirements\n\n[REQ-001] x\n\n"
+        "## Success Criteria\n\n- hits target\n"
+    )
+    result = inspect_text(text)
+    assert result.type == "requirement"
+    assert "success metrics" in result.present_sections
+    assert "success metrics" not in result.missing_sections
+
+
+def test_synonym_is_case_insensitive():
+    text = "# F\n\n## Problem\n\np\n\n## Requirements\n\nr\n\n## KPIs\n\n- x\n"
+    assert "success metrics" in inspect_text(text).present_sections
+
+
+# --- scoring breakdown / verbose --------------------------------------------
+
+
+def test_score_artifacts_breakdown():
+    sections = extract_sections(
+        Path(fixture_path("inspect", "decision.md")).read_text()
+    )
+    top = score_artifacts(sections)[0]
+    assert top.name == "decision"
+    assert set(top.matched_required) == {"context", "decision", "consequences"}
+    assert "status" in top.matched_recommended
+    assert top.points == 3.5 and top.ceiling == 4.0
+
+
+def test_cli_inspect_verbose(capsys):
+    rc = main(["inspect", fixture_path("inspect", "requirement.md"), "--verbose"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Required Matches:" in out
+    assert "Recommended Matches:" in out
+    assert "Score:" in out and "/ 3.5" in out
+
+
+# --- directory inspection ---------------------------------------------------
+
+
+def test_inspect_directory_recursive_vs_top_level():
+    d = fixture_path("inspect")
+    top = inspect_directory(d, recursive=False)
+    rec = inspect_directory(d, recursive=True)
+    assert top.total_files == 3  # requirement, decision, ambiguous
+    assert rec.total_files == 4  # + nested/another_requirement.md
+    assert rec.counts["requirement"] == 2
+    assert rec.counts["decision"] == 1
+    assert rec.counts["unknown"] == 1
+
+
+def test_cli_dir_inspect_human(capsys):
+    rc = main(["inspect", fixture_path("inspect")])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Files Inspected: 4" in out
+    assert "Requirements: 2" in out
+    assert "Decisions: 1" in out
+    assert "Unknown: 1" in out
+
+
+def test_cli_dir_inspect_json_is_versioned_and_flat(capsys):
+    rc = main(["inspect", fixture_path("inspect"), "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["schema_version"] == "1"
+    assert payload["recursive"] is True
+    assert payload["summary"]["total_files"] == 4
+    assert payload["summary"]["counts"]["requirement"] == 2
+    # File entries are flat: path/type/confidence only (no present/missing).
+    entry = payload["files"][0]
+    assert set(entry) == {"path", "type", "confidence"}
+
+
+def test_cli_dir_inspect_top_level_flag(capsys):
+    rc = main(["inspect", fixture_path("inspect"), "--top-level"])
+    assert rc == 0
+    assert "Files Inspected: 3" in capsys.readouterr().out
+
+
+def test_cli_dir_inspect_recursive_flag_accepted(capsys):
+    # --recursive is the default; accepted as a no-op for clarity.
+    rc = main(["inspect", fixture_path("inspect"), "--recursive"])
+    assert rc == 0
+    assert "Files Inspected: 4" in capsys.readouterr().out
+
+
+def test_dogfood_directory_targets():
+    # planning/roadmap is fully RAC-formatted -> all Requirements, no Unknown.
+    roadmap = inspect_directory(str(REPO_ROOT / "planning/roadmap"))
+    assert roadmap.unknown_count == 0
+    assert roadmap.counts["requirement"] == roadmap.total_files
+    # The well-formed ADRs classify as Decision.
+    adr = REPO_ROOT / "planning/adr/adr-010-documents-are-not-artifacts.md"
+    assert inspect_file(str(adr)).type == "decision"
 
 
 # --- CLI --------------------------------------------------------------------


### PR DESCRIPTION
- rac inspect <dir>: summarize artifact-type counts across a directory (recursive by default; --top-level to limit; --recursive accepted no-op). Human shows 'Files Inspected: N' + per-type counts; JSON is versioned (schema_version) with a summary{} and a flat files[] (path/type/confidence).
- rac inspect <file> --verbose: explainable breakdown (required/recommended matches, missing, and the score calculation), via a shared score_artifacts().
- Section synonyms (artifacts.py): Success Criteria/KPIs -> success metrics, Alternatives/Options Considered -> alternatives considered. Deterministic, case-insensitive; rename ArtifactSpec.aliases -> synonyms.
- stats.find_markdown_files gains a recursive flag (reused by inspect).
- Tests (+nested fixture), README, and planning/roadmap/v0.4.1-expansion.md.

No new artifact types; strictly observational. Builds on v0.4.0.