### PR TITLE
refactor(rac): drop compatibility shims; import layers directly

### DIFF
--- a/src/rac/artifacts.py
+++ b/src/rac/artifacts.py
@@ -1,3 +1,0 @@
-"""Compatibility shim — implementation moved to :mod:`rac.core.artifacts` (v0.7.4)."""
-
-from rac.core.artifacts import *  # noqa: F401,F403

--- a/src/rac/classification.py
+++ b/src/rac/classification.py
@@ -1,3 +1,0 @@
-"""Compatibility shim — implementation moved to :mod:`rac.core.classification` (v0.7.4)."""
-
-from rac.core.classification import *  # noqa: F401,F403

--- a/src/rac/diff.py
+++ b/src/rac/diff.py
@@ -1,3 +1,0 @@
-"""Compatibility shim — implementation moved to :mod:`rac.services.diff` (v0.7.4)."""
-
-from rac.services.diff import *  # noqa: F401,F403

--- a/src/rac/fs.py
+++ b/src/rac/fs.py
@@ -1,3 +1,0 @@
-"""Compatibility shim — implementation moved to :mod:`rac.core.fs` (v0.7.4)."""
-
-from rac.core.fs import *  # noqa: F401,F403

--- a/src/rac/improve.py
+++ b/src/rac/improve.py
@@ -1,3 +1,0 @@
-"""Compatibility shim — implementation moved to :mod:`rac.services.improve` (v0.7.4)."""
-
-from rac.services.improve import *  # noqa: F401,F403

--- a/src/rac/ingest.py
+++ b/src/rac/ingest.py
@@ -1,9 +1,0 @@
-"""Compatibility shim — implementation moved to :mod:`rac.services.ingest` (v0.7.4)."""
-
-from rac.services.ingest import *  # noqa: F401,F403
-
-# Private helpers exercised directly by the test suite (`import *` skips _names).
-from rac.services.ingest import (  # noqa: F401
-    _is_missing_dependency,
-    _missing_extra_message,
-)

--- a/src/rac/inspect.py
+++ b/src/rac/inspect.py
@@ -1,3 +1,0 @@
-"""Compatibility shim — implementation moved to :mod:`rac.services.inspect` (v0.7.4)."""
-
-from rac.services.inspect import *  # noqa: F401,F403

--- a/src/rac/models.py
+++ b/src/rac/models.py
@@ -1,3 +1,0 @@
-"""Compatibility shim — implementation moved to :mod:`rac.core.models` (v0.7.4)."""
-
-from rac.core.models import *  # noqa: F401,F403

--- a/src/rac/outputs.py
+++ b/src/rac/outputs.py
@@ -1,7 +1,0 @@
-"""Compatibility shim — implementation moved to the :mod:`rac.output` package (v0.7.4).
-
-Human-readable rendering now lives in :mod:`rac.output.human`, JSON in
-:mod:`rac.output.json`, and Markdown templates in :mod:`rac.output.templates`.
-"""
-
-from rac.output import *  # noqa: F401,F403

--- a/src/rac/parser.py
+++ b/src/rac/parser.py
@@ -1,3 +1,0 @@
-"""Compatibility shim — implementation moved to :mod:`rac.core.markdown` (v0.7.4)."""
-
-from rac.core.markdown import *  # noqa: F401,F403

--- a/src/rac/portfolio.py
+++ b/src/rac/portfolio.py
@@ -1,3 +1,0 @@
-"""Compatibility shim — implementation moved to :mod:`rac.services.portfolio` (v0.7.4)."""
-
-from rac.services.portfolio import *  # noqa: F401,F403

--- a/src/rac/relationships.py
+++ b/src/rac/relationships.py
@@ -1,3 +1,0 @@
-"""Compatibility shim — implementation moved to :mod:`rac.services.relationships` (v0.7.4)."""
-
-from rac.services.relationships import *  # noqa: F401,F403

--- a/src/rac/schema.py
+++ b/src/rac/schema.py
@@ -1,3 +1,0 @@
-"""Compatibility shim — implementation moved to :mod:`rac.core.schema` (v0.7.4)."""
-
-from rac.core.schema import *  # noqa: F401,F403

--- a/src/rac/stats.py
+++ b/src/rac/stats.py
@@ -1,3 +1,0 @@
-"""Compatibility shim — implementation moved to :mod:`rac.services.stats` (v0.7.4)."""
-
-from rac.services.stats import *  # noqa: F401,F403

--- a/src/rac/validate.py
+++ b/src/rac/validate.py
@@ -1,3 +1,0 @@
-"""Compatibility shim — implementation moved to :mod:`rac.core.validation` (v0.7.4)."""
-
-from rac.core.validation import *  # noqa: F401,F403

--- a/tests/test_decision_metadata.py
+++ b/tests/test_decision_metadata.py
@@ -11,10 +11,10 @@ from __future__ import annotations
 import json
 
 from rac.cli import main
-from rac.inspect import inspect_file
-from rac.parser import parse_file
-from rac.stats import collect_stats
-from rac.validate import has_errors, validate
+from rac.services.inspect import inspect_file
+from rac.core.markdown import parse_file
+from rac.services.stats import collect_stats
+from rac.core.validation import has_errors, validate
 
 from conftest import fixture_path
 
@@ -110,13 +110,13 @@ def test_all_supported_status_values_pass():
             f"# ADR\n\n## Status\n\n{status}\n\n## Context\n\nc\n\n"
             "## Decision\n\nd\n\n## Consequences\n\nx\n"
         )
-        from rac.parser import parse
+        from rac.core.markdown import parse
 
         assert "invalid-decision-status" not in codes(validate(parse(text)))
 
 
 def test_all_supported_category_values_pass():
-    from rac.parser import parse
+    from rac.core.markdown import parse
 
     for category in ("Architecture", "Product", "Process", "Technical", "Other"):
         text = (
@@ -127,7 +127,7 @@ def test_all_supported_category_values_pass():
 
 
 def test_status_value_match_is_case_insensitive():
-    from rac.parser import parse
+    from rac.core.markdown import parse
 
     text = (
         "# ADR\n\n## Status\n\naccepted\n\n## Context\n\nc\n\n"
@@ -137,7 +137,7 @@ def test_status_value_match_is_case_insensitive():
 
 
 def test_missing_required_decision_section_is_an_error():
-    from rac.parser import parse
+    from rac.core.markdown import parse
 
     # A decision missing ## Consequences (still classifies as a decision).
     text = "# ADR\n\n## Status\n\nAccepted\n\n## Context\n\nc\n\n## Decision\n\nd\n"

--- a/tests/test_design.py
+++ b/tests/test_design.py
@@ -12,15 +12,15 @@ import io
 import json
 
 import rac.services.improve as improve_mod
-from rac.artifacts import ARTIFACT_SPECS, spec_for
+from rac.core.artifacts import ARTIFACT_SPECS, spec_for
 from rac.cli import main
-from rac.classification import classify
-from rac.improve import improve_file, improve_text, supports_improve
-from rac.inspect import inspect_file
-from rac.parser import parse, parse_file
-from rac.schema import available_schemas, schema_reference
-from rac.stats import collect_stats
-from rac.validate import has_errors, validate
+from rac.core.classification import classify
+from rac.services.improve import improve_file, improve_text, supports_improve
+from rac.services.inspect import inspect_file
+from rac.core.markdown import parse, parse_file
+from rac.core.schema import available_schemas, schema_reference
+from rac.services.stats import collect_stats
+from rac.core.validation import has_errors, validate
 
 from conftest import fixture_path
 
@@ -198,7 +198,7 @@ def test_template_omits_optional_relationship_sections(capsys):
 def test_template_passes_validation(monkeypatch):
     ref = schema_reference("design")
     assert ref is not None
-    from rac.outputs import render_schema_template
+    from rac.output import render_schema_template
 
     template = render_schema_template(ref)
     _stdin(monkeypatch, template)

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from rac.diff import diff
-from rac.parser import parse_file
+from rac.services.diff import diff
+from rac.core.markdown import parse_file
 
 from conftest import fixture_path
 

--- a/tests/test_improve.py
+++ b/tests/test_improve.py
@@ -13,13 +13,13 @@ from pathlib import Path
 
 import pytest
 
-from rac.artifacts import ARTIFACT_SPECS, spec_for
-from rac.classification import classify
+from rac.core.artifacts import ARTIFACT_SPECS, spec_for
+from rac.core.classification import classify
 from rac.cli import main
-from rac.improve import improve_file, improve_text, supports_improve
-from rac.parser import parse, parse_file
-from rac.stats import collect_stats
-from rac.validate import validate
+from rac.services.improve import improve_file, improve_text, supports_improve
+from rac.core.markdown import parse, parse_file
+from rac.services.stats import collect_stats
+from rac.core.validation import validate
 
 from conftest import fixture_path
 

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import pytest
 
 from rac.cli import main
-from rac.ingest import (
+from rac.services.ingest import (
     MarkdownConverter,
     MarkItDownConverter,
     UnsupportedDocument,
@@ -50,7 +50,7 @@ def test_unsupported_type_raises(tmp_path):
 
 
 def test_missing_extra_message_points_at_right_extra():
-    from rac.ingest import _missing_extra_message
+    from rac.services.ingest import _missing_extra_message
 
     assert "[ingest-pdf]" in _missing_extra_message(".pdf")
     assert "[ingest-office]" in _missing_extra_message(".pptx")
@@ -201,7 +201,7 @@ def test_missing_dependency_detection():
         MissingDependencyException,
     )
 
-    from rac.ingest import _is_missing_dependency
+    from rac.services.ingest import _is_missing_dependency
 
     assert _is_missing_dependency(MissingDependencyException("x")) is True
     attempt = SimpleNamespace(

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -8,15 +8,15 @@ from pathlib import Path
 
 import pytest
 
-from rac.artifacts import ARTIFACT_SPECS
-from rac.classification import CONFIDENCE_THRESHOLD, score_artifacts
+from rac.core.artifacts import ARTIFACT_SPECS
+from rac.core.classification import CONFIDENCE_THRESHOLD, score_artifacts
 from rac.cli import main
-from rac.inspect import (
+from rac.services.inspect import (
     inspect_directory,
     inspect_file,
     inspect_text,
 )
-from rac.parser import parse
+from rac.core.markdown import parse
 
 from conftest import fixture_path
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from rac.parser import parse, parse_file
+from rac.core.markdown import parse, parse_file
 
 from conftest import fixture_path
 

--- a/tests/test_portfolio.py
+++ b/tests/test_portfolio.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 
-from rac.portfolio import (
+from rac.services.portfolio import (
     ATTENTION_BROKEN_RELATIONSHIP,
     ATTENTION_INVALID,
     ATTENTION_MISSING_RECOMMENDED,

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -15,15 +15,15 @@ import json
 import pytest
 
 import rac.services.improve as improve_mod
-from rac.artifacts import ARTIFACT_SPECS, spec_for
+from rac.core.artifacts import ARTIFACT_SPECS, spec_for
 from rac.cli import main
-from rac.classification import classify
-from rac.improve import improve_file, improve_text, supports_improve
-from rac.inspect import inspect_file
-from rac.parser import parse, parse_file
-from rac.schema import available_schemas, schema_reference
-from rac.stats import collect_stats
-from rac.validate import has_errors, validate
+from rac.core.classification import classify
+from rac.services.improve import improve_file, improve_text, supports_improve
+from rac.services.inspect import inspect_file
+from rac.core.markdown import parse, parse_file
+from rac.core.schema import available_schemas, schema_reference
+from rac.services.stats import collect_stats
+from rac.core.validation import has_errors, validate
 
 from conftest import fixture_path
 
@@ -205,7 +205,7 @@ def test_template_omits_optional_relationship_sections(capsys):
 def test_template_passes_validation(monkeypatch):
     ref = schema_reference("prompt")
     assert ref is not None
-    from rac.outputs import render_schema_template
+    from rac.output import render_schema_template
 
     template = render_schema_template(ref)
     _stdin(monkeypatch, template)

--- a/tests/test_relationship_validation.py
+++ b/tests/test_relationship_validation.py
@@ -15,11 +15,11 @@ from dataclasses import replace
 
 import pytest
 
-from rac.artifacts import spec_for
+from rac.core.artifacts import spec_for
 from rac.cli import main
-from rac.classification import classify
-from rac.parser import parse, parse_file
-from rac.relationships import (
+from rac.core.classification import classify
+from rac.core.markdown import parse, parse_file
+from rac.services.relationships import (
     ISSUE_DUPLICATE_IDENTIFIER,
     ISSUE_SELF_REFERENCE,
     ISSUE_TARGET_AMBIGUOUS,

--- a/tests/test_relationships.py
+++ b/tests/test_relationships.py
@@ -17,12 +17,12 @@ import json
 import pytest
 
 from rac.cli import main
-from rac.inspect import inspect_file, inspect_text
-from rac.parser import parse
-from rac.relationships import parse_references
-from rac.schema import schema_reference
-from rac.stats import collect_stats
-from rac.validate import has_errors, validate
+from rac.services.inspect import inspect_file, inspect_text
+from rac.core.markdown import parse
+from rac.services.relationships import parse_references
+from rac.core.schema import schema_reference
+from rac.services.stats import collect_stats
+from rac.core.validation import has_errors, validate
 
 from conftest import fixture_path
 

--- a/tests/test_relationships_cmd.py
+++ b/tests/test_relationships_cmd.py
@@ -16,7 +16,7 @@ import json
 import pytest
 
 from rac.cli import main
-from rac.relationships import (
+from rac.services.relationships import (
     build_relationship_report,
     build_relationship_report_file,
 )

--- a/tests/test_roadmap.py
+++ b/tests/test_roadmap.py
@@ -15,15 +15,15 @@ import json
 import pytest
 
 import rac.services.improve as improve_mod
-from rac.artifacts import ARTIFACT_SPECS, spec_for
+from rac.core.artifacts import ARTIFACT_SPECS, spec_for
 from rac.cli import main
-from rac.classification import classify
-from rac.improve import improve_file, improve_text, supports_improve
-from rac.inspect import inspect_file
-from rac.parser import parse, parse_file
-from rac.schema import available_schemas, schema_reference
-from rac.stats import collect_stats
-from rac.validate import has_errors, validate
+from rac.core.classification import classify
+from rac.services.improve import improve_file, improve_text, supports_improve
+from rac.services.inspect import inspect_file
+from rac.core.markdown import parse, parse_file
+from rac.core.schema import available_schemas, schema_reference
+from rac.services.stats import collect_stats
+from rac.core.validation import has_errors, validate
 
 from conftest import fixture_path
 
@@ -143,7 +143,7 @@ def test_template_omits_optional_relationship_sections(capsys):
 def test_template_passes_validation(monkeypatch):
     ref = schema_reference("roadmap")
     assert ref is not None
-    from rac.outputs import render_schema_template
+    from rac.output import render_schema_template
 
     template = render_schema_template(ref)
     _stdin(monkeypatch, template)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -7,9 +7,9 @@ import json
 
 import pytest
 
-from rac.artifacts import spec_for
+from rac.core.artifacts import spec_for
 from rac.cli import main
-from rac.schema import available_schemas, schema_reference
+from rac.core.schema import available_schemas, schema_reference
 
 from conftest import fixture_path
 

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -7,7 +7,7 @@ import json
 import pytest
 
 from rac.cli import main
-from rac.stats import collect_stats
+from rac.services.stats import collect_stats
 
 from conftest import fixture_path
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from rac.parser import parse, parse_file
-from rac.validate import has_errors, validate
+from rac.core.markdown import parse, parse_file
+from rac.core.validation import has_errors, validate
 
 from conftest import fixture_path
 


### PR DESCRIPTION
## What
Removes the 15 transitional compatibility shims left at the old top-level module paths by the v0.7.4 layering refactor (#33), and repoints test imports to the canonical layer modules.

## Why
The shims (`rac/parser.py → rac.core.markdown`, `rac/outputs.py → rac.output`, etc.) were re-export-only modules kept so tests wouldn't change. In the source tree they read as duplicate `.py` files for nearly every module — noise with no value now that `core/ services/ output/` are the canonical API.

## Changes
- Repoint test imports to `rac.core.*` / `rac.services.*` / `rac.output`.
- Delete the 15 `src/rac/*.py` shims. Top level is now just `__init__.py` + `cli.py`.

## Safety
- No `src/` logic or packaging changes — `cli.py` and the layer modules already imported canonically; the shims' only consumers were tests.
- 381 tests pass; `--json` tests confirm ADR-007 contracts unchanged.