### PR TITLE
Add relationship validation: rac relationships --validate (v0.7.2)

### DIFF
--- a/rac/artifacts.py
+++ b/rac/artifacts.py
@@ -50,6 +50,12 @@ class ArtifactSpec:
     # matching, so synonyms contribute to confidence. Matching is deterministic
     # (dict lookup) and case-insensitive (headings are normalized first).
     synonyms: dict[str, str] = field(default_factory=dict)
+    # Canonical-identifier section (v0.7.2 relationship validation): the normalized
+    # section name whose value is this artifact type's identifier, consulted by
+    # ``rac.relationships.artifact_identifier`` before falling back to the filename
+    # stem. A forward hook — no spec sets it today; relationship resolution works
+    # from the ``## ID`` section and filename stem until a type opts in.
+    id_field: str | None = None
 
     @property
     def expected(self) -> tuple[str, ...]:

--- a/rac/cli.py
+++ b/rac/cli.py
@@ -8,13 +8,14 @@ Commands:
     rac inspect <file.md | -> [--json]
     rac improve <file.md | -> [--json | --template]
     rac schema [--list] [type] [--json | --template]
-    rac relationships <dir | file.md> [--json] [--top-level]
+    rac relationships <dir | file.md> [--validate] [--json] [--top-level]
 
 Exit codes:
     0  success (incl. inspect/improve reporting Unknown; relationships found or
-       not)
+       not; --validate with all references resolved)
     1  validate: errors found; stats: no valid known artifacts; ingest:
-       conversion failed
+       conversion failed; relationships --validate: broken/ambiguous/self
+       references or duplicate identifiers found
     2  usage / IO error (file not found, not a directory, unsupported type,
        refuse-to-overwrite)
 """
@@ -36,6 +37,8 @@ from .parser import parse, parse_file
 from .relationships import (
     build_relationship_report,
     build_relationship_report_file,
+    validate_relationships,
+    validate_relationships_file,
 )
 from .schema import available_schemas, schema_reference
 from .stats import collect_stats
@@ -244,10 +247,10 @@ def cmd_schema(args: argparse.Namespace) -> int:
 
 def cmd_relationships(args: argparse.Namespace) -> int:
     path = Path(args.path)
+    # --recursive is the default; --top-level disables it. If both are given,
+    # --top-level wins (mirrors `rac inspect`).
     if path.is_dir():
-        # --recursive is the default; --top-level disables it. If both are given,
-        # --top-level wins (mirrors `rac inspect`).
-        report = build_relationship_report(args.path, recursive=not args.top_level)
+        is_dir = True
     elif path.is_file():
         if path.suffix.lower() not in (".md", ".markdown"):
             print(
@@ -256,11 +259,28 @@ def cmd_relationships(args: argparse.Namespace) -> int:
                 file=sys.stderr,
             )
             raise SystemExit(EXIT_USAGE)
-        report = build_relationship_report_file(args.path)
+        is_dir = False
     else:
         print(f"rac: path not found: {args.path}", file=sys.stderr)
         raise SystemExit(EXIT_USAGE)
 
+    if args.validate:
+        if is_dir:
+            report = validate_relationships(args.path, recursive=not args.top_level)
+        else:
+            report = validate_relationships_file(args.path)
+        if args.json:
+            print(outputs.render_relationship_validation_json(report))
+        else:
+            print(outputs.render_relationship_validation_human(report))
+        # Validation-style exit codes (REQ-007): 0 when everything resolves, 1 when
+        # any issue is found, 2 (above) for usage errors.
+        return EXIT_OK if report.ok else EXIT_VALIDATION_FAILED
+
+    if is_dir:
+        report = build_relationship_report(args.path, recursive=not args.top_level)
+    else:
+        report = build_relationship_report_file(args.path)
     if args.json:
         print(outputs.render_relationships_json(report))
     else:
@@ -431,6 +451,12 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p_relationships.add_argument(
         "--json", action="store_true", help="Emit JSON instead of human-readable text."
+    )
+    p_relationships.add_argument(
+        "--validate",
+        action="store_true",
+        help="Resolve references against discovered artifacts; exit 1 if any are "
+        "broken, ambiguous, self-referencing, or have duplicate identifiers.",
     )
     p_relationships.add_argument(
         "--top-level",

--- a/rac/outputs.py
+++ b/rac/outputs.py
@@ -16,7 +16,14 @@ from .improve import ImprovementResult
 from .ingest import IngestResult
 from .inspect import DirectoryInspection, InspectionResult
 from .models import Diff, Issue, Product
-from .relationships import RelationshipReport
+from .relationships import (
+    ISSUE_DUPLICATE_IDENTIFIER,
+    ISSUE_SELF_REFERENCE,
+    ISSUE_TARGET_AMBIGUOUS,
+    ISSUE_TARGET_NOT_FOUND,
+    RelationshipReport,
+    RelationshipValidation,
+)
 from .schema import SchemaReference, template_sections
 from .stats import PortfolioStats
 
@@ -675,6 +682,63 @@ def render_relationships_json(report: RelationshipReport) -> str:
             }
             for artifact in report.artifacts
         ],
+    }
+    return json.dumps(payload, indent=2)
+
+
+# --- relationship validation -------------------------------------------------
+
+# Suffix shown after a broken reference, per issue code.
+_REF_ISSUE_SUFFIX = {
+    ISSUE_TARGET_NOT_FOUND: "not found",
+    ISSUE_TARGET_AMBIGUOUS: "ambiguous",
+    ISSUE_SELF_REFERENCE: "self-reference",
+}
+
+
+def render_relationship_validation_human(report: RelationshipValidation) -> str:
+    lines = [
+        _bold("Relationship Validation"),
+        "",
+        f"Relationships Checked: {report.relationships_checked}",
+        f"Validation Issues: {report.validation_issues}",
+    ]
+
+    duplicates = [i for i in report.issues if i.code == ISSUE_DUPLICATE_IDENTIFIER]
+    references = [i for i in report.issues if i.code != ISSUE_DUPLICATE_IDENTIFIER]
+
+    if duplicates:
+        lines += ["", _bold("Duplicate Identifiers")]
+        for issue in duplicates:
+            count = len(issue.paths or [])
+            lines.append(_red(f"✗ {issue.identifier} ({count} files)"))
+            lines.extend(f"  - {p}" for p in issue.paths or [])
+
+    if references:
+        lines += ["", _bold("Broken Relationships")]
+        current_source = None
+        current_section = None
+        for issue in references:
+            if issue.source_path != current_source:
+                current_source = issue.source_path
+                current_section = None
+                lines += ["", issue.source_path or "<input>"]
+            if issue.relationship != current_section:
+                current_section = issue.relationship
+                lines.append(f"  {_relationship_label(issue.relationship or '')}:")
+            suffix = _REF_ISSUE_SUFFIX.get(issue.code, issue.code)
+            lines.append(_red(f"  ✗ {issue.target} {suffix}"))
+
+    return "\n".join(lines)
+
+
+def render_relationship_validation_json(report: RelationshipValidation) -> str:
+    payload = {
+        "directory": report.directory,
+        "recursive": report.recursive,
+        "relationships_checked": report.relationships_checked,
+        "validation_issues": report.validation_issues,
+        "issues": [issue.to_dict() for issue in report.issues],
     }
     return json.dumps(payload, indent=2)
 

--- a/rac/relationships.py
+++ b/rac/relationships.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass, field
+from pathlib import Path
 
 from .artifacts import ArtifactSpec, spec_for
 from .classification import classify
@@ -239,3 +240,201 @@ def build_relationship_report_file(path: str) -> RelationshipReport:
     Same model as a directory report, with one file and ``recursive=False``.
     """
     return _build_report(path, [path], recursive=False)
+
+
+# --- Relationship validation (v0.7.2) ----------------------------------------
+#
+# `rac relationships <path> --validate` resolves every explicit reference against
+# the identifiers of artifacts discovered in the repository, reporting missing,
+# ambiguous, and self-referencing targets plus duplicate identifiers. Read-only
+# and deterministic; no resolution heuristics, inference, or graphs (ADR-016).
+
+# A recognized leading ID prefix in a filename stem: <letters>-<digits>, e.g.
+# "adr-004" from "adr-004-parser-strategy". Case-insensitive at comparison time.
+_ID_PREFIX_RE = re.compile(r"^[A-Za-z]+-\d+")
+
+# The universal explicit-identifier section (normalized heading).
+_ID_SECTION = "id"
+
+# Stable issue codes (part of the JSON contract).
+ISSUE_DUPLICATE_IDENTIFIER = "duplicate-artifact-identifier"
+ISSUE_TARGET_NOT_FOUND = "relationship-target-not-found"
+ISSUE_TARGET_AMBIGUOUS = "relationship-target-ambiguous"
+ISSUE_SELF_REFERENCE = "relationship-self-reference"
+
+
+def _first_value(body: str | None) -> str:
+    """First non-empty line of a section body, leading list marker stripped."""
+    if not body:
+        return ""
+    for line in body.splitlines():
+        stripped = line.strip()
+        if stripped:
+            return _LIST_MARKER_RE.sub("", stripped, count=1).strip()
+    return ""
+
+
+def artifact_identifier(
+    product: Product, spec: ArtifactSpec | None, path: str
+) -> str:
+    """The deterministic identifier for the artifact at ``path`` (v0.7.2).
+
+    Precedence (first match wins); the discovered casing is preserved:
+
+    1. an explicit ``## ID`` section value;
+    2. the artifact type's declared ``spec.id_field`` section value;
+    3. a recognized ``<letters>-<digits>`` prefix of the filename stem
+       (e.g. ``adr-004`` from ``adr-004-parser-strategy.md``);
+    4. the whole filename stem.
+
+    The document title is never used, and inline ``[REQ-NNN]`` requirement lines
+    are not identifiers — relationship targets are whole artifact files.
+    """
+    explicit = _first_value(product.sections.get(_ID_SECTION))
+    if explicit:
+        return explicit
+    if spec is not None and spec.id_field:
+        declared = _first_value(product.sections.get(spec.id_field))
+        if declared:
+            return declared
+    stem = Path(path).stem
+    prefix = _ID_PREFIX_RE.match(stem)
+    return prefix.group(0) if prefix else stem
+
+
+@dataclass
+class RelationshipIssue:
+    """One relationship-validation finding (ADR-003).
+
+    ``to_dict`` emits only the keys relevant to ``code``: duplicate-identifier
+    issues carry ``identifier``/``paths``; reference issues carry
+    ``source_path``/``relationship``/``target``.
+    """
+
+    code: str
+    source_path: str | None = None
+    relationship: str | None = None
+    target: str | None = None
+    identifier: str | None = None
+    paths: list[str] | None = None
+
+    def to_dict(self) -> dict:
+        if self.code == ISSUE_DUPLICATE_IDENTIFIER:
+            return {
+                "identifier": self.identifier,
+                "paths": self.paths,
+                "code": self.code,
+            }
+        return {
+            "source_path": self.source_path,
+            "relationship": self.relationship,
+            "target": self.target,
+            "code": self.code,
+        }
+
+
+@dataclass
+class RelationshipValidation:
+    """Repository-level relationship validation result (REQ-006).
+
+    ``relationships_checked`` counts every reference examined. ``validation_issues``
+    counts *all* findings — missing/ambiguous/self references and duplicate
+    identifiers — because each makes the declared relationship metadata unreliable.
+    """
+
+    directory: str
+    recursive: bool
+    relationships_checked: int
+    issues: list[RelationshipIssue] = field(default_factory=list)
+
+    @property
+    def validation_issues(self) -> int:
+        return len(self.issues)
+
+    @property
+    def ok(self) -> bool:
+        return not self.issues
+
+
+def _parsed_items(paths: list) -> list[tuple[str, Product, ArtifactSpec | None]]:
+    """Parse and classify each path into ``(path, product, spec)``."""
+    items: list[tuple[str, Product, ArtifactSpec | None]] = []
+    for path in paths:
+        product = parse_file(str(path))
+        spec = spec_for(classify(product).type)
+        items.append((str(path), product, spec))
+    return items
+
+
+def _validate(
+    directory: str,
+    items: list[tuple[str, Product, ArtifactSpec | None]],
+    recursive: bool,
+) -> RelationshipValidation:
+    # Identifier index over *all* files (Unknown included — they can be targets).
+    index: dict[str, list[tuple[str, str]]] = {}
+    for path, product, spec in items:
+        ident = artifact_identifier(product, spec, path)
+        index.setdefault(ident.casefold(), []).append((path, ident))
+
+    issues: list[RelationshipIssue] = []
+
+    # Duplicate identifiers (repo-level), emitted first, sorted by identifier.
+    duplicates: list[tuple[str, list[str]]] = []
+    for entries in index.values():
+        if len(entries) > 1:
+            display = min(entries, key=lambda e: e[0])[1]  # first path's casing
+            duplicates.append((display, sorted(p for p, _ in entries)))
+    for display, dup_paths in sorted(duplicates, key=lambda d: d[0].casefold()):
+        issues.append(
+            RelationshipIssue(
+                code=ISSUE_DUPLICATE_IDENTIFIER, identifier=display, paths=dup_paths
+            )
+        )
+
+    # Per-reference resolution from known artifacts only (spec-driven).
+    checked = 0
+    for path, product, spec in items:
+        if spec is None:
+            continue
+        for section, refs in extract_relationships_full(product, spec).items():
+            for ref in refs:
+                checked += 1
+                targets = [p for p, _ in index.get(ref.casefold(), [])]
+                if not targets:
+                    code = ISSUE_TARGET_NOT_FOUND
+                elif len(targets) > 1:
+                    code = ISSUE_TARGET_AMBIGUOUS
+                elif targets == [path]:
+                    code = ISSUE_SELF_REFERENCE
+                else:
+                    continue  # resolved uniquely to another artifact
+                issues.append(
+                    RelationshipIssue(
+                        code=code, source_path=path, relationship=section, target=ref
+                    )
+                )
+
+    return RelationshipValidation(
+        directory=directory,
+        recursive=recursive,
+        relationships_checked=checked,
+        issues=issues,
+    )
+
+
+def validate_relationships(
+    directory: str, recursive: bool = True
+) -> RelationshipValidation:
+    """Validate explicit relationship references across a directory."""
+    items = _parsed_items(find_markdown_files(directory, recursive=recursive))
+    return _validate(directory, items, recursive)
+
+
+def validate_relationships_file(path: str) -> RelationshipValidation:
+    """Validate a single file (REQ-009).
+
+    The identifier index contains only this file, so cross-file references will not
+    resolve — repository validation needs a directory.
+    """
+    return _validate(path, _parsed_items([path]), recursive=False)

--- a/tests/fixtures/relationship_validation/ambiguous_target/adr-004-alt.md
+++ b/tests/fixtures/relationship_validation/ambiguous_target/adr-004-alt.md
@@ -1,0 +1,13 @@
+# ADR-004 Second
+
+## Context
+
+Second decision context.
+
+## Decision
+
+The second decision.
+
+## Consequences
+
+- Another consequence.

--- a/tests/fixtures/relationship_validation/ambiguous_target/adr-004.md
+++ b/tests/fixtures/relationship_validation/ambiguous_target/adr-004.md
@@ -1,0 +1,13 @@
+# ADR-004 First
+
+## Context
+
+First decision context.
+
+## Decision
+
+The first decision.
+
+## Consequences
+
+- A consequence.

--- a/tests/fixtures/relationship_validation/ambiguous_target/req-001.md
+++ b/tests/fixtures/relationship_validation/ambiguous_target/req-001.md
@@ -1,0 +1,13 @@
+# Search
+
+## Problem
+
+Users need to search the workspace quickly.
+
+## Requirements
+
+- [REQ-001] User can search the workspace.
+
+## Related Decisions
+
+- ADR-004

--- a/tests/fixtures/relationship_validation/broken/search.md
+++ b/tests/fixtures/relationship_validation/broken/search.md
@@ -1,0 +1,13 @@
+# Search
+
+## Problem
+
+Users need to search the workspace quickly.
+
+## Requirements
+
+- [REQ-001] User can search the workspace.
+
+## Related Decisions
+
+- ADR-999

--- a/tests/fixtures/relationship_validation/duplicate/adr-004-alt.md
+++ b/tests/fixtures/relationship_validation/duplicate/adr-004-alt.md
@@ -1,0 +1,13 @@
+# ADR-004 Second
+
+## Context
+
+Second decision context.
+
+## Decision
+
+The second decision.
+
+## Consequences
+
+- Another consequence.

--- a/tests/fixtures/relationship_validation/duplicate/adr-004.md
+++ b/tests/fixtures/relationship_validation/duplicate/adr-004.md
@@ -1,0 +1,13 @@
+# ADR-004 First
+
+## Context
+
+First decision context.
+
+## Decision
+
+The first decision.
+
+## Consequences
+
+- A consequence.

--- a/tests/fixtures/relationship_validation/resolved/adr-004.md
+++ b/tests/fixtures/relationship_validation/resolved/adr-004.md
@@ -1,0 +1,17 @@
+# ADR-004 Parser Strategy
+
+## Context
+
+We need a deterministic parsing approach.
+
+## Decision
+
+Use markdown-it for tokenization.
+
+## Consequences
+
+- Deterministic parsing across runs.
+
+## Related Requirements
+
+- REQ-001

--- a/tests/fixtures/relationship_validation/resolved/req-001.md
+++ b/tests/fixtures/relationship_validation/resolved/req-001.md
@@ -1,0 +1,13 @@
+# Search
+
+## Problem
+
+Users need to search the workspace quickly.
+
+## Requirements
+
+- [REQ-001] User can search the workspace.
+
+## Related Decisions
+
+- ADR-004

--- a/tests/fixtures/relationship_validation/resolved/roadmap-q3.md
+++ b/tests/fixtures/relationship_validation/resolved/roadmap-q3.md
@@ -1,0 +1,17 @@
+# Q3 Roadmap
+
+## Outcomes
+
+- Faster search across the workspace.
+
+## Initiatives
+
+- Build the search index.
+
+## Related Requirements
+
+- REQ-001
+
+## Related Decisions
+
+- ADR-004

--- a/tests/fixtures/relationship_validation/self_reference/adr-004.md
+++ b/tests/fixtures/relationship_validation/self_reference/adr-004.md
@@ -1,0 +1,17 @@
+# ADR-004 Recursive
+
+## Context
+
+A decision that mistakenly supersedes itself.
+
+## Decision
+
+Adopt the approach.
+
+## Consequences
+
+- A consequence.
+
+## Supersedes
+
+- ADR-004

--- a/tests/test_relationship_validation.py
+++ b/tests/test_relationship_validation.py
@@ -1,0 +1,265 @@
+"""Tests for v0.7.2 relationship validation (`rac relationships --validate`).
+
+Validation resolves explicit references against artifact identifiers discovered in
+the repository and reports missing targets, ambiguous targets, duplicate
+identifiers, and self-references — deterministically, read-only, with
+validation-style exit codes (0 ok / 1 issues / 2 usage). See ADR-016.
+
+Fixtures live under `fixtures/relationship_validation/<scenario>/`.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+
+import pytest
+
+from rac.artifacts import spec_for
+from rac.cli import main
+from rac.classification import classify
+from rac.parser import parse, parse_file
+from rac.relationships import (
+    ISSUE_DUPLICATE_IDENTIFIER,
+    ISSUE_SELF_REFERENCE,
+    ISSUE_TARGET_AMBIGUOUS,
+    ISSUE_TARGET_NOT_FOUND,
+    artifact_identifier,
+    validate_relationships,
+    validate_relationships_file,
+)
+
+from conftest import fixture_path
+
+
+def _scenario(name: str) -> str:
+    return fixture_path("relationship_validation", name)
+
+
+# --- identifier resolution precedence (REQ-002) -----------------------------
+
+
+def test_identifier_explicit_id_section_wins():
+    # Step 1: an explicit ## ID section overrides everything, casing preserved.
+    product = parse("# Title\n\n## ID\n\nADR-XYZ\n\n## Context\n\nc\n")
+    assert artifact_identifier(product, spec_for("decision"), "/x/adr-004-foo.md") == "ADR-XYZ"
+
+
+def test_identifier_spec_id_field():
+    # Step 2: the type's declared id_field section (no real spec sets it today).
+    product = parse("# Title\n\n## Key\n\nDEC-7\n")
+    spec = replace(spec_for("decision"), id_field="key")
+    assert artifact_identifier(product, spec, "/x/whatever.md") == "DEC-7"
+
+
+def test_identifier_recognized_prefix_from_stem():
+    # Step 3: leading <letters>-<digits> prefix of the filename stem.
+    product = parse("# Parser Strategy\n\n## Context\n\nc\n")
+    assert artifact_identifier(product, spec_for("decision"), "/x/adr-004-parser-strategy.md") == "adr-004"
+
+
+def test_identifier_falls_back_to_full_stem():
+    # Step 4: no recognized prefix -> the whole stem.
+    product = parse("# Q3 Roadmap\n\n## Outcomes\n\no\n\n## Initiatives\n\ni\n")
+    assert artifact_identifier(product, spec_for("roadmap"), "/x/roadmap-q3.md") == "roadmap-q3"
+
+
+def test_identifier_matching_is_case_insensitive():
+    # ADR-004 reference resolves to adr-004.md (resolved fixture has both).
+    report = validate_relationships(_scenario("resolved"))
+    assert report.ok  # references use ADR-004 / REQ-001 against adr-004.md / req-001.md
+
+
+# --- resolved repository (REQ-003 / REQ-005) --------------------------------
+
+
+def test_resolved_repo_passes():
+    report = validate_relationships(_scenario("resolved"))
+    assert report.relationships_checked == 4
+    assert report.validation_issues == 0
+    assert report.ok
+
+
+def test_resolved_cli_exits_zero(capsys):
+    rc = main(["relationships", _scenario("resolved"), "--validate"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Relationship Validation" in out
+    assert "Relationships Checked: 4" in out
+    assert "Validation Issues: 0" in out
+
+
+# --- broken references (REQ-004) --------------------------------------------
+
+
+def test_broken_reference_detected():
+    report = validate_relationships(_scenario("broken"))
+    assert not report.ok
+    assert report.validation_issues == 1
+    issue = report.issues[0]
+    assert issue.code == ISSUE_TARGET_NOT_FOUND
+    assert issue.target == "ADR-999"
+    assert issue.relationship == "related_decisions"
+    assert issue.source_path.endswith("search.md")
+
+
+def test_broken_cli_exits_one(capsys):
+    rc = main(["relationships", _scenario("broken"), "--validate"])
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "Broken Relationships" in out
+    assert "✗ ADR-999 not found" in out
+
+
+def test_broken_json(capsys):
+    rc = main(["relationships", _scenario("broken"), "--validate", "--json"])
+    assert rc == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert list(payload) == [
+        "directory",
+        "recursive",
+        "relationships_checked",
+        "validation_issues",
+        "issues",
+    ]
+    assert payload["relationships_checked"] == 1
+    assert payload["validation_issues"] == 1
+    issue = payload["issues"][0]
+    assert set(issue) == {"source_path", "relationship", "target", "code"}
+    assert issue["code"] == ISSUE_TARGET_NOT_FOUND
+    assert issue["target"] == "ADR-999"
+
+
+# --- duplicate identifiers (REQ-009) ----------------------------------------
+
+
+def test_duplicate_identifier_detected():
+    report = validate_relationships(_scenario("duplicate"))
+    assert not report.ok
+    assert report.validation_issues == 1
+    issue = report.issues[0]
+    assert issue.code == ISSUE_DUPLICATE_IDENTIFIER
+    # Identifier derives from the filename stem (the title is never used), so the
+    # discovered casing here is the lowercase stem.
+    assert issue.identifier == "adr-004"
+    assert len(issue.paths) == 2
+    assert issue.paths == sorted(issue.paths)  # deterministic ordering
+
+
+def test_duplicate_json_shape(capsys):
+    rc = main(["relationships", _scenario("duplicate"), "--validate", "--json"])
+    assert rc == 1
+    payload = json.loads(capsys.readouterr().out)
+    issue = payload["issues"][0]
+    assert set(issue) == {"identifier", "paths", "code"}
+    assert issue["code"] == ISSUE_DUPLICATE_IDENTIFIER
+
+
+# --- ambiguous target: duplicate + per-reference ambiguity (item 4 / item 8) --
+
+
+def test_ambiguous_target_emits_both_issues():
+    report = validate_relationships(_scenario("ambiguous_target"))
+    assert not report.ok
+    codes = [i.code for i in report.issues]
+    # Duplicate (repo-level) is emitted first, then the per-reference ambiguity.
+    assert codes == [ISSUE_DUPLICATE_IDENTIFIER, ISSUE_TARGET_AMBIGUOUS]
+    ambiguous = report.issues[1]
+    assert ambiguous.target == "ADR-004"
+    assert ambiguous.source_path.endswith("req-001.md")
+
+
+def test_ambiguous_cli_exits_one(capsys):
+    rc = main(["relationships", _scenario("ambiguous_target"), "--validate"])
+    assert rc == 1
+    assert "✗ ADR-004 ambiguous" in capsys.readouterr().out
+
+
+# --- self reference (REQ-010) -----------------------------------------------
+
+
+def test_self_reference_detected():
+    report = validate_relationships(_scenario("self_reference"))
+    assert not report.ok
+    assert report.validation_issues == 1
+    issue = report.issues[0]
+    assert issue.code == ISSUE_SELF_REFERENCE
+    assert issue.target == "ADR-004"
+    assert issue.relationship == "supersedes"
+
+
+def test_self_reference_cli_exits_one(capsys):
+    rc = main(["relationships", _scenario("self_reference"), "--validate"])
+    assert rc == 1
+    assert "✗ ADR-004 self-reference" in capsys.readouterr().out
+
+
+# --- unknown artifacts (REQ-008) --------------------------------------------
+
+
+def test_unknown_artifact_is_a_valid_target_but_emits_no_references(tmp_path):
+    # An Unknown file whose stem yields an id (legacy-api) satisfies an incoming
+    # reference, yet contributes no outgoing relationships of its own.
+    (tmp_path / "legacy-api.md").write_text("# Legacy API\n\nFree text, no sections.\n")
+    (tmp_path / "req-001.md").write_text(
+        "# Search\n\n## Problem\n\np\n\n## Requirements\n\n- [REQ-001] User can search.\n\n"
+        "## Related Designs\n\n- legacy-api\n"
+    )
+    # Sanity: legacy-api.md is Unknown.
+    assert classify(parse_file(str(tmp_path / "legacy-api.md"))).type == "unknown"
+    report = validate_relationships(str(tmp_path))
+    assert report.relationships_checked == 1  # only req-001 declares a reference
+    assert report.ok  # the reference resolves to the Unknown file
+
+
+# --- single-file validation (REQ-009 / item 6) ------------------------------
+
+
+def test_single_file_index_is_just_that_file():
+    # req-001.md references ADR-004, which is not in a single-file index -> broken.
+    report = validate_relationships_file(_scenario("resolved") + "/req-001.md")
+    assert report.recursive is False
+    assert report.relationships_checked == 1
+    assert report.issues[0].code == ISSUE_TARGET_NOT_FOUND
+
+
+# --- exit codes (REQ-007) ---------------------------------------------------
+
+
+def test_missing_path_exits_two():
+    with pytest.raises(SystemExit) as exc:
+        main(["relationships", "does-not-exist-xyz", "--validate"])
+    assert exc.value.code == 2
+
+
+def test_non_markdown_file_exits_two(tmp_path):
+    f = tmp_path / "data.txt"
+    f.write_text("not markdown")
+    with pytest.raises(SystemExit) as exc:
+        main(["relationships", str(f), "--validate"])
+    assert exc.value.code == 2
+
+
+# --- read-only + non-validate unchanged -------------------------------------
+
+
+def test_validate_is_read_only(tmp_path):
+    src = tmp_path / "req-001.md"
+    content = (
+        "# Search\n\n## Problem\n\np\n\n## Requirements\n\n- [REQ-001] User can search.\n\n"
+        "## Related Decisions\n\n- ADR-004\n"
+    )
+    src.write_text(content)
+    before = src.stat().st_mtime_ns
+    main(["relationships", str(tmp_path), "--validate", "--json"])
+    assert src.read_text() == content
+    assert src.stat().st_mtime_ns == before
+
+
+def test_non_validate_inspection_still_works(capsys):
+    # Without --validate the command is the v0.7.1 inspection (exit 0 regardless).
+    rc = main(["relationships", _scenario("broken")])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Files Inspected:" in out
+    assert "Validation Issues" not in out


### PR DESCRIPTION
Add a `--validate` mode to `rac relationships` that resolves every explicit reference against artifact identifiers discovered in the repository and reports the ones that don't hold up — with validation-style exit codes (0 ok / 1 issues / 2 usage). Read-only and deterministic; no inference, semantic matching, or graphs.

Identifier resolution precedence (case-insensitive; discovered casing preserved; title is never used; inline [REQ-NNN] lines are not identifiers):
  1. explicit ## ID section
  2. ArtifactSpec.id_field (new forward hook; no spec sets it yet)
  3. recognized <letters>-<digits> prefix of the filename stem (adr-004)
  4. whole filename stem (roadmap-q3)

Four issue codes: duplicate-artifact-identifier (repo-level, emitted first), relationship-target-not-found, relationship-target-ambiguous (distinct from the repo-level duplicate), relationship-self-reference. The identifier index spans all files (Unknown artifacts can be targets); references are extracted only from known artifacts (spec-driven, consistent with v0.7.1).

- artifacts.py: ArtifactSpec.id_field hook (default None).
- relationships.py: artifact_identifier resolver, RelationshipIssue / RelationshipValidation types, validate_relationships[_file].
- cli.py: --validate flag on the relationships subparser; exit 0/1/2.
- outputs.py: render_relationship_validation_{human,json} (validation_issues field; Duplicate Identifiers + Broken Relationships sections).

Notes:
- Count field is `validation_issues` (all findings), not `broken_relationships`.
- Single-file --validate limits the index to that file (documented).
- Existing relationships/inspect/stats/validate behavior unchanged.

Tests: tests/test_relationship_validation.py + five scenario fixtures (resolved, broken, duplicate, ambiguous_target, self_reference) covering REQ-001..011, identifier precedence, exit codes, Unknown targets, single-file behavior, and the read-only invariant (343 passing).