### PR TITLE
fix(decisions): correct ADR filenames and heading numbers

### DIFF
--- a/rac/decisions/adr-019-asset-management.md
+++ b/rac/decisions/adr-019-asset-management.md
@@ -1,4 +1,4 @@
-# ADR-017 Asset References
+# ADR-019: Asset References
 
 ## Status
 

--- a/rac/decisions/adr-024-rac-not-content-store.md
+++ b/rac/decisions/adr-024-rac-not-content-store.md
@@ -1,4 +1,4 @@
-# ADR-016: RAC Is Not a Content Store
+# ADR-024: RAC Is Not a Content Store
 
 ## Status
 

--- a/rac/decisions/adr-025-hybrid-artifact-metadata.md
+++ b/rac/decisions/adr-025-hybrid-artifact-metadata.md
@@ -1,4 +1,4 @@
-# ADR-XXX Hybrid Artifact Metadata
+# ADR-025: Hybrid Artifact Metadata
 
 ## Status
 

--- a/rac/decisions/adr-026-opaque-artifact-identities.md
+++ b/rac/decisions/adr-026-opaque-artifact-identities.md
@@ -1,4 +1,4 @@
-# ADR-XXX Opaque System-Assigned Artifact Identity
+# ADR-026: Opaque System-Assigned Artifact Identity
 
 ## Status
 


### PR DESCRIPTION
# Summary

Repository-hygiene fix for `rac/decisions/`. Corrects ADR filename and heading inconsistencies. No code, schema, or behavior changes.

- Renames `adr024-rac-not-content-store.md` → `adr-024-rac-not-content-store.md` to match the `adr-NNN-slug.md` convention every other ADR uses.
- Corrects four ADR H1 headings whose numbers did not match their filenames.

# Roadmap / ADR Trace

No roadmap item — this is a consistency fix, not roadmap-scoped work.

ADRs touched:

- `rac/decisions/adr-024-rac-not-content-store.md` — file rename + heading `ADR-016` → `ADR-024`
- `rac/decisions/adr-019-asset-management.md` — heading `ADR-017` → `ADR-019`
- `rac/decisions/adr-025-hybrid-artifact-metadata.md` — heading `ADR-XXX` → `ADR-025`
- `rac/decisions/adr-026-opaque-artifact-identities.md` — heading `ADR-XXX` → `ADR-026`

# Scope

## Included

- Rename adr-024 to the `adr-NNN-slug.md` convention.
- Normalize four headings to the canonical `# ADR-NNN: Title` form.
- Outcome: all 27 ADRs now have matching filename ↔ heading numbers.

## Excluded

- No ADR body content changed beyond the single H1 line.
- Did **not** add the recommended `Category` section to adr-024 (body content, out of scope for a naming fix).
- Did **not** reconcile adr-019's title ("Asset References") with its filename slug ("asset-management").
- Did **not** alter adr-025 / adr-026 `Status: Proposed` or any of their content.

# Product / Architecture Decisions

- Heading format normalized to `# ADR-NNN: Title` (colon separator) to match the existing corpus; adr-019/025/026 previously omitted the colon.
- adr-024's number is taken from its filename; its previous `ADR-016` heading collided with the genuine `adr-016-relationships-as-structural-references.md`.

# User-Facing Contract

None. No CLI, JSON, or exit-code changes.

# Verification

## Ran

```bash
.venv/bin/python -m pytest -q
.venv/bin/rac inspect rac/decisions/adr-024-rac-not-content-store.md
.venv/bin/rac inspect rac/decisions/adr-019-asset-management.md
.venv/bin/rac inspect rac/decisions/adr-025-hybrid-artifact-metadata.md
.venv/bin/rac inspect rac/decisions/adr-026-opaque-artifact-identities.md
```

## Covered

- Full suite: **398 passed** — confirms no ADR-scanning test regressed.
- All four edited ADRs still classify as **Decision** via `rac inspect`.
- Corpus scan: every `rac/decisions/adr-*.md` has filename number == heading number (27/27, zero mismatches).

# Review Path

1. `rac/decisions/adr-024-rac-not-content-store.md` — rename + heading (commit `e30051e`).
2. `rac/decisions/adr-019-asset-management.md` — heading (commit `c064e81`).
3. `rac/decisions/adr-025-hybrid-artifact-metadata.md` — heading (commit `c064e81`).
4. `rac/decisions/adr-026-opaque-artifact-identities.md` — heading (commit `c064e81`).

# Notes For Reviewer

- **Base branch is `ci/per-service-test-batteries`, not `main`** — these fixes reach `main` when the CI branch merges. The diff here is ADR-only; the CI-topology work lives on the base branch.
- Deferred follow-ups (not in scope): adr-024 missing `Category` section; adr-019 title/slug mismatch.
