### PR TITLE
v0.5.2: expose artifact schemas via rac schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -660,6 +660,77 @@ the exit code.
 
 ---
 
+## Schema
+
+Inspect RAC's registered artifact schemas without creating a file.
+
+```bash
+rac schema --list
+rac schema --list --json
+rac schema requirement
+rac schema decision --json
+rac schema requirement --template
+```
+
+`rac schema <type>` shows the full schema reference: required, recommended, and
+optional sections; descriptions; guidance; and metadata values where applicable.
+
+```text
+Artifact Type: Decision
+
+Required Sections:
+  - Context
+  - Decision
+  - Consequences
+
+Recommended Sections:
+  - Status
+  - Category
+  - Alternatives Considered
+
+Optional Sections:
+  - Supersedes
+
+Metadata Fields:
+  - Status: Proposed | Accepted | Superseded | Deprecated
+  - Category: Architecture | Product | Process | Technical | Other
+```
+
+`--json` returns the same schema data as grouped arrays and maps:
+
+```json
+{
+  "type": "requirement",
+  "required": ["problem", "requirements"],
+  "recommended": ["success_metrics", "risks", "assumptions"],
+  "optional": [],
+  "descriptions": {},
+  "guidance": {},
+  "metadata": {}
+}
+```
+
+`--template` emits a structurally valid Markdown starter. Templates are useful
+starting points, not finished artifacts: users still replace TODO text with
+meaningful product knowledge.
+
+```bash
+rac schema requirement --template > requirement.md
+rac schema decision --template > decision.md
+```
+
+Generated templates are validation-safe:
+
+```bash
+rac schema requirement --template | rac validate -
+rac schema decision --template | rac validate -
+```
+
+Unknown schemas fail with exit code `2` and list available schemas. Only
+registered schemas are supported; custom schemas are out of scope.
+
+---
+
 ## Review (Planned)
 
 AI-assisted product review.

--- a/planning/roadmap/v0.5.2-schema.md
+++ b/planning/roadmap/v0.5.2-schema.md
@@ -22,6 +22,10 @@ rac schema
 
 This command exposes RAC's artifact schemas directly through the CLI.
 
+Schema templates are structural starters. They should pass RAC validation, but
+users remain responsible for replacing TODO content with meaningful product
+knowledge.
+
 ---
 
 ## Problem
@@ -98,6 +102,27 @@ Example:
 Available Schemas:
 - requirement
 - decision
+```
+
+---
+
+The system shall also support:
+
+```bash
+rac schema --list --json
+```
+
+and return supported schemas in `ARTIFACT_SPECS` order.
+
+Example:
+
+```json
+{
+  "schemas": [
+    "requirement",
+    "decision"
+  ]
+}
 ```
 
 ---
@@ -181,36 +206,39 @@ Example:
 
 ## Problem
 
-_TODO_
+TODO: describe the problem being solved and who experiences it.
 
 <!-- Who experiences this problem? -->
 <!-- Why does it matter? -->
 
 ## Requirements
 
-_TODO_
+- [REQ-001] TODO: describe a required system behaviour.
 
 <!-- What must the system do? -->
 <!-- Are these testable [REQ-NNN] statements? -->
 
 ## Success Metrics
 
-_TODO_
+TODO: describe how success will be measured.
 
 <!-- How will success be measured? -->
 
 ## Risks
 
-_TODO_
+TODO: describe implementation, delivery, operational, or adoption risks.
 
 <!-- What could prevent successful delivery? -->
 
 ## Assumptions
 
-_TODO_
+TODO: describe conditions assumed to be true.
 
 <!-- What must be true for this requirement to hold? -->
 ```
+
+Generated templates shall be structurally valid RAC artifacts. They are not
+semantically complete artifacts.
 
 ---
 
@@ -290,6 +318,29 @@ It shall not duplicate schema definitions in CLI code or output rendering code.
 
 ---
 
+### REQ-009 — Stdin Validation Compatibility
+
+The system shall support:
+
+```bash
+rac validate -
+```
+
+to validate Markdown content from stdin.
+
+This enables schema-generated templates to be validated through standard shell
+pipelines.
+
+Example:
+
+```bash
+rac schema requirement --template | rac validate -
+```
+
+The behavior shall match validation of equivalent file-based Markdown input.
+
+---
+
 ## Non-Goals
 
 ### File Inspection
@@ -317,6 +368,20 @@ Validation remains the responsibility of:
 ```bash
 rac validate
 ```
+
+`rac validate -` is a narrow stdin compatibility improvement. It does not add
+schema validation behavior to `rac schema`.
+
+### Semantic Completeness
+
+Not:
+
+```text
+Generated templates are meaningful finished artifacts.
+```
+
+Generated templates are structurally valid starter documents; users remain
+responsible for replacing TODO content with meaningful product knowledge.
 
 ---
 
@@ -375,6 +440,7 @@ Custom or user-defined schemas are out of scope for v0.5.2.
 * Users can generate a starter template for supported artifact types.
 * JSON output exposes the same schema information as human output.
 * Unknown schema names fail clearly with actionable guidance.
+* Generated templates pass RAC validation through stdin pipelines.
 
 ### Product
 
@@ -399,6 +465,12 @@ rac schema --list
 ```
 
 lists supported schemas.
+
+```bash
+rac schema --list --json
+```
+
+returns supported schemas in machine-readable form.
 
 ```bash
 rac schema requirement
@@ -435,6 +507,18 @@ rac schema decision --template
 ```
 
 emits a complete Markdown starter template for a Decision artifact.
+
+```bash
+rac schema requirement --template | rac validate -
+```
+
+passes.
+
+```bash
+rac schema decision --template | rac validate -
+```
+
+passes.
 
 ```bash
 rac schema roadmap

--- a/rac/cli.py
+++ b/rac/cli.py
@@ -1,12 +1,13 @@
 """Command-line interface for RAC.
 
 Commands:
-    rac validate <file.md> [--json]
+    rac validate <file.md | -> [--json]
     rac diff <old.md> <new.md> [--json]
     rac stats <directory> [--json]
     rac ingest <file> [-o OUT | --stdout] [--force] [--json]
     rac inspect <file.md | -> [--json]
     rac improve <file.md | -> [--json | --template]
+    rac schema [--list] [type] [--json | --template]
 
 Exit codes:
     0  success (incl. inspect/improve reporting Unknown)
@@ -30,6 +31,7 @@ from .classification import score_artifacts
 from .improve import improve_product
 from .inspect import build_inspection, inspect_directory
 from .parser import parse, parse_file
+from .schema import available_schemas, schema_reference
 from .stats import collect_stats
 from .validate import has_errors, validate
 
@@ -50,8 +52,15 @@ def _read(path: str):
         raise SystemExit(EXIT_USAGE)
 
 
+def _read_validate_input(target: str):
+    """Parse validation input from a Markdown file or stdin."""
+    if target == "-":
+        return parse(sys.stdin.read(), source_path="-")
+    return _read(target)
+
+
 def cmd_validate(args: argparse.Namespace) -> int:
-    product = _read(args.file)
+    product = _read_validate_input(args.file)
     issues = validate(product)
     if args.json:
         print(outputs.render_validation_json(product, issues))
@@ -188,6 +197,39 @@ def cmd_improve(args: argparse.Namespace) -> int:
     return EXIT_OK
 
 
+def cmd_schema(args: argparse.Namespace) -> int:
+    names = available_schemas()
+    if args.list:
+        if args.template:
+            print("rac: --template cannot be used with --list", file=sys.stderr)
+            raise SystemExit(EXIT_USAGE)
+        if args.schema:
+            print("rac: schema name cannot be used with --list", file=sys.stderr)
+            raise SystemExit(EXIT_USAGE)
+        if args.json:
+            print(outputs.render_schema_list_json(names))
+        else:
+            print(outputs.render_schema_list_human(names))
+        return EXIT_OK
+
+    if not args.schema:
+        print("rac: schema name required unless --list is passed", file=sys.stderr)
+        raise SystemExit(EXIT_USAGE)
+
+    ref = schema_reference(args.schema)
+    if ref is None:
+        print(outputs.render_unknown_schema(args.schema, names), file=sys.stderr)
+        raise SystemExit(EXIT_USAGE)
+
+    if args.json:
+        print(outputs.render_schema_json(ref))
+    elif args.template:
+        print(outputs.render_schema_template(ref))
+    else:
+        print(outputs.render_schema_human(ref))
+    return EXIT_OK
+
+
 def build_parser() -> argparse.ArgumentParser:
     version_str = f"rac {__version__}"
 
@@ -210,7 +252,9 @@ def build_parser() -> argparse.ArgumentParser:
         help="Validate a single requirement file.",
         parents=[version_parent],
     )
-    p_validate.add_argument("file", help="Path to the requirement Markdown file.")
+    p_validate.add_argument(
+        "file", help="Path to a requirement Markdown file, or '-' to read from stdin."
+    )
     p_validate.add_argument(
         "--json", action="store_true", help="Emit JSON instead of human-readable text."
     )
@@ -310,6 +354,32 @@ def build_parser() -> argparse.ArgumentParser:
         help="Emit Markdown templates for the missing sections.",
     )
     p_improve.set_defaults(func=cmd_improve)
+
+    p_schema = sub.add_parser(
+        "schema",
+        help="Show registered artifact schemas and starter templates.",
+        parents=[version_parent],
+    )
+    p_schema.add_argument(
+        "schema",
+        nargs="?",
+        help="Schema name, e.g. requirement or decision.",
+    )
+    p_schema.add_argument(
+        "--list",
+        action="store_true",
+        help="List available schemas.",
+    )
+    schema_mode = p_schema.add_mutually_exclusive_group()
+    schema_mode.add_argument(
+        "--json", action="store_true", help="Emit JSON instead of human-readable text."
+    )
+    schema_mode.add_argument(
+        "--template",
+        action="store_true",
+        help="Emit a full Markdown starter template.",
+    )
+    p_schema.set_defaults(func=cmd_schema)
 
     return parser
 

--- a/rac/outputs.py
+++ b/rac/outputs.py
@@ -16,6 +16,7 @@ from .improve import ImprovementResult
 from .ingest import IngestResult
 from .inspect import DirectoryInspection, InspectionResult
 from .models import Diff, Issue, Product
+from .schema import SchemaReference, template_sections
 from .stats import PortfolioStats
 
 # --- Minimal color (auto-disabled when not writing to a TTY) ----------------
@@ -440,6 +441,74 @@ def render_improve_template(result: ImprovementResult) -> str:
         guidance_lines = result.guidance.get(section, [])
         if guidance_lines:
             block += "\n\n" + "\n".join(f"<!-- {q} -->" for q in guidance_lines)
+        blocks.append(block)
+    return "\n\n".join(blocks) + "\n"
+
+
+# --- schema ------------------------------------------------------------------
+
+
+def render_schema_list_human(names: list[str]) -> str:
+    lines = [_bold("Available Schemas:")]
+    lines.extend(f"- {name}" for name in names)
+    return "\n".join(lines)
+
+
+def render_schema_list_json(names: list[str]) -> str:
+    return json.dumps({"schemas": names}, indent=2)
+
+
+def render_unknown_schema(name: str, available: list[str]) -> str:
+    lines = [f"Unknown schema: {name}", "", "Available schemas:"]
+    lines.extend(f"- {schema}" for schema in available)
+    return "\n".join(lines)
+
+
+def render_schema_human(ref: SchemaReference) -> str:
+    lines = [_bold(f"Artifact Type: {ref.display}"), ""]
+
+    def section_block(title: str, names: list[str]) -> None:
+        lines.extend([_bold(title)])
+        if not names:
+            lines.append("  (none)")
+            lines.append("")
+            return
+        for name in names:
+            lines.append(f"  - {name.title()}")
+            description = ref.descriptions.get(name)
+            if description:
+                lines.append(f"      Description: {description}")
+            guidance = ref.guidance.get(name, [])
+            if guidance:
+                lines.append("      Guidance:")
+                lines.extend(f"        - {item}" for item in guidance)
+        lines.append("")
+
+    section_block("Required Sections:", ref.required)
+    section_block("Recommended Sections:", ref.recommended)
+    section_block("Optional Sections:", ref.optional)
+
+    if ref.metadata:
+        lines.append(_bold("Metadata Fields:"))
+        for name, values in ref.metadata.items():
+            lines.append(f"  - {name.title()}: {' | '.join(values)}")
+    return "\n".join(lines).rstrip()
+
+
+def render_schema_json(ref: SchemaReference) -> str:
+    return json.dumps(ref.to_dict(), indent=2)
+
+
+def render_schema_template(ref: SchemaReference) -> str:
+    blocks = ["# Title"]
+    for section in template_sections(ref):
+        block = f"## {section.name.title()}\n\n{section.body}"
+        comments: list[str] = []
+        if section.metadata_values:
+            comments.append(f"Choose one: {' | '.join(section.metadata_values)}")
+        comments.extend(section.guidance)
+        if comments:
+            block += "\n\n" + "\n".join(f"<!-- {comment} -->" for comment in comments)
         blocks.append(block)
     return "\n\n".join(blocks) + "\n"
 

--- a/rac/schema.py
+++ b/rac/schema.py
@@ -1,0 +1,152 @@
+"""Schema reference service — expose registered artifact schemas directly.
+
+`rac schema` answers "what should this artifact look like?" without requiring an
+existing file. It consumes :mod:`rac.artifacts` as the single source of truth and
+derives human/JSON/template data from registered :class:`ArtifactSpec` objects.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from .artifacts import ARTIFACT_SPECS, ArtifactSpec, spec_for
+
+
+@dataclass
+class SchemaReference:
+    """Public reference view for one registered artifact schema."""
+
+    type: str
+    display: str
+    required: list[str]
+    recommended: list[str]
+    optional: list[str]
+    descriptions: dict[str, str] = field(default_factory=dict)
+    guidance: dict[str, list[str]] = field(default_factory=dict)
+    metadata: dict[str, list[str]] = field(default_factory=dict)
+
+    def to_dict(self) -> dict:
+        return {
+            "type": self.type,
+            "required": [_snake(s) for s in self.required],
+            "recommended": [_snake(s) for s in self.recommended],
+            "optional": [_snake(s) for s in self.optional],
+            "descriptions": {
+                _snake(section): description
+                for section, description in self.descriptions.items()
+            },
+            "guidance": {
+                _snake(section): list(lines)
+                for section, lines in self.guidance.items()
+            },
+            "metadata": {
+                _snake(section): list(values)
+                for section, values in self.metadata.items()
+            },
+        }
+
+
+@dataclass
+class TemplateSection:
+    """One Markdown section in a structurally valid starter template."""
+
+    name: str
+    body: str
+    guidance: list[str] = field(default_factory=list)
+    metadata_values: list[str] = field(default_factory=list)
+
+
+def available_schemas() -> list[str]:
+    """Registered schema names, in :data:`ARTIFACT_SPECS` order."""
+    return [spec.name for spec in ARTIFACT_SPECS]
+
+
+def schema_reference(name: str) -> SchemaReference | None:
+    """Return a public schema reference for ``name``, or None if unknown."""
+    spec = spec_for(name)
+    if spec is None:
+        return None
+    return _reference_from_spec(spec)
+
+
+def template_sections(ref: SchemaReference) -> list[TemplateSection]:
+    """Full starter template sections: required first, then recommended.
+
+    Optional sections are intentionally omitted from the starter, while remaining
+    visible in the human and JSON schema reference.
+    """
+    return [_template_section(ref, section) for section in ref.required + ref.recommended]
+
+
+def _reference_from_spec(spec: ArtifactSpec) -> SchemaReference:
+    return SchemaReference(
+        type=spec.name,
+        display=spec.display,
+        required=list(spec.required),
+        recommended=list(spec.recommended),
+        optional=list(spec.optional),
+        descriptions=dict(spec.descriptions),
+        guidance={
+            section: list(lines)
+            for section, lines in spec.guidance.items()
+        },
+        metadata={
+            section: list(values)
+            for section, values in spec.metadata.items()
+        },
+    )
+
+
+def _template_section(ref: SchemaReference, section: str) -> TemplateSection:
+    metadata_values = ref.metadata.get(section, [])
+    return TemplateSection(
+        name=section,
+        body=_starter_body(ref, section, metadata_values),
+        guidance=list(ref.guidance.get(section, [])),
+        metadata_values=list(metadata_values),
+    )
+
+
+def _starter_body(
+    ref: SchemaReference, section: str, metadata_values: list[str]
+) -> str:
+    """Validation-safe starter body for one section."""
+    if metadata_values:
+        return _metadata_default(section, metadata_values)
+    if ref.type == "requirement" and section == "requirements":
+        return "- [REQ-001] TODO: describe a required system behaviour."
+    return _free_text_todo(section)
+
+
+def _metadata_default(section: str, values: list[str]) -> str:
+    if section == "status" and "Proposed" in values:
+        return "Proposed"
+    if section == "category" and "Other" in values:
+        return "Other"
+    return values[0] if values else "TODO"
+
+
+def _free_text_todo(section: str) -> str:
+    messages = {
+        "problem": "TODO: describe the problem being solved and who experiences it.",
+        "success metrics": "TODO: describe how success will be measured.",
+        "risks": (
+            "TODO: describe implementation, delivery, operational, "
+            "or adoption risks."
+        ),
+        "assumptions": "TODO: describe conditions assumed to be true.",
+        "context": "TODO: describe the situation, constraints, and background.",
+        "decision": "TODO: describe the decision that has been made.",
+        "consequences": (
+            "TODO: describe the expected positive and negative consequences."
+        ),
+        "alternatives considered": (
+            "TODO: describe the options that were considered and why they "
+            "were not chosen."
+        ),
+    }
+    return messages.get(section, f"TODO: describe {section}.")
+
+
+def _snake(section: str) -> str:
+    return section.replace(" ", "_")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,6 +21,7 @@ from conftest import fixture_path
         ["stats", "d", "--version"],
         ["ingest", "foo.docx", "--version"],
         ["ingest", "--version"],  # short-circuits before the required `file`
+        ["schema", "--version"],
     ],
 )
 def test_version_flag_on_root_and_subcommands(argv, capsys):

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -177,10 +177,16 @@ def test_cli_dir_inspect_recursive_flag_accepted(capsys):
 
 
 def test_dogfood_directory_targets():
-    # planning/roadmap is fully RAC-formatted -> all Requirements, no Unknown.
+    # RAC-formatted roadmap specs classify as Requirements; newer exploratory
+    # roadmap formats may remain Unknown until their schemas are formalized.
     roadmap = inspect_directory(str(REPO_ROOT / "planning/roadmap"))
-    assert roadmap.unknown_count == 0
-    assert roadmap.counts["requirement"] == roadmap.total_files
+    paths_by_type = {f.path: f.type for f in roadmap.files}
+    assert paths_by_type[
+        str(REPO_ROOT / "planning/roadmap/v0.5.2-schema.md")
+    ] == "requirement"
+    assert paths_by_type[
+        str(REPO_ROOT / "planning/roadmap/v0.6-roadmaps.md")
+    ] == "requirement"
     # The well-formed ADRs classify as Decision.
     adr = REPO_ROOT / "planning/adr/adr-010-documents-are-not-artifacts.md"
     assert inspect_file(str(adr)).type == "decision"

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,199 @@
+"""Tests for schema reference (`rac schema`, v0.5.2)."""
+
+from __future__ import annotations
+
+import io
+import json
+
+import pytest
+
+from rac.artifacts import spec_for
+from rac.cli import main
+from rac.schema import available_schemas, schema_reference
+
+from conftest import fixture_path
+
+
+def test_available_schemas_are_registered_artifacts():
+    assert available_schemas() == ["requirement", "decision"]
+
+
+def test_schema_reference_consumes_artifact_spec():
+    spec = spec_for("requirement")
+    assert spec is not None
+    ref = schema_reference("requirement")
+    assert ref is not None
+    assert ref.required == list(spec.required)
+    assert ref.recommended == list(spec.recommended)
+    assert ref.descriptions["problem"] == spec.descriptions["problem"]
+    assert ref.guidance["risks"] == list(spec.guidance["risks"])
+
+
+def test_schema_list_human(capsys):
+    rc = main(["schema", "--list"])
+    assert rc == 0
+    assert capsys.readouterr().out == (
+        "Available Schemas:\n"
+        "- requirement\n"
+        "- decision\n"
+    )
+
+
+def test_schema_list_json(capsys):
+    rc = main(["schema", "--list", "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == {"schemas": ["requirement", "decision"]}
+
+
+def test_schema_human_requirement(capsys):
+    rc = main(["schema", "requirement"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Artifact Type: Requirement" in out
+    assert "Required Sections:" in out
+    assert "Problem" in out
+    assert "Recommended Sections:" in out
+    assert "Success Metrics" in out
+    assert "Guidance:" in out
+    assert "What user or business problem does this solve?" in out
+    assert "Optional Sections:" in out
+    assert "  (none)" in out
+
+
+def test_schema_human_decision_includes_metadata(capsys):
+    rc = main(["schema", "decision"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Artifact Type: Decision" in out
+    assert "Optional Sections:" in out
+    assert "Supersedes" in out
+    assert "Metadata Fields:" in out
+    assert "Status: Proposed | Accepted | Superseded | Deprecated" in out
+    assert "Category: Architecture | Product | Process | Technical | Other" in out
+
+
+def test_schema_json_requirement_shape(capsys):
+    rc = main(["schema", "requirement", "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert set(payload) == {
+        "type",
+        "required",
+        "recommended",
+        "optional",
+        "descriptions",
+        "guidance",
+        "metadata",
+    }
+    assert payload["type"] == "requirement"
+    assert payload["required"] == ["problem", "requirements"]
+    assert payload["recommended"] == ["success_metrics", "risks", "assumptions"]
+    assert payload["optional"] == []
+    assert "success_metrics" in payload["descriptions"]
+    assert "success_metrics" in payload["guidance"]
+    assert payload["metadata"] == {}
+
+
+def test_schema_json_decision_metadata_values(capsys):
+    rc = main(["schema", "decision", "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["type"] == "decision"
+    assert payload["optional"] == ["supersedes"]
+    assert payload["metadata"]["status"] == [
+        "Proposed",
+        "Accepted",
+        "Superseded",
+        "Deprecated",
+    ]
+    assert payload["metadata"]["category"] == [
+        "Architecture",
+        "Product",
+        "Process",
+        "Technical",
+        "Other",
+    ]
+
+
+def test_requirement_template_is_validation_safe(capsys, monkeypatch):
+    rc = main(["schema", "requirement", "--template"])
+    assert rc == 0
+    template = capsys.readouterr().out
+    assert "# Title" in template
+    assert "## Problem" in template
+    assert "- [REQ-001] TODO: describe a required system behaviour." in template
+    assert "<!-- What must the system do? -->" in template
+    assert "## Assumptions" in template
+
+    monkeypatch.setattr("sys.stdin", io.StringIO(template))
+    assert main(["validate", "-"]) == 0
+
+
+def test_decision_template_is_validation_safe(capsys, monkeypatch):
+    rc = main(["schema", "decision", "--template"])
+    assert rc == 0
+    template = capsys.readouterr().out
+    assert "## Status" in template
+    assert "\nProposed\n" in template
+    assert "<!-- Choose one: Proposed | Accepted | Superseded | Deprecated -->" in template
+    assert "## Category" in template
+    assert "\nOther\n" in template
+    assert "<!-- Choose one: Architecture | Product | Process | Technical | Other -->" in template
+    assert "## Supersedes" not in template
+
+    monkeypatch.setattr("sys.stdin", io.StringIO(template))
+    assert main(["validate", "-"]) == 0
+
+
+def test_unknown_schema_exits_two_and_lists_available(capsys):
+    with pytest.raises(SystemExit) as exc:
+        main(["schema", "roadmap"])
+    assert exc.value.code == 2
+    err = capsys.readouterr().err
+    assert "Unknown schema: roadmap" in err
+    assert "Available schemas:" in err
+    assert "- requirement" in err
+    assert "- decision" in err
+
+
+def test_schema_requires_name_or_list(capsys):
+    with pytest.raises(SystemExit) as exc:
+        main(["schema"])
+    assert exc.value.code == 2
+    assert "schema name required" in capsys.readouterr().err
+
+
+def test_schema_rejects_template_with_list(capsys):
+    with pytest.raises(SystemExit) as exc:
+        main(["schema", "--list", "--template"])
+    assert exc.value.code == 2
+    assert "--template cannot be used with --list" in capsys.readouterr().err
+
+
+def test_schema_json_and_template_are_mutually_exclusive():
+    with pytest.raises(SystemExit):
+        main(["schema", "requirement", "--json", "--template"])
+
+
+def test_validate_stdin_matches_file(monkeypatch, capsys):
+    with open(fixture_path("valid", "feature.md"), encoding="utf-8") as fh:
+        text = fh.read()
+
+    file_rc = main(["validate", fixture_path("valid", "feature.md"), "--json"])
+    file_payload = json.loads(capsys.readouterr().out)
+
+    monkeypatch.setattr("sys.stdin", io.StringIO(text))
+    stdin_rc = main(["validate", "-", "--json"])
+    stdin_payload = json.loads(capsys.readouterr().out)
+
+    assert stdin_rc == file_rc == 0
+    file_payload["file"] = "-"
+    assert stdin_payload == file_payload
+
+
+def test_validate_stdin_invalid_returns_one(monkeypatch, capsys):
+    monkeypatch.setattr("sys.stdin", io.StringIO("# Bad\n\n## Problem\n\nx\n"))
+    rc = main(["validate", "-"])
+    assert rc == 1
+    assert "missing-requirements" in capsys.readouterr().out


### PR DESCRIPTION
Add rac schema as a read-only, file-free schema reference command for registered ArtifactSpec definitions.

Full suite: 151 passing.