### PR TITLE
chore(ci): add reusable test workflow and run it on PRs and pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+
+# Run the test suite on every pull request and on pushes to main. Push is
+# limited to main so PR branches don't run twice (once for push, once for the PR).
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+# Cancel superseded runs on the same ref (e.g. a new push to an open PR branch).
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  tests:
+    uses: ./.github/workflows/tests.yml

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -16,7 +16,13 @@ permissions:
   contents: read
 
 jobs:
+  test:
+    # Gate the release on the full test suite (reusable workflow). Tests must
+    # pass before anything is built or published.
+    uses: ./.github/workflows/tests.yml
+
   release-build:
+    needs: test
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,39 @@
+name: Tests
+
+# Reusable workflow — the single definition of how RAC's test suite runs.
+# Called by ci.yml (push / pull_request) and by python-publish.yml (release gate),
+# so the test steps live in one place rather than being duplicated.
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # setuptools-scm derives the version from git tags; fetch them so the
+          # editable install can resolve a version (mirrors python-publish.yml).
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install package with dev/test extras
+        run: |
+          python -m pip install --upgrade pip
+          # The dev extra pulls pytest plus the document libraries that
+          # tests/test_ingest.py uses to generate fixtures.
+          python -m pip install -e .[dev]
+
+      - name: Run tests
+        run: python -m pytest -q


### PR DESCRIPTION
# Summary

Adds continuous integration so RAC's test suite runs automatically and **gates
releases**. There is no roadmap item — this is release-pipeline infrastructure that
closes a real gap: today tests run only locally, so a broken commit can be tagged and
published to PyPI, and PRs get no automated signal.

Adds:
- `.github/workflows/tests.yml` — a reusable (`workflow_call`) pytest matrix on Python 3.11/3.12/3.13.
- `.github/workflows/ci.yml` — runs the suite on every pull request and every push to `main`.
- Gating in `.github/workflows/python-publish.yml` — a `test` job (the reusable workflow) now blocks build and publish.

# Roadmap / ADR Trace

Roadmap: none — CI infrastructure, no roadmap contract.

Relevant ADRs: none govern CI directly (no ADR invented for this). Tangentially, the
reusable-workflow choice keeps the test definition single-sourced, echoing the
single-owner principle recorded in `rac/decisions/adr-023-clean-break-internal-refactors.md`.

# Scope

## Included
- Reusable test workflow: matrix `3.11/3.12/3.13`, `fail-fast: false`, `checkout` with `fetch-depth: 0` (setuptools-scm tags), `pip install -e .[dev]`, `python -m pytest -q`.
- PR/push CI (`ci.yml`): `pull_request` + `push: [main]`, with a `concurrency` group that cancels superseded runs.
- Release gating: the `python-publish.yml` job graph becomes `test → release-build → pypi-publish`.

## Excluded (deliberately)
- **No lint / type-check / coverage gates.** None are configured in the repo today; CI mirrors the existing local command (`pytest`) only. Adding them is a separate decision.
- **No branch-protection rule.** Requiring this check before merge is a GitHub repository setting, not in-repo; recommended but out of scope here.
- **No change to release triggers or PyPI publish mechanics.** Trusted publishing and the `release: published` trigger are unchanged — only a `needs: test` gate is added.
- **No duplicated test definitions.** The matrix lives once in `tests.yml`; both pipelines reference it so they can't drift.
- **No matrix beyond supported versions.** Limited to the 3.11–3.13 range declared in `pyproject.toml`.

# Product / Architecture Decisions
- **Reusable `workflow_call` over duplicated jobs.** The test job is defined once in `tests.yml` and called by both `ci.yml` and `python-publish.yml`, so PR CI and the release gate stay identical.
- **`push` limited to `main`.** PR branches would otherwise run twice (push + pull_request); PRs are covered by `pull_request`, and `push: [main]` covers the post-merge state.
- **`fetch-depth: 0`.** setuptools-scm needs tags to resolve a version during the editable install — mirrors the rationale already present in `python-publish.yml`.
- **`.[dev]` install.** The full suite needs the document libraries `tests/test_ingest.py` uses to generate fixtures, which the `dev` extra provides; installing only `pytest` would break that module.
- **Gate placement.** `release-build` gains `needs: test`; since `pypi-publish` already needs `release-build`, a failing test blocks both build and publish.

# User-Facing Contract

No CLI / JSON / runtime surface — this is repository automation. Behavioral contract:

## CI behavior
- Every pull request and every push to `main` runs `pytest` on Python 3.11, 3.12, and 3.13.
- A published GitHub Release runs the same suite first; the build and PyPI publish proceed only if it passes.

## Status
- A red `Tests` check blocks the release build/publish, and (once a branch-protection rule is enabled) blocks merge to `main`.

# Verification

## Ran
```bash
ruby -ryaml -e '...'                 # all three workflows parse as valid YAML
.venv/bin/python -m pytest -q        # 381 passed (this branch == main baseline)
```

## Covered
- All three workflow files validated as well-formed YAML.
- The underlying test command is green on the branch base.
- **End-to-end:** this PR's own `pull_request` run exercises `ci.yml → tests.yml` across the 3.11/3.12/3.13 matrix — the checks on this PR are the first real proof the workflow runs.
- **Release gating:** verified structurally — `python-publish.yml`'s job graph is `test → release-build → pypi-publish`.

# Review Path
1. `.github/workflows/tests.yml` — the reusable matrix test job (the shared definition).
2. `.github/workflows/ci.yml` — the push/PR caller.
3. `.github/workflows/python-publish.yml` — the added `test` job and `release-build: needs: test` gate.

# Notes For Reviewer
- The real proof is this PR's own CI run — please confirm the `Tests (3.11/3.12/3.13)` checks appear and pass.
- `pip install -e .[dev]` pulls markitdown + document libraries; first runs are slower while Actions caches warm. If Python 3.13 ever hits a transient install issue, narrowing the extra on 3.13 is the fallback.
- A required-status-check branch-protection rule on `main` is recommended so red CI actually blocks merges — that's a repo setting, intentionally not part of this PR.
- Independent of PR #36 (v0.7.5); branched from `main`. Once this merges, #36's CI will run on its next push/rebase.
