### PR TITLE
docs: introduce user documentation layer (v0.7.6)

### DIFF
--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -1,0 +1,112 @@
+# Artifacts
+
+RAC understands five artifact types, all written in plain Markdown:
+
+| Type | Captures | Typical filename |
+| --- | --- | --- |
+| **Requirement** | What needs to exist | `login-flow.md` |
+| **Decision** | Why a choice was made | `adr-001-markdown-first.md` |
+| **Roadmap** | Where the product is heading | `v0.7.6-document-structure.md` |
+| **Prompt** | A reusable AI collaboration pattern | `requirement-review.md` |
+| **Design** | Product experience thinking | `checkout-flow.md` |
+
+You never declare a type. RAC infers it from the `##` section headings in the file.
+
+## How classification works
+
+Classification is **deterministic** — no AI, no scoring model. RAC reads the `##`
+headings, normalizes them (case- and whitespace-insensitive, so `## Problem` and
+`## problem` are the same), and matches them against each schema's expected sections.
+
+- The best-matching type wins, and `inspect` reports a confidence percentage.
+- If no type reaches a **50% confidence** match, the file is reported as `Unknown`.
+  That is a valid, expected outcome — not an error.
+
+```bash
+rac inspect login-flow.md      # Artifact Type: Requirement (71%)
+rac schema --list              # the five registered types
+```
+
+## Documents vs. artifacts
+
+A Markdown file is a *document*; an *artifact* is a recognized, structured piece of
+knowledge. Plenty of useful documents (notes, guides, planning files) won't match a
+schema, and that's fine — `stats` and `portfolio` list them as "unrecognized" rather
+than failing. RAC reports them, it doesn't reject them.
+
+## Artifact identity
+
+Most commands refer to artifacts by an **id**. RAC resolves an id in this order:
+
+1. An explicit `## ID` section, if present.
+2. A `<letters>-<digits>` prefix on the filename (e.g. `adr-004-...` → `adr-004`).
+3. The filename stem (e.g. `login-flow.md` → `login-flow`).
+
+Ids are compared case-insensitively. Identity is what
+[relationships](relationships.md) resolve against.
+
+---
+
+## The five types
+
+For each type, scaffold a starter file with `rac schema <type> --template` and read
+the full section guidance with `rac schema <type>`.
+
+### Requirement
+
+What the system must do.
+
+- **Required:** Problem · Requirements
+- **Recommended:** Success Metrics · Risks · Assumptions
+- **Optional:** Related Decisions · Related Roadmaps · Related Prompts · Related Designs
+- **Naming:** a descriptive slug, e.g. `login-flow.md`. Write requirements as
+  testable `[REQ-001]` statements.
+
+### Decision
+
+Why a choice was made — typically as an ADR (Architecture Decision Record). **ADRs
+are Decisions written in ADR format**, not a separate type.
+
+- **Required:** Context · Decision · Consequences
+- **Recommended:** Status · Category · Alternatives Considered
+- **Optional:** Supersedes · Related Requirements · Related Roadmaps · Related Designs
+- **Metadata values (validated when present):**
+  - `Status`: `Proposed` | `Accepted` | `Superseded` | `Deprecated`
+  - `Category`: `Architecture` | `Product` | `Process` | `Technical` | `Other`
+- **Naming:** `adr-NNN-slug.md` (e.g. `adr-001-markdown-first.md`), which gives the
+  id `adr-001`.
+
+### Roadmap
+
+Where the product is heading — outcomes and the work that supports them.
+
+- **Required:** Outcomes · Initiatives
+- **Recommended:** Success Measures · Assumptions · Risks
+- **Optional:** Related Decisions · Related Requirements · Related Prompts · Related Designs
+- **Naming:** `vX.Y.Z-slug.md` (e.g. `v0.7.6-document-structure.md`), which gives the
+  id `v0.7.6`.
+
+### Prompt
+
+A reusable pattern for collaborating with an AI model.
+
+- **Required:** Objective · Input · Instructions · Output
+- **Recommended:** Constraints · Examples · Evaluation
+- **Optional:** Related Requirements · Related Decisions · Related Roadmaps · Related Designs
+- **Naming:** a descriptive slug, e.g. `requirement-review.md`.
+
+### Design
+
+Product experience thinking — flows, interactions, and the constraints around them.
+
+- **Required:** Context · User Need · Design · Constraints
+- **Recommended:** Rationale · Alternatives · Accessibility · Style Guidance · Open Questions
+- **Optional:** Related Requirements · Related Decisions · Related Roadmaps · Related Prompts
+- **Naming:** a descriptive slug, e.g. `checkout-flow.md`.
+
+---
+
+## See also
+
+- [relationships.md](relationships.md) — connect artifacts with `## Related …` sections.
+- [cli.md](cli.md#schema) — the `schema`, `inspect`, and `improve` commands.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,263 @@
+# CLI Reference
+
+RAC ships a single command, `rac`, with ten subcommands. This page documents each
+one: its purpose, inputs, outputs, and exit codes.
+
+```bash
+rac <command> [arguments] [options]
+rac --version
+rac <command> --help
+```
+
+## Conventions
+
+These apply across every command.
+
+- **`--json`** — most commands accept `--json` to emit machine-readable output
+  instead of the human-readable report. JSON output is a stable contract intended
+  for tools, IDEs, CI, and agents.
+- **Standard input** — `validate`, `inspect`, and `improve` accept `-` in place of a
+  file to read Markdown from stdin (e.g. `cat file.md | rac validate -`).
+- **Recursion** — directory commands (`stats`, `inspect`, `relationships`,
+  `portfolio`, `index`) recurse into subdirectories by default. Pass `--top-level`
+  to scan only the immediate directory. `--recursive` is accepted explicitly for
+  clarity but is already the default.
+- **Exit codes** — every command follows the same convention:
+
+  | Code | Meaning |
+  | --- | --- |
+  | `0` | Success |
+  | `1` | Validation or relationship check failed |
+  | `2` | Usage or I/O error (bad arguments, file not found, not a directory) |
+
+---
+
+## validate
+
+Validate a single requirement file for structural and content issues.
+
+- **Input:** `rac validate <file>` — a Markdown file, or `-` for stdin.
+- **Options:** `--json`
+- **Exit codes:** `0` no errors · `1` validation errors · `2` file not found / unreadable
+
+```bash
+rac validate login-flow.md
+```
+
+```text
+PASS  login-flow.md
+  warning [missing-risks] login-flow.md
+          No ## Risks section (optional, but recommended).
+
+0 error(s), 1 warning(s).
+```
+
+Warnings do not fail the run; only errors return exit `1`. Use `--json` for the
+structured form (`valid`, `errors[]`, `warnings[]` with stable `code` fields).
+
+> `validate` checks **one file**. For a whole tree, use [`stats`](#stats).
+
+---
+
+## diff
+
+Compare two versions of a requirement file and report what changed.
+
+- **Input:** `rac diff <old> <new>` — two Markdown files.
+- **Options:** `--json`
+- **Exit codes:** `0` success · `2` file not found / unreadable
+
+```bash
+rac diff examples/example_dashboard_v1.md examples/example_dashboard_v2.md
+```
+
+```text
+Added Requirements
+
++ REQ-004 User can schedule a weekly usage summary email
+
+Removed Requirements
+
+- REQ-003 User can export the current chart as a CSV file
+
+Modified Requirements
+
+~ REQ-002
+  Before: User can filter usage charts by date range
+  After:  User can filter usage charts by date range and by team
+```
+
+---
+
+## stats
+
+Summarize a directory of artifacts: counts, quality signals, and per-type breakdowns.
+
+- **Input:** `rac stats <directory>` — scanned recursively for `*.md`.
+- **Options:** `--json`
+- **Exit codes:** `0` analyzable content found · `1` no valid artifacts · `2` not a directory
+
+```bash
+rac stats rac/
+```
+
+Reports feature/requirement/decision/roadmap/design counts, missing recommended
+sections, and a list of files that matched no schema (not errors — see
+[ADR-010](artifacts.md#documents-vs-artifacts)).
+
+---
+
+## ingest
+
+Convert a document (DOCX, PDF, HTML, PPTX, XLSX, or Markdown) into RAC-compatible
+Markdown.
+
+- **Input:** `rac ingest <file>` — the source document.
+- **Options:** `-o, --output <path>` (write to a file; errors if it exists unless
+  `--force`) · `--stdout` (explicit stdout, the default) · `--force` · `--json`
+- **Exit codes:** `0` success · `1` conversion failed · `2` unsupported type / file not found / output exists without `--force`
+
+```bash
+rac ingest spec.docx                 # preview Markdown on stdout
+rac ingest spec.docx -o spec.md      # write to a file
+rac ingest report.pdf -o report.md --force
+```
+
+Conversion uses optional extras. Install the readers you need:
+`pip install 'requirements-as-code[ingest]'` (DOCX/HTML), `[ingest-pdf]`,
+`[ingest-office]` (PPTX/XLSX), or `[ingest-all]`.
+
+---
+
+## inspect
+
+Identify a document's artifact type and which sections are present or missing. Works
+on a single file or a whole directory.
+
+- **Input:** `rac inspect <file|directory>` — or `-` for stdin (single file only).
+- **Options:** `--json` · `--verbose` (classification breakdown and score, single
+  file only) · `--top-level` · `--recursive`
+- **Exit codes:** `0` (a completed inspection always succeeds — `Unknown` is a valid result)
+
+```bash
+rac inspect login-flow.md
+rac inspect . --json            # aggregate type counts for a directory
+```
+
+```text
+Artifact Type: Requirement
+Confidence: 71%
+
+Present Sections:
+  ✓ Problem
+  ✓ Requirements
+  ✓ Success Metrics
+
+Missing Sections:
+  ✗ Risks
+  ✗ Assumptions
+```
+
+---
+
+## improve
+
+Suggest the sections an artifact is missing, optionally as ready-to-paste templates.
+
+- **Input:** `rac improve <file>` — or `-` for stdin.
+- **Options:** `--json` *or* `--template` (mutually exclusive)
+- **Exit codes:** `0` (suggestions are advice, not failure)
+
+```bash
+rac improve login-flow.md             # list missing sections
+rac improve login-flow.md --template  # emit Markdown stubs to paste in
+```
+
+---
+
+## schema
+
+Show registered artifact schemas and starter templates.
+
+- **Input:** `rac schema [name]` — `requirement`, `decision`, `roadmap`, `prompt`, or `design`.
+- **Options:** `--list` (list all schema names) · `--json` *or* `--template`
+  (mutually exclusive) · `--list` cannot be combined with a schema name
+- **Exit codes:** `0` success · `2` unknown schema name or flag misuse
+
+```bash
+rac schema --list                  # the five artifact types
+rac schema requirement             # required / recommended / optional sections
+rac schema decision --template     # starter Markdown for a decision
+rac schema roadmap --json          # machine-readable schema
+```
+
+---
+
+## relationships
+
+Inspect — and optionally validate — explicit references between artifacts in a file
+or directory.
+
+- **Input:** `rac relationships <path>` — a directory or a single Markdown file.
+- **Options:** `--validate` (resolve every reference; exit `1` on any broken,
+  ambiguous, self-referencing, or duplicate-identifier finding) · `--json` ·
+  `--top-level` · `--recursive`
+- **Exit codes:** `0` relationships found / all references valid · `1` validation
+  issues · `2` path not found
+
+```bash
+rac relationships rac/              # list the references RAC discovered
+rac relationships rac/ --validate   # check that every reference resolves
+```
+
+Finding no relationships is **not** an error. See [relationships.md](relationships.md)
+for the issue codes `--validate` reports.
+
+---
+
+## portfolio
+
+A one-screen repository intelligence summary: artifact counts by type, validity,
+completeness, relationship coverage, an attention list, and a health score.
+
+- **Input:** `rac portfolio <directory>` — scanned recursively for `*.md`.
+- **Options:** `--json` · `--top-level` · `--recursive`
+- **Exit codes:** `0` success · `2` not a directory
+
+```bash
+rac portfolio rac/
+```
+
+---
+
+## index
+
+Produce a flat inventory of every artifact — id, type, title, and path — so other
+tools can build navigation without re-scanning files.
+
+- **Input:** `rac index [directory]` — defaults to the current directory; scanned
+  recursively for `*.md`.
+- **Options:** `--json` · `--top-level` · `--recursive`
+- **Exit codes:** `0` success · `2` not a directory
+
+```bash
+rac index rac/
+rac index rac/ --json
+```
+
+```json
+{
+  "schema_version": "1",
+  "directory": "rac/requirements/",
+  "recursive": true,
+  "artifact_count": 4,
+  "artifacts": [
+    {
+      "id": "rac-documentation-structure",
+      "type": "unknown",
+      "title": "REQ-Documentation-Structure",
+      "path": "rac/requirements/rac-documentation-structure.md"
+    }
+  ]
+}
+```

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,141 @@
+# Examples
+
+Short, realistic artifacts you can adapt. These show the *shape* of each type — for a
+blank starter with section guidance, use `rac schema <type> --template`
+([cli.md](cli.md#schema)).
+
+## A requirement
+
+```markdown
+# Usage Export
+
+## Problem
+
+Analysts need to take dashboard data into their own spreadsheets, but today the only
+way out is copy-paste, which is slow and error-prone.
+
+## Requirements
+
+- [REQ-001] Users can export the current chart as a CSV file.
+- [REQ-002] The export reflects the active filters and date range.
+
+## Success Metrics
+
+- 25% of active accounts export at least once per month.
+
+## Risks
+
+- Large exports could time out for accounts with long histories.
+```
+
+Save it as `usage-export.md` and it resolves to the id `usage-export`.
+
+## A decision that references it
+
+Artifacts connect through `## Related …` sections. This decision points back at the
+requirement above:
+
+```markdown
+# ADR-010 CSV as the Export Format
+
+## Context
+
+Usage Export (REQ-001) needs a file format. The choices are CSV, XLSX, and JSON.
+
+## Decision
+
+Export as CSV. It opens everywhere, stays diff-friendly, and needs no new dependency.
+
+## Consequences
+
+Rich types (colors, formulas) are lost, which is acceptable for tabular analytics.
+
+## Status
+
+Accepted
+
+## Category
+
+Technical
+
+## Related Requirements
+
+- usage-export
+```
+
+Validate the link with `rac relationships . --validate` — see
+[relationships.md](relationships.md).
+
+## A roadmap
+
+```markdown
+# Export Capabilities
+
+## Outcomes
+
+Analysts can move dashboard data into their own tools without manual rekeying.
+
+## Initiatives
+
+- Ship CSV export for charts.
+- Add scheduled email summaries.
+
+## Success Measures
+
+- A quarter after launch, a quarter of accounts use an export feature.
+```
+
+## A prompt
+
+```markdown
+# Requirement Review
+
+## Objective
+
+Review a requirement artifact for structural completeness.
+
+## Input
+
+A single requirement Markdown file.
+
+## Instructions
+
+Check for a clear problem statement and testable [REQ-NNN] requirement lines.
+
+## Output
+
+A bulleted list of findings, one per gap.
+```
+
+## A design
+
+```markdown
+# Export Button Placement
+
+## Context
+
+The dashboard toolbar is getting crowded as we add an export action.
+
+## User Need
+
+Analysts want export within reach without hunting through a menu.
+
+## Design
+
+A single "Export" button in the toolbar opens a small menu (CSV today, more later).
+
+## Constraints
+
+Must stay keyboard-accessible and meet WCAG AA contrast.
+```
+
+## Diffing two versions
+
+This repository ships a before/after pair under `examples/`. Compare them to see how
+RAC reports requirement and metric changes:
+
+```bash
+rac diff examples/example_dashboard_v1.md examples/example_dashboard_v2.md
+```
+
+See [cli.md](cli.md#diff) for the full output.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,134 @@
+# Quickstart
+
+Try RAC in about five minutes. You will install the tool, scaffold your first
+artifact, and run the three commands you'll use most: `validate`, `inspect`, and
+`improve`.
+
+## 1. Install
+
+RAC is a Python package (requires Python 3.11+). Install it with `pip`:
+
+```bash
+pip install requirements-as-code
+```
+
+Or with [uv](https://docs.astral.sh/uv/):
+
+```bash
+uv tool install requirements-as-code
+```
+
+This puts a single command on your path: `rac`. Check it:
+
+```bash
+rac --version
+```
+
+## 2. Create your first artifact
+
+RAC works on plain Markdown files. The fastest way to start a well-formed artifact
+is to scaffold one from a schema template:
+
+```bash
+rac schema requirement --template > login-flow.md
+```
+
+That writes a starter file with the sections a requirement should have. Open it and
+replace the `TODO` placeholders with your own content. For this walkthrough, use:
+
+```markdown
+# Login Flow
+
+## Problem
+
+Users need a secure, reliable way to sign in to their account. Today there is no
+first-class authentication flow, so access control is inconsistent across the app.
+
+## Requirements
+
+- [REQ-001] Users can authenticate with an email address and password.
+- [REQ-002] Invalid credentials show a clear, non-revealing error message.
+- [REQ-003] A successful sign-in redirects the user to their dashboard.
+
+## Success Metrics
+
+- 95% of sign-in attempts complete in under 2 seconds.
+- Authentication-related support tickets drop by half within one quarter.
+```
+
+> RAC classifies artifacts by their `##` section headings — there is no `init`
+> command and no front matter to memorize. See [artifacts.md](artifacts.md).
+
+## 3. Validate it
+
+`validate` checks one file for structural problems:
+
+```bash
+rac validate login-flow.md
+```
+
+```text
+PASS  login-flow.md
+  warning [missing-risks] login-flow.md
+          No ## Risks section (optional, but recommended).
+
+0 error(s), 1 warning(s).
+```
+
+The file passes (exit code `0`). The warning is advisory — `## Risks` is recommended
+but not required.
+
+## 4. Inspect it
+
+`inspect` tells you what RAC thinks the file is and how complete it is:
+
+```bash
+rac inspect login-flow.md
+```
+
+```text
+Artifact Type: Requirement
+Confidence: 71%
+
+Present Sections:
+  ✓ Problem
+  ✓ Requirements
+  ✓ Success Metrics
+
+Missing Sections:
+  ✗ Risks
+  ✗ Assumptions
+```
+
+## 5. Improve it
+
+`improve` suggests what to add next:
+
+```bash
+rac improve login-flow.md
+```
+
+```text
+Artifact Type: Requirement
+
+Missing Required:
+  (none)
+
+Missing Recommended:
+  - Risks
+      • What could prevent successful delivery?
+      • What dependencies or unknowns exist?
+  - Assumptions
+      • What are you assuming to be true?
+      • What would change the approach if it turned out false?
+```
+
+Add a `## Risks` and `## Assumptions` section and run `rac inspect` again to watch
+the confidence climb.
+
+## Where to go next
+
+- [cli.md](cli.md) — every command, its flags, and its exit codes.
+- [artifacts.md](artifacts.md) — the five artifact types and their sections.
+- [relationships.md](relationships.md) — link artifacts together and validate the links.
+- [repo-workflow.md](repo-workflow.md) — organize a whole repository with RAC.

--- a/docs/relationships.md
+++ b/docs/relationships.md
@@ -1,0 +1,85 @@
+# Relationships
+
+Artifacts rarely stand alone — a requirement informs a decision, a roadmap pursues a
+requirement, a design references both. RAC lets you record those links **in the
+Markdown itself** and then validate that they resolve.
+
+## Declaring a relationship
+
+Add one of the `## Related …` sections and list the ids of the artifacts you're
+referencing, one per line:
+
+```markdown
+## Related Requirements
+- login-flow
+
+## Related Decisions
+- adr-001
+- adr-007
+```
+
+The five relationship sections, one per target type:
+
+- `## Related Requirements`
+- `## Related Decisions`
+- `## Related Roadmaps`
+- `## Related Prompts`
+- `## Related Designs`
+
+Decisions may also use `## Supersedes` to point at the decision they replace.
+
+Each non-empty line is one reference. A leading list marker (`-`, `*`, `+`, or `1.`)
+is stripped; the rest of the line is the id, matched case-insensitively against the
+[identity](artifacts.md#artifact-identity) of every artifact RAC discovers. A
+relationship section is only recognized on a type that declares it (so an unknown
+document contributes no relationships).
+
+## Viewing relationships
+
+```bash
+rac relationships rac/          # human-readable report
+rac relationships rac/ --json   # machine-readable
+```
+
+This lists the references RAC found. Finding none is not an error.
+
+## Validating relationships
+
+Add `--validate` to resolve every reference against the artifacts in the path:
+
+```bash
+rac relationships rac/ --validate
+```
+
+```text
+Relationship Validation
+
+Relationships Checked: 12
+Validation Issues: 0
+```
+
+If every reference resolves uniquely, the command exits `0`. Otherwise it reports
+each problem and exits `1`. The issue codes:
+
+| Code | Meaning |
+| --- | --- |
+| `relationship-target-not-found` | The referenced id matches no artifact. |
+| `relationship-target-ambiguous` | The referenced id matches more than one artifact. |
+| `relationship-self-reference` | An artifact references itself. |
+| `duplicate-artifact-identifier` | Two artifacts resolve to the same id. |
+
+Exit codes follow the standard convention: `0` all references valid · `1` issues
+found · `2` path not found.
+
+## Repository consistency
+
+Run `--validate` across your whole `rac/` tree to catch drift as artifacts are added,
+renamed, or removed — a broken reference usually means a target was renamed or a typo
+crept into an id. For a higher-level view that also surfaces **orphaned** artifacts
+(those nothing else references) and an overall relationship coverage percentage, use
+[`rac portfolio`](cli.md#portfolio).
+
+## See also
+
+- [artifacts.md](artifacts.md#artifact-identity) — how ids are resolved.
+- [repo-workflow.md](repo-workflow.md) — running these checks across a repository.

--- a/docs/repo-workflow.md
+++ b/docs/repo-workflow.md
@@ -1,0 +1,73 @@
+# Repository Workflow
+
+RAC runs against any directory of Markdown files, but it shines when a repository
+gives its product knowledge an intentional home. This page describes the convention
+RAC itself uses.
+
+## The `rac/` knowledge directory
+
+Collect your artifacts under a top-level `rac/` directory, grouped by type:
+
+```text
+rac/
+  requirements/   # what needs to exist
+  decisions/      # ADRs — why choices were made
+  designs/        # product experience thinking
+  prompts/        # reusable AI collaboration patterns
+  roadmaps/       # where the product is heading
+  assets/         # supporting images and files
+```
+
+The directory layout is a convention, not a requirement — RAC classifies each file by
+its [section headings](artifacts.md#how-classification-works), not its folder. Grouping
+by type simply keeps a growing corpus navigable and makes `stats`/`portfolio` output
+easy to read.
+
+### Three documentation layers
+
+RAC's own repository separates concerns into three layers
+([ADR-022](../rac/decisions/adr-022-documentation-boundaries.md)):
+
+- **`README.md`** — the front door: what RAC is and how to try it.
+- **`docs/`** — user-facing guides (this directory).
+- **`rac/`** — RAC's internal, structured product knowledge.
+
+`rac/` is the corpus RAC manages; `docs/` is documentation *for people*. Keep them
+distinct: users shouldn't need to read internal roadmaps or ADRs to be productive.
+
+## Naming
+
+- Requirements / prompts / designs: a descriptive slug — `login-flow.md`.
+- Decisions: `adr-NNN-slug.md` — `adr-001-markdown-first.md`.
+- Roadmaps: `vX.Y.Z-slug.md` — `v0.7.6-document-structure.md`.
+
+See [artifacts.md](artifacts.md) for the sections each type expects.
+
+## Everyday commands
+
+Run these from the repository root:
+
+```bash
+rac stats rac/                    # counts, quality signals, per-type breakdown
+rac relationships rac/ --validate # check that cross-artifact references resolve
+rac portfolio rac/                # one-screen health summary + attention list
+rac index rac/ --json             # flat inventory for tools, CI, and agents
+```
+
+To check a single file as you edit it:
+
+```bash
+rac validate rac/requirements/login-flow.md
+rac inspect  rac/requirements/login-flow.md
+```
+
+> `rac validate` operates on **one file**. For tree-wide health, use `rac stats rac/`
+> — pointing `validate` at a directory is a usage error.
+
+## In review and CI
+
+Because everything is Markdown in Git, documentation and artifacts move through the
+same pull-request workflow as code. A natural pre-merge check is to run `rac stats`
+and `rac relationships --validate` over `rac/` so reviewers can see whether new or
+edited artifacts are complete and their links still resolve. See
+[testing.md](testing.md) for the contributor verification workflow.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,79 @@
+# Testing & Contributing
+
+This page is for contributors working on RAC itself: how to set up a local
+environment, run the test suite, and verify a change before opening a pull request.
+
+## Local setup
+
+RAC requires **Python 3.11+**. Work inside a virtual environment and install the
+package in editable mode with the `dev` extra, which pulls in `pytest` and the
+libraries used to generate test fixtures:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -e '.[dev]'
+```
+
+If you prefer not to activate the environment, call the interpreter directly —
+`.venv/bin/python` — which is what the examples below do.
+
+## Running the tests
+
+The suite lives in `tests/` (configured via `testpaths` in `pyproject.toml`), so
+`pytest` needs no arguments:
+
+```bash
+.venv/bin/python -m pytest        # or: .venv/bin/pytest
+```
+
+Useful variations:
+
+```bash
+.venv/bin/python -m pytest -q                      # quieter output
+.venv/bin/python -m pytest tests/test_validate.py  # one module
+.venv/bin/python -m pytest -k relationships        # match by name
+```
+
+Tests are organized per capability — `test_validate.py`, `test_inspect.py`,
+`test_relationships.py`, `test_schema.py`, and so on — with Markdown inputs under
+`tests/fixtures/`. When you add a behavior, add fixtures and a matching test,
+including negative cases (an invalid file, or a neighboring artifact type that must
+*not* classify as the new one).
+
+## Source layout
+
+The package uses a `src/` layout. The import package `rac` is organized into layers
+([ADR-023](../rac/decisions/adr-023-clean-break-internal-refactors.md)):
+
+```text
+src/rac/
+  cli.py       command-line entry point
+  core/        domain primitives: parsing, classification, identity, schemas
+  services/    repository capabilities: inspect, stats, relationships, ingest
+  output/      human, JSON, and template rendering
+  explorer/    consumer boundary
+```
+
+## Verify before a pull request
+
+1. **Run the suite** — it must pass:
+
+   ```bash
+   .venv/bin/python -m pytest
+   ```
+
+2. **Review your artifact changes** with RAC's own tooling:
+
+   ```bash
+   .venv/bin/rac stats rac/
+   .venv/bin/rac relationships rac/ --validate
+   ```
+
+   `stats` shows whether new or edited artifacts are complete; `relationships
+   --validate` flags references that no longer resolve (it exits `1` when it finds
+   any, so read its report and confirm every issue is intended or pre-existing).
+
+3. **Follow the commit conventions** in
+   [`rac/prompts/rac-agent-commit-guidelines.md`](../rac/prompts/rac-agent-commit-guidelines.md):
+   `<type>(<area>): <summary> [reference]`.

--- a/rac/roadmaps/v0.7.6-document-structure.md
+++ b/rac/roadmaps/v0.7.6-document-structure.md
@@ -93,15 +93,18 @@ Must document:
 - Outputs
 - Common examples
 
-Initial commands:
+Commands (full reference in docs/cli.md):
 
 - validate
+- diff
+- stats
+- ingest
 - inspect
 - improve
-- stats
-- diff
 - schema
 - relationships
+- portfolio
+- index
 
 ---
 
@@ -110,8 +113,7 @@ Initial commands:
 Must explain supported RAC artifacts:
 
 - Requirements
-- Decisions
-- ADRs
+- Decisions (ADRs are Decisions written in ADR format)
 - Roadmaps
 - Prompts
 - Designs
@@ -145,19 +147,19 @@ Example:
 ```text
 rac/
   requirements/
-  adr/
-  roadmap/
-  design/
-  prompt/
-  decision/
+  decisions/
+  designs/
+  prompts/
+  roadmaps/
+  assets/
 ```
 
 Include workflows:
 
 ```bash
 rac stats rac/
-rac validate rac/
 rac relationships rac/ --validate
+rac portfolio rac/
 ```
 
 ---
@@ -201,14 +203,15 @@ This release does not:
 Run:
 
 ```bash
-rac validate rac/
 rac stats rac/
 rac relationships rac/ --validate
 pytest
 ```
 
+Note: `rac validate` checks a single file; use `rac stats rac/` for tree-wide health.
+
 ## Release
 
 Target:
 
-v0.7.3 patch release
+v0.7.6


### PR DESCRIPTION
Implements `rac/roadmaps/v0.7.6-document-structure.md` (REQ-Documentation-Structure)
and the three-layer model in ADR-022: README → `docs/` → `rac/`.

## What changed

Adds the `docs/` user-documentation layer (7 task-oriented guides):

- `quickstart.md` — install + first artifact in five minutes
- `cli.md` — reference for all 10 commands (inputs, outputs, exit codes)
- `artifacts.md` — the 5 artifact types, classification, identity
- `relationships.md` — references, validation, issue codes
- `repo-workflow.md` — `rac/` conventions and everyday commands
- `testing.md` — contributor setup and verification workflow
- `examples.md` — small, realistic artifacts (one per type)

Also corrects the roadmap file to match shipped behavior: v0.7.6 release target,
single-file `validate`, actual plural corpus directory names, 10 commands, and 5
artifact types (ADRs are Decisions in ADR format).

## Out of scope

- README.md is untouched (owned by v0.7.7 readme-simplification).
- No CLI behavior, schema, validation, or artifact-type changes.

## Verification

- `pytest` — 398 passed.
- Documented command output (quickstart, cli, relationships) captured from real runs.
- `rac relationships . --validate` on the examples.md linked pair resolves cleanly.