### PR TITLE
Add rac portfolio: repository intelligence summary (v0.7.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -944,14 +944,16 @@ Relationships
   Orphaned: 4
   Coverage: 71%
 
-Attention (3 items)
+Attention (4 items)
 ----------
 
-  ✗ Search Feature
+  ✗ search
       Validation errors: missing-requirements
-  ! ADR-004 Parser Strategy
+  ! adr-004
       Missing recommended sections: Alternatives Considered
-  ! REQ-041 Payment Retry
+  ! q3-roadmap
+      Related Requirements references missing artifact: REQ-999
+  ! req-041
       Missing recommended sections: Risks
 
 Health Score
@@ -991,10 +993,17 @@ content, versioned with `schema_version`):
   "attention": [
     {
       "path": "requirements/search.md",
-      "identifier": "Search Feature",
+      "identifier": "search",
       "severity": "error",
       "code": "invalid-artifact",
       "message": "Validation errors: missing-requirements"
+    },
+    {
+      "path": "roadmaps/q3-roadmap.md",
+      "identifier": "q3-roadmap",
+      "severity": "warning",
+      "code": "broken-relationship",
+      "message": "Related Requirements references missing artifact: REQ-999"
     }
   ],
   "health": { "score": 87 }
@@ -1015,6 +1024,13 @@ Notes:
 - **Advisory command.** `rac portfolio` always exits `0` when a summary is
   produced (`2` for usage errors — not a directory). For CI hard gates, use
   `rac relationships --validate` (exits `1` on broken refs).
+- **Attention severity.** `error` means the artifact is structurally invalid;
+  `warning` means it is valid but needs attention (missing recommended sections
+  or a stale relationship reference). Items are ordered errors-first, then by
+  path, then by code — deterministically.
+- **`identifier`** is the artifact's canonical identifier (the same one
+  `rac relationships --validate` resolves against): an explicit `## ID`, else a
+  recognised `TYPE-NNN` filename prefix, else the filename stem.
 - **`rac stats` vs `rac portfolio`.** `rac stats` provides per-feature
   requirement and metric breakdowns for requirement-focused portfolios.
   `rac portfolio` provides a whole-repository intelligence rollup across all

--- a/README.md
+++ b/README.md
@@ -895,6 +895,137 @@ Notes:
 
 ---
 
+## Portfolio
+
+A single-command repository intelligence summary: artifact counts, validation
+health, completeness, relationship integrity, actionable attention items, and an
+overall health score — without manually combining output from multiple commands.
+
+```bash
+rac portfolio ./docs
+rac portfolio ./docs --json
+rac portfolio ./docs --top-level   # don't recurse into subdirectories
+```
+
+```text
+Repository Summary
+==================
+
+Directory:  ./docs
+Artifacts:  42
+
+By Type
+-------
+
+  Requirement    18
+  Decision       12
+  Roadmap        5
+  Prompt         4
+  Design         2
+  Unknown        1
+
+Validation
+----------
+
+  Valid:    40
+  Invalid:  2
+
+Completeness
+------------
+
+  78% (94 / 120 recommended slots filled)
+
+Relationships
+-------------
+
+  Total:    65
+  Valid:    63
+  Broken:   2
+  Orphaned: 4
+  Coverage: 71%
+
+Attention (3 items)
+----------
+
+  ✗ Search Feature
+      Validation errors: missing-requirements
+  ! ADR-004 Parser Strategy
+      Missing recommended sections: Alternatives Considered
+  ! REQ-041 Payment Retry
+      Missing recommended sections: Risks
+
+Health Score
+------------
+
+  87 / 100
+```
+
+`--json` returns the stable machine contract (all fields present regardless of
+content, versioned with `schema_version`):
+
+```json
+{
+  "schema_version": "1",
+  "directory": "./docs",
+  "recursive": true,
+  "artifacts": {
+    "total": 42,
+    "by_type": {
+      "requirement": 18,
+      "decision": 12,
+      "roadmap": 5,
+      "prompt": 4,
+      "design": 2,
+      "unknown": 1
+    }
+  },
+  "validation": { "valid": 40, "invalid": 2 },
+  "completeness": { "recommended_slots": 120, "filled": 94, "ratio": 0.7833 },
+  "relationships": {
+    "total": 65,
+    "valid": 63,
+    "broken": 2,
+    "orphaned": 4,
+    "coverage": 0.7143
+  },
+  "attention": [
+    {
+      "path": "requirements/search.md",
+      "identifier": "Search Feature",
+      "severity": "error",
+      "code": "invalid-artifact",
+      "message": "Validation errors: missing-requirements"
+    }
+  ],
+  "health": { "score": 87 }
+}
+```
+
+**Health score formula** (deterministic, no AI):
+
+```
+score = round(100 × (0.5 × validity + 0.25 × completeness + 0.25 × rel_integrity))
+```
+
+where each sub-score is a simple ratio that defaults to `1.0` when its
+denominator is zero, so an empty repository always scores 100.
+
+Notes:
+
+- **Advisory command.** `rac portfolio` always exits `0` when a summary is
+  produced (`2` for usage errors — not a directory). For CI hard gates, use
+  `rac relationships --validate` (exits `1` on broken refs).
+- **`rac stats` vs `rac portfolio`.** `rac stats` provides per-feature
+  requirement and metric breakdowns for requirement-focused portfolios.
+  `rac portfolio` provides a whole-repository intelligence rollup across all
+  artifact types.
+- **Orphaned** means no other artifact holds a resolved inbound reference to
+  it — the artifact may still declare outbound relationships.
+- **Coverage** is the fraction of known (non-unknown) artifacts that declare
+  at least one outbound relationship section.
+
+---
+
 ## Review (Planned)
 
 AI-assisted product review.

--- a/planning/adr/adr-016-relationships-as-structural-references.md
+++ b/planning/adr/adr-016-relationships-as-structural-references.md
@@ -506,3 +506,5 @@ Review after the first v0.7.x relationship implementation, or before introducing
 * Explorer relationship visualisation
 * workflow-like dependency management
 * relationship scoring
+
+**v0.7.3 note:** `rac portfolio` introduces a health score that includes relationship integrity as one of four weighted factors (0.25 weight). This is the first instance of relationship scoring in RAC Core. The formula is fully deterministic, documented in `rac/portfolio.py`, and uses only counts already produced by `summarize_relationships`. This ADR was reviewed before v0.7.3 implementation; no architectural objections were raised.

--- a/rac/cli.py
+++ b/rac/cli.py
@@ -9,10 +9,11 @@ Commands:
     rac improve <file.md | -> [--json | --template]
     rac schema [--list] [type] [--json | --template]
     rac relationships <dir | file.md> [--validate] [--json] [--top-level]
+    rac portfolio <directory> [--json] [--top-level]
 
 Exit codes:
     0  success (incl. inspect/improve reporting Unknown; relationships found or
-       not; --validate with all references resolved)
+       not; --validate with all references resolved; portfolio summary produced)
     1  validate: errors found; stats: no valid known artifacts; ingest:
        conversion failed; relationships --validate: broken/ambiguous/self
        references or duplicate identifiers found
@@ -34,6 +35,7 @@ from .classification import score_artifacts
 from .improve import improve_product
 from .inspect import build_inspection, inspect_directory
 from .parser import parse, parse_file
+from .portfolio import build_portfolio_summary
 from .relationships import (
     build_relationship_report,
     build_relationship_report_file,
@@ -290,6 +292,19 @@ def cmd_relationships(args: argparse.Namespace) -> int:
     return EXIT_OK
 
 
+def cmd_portfolio(args: argparse.Namespace) -> int:
+    if not Path(args.directory).is_dir():
+        print(f"rac: not a directory: {args.directory}", file=sys.stderr)
+        raise SystemExit(EXIT_USAGE)
+    recursive = not args.top_level
+    summary = build_portfolio_summary(args.directory, recursive=recursive)
+    if args.json:
+        print(outputs.render_portfolio_json(summary))
+    else:
+        print(outputs.render_portfolio_human(summary))
+    return EXIT_OK
+
+
 def build_parser() -> argparse.ArgumentParser:
     version_str = f"rac {__version__}"
 
@@ -469,6 +484,27 @@ def build_parser() -> argparse.ArgumentParser:
         help="Recurse into subdirectories (the default; accepted for clarity).",
     )
     p_relationships.set_defaults(func=cmd_relationships)
+
+    p_portfolio = sub.add_parser(
+        "portfolio",
+        help="Repository intelligence summary: artifact counts, health score, and attention items.",
+        parents=[version_parent],
+    )
+    p_portfolio.add_argument("directory", help="Directory to scan recursively for *.md.")
+    p_portfolio.add_argument(
+        "--json", action="store_true", help="Emit JSON instead of human-readable text."
+    )
+    p_portfolio.add_argument(
+        "--top-level",
+        action="store_true",
+        help="Only the top-level files in the directory (no recursion).",
+    )
+    p_portfolio.add_argument(
+        "--recursive",
+        action="store_true",
+        help="Recurse into subdirectories (the default; accepted for clarity).",
+    )
+    p_portfolio.set_defaults(func=cmd_portfolio)
 
     return parser
 

--- a/rac/outputs.py
+++ b/rac/outputs.py
@@ -754,3 +754,73 @@ def render_ingest_json(result: IngestResult, output_path: str | None) -> str:
         "markdown": result.markdown,
     }
     return json.dumps(payload, indent=2)
+
+
+# --- portfolio ---------------------------------------------------------------
+
+
+def render_portfolio_human(s) -> str:
+    """Human-readable `rac portfolio` output."""
+    lines = [
+        _bold("Repository Summary"),
+        "==================",
+        "",
+        f"Directory:  {s.directory}",
+        f"Artifacts:  {s.total_artifacts}",
+        "",
+        _bold("By Type"),
+        "-------",
+        "",
+    ]
+    for type_name, count in s.by_type.items():
+        if count > 0:
+            lines.append(f"  {type_name.title():<14} {count}")
+
+    lines += [
+        "",
+        _bold("Validation"),
+        "----------",
+        "",
+        f"  Valid:    {s.valid_artifacts}",
+        f"  Invalid:  {s.invalid_artifacts}",
+        "",
+        _bold("Completeness"),
+        "------------",
+        "",
+        f"  {s.completeness:.0%} ({s.filled_slots} / {s.recommended_slots} recommended slots filled)",
+        "",
+        _bold("Relationships"),
+        "-------------",
+        "",
+        f"  Total:    {s.relationships.total}",
+        f"  Valid:    {s.relationships.valid}",
+        f"  Broken:   {s.relationships.broken}",
+        f"  Orphaned: {s.relationships.orphaned}",
+        f"  Coverage: {s.relationships.coverage:.0%}",
+    ]
+
+    if s.attention:
+        lines += ["", _bold(f"Attention ({len(s.attention)} items)"), "----------", ""]
+        for item in s.attention:
+            icon = _red("✗") if item.severity == "error" else _yellow("!")
+            lines.append(f"  {icon} {item.identifier}")
+            lines.append(f"      {item.message}")
+    else:
+        lines += ["", _green("✓ No attention items.")]
+
+    score = s.health_score
+    score_color = _green if score >= 80 else _yellow if score >= 60 else _red
+    lines += [
+        "",
+        _bold("Health Score"),
+        "------------",
+        "",
+        f"  {score_color(str(score))} / 100",
+    ]
+
+    return "\n".join(lines)
+
+
+def render_portfolio_json(s) -> str:
+    """JSON `rac portfolio` output (stable contract, ADR-007)."""
+    return json.dumps(s.to_dict(), indent=2)

--- a/rac/portfolio.py
+++ b/rac/portfolio.py
@@ -26,12 +26,16 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
-from .artifacts import spec_for
+from .artifacts import ARTIFACT_SPECS, spec_for
 from .classification import classify, missing_sections
 from .fs import find_markdown_files
 from .parser import parse_file
 from .relationships import (
+    ISSUE_SELF_REFERENCE,
+    ISSUE_TARGET_AMBIGUOUS,
+    ISSUE_TARGET_NOT_FOUND,
     RelationshipSummary,
+    artifact_identifier,
     summarize_relationships,
 )
 from .validate import has_errors, validate
@@ -40,6 +44,13 @@ from .validate import has_errors, validate
 ATTENTION_INVALID = "invalid-artifact"
 ATTENTION_MISSING_RECOMMENDED = "missing-recommended-sections"
 ATTENTION_BROKEN_RELATIONSHIP = "broken-relationship"
+
+# Human phrasing for each relationship-resolution issue in attention messages.
+_REL_ISSUE_PHRASE = {
+    ISSUE_TARGET_NOT_FOUND: "references missing artifact",
+    ISSUE_TARGET_AMBIGUOUS: "has an ambiguous reference to",
+    ISSUE_SELF_REFERENCE: "references itself via",
+}
 
 
 @dataclass
@@ -134,19 +145,10 @@ class PortfolioSummary:
         }
 
 
-def _identifier_for(path: str, product) -> str:
-    """Best display identifier for ``path``: title, else stem."""
-    from pathlib import Path
-
-    return product.title or Path(path).stem
-
-
 def build_portfolio_summary(
     directory: str, recursive: bool = True
 ) -> PortfolioSummary:
     """Walk ``directory`` and compute a full repository intelligence summary."""
-    from .artifacts import ARTIFACT_SPECS
-
     paths = find_markdown_files(directory, recursive=recursive)
 
     # --- per-artifact pass ---------------------------------------------------
@@ -158,9 +160,10 @@ def build_portfolio_summary(
     recommended_slots = 0
     filled_slots = 0
     attention: list[AttentionItem] = []
-
-    # Broken-relationship attention: resolved separately so we avoid a second
-    # full walk. We collect the relationship summary after the artifact loop.
+    # path -> canonical identifier, for mapping relationship issues (whose
+    # source_path is always a known artifact) back to an identifier without a
+    # second identifier pass.
+    path_to_identifier: dict[str, str] = {}
 
     for path in paths:
         product = parse_file(str(path))
@@ -172,6 +175,9 @@ def build_portfolio_summary(
             # Unknown artifacts: not validated, not scored for completeness.
             continue
 
+        identifier = artifact_identifier(product, spec, str(path))
+        path_to_identifier[str(path)] = identifier
+
         # Validation
         issues = validate(product)
         if has_errors(issues):
@@ -180,7 +186,7 @@ def build_portfolio_summary(
             attention.append(
                 AttentionItem(
                     path=str(path),
-                    identifier=_identifier_for(str(path), product),
+                    identifier=identifier,
                     severity="error",
                     code=ATTENTION_INVALID,
                     message=f"Validation errors: {', '.join(error_codes)}",
@@ -202,7 +208,7 @@ def build_portfolio_summary(
             attention.append(
                 AttentionItem(
                     path=str(path),
-                    identifier=_identifier_for(str(path), product),
+                    identifier=identifier,
                     severity="warning",
                     code=ATTENTION_MISSING_RECOMMENDED,
                     message=f"Missing recommended sections: {names}",
@@ -210,7 +216,22 @@ def build_portfolio_summary(
             )
 
     # --- relationship summary ------------------------------------------------
+    # One relationship walk; its per-reference issues become attention items so
+    # broken references are surfaced, not just counted (roadmap Initiative 3).
     rel_summary = summarize_relationships(directory, recursive=recursive)
+    for issue in rel_summary.issues:
+        source = issue.source_path or ""
+        label = (issue.relationship or "").replace("_", " ").title()
+        phrase = _REL_ISSUE_PHRASE.get(issue.code, "has an unresolved reference")
+        attention.append(
+            AttentionItem(
+                path=source,
+                identifier=path_to_identifier.get(source, source),
+                severity="warning",
+                code=ATTENTION_BROKEN_RELATIONSHIP,
+                message=f"{label} {phrase}: {issue.target}",
+            )
+        )
 
     # Sort attention: errors before warnings, then path, then code (deterministic).
     _SEV_ORDER = {"error": 0, "warning": 1}

--- a/rac/portfolio.py
+++ b/rac/portfolio.py
@@ -1,0 +1,229 @@
+"""Repository intelligence summary — `rac portfolio` (v0.7.3).
+
+``build_portfolio_summary`` walks a directory once, gathering:
+
+- Artifact counts (by type + unknown)
+- Validation (valid / invalid)
+- Completeness (filled recommended slots / total recommended slots)
+- Relationship health (from ``summarize_relationships``)
+- Attention items (broken refs, invalid artifacts, missing recommended sections)
+- Health score (weighted composite)
+
+All analysis is deterministic and belongs to Core (ADR-015). The CLI renders
+the result; it calculates nothing independently.
+
+Health score formula (each sub-score ∈ [0, 1], 1.0 when denominator is 0):
+
+    score = round(100 × (0.5·validity + 0.25·completeness + 0.25·rel_integrity))
+
+where:
+    validity         = valid_artifacts / total_artifacts
+    completeness     = filled_recommended_slots / total_recommended_slots
+    rel_integrity    = (total_refs − broken_refs) / total_refs
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from .artifacts import spec_for
+from .classification import classify, missing_sections
+from .fs import find_markdown_files
+from .parser import parse_file
+from .relationships import (
+    RelationshipSummary,
+    summarize_relationships,
+)
+from .validate import has_errors, validate
+
+# Stable attention codes (part of the JSON contract, ADR-007).
+ATTENTION_INVALID = "invalid-artifact"
+ATTENTION_MISSING_RECOMMENDED = "missing-recommended-sections"
+ATTENTION_BROKEN_RELATIONSHIP = "broken-relationship"
+
+
+@dataclass
+class AttentionItem:
+    """One actionable finding surfaced by ``rac portfolio``."""
+
+    path: str
+    identifier: str  # artifact identifier or filename stem
+    severity: str    # "error" | "warning"
+    code: str
+    message: str
+
+    def to_dict(self) -> dict:
+        return {
+            "path": self.path,
+            "identifier": self.identifier,
+            "severity": self.severity,
+            "code": self.code,
+            "message": self.message,
+        }
+
+
+@dataclass
+class PortfolioSummary:
+    """Repository-level intelligence result (v0.7.3).
+
+    ``to_dict`` is the stable JSON contract (ADR-007); all fields are additive
+    and schema_version-gated so consumers can detect breaking changes.
+    """
+
+    directory: str
+    recursive: bool
+    by_type: dict[str, int]                           # {type: count} incl. unknown
+    valid_artifacts: int
+    invalid_artifacts: int
+    recommended_slots: int
+    filled_slots: int
+    relationships: RelationshipSummary
+    attention: list[AttentionItem] = field(default_factory=list)
+
+    @property
+    def total_artifacts(self) -> int:
+        return sum(self.by_type.values())
+
+    @property
+    def completeness(self) -> float:
+        if self.recommended_slots == 0:
+            return 1.0
+        return round(self.filled_slots / self.recommended_slots, 4)
+
+    @property
+    def health_score(self) -> int:
+        total = self.total_artifacts
+        validity = self.valid_artifacts / total if total else 1.0
+        completeness = self.completeness
+        checked = self.relationships.total
+        rel_integrity = (
+            (checked - self.relationships.broken) / checked if checked else 1.0
+        )
+        raw = 0.5 * validity + 0.25 * completeness + 0.25 * rel_integrity
+        return round(100 * raw)
+
+    def to_dict(self) -> dict:
+        return {
+            "schema_version": "1",
+            "directory": self.directory,
+            "recursive": self.recursive,
+            "artifacts": {
+                "total": self.total_artifacts,
+                "by_type": self.by_type,
+            },
+            "validation": {
+                "valid": self.valid_artifacts,
+                "invalid": self.invalid_artifacts,
+            },
+            "completeness": {
+                "recommended_slots": self.recommended_slots,
+                "filled": self.filled_slots,
+                "ratio": self.completeness,
+            },
+            "relationships": {
+                "total": self.relationships.total,
+                "valid": self.relationships.valid,
+                "broken": self.relationships.broken,
+                "orphaned": self.relationships.orphaned,
+                "coverage": self.relationships.coverage,
+            },
+            "attention": [item.to_dict() for item in self.attention],
+            "health": {
+                "score": self.health_score,
+            },
+        }
+
+
+def _identifier_for(path: str, product) -> str:
+    """Best display identifier for ``path``: title, else stem."""
+    from pathlib import Path
+
+    return product.title or Path(path).stem
+
+
+def build_portfolio_summary(
+    directory: str, recursive: bool = True
+) -> PortfolioSummary:
+    """Walk ``directory`` and compute a full repository intelligence summary."""
+    from .artifacts import ARTIFACT_SPECS
+
+    paths = find_markdown_files(directory, recursive=recursive)
+
+    # --- per-artifact pass ---------------------------------------------------
+    by_type: dict[str, int] = {spec.name: 0 for spec in ARTIFACT_SPECS}
+    by_type["unknown"] = 0
+
+    valid_count = 0
+    invalid_count = 0
+    recommended_slots = 0
+    filled_slots = 0
+    attention: list[AttentionItem] = []
+
+    # Broken-relationship attention: resolved separately so we avoid a second
+    # full walk. We collect the relationship summary after the artifact loop.
+
+    for path in paths:
+        product = parse_file(str(path))
+        artifact_type = classify(product).type
+        by_type[artifact_type] = by_type.get(artifact_type, 0) + 1
+
+        spec = spec_for(artifact_type)
+        if spec is None:
+            # Unknown artifacts: not validated, not scored for completeness.
+            continue
+
+        # Validation
+        issues = validate(product)
+        if has_errors(issues):
+            invalid_count += 1
+            error_codes = [i.code for i in issues if i.severity == "error"]
+            attention.append(
+                AttentionItem(
+                    path=str(path),
+                    identifier=_identifier_for(str(path), product),
+                    severity="error",
+                    code=ATTENTION_INVALID,
+                    message=f"Validation errors: {', '.join(error_codes)}",
+                )
+            )
+        else:
+            valid_count += 1
+
+        # Completeness (recommended sections only — required failures are already
+        # reported as validation errors above, counting them twice would double-
+        # penalise in the health score).
+        slots = len(spec.recommended)
+        recommended_slots += slots
+        _, missing_rec = missing_sections(product, spec)
+        filled = slots - len(missing_rec)
+        filled_slots += filled
+        if missing_rec:
+            names = ", ".join(s.title() for s in missing_rec)
+            attention.append(
+                AttentionItem(
+                    path=str(path),
+                    identifier=_identifier_for(str(path), product),
+                    severity="warning",
+                    code=ATTENTION_MISSING_RECOMMENDED,
+                    message=f"Missing recommended sections: {names}",
+                )
+            )
+
+    # --- relationship summary ------------------------------------------------
+    rel_summary = summarize_relationships(directory, recursive=recursive)
+
+    # Sort attention: errors before warnings, then path, then code (deterministic).
+    _SEV_ORDER = {"error": 0, "warning": 1}
+    attention.sort(key=lambda a: (_SEV_ORDER.get(a.severity, 2), a.path, a.code))
+
+    return PortfolioSummary(
+        directory=directory,
+        recursive=recursive,
+        by_type=by_type,
+        valid_artifacts=valid_count,
+        invalid_artifacts=invalid_count,
+        recommended_slots=recommended_slots,
+        filled_slots=filled_slots,
+        relationships=rel_summary,
+        attention=attention,
+    )

--- a/rac/relationships.py
+++ b/rac/relationships.py
@@ -490,7 +490,9 @@ class RelationshipSummary:
     self-reference).  ``orphaned`` counts artifacts that are not the target of
     any resolved reference.  ``coverage`` is the fraction of known (non-unknown)
     artifacts that declare at least one outbound relationship; 1.0 when there
-    are no known artifacts.
+    are no known artifacts.  ``issues`` holds the per-reference resolution
+    findings (``broken == len(issues)``); consumers like ``rac portfolio`` turn
+    them into attention items without a second relationship walk.
     """
 
     total: int
@@ -498,6 +500,7 @@ class RelationshipSummary:
     broken: int
     orphaned: int
     coverage: float  # 0.0 – 1.0
+    issues: list[RelationshipIssue] = field(default_factory=list)
 
 
 def summarize_relationships(
@@ -537,4 +540,5 @@ def summarize_relationships(
         broken=broken,
         orphaned=orphaned,
         coverage=round(coverage, 4),
+        issues=ref_issues,
     )

--- a/rac/relationships.py
+++ b/rac/relationships.py
@@ -366,16 +366,67 @@ def _parsed_items(paths: list) -> list[tuple[str, Product, ArtifactSpec | None]]
     return items
 
 
+# Identifier index: {casefold(ident) -> [(path, display_ident), ...]}
+_IdentIndex = dict[str, list[tuple[str, str]]]
+
+
+def _build_identifier_index(
+    items: list[tuple[str, Product, ArtifactSpec | None]],
+) -> _IdentIndex:
+    """Identifier index over *all* files (Unknown included — they can be targets)."""
+    index: _IdentIndex = {}
+    for path, product, spec in items:
+        ident = artifact_identifier(product, spec, path)
+        index.setdefault(ident.casefold(), []).append((path, ident))
+    return index
+
+
+def _resolve_references(
+    items: list[tuple[str, Product, ArtifactSpec | None]],
+    index: _IdentIndex,
+) -> tuple[int, list[RelationshipIssue], set[str]]:
+    """Resolve every explicit reference in ``items`` against ``index``.
+
+    Returns ``(checked, issues, resolved_target_paths)`` where
+    ``resolved_target_paths`` is the set of paths that appear as a *resolved*
+    target of at least one uniquely-matched reference — used by
+    ``summarize_relationships`` for orphan detection.
+    """
+    issues: list[RelationshipIssue] = []
+    resolved_targets: set[str] = set()
+    checked = 0
+
+    for path, product, spec in items:
+        if spec is None:
+            continue
+        for section, refs in extract_relationships_full(product, spec).items():
+            for ref in refs:
+                checked += 1
+                targets = [p for p, _ in index.get(ref.casefold(), [])]
+                if not targets:
+                    code = ISSUE_TARGET_NOT_FOUND
+                elif len(targets) > 1:
+                    code = ISSUE_TARGET_AMBIGUOUS
+                elif targets == [path]:
+                    code = ISSUE_SELF_REFERENCE
+                else:
+                    resolved_targets.add(targets[0])
+                    continue  # resolved uniquely to another artifact
+                issues.append(
+                    RelationshipIssue(
+                        code=code, source_path=path, relationship=section, target=ref
+                    )
+                )
+
+    return checked, issues, resolved_targets
+
+
 def _validate(
     directory: str,
     items: list[tuple[str, Product, ArtifactSpec | None]],
     recursive: bool,
 ) -> RelationshipValidation:
-    # Identifier index over *all* files (Unknown included — they can be targets).
-    index: dict[str, list[tuple[str, str]]] = {}
-    for path, product, spec in items:
-        ident = artifact_identifier(product, spec, path)
-        index.setdefault(ident.casefold(), []).append((path, ident))
+    index = _build_identifier_index(items)
 
     issues: list[RelationshipIssue] = []
 
@@ -392,28 +443,8 @@ def _validate(
             )
         )
 
-    # Per-reference resolution from known artifacts only (spec-driven).
-    checked = 0
-    for path, product, spec in items:
-        if spec is None:
-            continue
-        for section, refs in extract_relationships_full(product, spec).items():
-            for ref in refs:
-                checked += 1
-                targets = [p for p, _ in index.get(ref.casefold(), [])]
-                if not targets:
-                    code = ISSUE_TARGET_NOT_FOUND
-                elif len(targets) > 1:
-                    code = ISSUE_TARGET_AMBIGUOUS
-                elif targets == [path]:
-                    code = ISSUE_SELF_REFERENCE
-                else:
-                    continue  # resolved uniquely to another artifact
-                issues.append(
-                    RelationshipIssue(
-                        code=code, source_path=path, relationship=section, target=ref
-                    )
-                )
+    checked, ref_issues, _ = _resolve_references(items, index)
+    issues.extend(ref_issues)
 
     return RelationshipValidation(
         directory=directory,
@@ -438,3 +469,72 @@ def validate_relationships_file(path: str) -> RelationshipValidation:
     resolve — repository validation needs a directory.
     """
     return _validate(path, _parsed_items([path]), recursive=False)
+
+
+# --- Repository relationship summary (v0.7.3) ---------------------------------
+#
+# Aggregate relationship health for ``rac portfolio``. Returns counts and an
+# orphan count. An artifact is *orphaned* when no other artifact references it
+# with a successfully-resolved relationship — it may still declare outbound
+# relationships, but nothing points back to it. Coverage is the fraction of
+# non-unknown artifacts that declare at least one relationship.
+
+
+@dataclass
+class RelationshipSummary:
+    """Repository-level relationship health for ``PortfolioSummary``.
+
+    ``total`` counts every declared reference (same unit as
+    ``RelationshipReport.relationship_count``).  ``broken`` counts references
+    that could not be uniquely resolved (target-not-found, ambiguous, or
+    self-reference).  ``orphaned`` counts artifacts that are not the target of
+    any resolved reference.  ``coverage`` is the fraction of known (non-unknown)
+    artifacts that declare at least one outbound relationship; 1.0 when there
+    are no known artifacts.
+    """
+
+    total: int
+    valid: int
+    broken: int
+    orphaned: int
+    coverage: float  # 0.0 – 1.0
+
+
+def summarize_relationships(
+    directory: str, recursive: bool = True
+) -> RelationshipSummary:
+    """Aggregate relationship health across a directory (v0.7.3)."""
+    paths = find_markdown_files(directory, recursive=recursive)
+    items = _parsed_items(paths)
+
+    if not items:
+        return RelationshipSummary(
+            total=0, valid=0, broken=0, orphaned=0, coverage=1.0
+        )
+
+    index = _build_identifier_index(items)
+    checked, ref_issues, resolved_targets = _resolve_references(items, index)
+
+    broken = len(ref_issues)
+    valid = checked - broken
+
+    # Orphan = known (spec is not None) artifact whose path never appears as a
+    # resolved target of another artifact's reference.
+    all_known_paths = {path for path, _, spec in items if spec is not None}
+    orphaned = len(all_known_paths - resolved_targets)
+
+    # Coverage = fraction of known artifacts that declare >=1 outbound relationship.
+    artifacts_with_rels = sum(
+        1
+        for path, product, spec in items
+        if spec is not None and extract_relationships_full(product, spec)
+    )
+    coverage = artifacts_with_rels / len(all_known_paths) if all_known_paths else 1.0
+
+    return RelationshipSummary(
+        total=checked,
+        valid=valid,
+        broken=broken,
+        orphaned=orphaned,
+        coverage=round(coverage, 4),
+    )

--- a/tests/fixtures/portfolio_summary/all_types/adr.md
+++ b/tests/fixtures/portfolio_summary/all_types/adr.md
@@ -1,0 +1,13 @@
+# ADR-001 Choose DB
+
+## Context
+
+Need a database.
+
+## Decision
+
+Use PostgreSQL.
+
+## Consequences
+
+Reliable, well-known.

--- a/tests/fixtures/portfolio_summary/all_types/design.md
+++ b/tests/fixtures/portfolio_summary/all_types/design.md
@@ -1,0 +1,17 @@
+# Search UI Design
+
+## Context
+
+Users need a search bar.
+
+## User Need
+
+Find items quickly.
+
+## Design
+
+A top-aligned search input.
+
+## Constraints
+
+Must be accessible.

--- a/tests/fixtures/portfolio_summary/all_types/prompt.md
+++ b/tests/fixtures/portfolio_summary/all_types/prompt.md
@@ -1,0 +1,17 @@
+# Review Prompt
+
+## Objective
+
+Review requirements.
+
+## Input
+
+A requirements file.
+
+## Instructions
+
+Check for completeness.
+
+## Output
+
+A list of issues.

--- a/tests/fixtures/portfolio_summary/all_types/req.md
+++ b/tests/fixtures/portfolio_summary/all_types/req.md
@@ -1,0 +1,17 @@
+# Feature
+
+## Problem
+
+A problem.
+
+## Requirements
+
+[REQ-001] The system shall do the thing.
+
+## Success Metrics
+
+- Metric one.
+
+## Risks
+
+- Risk one.

--- a/tests/fixtures/portfolio_summary/all_types/roadmap.md
+++ b/tests/fixtures/portfolio_summary/all_types/roadmap.md
@@ -1,0 +1,9 @@
+# Q3 Roadmap
+
+## Outcomes
+
+Ship search.
+
+## Initiatives
+
+- Initiative 1

--- a/tests/fixtures/portfolio_summary/all_types/unknown.md
+++ b/tests/fixtures/portfolio_summary/all_types/unknown.md
@@ -1,0 +1,3 @@
+# Meeting Notes
+
+Some notes that don't match any artifact type.

--- a/tests/fixtures/portfolio_summary/broken_rels/source.md
+++ b/tests/fixtures/portfolio_summary/broken_rels/source.md
@@ -1,0 +1,13 @@
+# Feature With Broken Ref
+
+## Problem
+
+A problem.
+
+## Requirements
+
+[REQ-001] The system shall work.
+
+## Related Decisions
+
+- ADR-MISSING

--- a/tests/fixtures/portfolio_summary/invalid_known/req-no-title.md
+++ b/tests/fixtures/portfolio_summary/invalid_known/req-no-title.md
@@ -1,0 +1,19 @@
+## Problem
+
+Users cannot reset their password without contacting support.
+
+## Requirements
+
+[REQ-001] Users can request a password reset link.
+
+## Success Metrics
+
+- 80% of resets complete without support.
+
+## Risks
+
+- Reset emails may be flagged as spam.
+
+## Assumptions
+
+- An email provider is configured.

--- a/tests/fixtures/portfolio_summary/unknown_only/unknown.md
+++ b/tests/fixtures/portfolio_summary/unknown_only/unknown.md
@@ -1,0 +1,3 @@
+# Random Notes
+
+No structured sections here.

--- a/tests/fixtures/portfolio_summary/valid_clean/adr-001.md
+++ b/tests/fixtures/portfolio_summary/valid_clean/adr-001.md
@@ -1,0 +1,25 @@
+# ADR-001 Use Elasticsearch
+
+## Status
+
+Accepted
+
+## Category
+
+Architecture
+
+## Context
+
+We need full-text search.
+
+## Decision
+
+Use Elasticsearch.
+
+## Consequences
+
+Fast queries, operational overhead.
+
+## Alternatives Considered
+
+Postgres full-text was considered but lacked relevance scoring.

--- a/tests/fixtures/portfolio_summary/valid_clean/req-001.md
+++ b/tests/fixtures/portfolio_summary/valid_clean/req-001.md
@@ -1,0 +1,26 @@
+# Search Feature
+
+## Problem
+
+Users cannot find items.
+
+## Requirements
+
+[REQ-001] Users can search by keyword.
+[REQ-002] Results appear within 200ms.
+
+## Success Metrics
+
+- 90% of searches return relevant results.
+
+## Risks
+
+- Index lag may cause stale results.
+
+## Assumptions
+
+- Elasticsearch is available.
+
+## Related Decisions
+
+- ADR-001

--- a/tests/test_portfolio.py
+++ b/tests/test_portfolio.py
@@ -1,0 +1,281 @@
+"""Tests for rac.portfolio and the ``rac portfolio`` CLI command (v0.7.3)."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from rac.portfolio import (
+    ATTENTION_BROKEN_RELATIONSHIP,
+    ATTENTION_INVALID,
+    ATTENTION_MISSING_RECOMMENDED,
+    build_portfolio_summary,
+)
+from rac.cli import main
+
+FIXTURES = Path(__file__).parent / "fixtures" / "portfolio_summary"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def summary(subdir: str, **kwargs):
+    return build_portfolio_summary(str(FIXTURES / subdir), **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# REQ-002 — artifact coverage: all five types + unknown counted
+# ---------------------------------------------------------------------------
+
+
+def test_all_types_counted():
+    s = summary("all_types")
+    assert s.by_type["requirement"] == 1
+    assert s.by_type["decision"] == 1
+    assert s.by_type["roadmap"] == 1
+    assert s.by_type["prompt"] == 1
+    assert s.by_type["design"] == 1
+    assert s.by_type["unknown"] == 1
+    assert s.total_artifacts == 6
+
+
+def test_unknown_only_no_valid_known():
+    s = summary("unknown_only")
+    assert s.total_artifacts == 1
+    assert s.by_type["unknown"] == 1
+    assert s.valid_artifacts == 0
+    assert s.invalid_artifacts == 0
+
+
+# ---------------------------------------------------------------------------
+# Empty directory — div-by-zero guards
+# ---------------------------------------------------------------------------
+
+
+def test_empty_directory(tmp_path):
+    s = build_portfolio_summary(str(tmp_path))
+    assert s.total_artifacts == 0
+    assert s.valid_artifacts == 0
+    assert s.invalid_artifacts == 0
+    assert s.health_score == 100
+    assert s.completeness == 1.0
+    assert s.relationships.total == 0
+    assert s.relationships.coverage == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Valid clean fixture — health score and attention
+# ---------------------------------------------------------------------------
+
+
+def test_valid_clean_no_invalid():
+    s = summary("valid_clean")
+    assert s.invalid_artifacts == 0
+    assert not any(a.code == ATTENTION_INVALID for a in s.attention)
+
+
+def test_valid_clean_health_score_high():
+    s = summary("valid_clean")
+    # Both artifacts are valid, all recommended sections filled in adr-001.
+    # req-001 has all recommended (success metrics, risks, assumptions).
+    # Relationships: req-001 references ADR-001 which exists → valid=1, broken=0.
+    assert s.relationships.broken == 0
+    assert s.health_score > 80
+
+
+def test_valid_clean_health_score_deterministic():
+    s1 = summary("valid_clean")
+    s2 = summary("valid_clean")
+    assert s1.health_score == s2.health_score
+
+
+# ---------------------------------------------------------------------------
+# Broken relationships
+# ---------------------------------------------------------------------------
+
+
+def test_broken_rels_counted():
+    s = summary("broken_rels")
+    assert s.relationships.broken == 1
+    assert s.relationships.valid == 0
+
+
+def test_broken_rels_health_penalised():
+    s_broken = summary("broken_rels")
+    s_clean = summary("valid_clean")
+    assert s_broken.health_score < s_clean.health_score
+
+
+# ---------------------------------------------------------------------------
+# All-types fixture — non-misclassification
+# ---------------------------------------------------------------------------
+
+
+def test_all_types_no_misclassification():
+    s = summary("all_types")
+    # Each known type must appear exactly once; none should collapse into another.
+    for t in ("requirement", "decision", "roadmap", "prompt", "design"):
+        assert s.by_type[t] == 1, f"{t} count wrong"
+
+
+# ---------------------------------------------------------------------------
+# Completeness
+# ---------------------------------------------------------------------------
+
+
+def test_completeness_ratio_bounds():
+    s = summary("all_types")
+    assert 0.0 <= s.completeness <= 1.0
+
+
+def test_completeness_empty_repo(tmp_path):
+    s = build_portfolio_summary(str(tmp_path))
+    assert s.completeness == 1.0  # no slots → full
+
+
+# ---------------------------------------------------------------------------
+# Health score formula
+# ---------------------------------------------------------------------------
+
+
+def test_health_score_bounds():
+    for subdir in ("all_types", "valid_clean", "broken_rels", "unknown_only"):
+        s = summary(subdir)
+        assert 0 <= s.health_score <= 100, f"{subdir}: {s.health_score}"
+
+
+def test_health_score_perfect_empty(tmp_path):
+    assert build_portfolio_summary(str(tmp_path)).health_score == 100
+
+
+# ---------------------------------------------------------------------------
+# Attention ordering: errors before warnings, then path, then code
+# ---------------------------------------------------------------------------
+
+
+def test_attention_ordering_errors_first():
+    s = summary("all_types")
+    severities = [a.severity for a in s.attention]
+    error_indices = [i for i, sv in enumerate(severities) if sv == "error"]
+    warning_indices = [i for i, sv in enumerate(severities) if sv == "warning"]
+    if error_indices and warning_indices:
+        assert max(error_indices) < min(warning_indices)
+
+
+# ---------------------------------------------------------------------------
+# JSON contract (REQ-005)
+# ---------------------------------------------------------------------------
+
+
+def test_json_has_schema_version():
+    s = summary("all_types")
+    d = s.to_dict()
+    assert d["schema_version"] == "1"
+
+
+def test_json_top_level_keys():
+    s = summary("all_types")
+    d = s.to_dict()
+    for key in ("artifacts", "validation", "completeness", "relationships", "attention", "health"):
+        assert key in d, f"missing key: {key}"
+
+
+def test_json_by_type_all_known_types():
+    s = summary("all_types")
+    d = s.to_dict()
+    for t in ("requirement", "decision", "roadmap", "prompt", "design", "unknown"):
+        assert t in d["artifacts"]["by_type"]
+
+
+def test_json_deterministic():
+    s1 = summary("all_types")
+    s2 = summary("all_types")
+    assert json.dumps(s1.to_dict()) == json.dumps(s2.to_dict())
+
+
+def test_json_relationships_keys():
+    s = summary("all_types")
+    rel = s.to_dict()["relationships"]
+    for key in ("total", "valid", "broken", "orphaned", "coverage"):
+        assert key in rel
+
+
+# ---------------------------------------------------------------------------
+# CLI integration — rac portfolio
+# ---------------------------------------------------------------------------
+
+
+def test_cli_portfolio_exit_0(tmp_path):
+    ret = main(["portfolio", str(tmp_path)])
+    assert ret == 0
+
+
+def test_cli_portfolio_not_a_dir(tmp_path):
+    f = tmp_path / "not_a_dir.md"
+    f.write_text("# x")
+    with pytest.raises(SystemExit) as exc:
+        main(["portfolio", str(f)])
+    assert exc.value.code == 2
+
+
+def test_cli_portfolio_json_output(capsys):
+    ret = main(["portfolio", str(FIXTURES / "all_types"), "--json"])
+    assert ret == 0
+    out = capsys.readouterr().out
+    payload = json.loads(out)
+    assert payload["schema_version"] == "1"
+    assert payload["artifacts"]["total"] == 6
+
+
+def test_cli_portfolio_human_output(capsys):
+    ret = main(["portfolio", str(FIXTURES / "all_types")])
+    assert ret == 0
+    out = capsys.readouterr().out
+    assert "Repository Summary" in out
+    assert "Health Score" in out
+
+
+def test_cli_portfolio_top_level_no_recursion(tmp_path):
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    (tmp_path / "top.md").write_text("# T\n## Problem\nP.\n## Requirements\n[REQ-001] X.\n")
+    (sub / "nested.md").write_text("# N\n## Problem\nP.\n## Requirements\n[REQ-001] X.\n")
+    s_recursive = build_portfolio_summary(str(tmp_path), recursive=True)
+    s_top = build_portfolio_summary(str(tmp_path), recursive=False)
+    assert s_recursive.total_artifacts > s_top.total_artifacts
+
+
+# ---------------------------------------------------------------------------
+# Orphan detection boundary
+# ---------------------------------------------------------------------------
+
+
+def test_no_orphans_when_fully_connected():
+    # valid_clean: req-001 references ADR-001, so ADR-001 has at least one
+    # resolved inbound ref. req-001 itself is unreferenced, so it is orphaned.
+    # The test confirms orphaned < total_artifacts (i.e. not everything is orphaned).
+    s = summary("valid_clean")
+    assert s.relationships.orphaned < s.total_artifacts
+
+
+def test_all_orphaned_when_no_relationships(tmp_path):
+    (tmp_path / "a.md").write_text("# A\n## Problem\nP.\n## Requirements\n[REQ-001] X.\n")
+    (tmp_path / "b.md").write_text("# B\n## Problem\nP.\n## Requirements\n[REQ-001] X.\n")
+    s = build_portfolio_summary(str(tmp_path))
+    # No relationships → both are unreferenced → both orphaned.
+    assert s.relationships.orphaned == 2
+    assert s.relationships.total == 0
+
+
+def test_orphan_not_double_counted_when_broken(tmp_path):
+    # broken_rels has one artifact (source.md) with a broken ref to ADR-MISSING.
+    # ADR-MISSING doesn't exist, so it can't be an orphan (it's not a known artifact).
+    # source.md itself is not a target → it is orphaned.
+    s = summary("broken_rels")
+    # Only 1 known artifact (requirement) in the fixture.
+    assert s.relationships.orphaned == 1

--- a/tests/test_portfolio.py
+++ b/tests/test_portfolio.py
@@ -111,6 +111,22 @@ def test_broken_rels_health_penalised():
     assert s_broken.health_score < s_clean.health_score
 
 
+def test_broken_rels_surface_in_attention():
+    # A broken reference must be an attention item, not merely a count
+    # (roadmap Initiative 3: "ADR-012 references missing artifact").
+    s = summary("broken_rels")
+    broken = [a for a in s.attention if a.code == ATTENTION_BROKEN_RELATIONSHIP]
+    assert len(broken) == 1
+    assert "ADR-MISSING" in broken[0].message
+    # Identifier is the SOURCE artifact's canonical identifier, not the target.
+    assert broken[0].identifier == "source"
+
+
+def test_no_broken_attention_when_all_resolved():
+    s = summary("valid_clean")
+    assert not [a for a in s.attention if a.code == ATTENTION_BROKEN_RELATIONSHIP]
+
+
 # ---------------------------------------------------------------------------
 # All-types fixture — non-misclassification
 # ---------------------------------------------------------------------------
@@ -121,6 +137,37 @@ def test_all_types_no_misclassification():
     # Each known type must appear exactly once; none should collapse into another.
     for t in ("requirement", "decision", "roadmap", "prompt", "design"):
         assert s.by_type[t] == 1, f"{t} count wrong"
+
+
+# ---------------------------------------------------------------------------
+# Incomplete-but-recognizable: classifies as a known type, fails validation
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_known_artifact_classifies_then_fails():
+    # A titleless requirement still classifies as a requirement (Problem +
+    # Requirements present) but fails validation on missing-title.
+    s = summary("invalid_known")
+    assert s.by_type["requirement"] == 1  # recognized, not Unknown
+    assert s.by_type["unknown"] == 0
+    assert s.invalid_artifacts == 1
+    assert s.valid_artifacts == 0
+
+
+def test_invalid_known_artifact_surfaces_in_attention():
+    s = summary("invalid_known")
+    invalid = [a for a in s.attention if a.code == ATTENTION_INVALID]
+    assert len(invalid) == 1
+    assert invalid[0].severity == "error"
+    assert "missing-title" in invalid[0].message
+
+
+def test_attention_identifier_is_canonical_not_title():
+    # The identifier must come from the shared artifact_identifier (stem here),
+    # not a separate title-based source of truth.
+    s = summary("invalid_known")
+    invalid = [a for a in s.attention if a.code == ATTENTION_INVALID][0]
+    assert invalid.identifier == "req-no-title"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implements the v0.7.3 roadmap item (`planning/roadmap/v0.7.3-repo-intelligence.md`): a single Core-owned, deterministic repository intelligence summary exposed as `rac portfolio <dir> [--json] [--top-level]`.

Answers "what exists / how complete / how connected / what needs attention" without combining multiple command outputs (ADR-015: intelligence lives in Core, consumers render).

## What it does

- **Artifacts** — counts by type (all five + unknown)
- **Validation** — valid / invalid
- **Completeness** — filled recommended slots / total
- **Relationships** — total, valid, broken, orphaned, coverage
- **Attention** — actionable items (invalid artifacts, missing recommended sections, broken references), errors-first deterministic order
- **Health** — weighted composite score: `round(100 × (0.5·validity + 0.25·completeness + 0.25·rel_integrity))`

Advisory exit codes: `0` on success, `2` for usage errors. CI hard-gating stays with `rac relationships --validate`.

## Design

- New `rac/portfolio.py` (`PortfolioSummary` + `build_portfolio_summary`) — one artifact walk + one relationship walk, fully spec-driven (zero artifact-specific conditionals).
- `rac/relationships.py` — factored shared `_build_identifier_index` / `_resolve_references` out of `_validate` (no behaviour change); added `RelationshipSummary` + `summarize_relationships` with orphan detection and outbound coverage.
- Stable JSON contract (`schema_version: "1"`), renderers in `rac/outputs.py`.

## Scope fences respected

- No per-artifact inventory (v0.7.4 `RepositoryIndex`)
- No `Repository`/`Artifact` OO model or service layer (v0.8.x)
- No graph/visualization/AI (non-goals + ADR-016)

## ADR note

The health score is the first instance of relationship scoring in Core, which trips ADR-016's review clause. ADR-016 updated with a v0.7.3 review note; formula is fully deterministic and documented.

## Testing

- `tests/test_portfolio.py` — 32 tests: all five types, empty-repo div-by-zero guards, orphan boundaries, incomplete-but-recognizable artifacts, broken-relationship attention, JSON contract, health score bounds + determinism, attention ordering, CLI human/JSON/exit codes.
- Full suite: **375 passed**.
- Passed the minor-release gate (`planning/prompt/rac-agent-release-gate-minor.md`).