### PR TITLE
v0.4.2: decision metadata (status, category, supersedes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,14 +379,36 @@ Invalid Features (1)
   ./features/draft.md — missing-title, missing-requirements
 ```
 
-Counts span all parsed files; a feature with only *warnings* (e.g. no metrics)
-still counts as valid. Invalid files are listed at the end so they are never
-silently skipped.
+Counts span all parsed requirement files; a feature with only *warnings* (e.g. no
+metrics) still counts as valid. Invalid files are listed at the end so they are
+never silently skipped.
 
-Add `--json` for machine-readable output. `stats` exits `0` when the directory
-has at least one valid feature, `1` if none are valid, and `2` if the path is
-not a directory. (A `--strict` flag for failing on *any* invalid file — handy in
-CI — is planned.)
+Decision artifacts are aggregated **separately** so they never distort the
+requirement totals or averages. When a directory contains decisions, a
+`Decisions` section reports the count plus a status and category breakdown:
+
+```text
+Decisions
+=========
+
+Total: 17
+
+Status
+  - Accepted: 12
+  - Proposed: 3
+  - Superseded: 2
+
+Category
+  - Architecture: 8
+  - Product: 5
+  - Process: 4
+```
+
+Add `--json` for machine-readable output (a `decisions` block is included only
+when decisions are present). `stats` exits `0` when the directory has at least
+one valid feature or decision, `1` if none, and `2` if the path is not a
+directory. (A `--strict` flag for failing on *any* invalid file — handy in CI —
+is planned.)
 
 ---
 
@@ -510,6 +532,37 @@ Missing:
 
 Score: 2 + 0.5 × 1 = 2.5 / 3.5 = 0.71
 ```
+
+### Decision metadata
+
+Decision artifacts (ADRs) may carry lightweight, optional metadata. When present,
+`inspect` extracts it and `validate` checks the values:
+
+```markdown
+## Status
+
+Accepted
+
+## Category
+
+Architecture
+
+## Supersedes
+
+ADR-012
+```
+
+| Field | Supported values | Validated? |
+|------------|--------------------------------------------------------------|------------|
+| Status | Proposed, Accepted, Superseded, Deprecated | yes |
+| Category | Architecture, Product, Process, Technical, Other | yes |
+| Supersedes | any reference (free text) | no — metadata only |
+
+`inspect` surfaces these under a **Decision Metadata** block (and in `--json` as
+`status` / `category` / `supersedes`, present only when declared). Metadata is
+**optional**: a decision without it is still valid. Only an *unsupported* Status
+or Category value fails validation (`invalid-decision-status` /
+`invalid-decision-category`); values are matched case-insensitively.
 
 ### Synonyms
 

--- a/rac/artifacts.py
+++ b/rac/artifacts.py
@@ -28,6 +28,13 @@ class ArtifactSpec:
     display: str  # human label, e.g. "Requirement"
     required: tuple[str, ...]  # normalized section names that define the type
     recommended: tuple[str, ...] = ()  # expected-but-optional sections
+    # Truly optional sections: recognized and extracted, but never scored and
+    # never reported as "missing" (e.g. a Decision's "supersedes" reference).
+    optional: tuple[str, ...] = ()
+    # Constrained metadata fields: {normalized section name -> allowed values}.
+    # A value present in one of these sections that is not in its allowed set is
+    # a validation error; a missing section is not (metadata stays optional).
+    metadata: dict[str, tuple[str, ...]] = field(default_factory=dict)
     # Synonyms: alternate normalized headings that map onto a canonical section
     # name (e.g. "success criteria" -> "success metrics"). Applied before
     # matching, so synonyms contribute to confidence. Matching is deterministic
@@ -36,7 +43,11 @@ class ArtifactSpec:
 
     @property
     def expected(self) -> tuple[str, ...]:
-        """All sections that belong to this artifact (required + recommended)."""
+        """Sections that count toward fit (required + recommended).
+
+        ``optional`` sections are deliberately excluded — they are extracted but
+        never scored, so they never show up as "missing".
+        """
         return self.required + self.recommended
 
 
@@ -56,10 +67,23 @@ ARTIFACT_SPECS: tuple[ArtifactSpec, ...] = (
         name="decision",
         display="Decision",
         required=("context", "decision", "consequences"),
-        recommended=("status", "alternatives considered"),
+        recommended=("status", "category", "alternatives considered"),
+        optional=("supersedes",),
+        metadata={
+            "status": ("Proposed", "Accepted", "Superseded", "Deprecated"),
+            "category": ("Architecture", "Product", "Process", "Technical", "Other"),
+        },
         synonyms={
             "alternatives": "alternatives considered",
             "options considered": "alternatives considered",
         },
     ),
 )
+
+
+def spec_for(name: str) -> ArtifactSpec | None:
+    """Return the :class:`ArtifactSpec` with canonical ``name``, or None."""
+    for spec in ARTIFACT_SPECS:
+        if spec.name == name:
+            return spec
+    return None

--- a/rac/classification.py
+++ b/rac/classification.py
@@ -1,0 +1,102 @@
+"""Artifact classification — the shared heuristic over a parsed document.
+
+Scores a :class:`~rac.models.Product` against the artifact schemas in
+:mod:`rac.artifacts` and picks the best-fit type (or Unknown). This is a pure,
+AI-optional function (ADR-002): it looks only at which ``##`` sections a document
+contains. It is the single home for classification, consumed by ``inspect``,
+``validate``, ``stats``, and future commands so they never reach it through one
+another.
+
+Classification works off ``product.sections`` (the canonical section map from the
+parser); it never re-parses the Markdown.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .artifacts import ARTIFACT_SPECS
+from .models import Product
+
+# Below this best-fit score, the document is reported as Unknown rather than
+# forced into a type. Unknown is a valid, successful outcome — not an error.
+CONFIDENCE_THRESHOLD = 0.5
+
+
+@dataclass
+class TypeScore:
+    """How well a document fits one artifact type — the explainable breakdown."""
+
+    name: str
+    display: str
+    matched_required: list[str]
+    matched_recommended: list[str]
+    missing: list[str]
+    points: float  # matched_required + 0.5 * matched_recommended
+    ceiling: float  # |required| + 0.5 * |recommended|
+    fit: float  # points / ceiling, 0.0 – 1.0 (unrounded)
+
+
+@dataclass
+class Classification:
+    """The chosen artifact type for a document (or Unknown)."""
+
+    type: str  # artifact name, or "unknown"
+    confidence: float  # 0.0 – 1.0 (rounded to 2dp)
+    present_sections: list[str]
+    missing_sections: list[str]
+
+
+def score_artifacts(product: Product) -> list[TypeScore]:
+    """Score the document against every artifact type, best fit first.
+
+    Synonyms (e.g. "success criteria" -> "success metrics") are applied before
+    matching, so they contribute to the score deterministically.
+    """
+    headings = list(product.sections)
+    scores: list[TypeScore] = []
+    for spec in ARTIFACT_SPECS:
+        mapped = {spec.synonyms.get(h, h) for h in headings}
+        matched_required = [s for s in spec.required if s in mapped]
+        matched_recommended = [s for s in spec.recommended if s in mapped]
+        missing = [s for s in spec.expected if s not in mapped]
+        points = len(matched_required) + 0.5 * len(matched_recommended)
+        ceiling = len(spec.required) + 0.5 * len(spec.recommended)
+        fit = points / ceiling if ceiling else 0.0
+        scores.append(
+            TypeScore(
+                name=spec.name,
+                display=spec.display,
+                matched_required=matched_required,
+                matched_recommended=matched_recommended,
+                missing=missing,
+                points=points,
+                ceiling=ceiling,
+                fit=fit,
+            )
+        )
+    # Best fit first; ties broken by more required matches, then ARTIFACT_SPECS
+    # order (stable sort preserves it).
+    scores.sort(key=lambda t: (t.fit, len(t.matched_required)), reverse=True)
+    return scores
+
+
+def classify(product: Product) -> Classification:
+    """Pick the best-fit artifact type for ``product`` (or Unknown)."""
+    scores = score_artifacts(product)
+    best = scores[0] if scores else None
+
+    if best is None or best.fit < CONFIDENCE_THRESHOLD or not best.matched_required:
+        return Classification(
+            type="unknown",
+            confidence=round(best.fit, 2) if best else 0.0,
+            present_sections=list(product.sections),
+            missing_sections=[],
+        )
+
+    return Classification(
+        type=best.name,
+        confidence=round(best.fit, 2),
+        present_sections=best.matched_required + best.matched_recommended,
+        missing_sections=best.missing,
+    )

--- a/rac/cli.py
+++ b/rac/cli.py
@@ -9,7 +9,8 @@ Commands:
 
 Exit codes:
     0  success (incl. inspect reporting Unknown)
-    1  validate: errors found; stats: no valid features; ingest: conversion failed
+    1  validate: errors found; stats: no valid features or decisions;
+       ingest: conversion failed
     2  usage / IO error (file not found, not a directory, unsupported type,
        refuse-to-overwrite)
 """
@@ -24,13 +25,9 @@ from . import __version__
 from . import outputs
 from .diff import diff as diff_asts
 from .ingest import ConversionError, UnsupportedDocument, ingest
-from .inspect import (
-    classify,
-    extract_sections,
-    inspect_directory,
-    inspect_text,
-)
-from .parser import parse_file
+from .classification import score_artifacts
+from .inspect import build_inspection, inspect_directory
+from .parser import parse, parse_file
 from .stats import collect_stats
 from .validate import has_errors, validate
 
@@ -81,10 +78,12 @@ def cmd_stats(args: argparse.Namespace) -> int:
         print(outputs.render_stats_json(stats))
     else:
         print(outputs.render_stats_human(stats))
-    # Success as long as the portfolio has at least one valid feature. Invalid
-    # files are reported but don't fail the run on their own. (A future --strict
-    # flag will fail the run if *any* file is invalid, for CI use.)
-    return EXIT_OK if stats.valid_features > 0 else EXIT_VALIDATION_FAILED
+    # Success as long as the portfolio has analysable content: at least one valid
+    # feature or at least one decision. Invalid files are reported but don't fail
+    # the run on their own. (A future --strict flag will fail the run if *any*
+    # file is invalid, for CI use.)
+    has_content = stats.valid_features > 0 or stats.decision_count > 0
+    return EXIT_OK if has_content else EXIT_VALIDATION_FAILED
 
 
 def cmd_ingest(args: argparse.Namespace) -> int:
@@ -162,13 +161,14 @@ def cmd_inspect(args: argparse.Namespace) -> int:
 
     # Single file (or stdin).
     text = _read_inspect_input(args.file)
+    product = parse(text)
+    result = build_inspection(product)
     if args.verbose and not args.json:
-        sections = extract_sections(text)
-        print(outputs.render_inspect_verbose(classify(sections), sections))
+        print(outputs.render_inspect_verbose(result, score_artifacts(product)))
     elif args.json:
-        print(outputs.render_inspect_json(inspect_text(text)))
+        print(outputs.render_inspect_json(result))
     else:
-        print(outputs.render_inspect_human(inspect_text(text)))
+        print(outputs.render_inspect_human(result))
     # A completed inspection always succeeds — Unknown is a valid outcome.
     return EXIT_OK
 

--- a/rac/fs.py
+++ b/rac/fs.py
@@ -1,0 +1,26 @@
+"""Filesystem helpers shared across RAC commands.
+
+Kept separate so that consumers (``stats``, ``inspect``) depend on a small,
+neutral module rather than on each other — avoiding import cycles as more
+commands need to walk a tree of Markdown files.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def find_markdown_files(directory: str, recursive: bool = True) -> list[Path]:
+    """Find `*.md` files, skipping dotted dirs (.git, .venv, ...).
+
+    Recursive by default (used by `stats` and `inspect`); pass ``recursive=False``
+    to look only at files directly inside ``directory``.
+    """
+    root = Path(directory)
+    glob = root.rglob if recursive else root.glob
+    found = [
+        p
+        for p in glob("*.md")
+        if not any(part.startswith(".") for part in p.relative_to(root).parts)
+    ]
+    return sorted(found)

--- a/rac/inspect.py
+++ b/rac/inspect.py
@@ -2,48 +2,22 @@
 
 `rac inspect <file>` answers, for a single document: *what kind of artifact is
 this, how confident are we, and which expected sections are present / missing?*
-`rac inspect <dir>` aggregates that across a directory into type counts. It is
-strictly observational — it never modifies content and never recommends changes
-(that is a future `improve` command's job). Classification is a pure heuristic
-over the document's ``##`` section headings (ADR-002: AI-optional), consuming the
-shared schemas in :mod:`rac.artifacts`.
+For Decisions it also surfaces lightweight metadata (status, category, supersedes)
+when present. `rac inspect <dir>` aggregates the type across a directory into
+counts. It is strictly observational — it never modifies content and never
+recommends changes (that is a future `improve` command's job). Classification is
+delegated to :mod:`rac.classification` (the shared, AI-optional heuristic).
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 
-from markdown_it import MarkdownIt
-
-from .artifacts import ARTIFACT_SPECS
-from .parser import _normalize_heading
-from .stats import find_markdown_files
-
-# Below this best-fit score, the document is reported as Unknown rather than
-# forced into a type. Unknown is a valid, successful outcome — not an error.
-CONFIDENCE_THRESHOLD = 0.5
-
-
-@dataclass
-class DocumentSections:
-    """The structural skeleton of a document: its title and ``##`` headings."""
-
-    title: str | None
-    headings: list[str]  # normalized h2 section names, in document order
-
-
-@dataclass
-class TypeScore:
-    """How well a document fits one artifact type — the explainable breakdown."""
-
-    name: str
-    display: str
-    matched_required: list[str]
-    matched_recommended: list[str]
-    missing: list[str]
-    points: float  # matched_required + 0.5 * matched_recommended
-    ceiling: float  # |required| + 0.5 * |recommended|
-    fit: float  # points / ceiling, 0.0 – 1.0 (unrounded)
+from .artifacts import ARTIFACT_SPECS, spec_for
+from .classification import classify
+from .fs import find_markdown_files
+from .models import Product
+from .parser import parse, parse_file
 
 
 @dataclass
@@ -51,21 +25,31 @@ class InspectionResult:
     """Typed single-file inspection result (ADR-003).
 
     Section names are stored normalized (e.g. ``"success metrics"``); renderers
-    format them. ``to_dict`` is the JSON contract and is additive-friendly.
+    format them. ``to_dict`` is the JSON contract and is additive-friendly:
+    decision metadata fields appear only when present.
     """
 
     type: str  # artifact name, or "unknown"
     confidence: float  # 0.0 – 1.0 (rounded to 2dp)
     present_sections: list[str]
     missing_sections: list[str]
+    # Decision metadata — populated only for decisions that declare it.
+    status: str | None = None
+    category: str | None = None
+    supersedes: str | None = None
 
     def to_dict(self) -> dict:
-        return {
+        payload = {
             "type": self.type,
             "confidence": self.confidence,
             "present_sections": [_snake(s) for s in self.present_sections],
             "missing_sections": [_snake(s) for s in self.missing_sections],
         }
+        for key in ("status", "category", "supersedes"):
+            value = getattr(self, key)
+            if value is not None:
+                payload[key] = value
+        return payload
 
 
 @dataclass
@@ -107,83 +91,60 @@ def _snake(section: str) -> str:
     return section.replace(" ", "_")
 
 
-def extract_sections(text: str) -> DocumentSections:
-    """Pull the ``#`` title and ordered, normalized ``##`` headings from Markdown."""
-    tokens = MarkdownIt("commonmark").parse(text)
-    title: str | None = None
-    headings: list[str] = []
-    for i, tok in enumerate(tokens):
-        if tok.type != "heading_open":
-            continue
-        content = tokens[i + 1].content if i + 1 < len(tokens) else ""
-        if tok.tag == "h1" and title is None:
-            title = content.strip()
-        elif tok.tag == "h2":
-            headings.append(_normalize_heading(content))
-    return DocumentSections(title=title, headings=headings)
+def _first_line(body: str) -> str:
+    """The first non-empty line of a section body (single-value metadata)."""
+    for line in body.splitlines():
+        stripped = line.strip()
+        if stripped:
+            return stripped
+    return ""
 
 
-def score_artifacts(sections: DocumentSections) -> list[TypeScore]:
-    """Score the document against every artifact type, best fit first.
-
-    Synonyms (e.g. "success criteria" -> "success metrics") are applied before
-    matching, so they contribute to the score deterministically.
-    """
-    scores: list[TypeScore] = []
-    for spec in ARTIFACT_SPECS:
-        mapped = {spec.synonyms.get(h, h) for h in sections.headings}
-        matched_required = [s for s in spec.required if s in mapped]
-        matched_recommended = [s for s in spec.recommended if s in mapped]
-        missing = [s for s in spec.expected if s not in mapped]
-        points = len(matched_required) + 0.5 * len(matched_recommended)
-        ceiling = len(spec.required) + 0.5 * len(spec.recommended)
-        fit = points / ceiling if ceiling else 0.0
-        scores.append(
-            TypeScore(
-                name=spec.name,
-                display=spec.display,
-                matched_required=matched_required,
-                matched_recommended=matched_recommended,
-                missing=missing,
-                points=points,
-                ceiling=ceiling,
-                fit=fit,
-            )
-        )
-    # Best fit first; ties broken by more required matches, then ARTIFACT_SPECS
-    # order (stable sort preserves it).
-    scores.sort(key=lambda t: (t.fit, len(t.matched_required)), reverse=True)
-    return scores
+def canonical_value(raw: str, allowed: tuple[str, ...]) -> str:
+    """Match ``raw`` against ``allowed`` case-insensitively, returning the
+    canonical spelling; if it matches nothing, return it stripped (an invalid
+    value that validation will flag)."""
+    candidate = _first_line(raw)
+    for value in allowed:
+        if value.casefold() == candidate.casefold():
+            return value
+    return candidate
 
 
-def classify(sections: DocumentSections) -> InspectionResult:
-    """Pick the best-fit artifact type for ``sections`` (or Unknown)."""
-    scores = score_artifacts(sections)
-    best = scores[0] if scores else None
+def _attach_decision_metadata(result: InspectionResult, product: Product) -> None:
+    spec = spec_for("decision")
+    if spec is None:  # pragma: no cover - decision spec always exists
+        return
+    for field_name, allowed in spec.metadata.items():
+        body = product.sections.get(field_name)
+        if body:
+            setattr(result, field_name, canonical_value(body, allowed))
+    supersedes = product.sections.get("supersedes")
+    if supersedes:
+        # Metadata only (REQ-003): no validation, just normalize the value.
+        result.supersedes = _first_line(supersedes)
 
-    if best is None or best.fit < CONFIDENCE_THRESHOLD or not best.matched_required:
-        return InspectionResult(
-            type="unknown",
-            confidence=round(best.fit, 2) if best else 0.0,
-            present_sections=list(sections.headings),
-            missing_sections=[],
-        )
 
-    return InspectionResult(
-        type=best.name,
-        confidence=round(best.fit, 2),
-        present_sections=best.matched_required + best.matched_recommended,
-        missing_sections=best.missing,
+def build_inspection(product: Product) -> InspectionResult:
+    """Classify ``product`` and attach decision metadata when applicable."""
+    c = classify(product)
+    result = InspectionResult(
+        type=c.type,
+        confidence=c.confidence,
+        present_sections=c.present_sections,
+        missing_sections=c.missing_sections,
     )
+    if c.type == "decision":
+        _attach_decision_metadata(result, product)
+    return result
 
 
 def inspect_text(text: str) -> InspectionResult:
-    return classify(extract_sections(text))
+    return build_inspection(parse(text))
 
 
 def inspect_file(path: str) -> InspectionResult:
-    with open(path, encoding="utf-8") as fh:
-        return inspect_text(fh.read())
+    return build_inspection(parse_file(path))
 
 
 def inspect_directory(directory: str, recursive: bool = True) -> DirectoryInspection:

--- a/rac/models.py
+++ b/rac/models.py
@@ -53,6 +53,11 @@ class Product:
     malformed_requirements: list[MalformedRequirement] = field(default_factory=list)
     success_metrics: list[str] = field(default_factory=list)
     risks: list[str] = field(default_factory=list)
+    # Every ``##`` section as {normalized heading -> stripped body text}, in
+    # document order. The canonical source of section content for all artifact
+    # types: classification, inspection metadata, and validation read from here
+    # rather than re-parsing the Markdown.
+    sections: dict[str, str] = field(default_factory=dict)
     # Distinguish "section absent" from "section present but empty".
     has_problem_section: bool = False
     has_requirements_section: bool = False

--- a/rac/outputs.py
+++ b/rac/outputs.py
@@ -11,14 +11,9 @@ import sys
 from dataclasses import asdict
 
 from .artifacts import ARTIFACT_SPECS
+from .classification import CONFIDENCE_THRESHOLD, TypeScore
 from .ingest import IngestResult
-from .inspect import (
-    CONFIDENCE_THRESHOLD,
-    DirectoryInspection,
-    DocumentSections,
-    InspectionResult,
-    score_artifacts,
-)
+from .inspect import DirectoryInspection, InspectionResult
 from .models import Diff, Issue, Product
 from .stats import PortfolioStats
 
@@ -214,6 +209,22 @@ def render_stats_human(s: PortfolioStats) -> str:
             reasons = ", ".join(f.error_codes) or "unknown"
             lines.append(f"  {_red(f.path)} — {reasons}")
 
+    # Decisions are reported separately; omit the section entirely when there are
+    # none so requirement-only portfolios render exactly as before.
+    if s.decisions:
+        lines += ["", _bold("Decisions"), "=========", "", f"Total: {s.decision_count}"]
+
+        def breakdown(label: str, counts: dict[str, int]) -> None:
+            lines.extend(["", _bold(label)])
+            if counts:
+                for name, count in counts.items():
+                    lines.append(f"  - {name}: {count}")
+            else:
+                lines.append("  (none recorded)")
+
+        breakdown("Status", s.decision_status_counts)
+        breakdown("Category", s.decision_category_counts)
+
     return "\n".join(lines)
 
 
@@ -243,6 +254,14 @@ def render_stats_json(s: PortfolioStats) -> str:
         ],
         "invalid": [{"file": f.path, "errors": f.error_codes} for f in s.invalid],
     }
+    # Additive: only present when the portfolio actually contains decisions, so
+    # requirement-only output is unchanged.
+    if s.decisions:
+        payload["decisions"] = {
+            "count": s.decision_count,
+            "by_status": s.decision_status_counts,
+            "by_category": s.decision_category_counts,
+        }
     return json.dumps(payload, indent=2)
 
 
@@ -263,20 +282,33 @@ def render_inspect_human(result: InspectionResult) -> str:
     if result.missing_sections:
         lines += ["", _bold("Missing Sections:")]
         lines.extend(_red(f"  ✗ {s.title()}") for s in result.missing_sections)
+    _append_decision_metadata(lines, result)
     return "\n".join(lines)
+
+
+def _append_decision_metadata(lines: list[str], result: InspectionResult) -> None:
+    """Add Status / Category / Supersedes lines when a decision declares them."""
+    pairs = [
+        ("Status", result.status),
+        ("Category", result.category),
+        ("Supersedes", result.supersedes),
+    ]
+    shown = [(label, value) for label, value in pairs if value]
+    if shown:
+        lines += ["", _bold("Decision Metadata:")]
+        lines.extend(f"  {label}: {value}" for label, value in shown)
 
 
 def render_inspect_json(result: InspectionResult) -> str:
     return json.dumps(result.to_dict(), indent=2)
 
 
-def render_inspect_verbose(result: InspectionResult, sections: DocumentSections) -> str:
+def render_inspect_verbose(
+    result: InspectionResult, scores: list[TypeScore]
+) -> str:
     """Explainable single-file output: matches, misses, and the score math."""
-    chosen = next(
-        (s for s in score_artifacts(sections) if s.name == result.type), None
-    )
+    chosen = next((s for s in scores if s.name == result.type), None)
     if chosen is None:  # Unknown — explain via the closest candidate
-        scores = score_artifacts(sections)
         chosen = scores[0] if scores else None
 
     lines = [

--- a/rac/parser.py
+++ b/rac/parser.py
@@ -75,11 +75,14 @@ def parse(text: str, source_path: str = "") -> Product:
     title: str | None = None
     extra_title_lines: list[int] = []
     section: str | None = None  # current tracked section key, or None/"other"
+    current_h2: str | None = None  # normalized heading of the current ## section
 
     problem_lines: list[str] = []
     requirement_lines: list[tuple[str, int]] = []
     metric_lines: list[str] = []
     risk_lines: list[str] = []
+    # Generic body text per ## section: {normalized heading -> [stripped lines]}.
+    section_bodies: dict[str, list[str]] = {}
 
     has = {
         "problem": False,
@@ -97,8 +100,14 @@ def parse(text: str, source_path: str = "") -> Product:
                 else:
                     extra_title_lines.append((tok.map[0] + 1) if tok.map else 0)
                 section = None  # content directly under the title is ignored
+                current_h2 = None
             elif tok.tag == "h2":
-                key = _SECTIONS.get(_normalize_heading(heading_text))
+                normalized = _normalize_heading(heading_text)
+                current_h2 = normalized
+                # Record the heading immediately so empty sections still appear
+                # in product.sections (classification keys off heading presence).
+                section_bodies.setdefault(normalized, [])
+                key = _SECTIONS.get(normalized)
                 section = key
                 if key is not None:
                     has[key] = True
@@ -106,11 +115,21 @@ def parse(text: str, source_path: str = "") -> Product:
                 section = "other"
             continue
 
-        if tok.type != "inline" or section is None or section == "other":
+        if tok.type != "inline":
             continue
 
         # Skip the inline that *is* a heading's text.
         if i > 0 and tokens[i - 1].type == "heading_open":
+            continue
+
+        # Generic body capture for every ## section (the canonical content map).
+        if current_h2 is not None:
+            for raw in tok.content.split("\n"):
+                stripped = raw.strip()
+                if stripped:
+                    section_bodies.setdefault(current_h2, []).append(stripped)
+
+        if section is None or section == "other":
             continue
 
         start_line = tok.map[0] if tok.map else 0
@@ -137,6 +156,8 @@ def parse(text: str, source_path: str = "") -> Product:
     # None = section absent; "" = present but empty; otherwise the joined text.
     problem = "\n".join(problem_lines).strip() if has["problem"] else None
 
+    sections = {h: "\n".join(lines) for h, lines in section_bodies.items()}
+
     return Product(
         title=title,
         extra_title_lines=extra_title_lines,
@@ -145,6 +166,7 @@ def parse(text: str, source_path: str = "") -> Product:
         malformed_requirements=malformed,
         success_metrics=metric_lines,
         risks=risk_lines,
+        sections=sections,
         has_problem_section=has["problem"],
         has_requirements_section=has["requirements"],
         has_metrics_section=has["success_metrics"],

--- a/rac/stats.py
+++ b/rac/stats.py
@@ -1,27 +1,33 @@
-"""Portfolio-level statistics across a directory of requirement files.
+"""Portfolio-level statistics across a directory of knowledge artifacts.
 
-`rac stats <directory>` walks the tree for Markdown files, parses and validates
+`rac stats <directory>` walks the tree for Markdown files, parses and classifies
 each one, and aggregates the results. Like the rest of RAC, it works on the
 Product AST: every `.md` is parsed into a :class:`~rac.models.Product`.
 
-Counting basis: totals, averages, and the per-feature breakdown span *all*
-parsed files (including ones that fail validation). A file counts as a *valid
-feature* when it has no error-severity issues; invalid files are still counted
-and are reported separately (never silently skipped).
+Requirement and Decision artifacts are aggregated separately so that one never
+distorts the other: requirement totals/averages span only requirement files, and
+decisions get their own status/category breakdown.
+
+Counting basis: requirement totals, averages, and the per-feature breakdown span
+*all* parsed requirement files (including ones that fail validation). A file
+counts as a *valid feature* when it has no error-severity issues; invalid files
+are still counted and are reported separately (never silently skipped).
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from pathlib import Path
 
+from .artifacts import spec_for
+from .fs import find_markdown_files
+from .inspect import build_inspection
 from .parser import parse_file
 from .validate import validate
 
 
 @dataclass
 class FeatureStat:
-    """Per-file result feeding the portfolio aggregate."""
+    """Per-file result for a Requirement artifact, feeding the portfolio aggregate."""
 
     path: str
     name: str  # the feature title, or the filename stem if it has none
@@ -33,13 +39,25 @@ class FeatureStat:
 
 
 @dataclass
+class DecisionStat:
+    """Per-file result for a Decision artifact (kept separate from features)."""
+
+    path: str
+    name: str  # the decision title, or the filename stem if it has none
+    status: str | None = None
+    category: str | None = None
+    supersedes: str | None = None
+
+
+@dataclass
 class PortfolioStats:
     """Aggregate view over all discovered requirement files."""
 
     directory: str
     features: list[FeatureStat] = field(default_factory=list)
+    decisions: list[DecisionStat] = field(default_factory=list)
 
-    # --- counts (all parsed files) ---
+    # --- counts (requirement features) ---
     @property
     def files_found(self) -> int:
         return len(self.features)
@@ -105,39 +123,72 @@ class PortfolioStats:
     def invalid(self) -> list[FeatureStat]:
         return [f for f in self.features if not f.valid]
 
+    # --- decisions ---
+    @property
+    def decision_count(self) -> int:
+        return len(self.decisions)
+
+    @property
+    def decision_status_counts(self) -> dict[str, int]:
+        """Decisions grouped by status, in schema order, omitting empty buckets."""
+        return _bucket(self.decisions, "status", "status")
+
+    @property
+    def decision_category_counts(self) -> dict[str, int]:
+        """Decisions grouped by category, in schema order, omitting empty buckets."""
+        return _bucket(self.decisions, "category", "category")
+
+
+def _bucket(decisions: list[DecisionStat], attr: str, metadata_key: str) -> dict[str, int]:
+    """Count ``decisions`` by ``attr`` in the artifact spec's declared order."""
+    spec = spec_for("decision")
+    order = spec.metadata.get(metadata_key, ()) if spec else ()
+    counts: dict[str, int] = {}
+    for d in decisions:
+        value = getattr(d, attr)
+        if value:
+            counts[value] = counts.get(value, 0) + 1
+    # Schema order first; then any out-of-vocabulary values seen, alphabetically.
+    ordered = {v: counts[v] for v in order if v in counts}
+    for v in sorted(counts):
+        if v not in ordered:
+            ordered[v] = counts[v]
+    return ordered
+
 
 def _neg_name(name: str) -> tuple[int, ...]:
     """Sort key that makes earlier names 'larger' (for max() tie-breaks)."""
     return tuple(-ord(c) for c in name)
 
 
-def find_markdown_files(directory: str, recursive: bool = True) -> list[Path]:
-    """Find `*.md` files, skipping dotted dirs (.git, .venv, ...).
-
-    Recursive by default (used by `stats` and `inspect`); pass ``recursive=False``
-    to look only at files directly inside ``directory``.
-    """
-    root = Path(directory)
-    glob = root.rglob if recursive else root.glob
-    found = [
-        p
-        for p in glob("*.md")
-        if not any(part.startswith(".") for part in p.relative_to(root).parts)
-    ]
-    return sorted(found)
-
-
 def collect_stats(directory: str) -> PortfolioStats:
-    """Parse and validate every Markdown file under ``directory``."""
+    """Parse and classify every Markdown file under ``directory``.
+
+    Decisions are routed to their own aggregate; everything else is treated as a
+    requirement feature (preserving prior behavior for requirement repositories).
+    """
     stats = PortfolioStats(directory=directory)
     for path in find_markdown_files(directory):
         product = parse_file(str(path))
+        name = product.title or path.stem
+        result = build_inspection(product)
+        if result.type == "decision":
+            stats.decisions.append(
+                DecisionStat(
+                    path=str(path),
+                    name=name,
+                    status=result.status,
+                    category=result.category,
+                    supersedes=result.supersedes,
+                )
+            )
+            continue
         issues = validate(product)
         error_codes = [i.code for i in issues if i.severity == "error"]
         stats.features.append(
             FeatureStat(
                 path=str(path),
-                name=product.title or path.stem,
+                name=name,
                 valid=not error_codes,
                 error_codes=error_codes,
                 requirements=len(product.requirements),

--- a/rac/validate.py
+++ b/rac/validate.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import re
 from collections import Counter
 
+from .artifacts import spec_for
+from .classification import classify
 from .models import Issue, Product
 
 # A file with more requirements than this earns a (non-failing) warning.
@@ -28,6 +30,79 @@ def has_errors(issues: list[Issue]) -> bool:
 
 
 def validate(product: Product) -> list[Issue]:
+    """Check ``product`` and return all structural and quality findings.
+
+    Dispatches on artifact type: Decisions are validated against the Decision
+    schema; everything else (Requirements and Unknown documents) keeps RAC's
+    original Requirement rules unchanged.
+    """
+    if classify(product).type == "decision":
+        return _validate_decision(product)
+    return _validate_requirement(product)
+
+
+def _first_value(body: str) -> str:
+    """First non-empty line of a section body (single-value metadata)."""
+    for line in body.splitlines():
+        stripped = line.strip()
+        if stripped:
+            return stripped
+    return ""
+
+
+def _validate_decision(product: Product) -> list[Issue]:
+    """Validate a Decision artifact (REQ-001/002/006/007).
+
+    Missing metadata never fails (it is optional); only *invalid values* are
+    errors. Required sections (Context, Decision, Consequences) must be present.
+    """
+    spec = spec_for("decision")
+    assert spec is not None  # the decision spec always exists
+    issues: list[Issue] = []
+
+    if not product.title:
+        issues.append(Issue("error", "missing-title", "File has no top-level # title."))
+
+    if product.extra_title_lines:
+        issues.append(
+            Issue(
+                "error",
+                "multiple-titles",
+                "File has more than one top-level # title; expected exactly one.",
+                product.extra_title_lines[0],
+            )
+        )
+
+    # Required sections define the artifact (ADR format).
+    for section in spec.required:
+        if section not in product.sections:
+            issues.append(
+                Issue(
+                    "error",
+                    f"missing-{section}",
+                    f"Decision is missing a ## {section.title()} section.",
+                )
+            )
+
+    # Constrained metadata: a present value must be in the allowed set. A missing
+    # section is fine — metadata is optional (REQ-007).
+    for field_name, allowed in spec.metadata.items():
+        body = product.sections.get(field_name, "")
+        value = _first_value(body)
+        if value and not any(value.casefold() == a.casefold() for a in allowed):
+            issues.append(
+                Issue(
+                    "error",
+                    f"invalid-decision-{field_name}",
+                    f"## {field_name.title()} value {value!r} is not one of: "
+                    f"{', '.join(allowed)}.",
+                )
+            )
+
+    return issues
+
+
+def _validate_requirement(product: Product) -> list[Issue]:
     """Check ``product`` and return all structural and quality findings."""
     issues: list[Issue] = []
 

--- a/tests/fixtures/decision/bad_category.md
+++ b/tests/fixtures/decision/bad_category.md
@@ -1,0 +1,21 @@
+# ADR-010 Message Queue
+
+## Status
+
+Accepted
+
+## Category
+
+Networking
+
+## Context
+
+Services need to communicate asynchronously.
+
+## Decision
+
+Adopt a message queue for inter-service events.
+
+## Consequences
+
+- Looser coupling between services.

--- a/tests/fixtures/decision/bad_status.md
+++ b/tests/fixtures/decision/bad_status.md
@@ -1,0 +1,17 @@
+# ADR-009 Caching
+
+## Status
+
+OnHold
+
+## Context
+
+We need to reduce database load.
+
+## Decision
+
+Add a Redis cache in front of the database.
+
+## Consequences
+
+- One more service to operate.

--- a/tests/fixtures/decision/minimal.md
+++ b/tests/fixtures/decision/minimal.md
@@ -1,0 +1,13 @@
+# ADR-008 Logging Format
+
+## Context
+
+We need consistent, queryable logs across services.
+
+## Decision
+
+Emit structured JSON logs.
+
+## Consequences
+
+- Logs are machine-parseable.

--- a/tests/fixtures/decision/portfolio/01_accepted_arch.md
+++ b/tests/fixtures/decision/portfolio/01_accepted_arch.md
@@ -1,0 +1,25 @@
+# ADR-001 Source Format
+
+## Status
+
+Accepted
+
+## Category
+
+Architecture
+
+## Supersedes
+
+ADR-000
+
+## Context
+
+We need a canonical source format for requirements.
+
+## Decision
+
+Markdown is the source format.
+
+## Consequences
+
+- Human-readable and Git-friendly.

--- a/tests/fixtures/decision/portfolio/02_proposed_process.md
+++ b/tests/fixtures/decision/portfolio/02_proposed_process.md
@@ -1,0 +1,21 @@
+# ADR-002 Review Cadence
+
+## Status
+
+Proposed
+
+## Category
+
+Process
+
+## Context
+
+Requirement changes need a review rhythm.
+
+## Decision
+
+Review the portfolio weekly.
+
+## Consequences
+
+- Predictable cadence for stakeholders.

--- a/tests/fixtures/decision/portfolio/03_no_metadata.md
+++ b/tests/fixtures/decision/portfolio/03_no_metadata.md
@@ -1,0 +1,13 @@
+# ADR-003 Directory Layout
+
+## Context
+
+Artifacts need a predictable place to live.
+
+## Decision
+
+Store decisions under `planning/adr/`.
+
+## Consequences
+
+- Easy to find and to glob.

--- a/tests/fixtures/decision/with_metadata.md
+++ b/tests/fixtures/decision/with_metadata.md
@@ -1,0 +1,26 @@
+# ADR-007 API Versioning
+
+## Status
+
+Accepted
+
+## Category
+
+Architecture
+
+## Supersedes
+
+  ADR-003
+
+## Context
+
+Our public APIs need a versioning strategy as they evolve.
+
+## Decision
+
+Use URL-based versioning (`/v1`, `/v2`).
+
+## Consequences
+
+- The version is explicit in every request.
+- Clients migrate on their own schedule.

--- a/tests/test_decision_metadata.py
+++ b/tests/test_decision_metadata.py
@@ -1,0 +1,188 @@
+"""Tests for v0.4.2 decision metadata: status, category, supersedes.
+
+Covers inspection (extraction + output), artifact-aware validation, and
+portfolio statistics. Decision fixtures live under ``fixtures/decision/`` so they
+do not disturb the directory-count assertions in ``test_inspect.py`` /
+``test_stats.py``.
+"""
+
+from __future__ import annotations
+
+import json
+
+from rac.cli import main
+from rac.inspect import inspect_file
+from rac.parser import parse_file
+from rac.stats import collect_stats
+from rac.validate import has_errors, validate
+
+from conftest import fixture_path
+
+
+def codes(issues):
+    return {i.code for i in issues}
+
+
+# --- inspection: metadata extraction ----------------------------------------
+
+
+def test_inspect_extracts_decision_metadata():
+    result = inspect_file(fixture_path("decision", "with_metadata.md"))
+    assert result.type == "decision"
+    assert result.status == "Accepted"
+    assert result.category == "Architecture"
+    assert result.supersedes == "ADR-003"  # leading whitespace normalized away
+
+
+def test_minimal_decision_has_no_metadata():
+    result = inspect_file(fixture_path("decision", "minimal.md"))
+    assert result.type == "decision"
+    assert result.status is None
+    assert result.category is None
+    assert result.supersedes is None
+
+
+def test_inspect_json_includes_metadata_only_when_present(capsys):
+    rc = main(["inspect", fixture_path("decision", "with_metadata.md"), "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "Accepted"
+    assert payload["category"] == "Architecture"
+    assert payload["supersedes"] == "ADR-003"
+
+
+def test_inspect_json_omits_absent_metadata(capsys):
+    rc = main(["inspect", fixture_path("decision", "minimal.md"), "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert "status" not in payload
+    assert "category" not in payload
+    assert "supersedes" not in payload
+
+
+def test_inspect_human_shows_metadata(capsys):
+    rc = main(["inspect", fixture_path("decision", "with_metadata.md")])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Status: Accepted" in out
+    assert "Category: Architecture" in out
+    assert "Supersedes: ADR-003" in out
+
+
+# --- validation: artifact-aware dispatch ------------------------------------
+
+
+def validate_decision(*parts):
+    return validate(parse_file(fixture_path(*parts)))
+
+
+def test_decision_is_not_validated_as_a_requirement():
+    # The headline gap this release closes: a valid ADR must not fail with the
+    # Requirement-only errors.
+    issues = validate_decision("decision", "with_metadata.md")
+    assert not has_errors(issues)
+    assert "missing-problem" not in codes(issues)
+    assert "missing-requirements" not in codes(issues)
+
+
+def test_decision_without_metadata_is_valid():
+    issues = validate_decision("decision", "minimal.md")
+    assert not has_errors(issues)
+    # Optional metadata absent -> no warnings or errors about it (REQ-007).
+    assert codes(issues) == set()
+
+
+def test_invalid_status_is_an_error():
+    issues = validate_decision("decision", "bad_status.md")
+    assert "invalid-decision-status" in codes(issues)
+    assert has_errors(issues)
+
+
+def test_invalid_category_is_an_error():
+    issues = validate_decision("decision", "bad_category.md")
+    assert "invalid-decision-category" in codes(issues)
+    assert has_errors(issues)
+
+
+def test_all_supported_status_values_pass():
+    for status in ("Proposed", "Accepted", "Superseded", "Deprecated"):
+        text = (
+            f"# ADR\n\n## Status\n\n{status}\n\n## Context\n\nc\n\n"
+            "## Decision\n\nd\n\n## Consequences\n\nx\n"
+        )
+        from rac.parser import parse
+
+        assert "invalid-decision-status" not in codes(validate(parse(text)))
+
+
+def test_all_supported_category_values_pass():
+    from rac.parser import parse
+
+    for category in ("Architecture", "Product", "Process", "Technical", "Other"):
+        text = (
+            f"# ADR\n\n## Category\n\n{category}\n\n## Context\n\nc\n\n"
+            "## Decision\n\nd\n\n## Consequences\n\nx\n"
+        )
+        assert "invalid-decision-category" not in codes(validate(parse(text)))
+
+
+def test_status_value_match_is_case_insensitive():
+    from rac.parser import parse
+
+    text = (
+        "# ADR\n\n## Status\n\naccepted\n\n## Context\n\nc\n\n"
+        "## Decision\n\nd\n\n## Consequences\n\nx\n"
+    )
+    assert "invalid-decision-status" not in codes(validate(parse(text)))
+
+
+def test_missing_required_decision_section_is_an_error():
+    from rac.parser import parse
+
+    # A decision missing ## Consequences (still classifies as a decision).
+    text = "# ADR\n\n## Status\n\nAccepted\n\n## Context\n\nc\n\n## Decision\n\nd\n"
+    issues = validate(parse(text))
+    assert "missing-consequences" in codes(issues)
+
+
+# --- statistics: separated aggregation --------------------------------------
+
+
+def test_stats_counts_decisions_separately():
+    s = collect_stats(fixture_path("decision", "portfolio"))
+    assert s.decision_count == 3
+    # Decisions never count as requirement features.
+    assert s.files_found == 0
+    assert s.total_requirements == 0
+
+
+def test_stats_status_and_category_breakdown():
+    s = collect_stats(fixture_path("decision", "portfolio"))
+    assert s.decision_status_counts == {"Accepted": 1, "Proposed": 1}
+    assert s.decision_category_counts == {"Architecture": 1, "Process": 1}
+
+
+def test_stats_human_shows_decisions_section(capsys):
+    rc = main(["stats", fixture_path("decision", "portfolio")])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Decisions" in out
+    assert "Total: 3" in out
+    assert "Accepted: 1" in out
+    assert "Architecture: 1" in out
+
+
+def test_stats_json_includes_decisions_block(capsys):
+    rc = main(["stats", fixture_path("decision", "portfolio"), "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["decisions"]["count"] == 3
+    assert payload["decisions"]["by_status"] == {"Accepted": 1, "Proposed": 1}
+    assert payload["decisions"]["by_category"] == {"Architecture": 1, "Process": 1}
+
+
+def test_stats_json_omits_decisions_block_for_requirement_only(capsys):
+    rc = main(["stats", fixture_path("portfolio"), "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert "decisions" not in payload

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -9,16 +9,14 @@ from pathlib import Path
 import pytest
 
 from rac.artifacts import ARTIFACT_SPECS
+from rac.classification import CONFIDENCE_THRESHOLD, score_artifacts
 from rac.cli import main
 from rac.inspect import (
-    CONFIDENCE_THRESHOLD,
-    classify,
-    extract_sections,
     inspect_directory,
     inspect_file,
     inspect_text,
-    score_artifacts,
 )
+from rac.parser import parse
 
 from conftest import fixture_path
 
@@ -33,10 +31,10 @@ def test_artifact_specs_are_the_two_concrete_types():
     assert names == {"requirement", "decision"}
 
 
-def test_extract_sections_returns_title_and_headings():
-    doc = extract_sections("# Title\n\n## Problem\n\nx\n\n## Requirements\n\ny\n")
-    assert doc.title == "Title"
-    assert doc.headings == ["problem", "requirements"]
+def test_parse_captures_title_and_sections():
+    product = parse("# Title\n\n## Problem\n\nx\n\n## Requirements\n\ny\n")
+    assert product.title == "Title"
+    assert list(product.sections) == ["problem", "requirements"]
 
 
 def test_classify_requirement():
@@ -110,14 +108,13 @@ def test_synonym_is_case_insensitive():
 
 
 def test_score_artifacts_breakdown():
-    sections = extract_sections(
-        Path(fixture_path("inspect", "decision.md")).read_text()
-    )
-    top = score_artifacts(sections)[0]
+    product = parse(Path(fixture_path("inspect", "decision.md")).read_text())
+    top = score_artifacts(product)[0]
     assert top.name == "decision"
     assert set(top.matched_required) == {"context", "decision", "consequences"}
     assert "status" in top.matched_recommended
-    assert top.points == 3.5 and top.ceiling == 4.0
+    # required (3) + 0.5×(status) = 3.5 / (3 + 0.5×3 recommended) = 3.5 / 4.5
+    assert top.points == 3.5 and top.ceiling == 4.5
 
 
 def test_cli_inspect_verbose(capsys):


### PR DESCRIPTION
Give RAC a lightweight, file-first, AI-optional understanding of Decision artifacts: extract and report Status / Category / Supersedes, validate the values, and aggregate decisions in `rac stats`. OK 

- New shared classification service (rac/classification.py) consumed by inspect, validate, and stats; find_markdown_files moved to rac/fs.py to break the validate->inspect->stats import cycle.
- Parser now populates a canonical product.sections map (every ## section); inspect's duplicate extraction removed.
- ArtifactSpec gains an `optional` tier and per-type `metadata` vocab; the Decision spec owns the Status/Category value sets and Supersedes.
- Validation is artifact-aware: decisions validate required sections and reject out-of-vocabulary Status/Category values (errors). Missing metadata stays valid; requirement validation is unchanged.
- inspect surfaces decision metadata (human + additive JSON); stats reports decisions separately via DecisionStat with status/category breakdowns, keeping them out of requirement totals/averages.
- Tests + fixtures for decision metadata; requirement output verified byte-identical to before.