### PR TITLE
v0.5.1: guided improvement for missing sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,10 +579,11 @@ usage errors (file not found, or a non-Markdown file — convert it with
 ## Improve
 
 Where `inspect` tells you *what an artifact is*, `improve` tells you *what to add
-next*. It reports the required and recommended sections an artifact is missing —
-**deterministically, from the schema, with no AI** (ADR-002) — and can emit
-Markdown templates for them. `improve` is **advisory and read-only**: it never
-modifies your files and never generates content beyond `_TODO_` placeholders.
+next* and how to think about completing it. It reports the required and
+recommended sections an artifact is missing, plus schema-defined guidance for
+those sections — **deterministically, from the schema, with no AI** (ADR-002).
+`improve` is **advisory and read-only**: it never modifies your files and never
+generates content beyond `_TODO_` placeholders and guidance comments.
 
 ```bash
 rac improve requirement.md
@@ -602,18 +603,23 @@ Missing Required:
 
 Missing Recommended:
   - Risks
+      • What could prevent successful delivery?
+      • What dependencies or unknowns exist?
   - Assumptions
+      • What are you assuming to be true?
+      • What would change the approach if it turned out false?
 ```
 
 `--template` turns the gaps into a ready-to-paste skeleton (required sections
-first, then recommended), with a short guidance hint per section:
+first, then recommended), with deterministic guidance comments per section:
 
 ```markdown
 ## Risks
 
 _TODO_
 
-<!-- Potential implementation, delivery, or adoption risks -->
+<!-- What could prevent successful delivery? -->
+<!-- What dependencies or unknowns exist? -->
 ```
 
 So you can go straight from `rac inspect requirement.md` to
@@ -625,12 +631,29 @@ So you can go straight from `rac inspect requirement.md` to
 {
   "type": "requirement",
   "missing_required": [],
-  "missing_recommended": ["risks", "assumptions"]
+  "missing_recommended": ["risks", "assumptions"],
+  "guidance": {
+    "risks": [
+      "What could prevent successful delivery?",
+      "What dependencies or unknowns exist?"
+    ],
+    "assumptions": [
+      "What are you assuming to be true?",
+      "What would change the approach if it turned out false?"
+    ]
+  }
 }
 ```
 
-v0.5.0 generates suggestions for **Requirement** artifacts. Other known types
-(e.g. Decision) and Unknown documents return a short explanatory message instead.
+`improve` generates suggestions for artifact types with complete schema guidance
+coverage. Today that means **Requirement** and **Decision** artifacts. Unknown
+documents return a short explanatory message instead. Future artifact types do
+not become improvable until their schemas define guidance for every required and
+recommended section.
+
+Guidance is informational metadata only: it does not influence classification,
+validation, confidence scoring, statistics, or repository analysis.
+
 `improve` is advisory: it exits `0` for any completed analysis (with or without
 suggestions) and `2` for usage errors. The presence of suggestions never changes
 the exit code.

--- a/planning/roadmap/v0.5.1-guided-improvement.md
+++ b/planning/roadmap/v0.5.1-guided-improvement.md
@@ -16,6 +16,11 @@ The purpose of v0.5.1 is to make RAC schemas self-describing by embedding sectio
 
 Per ADR-002, guidance must remain deterministic and AI-optional.
 
+Guidance is informational metadata only.
+
+Guidance must not influence artifact classification, confidence calculations,
+validation outcomes, statistics, or repository analysis.
+
 ---
 
 ## Problem
@@ -100,11 +105,17 @@ Example:
 
 ```json
 {
-  "section": "risks",
-  "guidance": [
-    "What could prevent successful delivery?",
-    "What dependencies exist?"
-  ]
+  "type": "requirement",
+  "missing_required": [],
+  "missing_recommended": [
+    "risks"
+  ],
+  "guidance": {
+    "risks": [
+      "What could prevent successful delivery?",
+      "What dependencies exist?"
+    ]
+  }
 }
 ```
 
@@ -118,7 +129,9 @@ No AI service shall be required.
 
 Guidance shall complement existing template generation.
 
-Template output remains unchanged.
+Template output shall continue to emit Markdown sections and `_TODO_` placeholders.
+
+Guidance may be rendered as Markdown comments below the placeholder.
 
 ### REQ-006 — Supported Artifact Types
 
@@ -126,8 +139,11 @@ Guidance shall be available for all supported artifact types:
 
 - Requirement
 - Decision
-- Roadmap
-- Prompt
+
+Roadmap and Prompt are deferred until those artifact schemas formally exist.
+
+Future artifact types shall not become supported by `rac improve` until their
+artifact specs include guidance for every required and recommended section.
 
 ---
 
@@ -174,6 +190,8 @@ rac improve file.md --fix
 - Guidance is available for all artifact schemas.
 - Human output displays guidance consistently.
 - JSON output exposes guidance predictably.
+- Every required and recommended section of every supported artifact type has guidance.
+- Changing guidance text does not change classification, validation, statistics, or confidence.
 
 ### Product
 
@@ -198,5 +216,7 @@ rac improve requirement.md --json
 returns guidance in machine-readable format.
 
 All supported artifact types provide guidance.
+
+Roadmap and Prompt remain deferred until those schemas are introduced.
 
 No AI dependency is introduced.

--- a/rac/artifacts.py
+++ b/rac/artifacts.py
@@ -39,6 +39,10 @@ class ArtifactSpec:
     # --template` as guidance comments. Optional; sections without a hint render
     # without one.
     descriptions: dict[str, str] = field(default_factory=dict)
+    # Prompting questions per normalized section name. This is informational
+    # metadata only: improve renders it, but classification, validation, and
+    # statistics must not use it.
+    guidance: dict[str, tuple[str, ...]] = field(default_factory=dict)
     # Synonyms: alternate normalized headings that map onto a canonical section
     # name (e.g. "success criteria" -> "success metrics"). Applied before
     # matching, so synonyms contribute to confidence. Matching is deterministic
@@ -68,6 +72,28 @@ ARTIFACT_SPECS: tuple[ArtifactSpec, ...] = (
             "risks": "Potential implementation, delivery, or adoption risks",
             "assumptions": "Assumptions this artifact depends on",
         },
+        guidance={
+            "problem": (
+                "What user or business problem does this solve?",
+                "Who is affected, and why does it matter now?",
+            ),
+            "requirements": (
+                "What must the system do?",
+                "Is each one a testable [REQ-NNN] statement?",
+            ),
+            "success metrics": (
+                "How will you know this succeeded?",
+                "What measurable target indicates success?",
+            ),
+            "risks": (
+                "What could prevent successful delivery?",
+                "What dependencies or unknowns exist?",
+            ),
+            "assumptions": (
+                "What are you assuming to be true?",
+                "What would change the approach if it turned out false?",
+            ),
+        },
         synonyms={
             "success criteria": "success metrics",
             "kpis": "success metrics",
@@ -83,6 +109,30 @@ ARTIFACT_SPECS: tuple[ArtifactSpec, ...] = (
         metadata={
             "status": ("Proposed", "Accepted", "Superseded", "Deprecated"),
             "category": ("Architecture", "Product", "Process", "Technical", "Other"),
+        },
+        guidance={
+            "context": (
+                "What forces, constraints, or problems led to this decision?",
+                "What background does a reader need?",
+            ),
+            "decision": (
+                "What was decided?",
+                "State it as a clear, active choice.",
+            ),
+            "consequences": (
+                "What becomes easier or harder as a result?",
+                "What trade-offs are you accepting?",
+            ),
+            "status": (
+                "Is this Proposed, Accepted, Superseded, or Deprecated?",
+            ),
+            "category": (
+                "Which area: Architecture, Product, Process, Technical, or Other?",
+            ),
+            "alternatives considered": (
+                "What other options were weighed?",
+                "Why were they not chosen?",
+            ),
         },
         synonyms={
             "alternatives": "alternatives considered",

--- a/rac/improve.py
+++ b/rac/improve.py
@@ -1,28 +1,37 @@
 """Artifact improvement — deterministic, schema-driven guidance (ADR-002).
 
-`rac improve <file>` is RAC's first *advisory* capability: it reports which
-required and recommended sections an artifact is missing and can emit Markdown
-templates for them. It is strictly read-only (REQ-004) and generates no content
-beyond schema-derived placeholders — no AI, no rewriting.
+`rac improve <file>` is RAC's *advisory* capability: it reports which required and
+recommended sections an artifact is missing, explains *how to complete them* with
+schema-defined guidance (v0.5.1), and can emit Markdown templates. It is strictly
+read-only (REQ-004) and generates no content beyond schema-derived placeholders —
+no AI, no rewriting.
 
 Improvement depends only on the artifact *type* and a *schema comparison*
 (:func:`rac.classification.missing_sections`); it never reaches into classification
-confidence internals. v0.5.0 produces suggestions for Requirement artifacts only;
-other known types and Unknown return no suggestions (the renderers explain why).
+confidence internals. A type is *supported* when it has an :class:`ArtifactSpec`
+**and** complete guidance coverage for its expected sections — so requirement and
+decision are supported today, while Unknown (and any future spec lacking guidance)
+is not. Guidance is informational only: it never affects classification, validation,
+or statistics.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
-from .artifacts import spec_for
+from .artifacts import ArtifactSpec, spec_for
 from .classification import classify, missing_sections
 from .models import Product
 from .parser import parse, parse_file
 
-# The single artifact type that v0.5.0 generates suggestions for. Written as a
-# constant (not hard-coded throughout) so widening scope later is a one-line change.
-SUPPORTED_TYPE = "requirement"
+
+def supports_improve(spec: ArtifactSpec) -> bool:
+    """True when every expected section of ``spec`` defines guidance.
+
+    Gates ``rac improve`` so a future artifact type cannot become improvable until
+    its schema includes guidance for all required and recommended sections.
+    """
+    return all(section in spec.guidance for section in spec.expected)
 
 
 @dataclass
@@ -31,26 +40,25 @@ class ImprovementResult:
 
     Section names are stored normalized (e.g. ``"success metrics"``); renderers
     format them. ``to_dict`` is the stable JSON contract (ADR-007):
-    ``{type, missing_required, missing_recommended}``.
+    ``{type, missing_required, missing_recommended, guidance}``.
     """
 
     type: str  # classified artifact type, or "unknown"
     missing_required: list[str]
     missing_recommended: list[str]
-    # Reserved for future Unknown handling (e.g. "closest match" guidance). Always
-    # None in v0.5.0 and intentionally not serialized yet — additive later (ADR-007).
+    # Schema guidance for the missing sections: {section -> prompting questions}.
+    guidance: dict[str, list[str]] = field(default_factory=dict)
+    # Whether `improve` produces suggestions for this type (spec + full coverage).
+    supported: bool = False
+    # Reserved for future Unknown handling (e.g. "closest match"); not serialized.
     closest_type: str | None = None
-
-    @property
-    def supported(self) -> bool:
-        """True when this is a type ``improve`` generates suggestions for."""
-        return self.type == SUPPORTED_TYPE
 
     def to_dict(self) -> dict:
         return {
             "type": self.type,
             "missing_required": [_snake(s) for s in self.missing_required],
             "missing_recommended": [_snake(s) for s in self.missing_recommended],
+            "guidance": {_snake(s): list(g) for s, g in self.guidance.items()},
         }
 
 
@@ -61,18 +69,27 @@ def _snake(section: str) -> str:
 def improve_product(product: Product) -> ImprovementResult:
     """Analyze a parsed ``product`` and return improvement guidance."""
     artifact_type = classify(product).type
-    if artifact_type != SUPPORTED_TYPE:
-        # Decision / other known types and Unknown: no suggestions in v0.5.0.
+    spec = spec_for(artifact_type)
+    if spec is None or not supports_improve(spec):
+        # Unknown, or a known type whose schema lacks complete guidance.
         return ImprovementResult(
-            type=artifact_type, missing_required=[], missing_recommended=[]
+            type=artifact_type,
+            missing_required=[],
+            missing_recommended=[],
+            supported=False,
         )
-    spec = spec_for(SUPPORTED_TYPE)
-    assert spec is not None  # the requirement spec always exists
     missing_required, missing_recommended = missing_sections(product, spec)
+    guidance = {
+        s: list(spec.guidance[s])
+        for s in missing_required + missing_recommended
+        if spec.guidance.get(s)
+    }
     return ImprovementResult(
         type=artifact_type,
         missing_required=missing_required,
         missing_recommended=missing_recommended,
+        guidance=guidance,
+        supported=True,
     )
 
 

--- a/rac/outputs.py
+++ b/rac/outputs.py
@@ -10,7 +10,7 @@ import json
 import sys
 from dataclasses import asdict
 
-from .artifacts import ARTIFACT_SPECS, spec_for
+from .artifacts import ARTIFACT_SPECS
 from .classification import CONFIDENCE_THRESHOLD, TypeScore
 from .improve import ImprovementResult
 from .ingest import IngestResult
@@ -405,9 +405,11 @@ def render_improve_human(result: ImprovementResult) -> str:
         return "\n".join(lines)
 
     def block(title: str, names: list[str]) -> None:
-        lines.extend([_bold(title)])
+        lines.append(_bold(title))
         if names:
-            lines.extend(f"  - {s.title()}" for s in names)
+            for s in names:
+                lines.append(f"  - {s.title()}")
+                lines.extend(f"      • {q}" for q in result.guidance.get(s, []))
         else:
             lines.append("  (none)")
         lines.append("")
@@ -432,14 +434,12 @@ def render_improve_template(result: ImprovementResult) -> str:
     if not missing:
         return "# Nothing to add — all expected sections present."
 
-    spec = spec_for(result.type)
-    descriptions = spec.descriptions if spec else {}
     blocks: list[str] = []
     for section in missing:
         block = f"## {section.title()}\n\n_TODO_"
-        hint = descriptions.get(section)
-        if hint:
-            block += f"\n\n<!-- {hint} -->"
+        guidance_lines = result.guidance.get(section, [])
+        if guidance_lines:
+            block += "\n\n" + "\n".join(f"<!-- {q} -->" for q in guidance_lines)
         blocks.append(block)
     return "\n\n".join(blocks) + "\n"
 

--- a/tests/test_improve.py
+++ b/tests/test_improve.py
@@ -1,8 +1,8 @@
-"""Tests for artifact improvement (`rac improve`, v0.5.0).
+"""Tests for artifact improvement (`rac improve`).
 
-Advisory, deterministic, schema-driven, read-only. Requirement artifacts get
-missing-section suggestions; other known types and Unknown get explanatory
-guidance. Exit code is always 0 for a completed analysis, 2 for usage errors.
+Advisory, deterministic, schema-driven, read-only. Supported artifact types get
+missing-section suggestions and guidance. Exit code is always 0 for a completed
+analysis, 2 for usage errors.
 """
 
 from __future__ import annotations
@@ -13,8 +13,13 @@ from pathlib import Path
 
 import pytest
 
+from rac.artifacts import ARTIFACT_SPECS, spec_for
+from rac.classification import classify
 from rac.cli import main
-from rac.improve import improve_file, improve_text
+from rac.improve import improve_file, improve_text, supports_improve
+from rac.parser import parse, parse_file
+from rac.stats import collect_stats
+from rac.validate import validate
 
 from conftest import fixture_path
 
@@ -61,11 +66,13 @@ def test_unknown_artifact_yields_no_suggestions():
     assert result.missing_recommended == []
 
 
-def test_decision_is_out_of_scope_for_v050():
+def test_decision_is_supported_when_guidance_is_complete():
     result = improve_file(fixture_path("decision", "with_metadata.md"))
     assert result.type == "decision"
-    assert not result.supported
+    assert result.supported
     assert result.missing_required == []
+    assert result.missing_recommended == ["alternatives considered"]
+    assert "alternatives considered" in result.guidance
 
 
 def test_improve_does_not_depend_on_typescore():
@@ -86,9 +93,16 @@ def test_json_shape_is_stable(capsys):
     rc = main(["improve", fixture_path("inspect", "requirement.md"), "--json"])
     assert rc == 0
     payload = json.loads(capsys.readouterr().out)
-    assert set(payload) == {"type", "missing_required", "missing_recommended"}
+    assert set(payload) == {
+        "type",
+        "missing_required",
+        "missing_recommended",
+        "guidance",
+    }
     assert payload["type"] == "requirement"
-    # closest_type is reserved on the model but not serialized in v0.5.0.
+    assert set(payload["guidance"]) == set(payload["missing_recommended"])
+    assert payload["guidance"]["risks"]
+    # closest_type is reserved on the model but not serialized.
     assert "closest_type" not in payload
 
 
@@ -109,6 +123,32 @@ def test_json_unknown_has_empty_arrays(capsys):
     assert payload["type"] == "unknown"
     assert payload["missing_required"] == []
     assert payload["missing_recommended"] == []
+    assert payload["guidance"] == {}
+
+
+def test_json_guidance_is_map_keyed_by_snake_cased_sections(capsys):
+    rc = main(["improve", fixture_path("inspect", "requirement.md"), "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert isinstance(payload["guidance"], dict)
+    assert sorted(payload["guidance"]) == ["assumptions", "risks"]
+    assert payload["guidance"]["risks"] == [
+        "What could prevent successful delivery?",
+        "What dependencies or unknowns exist?",
+    ]
+
+
+def test_json_decision_guidance(capsys):
+    rc = main(["improve", fixture_path("decision", "with_metadata.md"), "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["type"] == "decision"
+    assert payload["missing_required"] == []
+    assert payload["missing_recommended"] == ["alternatives_considered"]
+    assert payload["guidance"]["alternatives_considered"] == [
+        "What other options were weighed?",
+        "Why were they not chosen?",
+    ]
 
 
 # --- template (REQ-003) -----------------------------------------------------
@@ -120,7 +160,7 @@ def test_template_emits_todo_and_guidance(capsys):
     out = capsys.readouterr().out
     assert "## Risks" in out
     assert "_TODO_" in out
-    assert "<!--" in out  # schema guidance comment
+    assert "<!-- What could prevent successful delivery? -->" in out
 
 
 def test_template_orders_required_before_recommended(capsys):
@@ -141,6 +181,7 @@ def test_human_output_lists_missing(capsys):
     assert "Artifact Type: Requirement" in out
     assert "Missing Recommended:" in out
     assert "Risks" in out
+    assert "What could prevent successful delivery?" in out
 
 
 def test_human_unknown_message(capsys):
@@ -151,12 +192,13 @@ def test_human_unknown_message(capsys):
     assert "could not be determined" in out
 
 
-def test_human_decision_is_generic_not_requirement_worded(capsys):
+def test_human_decision_shows_guidance(capsys):
     rc = main(["improve", fixture_path("decision", "with_metadata.md")])
     assert rc == 0
     out = capsys.readouterr().out
     assert "Artifact Type: Decision" in out
-    assert "not currently available for this artifact type" in out
+    assert "Alternatives Considered" in out
+    assert "What other options were weighed?" in out
     assert "Requirement" not in out  # no hard-coded requirement wording
 
 
@@ -211,3 +253,73 @@ def test_improve_does_not_modify_the_file(tmp_path):
     main(["improve", str(f), "--template"])
     assert f.read_text() == original
     assert f.stat().st_mtime_ns == before
+
+
+# --- guidance model (v0.5.1) ------------------------------------------------
+
+
+def test_supported_specs_have_guidance_for_every_expected_section():
+    supported = {"requirement", "decision"}
+    for spec in ARTIFACT_SPECS:
+        if spec.name not in supported:
+            continue
+        assert supports_improve(spec)
+        assert set(spec.expected) <= set(spec.guidance)
+
+
+def test_incomplete_guidance_makes_known_type_unsupported(monkeypatch, capsys):
+    spec = spec_for("requirement")
+    assert spec is not None
+    original = spec.guidance["risks"]
+    monkeypatch.delitem(spec.guidance, "risks")
+    assert not supports_improve(spec)
+
+    rc = main(["improve", fixture_path("inspect", "requirement.md")])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Artifact Type: Requirement" in out
+    assert "not currently available for this artifact type" in out
+
+    spec.guidance["risks"] = original
+
+
+def test_guidance_is_informational_metadata_only(monkeypatch):
+    spec = spec_for("requirement")
+    assert spec is not None
+    original = spec.guidance["risks"]
+    product = parse_file(fixture_path("inspect", "requirement.md"))
+    stats_dir = fixture_path("portfolio")
+
+    before_classify = classify(product)
+    before_validate = [(i.severity, i.code, i.message) for i in validate(product)]
+    before_stats = collect_stats(stats_dir)
+    before_stats_tuple = (
+        before_stats.files_found,
+        before_stats.total_requirements,
+        before_stats.total_metrics,
+        before_stats.total_risks,
+        before_stats.decision_status_counts,
+        before_stats.decision_category_counts,
+    )
+    before_improve = improve_file(fixture_path("inspect", "requirement.md"))
+
+    monkeypatch.setitem(spec.guidance, "risks", ("Changed guidance text?",))
+
+    after_classify = classify(product)
+    after_validate = [(i.severity, i.code, i.message) for i in validate(product)]
+    after_stats = collect_stats(stats_dir)
+    after_stats_tuple = (
+        after_stats.files_found,
+        after_stats.total_requirements,
+        after_stats.total_metrics,
+        after_stats.total_risks,
+        after_stats.decision_status_counts,
+        after_stats.decision_category_counts,
+    )
+    after_improve = improve_file(fixture_path("inspect", "requirement.md"))
+
+    assert after_classify == before_classify
+    assert after_validate == before_validate
+    assert after_stats_tuple == before_stats_tuple
+    assert before_improve.guidance["risks"] == list(original)
+    assert after_improve.guidance["risks"] == ["Changed guidance text?"]


### PR DESCRIPTION
Extend `rac improve` with schema-defined guidance so users can understand how to complete missing sections, not just which sections are absent.

- Add `ArtifactSpec.guidance` alongside `descriptions`: descriptions define what a section is; guidance provides prompting questions for completing it.
- Add complete guidance coverage for Requirement and Decision artifact specs.
- Widen `rac improve` from Requirement-only to any artifact type with complete guidance coverage; Requirement and Decision are supported today.
- Add guidance to improve JSON output as an additive section-keyed map.
- Render guidance in human output and template comments.
- Keep guidance informational only: it does not affect classification, validation, confidence, stats, or repository analysis.
- Update README, v0.5.1 roadmap notes, and improve tests.

Full suite: 134 passing.