### PR TITLE
Add rac relationships repository inspection (v0.7.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -823,6 +823,78 @@ registered schemas are supported; custom schemas are out of scope.
 
 ---
 
+## Relationships
+
+Inspect the explicit [relationship metadata](#relationship-metadata) declared
+across a repository — a deterministic, read-only view of how artifacts reference
+one another, without opening every file.
+
+```bash
+rac relationships planning/
+rac relationships planning/ --json
+rac relationships planning/ --top-level     # don't recurse into subdirectories
+rac relationships requirements/search.md    # a single file works too
+```
+
+```text
+Relationships
+
+Files Inspected: 24
+Artifacts With Relationships: 8
+Relationships Found: 14
+
+By Type:
+- Related Requirements: 4
+- Related Decisions: 6
+- Related Roadmaps: 2
+- Related Prompts: 1
+- Supersedes: 1
+
+requirements/search.md
+  Related Decisions:
+  - ADR-004
+```
+
+`--json` returns structured data for automation and future viewers (ADR-015 —
+relationship intelligence lives in RAC Core, not the UI):
+
+```json
+{
+  "directory": "planning",
+  "recursive": true,
+  "total_files": 24,
+  "artifacts_with_relationships": 8,
+  "relationship_count": 14,
+  "counts": { "related_decisions": 6, "related_requirements": 4 },
+  "artifacts": [
+    {
+      "path": "requirements/search.md",
+      "type": "requirement",
+      "relationships": { "related_decisions": ["ADR-004"] }
+    }
+  ]
+}
+```
+
+Notes:
+
+- **Counts are individual references.** `relationship_count` equals
+  `sum(counts.values())`; an artifact listing two decisions contributes two.
+- **`total_files`** counts every Markdown file considered — including files with
+  no relationships and Unknown artifacts.
+- **Supersedes is a relationship here.** Unlike `rac inspect` (where `supersedes`
+  is a top-level scalar), this command reports it alongside the `related_*`
+  sections, in both `counts` and per-artifact `relationships`.
+- **Spec-driven.** Extraction is keyed off each artifact type's declared sections.
+  Unknown artifacts are counted but contribute no relationships (and never appear
+  in `artifacts`); RAC does not scan arbitrary Markdown.
+- **Read-only and exit `0`.** The command never modifies files and exits `0`
+  whether or not relationships are found (`2` only for a missing path or a
+  non-Markdown file). It does **not** resolve or validate targets — broken-link
+  detection is a later release.
+
+---
+
 ## Review (Planned)
 
 AI-assisted product review.

--- a/rac/artifacts.py
+++ b/rac/artifacts.py
@@ -68,23 +68,11 @@ class ArtifactSpec:
 # extracted, but never scored, never templated, never reported as missing
 # (REQ-002). v0.7.0 treats them as metadata only — RAC extracts and counts the
 # references but does not resolve, validate, or graph them.
-
-# The cross-artifact "Related X" sections. These populate the ``relationships``
-# dict in ``rac inspect`` output. ``related designs`` is included so every peer
-# artifact type can be referenced.
-RELATED_SECTIONS: tuple[str, ...] = (
-    "related requirements",
-    "related decisions",
-    "related roadmaps",
-    "related prompts",
-    "related designs",
-)
-
-# The full relationship-section vocabulary, including ``supersedes``. ``stats``
-# counts presence across all of these. ``supersedes`` is the one exception that
-# does *not* appear in the inspect ``relationships`` dict: it remains a top-level
-# scalar field for backwards compatibility (see rac.inspect / ADR-007).
-RELATIONSHIP_SECTIONS: tuple[str, ...] = RELATED_SECTIONS + ("supersedes",)
+#
+# The relationship-section vocabulary and its canonical ordering live in
+# :mod:`rac.relationships` (the module that owns relationship logic). This module
+# only owns the human-facing ``descriptions`` for those sections, which the specs
+# below consume.
 
 # One-line descriptions for every relationship section, surfaced by `rac schema`.
 # Relationship sections deliberately carry no ``guidance`` — guidance gates

--- a/rac/cli.py
+++ b/rac/cli.py
@@ -8,9 +8,11 @@ Commands:
     rac inspect <file.md | -> [--json]
     rac improve <file.md | -> [--json | --template]
     rac schema [--list] [type] [--json | --template]
+    rac relationships <dir | file.md> [--json] [--top-level]
 
 Exit codes:
-    0  success (incl. inspect/improve reporting Unknown)
+    0  success (incl. inspect/improve reporting Unknown; relationships found or
+       not)
     1  validate: errors found; stats: no valid known artifacts; ingest:
        conversion failed
     2  usage / IO error (file not found, not a directory, unsupported type,
@@ -31,6 +33,10 @@ from .classification import score_artifacts
 from .improve import improve_product
 from .inspect import build_inspection, inspect_directory
 from .parser import parse, parse_file
+from .relationships import (
+    build_relationship_report,
+    build_relationship_report_file,
+)
 from .schema import available_schemas, schema_reference
 from .stats import collect_stats
 from .validate import has_errors, validate
@@ -236,6 +242,34 @@ def cmd_schema(args: argparse.Namespace) -> int:
     return EXIT_OK
 
 
+def cmd_relationships(args: argparse.Namespace) -> int:
+    path = Path(args.path)
+    if path.is_dir():
+        # --recursive is the default; --top-level disables it. If both are given,
+        # --top-level wins (mirrors `rac inspect`).
+        report = build_relationship_report(args.path, recursive=not args.top_level)
+    elif path.is_file():
+        if path.suffix.lower() not in (".md", ".markdown"):
+            print(
+                f"rac: relationships expects a Markdown file or directory; "
+                f"convert it first with: rac ingest {args.path}",
+                file=sys.stderr,
+            )
+            raise SystemExit(EXIT_USAGE)
+        report = build_relationship_report_file(args.path)
+    else:
+        print(f"rac: path not found: {args.path}", file=sys.stderr)
+        raise SystemExit(EXIT_USAGE)
+
+    if args.json:
+        print(outputs.render_relationships_json(report))
+    else:
+        print(outputs.render_relationships_human(report))
+    # A completed inspection always succeeds — finding no relationships is a valid
+    # outcome, not an error (REQ-010).
+    return EXIT_OK
+
+
 def build_parser() -> argparse.ArgumentParser:
     version_str = f"rac {__version__}"
 
@@ -386,6 +420,29 @@ def build_parser() -> argparse.ArgumentParser:
         help="Emit a full Markdown starter template.",
     )
     p_schema.set_defaults(func=cmd_schema)
+
+    p_relationships = sub.add_parser(
+        "relationships",
+        help="Inspect explicit relationships across a directory (or single file).",
+        parents=[version_parent],
+    )
+    p_relationships.add_argument(
+        "path", help="A directory to scan, or a single Markdown file."
+    )
+    p_relationships.add_argument(
+        "--json", action="store_true", help="Emit JSON instead of human-readable text."
+    )
+    p_relationships.add_argument(
+        "--top-level",
+        action="store_true",
+        help="When inspecting a directory, only its top-level files (no recursion).",
+    )
+    p_relationships.add_argument(
+        "--recursive",
+        action="store_true",
+        help="Recurse into subdirectories (the default; accepted for clarity).",
+    )
+    p_relationships.set_defaults(func=cmd_relationships)
 
     return parser
 

--- a/rac/outputs.py
+++ b/rac/outputs.py
@@ -16,6 +16,7 @@ from .improve import ImprovementResult
 from .ingest import IngestResult
 from .inspect import DirectoryInspection, InspectionResult
 from .models import Diff, Issue, Product
+from .relationships import RelationshipReport
 from .schema import SchemaReference, template_sections
 from .stats import PortfolioStats
 
@@ -621,6 +622,61 @@ def render_schema_template(ref: SchemaReference) -> str:
             block += "\n\n" + "\n".join(f"<!-- {comment} -->" for comment in comments)
         blocks.append(block)
     return "\n\n".join(blocks) + "\n"
+
+
+# --- relationships -----------------------------------------------------------
+
+
+def _relationship_label(snake_section: str) -> str:
+    """``related_decisions`` -> ``Related Decisions``; ``supersedes`` -> ``Supersedes``."""
+    return snake_section.replace("_", " ").title()
+
+
+def render_relationships_human(report: RelationshipReport) -> str:
+    lines = [
+        _bold("Relationships"),
+        "",
+        f"Files Inspected: {report.total_files}",
+        f"Artifacts With Relationships: {report.artifacts_with_relationships}",
+        f"Relationships Found: {report.relationship_count}",
+    ]
+
+    counts = report.counts
+    if counts:
+        lines += ["", _bold("By Type:")]
+        lines.extend(
+            f"- {_relationship_label(section)}: {count}"
+            for section, count in counts.items()
+        )
+
+    # Per-artifact detail (REQ-005), only for artifacts that declare relationships.
+    for artifact in report.artifacts:
+        lines += ["", artifact.path]
+        for section, refs in artifact.relationships.items():
+            lines.append(f"  {_relationship_label(section)}:")
+            lines.extend(f"  - {ref}" for ref in refs)
+
+    return "\n".join(lines)
+
+
+def render_relationships_json(report: RelationshipReport) -> str:
+    payload = {
+        "directory": report.directory,
+        "recursive": report.recursive,
+        "total_files": report.total_files,
+        "artifacts_with_relationships": report.artifacts_with_relationships,
+        "relationship_count": report.relationship_count,
+        "counts": report.counts,
+        "artifacts": [
+            {
+                "path": artifact.path,
+                "type": artifact.type,
+                "relationships": artifact.relationships,
+            }
+            for artifact in report.artifacts
+        ],
+    }
+    return json.dumps(payload, indent=2)
 
 
 # --- ingest ------------------------------------------------------------------

--- a/rac/relationships.py
+++ b/rac/relationships.py
@@ -17,9 +17,31 @@ recognized exactly where its schema allows it.
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass, field
 
-from .artifacts import RELATED_SECTIONS, RELATIONSHIP_SECTIONS, ArtifactSpec
+from .artifacts import ArtifactSpec, spec_for
+from .classification import classify
+from .fs import find_markdown_files
 from .models import Product
+from .parser import parse_file
+
+# The cross-artifact "Related X" sections. These populate the ``relationships``
+# dict in ``rac inspect`` output. ``related designs`` is included so every peer
+# artifact type can be referenced.
+RELATED_SECTIONS: tuple[str, ...] = (
+    "related requirements",
+    "related decisions",
+    "related roadmaps",
+    "related prompts",
+    "related designs",
+)
+
+# The full relationship-section vocabulary and its canonical ordering, including
+# ``supersedes``. This module owns the ordering; ``stats`` and the
+# ``relationships`` command both render by-type output in this order. ``supersedes``
+# is the one section that does *not* appear in the inspect ``relationships`` dict:
+# there it stays a top-level scalar for backwards compatibility (ADR-007).
+RELATIONSHIP_SECTIONS: tuple[str, ...] = RELATED_SECTIONS + ("supersedes",)
 
 # A *well-formed* leading Markdown list marker: ``-``, ``*``, ``+``, or ``N.``
 # followed by whitespace. Only these are stripped; any other leading text is
@@ -48,16 +70,18 @@ def parse_references(body: str) -> list[str]:
     return references
 
 
-def extract_relationships(product: Product, spec: ArtifactSpec) -> dict[str, list[str]]:
-    """Cross-artifact references declared by ``product`` under ``spec``.
+def _collect(
+    product: Product, spec: ArtifactSpec, allowed: tuple[str, ...]
+) -> dict[str, list[str]]:
+    """References for the relationship sections in ``spec.optional`` ∩ ``allowed``.
 
-    Returns ``{snake_section -> [references]}`` in ``spec.optional`` order,
-    including only sections present with at least one parsed reference. Excludes
-    ``supersedes`` — that stays a top-level scalar in inspect output (ADR-007).
+    Returns ``{snake_section -> [references]}`` in ``spec.optional`` order (each
+    artifact's own schema order), including only sections present with at least
+    one parsed reference. The single core behind the two public extractors.
     """
     relationships: dict[str, list[str]] = {}
     for section in spec.optional:
-        if section not in RELATED_SECTIONS:
+        if section not in allowed:
             continue
         body = product.sections.get(section)
         if not body:
@@ -66,6 +90,27 @@ def extract_relationships(product: Product, spec: ArtifactSpec) -> dict[str, lis
         if refs:
             relationships[_snake(section)] = refs
     return relationships
+
+
+def extract_relationships(product: Product, spec: ArtifactSpec) -> dict[str, list[str]]:
+    """Cross-artifact references for ``rac inspect``.
+
+    Excludes ``supersedes`` — that stays a top-level scalar in inspect output
+    (ADR-007). Order follows ``spec.optional`` (the artifact's own schema order).
+    """
+    return _collect(product, spec, RELATED_SECTIONS)
+
+
+def extract_relationships_full(
+    product: Product, spec: ArtifactSpec
+) -> dict[str, list[str]]:
+    """Cross-artifact references for ``rac relationships`` — *including* Supersedes.
+
+    The repository-level relationship command treats Supersedes as a first-class
+    relationship (REQ-003), so it is reported here alongside the ``related_*``
+    sections. Order follows ``spec.optional``.
+    """
+    return _collect(product, spec, RELATIONSHIP_SECTIONS)
 
 
 def present_relationship_sections(product: Product, spec: ArtifactSpec) -> list[str]:
@@ -84,3 +129,113 @@ def present_relationship_sections(product: Product, spec: ArtifactSpec) -> list[
         if body and parse_references(body):
             present.append(section)
     return present
+
+
+# --- Repository-level relationship inspection (v0.7.1) -----------------------
+#
+# `rac relationships <path>` discovers the explicit relationships declared across
+# a tree of artifacts (ADR-015: repository intelligence in Core, exposed via CLI +
+# JSON for future consumers). It is read-only and deterministic: it reports the
+# references that exist, but never resolves, validates, or graphs them.
+
+
+@dataclass
+class ArtifactRelationships:
+    """One artifact's relationships in a repository report.
+
+    ``relationships`` includes Supersedes (unlike ``rac inspect``) and is keyed by
+    snake_case section name in the artifact's own ``spec.optional`` order.
+    """
+
+    path: str
+    type: str
+    relationships: dict[str, list[str]]
+
+
+@dataclass
+class RelationshipReport:
+    """Repository-level relationship inspection result (ADR-003).
+
+    ``total_files`` counts every Markdown file considered — including files with
+    no relationships and Unknown artifacts. ``artifacts`` lists only those with at
+    least one relationship. Counts are *reference* counts (each declared target is
+    one relationship), aggregated by type in the canonical
+    :data:`RELATIONSHIP_SECTIONS` order.
+    """
+
+    directory: str
+    recursive: bool
+    total_files: int
+    artifacts: list[ArtifactRelationships] = field(default_factory=list)
+
+    @property
+    def artifacts_with_relationships(self) -> int:
+        return len(self.artifacts)
+
+    @property
+    def counts(self) -> dict[str, int]:
+        """References per relationship type, canonical order, zero types omitted."""
+        totals: dict[str, int] = {}
+        for artifact in self.artifacts:
+            for section, refs in artifact.relationships.items():
+                totals[section] = totals.get(section, 0) + len(refs)
+        return {
+            _snake(section): totals[_snake(section)]
+            for section in RELATIONSHIP_SECTIONS
+            if _snake(section) in totals
+        }
+
+    @property
+    def relationship_count(self) -> int:
+        """Total references found across all artifacts (sum of ``counts``)."""
+        return sum(self.counts.values())
+
+
+def _artifact_relationships(path: str) -> tuple[str, dict[str, list[str]]]:
+    """Classify the file at ``path`` and extract its full relationships.
+
+    Returns ``(type, relationships)``. Unknown artifacts (no spec) yield an empty
+    relationship dict — extraction stays spec-driven (REQ-007), no generic scan.
+    """
+    product = parse_file(path)
+    artifact_type = classify(product).type
+    spec = spec_for(artifact_type)
+    relationships = extract_relationships_full(product, spec) if spec else {}
+    return artifact_type, relationships
+
+
+def _build_report(
+    directory: str, paths: list, recursive: bool
+) -> RelationshipReport:
+    """Assemble a :class:`RelationshipReport` from ``paths`` (already ordered)."""
+    artifacts: list[ArtifactRelationships] = []
+    for path in paths:
+        artifact_type, relationships = _artifact_relationships(str(path))
+        if relationships:
+            artifacts.append(
+                ArtifactRelationships(
+                    path=str(path), type=artifact_type, relationships=relationships
+                )
+            )
+    return RelationshipReport(
+        directory=directory,
+        recursive=recursive,
+        total_files=len(paths),
+        artifacts=artifacts,
+    )
+
+
+def build_relationship_report(
+    directory: str, recursive: bool = True
+) -> RelationshipReport:
+    """Inspect explicit relationships across a directory of Markdown files."""
+    paths = find_markdown_files(directory, recursive=recursive)
+    return _build_report(directory, paths, recursive)
+
+
+def build_relationship_report_file(path: str) -> RelationshipReport:
+    """Inspect relationships in a single file (REQ-009).
+
+    Same model as a directory report, with one file and ``recursive=False``.
+    """
+    return _build_report(path, [path], recursive=False)

--- a/rac/stats.py
+++ b/rac/stats.py
@@ -19,11 +19,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
-from .artifacts import RELATIONSHIP_SECTIONS, spec_for
+from .artifacts import spec_for
 from .fs import find_markdown_files
 from .inspect import build_inspection
 from .parser import parse_file
-from .relationships import present_relationship_sections
+from .relationships import RELATIONSHIP_SECTIONS, present_relationship_sections
 from .validate import validate
 
 

--- a/tests/fixtures/no_relationships/decision.md
+++ b/tests/fixtures/no_relationships/decision.md
@@ -1,0 +1,22 @@
+# ADR-031 Search Index Engine
+
+## Status
+
+Accepted
+
+## Category
+
+Architecture
+
+## Context
+
+Search needs a dedicated index to meet latency targets.
+
+## Decision
+
+Adopt an embedded inverted-index engine maintained alongside the primary store.
+
+## Consequences
+
+- Search latency improves substantially.
+- The index must be kept in sync on writes.

--- a/tests/fixtures/no_relationships/requirement.md
+++ b/tests/fixtures/no_relationships/requirement.md
@@ -1,0 +1,17 @@
+# Search Latency
+
+## Problem
+
+Search results take too long to return for large workspaces.
+
+## Requirements
+
+- [REQ-001] User receives search results within 500ms for workspaces under 10k items.
+
+## Success Metrics
+
+- 95th-percentile search latency stays under 500ms.
+
+## Risks
+
+- Index rebuilds may temporarily degrade latency.

--- a/tests/test_relationships_cmd.py
+++ b/tests/test_relationships_cmd.py
@@ -1,0 +1,233 @@
+"""Tests for the v0.7.1 `rac relationships` command.
+
+Repository-level relationship inspection (ADR-015): discovers the explicit
+relationships declared across artifacts, counts individual references, and emits
+deterministic human + JSON output. Read-only; no resolution, validation,
+graphing, or inference (those are v0.7.2+).
+
+Reuses the shared `fixtures/relationships/` artifacts and a dedicated
+`fixtures/no_relationships/` directory for the empty-repository case.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from rac.cli import main
+from rac.relationships import (
+    build_relationship_report,
+    build_relationship_report_file,
+)
+
+from conftest import fixture_path
+
+# Reference counts (individual edges) over fixtures/relationships/, canonical order.
+EXPECTED_COUNTS = {
+    "related_requirements": 5,
+    "related_decisions": 5,
+    "related_roadmaps": 4,
+    "related_prompts": 3,
+    "related_designs": 4,
+    "supersedes": 1,
+}
+
+
+# --- service layer -----------------------------------------------------------
+
+
+def test_build_report_counts_individual_references():
+    report = build_relationship_report(fixture_path("relationships"))
+    assert report.total_files == 5
+    assert report.artifacts_with_relationships == 5
+    assert report.counts == EXPECTED_COUNTS
+    assert report.relationship_count == 22
+    assert report.relationship_count == sum(report.counts.values())
+
+
+def test_build_report_file_single_artifact():
+    path = fixture_path("relationships", "decision_with_links.md")
+    report = build_relationship_report_file(path)
+    assert report.total_files == 1
+    assert report.recursive is False
+    assert report.directory == path
+    assert len(report.artifacts) == 1
+    assert report.artifacts[0].type == "decision"
+
+
+# --- human output (REQ-004 / REQ-005) ---------------------------------------
+
+
+def test_human_summary(capsys):
+    rc = main(["relationships", fixture_path("relationships")])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Relationships" in out
+    assert "Files Inspected: 5" in out
+    assert "Artifacts With Relationships: 5" in out
+    assert "Relationships Found: 22" in out
+    assert "By Type:" in out
+    assert "- Related Decisions: 5" in out
+    assert "- Supersedes: 1" in out
+
+
+def test_human_per_artifact_detail(capsys):
+    rc = main(["relationships", fixture_path("relationships")])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "requirement_with_links.md" in out
+    assert "  Related Decisions:" in out
+    assert "  - ADR-004" in out
+    # Supersedes renders as a relationship in this command (unlike inspect).
+    assert "  Supersedes:" in out
+    assert "  - ADR-011" in out
+
+
+# --- JSON output (REQ-006) ---------------------------------------------------
+
+
+def test_json_field_order_and_values(capsys):
+    rc = main(["relationships", fixture_path("relationships"), "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert list(payload) == [
+        "directory",
+        "recursive",
+        "total_files",
+        "artifacts_with_relationships",
+        "relationship_count",
+        "counts",
+        "artifacts",
+    ]
+    assert payload["recursive"] is True
+    assert payload["total_files"] == 5
+    assert payload["artifacts_with_relationships"] == 5
+    assert payload["relationship_count"] == 22
+    assert payload["counts"] == EXPECTED_COUNTS
+    assert payload["relationship_count"] == sum(payload["counts"].values())
+    assert len(payload["artifacts"]) == 5
+
+
+def test_json_per_artifact_entries(capsys):
+    rc = main(["relationships", fixture_path("relationships"), "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    for entry in payload["artifacts"]:
+        assert set(entry) == {"path", "type", "relationships"}
+    decision = next(e for e in payload["artifacts"] if e["type"] == "decision")
+    assert decision["relationships"]["supersedes"] == ["ADR-011"]
+    requirement = next(e for e in payload["artifacts"] if e["type"] == "requirement")
+    assert requirement["relationships"]["related_decisions"] == ["ADR-004", "ADR-012"]
+
+
+# --- traversal flags (REQ-002, review item 5) -------------------------------
+
+
+def test_top_level_sets_recursive_false(capsys):
+    rc = main(["relationships", fixture_path("relationships"), "--top-level", "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["recursive"] is False
+    assert payload["total_files"] == 5  # the fixtures dir is flat
+
+
+def test_both_flags_top_level_wins(capsys):
+    rc = main(
+        ["relationships", fixture_path("relationships"), "--top-level", "--recursive", "--json"]
+    )
+    assert rc == 0
+    assert json.loads(capsys.readouterr().out)["recursive"] is False
+
+
+# --- single file (REQ-009) ---------------------------------------------------
+
+
+def test_cli_single_file(capsys):
+    path = fixture_path("relationships", "decision_with_links.md")
+    rc = main(["relationships", path, "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["total_files"] == 1
+    assert payload["recursive"] is False
+    assert payload["directory"] == path
+    assert len(payload["artifacts"]) == 1
+    assert "supersedes" in payload["artifacts"][0]["relationships"]
+
+
+# --- empty repository (REQ-008) ---------------------------------------------
+
+
+def test_empty_repo_human(capsys):
+    rc = main(["relationships", fixture_path("no_relationships")])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Files Inspected: 2" in out
+    assert "Artifacts With Relationships: 0" in out
+    assert "Relationships Found: 0" in out
+    assert "By Type:" not in out
+
+
+def test_empty_repo_json(capsys):
+    rc = main(["relationships", fixture_path("no_relationships"), "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["total_files"] == 2
+    assert payload["artifacts_with_relationships"] == 0
+    assert payload["relationship_count"] == 0
+    assert payload["counts"] == {}
+    assert payload["artifacts"] == []
+
+
+# --- unknown artifacts (REQ-007) --------------------------------------------
+
+
+def test_unknown_artifact_counted_but_not_extracted(tmp_path):
+    # An Unknown document (no schema) that nonetheless has a relationship heading.
+    f = tmp_path / "notes.md"
+    f.write_text("# Notes\n\n## Random Musings\n\nstuff\n\n## Related Decisions\n\n- ADR-004\n")
+    report = build_relationship_report(str(tmp_path))
+    assert report.total_files == 1            # counted
+    assert report.artifacts_with_relationships == 0  # spec-driven: nothing extracted
+    assert report.relationship_count == 0
+    assert report.artifacts == []
+
+
+def test_unknown_repo_exits_zero(tmp_path, capsys):
+    (tmp_path / "notes.md").write_text("# Notes\n\nfree text with no sections\n")
+    rc = main(["relationships", str(tmp_path)])
+    assert rc == 0
+    assert "Artifacts With Relationships: 0" in capsys.readouterr().out
+
+
+# --- exit codes (REQ-010) ----------------------------------------------------
+
+
+def test_missing_path_exits_two():
+    with pytest.raises(SystemExit) as exc:
+        main(["relationships", "does-not-exist-xyz"])
+    assert exc.value.code == 2
+
+
+def test_non_markdown_file_exits_two(tmp_path):
+    f = tmp_path / "data.txt"
+    f.write_text("not markdown")
+    with pytest.raises(SystemExit) as exc:
+        main(["relationships", str(f)])
+    assert exc.value.code == 2
+
+
+# --- read-only invariant (review item 6) ------------------------------------
+
+
+def test_command_is_read_only(tmp_path):
+    src = tmp_path / "requirement.md"
+    content = (
+        "# R\n\n## Problem\n\np\n\n## Requirements\n\n- [REQ-001] User can search.\n\n"
+        "## Related Decisions\n\n- ADR-004\n"
+    )
+    src.write_text(content)
+    before_mtime = src.stat().st_mtime_ns
+    main(["relationships", str(tmp_path), "--json"])
+    assert src.read_text() == content
+    assert src.stat().st_mtime_ns == before_mtime


### PR DESCRIPTION
Introduce `rac relationships <dir|file.md>` — a deterministic, read-only, repository-level view of the explicit relationships declared across artifacts (v0.7.0 metadata). It reports a summary, per-artifact entries, and JSON, counting individual references. It does not resolve, validate, graph, or infer relationships (deferred to v0.7.2+).

Repository intelligence lives in RAC Core and is exposed via CLI + JSON for future consumers like Explorer (ADR-015: JSON before UI).

- relationships.py: now owns the relationship vocabulary/ordering constants (RELATED_SECTIONS / RELATIONSHIP_SECTIONS moved here from artifacts.py, which never used them internally). Refactor extract_relationships onto a shared _collect core; add extract_relationships_full (includes Supersedes). Add ArtifactRelationships / RelationshipReport result types and the build_relationship_report[_file] entry points.
- cli.py: add the `relationships` command and subparser. Recursive by default; --top-level disables recursion (wins if both passed), mirroring `rac inspect`. Exit 0 on any completed run; 2 for a missing path or non-Markdown file.
- outputs.py: render_relationships_human (summary + per-artifact, empty-safe) and render_relationships_json (REQ-006 field order).
- stats.py: import RELATIONSHIP_SECTIONS from its new home.

Design notes:
- Counts are individual references; relationship_count == sum(counts.values()).
- total_files counts every Markdown file considered, including files without relationships and Unknown artifacts.
- Extraction is spec-driven: Unknown artifacts are counted but contribute no relationships and never appear in artifacts[]; no generic Markdown scanning.
- Supersedes is treated as a relationship in this command (it stays a top-level scalar in `rac inspect` for backwards compatibility).
- Per-artifact dict order follows each artifact's spec.optional (so inspect is unchanged); aggregate by-type order is the canonical RELATIONSHIP_SECTIONS.

Tests: new tests/test_relationships_cmd.py covering REQ-004..010 (human, JSON, traversal flags, single file, empty repo, Unknown handling, exit codes, read-only invariant) plus a dedicated tests/fixtures/no_relationships/ directory. Existing inspect/stats/validate behavior is unchanged (321 passing). README documents the new command.