### PR TITLE
docs: simplify README into a concise landing page (v0.7.7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,237 +1,76 @@
-# RAC — Requirements as Code
+# Requirements as Code
 
-**Treat product knowledge like source code.**
+> **Treat product knowledge like source code.**
 
-RAC is an open-source toolkit for managing requirements, decisions, roadmaps, prompts, and design artifacts directly inside your repository.
-
-Write your product thinking in Markdown.
-Version it with Git.
-Inspect it. Improve it. Connect it. Use it as context for humans and AI.
+RAC is a command-line tool for managing requirements, decisions, roadmaps, prompts,
+and design artifacts as plain Markdown, right inside your Git repository.
 
 ```bash
 pip install requirements-as-code
 ```
 
----
+## What is RAC?
 
-## Why RAC?
+The code is structured, the tests are automated, the infrastructure is versioned —
+but the *reasoning* behind what you build is scattered across documents, tickets,
+chats, and AI conversations. RAC brings that knowledge back into the repository.
 
-Modern software teams have a problem.
+You write product thinking in Markdown; RAC validates it, inspects it, and connects
+it — so it stays durable, reviewable, and usable as context for both humans and AI.
+No proprietary formats, no hosted platform, no lock-in.
 
-The code is structured.
+## Who is it for?
 
-The tests are automated.
-
-The infrastructure is versioned.
-
-But the reasoning behind what we build is scattered across:
-
-* documents
-* tickets
-* chats
-* whiteboards
-* AI conversations
-
-The context disappears.
-
-RAC brings that knowledge back into the repository.
-
-If code deserves version control, the decisions behind the code do too.
-
----
-
-## Requirements are just the beginning
-
-Despite the name, RAC is not only about requirements.
-
-RAC supports structured product artifacts:
-
-* Requirements — what needs to exist
-* Decisions — why choices were made
-* Roadmaps — where the product is heading
-* Prompts — reusable AI collaboration patterns
-* Designs — product experience thinking
-
-Everything remains plain Markdown.
-
-No proprietary formats.
-
-No hosted platform.
-
-No lock-in.
-
----
-
-## Example
-
-Create a requirement:
-
-```bash
-rac init requirement login-flow.md
-```
-
-Write naturally:
-
-```markdown
-# Login Flow
-
-## Context
-
-Users need a secure way to access their account.
-
-## Requirement
-
-Users should be able to authenticate using email and password.
-
-## Acceptance Criteria
-
-- User can enter credentials
-- Invalid attempts show an error
-- Successful login redirects to dashboard
-```
-
-Inspect it:
-
-```bash
-rac inspect login-flow.md
-```
-
-Improve it:
-
-```bash
-rac improve login-flow.md
-```
-
-RAC helps identify missing context before humans or AI depend on it.
-
----
-
-## Repository intelligence
-
-RAC understands collections of artifacts.
-
-```bash
-rac inspect .
-```
-
-Understand:
-
-* what knowledge exists
-* what is missing
-* artifact completeness
-* repository health
-
-Your product knowledge becomes queryable.
-
-Or list everything as a machine-readable inventory:
-
-```bash
-rac index
-rac index --json
-```
-
-`rac index` answers one question — what exists, where, and what type — so consumers
-like Explorer, IDEs, CI, and AI agents can build navigation without re-scanning files.
-
----
-
-## Built for AI-native development
-
-AI is only as useful as the context you provide.
-
-RAC helps create durable context that AI tools can consume:
-
-* structured requirements
-* architectural decisions
-* design constraints
-* product direction
-* reusable prompts
-
-Your repository becomes the source of truth.
-
----
-
-## Git is the database
-
-RAC does not replace your existing workflow.
-
-It builds on it.
-
-You already have:
-
-* history
-* branches
-* reviews
-* ownership
-* collaboration
-
-RAC treats Git as the system of record for product knowledge.
-
----
-
-## Explorer
-
-RAC includes a terminal interface for exploring your product knowledge.
-
-```bash
-rac explorer
-```
-
-Navigate your repository:
-
-* browse artifacts
-* inspect relationships
-* understand product health
-* discover missing context
-
-Explorer is a viewer.
-
-RAC Core remains the intelligence layer.
-
----
-
-## Philosophy
-
-RAC believes:
-
-* Markdown is enough.
-* Git is enough.
-* Product knowledge should live beside the product.
-* AI needs structured context, not more chat history.
-* The reasoning behind software matters.
-
-Requirements as Code is not about writing more documentation.
-
-It is about making product knowledge durable.
-
----
-
-## Status
-
-RAC is early and evolving quickly.
-
-Current focus:
-
-* artifact schemas
-* repository intelligence
-* AI-ready context
-* terminal-first workflows
-
-Contributions, ideas, and experiments welcome.
-
----
+- **Software and product teams** who want the *why* behind their software versioned
+  alongside the code.
+- **AI-native teams** who need structured, durable context instead of more scattered
+  chat history.
 
 ## Install
 
-```bash
-pip install requirements-as-code
-```
+Requires Python 3.11+.
 
 ```bash
+pip install requirements-as-code
+# or
 uv tool install requirements-as-code
 ```
 
----
+## Quick Start
+
+```bash
+rac validate requirement.md   # check one artifact
+rac inspect requirement.md    # see its type and completeness
+rac stats rac/                # summarize a directory of artifacts
+```
+
+New to RAC? Walk through your first artifact in five minutes:
+**[docs/quickstart.md](docs/quickstart.md)**.
+
+## Supported Artifact Types
+
+- **Requirements** — what needs to exist
+- **Decisions** — why choices were made (ADRs)
+- **Roadmaps** — where the product is heading
+- **Prompts** — reusable AI collaboration patterns
+- **Designs** — product experience thinking
+
+Everything stays plain Markdown — see **[docs/artifacts.md](docs/artifacts.md)**.
+
+## Documentation
+
+- [Quickstart](docs/quickstart.md) — install and try RAC in five minutes
+- [CLI reference](docs/cli.md) — every command, flag, and exit code
+- [Artifact types](docs/artifacts.md) — the five types and their sections
+- [Relationships](docs/relationships.md) — link artifacts and validate the links
+- [Repository workflow](docs/repo-workflow.md) — organize a repo with RAC
+- [Testing & contributing](docs/testing.md) — local setup and verification
+- [Examples](docs/examples.md) — small, realistic artifacts
+
+## Project Status
+
+RAC is early and evolving quickly. A terminal Explorer for browsing your knowledge
+base is planned. Contributions, ideas, and experiments are welcome.
 
 ## License
 

--- a/rac/roadmaps/v0.7.7-readme-simplification.md
+++ b/rac/roadmaps/v0.7.7-readme-simplification.md
@@ -127,4 +127,4 @@ pytest
 
 Target:
 
-v0.7.4 patch release
+v0.7.7


### PR DESCRIPTION
Implements `rac/roadmaps/v0.7.7-readme-simplification.md` (REQ-Documentation-Structure),
the README half of ADR-022's three-layer model. Follow-up to the v0.7.6 `docs/` layer.

## What changed

Refactors `README.md` from **238 → 77 lines** into a ~1-minute landing page:

- Sections: What is RAC? · Who is it for? · Install · Quick Start · Supported Artifact
  Types · Documentation · Project Status · License.
- Quick Start uses only real commands (`rac validate` / `inspect` / `stats`).
- A Documentation section routes every deeper topic into `docs/`.

Removed: the `rac init` and `rac explorer` examples (neither command exists), plus the
inline CLI reference, artifact schemas, and long examples now owned by `docs/`. A
terminal Explorer is noted as *planned* rather than documented as available.

Also fixes the roadmap's stale Release line (`v0.7.4` → `v0.7.7`).

## Out of scope

- No `docs/` content rewrites (README only links to them).
- No packaging-metadata changes (`pyproject.toml` `readme` field untouched).

## Verification

- `pytest` — 398 passed.
- `grep -E 'rac (init|explorer)' README.md` — none.
- All seven `docs/*.md` links resolve.