### PR TITLE
feat(explorer): v0.8.0 Explorer foundation — repository model, operations, Textual shell

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -66,4 +66,5 @@ jobs:
           tests/test_identity.py tests/test_frontmatter.py
           tests/test_metadata_identity.py tests/test_idgen.py
           tests/test_ci_batteries.py tests/test_corpus.py
+          tests/test_operations.py
           tests/test_golden.py tests/test_dogfood.py

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,7 +56,7 @@ jobs:
         # enforced by tests/test_ci_batteries.py in the core battery.
         battery:
           - name: core
-            paths: "tests/test_validate.py tests/test_parser.py tests/test_schema.py tests/test_identity.py tests/test_frontmatter.py tests/test_metadata_identity.py tests/test_idgen.py tests/test_ci_batteries.py tests/test_corpus.py"
+            paths: "tests/test_validate.py tests/test_parser.py tests/test_schema.py tests/test_identity.py tests/test_frontmatter.py tests/test_metadata_identity.py tests/test_idgen.py tests/test_ci_batteries.py tests/test_corpus.py tests/test_operations.py"
           - name: cli
             paths: "tests/test_cli.py"
           - name: artifacts

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -81,6 +81,8 @@ jobs:
             paths: "tests/test_portfolio.py"
           - name: repository
             paths: "tests/test_repository.py tests/test_repository_perf.py"
+          - name: explorer
+            paths: "tests/test_explorer_adapter.py"
           - name: relationships
             paths: "tests/test_relationships.py tests/test_relationships_cmd.py tests/test_relationship_validation.py"
           - name: resolve

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,7 +82,7 @@ jobs:
           - name: repository
             paths: "tests/test_repository.py tests/test_repository_perf.py"
           - name: explorer
-            paths: "tests/test_explorer_adapter.py tests/test_explorer_app.py tests/test_explorer_isolation.py"
+            paths: "tests/test_explorer_adapter.py tests/test_explorer_app.py tests/test_explorer_cli.py tests/test_explorer_isolation.py"
           - name: relationships
             paths: "tests/test_relationships.py tests/test_relationships_cmd.py tests/test_relationship_validation.py"
           - name: resolve

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,6 +79,8 @@ jobs:
             paths: "tests/test_migrate.py"
           - name: portfolio
             paths: "tests/test_portfolio.py"
+          - name: repository
+            paths: "tests/test_repository.py"
           - name: relationships
             paths: "tests/test_relationships.py tests/test_relationships_cmd.py tests/test_relationship_validation.py"
           - name: resolve

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,7 +82,7 @@ jobs:
           - name: repository
             paths: "tests/test_repository.py tests/test_repository_perf.py"
           - name: explorer
-            paths: "tests/test_explorer_adapter.py"
+            paths: "tests/test_explorer_adapter.py tests/test_explorer_app.py tests/test_explorer_isolation.py"
           - name: relationships
             paths: "tests/test_relationships.py tests/test_relationships_cmd.py tests/test_relationship_validation.py"
           - name: resolve

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,7 +80,7 @@ jobs:
           - name: portfolio
             paths: "tests/test_portfolio.py"
           - name: repository
-            paths: "tests/test_repository.py"
+            paths: "tests/test_repository.py tests/test_repository_perf.py"
           - name: relationships
             paths: "tests/test_relationships.py tests/test_relationships_cmd.py tests/test_relationship_validation.py"
           - name: resolve

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ details, release history over commit history.
 
 ### Added
 
+- `rac explorer [directory]` — interactive terminal Explorer application
+  shell (Textual): loads a repository without blocking the interface, shows
+  live progress and a repository summary (artifact counts, relationships,
+  diagnostics, health score), and recovers from failures in place with
+  reload. Ships as the optional `explorer` extra
+  (`pip install 'requirements-as-code[explorer]'`); without it the command
+  prints an install hint (v0.8.0).
+- First-class repository model in the service layer: `load_repository`
+  composes index, validation, relationships, and portfolio over a single
+  corpus walk into one navigable object (artifacts, relationships with
+  resolution outcomes, unified diagnostics) for Explorer and future
+  consumers; no CLI or JSON output changes (v0.8.0).
+- Operation primitives for long-lived consumers: progress reporting and
+  cooperative cancellation across repository loading, validated against
+  1000+ artifact corpora (v0.8.0).
 - CI battery integrity (v0.7.14): eight test files (~1,300 lines, including
   all coverage for `rac new` and `rac migrate`) were missing from the CI
   battery matrix and never ran; they are restored, and a new guard test

--- a/README.md
+++ b/README.md
@@ -89,7 +89,14 @@ same standard it applies to your repository:
 ## Project Status
 
 RAC is early and evolving quickly. A terminal Explorer for browsing your knowledge
-base is planned. Contributions, ideas, and experiments are welcome — see
+base is under construction — the application shell ships today:
+
+```bash
+pip install 'requirements-as-code[explorer]'
+rac explorer rac/
+```
+
+Contributions, ideas, and experiments are welcome — see
 [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## License

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,6 +1,6 @@
 # CLI Reference
 
-RAC ships a single command, `rac`, with seventeen subcommands. This page documents each
+RAC ships a single command, `rac`, with eighteen subcommands. This page documents each
 one: its purpose, inputs, outputs, and exit codes.
 
 ```bash
@@ -19,8 +19,8 @@ These apply across every command.
 - **Standard input** — `validate`, `inspect`, and `improve` accept `-` in place of a
   file to read Markdown from stdin (e.g. `cat file.md | rac validate -`).
 - **Recursion** — directory commands (`validate`, `stats`, `inspect`,
-  `relationships`, `review`, `portfolio`, `index`) recurse into subdirectories
-  by default. Pass `--top-level`
+  `relationships`, `review`, `portfolio`, `index`, `explorer`) recurse into
+  subdirectories by default. Pass `--top-level`
   to scan only the immediate directory. `--recursive` is accepted explicitly for
   clarity but is already the default.
 - **Exit codes** — every command follows the same convention:
@@ -333,6 +333,35 @@ rac index rac/ --json
   ]
 }
 ```
+
+---
+
+## explorer
+
+Launch the interactive terminal Explorer (v0.8.0) — an application shell that
+loads a repository without blocking, shows a summary (artifact counts,
+relationships, diagnostics, health score), and recovers from failures in place.
+Navigation, health detail, and recommendations arrive in later v0.8.x releases.
+
+Explorer is a presentation layer over the same services the CLI uses: everything
+it shows is also available through `rac portfolio`, `rac index`, and friends
+(ADR-015).
+
+- **Input:** `rac explorer [directory]` — defaults to the current directory; scanned
+  recursively for `*.md`.
+- **Options:** `--top-level` · `--recursive` (no `--json`: the surface is interactive)
+- **Keys:** `q` quit · `r` reload
+- **Exit codes:** `0` session quit · `2` not a directory, or the `explorer` extra is
+  not installed
+
+The TUI dependency ships as an optional extra, so the core install stays light:
+
+```bash
+pip install 'requirements-as-code[explorer]'
+rac explorer rac/
+```
+
+Without the extra, `rac explorer` prints the install hint above and exits `2`.
 
 ---
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -46,6 +46,13 @@ Every `tests/test_*.py` must belong to exactly one CI battery in
 file is orphaned, duplicated, or stale, so add new test files to the matrix as you
 create them.
 
+The `explorer` battery tests the terminal Explorer without a terminal: screens run
+headlessly through Textual's `App.run_test()` pilot (`pytest-asyncio`, awaiting
+`app.workers.wait_for_complete()` before asserting), the adapter is tested as a
+plain service boundary, and `tests/test_explorer_isolation.py` enforces the layer
+rules with AST checks — `rac.core`/`rac.services` never import Textual or the
+Explorer, and widgets never import Core internals (ADR-015).
+
 ## Lint, format, and types
 
 CI gates on ruff and mypy (configured in `pyproject.toml`); run them locally
@@ -74,7 +81,7 @@ src/rac/
   core/        domain primitives: parsing, classification, identity, schemas
   services/    repository capabilities: inspect, stats, relationships, ingest
   output/      human, JSON, and template rendering
-  explorer/    consumer boundary
+  explorer/    terminal Explorer TUI (consumer of services, ADR-015)
 ```
 
 ## Verify before a pull request

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,13 +40,19 @@ ingest = ["markitdown[docx]"]                        # DOCX (+ HTML, Markdown)
 ingest-pdf = ["markitdown[pdf]"]                     # + PDF
 ingest-office = ["markitdown[pptx,xlsx,xls]"]        # + PPTX / XLSX / XLS
 ingest-all = ["markitdown[docx,pdf,pptx,xlsx,xls]"]  # every supported format
-# dev also pulls the libraries used to *generate* fixture files in the tests.
+# Interactive Explorer TUI (rac explorer, v0.8.0). Optional so the core
+# install stays light; without it `rac explorer` prints an install hint.
+explorer = ["textual>=1.0"]
+# dev also pulls the libraries used to *generate* fixture files in the tests,
+# plus the explorer extra so its batteries run headlessly in CI.
 dev = [
     "pytest>=7.0",
     "pytest-cov",
+    "pytest-asyncio",
     "ruff",
     "mypy",
     "types-PyYAML",
+    "textual>=1.0",
     "markitdown[docx,pdf,pptx,xlsx,xls]",
     "python-docx",
     "python-pptx",

--- a/rac/roadmaps/v0.8.x-explorer/v0.8.0-explorer-foundation.md
+++ b/rac/roadmaps/v0.8.x-explorer/v0.8.0-explorer-foundation.md
@@ -126,6 +126,92 @@ crash the interface.
 - Background daemons or hosted services
 - Navigation, health, or recommendation experiences (delivered by v0.8.1+)
 
+## Implementation Contract
+
+The following decisions are pinned for v0.8.0.
+
+### Module Locations
+
+- The repository model lives in `rac/services/repository.py`. It composes
+  existing services (index, validation, relationships, portfolio), and the
+  service layer depends on `rac.core`, never the reverse — so the model
+  cannot live under `rac/core/`.
+- Operation primitives (progress, cancellation) live in
+  `rac/core/operations.py`. They are pure primitives with no CLI or TUI
+  concepts, usable by core traversal and services alike.
+- Explorer layout: `rac/explorer/launch.py` (entry point and lazy import
+  seam), `adapter.py` (service boundary), `state.py` (frozen UI-state
+  dataclasses), `app.py` (Textual application), `screens/`, `widgets/`.
+  Only `app.py`, `screens/`, and `widgets/` may import Textual.
+
+### Public APIs
+
+- `rac.services.repository`: `Repository`, `Artifact`, `Diagnostic`,
+  `load_repository(directory, *, recursive=True, on_progress=None,
+  cancel=None)`.
+- `rac.services.relationships`: `Relationship`,
+  `relationships_from_corpus(entries)`.
+- `rac.core.operations`: `Progress`, `ProgressCallback`, `CancelToken`
+  (protocol), `CancellationToken`, `OperationCancelled`, `checkpoint`.
+- `rac.core.corpus`: `collect_corpus(directory, *, recursive=True,
+  on_progress=None, cancel=None)` — the single-walk snapshot that
+  `load_repository` and future incremental refresh build on.
+- `rac.explorer.launch`: `run_explorer`, `ExplorerUnavailable`.
+- `rac.explorer.adapter`: `ExplorerAdapter`.
+
+### Dependencies
+
+- Textual ships as the optional extra `explorer` (`textual>=1.0`); base
+  dependencies are unchanged.
+- The dev extra gains `textual` and `pytest-asyncio` so explorer batteries
+  run in CI on all supported Python versions.
+
+### CLI and Exit Codes
+
+`rac explorer [directory]` defaults to the current directory, matching
+`rac index`, `rac resolve`, and `rac find`.
+
+| Outcome | Exit code |
+| --- | --- |
+| User quits the Explorer session | `0` |
+| Usage error (not a directory, explorer extra not installed) | `2` |
+
+- A missing extra prints an install hint
+  (`pip install 'requirements-as-code[explorer]'`) on stderr.
+- Core failures during a session surface as recoverable Explorer states,
+  never exit codes.
+- No new JSON contract: the repository model types carry no `to_dict`,
+  and no existing CLI or JSON output changes (ADR-007).
+
+### v0.8.0 Shell Contents
+
+The shell renders exactly three states — loading with live progress, a
+repository summary (artifact counts by type, relationship totals, broken
+references, diagnostics counts, health score), and a recoverable error
+panel — with `q` (quit) and `r` (reload) bindings. Navigation, health
+detail, and recommendations remain v0.8.1+ scope.
+
+### Deferrals
+
+- Refresh re-runs the single-walk load off the UI thread; incremental
+  refresh is deferred, with the corpus snapshot as its enabler.
+- Core stays synchronous; Explorer uses Textual thread workers.
+- No golden tests cover Explorer output (terminal-size dependent).
+
+### Testing
+
+- New CI batteries `repository` and `explorer`; every new test file joins
+  exactly one battery (ADR-027).
+- Explorer screens are tested headlessly through Textual's `App.run_test`
+  pilot; the missing-extra path is tested through a module-level import
+  seam in `launch.py`.
+- An AST-based isolation battery asserts `rac.core` and `rac.services`
+  never import `textual` or `rac.explorer`, and widgets never import core
+  internals.
+- The 1000+ artifact target is validated against a generated corpus
+  fixture, asserting correctness, monotonic progress, and early
+  cancellation.
+
 ## Success Measures
 
 - `rac explorer` opens a repository and renders an application shell without

--- a/src/rac/cli.py
+++ b/src/rac/cli.py
@@ -12,6 +12,7 @@ Commands:
     rac review <directory> [--json] [--top-level]
     rac portfolio <directory> [--json] [--top-level]
     rac index [directory] [--json] [--top-level]
+    rac explorer [directory] [--top-level]
     rac new <artifact-type> <output-path> [--json]
     rac templates [--json]
     rac init [directory] [--key KEY] [--json]
@@ -23,7 +24,8 @@ Exit codes:
     0  success (incl. inspect/improve reporting Unknown; relationships found or
        not; --validate with all references resolved; portfolio summary produced;
        index produced; artifact created; templates listed; find with or without
-       matches; migration or dry run completed, even with nothing to migrate)
+       matches; migration or dry run completed, even with nothing to migrate;
+       explorer session quit by the user)
     1  validate: errors found; stats: no valid known artifacts; ingest:
        conversion failed; relationships --validate: broken/ambiguous/self
        references or duplicate identifiers found; review: invalid artifacts
@@ -34,7 +36,7 @@ Exit codes:
        config or ID generation exhausted
     2  usage / IO error (file not found, not a directory, unsupported type,
        refuse-to-overwrite, missing output directory, repository not
-       initialized, invalid repository key)
+       initialized, invalid repository key, explorer extra not installed)
 """
 
 from __future__ import annotations
@@ -387,6 +389,21 @@ def cmd_index(args: argparse.Namespace) -> int:
     else:
         print(outputs.render_index_human(index))
     return EXIT_OK
+
+
+def cmd_explorer(args: argparse.Namespace) -> int:
+    if not Path(args.directory).is_dir():
+        print(f"rac: not a directory: {args.directory}", file=sys.stderr)
+        raise SystemExit(EXIT_USAGE)
+    # Imported lazily: launch decides whether the explorer extra is installed,
+    # and the base CLI must not pay an import cost for the optional TUI.
+    from rac.explorer.launch import ExplorerUnavailable, run_explorer
+
+    try:
+        return run_explorer(args.directory, recursive=not args.top_level)
+    except ExplorerUnavailable as exc:
+        print(f"rac: {exc}", file=sys.stderr)
+        raise SystemExit(EXIT_USAGE) from None
 
 
 def cmd_new(args: argparse.Namespace) -> int:
@@ -762,6 +779,29 @@ def build_parser() -> argparse.ArgumentParser:
         help="Recurse into subdirectories (the default; accepted for clarity).",
     )
     p_index.set_defaults(func=cmd_index)
+
+    p_explorer = sub.add_parser(
+        "explorer",
+        help="Launch the interactive terminal Explorer (needs the explorer extra).",
+        parents=[version_parent],
+    )
+    p_explorer.add_argument(
+        "directory",
+        nargs="?",
+        default=".",
+        help="Repository to explore (default: current directory).",
+    )
+    p_explorer.add_argument(
+        "--top-level",
+        action="store_true",
+        help="Only the top-level files in the directory (no recursion).",
+    )
+    p_explorer.add_argument(
+        "--recursive",
+        action="store_true",
+        help="Recurse into subdirectories (the default; accepted for clarity).",
+    )
+    p_explorer.set_defaults(func=cmd_explorer)
 
     p_new = sub.add_parser(
         "new",

--- a/src/rac/core/corpus.py
+++ b/src/rac/core/corpus.py
@@ -23,6 +23,7 @@ from .classification import Classification, classify
 from .fs import find_markdown_files
 from .markdown import parse_file
 from .models import Product
+from .operations import CancelToken, Progress, ProgressCallback, checkpoint
 
 
 @dataclass(frozen=True)
@@ -48,3 +49,29 @@ def walk_corpus(directory: str, *, recursive: bool = True) -> Iterator[CorpusEnt
     for path in find_markdown_files(directory, recursive=recursive):
         product = parse_file(str(path))
         yield CorpusEntry(path=path, product=product, classification=classify(product))
+
+
+def collect_corpus(
+    directory: str,
+    *,
+    recursive: bool = True,
+    on_progress: ProgressCallback | None = None,
+    cancel: CancelToken | None = None,
+) -> list[CorpusEntry]:
+    """Materialize the corpus walk as a reusable snapshot (v0.8.0).
+
+    The snapshot lets one walk feed every analysis a consumer needs — index,
+    validation, relationships, portfolio — instead of each re-walking the
+    tree. Long-lived consumers get per-file progress (the file count is known
+    up front) and a cancellation checkpoint before each parse.
+    """
+    paths = find_markdown_files(directory, recursive=recursive)
+    total = len(paths)
+    entries: list[CorpusEntry] = []
+    for completed, path in enumerate(paths, start=1):
+        checkpoint(cancel)
+        product = parse_file(str(path))
+        entries.append(CorpusEntry(path=path, product=product, classification=classify(product)))
+        if on_progress is not None:
+            on_progress(Progress(phase="scan", completed=completed, total=total))
+    return entries

--- a/src/rac/core/operations.py
+++ b/src/rac/core/operations.py
@@ -1,0 +1,71 @@
+"""Operation primitives for long-lived consumers (v0.8.0).
+
+CLI workflows are short-lived: walk, analyse, print, exit. An interactive
+consumer such as the Explorer runs the same operations repeatedly inside a
+long-lived session, so it needs progress reporting and cooperative
+cancellation without core knowing anything about terminals or UI frameworks.
+These primitives stay pure and synchronous — callbacks fire inline on the
+calling thread, and cancellation is a structural protocol any consumer can
+satisfy (a Textual worker bridges its own cancelled flag; tests use the
+concrete :class:`CancellationToken`).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Protocol
+
+
+@dataclass(frozen=True)
+class Progress:
+    """A point-in-time progress report for a long-running operation.
+
+    ``total`` is ``None`` when the amount of work is not known up front.
+    """
+
+    phase: str
+    completed: int
+    total: int | None
+
+
+ProgressCallback = Callable[[Progress], None]
+
+
+class OperationCancelled(Exception):
+    """Raised when an operation observes a cancelled token at a checkpoint."""
+
+
+class CancelToken(Protocol):
+    """Structural cancellation: anything exposing a ``cancelled`` flag.
+
+    Consumers supply their own implementations (for example, an Explorer
+    worker wrapping Textual's cancelled state) without core importing them.
+    """
+
+    @property
+    def cancelled(self) -> bool: ...
+
+
+class CancellationToken:
+    """Default in-memory :class:`CancelToken`; cancellation is one-way."""
+
+    def __init__(self) -> None:
+        self._cancelled = False
+
+    @property
+    def cancelled(self) -> bool:
+        return self._cancelled
+
+    def cancel(self) -> None:
+        self._cancelled = True
+
+
+def checkpoint(cancel: CancelToken | None) -> None:
+    """Raise :class:`OperationCancelled` if ``cancel`` has been cancelled.
+
+    Operations call this at safe boundaries (between files, between phases);
+    ``None`` means the caller did not request cancellation support.
+    """
+    if cancel is not None and cancel.cancelled:
+        raise OperationCancelled

--- a/src/rac/explorer/__init__.py
+++ b/src/rac/explorer/__init__.py
@@ -1,8 +1,18 @@
-"""RAC Explorer boundary package (consumer of RAC services).
+"""RAC Explorer — interactive terminal UI over RAC services (v0.8.0, ADR-028).
 
-Intentionally empty for v0.7.4. Explorer is a *presentation* layer: when it is
-built it must consume existing RAC service-layer APIs (rac.services) rather than
-implementing its own repository intelligence (ADR-015). Anything visible in
-Explorer must also be obtainable through ``rac <command>`` or an equivalent
-service call.
+Explorer is a *presentation* layer: it consumes RAC service-layer APIs
+(rac.services) through a dedicated adapter and implements no repository
+intelligence of its own (ADR-015). Anything visible in Explorer is also
+obtainable through ``rac <command>`` or an equivalent service call.
+
+Layout:
+
+- ``launch``  — ``run_explorer`` entry point; lazily imports the Textual app
+  so the base install works without the ``explorer`` extra.
+- ``adapter`` — invokes services, translates Core models into UI state.
+- ``state``   — frozen UI-state dataclasses widgets render.
+- ``app`` / ``screens`` / ``widgets`` — the Textual application (the only
+  modules that import Textual).
+
+This package import stays Textual-free.
 """

--- a/src/rac/explorer/adapter.py
+++ b/src/rac/explorer/adapter.py
@@ -1,0 +1,101 @@
+"""Explorer adapter — the boundary between RAC services and the TUI (v0.8.0).
+
+The adapter invokes RAC services, translates Core models into UI state, and
+owns no repository intelligence (ADR-015). It is the single place the
+Explorer touches ``rac.services`` / ``rac.core``; widgets depend on
+:mod:`rac.explorer.state` only. This module never imports Textual, so it is
+testable without a terminal.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from rac.core.operations import CancelToken, OperationCancelled, Progress
+from rac.services.repository import Repository, load_repository
+
+from .state import LoadErrorState, LoadProgressState, RepositorySummaryState
+
+# Presentation labels for the analysis phases that follow the scan.
+_PHASE_LABELS = {
+    "index": "Indexing artifacts",
+    "validate": "Validating artifacts",
+    "relationships": "Analyzing relationships",
+    "portfolio": "Calculating portfolio",
+}
+
+ProgressHandler = Callable[[LoadProgressState], None]
+
+
+def _progress_state(progress: Progress) -> LoadProgressState:
+    if progress.phase == "scan":
+        counter = f" ({progress.completed}/{progress.total})" if progress.total else ""
+        label = f"Scanning artifacts{counter}"
+    else:
+        label = _PHASE_LABELS.get(progress.phase, progress.phase.title())
+    return LoadProgressState(
+        phase=progress.phase,
+        completed=progress.completed,
+        total=progress.total,
+        label=label,
+    )
+
+
+class ExplorerAdapter:
+    """Loads a repository through Core services and yields UI state.
+
+    Failures surface as :class:`LoadErrorState` (Initiative 6 — recoverable,
+    never a crash); cancellation propagates as
+    :class:`~rac.core.operations.OperationCancelled` so workers can treat an
+    interrupted load as cancelled rather than failed. The last successful
+    :class:`Repository` is kept for navigation milestones (v0.8.1+).
+    """
+
+    def __init__(self, directory: str, recursive: bool = True) -> None:
+        self.directory = directory
+        self.recursive = recursive
+        self.repository: Repository | None = None
+
+    def load(
+        self,
+        *,
+        on_progress: ProgressHandler | None = None,
+        cancel: CancelToken | None = None,
+    ) -> RepositorySummaryState | LoadErrorState:
+        def relay(progress: Progress) -> None:
+            if on_progress is not None:
+                on_progress(_progress_state(progress))
+
+        try:
+            repository = load_repository(
+                self.directory,
+                recursive=self.recursive,
+                on_progress=relay,
+                cancel=cancel,
+            )
+        except OperationCancelled:
+            raise
+        except Exception as exc:  # noqa: BLE001 — the recoverable boundary (Initiative 6)
+            return LoadErrorState(
+                title="Could not load repository",
+                detail=f"{type(exc).__name__}: {exc}",
+                can_retry=True,
+            )
+
+        self.repository = repository
+        return self._summary(repository)
+
+    @staticmethod
+    def _summary(repository: Repository) -> RepositorySummaryState:
+        portfolio = repository.portfolio
+        severities = [d.severity for d in repository.diagnostics]
+        return RepositorySummaryState(
+            directory=repository.directory,
+            artifact_total=portfolio.total_artifacts,
+            by_type=tuple((name, count) for name, count in portfolio.by_type.items() if count),
+            relationship_total=portfolio.relationships.total,
+            broken_relationships=portfolio.relationships.broken,
+            error_count=severities.count("error"),
+            warning_count=severities.count("warning"),
+            health_score=repository.health_score,
+        )

--- a/src/rac/explorer/adapter.py
+++ b/src/rac/explorer/adapter.py
@@ -45,9 +45,8 @@ class ExplorerAdapter:
     """Loads a repository through Core services and yields UI state.
 
     Failures surface as :class:`LoadErrorState` (Initiative 6 — recoverable,
-    never a crash); cancellation propagates as
-    :class:`~rac.core.operations.OperationCancelled` so workers can treat an
-    interrupted load as cancelled rather than failed. The last successful
+    never a crash); a cancelled load returns ``None`` so workers can discard
+    it without handling Core exception types. The last successful
     :class:`Repository` is kept for navigation milestones (v0.8.1+).
     """
 
@@ -61,7 +60,7 @@ class ExplorerAdapter:
         *,
         on_progress: ProgressHandler | None = None,
         cancel: CancelToken | None = None,
-    ) -> RepositorySummaryState | LoadErrorState:
+    ) -> RepositorySummaryState | LoadErrorState | None:
         def relay(progress: Progress) -> None:
             if on_progress is not None:
                 on_progress(_progress_state(progress))
@@ -74,7 +73,7 @@ class ExplorerAdapter:
                 cancel=cancel,
             )
         except OperationCancelled:
-            raise
+            return None  # discarded by the caller; not an error
         except Exception as exc:  # noqa: BLE001 — the recoverable boundary (Initiative 6)
             return LoadErrorState(
                 title="Could not load repository",

--- a/src/rac/explorer/app.py
+++ b/src/rac/explorer/app.py
@@ -1,0 +1,36 @@
+"""The Explorer Textual application (v0.8.0, ADR-028).
+
+Keyboard-first and terminal-native: the footer surfaces the bindings, and the
+shell stays responsive because every Core operation runs through workers
+(see :mod:`rac.explorer.screens.repository`). This is the first module on the
+import path that requires Textual; :mod:`rac.explorer.launch` imports it
+lazily so the base install works without the ``explorer`` extra.
+"""
+
+from __future__ import annotations
+
+from textual.app import App
+from textual.binding import Binding
+
+from rac.explorer.adapter import ExplorerAdapter
+from rac.explorer.screens.repository import RepositoryScreen
+
+
+class ExplorerApp(App[None]):
+    """Application shell over one repository (navigation arrives in v0.8.1)."""
+
+    TITLE = "RAC Explorer"
+    BINDINGS = [Binding("q", "quit", "Quit")]
+    CSS = """
+    RepositoryPanel {
+        padding: 1 2;
+    }
+    """
+
+    def __init__(self, directory: str, recursive: bool = True) -> None:
+        super().__init__()
+        self.adapter = ExplorerAdapter(directory, recursive=recursive)
+        self.sub_title = directory
+
+    def on_mount(self) -> None:
+        self.push_screen(RepositoryScreen(self.adapter))

--- a/src/rac/explorer/launch.py
+++ b/src/rac/explorer/launch.py
@@ -1,0 +1,42 @@
+"""Explorer entry point — `rac explorer` lands here (v0.8.0).
+
+Textual ships in the optional ``explorer`` extra, so the Textual application
+is imported lazily: the base install keeps working, and a missing extra
+becomes :class:`ExplorerUnavailable` with an install hint instead of an
+ImportError traceback. This module itself never imports Textual.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover — typing only, never at runtime
+    from rac.explorer.app import ExplorerApp
+
+MISSING_EXTRA_HINT = (
+    "explorer needs the explorer extra: pip install 'requirements-as-code[explorer]'"
+)
+
+
+class ExplorerUnavailable(Exception):
+    """The Explorer cannot start because the ``explorer`` extra is missing."""
+
+
+def _import_app() -> type[ExplorerApp]:
+    # Module-level seam: tests monkeypatch this to exercise the missing-extra
+    # path without uninstalling Textual.
+    from rac.explorer.app import ExplorerApp
+
+    return ExplorerApp
+
+
+def run_explorer(directory: str, recursive: bool = True) -> int:
+    """Launch the Explorer over ``directory``; returns the exit code (0)."""
+    try:
+        app_cls = _import_app()
+    except ModuleNotFoundError as exc:
+        if (exc.name or "").partition(".")[0] != "textual":
+            raise  # a genuine import bug, not a missing extra
+        raise ExplorerUnavailable(MISSING_EXTRA_HINT) from exc
+    app_cls(directory, recursive=recursive).run()
+    return 0

--- a/src/rac/explorer/screens/__init__.py
+++ b/src/rac/explorer/screens/__init__.py
@@ -1,0 +1,1 @@
+"""Explorer screens — Textual screens composing the application views."""

--- a/src/rac/explorer/screens/repository.py
+++ b/src/rac/explorer/screens/repository.py
@@ -1,0 +1,89 @@
+"""Repository screen — the v0.8.0 application shell (loading → summary → error).
+
+The screen never executes Core operations in UI handlers (Initiative 5):
+loading runs in a thread worker (Core is synchronous), progress is marshalled
+back with ``call_from_thread``, and ``r`` cancels any in-flight load before
+starting a fresh one (``exclusive=True``). Failures arrive as
+``LoadErrorState`` and render as a recoverable view (Initiative 6).
+"""
+
+from __future__ import annotations
+
+from textual import work
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.screen import Screen
+from textual.widgets import Footer, Header
+from textual.worker import Worker, WorkerState, get_current_worker
+
+from rac.explorer.adapter import ExplorerAdapter
+from rac.explorer.state import LoadErrorState, LoadProgressState, RepositorySummaryState
+from rac.explorer.widgets import RepositoryPanel
+
+
+class _WorkerCancelToken:
+    """Bridges Textual's worker cancellation into the Core CancelToken protocol."""
+
+    def __init__(self, worker: Worker[object]) -> None:
+        self._worker = worker
+
+    @property
+    def cancelled(self) -> bool:
+        return self._worker.is_cancelled
+
+
+class RepositoryScreen(Screen[None]):
+    """Loads the repository off the UI thread and renders its summary."""
+
+    BINDINGS = [Binding("r", "reload", "Reload")]
+
+    def __init__(self, adapter: ExplorerAdapter) -> None:
+        super().__init__()
+        self.adapter = adapter
+
+    def compose(self) -> ComposeResult:
+        yield Header()
+        yield RepositoryPanel(id="repository-panel")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        self.action_reload()
+
+    def action_reload(self) -> None:
+        self.query_one(RepositoryPanel).show_progress(
+            LoadProgressState(phase="scan", completed=0, total=None, label="Scanning artifacts")
+        )
+        self._load_repository()
+
+    @work(thread=True, exclusive=True, group="repository-load")
+    def _load_repository(self) -> RepositorySummaryState | LoadErrorState | None:
+        worker = get_current_worker()
+        token = _WorkerCancelToken(worker)
+
+        def relay(progress: LoadProgressState) -> None:
+            if not worker.is_cancelled:
+                self.app.call_from_thread(self.query_one(RepositoryPanel).show_progress, progress)
+
+        return self.adapter.load(on_progress=relay, cancel=token)
+
+    def on_worker_state_changed(self, event: Worker.StateChanged) -> None:
+        if event.worker.group != "repository-load":
+            return
+        panel = self.query_one(RepositoryPanel)
+        if event.state == WorkerState.SUCCESS:
+            result = event.worker.result
+            if isinstance(result, RepositorySummaryState):
+                panel.show_summary(result)
+            elif isinstance(result, LoadErrorState):
+                panel.show_error(result)
+            # None — the load was cancelled; a fresh worker is taking over.
+        elif event.state == WorkerState.ERROR:
+            # The adapter is the recoverable boundary, so this is unexpected —
+            # but the interface must still never crash (Initiative 6).
+            panel.show_error(
+                LoadErrorState(
+                    title="Unexpected failure",
+                    detail=str(event.worker.error),
+                    can_retry=True,
+                )
+            )

--- a/src/rac/explorer/state.py
+++ b/src/rac/explorer/state.py
@@ -1,0 +1,43 @@
+"""Explorer UI state — what the widgets render (v0.8.0).
+
+Frozen, presentation-ready snapshots translated from Core models by the
+adapter (ADR-015). Widgets and screens consume these types only; they never
+import Core models, and this module never imports Textual.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class LoadProgressState:
+    """One progress update while the repository loads."""
+
+    phase: str
+    completed: int
+    total: int | None
+    label: str  # presentation-ready, e.g. "Scanning artifacts (12/95)"
+
+
+@dataclass(frozen=True)
+class RepositorySummaryState:
+    """The repository summary the v0.8.0 shell renders."""
+
+    directory: str
+    artifact_total: int
+    by_type: tuple[tuple[str, int], ...]  # (type, count), zero counts omitted
+    relationship_total: int
+    broken_relationships: int
+    error_count: int
+    warning_count: int
+    health_score: int
+
+
+@dataclass(frozen=True)
+class LoadErrorState:
+    """A recoverable failure: the shell shows it and offers retry."""
+
+    title: str
+    detail: str
+    can_retry: bool

--- a/src/rac/explorer/widgets/__init__.py
+++ b/src/rac/explorer/widgets/__init__.py
@@ -1,0 +1,56 @@
+"""Explorer widgets — render UI state, own no intelligence (ADR-015).
+
+Widgets consume :mod:`rac.explorer.state` types only. Meaning never depends
+on colour alone (DESIGN-visual-system): every status carries a text label.
+"""
+
+from __future__ import annotations
+
+from textual.widgets import Static
+
+from rac.explorer.state import LoadErrorState, LoadProgressState, RepositorySummaryState
+
+
+def _health_label(score: int) -> str:
+    # Labels alongside the number — never colour-only meaning (ADR-028).
+    if score >= 80:
+        return "✓ Healthy"
+    if score >= 50:
+        return "! Needs attention"
+    return "✗ Unhealthy"
+
+
+class RepositoryPanel(Static):
+    """The single content panel of the v0.8.0 shell.
+
+    Renders whichever state the screen is in: loading progress, the
+    repository summary, or a recoverable error.
+    """
+
+    def show_progress(self, progress: LoadProgressState) -> None:
+        self.update(f"{progress.label}…")
+
+    def show_summary(self, summary: RepositorySummaryState) -> None:
+        lines = [
+            f"Repository  {summary.directory}",
+            "",
+            f"Artifacts   {summary.artifact_total}",
+        ]
+        lines.extend(f"  {name:<12} {count}" for name, count in summary.by_type)
+        broken = f" ({summary.broken_relationships} broken)" if summary.broken_relationships else ""
+        health = f"{summary.health_score} / 100  {_health_label(summary.health_score)}"
+        lines.extend(
+            [
+                "",
+                f"Relationships  {summary.relationship_total}{broken}",
+                f"Diagnostics    {summary.error_count} errors, {summary.warning_count} warnings",
+                f"Health         {health}",
+            ]
+        )
+        self.update("\n".join(lines))
+
+    def show_error(self, error: LoadErrorState) -> None:
+        lines = [f"✗ {error.title}", "", error.detail]
+        if error.can_retry:
+            lines.extend(["", "Press r to retry."])
+        self.update("\n".join(lines))

--- a/src/rac/services/index.py
+++ b/src/rac/services/index.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 from rac.core.artifacts import spec_for
-from rac.core.corpus import walk_corpus
+from rac.core.corpus import CorpusEntry, walk_corpus
 from rac.core.identity import artifact_identifier, artifact_identifiers
 
 
@@ -79,8 +79,20 @@ class RepositoryIndex:
 
 def build_repository_index(directory: str, recursive: bool = True) -> RepositoryIndex:
     """Walk ``directory`` and inventory every Markdown artifact (one parse each)."""
+    entries = list(walk_corpus(directory, recursive=recursive))
+    return index_from_corpus(directory, entries, recursive=recursive)
+
+
+def index_from_corpus(
+    directory: str, entries: list[CorpusEntry], recursive: bool = True
+) -> RepositoryIndex:
+    """Inventory an already-walked corpus snapshot (v0.8.0).
+
+    Same result as :func:`build_repository_index`; the snapshot lets one walk
+    feed several analyses (repository model, future incremental refresh).
+    """
     artifacts: list[IndexEntry] = []
-    for entry in walk_corpus(directory, recursive=recursive):
+    for entry in entries:
         path, product = entry.path, entry.product
         spec = spec_for(entry.artifact_type)  # None for Unknown
         artifacts.append(

--- a/src/rac/services/portfolio.py
+++ b/src/rac/services/portfolio.py
@@ -28,7 +28,7 @@ from dataclasses import dataclass, field
 
 from rac.core.artifacts import ARTIFACT_SPECS, spec_for
 from rac.core.classification import missing_sections
-from rac.core.corpus import walk_corpus
+from rac.core.corpus import CorpusEntry, walk_corpus
 from rac.core.identity import artifact_identifier
 from rac.core.validation import has_errors, validate
 
@@ -37,7 +37,7 @@ from .relationships import (
     ISSUE_TARGET_AMBIGUOUS,
     ISSUE_TARGET_NOT_FOUND,
     RelationshipSummary,
-    summarize_relationships,
+    summary_from_corpus,
 )
 
 # Stable attention codes (part of the JSON contract, ADR-007).
@@ -151,6 +151,18 @@ class PortfolioSummary:
 
 def build_portfolio_summary(directory: str, recursive: bool = True) -> PortfolioSummary:
     """Walk ``directory`` and compute a full repository intelligence summary."""
+    entries = list(walk_corpus(directory, recursive=recursive))
+    return portfolio_from_corpus(directory, entries, recursive=recursive)
+
+
+def portfolio_from_corpus(
+    directory: str, entries: list[CorpusEntry], recursive: bool = True
+) -> PortfolioSummary:
+    """Summarize an already-walked corpus snapshot (v0.8.0).
+
+    Same result as :func:`build_portfolio_summary`. The snapshot also feeds
+    the relationship summary, so a portfolio costs one walk instead of two.
+    """
 
     # --- per-artifact pass ---------------------------------------------------
     by_type: dict[str, int] = {spec.name: 0 for spec in ARTIFACT_SPECS}
@@ -167,7 +179,7 @@ def build_portfolio_summary(directory: str, recursive: bool = True) -> Portfolio
     # second identifier pass.
     path_to_identifier: dict[str, str] = {}
 
-    for entry in walk_corpus(directory, recursive=recursive):
+    for entry in entries:
         path, product = entry.path, entry.product
         artifact_type = entry.artifact_type
         by_type[artifact_type] = by_type.get(artifact_type, 0) + 1
@@ -219,9 +231,9 @@ def build_portfolio_summary(directory: str, recursive: bool = True) -> Portfolio
             )
 
     # --- relationship summary ------------------------------------------------
-    # One relationship walk; its per-reference issues become attention items so
-    # broken references are surfaced, not just counted (roadmap Initiative 3).
-    rel_summary = summarize_relationships(directory, recursive=recursive)
+    # Reuses the snapshot (no second walk); per-reference issues become
+    # attention items so broken references are surfaced, not just counted.
+    rel_summary = summary_from_corpus(entries)
     for issue in rel_summary.issues:
         source = issue.source_path or ""
         label = (issue.relationship or "").replace("_", " ").title()

--- a/src/rac/services/relationships.py
+++ b/src/rac/services/relationships.py
@@ -21,7 +21,7 @@ from dataclasses import dataclass, field
 
 from rac.core.artifacts import ArtifactSpec, spec_for
 from rac.core.classification import classify
-from rac.core.corpus import walk_corpus
+from rac.core.corpus import CorpusEntry, walk_corpus
 from rac.core.identity import artifact_identifier, artifact_identifiers
 from rac.core.markdown import parse_file
 from rac.core.models import Product
@@ -259,6 +259,17 @@ def build_relationship_report(directory: str, recursive: bool = True) -> Relatio
     return _build_report(directory, _corpus_items(directory, recursive), recursive)
 
 
+def report_from_corpus(
+    directory: str, entries: list[CorpusEntry], recursive: bool = True
+) -> RelationshipReport:
+    """Inspect relationships in an already-walked corpus snapshot (v0.8.0).
+
+    Same result as :func:`build_relationship_report`; the snapshot lets one
+    walk feed several analyses (repository model, future incremental refresh).
+    """
+    return _build_report(directory, _entry_items(entries), recursive)
+
+
 def build_relationship_report_file(path: str) -> RelationshipReport:
     """Inspect relationships in a single file (REQ-009).
 
@@ -349,10 +360,14 @@ def _corpus_items(
     directory: str, recursive: bool
 ) -> list[tuple[str, Product, ArtifactSpec | None]]:
     """Every document under ``directory`` as ``(path, product, spec)`` (one walk)."""
-    return [
-        (str(entry.path), entry.product, spec_for(entry.artifact_type))
-        for entry in walk_corpus(directory, recursive=recursive)
-    ]
+    return _entry_items(list(walk_corpus(directory, recursive=recursive)))
+
+
+def _entry_items(
+    entries: list[CorpusEntry],
+) -> list[tuple[str, Product, ArtifactSpec | None]]:
+    """An already-walked corpus snapshot as ``(path, product, spec)`` items."""
+    return [(str(entry.path), entry.product, spec_for(entry.artifact_type)) for entry in entries]
 
 
 # Identifier index: {casefold(ident) -> [(path, display_ident), ...]}
@@ -466,6 +481,17 @@ def validate_relationships(directory: str, recursive: bool = True) -> Relationsh
     return _validate(directory, items, recursive)
 
 
+def validation_from_corpus(
+    directory: str, entries: list[CorpusEntry], recursive: bool = True
+) -> RelationshipValidation:
+    """Validate relationships in an already-walked corpus snapshot (v0.8.0).
+
+    Same result as :func:`validate_relationships`; the snapshot lets one walk
+    feed several analyses (repository model, future incremental refresh).
+    """
+    return _validate(directory, _entry_items(entries), recursive)
+
+
 def validate_relationships_file(path: str) -> RelationshipValidation:
     """Validate a single file (REQ-009).
 
@@ -509,8 +535,19 @@ class RelationshipSummary:
 
 def summarize_relationships(directory: str, recursive: bool = True) -> RelationshipSummary:
     """Aggregate relationship health across a directory (v0.7.3)."""
-    items = _corpus_items(directory, recursive)
+    return _summarize(_corpus_items(directory, recursive))
 
+
+def summary_from_corpus(entries: list[CorpusEntry]) -> RelationshipSummary:
+    """Aggregate relationship health for an already-walked snapshot (v0.8.0).
+
+    Same result as :func:`summarize_relationships`; the snapshot lets one walk
+    feed several analyses (repository model, future incremental refresh).
+    """
+    return _summarize(_entry_items(entries))
+
+
+def _summarize(items: list[tuple[str, Product, ArtifactSpec | None]]) -> RelationshipSummary:
     if not items:
         return RelationshipSummary(total=0, valid=0, broken=0, orphaned=0, coverage=1.0)
 
@@ -541,3 +578,67 @@ def summarize_relationships(directory: str, recursive: bool = True) -> Relations
         coverage=round(coverage, 4),
         issues=ref_issues,
     )
+
+
+# --- Relationship objects for the repository model (v0.8.0) -------------------
+#
+# The repository model (rac.services.repository) needs every declared reference
+# as one navigable object: where it points from, what it says, and where it
+# resolves to. The raw reference text remains the source of truth (ADR-016);
+# resolution reuses the same alias index as `--validate`, so a reference is
+# resolved here exactly when validation reports no issue for it.
+
+
+@dataclass(frozen=True)
+class Relationship:
+    """One declared cross-artifact reference, with its resolution outcome.
+
+    ``resolved_path`` is set only when the reference resolves uniquely to
+    another artifact; otherwise ``issue`` carries the stable validation code
+    (:data:`ISSUE_TARGET_NOT_FOUND`, :data:`ISSUE_TARGET_AMBIGUOUS`, or
+    :data:`ISSUE_SELF_REFERENCE`).
+    """
+
+    source_path: str
+    relationship: str  # snake_case section name ("related_decisions", ...)
+    target: str  # raw reference text (source of truth, ADR-016)
+    resolved_path: str | None
+    issue: str | None
+
+
+def relationships_from_corpus(entries: list[CorpusEntry]) -> list[Relationship]:
+    """Every declared reference in a corpus snapshot as :class:`Relationship`.
+
+    Ordering is deterministic: source artifacts in snapshot (sorted path)
+    order, sections in each artifact's own schema order, references in
+    declaration order — matching ``_resolve_references``.
+    """
+    items = _entry_items(entries)
+    index = _build_resolution_index(items)
+    relationships: list[Relationship] = []
+    for path, product, spec in items:
+        if spec is None:
+            continue
+        for section, refs in extract_relationships_full(product, spec).items():
+            for ref in refs:
+                targets = [p for p, _ in index.get(ref.casefold(), [])]
+                resolved: str | None = None
+                issue: str | None = None
+                if not targets:
+                    issue = ISSUE_TARGET_NOT_FOUND
+                elif len(targets) > 1:
+                    issue = ISSUE_TARGET_AMBIGUOUS
+                elif targets == [path]:
+                    issue = ISSUE_SELF_REFERENCE
+                else:
+                    resolved = targets[0]
+                relationships.append(
+                    Relationship(
+                        source_path=path,
+                        relationship=section,
+                        target=ref,
+                        resolved_path=resolved,
+                        issue=issue,
+                    )
+                )
+    return relationships

--- a/src/rac/services/repository.py
+++ b/src/rac/services/repository.py
@@ -1,0 +1,223 @@
+"""First-class repository model — the navigable view of a RAC repository (v0.8.0).
+
+``load_repository`` walks a directory once and composes the existing services
+into one object a long-lived consumer can navigate without scanning files
+(ADR-015): indexed artifacts, declared relationships with their resolution
+outcomes, unified diagnostics, and the portfolio summary. It contains no CLI
+or TUI concepts and adds no new intelligence — every number here is obtainable
+through ``rac index`` / ``rac validate`` / ``rac relationships`` /
+``rac portfolio``.
+
+The model types carry no ``to_dict``: there is no new JSON contract until a
+CLI command exposes one (ADR-007).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from rac.core.corpus import collect_corpus
+from rac.core.operations import CancelToken, Progress, ProgressCallback, checkpoint
+
+from .index import index_from_corpus
+from .portfolio import PortfolioSummary, portfolio_from_corpus
+from .relationships import (
+    ISSUE_DUPLICATE_IDENTIFIER,
+    ISSUE_SELF_REFERENCE,
+    ISSUE_TARGET_AMBIGUOUS,
+    ISSUE_TARGET_NOT_FOUND,
+    Relationship,
+    RelationshipIssue,
+    relationships_from_corpus,
+    validation_from_corpus,
+)
+from .validate import validate_corpus
+
+# Diagnostic sources (which analysis produced the finding).
+SOURCE_VALIDATION = "validation"
+SOURCE_RELATIONSHIPS = "relationships"
+
+# Human phrasing for relationship findings, keyed by their stable issue codes.
+_REL_PHRASE = {
+    ISSUE_TARGET_NOT_FOUND: "target not found",
+    ISSUE_TARGET_AMBIGUOUS: "ambiguous target",
+    ISSUE_SELF_REFERENCE: "self-reference",
+}
+
+
+@dataclass(frozen=True)
+class Artifact:
+    """One artifact in the navigable repository view.
+
+    A join of the index inventory (identity, type, title, path, aliases) and
+    directory validation (``status``: ``valid`` / ``invalid`` / ``skipped``),
+    covering every supported type plus ``unknown``.
+    """
+
+    id: str
+    type: str
+    title: str | None
+    path: str
+    aliases: tuple[str, ...]
+    status: str
+
+
+@dataclass(frozen=True)
+class Diagnostic:
+    """One finding about the repository, unified across analyses.
+
+    ``code`` reuses the stable codes of the producing analysis verbatim
+    (validation issue codes, relationship issue codes), so a diagnostic always
+    corresponds to a finding the CLI reports.
+    """
+
+    source: str  # SOURCE_VALIDATION | SOURCE_RELATIONSHIPS
+    severity: str  # "error" | "warning"
+    code: str
+    message: str
+    path: str
+    identifier: str | None
+
+
+@dataclass
+class Repository:
+    """The navigable representation of a RAC repository (v0.8.0).
+
+    Artifacts, relationships, and diagnostics arrive in deterministic
+    (sorted-path walk) order; ``portfolio`` carries the repository-level
+    intelligence (counts, completeness, attention, health score).
+    """
+
+    directory: str
+    recursive: bool
+    artifacts: list[Artifact]
+    relationships: list[Relationship]
+    diagnostics: list[Diagnostic]
+    portfolio: PortfolioSummary
+
+    @property
+    def health_score(self) -> int:
+        return self.portfolio.health_score
+
+    def artifact(self, ref: str) -> Artifact | None:
+        """The artifact uniquely answering to ``ref`` (id or alias), else None.
+
+        Matching is casefolded. Ambiguous references return None — reporting
+        ambiguity is relationship validation's job, ranking is ``rac find``'s.
+        """
+        key = ref.casefold()
+        matches = [a for a in self.artifacts if key in (alias.casefold() for alias in a.aliases)]
+        if len(matches) == 1:
+            return matches[0]
+        return None
+
+    def artifacts_of_type(self, type: str) -> list[Artifact]:
+        """Artifacts of ``type`` (including ``"unknown"``), walk order."""
+        return [a for a in self.artifacts if a.type == type]
+
+    def diagnostics_for(self, path: str) -> list[Diagnostic]:
+        """Diagnostics concerning the artifact at ``path``."""
+        return [d for d in self.diagnostics if d.path == path]
+
+    def relationships_for(self, path: str) -> list[Relationship]:
+        """Relationships declared by, or resolving to, the artifact at ``path``."""
+        return [r for r in self.relationships if path in (r.source_path, r.resolved_path)]
+
+
+def _relationship_diagnostic(issue: RelationshipIssue, identifiers: dict[str, str]) -> Diagnostic:
+    """Translate one relationship-validation finding into a Diagnostic."""
+    if issue.code == ISSUE_DUPLICATE_IDENTIFIER:
+        paths = issue.paths or []
+        return Diagnostic(
+            source=SOURCE_RELATIONSHIPS,
+            severity="warning",
+            code=issue.code,
+            message=f"Duplicate identifier shared by: {', '.join(paths)}",
+            path=paths[0] if paths else "",
+            identifier=issue.identifier,
+        )
+    label = (issue.relationship or "").replace("_", " ").title()
+    phrase = _REL_PHRASE.get(issue.code, "unresolved reference")
+    path = issue.source_path or ""
+    return Diagnostic(
+        source=SOURCE_RELATIONSHIPS,
+        severity="warning",
+        code=issue.code,
+        message=f"{label} reference '{issue.target}': {phrase}",
+        path=path,
+        identifier=identifiers.get(path),
+    )
+
+
+def load_repository(
+    directory: str,
+    *,
+    recursive: bool = True,
+    on_progress: ProgressCallback | None = None,
+    cancel: CancelToken | None = None,
+) -> Repository:
+    """Walk ``directory`` once and compose the navigable repository model.
+
+    Progress is per-file during the ``scan`` phase, then per-phase for the
+    derived analyses (``index``, ``validate``, ``relationships``,
+    ``portfolio``); cancellation is checked between files and phases.
+    """
+
+    def phase_done(phase: str) -> None:
+        checkpoint(cancel)
+        if on_progress is not None:
+            on_progress(Progress(phase=phase, completed=1, total=1))
+
+    entries = collect_corpus(directory, recursive=recursive, on_progress=on_progress, cancel=cancel)
+
+    index = index_from_corpus(directory, entries, recursive=recursive)
+    identifiers = {entry.path: entry.id for entry in index.artifacts}
+    phase_done("index")
+
+    validation = validate_corpus(directory, entries, recursive=recursive)
+    status_by_path = {f.path: f.status for f in validation.files}
+    phase_done("validate")
+
+    relationships = relationships_from_corpus(entries)
+    rel_validation = validation_from_corpus(directory, entries, recursive=recursive)
+    phase_done("relationships")
+
+    portfolio = portfolio_from_corpus(directory, entries, recursive=recursive)
+    phase_done("portfolio")
+
+    artifacts = [
+        Artifact(
+            id=entry.id,
+            type=entry.type,
+            title=entry.title,
+            path=entry.path,
+            aliases=tuple(entry.aliases),
+            status=status_by_path[entry.path],
+        )
+        for entry in index.artifacts
+    ]
+
+    diagnostics: list[Diagnostic] = [
+        Diagnostic(
+            source=SOURCE_VALIDATION,
+            severity=issue.severity,
+            code=issue.code,
+            message=issue.message,
+            path=file.path,
+            identifier=identifiers.get(file.path),
+        )
+        for file in validation.files
+        for issue in file.issues
+    ]
+    diagnostics.extend(
+        _relationship_diagnostic(issue, identifiers) for issue in rel_validation.issues
+    )
+
+    return Repository(
+        directory=directory,
+        recursive=recursive,
+        artifacts=artifacts,
+        relationships=relationships,
+        diagnostics=diagnostics,
+        portfolio=portfolio,
+    )

--- a/src/rac/services/validate.py
+++ b/src/rac/services/validate.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 from dataclasses import asdict, dataclass
 
 from rac.core.artifacts import spec_for
-from rac.core.corpus import walk_corpus
+from rac.core.corpus import CorpusEntry, walk_corpus
 from rac.core.models import Issue
 from rac.core.validation import has_errors, validate
 
@@ -98,8 +98,20 @@ def validate_directory(directory: str, recursive: bool = True) -> DirectoryValid
     Files are processed in sorted path order (``walk_corpus``), so the
     result — and everything rendered from it — is deterministic.
     """
+    entries = list(walk_corpus(directory, recursive=recursive))
+    return validate_corpus(directory, entries, recursive=recursive)
+
+
+def validate_corpus(
+    directory: str, entries: list[CorpusEntry], recursive: bool = True
+) -> DirectoryValidation:
+    """Validate an already-walked corpus snapshot (v0.8.0).
+
+    Same result as :func:`validate_directory`; the snapshot lets one walk
+    feed several analyses (repository model, future incremental refresh).
+    """
     files: list[FileValidation] = []
-    for entry in walk_corpus(directory, recursive=recursive):
+    for entry in entries:
         path, product = entry.path, entry.product
         artifact_type = entry.artifact_type
         if spec_for(artifact_type) is None:

--- a/tests/test_explorer_adapter.py
+++ b/tests/test_explorer_adapter.py
@@ -1,0 +1,88 @@
+"""Tests for the Explorer adapter — service boundary without a TUI (v0.8.0)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from rac.core.operations import CancellationToken, OperationCancelled
+from rac.explorer.adapter import ExplorerAdapter
+from rac.explorer.state import LoadErrorState, LoadProgressState, RepositorySummaryState
+from rac.services.portfolio import build_portfolio_summary
+
+FIXTURES = Path(__file__).parent / "fixtures" / "portfolio_summary"
+
+
+def test_load_returns_summary_state_from_core_numbers():
+    directory = str(FIXTURES / "valid_clean")
+    result = ExplorerAdapter(directory).load()
+
+    assert isinstance(result, RepositorySummaryState)
+    portfolio = build_portfolio_summary(directory)
+    assert result.directory == directory
+    assert result.artifact_total == portfolio.total_artifacts
+    assert dict(result.by_type) == {t: c for t, c in portfolio.by_type.items() if c}
+    assert result.relationship_total == portfolio.relationships.total
+    assert result.broken_relationships == portfolio.relationships.broken
+    assert result.health_score == portfolio.health_score
+    assert result.error_count == 0
+    assert result.warning_count == 0
+
+
+def test_load_counts_diagnostics_by_severity():
+    result = ExplorerAdapter(str(FIXTURES / "broken_rels")).load()
+    assert isinstance(result, RepositorySummaryState)
+    assert result.broken_relationships == 1
+    assert result.warning_count >= 1
+
+
+def test_load_keeps_repository_for_navigation():
+    adapter = ExplorerAdapter(str(FIXTURES / "valid_clean"))
+    assert adapter.repository is None
+    adapter.load()
+    assert adapter.repository is not None
+    assert adapter.repository.artifact("ADR-001") is not None
+
+
+def test_load_translates_progress_with_labels():
+    states: list[LoadProgressState] = []
+    ExplorerAdapter(str(FIXTURES / "valid_clean")).load(on_progress=states.append)
+
+    scan = [s for s in states if s.phase == "scan"]
+    assert scan
+    assert all("Scanning artifacts" in s.label for s in scan)
+    assert f"({len(scan)}/{len(scan)})" in scan[-1].label
+    assert [s.label for s in states if s.phase != "scan"] == [
+        "Indexing artifacts",
+        "Validating artifacts",
+        "Analyzing relationships",
+        "Calculating portfolio",
+    ]
+
+
+def test_failures_become_recoverable_error_state(tmp_path):
+    (tmp_path / "bad.md").write_bytes(b"\xff\xfe not utf-8 \xff")
+    result = ExplorerAdapter(str(tmp_path)).load()
+    assert isinstance(result, LoadErrorState)
+    assert result.can_retry
+    assert result.title == "Could not load repository"
+    assert "UnicodeDecodeError" in result.detail
+
+
+def test_empty_directory_is_a_summary_not_an_error(tmp_path):
+    result = ExplorerAdapter(str(tmp_path)).load()
+    assert isinstance(result, RepositorySummaryState)
+    assert result.artifact_total == 0
+
+
+def test_cancellation_propagates_not_an_error():
+    token = CancellationToken()
+    adapter = ExplorerAdapter(str(FIXTURES / "all_types"))
+
+    def cancel_immediately(state: LoadProgressState) -> None:
+        token.cancel()
+
+    with pytest.raises(OperationCancelled):
+        adapter.load(on_progress=cancel_immediately, cancel=token)
+    assert adapter.repository is None

--- a/tests/test_explorer_adapter.py
+++ b/tests/test_explorer_adapter.py
@@ -4,9 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
-
-from rac.core.operations import CancellationToken, OperationCancelled
+from rac.core.operations import CancellationToken
 from rac.explorer.adapter import ExplorerAdapter
 from rac.explorer.state import LoadErrorState, LoadProgressState, RepositorySummaryState
 from rac.services.portfolio import build_portfolio_summary
@@ -76,13 +74,12 @@ def test_empty_directory_is_a_summary_not_an_error(tmp_path):
     assert result.artifact_total == 0
 
 
-def test_cancellation_propagates_not_an_error():
+def test_cancelled_load_returns_none_not_an_error():
     token = CancellationToken()
     adapter = ExplorerAdapter(str(FIXTURES / "all_types"))
 
     def cancel_immediately(state: LoadProgressState) -> None:
         token.cancel()
 
-    with pytest.raises(OperationCancelled):
-        adapter.load(on_progress=cancel_immediately, cancel=token)
+    assert adapter.load(on_progress=cancel_immediately, cancel=token) is None
     assert adapter.repository is None

--- a/tests/test_explorer_app.py
+++ b/tests/test_explorer_app.py
@@ -1,0 +1,88 @@
+"""Headless screen tests for the Explorer shell (v0.8.0, ADR-027).
+
+Runs the Textual app through ``App.run_test()`` (no real terminal). Worker
+results are awaited via ``app.workers.wait_for_complete()`` before asserting,
+keeping the thread-worker tests deterministic.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from rac.explorer.app import ExplorerApp
+from rac.explorer.widgets import RepositoryPanel
+
+FIXTURES = Path(__file__).parent / "fixtures" / "portfolio_summary"
+
+
+async def _settled_panel_text(app: ExplorerApp, pilot) -> str:
+    await app.workers.wait_for_complete()
+    await pilot.pause()
+    return str(app.screen.query_one(RepositoryPanel).content)
+
+
+@pytest.mark.asyncio
+async def test_shell_renders_repository_summary():
+    app = ExplorerApp(str(FIXTURES / "valid_clean"))
+    async with app.run_test() as pilot:
+        text = await _settled_panel_text(app, pilot)
+        assert "Artifacts   2" in text
+        assert "requirement" in text and "decision" in text
+        assert "Relationships  1" in text
+        assert "Health         100 / 100  ✓ Healthy" in text
+
+
+def test_summary_states_meaning_in_text_not_colour_alone():
+    # DESIGN-visual-system: health carries a text label at every level.
+    app = ExplorerApp(str(FIXTURES / "valid_clean"))
+    assert app  # construction requires no terminal
+    from rac.explorer.widgets import _health_label
+
+    assert _health_label(90) == "✓ Healthy"
+    assert _health_label(60) == "! Needs attention"
+    assert _health_label(10) == "✗ Unhealthy"
+
+
+@pytest.mark.asyncio
+async def test_broken_references_surface_in_summary():
+    app = ExplorerApp(str(FIXTURES / "broken_rels"))
+    async with app.run_test() as pilot:
+        text = await _settled_panel_text(app, pilot)
+        assert "(1 broken)" in text
+        assert "warnings" in text
+
+
+@pytest.mark.asyncio
+async def test_core_failure_renders_recoverable_error_state(tmp_path):
+    (tmp_path / "bad.md").write_bytes(b"\xff\xfe not utf-8 \xff")
+    app = ExplorerApp(str(tmp_path))
+    async with app.run_test() as pilot:
+        text = await _settled_panel_text(app, pilot)
+        assert "✗ Could not load repository" in text
+        assert "Press r to retry." in text
+
+
+@pytest.mark.asyncio
+async def test_reload_binding_recovers_after_repair(tmp_path):
+    bad = tmp_path / "bad.md"
+    bad.write_bytes(b"\xff\xfe not utf-8 \xff")
+    app = ExplorerApp(str(tmp_path))
+    async with app.run_test() as pilot:
+        text = await _settled_panel_text(app, pilot)
+        assert "Could not load repository" in text
+
+        bad.write_text("# Repaired Note\n", encoding="utf-8")
+        await pilot.press("r")
+        text = await _settled_panel_text(app, pilot)
+        assert "Artifacts   1" in text
+
+
+@pytest.mark.asyncio
+async def test_quit_binding_exits_cleanly():
+    app = ExplorerApp(str(FIXTURES / "valid_clean"))
+    async with app.run_test() as pilot:
+        await app.workers.wait_for_complete()
+        await pilot.press("q")
+    assert not app.is_running

--- a/tests/test_explorer_cli.py
+++ b/tests/test_explorer_cli.py
@@ -1,0 +1,91 @@
+"""Tests for the `rac explorer` CLI wiring (v0.8.0)."""
+
+from __future__ import annotations
+
+import pytest
+
+import rac.explorer.launch as launch
+from rac.cli import main
+from rac.explorer.launch import MISSING_EXTRA_HINT, ExplorerUnavailable, run_explorer
+
+
+class _AppSpy:
+    """Stands in for ExplorerApp: records construction, runs without a TTY."""
+
+    instances: list[_AppSpy] = []
+
+    def __init__(self, directory: str, recursive: bool = True) -> None:
+        self.directory = directory
+        self.recursive = recursive
+        self.ran = False
+        _AppSpy.instances.append(self)
+
+    def run(self) -> None:
+        self.ran = True
+
+
+@pytest.fixture(autouse=True)
+def _reset_spy():
+    _AppSpy.instances = []
+
+
+def test_explorer_launches_app_over_directory(tmp_path, monkeypatch):
+    monkeypatch.setattr(launch, "_import_app", lambda: _AppSpy)
+    assert main(["explorer", str(tmp_path)]) == 0
+    [app] = _AppSpy.instances
+    assert app.directory == str(tmp_path)
+    assert app.recursive is True
+    assert app.ran
+
+
+def test_explorer_defaults_to_current_directory(tmp_path, monkeypatch):
+    monkeypatch.setattr(launch, "_import_app", lambda: _AppSpy)
+    monkeypatch.chdir(tmp_path)
+    assert main(["explorer"]) == 0
+    [app] = _AppSpy.instances
+    assert app.directory == "."
+
+
+def test_explorer_top_level_disables_recursion(tmp_path, monkeypatch):
+    monkeypatch.setattr(launch, "_import_app", lambda: _AppSpy)
+    assert main(["explorer", str(tmp_path), "--top-level"]) == 0
+    [app] = _AppSpy.instances
+    assert app.recursive is False
+
+
+def test_explorer_rejects_missing_directory(tmp_path, capsys):
+    with pytest.raises(SystemExit) as excinfo:
+        main(["explorer", str(tmp_path / "nope")])
+    assert excinfo.value.code == 2
+    assert "not a directory" in capsys.readouterr().err
+
+
+def test_missing_extra_exits_2_with_install_hint(tmp_path, monkeypatch, capsys):
+    def import_fails() -> type:
+        raise ModuleNotFoundError("No module named 'textual'", name="textual")
+
+    monkeypatch.setattr(launch, "_import_app", import_fails)
+    with pytest.raises(SystemExit) as excinfo:
+        main(["explorer", str(tmp_path)])
+    assert excinfo.value.code == 2
+    err = capsys.readouterr().err
+    assert "pip install 'requirements-as-code[explorer]'" in err
+
+
+def test_unavailable_error_carries_the_hint(monkeypatch):
+    def import_fails() -> type:
+        raise ModuleNotFoundError("No module named 'textual.app'", name="textual.app")
+
+    monkeypatch.setattr(launch, "_import_app", import_fails)
+    with pytest.raises(ExplorerUnavailable, match="explorer extra"):
+        run_explorer(".")
+    assert "requirements-as-code[explorer]" in MISSING_EXTRA_HINT
+
+
+def test_other_import_errors_are_real_bugs(monkeypatch):
+    def import_fails() -> type:
+        raise ModuleNotFoundError("No module named 'nonexistent'", name="nonexistent")
+
+    monkeypatch.setattr(launch, "_import_app", import_fails)
+    with pytest.raises(ModuleNotFoundError, match="nonexistent"):
+        run_explorer(".")

--- a/tests/test_explorer_isolation.py
+++ b/tests/test_explorer_isolation.py
@@ -1,0 +1,65 @@
+"""Core isolation — the Explorer boundary holds in both directions (v0.8.0).
+
+AST-based rules over the source tree (ADR-015 / ADR-028):
+
+- ``rac.core`` and ``rac.services`` never import Textual or the Explorer.
+- Textual widgets/screens/app never import Core internals — they reach RAC
+  only through ``rac.explorer.adapter`` / ``state`` / ``launch``.
+- The adapter, state, and launch modules never import Textual, so the base
+  install (no ``explorer`` extra) and headless tests work without it.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+SRC = Path(__file__).parent.parent / "src" / "rac"
+
+
+def _imported_modules(path: Path) -> set[str]:
+    """Every module name imported anywhere in ``path`` (absolute imports)."""
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            modules.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+            modules.add(node.module)
+    return modules
+
+
+def _violations(files: list[Path], forbidden: tuple[str, ...]) -> list[str]:
+    found: list[str] = []
+    for file in files:
+        for module in sorted(_imported_modules(file)):
+            if any(module == f or module.startswith(f + ".") for f in forbidden):
+                found.append(f"{file.relative_to(SRC.parent)} imports {module}")
+    return found
+
+
+def test_core_and_services_never_import_textual_or_explorer():
+    files = sorted((SRC / "core").rglob("*.py")) + sorted((SRC / "services").rglob("*.py"))
+    assert files
+    assert _violations(files, ("textual", "rac.explorer")) == []
+
+
+def test_widgets_never_import_core_internals():
+    ui_files = [SRC / "explorer" / "app.py"]
+    for sub in ("screens", "widgets"):
+        ui_files.extend(sorted((SRC / "explorer" / sub).rglob("*.py")))
+    ui_files = [f for f in ui_files if f.exists()]
+    assert ui_files, "the Textual application modules must exist"
+    assert _violations(ui_files, ("rac.core", "rac.services")) == []
+
+
+def test_adapter_state_and_launch_never_import_textual():
+    files = [
+        SRC / "explorer" / "__init__.py",
+        SRC / "explorer" / "state.py",
+        SRC / "explorer" / "adapter.py",
+        SRC / "explorer" / "launch.py",
+    ]
+    files = [f for f in files if f.exists()]
+    assert (SRC / "explorer" / "adapter.py") in files
+    assert _violations(files, ("textual",)) == []

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -1,0 +1,81 @@
+"""Tests for operation primitives and the corpus snapshot (v0.8.0)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from rac.core.corpus import collect_corpus, walk_corpus
+from rac.core.operations import (
+    CancellationToken,
+    OperationCancelled,
+    Progress,
+    checkpoint,
+)
+
+FIXTURES = str(Path(__file__).parent / "fixtures")
+
+
+def test_checkpoint_passes_without_token():
+    checkpoint(None)
+
+
+def test_checkpoint_passes_with_live_token():
+    checkpoint(CancellationToken())
+
+
+def test_checkpoint_raises_once_cancelled():
+    token = CancellationToken()
+    token.cancel()
+    with pytest.raises(OperationCancelled):
+        checkpoint(token)
+
+
+def test_cancellation_is_one_way():
+    token = CancellationToken()
+    assert not token.cancelled
+    token.cancel()
+    token.cancel()
+    assert token.cancelled
+
+
+def test_collect_matches_walk_order():
+    entries = collect_corpus(FIXTURES)
+    assert [e.path for e in entries] == [e.path for e in walk_corpus(FIXTURES)]
+
+
+def test_collect_reports_monotonic_progress_with_known_total():
+    reports: list[Progress] = []
+    entries = collect_corpus(FIXTURES, on_progress=reports.append)
+
+    assert [r.completed for r in reports] == list(range(1, len(entries) + 1))
+    assert {r.total for r in reports} == {len(entries)}
+    assert {r.phase for r in reports} == {"scan"}
+
+
+def test_collect_cancels_before_completing(tmp_path):
+    for i in range(5):
+        (tmp_path / f"doc-{i}.md").write_text(f"# Doc {i}\n", encoding="utf-8")
+
+    token = CancellationToken()
+    parsed: list[Progress] = []
+
+    def cancel_after_two(progress: Progress) -> None:
+        parsed.append(progress)
+        if progress.completed == 2:
+            token.cancel()
+
+    with pytest.raises(OperationCancelled):
+        collect_corpus(str(tmp_path), on_progress=cancel_after_two, cancel=token)
+    assert len(parsed) == 2
+
+
+def test_collect_respects_recursive_flag(tmp_path):
+    (tmp_path / "top.md").write_text("# Top\n", encoding="utf-8")
+    nested = tmp_path / "nested"
+    nested.mkdir()
+    (nested / "deep.md").write_text("# Deep\n", encoding="utf-8")
+
+    top_only = collect_corpus(str(tmp_path), recursive=False)
+    assert [e.path.name for e in top_only] == ["top.md"]

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -1,0 +1,184 @@
+"""Tests for the first-class repository model (v0.8.0)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from rac.core.operations import CancellationToken, OperationCancelled, Progress
+from rac.services.index import build_repository_index
+from rac.services.portfolio import build_portfolio_summary
+from rac.services.relationships import ISSUE_TARGET_NOT_FOUND
+from rac.services.repository import (
+    SOURCE_RELATIONSHIPS,
+    SOURCE_VALIDATION,
+    load_repository,
+)
+from rac.services.validate import validate_directory
+
+FIXTURES = Path(__file__).parent / "fixtures" / "portfolio_summary"
+
+
+def load(subdir: str, **kwargs):
+    return load_repository(str(FIXTURES / subdir), **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Composition: the model re-exposes the services, never re-derives them
+# ---------------------------------------------------------------------------
+
+
+def test_artifacts_match_repository_index():
+    repo = load("all_types")
+    index = build_repository_index(str(FIXTURES / "all_types"))
+    assert [(a.id, a.type, a.title, a.path, list(a.aliases)) for a in repo.artifacts] == [
+        (e.id, e.type, e.title, e.path, e.aliases) for e in index.artifacts
+    ]
+
+
+def test_statuses_match_directory_validation():
+    repo = load("all_types")
+    validation = validate_directory(str(FIXTURES / "all_types"))
+    assert {a.path: a.status for a in repo.artifacts} == {
+        f.path: f.status for f in validation.files
+    }
+
+
+def test_portfolio_matches_portfolio_summary():
+    repo = load("valid_clean")
+    summary = build_portfolio_summary(str(FIXTURES / "valid_clean"))
+    assert repo.portfolio == summary
+    assert repo.health_score == summary.health_score
+
+
+def test_unknown_artifacts_are_included_and_skipped():
+    repo = load("all_types")
+    [unknown] = repo.artifacts_of_type("unknown")
+    assert unknown.status == "skipped"
+
+
+# ---------------------------------------------------------------------------
+# Lookup surface for v0.8.1 navigation
+# ---------------------------------------------------------------------------
+
+
+def test_artifact_lookup_by_alias_is_casefolded():
+    repo = load("valid_clean")
+    adr = repo.artifact("adr-001")
+    assert adr is not None
+    assert adr.type == "decision"
+    assert repo.artifact("ADR-001") == adr
+
+
+def test_artifact_lookup_misses_return_none():
+    repo = load("valid_clean")
+    assert repo.artifact("no-such-artifact") is None
+
+
+def test_artifacts_of_type_filters_in_walk_order():
+    repo = load("all_types")
+    types = {a.type for a in repo.artifacts}
+    assert types == {"requirement", "decision", "roadmap", "prompt", "design", "unknown"}
+    for artifact_type in types:
+        subset = repo.artifacts_of_type(artifact_type)
+        assert [a.path for a in subset] == [
+            a.path for a in repo.artifacts if a.type == artifact_type
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Relationships: declared references with resolution outcomes
+# ---------------------------------------------------------------------------
+
+
+def test_resolved_relationship_links_source_to_target():
+    repo = load("valid_clean")
+    [rel] = repo.relationships
+    assert rel.relationship == "related_decisions"
+    assert rel.target == "ADR-001"
+    assert rel.issue is None
+    adr = repo.artifact("ADR-001")
+    assert adr is not None
+    assert rel.resolved_path == adr.path
+
+
+def test_relationships_for_covers_both_endpoints():
+    repo = load("valid_clean")
+    [rel] = repo.relationships
+    assert repo.relationships_for(rel.source_path) == [rel]
+    assert rel.resolved_path is not None
+    assert repo.relationships_for(rel.resolved_path) == [rel]
+
+
+def test_broken_reference_carries_issue_code():
+    repo = load("broken_rels")
+    [rel] = repo.relationships
+    assert rel.resolved_path is None
+    assert rel.issue == ISSUE_TARGET_NOT_FOUND
+
+
+# ---------------------------------------------------------------------------
+# Diagnostics: unified findings, stable codes reused verbatim
+# ---------------------------------------------------------------------------
+
+
+def test_validation_errors_become_diagnostics():
+    repo = load("invalid_known")
+    [artifact] = repo.artifacts
+    assert artifact.status == "invalid"
+    diagnostics = repo.diagnostics_for(artifact.path)
+    assert diagnostics
+    assert all(d.source == SOURCE_VALIDATION for d in diagnostics)
+    assert any(d.severity == "error" for d in diagnostics)
+    assert all(d.identifier == artifact.id for d in diagnostics)
+
+
+def test_broken_references_become_diagnostics():
+    repo = load("broken_rels")
+    [diag] = [d for d in repo.diagnostics if d.source == SOURCE_RELATIONSHIPS]
+    assert diag.code == ISSUE_TARGET_NOT_FOUND
+    assert diag.severity == "warning"
+    assert "ADR-MISSING" in diag.message
+    [artifact] = repo.artifacts
+    assert diag.path == artifact.path
+    assert diag.identifier == artifact.id
+
+
+def test_clean_repository_has_no_diagnostics():
+    repo = load("valid_clean")
+    assert repo.diagnostics == []
+
+
+# ---------------------------------------------------------------------------
+# Operation interface: progress phases and cancellation
+# ---------------------------------------------------------------------------
+
+
+def test_load_reports_scan_then_analysis_phases():
+    reports: list[Progress] = []
+    repo = load("all_types", on_progress=reports.append)
+
+    scan = [r for r in reports if r.phase == "scan"]
+    assert [r.completed for r in scan] == list(range(1, len(repo.artifacts) + 1))
+
+    analysis = [r.phase for r in reports if r.phase != "scan"]
+    assert analysis == ["index", "validate", "relationships", "portfolio"]
+    assert reports.index(scan[-1]) < reports.index(next(r for r in reports if r.phase == "index"))
+
+
+def test_load_cancels_during_scan():
+    token = CancellationToken()
+
+    def cancel_immediately(progress: Progress) -> None:
+        token.cancel()
+
+    with pytest.raises(OperationCancelled):
+        load("all_types", on_progress=cancel_immediately, cancel=token)
+
+
+def test_load_respects_recursive_flag():
+    nested = load_repository(str(FIXTURES), recursive=True)
+    top_only = load_repository(str(FIXTURES), recursive=False)
+    assert top_only.artifacts == []
+    assert nested.artifacts

--- a/tests/test_repository_perf.py
+++ b/tests/test_repository_perf.py
@@ -1,0 +1,105 @@
+"""Repository model at scale — the 1000+ artifact target (v0.8.0).
+
+Generates a synthetic corpus once per session and validates correctness,
+progress, and cancellation at repository scale. Wall-clock time is asserted
+only against a generous ceiling — CI runners are noisy, and the goal is
+catching pathological slowdowns, not benchmarking.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from rac.core.operations import CancellationToken, OperationCancelled, Progress
+from rac.services.repository import SOURCE_RELATIONSHIPS, load_repository
+
+DECISIONS = 600
+REQUIREMENTS = 600
+BROKEN_REFS = 10
+TOTAL = DECISIONS + REQUIREMENTS
+
+
+def _decision(i: int) -> str:
+    return (
+        f"# ADR-{i:04d} Decision {i}\n\n"
+        "## Status\n\nAccepted\n\n"
+        "## Context\n\nGenerated corpus entry.\n\n"
+        "## Decision\n\nUse the generated approach.\n\n"
+        "## Consequences\n\nNone — synthetic fixture.\n"
+    )
+
+
+def _requirement(i: int, reference: str) -> str:
+    return (
+        f"# Feature {i}\n\n"
+        "## Problem\n\nGenerated corpus entry.\n\n"
+        "## Requirements\n\n"
+        f"[REQ-{i:04d}] The system shall handle case {i}.\n\n"
+        "## Related Decisions\n\n"
+        f"- {reference}\n"
+    )
+
+
+@pytest.fixture(scope="session")
+def large_corpus(tmp_path_factory) -> str:
+    root = tmp_path_factory.mktemp("large_corpus")
+    for i in range(DECISIONS):
+        (root / f"adr-{i:04d}.md").write_text(_decision(i), encoding="utf-8")
+    for i in range(REQUIREMENTS):
+        # The last BROKEN_REFS requirements reference artifacts that do not
+        # exist, so the corpus carries findings as well as clean links.
+        if i >= REQUIREMENTS - BROKEN_REFS:
+            reference = f"ADR-MISSING-{i:04d}"
+        else:
+            reference = f"ADR-{i % DECISIONS:04d}"
+        (root / f"req-{i:04d}.md").write_text(_requirement(i, reference), encoding="utf-8")
+    return str(root)
+
+
+def test_scale_counts_and_diagnostics(large_corpus):
+    started = time.monotonic()
+    repo = load_repository(large_corpus)
+    elapsed = time.monotonic() - started
+
+    assert len(repo.artifacts) == TOTAL
+    assert len(repo.artifacts_of_type("decision")) == DECISIONS
+    assert len(repo.artifacts_of_type("requirement")) == REQUIREMENTS
+    assert len(repo.relationships) == REQUIREMENTS
+
+    broken = [d for d in repo.diagnostics if d.source == SOURCE_RELATIONSHIPS]
+    assert len(broken) == BROKEN_REFS
+    assert repo.portfolio.relationships.broken == BROKEN_REFS
+
+    # Generous ceiling: catch pathological slowdowns only.
+    assert elapsed < 60
+
+
+def test_scale_progress_is_monotonic_and_complete(large_corpus):
+    reports: list[Progress] = []
+    load_repository(large_corpus, on_progress=reports.append)
+
+    scan = [r for r in reports if r.phase == "scan"]
+    assert [r.completed for r in scan] == list(range(1, TOTAL + 1))
+    assert {r.total for r in scan} == {TOTAL}
+    assert [r.phase for r in reports if r.phase != "scan"] == [
+        "index",
+        "validate",
+        "relationships",
+        "portfolio",
+    ]
+
+
+def test_scale_cancellation_aborts_early(large_corpus):
+    token = CancellationToken()
+    reports: list[Progress] = []
+
+    def cancel_after_fifty(progress: Progress) -> None:
+        reports.append(progress)
+        if progress.completed == 50:
+            token.cancel()
+
+    with pytest.raises(OperationCancelled):
+        load_repository(large_corpus, on_progress=cancel_after_fifty, cancel=token)
+    assert len(reports) == 50


### PR DESCRIPTION
# Summary

Implements `rac/roadmaps/v0.8.x-explorer/v0.8.0-explorer-foundation.md`.

Adds:

- `rac explorer [directory]` — a Textual TUI application shell that loads a repository without blocking, shows live progress and a repository summary (artifact counts by type, relationship totals and broken references, diagnostic counts, health score), and recovers from Core failures in place
- A first-class repository model in the service layer: `load_repository` composes index, validation, relationships, and portfolio over a single corpus walk into one navigable `Repository` object
- Operation primitives for long-lived consumers: per-file progress reporting and cooperative cancellation, validated against a 1,200-artifact corpus
- The `explorer` optional extra (`textual>=1.0`), new `repository` and `explorer` CI batteries, headless screen tests, an AST-based layer-isolation battery, CLI reference / README / testing-guide documentation, and changelog entries

# Roadmap / ADR Trace

Roadmap:

- `rac/roadmaps/v0.8.x-explorer/v0.8.0-explorer-foundation.md` (implementation contract pinned in the first commit)

Relevant ADRs:

- ADR-015 — Explorer is a consumer of RAC capabilities; no intelligence lives in Explorer
- ADR-028 — Explorer ships as a terminal UI: keyboard-first, no colour-only meaning
- ADR-024 — RAC is not a content store: no editing or authoring surfaces
- ADR-027 — CI test topology: every test file belongs to exactly one battery
- ADR-007 — existing CLI/JSON contracts unchanged

# Scope

## Included

- `rac.core.operations`: `Progress`, `ProgressCallback`, `CancelToken` (structural protocol), `CancellationToken`, `OperationCancelled`, `checkpoint`
- `rac.core.corpus.collect_corpus`: materialized single-walk snapshot with per-file progress and cancellation checkpoints
- `*_from_corpus` entry points on index, validate, relationships, and portfolio so one walk feeds every analysis; portfolio's internal second walk removed with byte-identical output
- `rac.services.relationships.Relationship` + `relationships_from_corpus`: every declared reference as one object with its resolution outcome (`resolved_path` or a stable issue code)
- `rac.services.repository`: `Repository` (artifacts, relationships, diagnostics, portfolio) with the lookup surface v0.8.1 navigation needs (`artifact`, `artifacts_of_type`, `diagnostics_for`, `relationships_for`)
- `rac.explorer`: `launch` (lazy-import seam + install hint), `adapter` (service boundary, recoverable errors), `state` (frozen UI dataclasses), `app` / `screens` / `widgets` (the only Textual-importing modules)
- `rac explorer [directory]` CLI command, defaulting to the current directory

## Excluded (deliberately)

- Navigation, artifact browsing, context views, and the `/` command surface — v0.8.1
- Health detail and attention-item presentation — v0.8.2; recommendations — v0.8.3; action workflows — v0.8.4
- Artifact editing or authoring of any kind (ADR-024)
- New repository intelligence: every number Explorer shows is obtainable via `rac portfolio` / `rac index` / `rac validate` / `rac relationships`
- Incremental refresh: reload re-runs the single-walk load off the UI thread; the corpus snapshot is the documented enabler for true incremental refresh later
- An async rewrite of Core: Core stays synchronous; Explorer uses Textual thread workers
- New JSON contracts: the repository model types carry no `to_dict`

# Product / Architecture Decisions

- The repository model lives in `rac/services/repository.py`, not `rac/core/`: it composes services, and services depend on core, never the reverse. The roadmap's "RAC Core" language is the ADR-015 engine/consumer distinction, not the `rac.core` package.
- Operation primitives live in `rac/core/operations.py` as pure, framework-free types; `CancelToken` is a structural `Protocol`, so the Explorer bridges Textual's worker cancellation without core knowing Textual exists.
- Textual ships as the optional `explorer` extra to keep the base install light (mirroring the `ingest` extras); a missing extra is a usage error (exit 2) with an install hint, detected through a lazy-import seam that distinguishes a missing `textual` from a genuine import bug.
- `rac explorer` defaults to `.`, consistent with `index`/`resolve`/`find`; v0.8.1's `rac/`-root discovery can refine this when navigation lands.
- A cancelled load returns `None` from the adapter rather than leaking `OperationCancelled` into the UI layer, keeping widgets free of Core exception types.
- `Diagnostic` reuses the producing analysis's stable issue codes verbatim, so every Explorer finding corresponds to a finding the CLI reports.

# User-Facing Contract

## CLI

```bash
pip install 'requirements-as-code[explorer]'
rac explorer rac/
rac explorer            # current directory
rac explorer rac/ --top-level
```

## Human Output

- Loading state with live file counts, then a summary panel: artifact counts by type, relationship total with broken count, error/warning counts, and health score with a text label (`✓ Healthy` / `! Needs attention` / `✗ Unhealthy`) — meaning never depends on colour alone
- Failures render as a recoverable panel; `r` reloads, `q` quits (footer shows bindings)
- Without the extra: `rac: explorer needs the explorer extra: pip install 'requirements-as-code[explorer]'` on stderr

## JSON Output

No JSON changes. `rac explorer` has no `--json` (interactive surface), and all existing JSON contracts are byte-identical (golden battery).

## Exit Codes

- `0`: session quit by the user
- `2`: not a directory, or the `explorer` extra is not installed
- In-session Core failures are recoverable UI states, never exit codes

# Verification

## Ran

```bash
python -m pytest                      # 673 passed
python -m ruff check src/ tests/
python -m ruff format --check src/ tests/
python -m mypy src/
rac validate rac/                     # exit 0
rac relationships rac/ --validate     # exit 0
rac review rac/                       # no priority 1–2 findings
```

A headless run of the real app over `rac/` itself renders 103 artifacts, 117 relationships, 18 warnings, health 75/100 — matching `rac portfolio rac/ --json` exactly.

## Covered

- Repository model equivalence with the individual services (index entries, validation statuses, portfolio object) — the model re-exposes, never re-derives
- Resolved, broken, ambiguous-adjacent, and unknown-artifact cases; lookup by canonical ID and casefolded alias; both relationship endpoints
- Scale: a generated 1,200-artifact corpus loads in ~0.55s with correct counts, monotonic phase-complete progress, and early cancellation after exactly N callbacks
- Headless screen tests via Textual's `run_test()` pilot: summary rendering, broken-reference surfacing, error state, `r` recovery after the file is repaired, `q` clean exit
- CLI: default directory, `--top-level`, exit 2 on missing directory, exit 2 + hint via the import seam, non-textual import errors re-raised as real bugs
- Layer isolation (AST): core/services never import `textual` or `rac.explorer`; app/screens/widgets never import `rac.core`/`rac.services`; adapter/state/launch never import `textual`
- Snapshot refactor proven behavior-preserving by the golden battery (byte-identical CLI output)

# Review Path

1. `rac/roadmaps/v0.8.x-explorer/v0.8.0-explorer-foundation.md` — the pinned implementation contract this PR fulfils
2. `src/rac/core/operations.py`, `src/rac/core/corpus.py` — the operation primitives and single-walk snapshot
3. `src/rac/services/{index,validate,relationships,portfolio}.py` — the `*_from_corpus` seams and the `Relationship` model
4. `src/rac/services/repository.py` — the composed repository model
5. `src/rac/explorer/` — `state.py` → `adapter.py` → `launch.py` → `app.py` → `screens/repository.py` → `widgets/`
6. `src/rac/cli.py`, `pyproject.toml`, `.github/workflows/tests.yml` — wiring, extra, batteries
7. `tests/` — repository, perf, adapter, app, CLI, and isolation batteries
8. `docs/cli.md`, `docs/testing.md`, `README.md`, `CHANGELOG.md`

# Notes For Reviewer

- `tests/test_explorer_isolation.py` is the long-term guard on the architecture: if a later milestone tries to put intelligence in a widget or Textual in a service, it fails the suite.
- The portfolio service no longer walks the tree twice; the golden battery is the tripwire that this was purely internal.
- The roadmap artifact's Status remains `Planned` — flipping it looks like a release-time step in this repo's history rather than an implementation step.
- Known limitation: the v0.8.0 shell is intentionally a single summary screen; `rac/prompts` artifacts currently classify as `unknown` in the counts, which is pre-existing classification behavior, not a model change.

# Implementation Process

Implemented with AI assistance under the roadmap contract.

Final scope, review, and acceptance decisions were made by the maintainer.