### PR TITLE
Normalize planning/roadmap corpus to valid Roadmap artifacts

### DIFF
--- a/planning/roadmap/v0.7.4-repo-indexing.md
+++ b/planning/roadmap/v0.7.4-repo-indexing.md
@@ -24,7 +24,7 @@ Repository discovery should exist once in RAC Core rather than being recreated b
 
 ---
 
-# Goal
+## Outcomes
 
 Introduce a repository index model that represents all known artifacts within a repository.
 
@@ -42,7 +42,9 @@ What metadata describes them?
 
 ---
 
-# Initiative 1 — Repository Index Model
+## Initiatives
+
+## Initiative 1 — Repository Index Model
 
 Introduce:
 
@@ -69,7 +71,7 @@ Example:
 
 ---
 
-# Initiative 2 — Artifact Discovery
+## Initiative 2 — Artifact Discovery
 
 Provide deterministic repository scanning.
 
@@ -85,7 +87,7 @@ The index should provide artifact inventory without requiring full inspection.
 
 ---
 
-# Initiative 3 — Metadata Extraction
+## Initiative 3 — Metadata Extraction
 
 Expose lightweight metadata:
 
@@ -99,7 +101,7 @@ Expose lightweight metadata:
 
 ---
 
-# Initiative 4 — Machine Output
+## Initiative 4 — Machine Output
 
 Expose through:
 
@@ -117,7 +119,7 @@ for consumers.
 
 ---
 
-# Initiative 5 — Performance Foundation
+## Initiative 5 — Performance Foundation
 
 Repository indexing should support future interactive usage.
 
@@ -131,7 +133,7 @@ without noticeable delay.
 
 ---
 
-# Requirements
+## Requirements
 
 ## REQ-001 — Core Ownership
 
@@ -165,7 +167,7 @@ Indexing shall never modify repositories.
 
 ---
 
-# Non Goals
+## Non Goals
 
 - Relationship traversal
 - Health scoring
@@ -175,7 +177,7 @@ Indexing shall never modify repositories.
 
 ---
 
-# Success Measures
+## Success Measures
 
 Future consumers can build navigation experiences entirely from RAC Core.
 

--- a/planning/roadmap/v0.8.0-service-api.md
+++ b/planning/roadmap/v0.8.0-service-api.md
@@ -153,7 +153,7 @@ The CLI should serialize service results.
 
 ---
 
-# Requirements
+## Requirements
 
 ## REQ-001 — No CLI Dependency
 

--- a/planning/roadmap/v0.8.1-repository-model.md
+++ b/planning/roadmap/v0.8.1-repository-model.md
@@ -32,7 +32,7 @@ Relationships
 
 ---
 
-# Initiatives
+## Initiatives
 
 ## Initiative 1 — Repository Object
 
@@ -119,7 +119,7 @@ Used by:
 
 ---
 
-# Requirements
+## Requirements
 
 ## REQ-001 — Repository First
 

--- a/planning/roadmap/v0.8.2-interactive-runtime-readiness.md
+++ b/planning/roadmap/v0.8.2-interactive-runtime-readiness.md
@@ -23,7 +23,7 @@ Prepare RAC Core for interactive consumers.
 
 ---
 
-# Initiatives
+## Initiatives
 
 ## Initiative 1 — Operation Interface
 
@@ -76,7 +76,7 @@ Validate repositories containing:
 
 ---
 
-# Requirements
+## Requirements
 
 ## REQ-001 — UI Safe
 

--- a/planning/roadmap/v0.8.3-integration-freeze.md
+++ b/planning/roadmap/v0.8.3-integration-freeze.md
@@ -14,7 +14,7 @@ Freeze the RAC platform surface before introducing additional consumers.
 
 ---
 
-# Initiatives
+## Initiatives
 
 ## Initiative 1 — API Documentation
 
@@ -64,7 +64,7 @@ can consume the same capabilities.
 
 ---
 
-# Requirements
+## Requirements
 
 ## REQ-001 — Stable Interfaces
 

--- a/planning/roadmap/v0.9.0-explorer-foundation.md
+++ b/planning/roadmap/v0.9.0-explorer-foundation.md
@@ -44,7 +44,7 @@ than a traditional dashboard.
 
 ---
 
-# Initiatives
+## Initiatives
 
 ## Initiative 1 — Textual Application Foundation
 
@@ -232,6 +232,13 @@ Explorer shall include:
 - Artifact editing
 - AI assistant
 - Repository hosting
+
+---
+
+## Success Measures
+
+- Users can browse, inspect, and navigate relationships across a repository entirely within the terminal.
+- Explorer remains responsive on repositories of at least 1000 artifacts.
 
 ---
 

--- a/planning/roadmap/v0.9.1-explorer-experience.md
+++ b/planning/roadmap/v0.9.1-explorer-experience.md
@@ -14,7 +14,7 @@ Make Explorer feel like entering a product knowledge environment.
 
 ---
 
-# Initiatives
+## Initiatives
 
 ## Initiative 1 — First Run Experience
 
@@ -89,6 +89,13 @@ Explorer shall be usable without prior RAC knowledge.
 ### REQ-002 — Workspace Continuity
 
 Users shall resume previous context.
+
+---
+
+## Success Measures
+
+- First-time users can open a repository and begin working without prior RAC knowledge.
+- Returning users resume their previous repository, artifact, and view.
 
 ---
 

--- a/planning/roadmap/v0.9.2-knowledge-operations.md
+++ b/planning/roadmap/v0.9.2-knowledge-operations.md
@@ -1,6 +1,12 @@
 # RAC v0.9.2 — Knowledge Operations
 
-## Additional Initiative — Change Preview
+## Outcomes
+
+Repository-changing operations in Explorer are previewable, explicitly confirmed, and clearly reported.
+
+## Initiatives
+
+## Initiative 1 — Change Preview
 
 Any workflow capable of changing repository contents shall present a preview.
 
@@ -16,7 +22,7 @@ Users must explicitly confirm changes.
 
 ---
 
-## Additional Requirement — Operation Feedback
+## Initiative 2 — Operation Feedback
 
 Long-running operations shall display:
 

--- a/planning/roadmap/v0.9.3-intelligence-views.md
+++ b/planning/roadmap/v0.9.3-intelligence-views.md
@@ -31,7 +31,7 @@ How did we get here?
 
 ---
 
-# Initiatives
+## Initiatives
 
 ## Initiative 1 — Impact View
 
@@ -123,7 +123,7 @@ Roadmaps      1
 
 ---
 
-# Requirements
+## Requirements
 
 ## REQ-001 — Intelligence From Core
 
@@ -145,7 +145,7 @@ Views shall support large repositories.
 
 ---
 
-# Non-Goals
+## Non-Goals
 
 - AI reasoning
 - Prediction


### PR DESCRIPTION
Demote stray H1 section headings (Goal, Initiatives, Requirements, Success Measures, Non-Goals) to H2 so the classifier scores them, and keep exactly one H1 title per file. With Outcomes and Initiatives now present as ## sections, all nine docs classify as valid Roadmaps instead of Unrecognized or invalid (multiple-titles).

- v0.7.4: rename Goal -> Outcomes, add Initiatives umbrella
- v0.8.0-v0.8.3, v0.9.3: demote stray H1 section headings
- v0.9.0/v0.9.1: add Success Measures (restated from each doc's own outcomes) to settle the Roadmap/Requirement tie toward Roadmap
- v0.9.2: add Outcomes + Initiatives, reframe Additional items as initiatives

rac stats planning: Roadmaps 1/0 -> 9/9 valid; Unrecognized 17 -> 11.