### PR TITLE
RAC v0.6.0 - Add Roadmap as a first-class artifact type 

### DIFF
--- a/rac/artifacts.py
+++ b/rac/artifacts.py
@@ -9,10 +9,10 @@ there is a single source of truth.
 Section names are normalized (stripped + casefolded) for matching; ``display``
 holds the human-facing label.
 
-v0.4 defines only the two artifact types that have a concrete schema today:
-Requirement (RAC's own format / validator) and Decision (the ADR format used in
-this repository). Roadmap, Prompt, and Meeting are intentionally deferred until
-their schemas are formalized — see planning/roadmap/.
+Three artifact types have a concrete schema today: Requirement (RAC's own format /
+validator), Decision (the ADR format used in this repository), and Roadmap
+(outcome- and initiative-focused knowledge, added in v0.6.0). Prompt and Meeting
+are intentionally deferred until their schemas are formalized — see planning/roadmap/.
 """
 
 from __future__ import annotations
@@ -137,6 +137,48 @@ ARTIFACT_SPECS: tuple[ArtifactSpec, ...] = (
         synonyms={
             "alternatives": "alternatives considered",
             "options considered": "alternatives considered",
+        },
+    ),
+    ArtifactSpec(
+        name="roadmap",
+        display="Roadmap",
+        required=("outcomes", "initiatives"),
+        recommended=("success measures", "assumptions", "risks"),
+        # Relationship sections are recognized but never scored or templated; they
+        # exist so v0.6.0 roadmaps can reference Decisions/Requirements as text
+        # without RAC analyzing those links (relationship analysis is v0.7.x).
+        optional=("related decisions", "related requirements"),
+        descriptions={
+            "outcomes": "The user, business, or operational outcomes this roadmap pursues",
+            "initiatives": "The major bodies of work that support those outcomes",
+            "success measures": "How progress toward the outcomes will be measured",
+            "assumptions": "Conditions that must hold for this roadmap to stay valid",
+            "risks": "What could prevent the outcomes from being achieved",
+        },
+        guidance={
+            "outcomes": (
+                "What user, business, or operational outcomes matter?",
+                "Why are these outcomes important now?",
+            ),
+            "initiatives": (
+                "What major bodies of work support these outcomes?",
+                "How does each initiative connect to an outcome?",
+            ),
+            "success measures": (
+                "How will the team know the roadmap is succeeding?",
+            ),
+            "assumptions": (
+                "What must be true for this roadmap to remain valid?",
+            ),
+            "risks": (
+                "What could prevent these outcomes from being achieved?",
+            ),
+        },
+        # Artifact-scoped: this only normalizes "success metrics" when scoring a
+        # document against the Roadmap spec (see rac.classification._mapped), so it
+        # never affects the Requirement spec's canonical "success metrics" section.
+        synonyms={
+            "success metrics": "success measures",
         },
     ),
 )

--- a/rac/cli.py
+++ b/rac/cli.py
@@ -90,10 +90,14 @@ def cmd_stats(args: argparse.Namespace) -> int:
     else:
         print(outputs.render_stats_human(stats))
     # Success as long as the portfolio has analysable content: at least one valid
-    # feature or at least one decision. Invalid files are reported but don't fail
-    # the run on their own. (A future --strict flag will fail the run if *any*
-    # file is invalid, for CI use.)
-    has_content = stats.valid_features > 0 or stats.decision_count > 0
+    # feature, one decision, or one valid roadmap. Invalid files are reported but
+    # don't fail the run on their own. (A future --strict flag will fail the run if
+    # *any* file is invalid, for CI use.)
+    has_content = (
+        stats.valid_features > 0
+        or stats.decision_count > 0
+        or stats.valid_roadmaps > 0
+    )
     return EXIT_OK if has_content else EXIT_VALIDATION_FAILED
 
 
@@ -363,7 +367,7 @@ def build_parser() -> argparse.ArgumentParser:
     p_schema.add_argument(
         "schema",
         nargs="?",
-        help="Schema name, e.g. requirement or decision.",
+        help="Schema name, e.g. requirement, decision, or roadmap.",
     )
     p_schema.add_argument(
         "--list",

--- a/rac/outputs.py
+++ b/rac/outputs.py
@@ -227,6 +227,24 @@ def render_stats_human(s: PortfolioStats) -> str:
         breakdown("Status", s.decision_status_counts)
         breakdown("Category", s.decision_category_counts)
 
+    # Roadmaps are reported separately and lightly (count + invalid only); the
+    # section is omitted entirely when there are none.
+    if s.roadmaps:
+        lines += [
+            "",
+            _bold("Roadmaps"),
+            "========",
+            "",
+            f"Total: {s.roadmap_count}",
+            f"Valid: {s.valid_roadmaps}",
+        ]
+        invalid_roadmaps = s.invalid_roadmaps
+        if invalid_roadmaps:
+            lines += ["", _bold(f"Invalid Roadmaps ({len(invalid_roadmaps)})")]
+            for r in invalid_roadmaps:
+                reasons = ", ".join(r.error_codes) or "unknown"
+                lines.append(f"  {_red(r.path)} — {reasons}")
+
     return "\n".join(lines)
 
 
@@ -263,6 +281,16 @@ def render_stats_json(s: PortfolioStats) -> str:
             "count": s.decision_count,
             "by_status": s.decision_status_counts,
             "by_category": s.decision_category_counts,
+        }
+    # Additive: only present when the portfolio contains roadmaps. Lightweight by
+    # design — count and validity only (no section-completeness breakdown).
+    if s.roadmaps:
+        payload["roadmaps"] = {
+            "count": s.roadmap_count,
+            "valid": s.valid_roadmaps,
+            "invalid": [
+                {"file": r.path, "errors": r.error_codes} for r in s.invalid_roadmaps
+            ],
         }
     return json.dumps(payload, indent=2)
 

--- a/rac/schema.py
+++ b/rac/schema.py
@@ -135,6 +135,9 @@ def _free_text_todo(section: str) -> str:
             "or adoption risks."
         ),
         "assumptions": "TODO: describe conditions assumed to be true.",
+        "outcomes": "TODO: describe the outcomes this roadmap is intended to achieve.",
+        "initiatives": "TODO: describe the major initiatives that support the outcomes.",
+        "success measures": "TODO: describe how progress or success will be measured.",
         "context": "TODO: describe the situation, constraints, and background.",
         "decision": "TODO: describe the decision that has been made.",
         "consequences": (

--- a/rac/stats.py
+++ b/rac/stats.py
@@ -4,9 +4,10 @@
 each one, and aggregates the results. Like the rest of RAC, it works on the
 Product AST: every `.md` is parsed into a :class:`~rac.models.Product`.
 
-Requirement and Decision artifacts are aggregated separately so that one never
-distorts the other: requirement totals/averages span only requirement files, and
-decisions get their own status/category breakdown.
+Requirement, Decision, and Roadmap artifacts are aggregated separately so that one
+never distorts another: requirement totals/averages span only requirement files,
+decisions get their own status/category breakdown, and roadmaps get a lightweight
+count of how many exist and how many are valid.
 
 Counting basis: requirement totals, averages, and the per-feature breakdown span
 *all* parsed requirement files (including ones that fail validation). A file
@@ -50,12 +51,28 @@ class DecisionStat:
 
 
 @dataclass
+class RoadmapStat:
+    """Per-file result for a Roadmap artifact (kept separate from features).
+
+    Deliberately lightweight (v0.6.0): identity plus validity. Section-completeness
+    or quality breakdowns are intentionally absent — those belong to `rac improve`,
+    not portfolio statistics.
+    """
+
+    path: str
+    name: str  # the roadmap title, or the filename stem if it has none
+    valid: bool
+    error_codes: list[str]
+
+
+@dataclass
 class PortfolioStats:
     """Aggregate view over all discovered requirement files."""
 
     directory: str
     features: list[FeatureStat] = field(default_factory=list)
     decisions: list[DecisionStat] = field(default_factory=list)
+    roadmaps: list[RoadmapStat] = field(default_factory=list)
 
     # --- counts (requirement features) ---
     @property
@@ -138,6 +155,19 @@ class PortfolioStats:
         """Decisions grouped by category, in schema order, omitting empty buckets."""
         return _bucket(self.decisions, "category", "category")
 
+    # --- roadmaps ---
+    @property
+    def roadmap_count(self) -> int:
+        return len(self.roadmaps)
+
+    @property
+    def valid_roadmaps(self) -> int:
+        return sum(1 for r in self.roadmaps if r.valid)
+
+    @property
+    def invalid_roadmaps(self) -> list[RoadmapStat]:
+        return [r for r in self.roadmaps if not r.valid]
+
 
 def _bucket(decisions: list[DecisionStat], attr: str, metadata_key: str) -> dict[str, int]:
     """Count ``decisions`` by ``attr`` in the artifact spec's declared order."""
@@ -180,6 +210,18 @@ def collect_stats(directory: str) -> PortfolioStats:
                     status=result.status,
                     category=result.category,
                     supersedes=result.supersedes,
+                )
+            )
+            continue
+        if result.type == "roadmap":
+            issues = validate(product)
+            error_codes = [i.code for i in issues if i.severity == "error"]
+            stats.roadmaps.append(
+                RoadmapStat(
+                    path=str(path),
+                    name=name,
+                    valid=not error_codes,
+                    error_codes=error_codes,
                 )
             )
             continue

--- a/rac/validate.py
+++ b/rac/validate.py
@@ -32,12 +32,17 @@ def has_errors(issues: list[Issue]) -> bool:
 def validate(product: Product) -> list[Issue]:
     """Check ``product`` and return all structural and quality findings.
 
-    Dispatches on artifact type: Decisions are validated against the Decision
-    schema; everything else (Requirements and Unknown documents) keeps RAC's
-    original Requirement rules unchanged.
+    Dispatches on artifact type. Each type with its own schema is routed
+    explicitly; the final ``_validate_requirement`` arm is a
+    backwards-compatibility fallback for Unknown/legacy documents (and RAC's
+    original Requirement rules), *not* the long-term model — new artifact types
+    must be routed explicitly above it.
     """
-    if classify(product).type == "decision":
+    artifact_type = classify(product).type
+    if artifact_type == "decision":
         return _validate_decision(product)
+    if artifact_type == "roadmap":
+        return _validate_roadmap(product)
     return _validate_requirement(product)
 
 
@@ -96,6 +101,43 @@ def _validate_decision(product: Product) -> list[Issue]:
                     f"invalid-decision-{field_name}",
                     f"## {field_name.title()} value {value!r} is not one of: "
                     f"{', '.join(allowed)}.",
+                )
+            )
+
+    return issues
+
+
+def _validate_roadmap(product: Product) -> list[Issue]:
+    """Validate a Roadmap artifact (REQ-003).
+
+    Required sections (Outcomes, Initiatives) must be present; missing recommended
+    sections never fail. Roadmaps carry no constrained metadata (no owners, dates,
+    or status — ADR-017: RAC manages knowledge, not work).
+    """
+    spec = spec_for("roadmap")
+    assert spec is not None  # the roadmap spec always exists
+    issues: list[Issue] = []
+
+    if not product.title:
+        issues.append(Issue("error", "missing-title", "File has no top-level # title."))
+
+    if product.extra_title_lines:
+        issues.append(
+            Issue(
+                "error",
+                "multiple-titles",
+                "File has more than one top-level # title; expected exactly one.",
+                product.extra_title_lines[0],
+            )
+        )
+
+    for section in spec.required:
+        if section not in product.sections:
+            issues.append(
+                Issue(
+                    "error",
+                    f"missing-{section}",
+                    f"Roadmap is missing a ## {section.title()} section.",
                 )
             )
 

--- a/tests/fixtures/roadmap/minimal.md
+++ b/tests/fixtures/roadmap/minimal.md
@@ -1,0 +1,9 @@
+# Billing Roadmap
+
+## Outcomes
+
+- Customers can self-serve plan changes without contacting support.
+
+## Initiatives
+
+- Build a self-service plan-change flow with proration.

--- a/tests/fixtures/roadmap/missing_initiatives.md
+++ b/tests/fixtures/roadmap/missing_initiatives.md
@@ -1,0 +1,17 @@
+# Onboarding Roadmap
+
+## Outcomes
+
+- New users reach first value within their first session.
+
+## Success Measures
+
+- 70% of new accounts complete activation within 24 hours.
+
+## Assumptions
+
+- Most new accounts arrive through a self-serve signup, not sales.
+
+## Risks
+
+- A longer activation flow could increase early drop-off.

--- a/tests/fixtures/roadmap/valid.md
+++ b/tests/fixtures/roadmap/valid.md
@@ -1,0 +1,31 @@
+# Mobile Platform Roadmap
+
+## Outcomes
+
+- Customers can complete every core workflow from a phone, not just the desktop app.
+- Mobile becomes a credible reason to choose us over competitors in field-heavy teams.
+
+## Initiatives
+
+- Rebuild the navigation shell as a responsive, offline-capable client.
+- Ship native push notifications for the three highest-volume workflows.
+- Close the feature gap on reporting so mobile is not a read-only experience.
+
+## Success Measures
+
+- 40% of weekly active accounts have at least one mobile session.
+- Mobile task-completion rate reaches parity (within 10%) of desktop.
+
+## Assumptions
+
+- The existing API can serve mobile clients without a separate backend.
+- Customers in the target segment carry company-managed devices.
+
+## Risks
+
+- Offline sync conflicts could erode trust if data is silently lost.
+- App store review cycles may slow the cadence of fixes.
+
+## Related Decisions
+
+- ADR-014 chose a single shared API for web and mobile.

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -26,9 +26,9 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 # --- service layer ----------------------------------------------------------
 
 
-def test_artifact_specs_are_the_two_concrete_types():
+def test_artifact_specs_are_the_concrete_types():
     names = {spec.name for spec in ARTIFACT_SPECS}
-    assert names == {"requirement", "decision"}
+    assert names == {"requirement", "decision", "roadmap"}
 
 
 def test_parse_captures_title_and_sections():

--- a/tests/test_roadmap.py
+++ b/tests/test_roadmap.py
@@ -1,0 +1,285 @@
+"""Tests for the Roadmap artifact type (v0.6.0).
+
+Roadmap is a first-class artifact recognized by its Outcomes/Initiatives sections.
+It rides the shared, schema-driven machinery (classify, validate, stats, improve,
+schema) the same way Requirement and Decision do. Per ADR-017 and the v0.6.0 spec
+it carries no work-management metadata (owners, dates, status), and improvement
+stays strictly structural (missing sections + schema guidance, never quality).
+"""
+
+from __future__ import annotations
+
+import io
+import json
+
+import pytest
+
+from rac.artifacts import spec_for
+from rac.cli import main
+from rac.classification import classify
+from rac.improve import improve_file, supports_improve
+from rac.inspect import inspect_file
+from rac.parser import parse, parse_file
+from rac.schema import available_schemas, schema_reference
+from rac.stats import collect_stats
+from rac.validate import has_errors, validate
+
+from conftest import fixture_path
+
+
+def _stdin(monkeypatch, text: str) -> None:
+    monkeypatch.setattr("sys.stdin", io.StringIO(text))
+
+
+# --- classification ---------------------------------------------------------
+
+
+def test_roadmap_classifies_as_roadmap():
+    result = inspect_file(fixture_path("roadmap", "valid.md"))
+    assert result.type == "roadmap"
+    assert result.confidence >= 0.5
+
+
+def test_minimal_roadmap_classifies_on_required_sections_alone():
+    # Outcomes + Initiatives only -> 2/3.5 fit, above the 0.5 threshold.
+    result = inspect_file(fixture_path("roadmap", "minimal.md"))
+    assert result.type == "roadmap"
+
+
+def test_requirement_does_not_classify_as_roadmap():
+    # A Requirement has no Outcomes/Initiatives, so it never wins the roadmap slot.
+    assert inspect_file(fixture_path("valid", "feature.md")).type == "requirement"
+
+
+def test_roadmap_carries_no_metadata():
+    # Roadmap manages knowledge, not work: no status/category/supersedes fields.
+    spec = spec_for("roadmap")
+    assert spec is not None
+    assert spec.metadata == {}
+
+
+# --- validation -------------------------------------------------------------
+
+
+def _codes(parts):
+    return {i.code for i in validate(parse_file(fixture_path(*parts)))}
+
+
+def test_valid_roadmap_has_no_errors():
+    assert not has_errors(validate(parse_file(fixture_path("roadmap", "valid.md"))))
+
+
+def test_minimal_roadmap_has_no_errors():
+    # Missing recommended sections must never fail validation (REQ-003).
+    assert not has_errors(validate(parse_file(fixture_path("roadmap", "minimal.md"))))
+
+
+def test_roadmap_missing_required_section_fails():
+    codes = _codes(("roadmap", "missing_initiatives.md"))
+    assert "missing-initiatives" in codes
+
+
+def test_roadmap_missing_title_fails(monkeypatch):
+    text = "## Outcomes\n\n- o\n\n## Initiatives\n\n- i\n"
+    issues = validate(parse(text))
+    assert "missing-title" in {i.code for i in issues}
+
+
+# --- schema reference & template --------------------------------------------
+
+
+def test_roadmap_is_a_registered_schema():
+    assert "roadmap" in available_schemas()
+
+
+def test_schema_reference_shape():
+    ref = schema_reference("roadmap")
+    assert ref is not None
+    assert ref.required == ["outcomes", "initiatives"]
+    assert ref.recommended == ["success measures", "assumptions", "risks"]
+    assert ref.optional == ["related decisions", "related requirements"]
+
+
+def test_schema_json_includes_optional_relationship_sections(capsys):
+    rc = main(["schema", "roadmap", "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["type"] == "roadmap"
+    assert payload["required"] == ["outcomes", "initiatives"]
+    assert payload["optional"] == ["related_decisions", "related_requirements"]
+
+
+def test_schema_human_shows_optional_relationship_sections(capsys):
+    rc = main(["schema", "roadmap"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Artifact Type: Roadmap" in out
+    assert "Related Decisions" in out
+
+
+def test_template_omits_optional_relationship_sections(capsys):
+    rc = main(["schema", "roadmap", "--template"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "## Outcomes" in out
+    assert "## Initiatives" in out
+    assert "## Success Measures" in out
+    # Optional relationship sections stay out of the starter (v0.7.x territory).
+    assert "## Related Decisions" not in out
+    assert "## Related Requirements" not in out
+
+
+def test_template_passes_validation(monkeypatch):
+    ref = schema_reference("roadmap")
+    assert ref is not None
+    from rac.outputs import render_schema_template
+
+    template = render_schema_template(ref)
+    _stdin(monkeypatch, template)
+    assert main(["validate", "-"]) == 0
+
+
+# --- improvement (structural only) ------------------------------------------
+
+
+def test_roadmap_is_supported_when_guidance_is_complete():
+    spec = spec_for("roadmap")
+    assert spec is not None
+    assert supports_improve(spec) is True
+
+
+def test_complete_roadmap_has_nothing_to_improve():
+    result = improve_file(fixture_path("roadmap", "valid.md"))
+    assert result.type == "roadmap"
+    assert result.missing_required == []
+    assert result.missing_recommended == []
+
+
+def test_minimal_roadmap_reports_missing_recommended():
+    result = improve_file(fixture_path("roadmap", "minimal.md"))
+    assert result.type == "roadmap"
+    assert result.missing_required == []
+    assert result.missing_recommended == ["success measures", "assumptions", "risks"]
+    assert result.guidance["success measures"]
+
+
+def test_improve_json_shape_is_structural_only(capsys):
+    rc = main(["improve", fixture_path("roadmap", "minimal.md"), "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    # Exactly the shared structural contract — no quality/score fields.
+    assert set(payload) == {
+        "type",
+        "missing_required",
+        "missing_recommended",
+        "guidance",
+    }
+    assert payload["type"] == "roadmap"
+    assert "success_measures" in payload["missing_recommended"]
+    assert payload["guidance"]["success_measures"] == [
+        "How will the team know the roadmap is succeeding?"
+    ]
+
+
+def test_improve_human_lists_missing_with_guidance(capsys):
+    rc = main(["improve", fixture_path("roadmap", "minimal.md")])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Artifact Type: Roadmap" in out
+    assert "Missing Recommended:" in out
+    assert "Success Measures" in out
+
+
+# --- inspection CLI ---------------------------------------------------------
+
+
+def test_cli_inspect_human(capsys):
+    rc = main(["inspect", fixture_path("roadmap", "valid.md")])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Artifact Type: Roadmap" in out
+
+
+def test_cli_inspect_json(capsys):
+    rc = main(["inspect", fixture_path("roadmap", "valid.md"), "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["type"] == "roadmap"
+    # No decision-style metadata leaks onto a roadmap.
+    assert "status" not in payload
+    assert "category" not in payload
+
+
+def test_cli_validate_invalid_roadmap_exits_one(capsys):
+    rc = main(["validate", fixture_path("roadmap", "missing_initiatives.md")])
+    assert rc == 1
+
+
+def test_cli_validate_valid_roadmap_exits_zero():
+    assert main(["validate", fixture_path("roadmap", "valid.md")]) == 0
+
+
+# --- statistics: separated aggregation --------------------------------------
+
+
+def test_stats_counts_roadmaps_separately():
+    s = collect_stats(fixture_path("roadmap"))
+    assert s.roadmap_count == 3
+    # Roadmaps never count as requirement features.
+    assert s.files_found == 0
+    assert s.total_requirements == 0
+    assert s.valid_roadmaps == 2  # valid.md + minimal.md
+    assert len(s.invalid_roadmaps) == 1
+    assert s.invalid_roadmaps[0].path.endswith("missing_initiatives.md")
+
+
+def test_stats_human_shows_roadmaps_section(capsys):
+    rc = main(["stats", fixture_path("roadmap")])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Roadmaps" in out
+    assert "Total: 3" in out
+    assert "Valid: 2" in out
+    assert "Invalid Roadmaps (1)" in out
+
+
+def test_stats_json_includes_roadmaps_block(capsys):
+    rc = main(["stats", fixture_path("roadmap"), "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["roadmaps"]["count"] == 3
+    assert payload["roadmaps"]["valid"] == 2
+    assert payload["roadmaps"]["invalid"][0]["file"].endswith("missing_initiatives.md")
+
+
+# --- regression: existing artifact behavior is unchanged (Amendment 6) ------
+
+
+def test_requirement_validation_unchanged():
+    # The original Requirement rules still fire exactly as before.
+    assert not has_errors(validate(parse_file(fixture_path("valid", "feature.md"))))
+    assert "missing-title" in _codes(("invalid", "missing_title.md"))
+    assert "missing-requirements" in _codes(("invalid", "missing_requirements.md"))
+
+
+def test_decision_validation_unchanged():
+    # A Decision still routes to the Decision validator, not roadmap/requirement.
+    product = parse_file(fixture_path("decision", "with_metadata.md"))
+    assert classify(product).type == "decision"
+    assert not has_errors(validate(product))
+
+
+def test_requirement_only_stats_omit_roadmaps_block(capsys):
+    rc = main(["stats", fixture_path("portfolio"), "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    # Additive guarantee: no roadmaps key when the portfolio has none.
+    assert "roadmaps" not in payload
+
+
+def test_decision_stats_unchanged_and_omit_roadmaps(capsys):
+    rc = main(["stats", fixture_path("decision", "portfolio"), "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["decisions"]["count"] == 3
+    assert "roadmaps" not in payload

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -15,7 +15,7 @@ from conftest import fixture_path
 
 
 def test_available_schemas_are_registered_artifacts():
-    assert available_schemas() == ["requirement", "decision"]
+    assert available_schemas() == ["requirement", "decision", "roadmap"]
 
 
 def test_schema_reference_consumes_artifact_spec():
@@ -36,6 +36,7 @@ def test_schema_list_human(capsys):
         "Available Schemas:\n"
         "- requirement\n"
         "- decision\n"
+        "- roadmap\n"
     )
 
 
@@ -43,7 +44,7 @@ def test_schema_list_json(capsys):
     rc = main(["schema", "--list", "--json"])
     assert rc == 0
     payload = json.loads(capsys.readouterr().out)
-    assert payload == {"schemas": ["requirement", "decision"]}
+    assert payload == {"schemas": ["requirement", "decision", "roadmap"]}
 
 
 def test_schema_human_requirement(capsys):
@@ -147,14 +148,16 @@ def test_decision_template_is_validation_safe(capsys, monkeypatch):
 
 
 def test_unknown_schema_exits_two_and_lists_available(capsys):
+    # "meeting" is a deferred type with no concrete schema yet (see rac/artifacts.py).
     with pytest.raises(SystemExit) as exc:
-        main(["schema", "roadmap"])
+        main(["schema", "meeting"])
     assert exc.value.code == 2
     err = capsys.readouterr().err
-    assert "Unknown schema: roadmap" in err
+    assert "Unknown schema: meeting" in err
     assert "Available schemas:" in err
     assert "- requirement" in err
     assert "- decision" in err
+    assert "- roadmap" in err
 
 
 def test_schema_requires_name_or_list(capsys):


### PR DESCRIPTION
Register a Roadmap ArtifactSpec (required: Outcomes, Initiatives; recommended: Success Measures, Assumptions, Risks; optional relationship sections) so it rides the shared, schema-driven machinery across schema, inspect, validate, stats, and improve.