### PR TITLE
[claude] Add relationship metadata model (v0.7.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,9 +420,23 @@ Invalid Designs (1)
   ./planning/design/draft.md — missing-constraints
 ```
 
+When artifacts declare [relationship metadata](#relationship-metadata), a
+`Relationships` section reports **declared-presence counts** — how many artifacts
+contain each relationship section with at least one reference. These are presence
+counts, not resolved links or edge totals:
+
+```text
+Relationships
+=============
+
+Artifacts with Related Decisions: 6
+Artifacts with Related Requirements: 4
+Artifacts with Supersedes: 2
+```
+
 Add `--json` for machine-readable output. Artifact-specific blocks such as
-`decisions`, `roadmaps`, `prompts`, and `designs` are included only when those
-artifacts are present. `stats` exits `0` when the directory has at least one
+`decisions`, `roadmaps`, `prompts`, `designs`, and `relationships` are included
+only when those artifacts (or relationship sections) are present. `stats` exits `0` when the directory has at least one
 valid known artifact, `1` if none, and `2` if the path is not a directory. (A
 `--strict` flag for failing on *any* invalid file — handy in CI — is planned.)
 
@@ -504,7 +518,9 @@ RAC classifies the document against known artifact schemas (no AI) and reports a
 confidence score. RAC recognizes **Requirement**, **Decision**, **Roadmap**,
 **Prompt**, and **Design** artifacts; anything that doesn't fit well is reported
 as **Unknown** (a valid, successful result — not an error). `--json` emits
-`{ type, confidence, present_sections, missing_sections }`.
+`{ type, confidence, present_sections, missing_sections }`, plus an additive
+`relationships` object when the artifact declares relationship sections (see
+[Relationship metadata](#relationship-metadata)).
 
 ### Inspect a directory
 
@@ -582,6 +598,57 @@ ADR-012
 **optional**: a decision without it is still valid. Only an *unsupported* Status
 or Category value fails validation (`invalid-decision-status` /
 `invalid-decision-category`); values are matched case-insensitively.
+
+### Relationship metadata
+
+Artifacts can reference each other with explicit Markdown sections (v0.7.0). RAC
+extracts these as **metadata only** — it records the references but does **not**
+resolve, validate, or graph them (those come in a later v0.7.x release).
+
+```markdown
+## Related Decisions
+
+- ADR-004
+- ADR-012
+
+## Related Roadmaps
+
+- ROADMAP-Q3-PLATFORM
+```
+
+Each artifact type recognizes the relationship sections that make sense for it:
+
+| Artifact | Relationship sections |
+|-------------|--------------------------------------------------------------------------|
+| Requirement | Related Decisions, Related Roadmaps, Related Prompts, Related Designs |
+| Decision | Supersedes, Related Requirements, Related Roadmaps, Related Designs |
+| Roadmap | Related Decisions, Related Requirements, Related Prompts, Related Designs |
+| Prompt | Related Requirements, Related Decisions, Related Roadmaps, Related Designs |
+| Design | Related Requirements, Related Decisions, Related Roadmaps, Related Prompts |
+
+Relationship sections are **optional**: they are never scored, never reported as
+missing, and never appear in starter templates — an artifact without them stays
+valid. `inspect` surfaces them under a **Relationships** block, and in `--json`
+as an additive `relationships` object (snake_case keys, string arrays, present
+only when at least one reference is declared):
+
+```json
+{
+  "type": "requirement",
+  "present_sections": ["problem", "requirements"],
+  "relationships": {
+    "related_decisions": ["ADR-004", "ADR-012"],
+    "related_roadmaps": ["ROADMAP-Q3-PLATFORM"]
+  }
+}
+```
+
+References are kept verbatim (an `ADR-004`, a `REQ-001`, or a relative path are
+all valid) — RAC does not parse out IDs or check that the targets exist.
+
+**`supersedes` is a backwards-compatible exception:** it remains a top-level
+scalar (`"supersedes": "ADR-012"`) rather than moving into `relationships`, so the
+existing Decision contract is unchanged.
 
 ### Synonyms
 

--- a/rac/artifacts.py
+++ b/rac/artifacts.py
@@ -61,18 +61,75 @@ class ArtifactSpec:
         return self.required + self.recommended
 
 
+# --- Relationship metadata (v0.7.0) -----------------------------------------
+#
+# Relationships are explicit Markdown sections that reference other artifacts
+# (ADR-016). They ride the existing ``optional`` mechanism: recognized and
+# extracted, but never scored, never templated, never reported as missing
+# (REQ-002). v0.7.0 treats them as metadata only — RAC extracts and counts the
+# references but does not resolve, validate, or graph them.
+
+# The cross-artifact "Related X" sections. These populate the ``relationships``
+# dict in ``rac inspect`` output. ``related designs`` is included so every peer
+# artifact type can be referenced.
+RELATED_SECTIONS: tuple[str, ...] = (
+    "related requirements",
+    "related decisions",
+    "related roadmaps",
+    "related prompts",
+    "related designs",
+)
+
+# The full relationship-section vocabulary, including ``supersedes``. ``stats``
+# counts presence across all of these. ``supersedes`` is the one exception that
+# does *not* appear in the inspect ``relationships`` dict: it remains a top-level
+# scalar field for backwards compatibility (see rac.inspect / ADR-007).
+RELATIONSHIP_SECTIONS: tuple[str, ...] = RELATED_SECTIONS + ("supersedes",)
+
+# One-line descriptions for every relationship section, surfaced by `rac schema`.
+# Relationship sections deliberately carry no ``guidance`` — guidance gates
+# `rac improve`, and relationships must stay out of improve and templates.
+RELATIONSHIP_DESCRIPTIONS: dict[str, str] = {
+    "related requirements": "Requirement artifacts this artifact references",
+    "related decisions": "Decision artifacts this artifact references",
+    "related roadmaps": "Roadmap artifacts this artifact references",
+    "related prompts": "Prompt artifacts this artifact references",
+    "related designs": "Design artifacts this artifact references",
+    "supersedes": "The artifact this one supersedes",
+}
+
+
+def _relationship_descriptions(*sections: str) -> dict[str, str]:
+    """Descriptions for the given relationship ``sections`` (declaration order)."""
+    return {section: RELATIONSHIP_DESCRIPTIONS[section] for section in sections}
+
+
 ARTIFACT_SPECS: tuple[ArtifactSpec, ...] = (
     ArtifactSpec(
         name="requirement",
         display="Requirement",
         required=("problem", "requirements"),
         recommended=("success metrics", "risks", "assumptions"),
+        # Relationship sections (v0.7.0): metadata only — extracted and counted,
+        # never scored or templated (REQ-003).
+        optional=(
+            "related decisions",
+            "related roadmaps",
+            "related prompts",
+            "related designs",
+        ),
         descriptions={
             "problem": "The user or business problem this addresses",
             "requirements": "Numbered requirement statements, e.g. [REQ-001] ...",
             "success metrics": "How success will be measured",
             "risks": "Potential implementation, delivery, or adoption risks",
             "assumptions": "Assumptions this artifact depends on",
+            **_relationship_descriptions(
+                "related decisions",
+                "related roadmaps",
+                "related prompts",
+                "related designs",
+            ),
         },
         guidance={
             "problem": (
@@ -107,11 +164,25 @@ ARTIFACT_SPECS: tuple[ArtifactSpec, ...] = (
         display="Decision",
         required=("context", "decision", "consequences"),
         recommended=("status", "category", "alternatives considered"),
-        optional=("supersedes",),
+        # ``supersedes`` stays first (the original v0.4.2 entry). The remaining
+        # relationship sections are added in v0.7.0 (REQ-004). All are metadata
+        # only; ``supersedes`` is also surfaced as a top-level scalar by inspect.
+        optional=(
+            "supersedes",
+            "related requirements",
+            "related roadmaps",
+            "related designs",
+        ),
         metadata={
             "status": ("Proposed", "Accepted", "Superseded", "Deprecated"),
             "category": ("Architecture", "Product", "Process", "Technical", "Other"),
         },
+        descriptions=_relationship_descriptions(
+            "supersedes",
+            "related requirements",
+            "related roadmaps",
+            "related designs",
+        ),
         guidance={
             "context": (
                 "What forces, constraints, or problems led to this decision?",
@@ -147,15 +218,27 @@ ARTIFACT_SPECS: tuple[ArtifactSpec, ...] = (
         required=("outcomes", "initiatives"),
         recommended=("success measures", "assumptions", "risks"),
         # Relationship sections are recognized but never scored or templated; they
-        # exist so v0.6.0 roadmaps can reference Decisions/Requirements as text
-        # without RAC analyzing those links (relationship analysis is v0.7.x).
-        optional=("related decisions", "related requirements"),
+        # let a roadmap reference Decisions/Requirements/Prompts/Designs as text.
+        # The first two predate v0.7.0; ``related prompts``/``related designs`` are
+        # added in v0.7.0 (REQ-005). Order is append-only (ADR-007).
+        optional=(
+            "related decisions",
+            "related requirements",
+            "related prompts",
+            "related designs",
+        ),
         descriptions={
             "outcomes": "The user, business, or operational outcomes this roadmap pursues",
             "initiatives": "The major bodies of work that support those outcomes",
             "success measures": "How progress toward the outcomes will be measured",
             "assumptions": "Conditions that must hold for this roadmap to stay valid",
             "risks": "What could prevent the outcomes from being achieved",
+            **_relationship_descriptions(
+                "related decisions",
+                "related requirements",
+                "related prompts",
+                "related designs",
+            ),
         },
         guidance={
             "outcomes": (
@@ -190,9 +273,14 @@ ARTIFACT_SPECS: tuple[ArtifactSpec, ...] = (
         required=("objective", "input", "instructions", "output"),
         recommended=("constraints", "examples", "evaluation"),
         # Relationship sections are recognized but never scored or templated; they
-        # let a Prompt reference other artifacts as text without RAC analyzing those
-        # links (relationship analysis is v0.7.x).
-        optional=("related requirements", "related decisions", "related roadmaps"),
+        # let a Prompt reference other artifacts as text. ``related designs`` is
+        # added in v0.7.0 (REQ-006); order is append-only (ADR-007).
+        optional=(
+            "related requirements",
+            "related decisions",
+            "related roadmaps",
+            "related designs",
+        ),
         descriptions={
             "objective": "What this prompt is intended to achieve",
             "input": "The information, context, or source material the prompt expects",
@@ -202,6 +290,12 @@ ARTIFACT_SPECS: tuple[ArtifactSpec, ...] = (
             "examples": "Example inputs and outputs that clarify intended behavior",
             # Human criteria for judging a response — not automated testing or scoring.
             "evaluation": "Human criteria for judging whether a response is good",
+            **_relationship_descriptions(
+                "related requirements",
+                "related decisions",
+                "related roadmaps",
+                "related designs",
+            ),
         },
         guidance={
             "objective": (
@@ -272,6 +366,12 @@ ARTIFACT_SPECS: tuple[ArtifactSpec, ...] = (
             "accessibility": "Accessibility needs and expectations for the design",
             "style guidance": "Visual, tone, layout, or interaction style guidance",
             "open questions": "Unresolved design questions to validate or decide later",
+            **_relationship_descriptions(
+                "related requirements",
+                "related decisions",
+                "related roadmaps",
+                "related prompts",
+            ),
         },
         guidance={
             "context": (

--- a/rac/inspect.py
+++ b/rac/inspect.py
@@ -11,13 +11,14 @@ delegated to :mod:`rac.classification` (the shared, AI-optional heuristic).
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from .artifacts import ARTIFACT_SPECS, spec_for
 from .classification import classify
 from .fs import find_markdown_files
 from .models import Product
 from .parser import parse, parse_file
+from .relationships import extract_relationships
 
 
 @dataclass
@@ -26,7 +27,7 @@ class InspectionResult:
 
     Section names are stored normalized (e.g. ``"success metrics"``); renderers
     format them. ``to_dict`` is the JSON contract and is additive-friendly:
-    decision metadata fields appear only when present.
+    decision metadata fields and ``relationships`` appear only when present.
     """
 
     type: str  # artifact name, or "unknown"
@@ -36,7 +37,13 @@ class InspectionResult:
     # Decision metadata — populated only for decisions that declare it.
     status: str | None = None
     category: str | None = None
+    # ``supersedes`` is a relationship section but, for backwards compatibility
+    # (v0.4.2 / ADR-007), it stays a top-level scalar here rather than going into
+    # ``relationships`` — the documented exception to the v0.7.0 model.
     supersedes: str | None = None
+    # Cross-artifact relationship metadata (v0.7.0): {snake_section -> [refs]}.
+    # Holds only the ``related_*`` sections; never resolved or validated.
+    relationships: dict[str, list[str]] = field(default_factory=dict)
 
     def to_dict(self) -> dict:
         payload = {
@@ -49,6 +56,9 @@ class InspectionResult:
             value = getattr(self, key)
             if value is not None:
                 payload[key] = value
+        # Additive: only present when the artifact declares relationship sections.
+        if self.relationships:
+            payload["relationships"] = self.relationships
         return payload
 
 
@@ -126,7 +136,7 @@ def _attach_decision_metadata(result: InspectionResult, product: Product) -> Non
 
 
 def build_inspection(product: Product) -> InspectionResult:
-    """Classify ``product`` and attach decision metadata when applicable."""
+    """Classify ``product``, attach decision metadata and relationships."""
     c = classify(product)
     result = InspectionResult(
         type=c.type,
@@ -136,6 +146,11 @@ def build_inspection(product: Product) -> InspectionResult:
     )
     if c.type == "decision":
         _attach_decision_metadata(result, product)
+    # Relationship metadata is spec-driven, so it applies to any recognized type
+    # (Unknown has no spec and therefore no relationships).
+    spec = spec_for(c.type)
+    if spec is not None:
+        result.relationships = extract_relationships(product, spec)
     return result
 
 

--- a/rac/outputs.py
+++ b/rac/outputs.py
@@ -281,6 +281,14 @@ def render_stats_human(s: PortfolioStats) -> str:
                 reasons = ", ".join(d.error_codes) or "unknown"
                 lines.append(f"  {_red(d.path)} — {reasons}")
 
+    # Declared relationship-presence counts (v0.7.0). Omitted entirely when no
+    # artifact declares a relationship section, so existing portfolios are
+    # unchanged. These are presence counts, not resolved/edge counts.
+    if s.relationship_counts:
+        lines += ["", _bold("Relationships"), "=============", ""]
+        for section, count in s.relationship_counts.items():
+            lines.append(f"Artifacts with {section.title()}: {count}")
+
     return "\n".join(lines)
 
 
@@ -348,6 +356,13 @@ def render_stats_json(s: PortfolioStats) -> str:
                 {"file": d.path, "errors": d.error_codes} for d in s.invalid_designs
             ],
         }
+    # Additive: only present when some artifact declares a relationship section.
+    # Declared-presence counts (REQ-011), snake_case keys — not resolution.
+    if s.relationship_counts:
+        payload["relationships"] = {
+            section.replace(" ", "_"): count
+            for section, count in s.relationship_counts.items()
+        }
     return json.dumps(payload, indent=2)
 
 
@@ -369,7 +384,18 @@ def render_inspect_human(result: InspectionResult) -> str:
         lines += ["", _bold("Missing Sections:")]
         lines.extend(_red(f"  ✗ {s.title()}") for s in result.missing_sections)
     _append_decision_metadata(lines, result)
+    _append_relationships(lines, result)
     return "\n".join(lines)
+
+
+def _append_relationships(lines: list[str], result: InspectionResult) -> None:
+    """Add a Relationships block when the artifact declares related artifacts."""
+    if not result.relationships:
+        return
+    lines += ["", _bold("Relationships:")]
+    for section, refs in result.relationships.items():
+        lines.append(f"  {section.replace('_', ' ').title()}:")
+        lines.extend(f"    - {ref}" for ref in refs)
 
 
 def _append_decision_metadata(lines: list[str], result: InspectionResult) -> None:

--- a/rac/relationships.py
+++ b/rac/relationships.py
@@ -1,0 +1,86 @@
+"""Relationship metadata service — extract cross-artifact references (v0.7.0).
+
+Relationships are explicit Markdown sections (``## Related Decisions``,
+``## Supersedes``, ...) that reference other artifacts (ADR-016). This module is
+the single home for turning those sections into reference strings, shared by
+``rac inspect`` (which exposes them as the additive ``relationships`` field) and
+``rac stats`` (which counts their presence).
+
+It is pure and deterministic (ADR-002 / ADR-016): it parses section text only and
+never resolves, validates, or graphs the references — v0.7.0 is metadata only.
+
+Recognition is spec-driven (REQ-002): only the relationship sections an artifact
+type declares in :attr:`ArtifactSpec.optional` are considered, so a section is
+recognized exactly where its schema allows it.
+"""
+
+from __future__ import annotations
+
+import re
+
+from .artifacts import RELATED_SECTIONS, RELATIONSHIP_SECTIONS, ArtifactSpec
+from .models import Product
+
+# A *well-formed* leading Markdown list marker: ``-``, ``*``, ``+``, or ``N.``
+# followed by whitespace. Only these are stripped; any other leading text is
+# preserved verbatim, so references like "REQ-001 (blocked)" or a path beginning
+# with "../" survive intact (the whole line is the reference, per ADR-016).
+_LIST_MARKER_RE = re.compile(r"^(?:[-*+]|\d+\.)\s+")
+
+
+def _snake(section: str) -> str:
+    return section.replace(" ", "_")
+
+
+def parse_references(body: str) -> list[str]:
+    """Split a relationship section body into individual reference strings.
+
+    One reference per non-empty line. A well-formed leading list marker is
+    stripped; otherwise the line is preserved verbatim. No ID parsing and no
+    resolution — the line text *is* the reference.
+    """
+    references: list[str] = []
+    for line in body.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        references.append(_LIST_MARKER_RE.sub("", stripped, count=1).strip())
+    return references
+
+
+def extract_relationships(product: Product, spec: ArtifactSpec) -> dict[str, list[str]]:
+    """Cross-artifact references declared by ``product`` under ``spec``.
+
+    Returns ``{snake_section -> [references]}`` in ``spec.optional`` order,
+    including only sections present with at least one parsed reference. Excludes
+    ``supersedes`` — that stays a top-level scalar in inspect output (ADR-007).
+    """
+    relationships: dict[str, list[str]] = {}
+    for section in spec.optional:
+        if section not in RELATED_SECTIONS:
+            continue
+        body = product.sections.get(section)
+        if not body:
+            continue
+        refs = parse_references(body)
+        if refs:
+            relationships[_snake(section)] = refs
+    return relationships
+
+
+def present_relationship_sections(product: Product, spec: ArtifactSpec) -> list[str]:
+    """Relationship sections ``product`` declares *and* populates.
+
+    Spec-driven and inclusive of ``supersedes`` (unlike
+    :func:`extract_relationships`). A section counts only when present with at
+    least one parsed reference (REQ-011). Returns the normalized section names in
+    ``spec.optional`` order, for ``rac stats`` declared-presence counts.
+    """
+    present: list[str] = []
+    for section in spec.optional:
+        if section not in RELATIONSHIP_SECTIONS:
+            continue
+        body = product.sections.get(section)
+        if body and parse_references(body):
+            present.append(section)
+    return present

--- a/rac/stats.py
+++ b/rac/stats.py
@@ -19,10 +19,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
-from .artifacts import spec_for
+from .artifacts import RELATIONSHIP_SECTIONS, spec_for
 from .fs import find_markdown_files
 from .inspect import build_inspection
 from .parser import parse_file
+from .relationships import present_relationship_sections
 from .validate import validate
 
 
@@ -103,6 +104,10 @@ class PortfolioStats:
     roadmaps: list[RoadmapStat] = field(default_factory=list)
     prompts: list[PromptStat] = field(default_factory=list)
     designs: list[DesignStat] = field(default_factory=list)
+    # Declared relationship-presence counts (v0.7.0, REQ-011): {normalized
+    # section -> number of artifacts that declare it with >=1 reference}. Ordered
+    # by RELATIONSHIP_SECTIONS. Not resolution, not edge totals — just presence.
+    relationship_counts: dict[str, int] = field(default_factory=dict)
 
     # --- counts (requirement features) ---
     @property
@@ -257,10 +262,17 @@ def collect_stats(directory: str) -> PortfolioStats:
     for requirement repositories).
     """
     stats = PortfolioStats(directory=directory)
+    rel_counts: dict[str, int] = {}
     for path in find_markdown_files(directory):
         product = parse_file(str(path))
         name = product.title or path.stem
         result = build_inspection(product)
+        # Declared relationship-presence counts span every artifact type, so they
+        # are tallied before the per-type routing below (each branch continues).
+        spec = spec_for(result.type)
+        if spec is not None:
+            for section in present_relationship_sections(product, spec):
+                rel_counts[section] = rel_counts.get(section, 0) + 1
         if result.type == "decision":
             stats.decisions.append(
                 DecisionStat(
@@ -321,4 +333,10 @@ def collect_stats(directory: str) -> PortfolioStats:
                 risks=len(product.risks),
             )
         )
+    # Order the relationship counts by the canonical vocabulary for stable output.
+    stats.relationship_counts = {
+        section: rel_counts[section]
+        for section in RELATIONSHIP_SECTIONS
+        if section in rel_counts
+    }
     return stats

--- a/tests/fixtures/relationships/decision_with_links.md
+++ b/tests/fixtures/relationships/decision_with_links.md
@@ -1,0 +1,38 @@
+# ADR-020 Event Bus
+
+## Status
+
+Accepted
+
+## Category
+
+Architecture
+
+## Context
+
+Services need decoupled communication as the platform grows.
+
+## Decision
+
+Adopt an internal event bus for service-to-service messaging.
+
+## Consequences
+
+- Services decouple via published events.
+- Debugging spans more hops.
+
+## Supersedes
+
+ADR-011
+
+## Related Requirements
+
+- REQ-014
+
+## Related Roadmaps
+
+- ROADMAP-PLATFORM
+
+## Related Designs
+
+- DESIGN-EVENT-CONSOLE

--- a/tests/fixtures/relationships/design_with_links.md
+++ b/tests/fixtures/relationships/design_with_links.md
@@ -1,0 +1,33 @@
+# Checkout Flow Design
+
+## Context
+
+The checkout experience needs a redesign to reduce abandonment.
+
+## User Need
+
+Users want a fast, clear path from cart to confirmation.
+
+## Design
+
+A single-page checkout with a visible progress indicator.
+
+## Constraints
+
+Must work on mobile and meet WCAG AA contrast.
+
+## Related Requirements
+
+- REQ-001
+
+## Related Decisions
+
+- ADR-012
+
+## Related Roadmaps
+
+- ROADMAP-Q3
+
+## Related Prompts
+
+- PROMPT-DESIGN-REVIEW

--- a/tests/fixtures/relationships/prompt_with_links.md
+++ b/tests/fixtures/relationships/prompt_with_links.md
@@ -1,0 +1,33 @@
+# Requirement Review Prompt
+
+## Objective
+
+Review a requirement artifact for structural completeness.
+
+## Input
+
+A requirement Markdown file.
+
+## Instructions
+
+Check for a problem statement and testable requirement lines.
+
+## Output
+
+A list of findings, one per gap.
+
+## Related Requirements
+
+- REQ-001
+
+## Related Decisions
+
+- ADR-004
+
+## Related Roadmaps
+
+- ROADMAP-Q3
+
+## Related Designs
+
+- DESIGN-REVIEW-PANEL

--- a/tests/fixtures/relationships/requirement_with_links.md
+++ b/tests/fixtures/relationships/requirement_with_links.md
@@ -1,0 +1,26 @@
+# Checkout Speed
+
+## Problem
+
+Checkout is slow and users abandon their carts.
+
+## Requirements
+
+- [REQ-001] User can finish checkout in under three steps.
+
+## Related Decisions
+
+- ADR-004
+- ADR-012
+
+## Related Roadmaps
+
+- ROADMAP-Q3-PLATFORM
+
+## Related Prompts
+
+- PROMPT-REQUIREMENT-REVIEW
+
+## Related Designs
+
+- DESIGN-CHECKOUT-FLOW

--- a/tests/fixtures/relationships/roadmap_with_links.md
+++ b/tests/fixtures/relationships/roadmap_with_links.md
@@ -1,0 +1,26 @@
+# Platform Roadmap
+
+## Outcomes
+
+- Teams ship faster on a single unified platform.
+
+## Initiatives
+
+- Consolidate the deployment pipeline across services.
+
+## Related Requirements
+
+- REQ-001
+- REQ-002
+
+## Related Decisions
+
+- ADR-004
+
+## Related Prompts
+
+- PROMPT-ROADMAP-REVIEW
+
+## Related Designs
+
+- DESIGN-PLATFORM-NAV

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -164,6 +164,7 @@ def test_schema_reference_shape():
         "related requirements",
         "related decisions",
         "related roadmaps",
+        "related designs",
     ]
 
 
@@ -177,6 +178,7 @@ def test_schema_json_includes_optional_relationship_sections(capsys):
         "related_requirements",
         "related_decisions",
         "related_roadmaps",
+        "related_designs",
     ]
 
 

--- a/tests/test_relationships.py
+++ b/tests/test_relationships.py
@@ -1,0 +1,256 @@
+"""Tests for v0.7.0 relationship metadata.
+
+Relationship sections (``## Related Decisions``, ``## Supersedes``, ...) are
+explicit cross-artifact references (ADR-016). v0.7.0 extracts and counts them as
+metadata only — no resolution, validation, or graphing. They ride the existing
+``optional`` mechanism, so they are never scored, templated, or required, and
+artifacts without them stay valid (REQ-012).
+
+Fixtures live under ``fixtures/relationships/`` so they do not disturb the
+directory-count assertions in ``test_inspect.py`` / ``test_stats.py``.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from rac.cli import main
+from rac.inspect import inspect_file, inspect_text
+from rac.parser import parse
+from rac.relationships import parse_references
+from rac.schema import schema_reference
+from rac.stats import collect_stats
+from rac.validate import has_errors, validate
+
+from conftest import fixture_path
+
+# Each fixture and the relationship keys (snake_case) it should expose via inspect.
+# Note: keys are spec-driven — only relationship sections declared optional for
+# that artifact type are extracted (REQ-002).
+LINKED_FIXTURES = {
+    "requirement": (
+        "requirement_with_links.md",
+        ["related_decisions", "related_roadmaps", "related_prompts", "related_designs"],
+    ),
+    "decision": (
+        "decision_with_links.md",
+        ["related_requirements", "related_roadmaps", "related_designs"],
+    ),
+    "roadmap": (
+        "roadmap_with_links.md",
+        ["related_decisions", "related_requirements", "related_prompts", "related_designs"],
+    ),
+    "prompt": (
+        "prompt_with_links.md",
+        ["related_requirements", "related_decisions", "related_roadmaps", "related_designs"],
+    ),
+    "design": (
+        "design_with_links.md",
+        ["related_requirements", "related_decisions", "related_roadmaps", "related_prompts"],
+    ),
+}
+
+
+# --- parse_references service (amendment 4) ----------------------------------
+
+
+def test_parse_references_strips_well_formed_markers():
+    body = "- ADR-004\n* ADR-012\n+ ADR-020\n1. ADR-030"
+    assert parse_references(body) == ["ADR-004", "ADR-012", "ADR-020", "ADR-030"]
+
+
+def test_parse_references_preserves_non_marker_text():
+    # A hyphen mid-token and a leading dash without a following space are NOT
+    # list markers, so the text is preserved verbatim.
+    body = "REQ-001 (blocked)\n../decisions/adr-004.md\n-no-space"
+    assert parse_references(body) == [
+        "REQ-001 (blocked)",
+        "../decisions/adr-004.md",
+        "-no-space",
+    ]
+
+
+def test_parse_references_drops_blank_lines():
+    assert parse_references("\n- ADR-004\n\n- ADR-012\n") == ["ADR-004", "ADR-012"]
+
+
+# --- inspect: extraction across all five artifact types (amendment 7) --------
+
+
+@pytest.mark.parametrize("artifact,info", LINKED_FIXTURES.items())
+def test_inspect_extracts_relationships_per_type(artifact, info):
+    filename, expected_keys = info
+    result = inspect_file(fixture_path("relationships", filename))
+    assert result.type == artifact
+    assert list(result.relationships) == expected_keys
+    for key in expected_keys:
+        assert result.relationships[key], f"{key} should have at least one reference"
+
+
+def test_inspect_extracts_multiple_references():
+    result = inspect_file(fixture_path("relationships", "requirement_with_links.md"))
+    assert result.relationships["related_decisions"] == ["ADR-004", "ADR-012"]
+
+
+def test_inspect_json_includes_relationships(capsys):
+    rc = main(["inspect", fixture_path("relationships", "requirement_with_links.md"), "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["relationships"]["related_decisions"] == ["ADR-004", "ADR-012"]
+    assert payload["relationships"]["related_designs"] == ["DESIGN-CHECKOUT-FLOW"]
+
+
+def test_inspect_human_shows_relationships(capsys):
+    rc = main(["inspect", fixture_path("relationships", "requirement_with_links.md")])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Relationships:" in out
+    assert "Related Decisions:" in out
+    assert "- ADR-004" in out
+
+
+# --- supersedes: backwards-compatible scalar exception (amendment 6) ---------
+
+
+def test_supersedes_stays_top_level_not_in_relationships():
+    result = inspect_file(fixture_path("relationships", "decision_with_links.md"))
+    assert result.supersedes == "ADR-011"  # top-level scalar, unchanged contract
+    assert "supersedes" not in result.relationships
+
+
+def test_inspect_json_supersedes_scalar_not_in_relationships(capsys):
+    rc = main(["inspect", fixture_path("relationships", "decision_with_links.md"), "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["supersedes"] == "ADR-011"
+    assert "supersedes" not in payload["relationships"]
+
+
+# --- additive / spec-driven / present_sections behavior ----------------------
+
+
+def test_relationships_absent_when_no_sections():
+    result = inspect_file(fixture_path("valid", "feature.md"))
+    assert result.relationships == {}
+
+
+def test_inspect_json_omits_relationships_when_absent(capsys):
+    rc = main(["inspect", fixture_path("valid", "feature.md"), "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert "relationships" not in payload
+
+
+def test_empty_relationship_section_is_omitted():
+    # Heading present but no references → no key (the >=1 reference rule).
+    text = (
+        "# Checkout\n\n## Problem\n\np\n\n## Requirements\n\n"
+        "- [REQ-001] User can finish checkout.\n\n## Related Decisions\n"
+    )
+    result = inspect_text(text)
+    assert result.type == "requirement"
+    assert "related_decisions" not in result.relationships
+
+
+def test_undeclared_relationship_section_is_ignored():
+    # Requirement does not declare "Related Requirements" as optional, so it is
+    # not extracted even though it is a relationship-vocabulary section (REQ-002).
+    text = (
+        "# Checkout\n\n## Problem\n\np\n\n## Requirements\n\n"
+        "- [REQ-001] User can finish checkout.\n\n## Related Requirements\n\n- REQ-002\n"
+    )
+    result = inspect_text(text)
+    assert result.type == "requirement"
+    assert "related_requirements" not in result.relationships
+
+
+def test_present_sections_unchanged_by_relationships():
+    # Relationship sections are optional: they must not appear in present_sections.
+    result = inspect_file(fixture_path("relationships", "requirement_with_links.md"))
+    assert "related_decisions" not in [s.replace(" ", "_") for s in result.present_sections]
+    assert set(result.present_sections) <= {"problem", "requirements"}
+
+
+# --- schema & template across all five types (amendment 7) -------------------
+
+
+@pytest.mark.parametrize("artifact", list(LINKED_FIXTURES))
+def test_schema_json_lists_relationship_optionals(artifact, capsys):
+    rc = main(["schema", artifact, "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    # Every related_* optional section carries a description (amendment 5).
+    related = [s for s in payload["optional"] if s.startswith("related_")]
+    assert related, f"{artifact} should declare related_* optional sections"
+    for section in related:
+        assert payload["descriptions"][section]
+
+
+@pytest.mark.parametrize("artifact", list(LINKED_FIXTURES))
+def test_template_omits_relationship_sections(artifact, capsys):
+    rc = main(["schema", artifact, "--template"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "## Related" not in out
+    assert "## Supersedes" not in out
+
+
+# --- stats: declared relationship-presence counts (amendment 9) --------------
+
+
+def test_stats_counts_relationship_presence():
+    s = collect_stats(fixture_path("relationships"))
+    assert s.relationship_counts == {
+        "related requirements": 4,
+        "related decisions": 4,
+        "related roadmaps": 4,
+        "related prompts": 3,
+        "related designs": 4,
+        "supersedes": 1,
+    }
+
+
+def test_stats_human_shows_relationships(capsys):
+    rc = main(["stats", fixture_path("relationships")])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Relationships" in out
+    assert "Artifacts with Related Decisions: 4" in out
+    assert "Artifacts with Supersedes: 1" in out
+
+
+def test_stats_json_includes_relationships_block(capsys):
+    rc = main(["stats", fixture_path("relationships"), "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["relationships"] == {
+        "related_requirements": 4,
+        "related_decisions": 4,
+        "related_roadmaps": 4,
+        "related_prompts": 3,
+        "related_designs": 4,
+        "supersedes": 1,
+    }
+
+
+def test_stats_omits_relationships_when_none(capsys):
+    rc = main(["stats", fixture_path("portfolio"), "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert "relationships" not in payload
+
+
+# --- backwards compatibility (REQ-012) ---------------------------------------
+
+
+def test_artifact_without_relationships_still_valid():
+    assert not has_errors(validate(parse(open(fixture_path("valid", "feature.md")).read())))
+
+
+@pytest.mark.parametrize("artifact,info", LINKED_FIXTURES.items())
+def test_linked_fixtures_validate(artifact, info):
+    filename, _ = info
+    issues = validate(parse(open(fixture_path("relationships", filename)).read()))
+    assert not has_errors(issues), f"{filename} should validate without errors"

--- a/tests/test_roadmap.py
+++ b/tests/test_roadmap.py
@@ -98,7 +98,12 @@ def test_schema_reference_shape():
     assert ref is not None
     assert ref.required == ["outcomes", "initiatives"]
     assert ref.recommended == ["success measures", "assumptions", "risks"]
-    assert ref.optional == ["related decisions", "related requirements"]
+    assert ref.optional == [
+        "related decisions",
+        "related requirements",
+        "related prompts",
+        "related designs",
+    ]
 
 
 def test_schema_json_includes_optional_relationship_sections(capsys):
@@ -107,7 +112,12 @@ def test_schema_json_includes_optional_relationship_sections(capsys):
     payload = json.loads(capsys.readouterr().out)
     assert payload["type"] == "roadmap"
     assert payload["required"] == ["outcomes", "initiatives"]
-    assert payload["optional"] == ["related_decisions", "related_requirements"]
+    assert payload["optional"] == [
+        "related_decisions",
+        "related_requirements",
+        "related_prompts",
+        "related_designs",
+    ]
 
 
 def test_schema_human_shows_optional_relationship_sections(capsys):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -69,7 +69,9 @@ def test_schema_human_requirement(capsys):
     assert "Guidance:" in out
     assert "What user or business problem does this solve?" in out
     assert "Optional Sections:" in out
-    assert "  (none)" in out
+    # v0.7.0: requirements now declare relationship sections as optional.
+    assert "Related Decisions" in out
+    assert "Decision artifacts this artifact references" in out
 
 
 def test_schema_human_decision_includes_metadata(capsys):
@@ -100,7 +102,12 @@ def test_schema_json_requirement_shape(capsys):
     assert payload["type"] == "requirement"
     assert payload["required"] == ["problem", "requirements"]
     assert payload["recommended"] == ["success_metrics", "risks", "assumptions"]
-    assert payload["optional"] == []
+    assert payload["optional"] == [
+        "related_decisions",
+        "related_roadmaps",
+        "related_prompts",
+        "related_designs",
+    ]
     assert "success_metrics" in payload["descriptions"]
     assert "success_metrics" in payload["guidance"]
     assert payload["metadata"] == {}
@@ -111,7 +118,12 @@ def test_schema_json_decision_metadata_values(capsys):
     assert rc == 0
     payload = json.loads(capsys.readouterr().out)
     assert payload["type"] == "decision"
-    assert payload["optional"] == ["supersedes"]
+    assert payload["optional"] == [
+        "supersedes",
+        "related_requirements",
+        "related_roadmaps",
+        "related_designs",
+    ]
     assert payload["metadata"]["status"] == [
         "Proposed",
         "Accepted",


### PR DESCRIPTION
Introduce a machine-readable, Markdown-native relationship metadata model so artifacts can reference each other via explicit sections (## Related Decisions, ## Supersedes, ...). v0.7.0 extracts and counts these references as metadata only — no resolution, validation, or graphing (ADR-016, deferred to later v0.7.x).

Relationships ride the existing ArtifactSpec.optional mechanism (REQ-002): they are recognized and extracted but never scored, templated, or reported missing, so artifacts without them stay valid (REQ-012). All output changes are strictly additive (ADR-007).

- artifacts.py: RELATED_SECTIONS / RELATIONSHIP_SECTIONS / RELATIONSHIP_- DESCRIPTIONS constants; extend optional tuples for Requirement, Decision, Roadmap, Prompt (incl. related designs); descriptions for every relationship section across all five specs (no guidance — keeps them out of improve).
- relationships.py (new): shared service — parse_references (strips only well-formed list markers, preserves other text verbatim), extract_relationships (related_* dict, spec-driven, >=1 ref), present_relationship_sections (stats).
- inspect.py: additive InspectionResult.relationships for any recognized type.
- stats.py + outputs.py: declared relationship-presence counts (human section + additive JSON block); inspect Relationships render block.

supersedes stays a top-level scalar (backwards-compatible exception) rather than moving into the relationships dict.

Tests: new test_relationships.py + fixtures across all five artifact types (schema, template omission, extraction, supersedes exception, spec-driven exclusion, stats counts, backward-compat). Update stale optional assertions in test_schema/test_roadmap/test_prompt. README documents relationship sections, the additive inspect JSON field, the supersedes exception, and stats counts.