### PR TITLE
feat(explorer): v0.8.1 Explorer navigation — browser, context view, slash command surface

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,7 +82,7 @@ jobs:
           - name: repository
             paths: "tests/test_repository.py tests/test_repository_perf.py"
           - name: explorer
-            paths: "tests/test_explorer_adapter.py tests/test_explorer_app.py tests/test_explorer_cli.py tests/test_explorer_isolation.py"
+            paths: "tests/test_explorer_adapter.py tests/test_explorer_app.py tests/test_explorer_cli.py tests/test_explorer_commands.py tests/test_explorer_isolation.py"
           - name: relationships
             paths: "tests/test_relationships.py tests/test_relationships_cmd.py tests/test_relationship_validation.py"
           - name: resolve

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ details, release history over commit history.
 
 ### Added
 
+- Explorer navigation (v0.8.1): browse every artifact grouped by type, open
+  any artifact's context view (identity, validation state, completeness,
+  relationships, diagnostics), and reach anything through the `/` command
+  surface — `open`, `find`, `browse`, `home`, `help`, `quit`, with bare text
+  treated as a search using `rac resolve` / `rac find` semantics.
+- Explorer first-run onboarding (v0.8.1): launch states derive from
+  repository content (existing, empty, or invalid repository); returning
+  users skip onboarding via a marker under the XDG state directory — the
+  only state Explorer persists.
+- `rac explorer` now defaults to the `rac/` root when present (ADR-018),
+  falling back to the current directory (v0.8.1).
 - `rac explorer [directory]` — interactive terminal Explorer application
   shell (Textual): loads a repository without blocking the interface, shows
   live progress and a repository summary (artifact counts, relationships,

--- a/README.md
+++ b/README.md
@@ -89,11 +89,12 @@ same standard it applies to your repository:
 ## Project Status
 
 RAC is early and evolving quickly. A terminal Explorer for browsing your knowledge
-base is under construction — the application shell ships today:
+base is under construction — browse artifacts, open them in context, and search
+or run commands from `/`:
 
 ```bash
 pip install 'requirements-as-code[explorer]'
-rac explorer rac/
+rac explorer
 ```
 
 Contributions, ideas, and experiments are welcome — see

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -338,19 +338,27 @@ rac index rac/ --json
 
 ## explorer
 
-Launch the interactive terminal Explorer (v0.8.0) — an application shell that
-loads a repository without blocking, shows a summary (artifact counts,
-relationships, diagnostics, health score), and recovers from failures in place.
-Navigation, health detail, and recommendations arrive in later v0.8.x releases.
+Launch the interactive terminal Explorer — browse every artifact, inspect any
+of them in context, and reach anything through the `/` command surface, without
+memorizing RAC commands. The home view shows the repository summary, health
+score, and attention items; health detail and recommendations arrive in later
+v0.8.x releases.
 
 Explorer is a presentation layer over the same services the CLI uses: everything
-it shows is also available through `rac portfolio`, `rac index`, and friends
-(ADR-015).
+it shows is also available through `rac portfolio`, `rac index`, `rac resolve`,
+`rac find`, and friends (ADR-015). It never edits artifacts (ADR-024).
 
-- **Input:** `rac explorer [directory]` — defaults to the current directory; scanned
-  recursively for `*.md`.
+- **Input:** `rac explorer [directory]` — defaults to `rac/` when present
+  (ADR-018), else the current directory; scanned recursively for `*.md`.
 - **Options:** `--top-level` · `--recursive` (no `--json`: the surface is interactive)
-- **Keys:** `q` quit · `r` reload
+- **Keys:** `/` commands and search · `↑ ↓` navigate · `Enter` select ·
+  `Esc` back · `r` reload (home) · `q` quit
+- **Commands (`/`):** `open <ref>` · `find <query> [type]` · `browse [type]` ·
+  `home` · `help` · `quit` — anything else is a search. Lookup resolves
+  canonical IDs and legacy aliases with `rac resolve` / `rac find` semantics.
+- **First run:** onboarding derives from repository content (existing, empty, or
+  invalid repository) and is skipped for returning users; the completion marker
+  under `$XDG_STATE_HOME/rac/` is the only state Explorer persists.
 - **Exit codes:** `0` session quit · `2` not a directory, or the `explorer` extra is
   not installed
 

--- a/rac/roadmaps/v0.8.x-explorer/v0.8.1-explorer-navigation.md
+++ b/rac/roadmaps/v0.8.x-explorer/v0.8.1-explorer-navigation.md
@@ -116,6 +116,81 @@ Implement onboarding per DESIGN-first-run-experience:
 Startup reaches repository context in seconds, with no login, cloud, sync, or
 forced setup.
 
+## Implementation Contract
+
+The following decisions are pinned for v0.8.1.
+
+### Default Directory (ADR-018)
+
+`rac explorer` without a directory argument opens `rac/` when that directory
+exists, falling back to the current directory. An explicitly supplied path is
+always used as given. Other commands' defaults are unchanged.
+
+### Repository Model Additions
+
+- `Artifact` gains `missing_recommended: tuple[str, ...]` (empty for unknown
+  artifacts), derived from the existing core `missing_sections` rules during
+  the same single walk. Already obtainable via `rac inspect`; no JSON change.
+- The resolve service gains snapshot seams — `resolve_in_index` and
+  `search_index` — so `/open` and `/find` rank with identical semantics to
+  `rac resolve` and `rac find` (ADR-026) without re-walking a loaded
+  repository.
+
+### Screens and Navigation
+
+- Home evolves the v0.8.0 summary: health score plus an Attention section
+  aggregated from portfolio attention items. Scoring detail remains v0.8.2.
+- Browser lists artifacts grouped by type (the five canonical types plus
+  unknown); Enter opens the selected artifact's context view.
+- Context view renders identity and metadata, validation state, completeness
+  (missing recommended sections), relationships with resolved titles, and
+  diagnostics — all from the loaded repository model.
+- Esc pops the screen stack (context → browser → home); `q` quits from
+  anywhere; `r` reloads from home. No mouse required (ADR-028).
+
+### Command Surface (DESIGN-command-surface)
+
+- `/` opens a modal command surface backed by a single registry. The v0.8.1
+  registry: `open <ref>`, `find <query> [type]`, `browse [type]`, `home`,
+  `help`, `quit`. Input matching no registered command is treated as a
+  search; users never distinguish search from command.
+- `/health` is delivered by v0.8.2 (its roadmap owns the health command);
+  the example above is illustrative of the surface, not v0.8.1 scope.
+- The empty surface teaches by example. Command routing lives in Explorer;
+  every answer comes from Core services (ADR-015).
+
+### First Run Experience (minimal v0.8.1 cut)
+
+- Launch states derive from repository content: existing repository
+  (artifact and relationship counts, key cheat sheet, "Press / for
+  anything"), empty repository (teaching state pointing at `rac new` and
+  `rac ingest` — the guided import workflow is v0.8.4), invalid repository
+  (issue counts with open-anyway; full issue navigation arrives with
+  v0.8.2 health).
+- Returning users skip onboarding via a first-run marker file under the XDG
+  state directory (`$XDG_STATE_HOME/rac/`, default `~/.local/state/rac/`).
+  The marker is the only persisted state: no last-repository, view, or
+  artifact restoration, no recent-repositories list, no preferences
+  (v0.8.6), and no repository chooser — the directory comes from the CLI.
+
+### Exit Codes and Contracts
+
+Unchanged from v0.8.0: `0` session quit, `2` usage error or missing
+`explorer` extra. No new JSON contracts; existing CLI output remains
+byte-identical.
+
+### Testing
+
+- Registry routing (including unknown-input-as-search) is unit-tested
+  without Textual; screens are tested headlessly through the existing
+  pilot harness, covering browser navigation, context rendering, the
+  Esc stack, the command surface, and each first-run state.
+- First-run marker tests isolate state via `XDG_STATE_HOME` pointed at a
+  temporary directory.
+- Resolve seams are covered in the resolve battery; per-artifact
+  completeness in the repository battery. The AST isolation battery
+  extends to the new `commands` and `firstrun` modules (Textual-free).
+
 ## Non-Goals
 
 - Health scoring detail (v0.8.2)

--- a/src/rac/cli.py
+++ b/src/rac/cli.py
@@ -392,6 +392,10 @@ def cmd_index(args: argparse.Namespace) -> int:
 
 
 def cmd_explorer(args: argparse.Namespace) -> int:
+    if args.directory is None:
+        # ADR-018: rac/ is the conventional knowledge root — open it when it
+        # exists; otherwise the current directory (v0.8.1).
+        args.directory = "rac" if Path("rac").is_dir() else "."
     if not Path(args.directory).is_dir():
         print(f"rac: not a directory: {args.directory}", file=sys.stderr)
         raise SystemExit(EXIT_USAGE)
@@ -788,8 +792,8 @@ def build_parser() -> argparse.ArgumentParser:
     p_explorer.add_argument(
         "directory",
         nargs="?",
-        default=".",
-        help="Repository to explore (default: current directory).",
+        default=None,
+        help="Repository to explore (default: rac/ when present, else the current directory).",
     )
     p_explorer.add_argument(
         "--top-level",

--- a/src/rac/explorer/adapter.py
+++ b/src/rac/explorer/adapter.py
@@ -12,9 +12,16 @@ from __future__ import annotations
 from collections.abc import Callable
 
 from rac.core.operations import CancelToken, OperationCancelled, Progress
-from rac.services.repository import Repository, load_repository
+from rac.services.repository import Artifact, Repository, load_repository
 
-from .state import LoadErrorState, LoadProgressState, RepositorySummaryState
+from .state import (
+    ArtifactRow,
+    BrowserState,
+    ContextState,
+    LoadErrorState,
+    LoadProgressState,
+    RepositorySummaryState,
+)
 
 # Presentation labels for the analysis phases that follow the scan.
 _PHASE_LABELS = {
@@ -24,7 +31,32 @@ _PHASE_LABELS = {
     "portfolio": "Calculating portfolio",
 }
 
+# Validation status → text-bearing label (never colour or symbol alone).
+_STATUS_LABELS = {
+    "valid": "✓ valid",
+    "invalid": "✗ invalid",
+    "skipped": "– unknown",
+}
+
 ProgressHandler = Callable[[LoadProgressState], None]
+
+
+def _plural(count: int, noun: str) -> str:
+    return f"{count} {noun}" + ("" if count == 1 else "s")
+
+
+def _status_label(status: str) -> str:
+    return _STATUS_LABELS.get(status, status)
+
+
+def _row(artifact: Artifact) -> ArtifactRow:
+    return ArtifactRow(
+        path=artifact.path,
+        id=artifact.id,
+        type=artifact.type,
+        title=artifact.title,
+        status_label=_status_label(artifact.status),
+    )
 
 
 def _progress_state(progress: Progress) -> LoadProgressState:
@@ -88,6 +120,17 @@ class ExplorerAdapter:
     def _summary(repository: Repository) -> RepositorySummaryState:
         portfolio = repository.portfolio
         severities = [d.severity for d in repository.diagnostics]
+        incomplete = sum(1 for a in repository.artifacts if a.missing_recommended)
+        attention = tuple(
+            line
+            for count, noun in (
+                (portfolio.invalid_artifacts, "invalid artifact"),
+                (portfolio.relationships.broken, "broken relationship"),
+                (incomplete, "incomplete artifact"),
+            )
+            if count
+            for line in (_plural(count, noun),)
+        )
         return RepositorySummaryState(
             directory=repository.directory,
             artifact_total=portfolio.total_artifacts,
@@ -97,4 +140,63 @@ class ExplorerAdapter:
             error_count=severities.count("error"),
             warning_count=severities.count("warning"),
             health_score=repository.health_score,
+            attention=attention,
+        )
+
+    # --- navigation state (v0.8.1) — requires a loaded repository -----------
+
+    def browser_state(self) -> BrowserState | None:
+        """Artifacts grouped by type for the browser, or None before a load."""
+        if self.repository is None:
+            return None
+        repository = self.repository
+        groups = tuple(
+            (artifact_type, tuple(_row(a) for a in repository.artifacts_of_type(artifact_type)))
+            for artifact_type, count in repository.portfolio.by_type.items()
+            if count
+        )
+        return BrowserState(
+            directory=self.repository.directory,
+            groups=groups,
+            total=self.repository.portfolio.total_artifacts,
+        )
+
+    def context_state(self, path: str) -> ContextState | None:
+        """The context view for the artifact at ``path``, or None if unknown."""
+        repository = self.repository
+        if repository is None:
+            return None
+        artifact = next((a for a in repository.artifacts if a.path == path), None)
+        if artifact is None:
+            return None
+
+        titles = {a.path: a.title or a.id for a in repository.artifacts}
+        outgoing: list[str] = []
+        incoming: list[str] = []
+        for rel in repository.relationships_for(path):
+            label = rel.relationship.replace("_", " ").title()
+            if rel.source_path == path:
+                if rel.resolved_path is not None:
+                    outgoing.append(f"{label} → {rel.target} ({titles[rel.resolved_path]})")
+                else:
+                    phrase = (rel.issue or "unresolved").replace("-", " ")
+                    outgoing.append(f"{label} → {rel.target} (✗ {phrase})")
+            else:
+                incoming.append(f"← {titles.get(rel.source_path, rel.source_path)} ({label})")
+
+        diagnostics = tuple(
+            f"{'✗' if d.severity == 'error' else '!'} {d.severity}: {d.message}"
+            for d in repository.diagnostics_for(path)
+        )
+        return ContextState(
+            id=artifact.id,
+            type=artifact.type,
+            title=artifact.title,
+            path=artifact.path,
+            aliases=artifact.aliases,
+            status_label=_status_label(artifact.status),
+            missing_recommended=artifact.missing_recommended,
+            outgoing=tuple(outgoing),
+            incoming=tuple(incoming),
+            diagnostics=diagnostics,
         )

--- a/src/rac/explorer/adapter.py
+++ b/src/rac/explorer/adapter.py
@@ -13,6 +13,12 @@ from collections.abc import Callable
 
 from rac.core.operations import CancelToken, OperationCancelled, Progress
 from rac.services.repository import Artifact, Repository, load_repository
+from rac.services.resolve import (
+    OUTCOME_DUPLICATE,
+    OUTCOME_RESOLVED,
+    resolve_in_index,
+    search_index,
+)
 
 from .state import (
     ArtifactRow,
@@ -20,6 +26,7 @@ from .state import (
     ContextState,
     LoadErrorState,
     LoadProgressState,
+    LookupState,
     RepositorySummaryState,
 )
 
@@ -145,21 +152,63 @@ class ExplorerAdapter:
 
     # --- navigation state (v0.8.1) — requires a loaded repository -----------
 
-    def browser_state(self) -> BrowserState | None:
-        """Artifacts grouped by type for the browser, or None before a load."""
+    def browser_state(self, artifact_type: str | None = None) -> BrowserState | None:
+        """Artifacts grouped by type for the browser, or None before a load.
+
+        ``artifact_type`` narrows the browser to one group (`/browse decision`).
+        """
         if self.repository is None:
             return None
         repository = self.repository
         groups = tuple(
-            (artifact_type, tuple(_row(a) for a in repository.artifacts_of_type(artifact_type)))
-            for artifact_type, count in repository.portfolio.by_type.items()
-            if count
+            (group_type, tuple(_row(a) for a in repository.artifacts_of_type(group_type)))
+            for group_type, count in repository.portfolio.by_type.items()
+            if count and (artifact_type is None or group_type == artifact_type)
         )
         return BrowserState(
-            directory=self.repository.directory,
+            directory=repository.directory,
             groups=groups,
-            total=self.repository.portfolio.total_artifacts,
+            total=sum(len(rows) for _, rows in groups),
         )
+
+    def open_ref(self, ref: str) -> LookupState:
+        """Exact lookup for `/open`, with `rac resolve` semantics (ADR-026).
+
+        One row resolves unambiguously; duplicates list every file so the
+        user chooses; not-found explains and suggests search.
+        """
+        repository = self.repository
+        if repository is None:
+            return LookupState(rows=(), message="Repository not loaded yet")
+        result = resolve_in_index(repository.artifacts, ref)
+        if result.outcome == OUTCOME_RESOLVED and result.artifact is not None:
+            artifact = next(a for a in repository.artifacts if a.path == result.artifact.path)
+            return LookupState(rows=(_row(artifact),))
+        if result.outcome == OUTCOME_DUPLICATE:
+            rows = tuple(_row(a) for a in repository.artifacts if a.path in result.duplicate_paths)
+            return LookupState(rows=rows, message=f"Duplicate identifier: {ref} — choose a file")
+        return LookupState(rows=(), message=f"Not found: {ref} — try a search")
+
+    def search_rows(self, args: str) -> LookupState:
+        """Search for `/find` and bare input, with `rac find` semantics.
+
+        A trailing word naming an artifact type filters to it
+        (``find payments decision``).
+        """
+        repository = self.repository
+        if repository is None:
+            return LookupState(rows=(), message="Repository not loaded yet")
+        query, artifact_type = args.strip(), None
+        tokens = query.split()
+        if len(tokens) > 1 and tokens[-1].casefold() in repository.portfolio.by_type:
+            artifact_type = tokens[-1].casefold()
+            query = " ".join(tokens[:-1])
+        result = search_index(repository.artifacts, query, artifact_type=artifact_type)
+        by_path = {a.path: a for a in repository.artifacts}
+        rows = tuple(_row(by_path[m.path]) for m in result.matches)
+        if not rows:
+            return LookupState(rows=(), message=f"No matches for '{args.strip()}'")
+        return LookupState(rows=rows)
 
     def context_state(self, path: str) -> ContextState | None:
         """The context view for the artifact at ``path``, or None if unknown."""

--- a/src/rac/explorer/app.py
+++ b/src/rac/explorer/app.py
@@ -13,17 +13,35 @@ from textual.app import App
 from textual.binding import Binding
 
 from rac.explorer.adapter import ExplorerAdapter
+from rac.explorer.screens.command import CommandScreen
 from rac.explorer.screens.repository import RepositoryScreen
 
 
 class ExplorerApp(App[None]):
-    """Application shell over one repository (navigation arrives in v0.8.1)."""
+    """Application shell over one repository: home, browser, context, `/`."""
 
     TITLE = "RAC Explorer"
-    BINDINGS = [Binding("q", "quit", "Quit")]
+    BINDINGS = [
+        Binding("q", "quit", "Quit"),
+        Binding("slash", "command_surface", "Commands"),
+    ]
     CSS = """
     RepositoryPanel {
         padding: 1 2;
+    }
+    #context-panel {
+        padding: 1 2;
+    }
+    CommandScreen {
+        align: center top;
+    }
+    #command-surface {
+        width: 80%;
+        max-height: 70%;
+        margin: 2 4;
+        padding: 1 2;
+        background: $surface;
+        border: solid $accent;
     }
     """
 
@@ -34,3 +52,8 @@ class ExplorerApp(App[None]):
 
     def on_mount(self) -> None:
         self.push_screen(RepositoryScreen(self.adapter))
+
+    def action_command_surface(self) -> None:
+        if isinstance(self.screen, CommandScreen):
+            return
+        self.push_screen(CommandScreen(self.adapter))

--- a/src/rac/explorer/commands.py
+++ b/src/rac/explorer/commands.py
@@ -1,0 +1,75 @@
+"""Explorer command registry and routing (v0.8.1, DESIGN-command-surface).
+
+The `/` surface is backed by this single registry: an action not registered
+here is not discoverable. Routing is the only logic that lives in Explorer —
+every answer comes from Core services through the adapter (ADR-015).
+
+Search and commands share the one entry point: input whose first word is not
+a registered command name is a search, so users never have to decide which
+they are doing. This module imports neither Textual nor Core, keeping the
+routing unit-testable without a terminal.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# The implicit route for input that names no registered command.
+SEARCH = "search"
+
+
+@dataclass(frozen=True)
+class CommandSpec:
+    """One discoverable command on the `/` surface."""
+
+    name: str
+    usage: str
+    summary: str
+
+
+@dataclass(frozen=True)
+class Invocation:
+    """A routed input: a registry command (or SEARCH) plus its arguments."""
+
+    command: str
+    args: str
+
+
+# The v0.8.1 registry. /health arrives with v0.8.2 (its roadmap owns it).
+REGISTRY: tuple[CommandSpec, ...] = (
+    CommandSpec("open", "open <ref>", "Open an artifact by ID or alias"),
+    CommandSpec("find", "find <query> [type]", "Search artifacts by ID, title, or path"),
+    CommandSpec("browse", "browse [type]", "Browse all artifacts"),
+    CommandSpec("home", "home", "Return to the repository home"),
+    CommandSpec("help", "help", "List available commands"),
+    CommandSpec("quit", "quit", "Quit the Explorer"),
+)
+
+_NAMES = {spec.name: spec for spec in REGISTRY}
+
+# Shown when the surface is empty: teach by example (DESIGN-command-surface).
+EXAMPLES: tuple[str, ...] = (
+    "open req-001",
+    "find payments",
+    "browse decision",
+)
+
+
+def parse(text: str) -> Invocation:
+    """Route raw surface input to a command or a search.
+
+    A leading ``/`` is tolerated (users may type it out of habit); matching
+    on the command name is casefolded. Anything else — including input that
+    merely *contains* a command name — is a search.
+    """
+    stripped = text.strip().lstrip("/").strip()
+    head, _, rest = stripped.partition(" ")
+    if head.casefold() in _NAMES:
+        return Invocation(command=head.casefold(), args=rest.strip())
+    return Invocation(command=SEARCH, args=stripped)
+
+
+def suggestions(text: str) -> tuple[CommandSpec, ...]:
+    """Registry commands whose name starts with the (partial) first word."""
+    head = text.strip().lstrip("/").strip().partition(" ")[0].casefold()
+    return tuple(spec for spec in REGISTRY if spec.name.startswith(head))

--- a/src/rac/explorer/firstrun.py
+++ b/src/rac/explorer/firstrun.py
@@ -1,0 +1,35 @@
+"""First-run marker — the only state Explorer persists in v0.8.1.
+
+Returning users skip onboarding (DESIGN-first-run-experience); everything
+else — last repository, views, preferences — is deliberately not stored
+until v0.8.6 workspace persistence. The marker lives under the XDG state
+directory and persistence failures are silently tolerated: onboarding
+showing twice is better than a crash on a read-only home.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+_MARKER_NAME = "explorer-first-run"
+
+
+def _marker_path() -> Path:
+    base = os.environ.get("XDG_STATE_HOME") or str(Path.home() / ".local" / "state")
+    return Path(base) / "rac" / _MARKER_NAME
+
+
+def is_first_run() -> bool:
+    """True until :func:`mark_onboarded` has recorded a completed first run."""
+    return not _marker_path().exists()
+
+
+def mark_onboarded() -> None:
+    """Record that onboarding completed; never raises on filesystem trouble."""
+    marker = _marker_path()
+    try:
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.write_text("onboarded\n", encoding="utf-8")
+    except OSError:
+        pass

--- a/src/rac/explorer/screens/browser.py
+++ b/src/rac/explorer/screens/browser.py
@@ -1,0 +1,58 @@
+"""Browser screen — every artifact in the repository, grouped by type (v0.8.1).
+
+Renders the loaded repository model only (no Core operations run here); Enter
+opens an artifact's context view, Esc returns to the previous screen.
+"""
+
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.screen import Screen
+from textual.widgets import Footer, Header, OptionList
+from textual.widgets.option_list import Option
+
+from rac.explorer.adapter import ExplorerAdapter
+from rac.explorer.state import BrowserState
+
+from .context import ContextScreen
+
+
+class BrowserScreen(Screen[None]):
+    """Keyboard-first artifact list: ↑↓ navigate, Enter opens, Esc backs."""
+
+    BINDINGS = [Binding("escape", "back", "Back")]
+
+    def __init__(self, adapter: ExplorerAdapter, browser: BrowserState) -> None:
+        super().__init__()
+        self.adapter = adapter
+        self.browser = browser
+
+    def compose(self) -> ComposeResult:
+        yield Header()
+        # A None entry renders as a separator line between type groups.
+        options: list[Option | None] = []
+        for artifact_type, rows in self.browser.groups:
+            if options:
+                options.append(None)
+            options.append(Option(f"{artifact_type} ({len(rows)})", id=None, disabled=True))
+            for row in rows:
+                title = row.title or row.id
+                options.append(Option(f"  {row.status_label}  {title}", id=row.path))
+        option_list = OptionList(*options, id="artifact-list")
+        option_list.border_title = f"Artifacts ({self.browser.total})"
+        yield option_list
+        yield Footer()
+
+    def on_mount(self) -> None:
+        self.query_one(OptionList).focus()
+
+    def on_option_list_option_selected(self, event: OptionList.OptionSelected) -> None:
+        if event.option_id is None:
+            return
+        context = self.adapter.context_state(event.option_id)
+        if context is not None:
+            self.app.push_screen(ContextScreen(context))
+
+    def action_back(self) -> None:
+        self.app.pop_screen()

--- a/src/rac/explorer/screens/command.py
+++ b/src/rac/explorer/screens/command.py
@@ -1,0 +1,143 @@
+"""The `/` command surface — one entry point for search and commands (v0.8.1).
+
+A modal over the current screen: type, Enter routes (registry command or
+search), ↑↓ pick a result, Enter opens it, Esc closes. Routing lives in
+:mod:`rac.explorer.commands`; every answer comes from the adapter (ADR-015).
+"""
+
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Input, OptionList
+from textual.widgets.option_list import Option
+
+from rac.explorer import commands
+from rac.explorer.adapter import ExplorerAdapter
+from rac.explorer.state import LookupState
+
+from .context import ContextScreen
+
+
+class CommandScreen(ModalScreen[None]):
+    """The universal `/` surface (DESIGN-command-surface)."""
+
+    BINDINGS = [Binding("escape", "dismiss_surface", "Close")]
+
+    def __init__(self, adapter: ExplorerAdapter) -> None:
+        super().__init__()
+        self.adapter = adapter
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="command-surface"):
+            yield Input(placeholder="Type a command or search…", id="command-input")
+            yield OptionList(id="command-results")
+
+    def on_mount(self) -> None:
+        self.query_one(Input).focus()
+        self._show_examples()
+
+    # --- result list helpers -------------------------------------------------
+
+    def _set_options(self, options: list[Option | None]) -> None:
+        result_list = self.query_one(OptionList)
+        result_list.clear_options()
+        result_list.add_options(options)
+
+    def _show_examples(self) -> None:
+        options: list[Option | None] = [Option("Start typing…  Try:", disabled=True)]
+        options.extend(Option(f"  {example}", disabled=True) for example in commands.EXAMPLES)
+        self._set_options(options)
+
+    def _show_help(self) -> None:
+        self._set_options(
+            [
+                Option(f"/{spec.usage:<22} {spec.summary}", disabled=True)
+                for spec in commands.REGISTRY
+            ]
+        )
+
+    def _show_lookup(self, lookup: LookupState) -> None:
+        options: list[Option | None] = []
+        if lookup.message:
+            options.append(Option(lookup.message, disabled=True))
+        options.extend(
+            Option(f"{row.status_label}  {row.title or row.id}  ({row.type})", id=row.path)
+            for row in lookup.rows
+        )
+        self._set_options(options)
+        if lookup.rows:
+            result_list = self.query_one(OptionList)
+            result_list.focus()
+            result_list.highlighted = 1 if lookup.message else 0
+
+    # --- routing --------------------------------------------------------------
+
+    def on_input_changed(self, event: Input.Changed) -> None:
+        text = event.value
+        if not text.strip().lstrip("/").strip():
+            self._show_examples()
+            return
+        matched = commands.suggestions(text)
+        if matched:
+            self._set_options(
+                [Option(f"/{spec.usage:<22} {spec.summary}", disabled=True) for spec in matched]
+            )
+        else:
+            hint = Option(f"Press Enter to search for '{text.strip()}'", disabled=True)
+            self._set_options([hint])
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        invocation = commands.parse(event.value)
+        if not invocation.args and invocation.command == commands.SEARCH:
+            self._show_examples()
+            return
+
+        if invocation.command == "quit":
+            self.app.exit()
+        elif invocation.command == "help":
+            self._show_help()
+        elif invocation.command == "home":
+            self._pop_to_home()
+        elif invocation.command == "browse":
+            artifact_type = invocation.args.casefold() or None
+            browser = self.adapter.browser_state(artifact_type)
+            if browser is None or not browser.groups:
+                self._set_options([Option(f"Nothing to browse: {invocation.args}", disabled=True)])
+                return
+            from .browser import BrowserScreen
+
+            self.app.pop_screen()
+            self.app.push_screen(BrowserScreen(self.adapter, browser))
+        elif invocation.command == "open":
+            lookup = self.adapter.open_ref(invocation.args)
+            if len(lookup.rows) == 1 and lookup.message is None:
+                self._open_path(lookup.rows[0].path)
+            else:
+                self._show_lookup(lookup)
+        else:  # search — explicit /find or bare input
+            self._show_lookup(self.adapter.search_rows(invocation.args))
+
+    def on_option_list_option_selected(self, event: OptionList.OptionSelected) -> None:
+        if event.option_id is not None:
+            self._open_path(event.option_id)
+
+    # --- navigation -----------------------------------------------------------
+
+    def _open_path(self, path: str) -> None:
+        context = self.adapter.context_state(path)
+        if context is not None:
+            self.app.pop_screen()
+            self.app.push_screen(ContextScreen(context))
+
+    def _pop_to_home(self) -> None:
+        from .repository import RepositoryScreen
+
+        self.app.pop_screen()  # the surface itself
+        while not isinstance(self.app.screen, RepositoryScreen) and len(self.app.screen_stack) > 1:
+            self.app.pop_screen()
+
+    def action_dismiss_surface(self) -> None:
+        self.app.pop_screen()

--- a/src/rac/explorer/screens/context.py
+++ b/src/rac/explorer/screens/context.py
@@ -1,0 +1,68 @@
+"""Context screen — one artifact in full (v0.8.1).
+
+Identity, validation state, completeness, relationships, and diagnostics,
+rendered from the loaded repository model. Esc returns to the browser.
+"""
+
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.screen import Screen
+from textual.widgets import Footer, Header, Static
+
+from rac.explorer.state import ContextState
+
+
+def render_context(context: ContextState) -> str:
+    """The context view as terminal-readable text (icons + labels, ADR-028)."""
+    lines = [
+        context.title or context.id,
+        "",
+        f"ID          {context.id}",
+        f"Type        {context.type}",
+        f"Path        {context.path}",
+        f"Status      {context.status_label}",
+    ]
+    aliases = [a for a in context.aliases if a != context.id]
+    if aliases:
+        lines.append(f"Aliases     {', '.join(aliases)}")
+
+    lines.append("")
+    if context.missing_recommended:
+        names = ", ".join(s.title() for s in context.missing_recommended)
+        lines.append(f"Completeness  ! missing recommended: {names}")
+    else:
+        lines.append("Completeness  ✓ all recommended sections present")
+
+    lines.extend(["", "Relationships"])
+    if context.outgoing or context.incoming:
+        lines.extend(f"  {line}" for line in context.outgoing)
+        lines.extend(f"  {line}" for line in context.incoming)
+    else:
+        lines.append("  none declared or inbound")
+
+    lines.extend(["", "Diagnostics"])
+    if context.diagnostics:
+        lines.extend(f"  {line}" for line in context.diagnostics)
+    else:
+        lines.append("  ✓ none")
+    return "\n".join(lines)
+
+
+class ContextScreen(Screen[None]):
+    """Read-only artifact context; editing belongs to external tools (ADR-024)."""
+
+    BINDINGS = [Binding("escape", "back", "Back")]
+
+    def __init__(self, context: ContextState) -> None:
+        super().__init__()
+        self.context = context
+
+    def compose(self) -> ComposeResult:
+        yield Header()
+        yield Static(render_context(self.context), id="context-panel")
+        yield Footer()
+
+    def action_back(self) -> None:
+        self.app.pop_screen()

--- a/src/rac/explorer/screens/repository.py
+++ b/src/rac/explorer/screens/repository.py
@@ -16,6 +16,7 @@ from textual.screen import Screen
 from textual.widgets import Footer, Header
 from textual.worker import Worker, WorkerState, get_current_worker
 
+from rac.explorer import firstrun
 from rac.explorer.adapter import ExplorerAdapter
 from rac.explorer.state import LoadErrorState, LoadProgressState, RepositorySummaryState
 from rac.explorer.widgets import RepositoryPanel
@@ -45,6 +46,9 @@ class RepositoryScreen(Screen[None]):
     def __init__(self, adapter: ExplorerAdapter) -> None:
         super().__init__()
         self.adapter = adapter
+        # The summary held back while first-run onboarding is on screen;
+        # Enter dismisses onboarding and reveals it (no forced setup).
+        self._onboarding_summary: RepositorySummaryState | None = None
 
     def compose(self) -> ComposeResult:
         yield Header()
@@ -61,6 +65,11 @@ class RepositoryScreen(Screen[None]):
         self._load_repository()
 
     def action_browse(self) -> None:
+        if self._onboarding_summary is not None:
+            summary, self._onboarding_summary = self._onboarding_summary, None
+            firstrun.mark_onboarded()
+            self.query_one(RepositoryPanel).show_summary(summary)
+            return
         browser = self.adapter.browser_state()
         if browser is not None:
             self.app.push_screen(BrowserScreen(self.adapter, browser))
@@ -83,7 +92,11 @@ class RepositoryScreen(Screen[None]):
         if event.state == WorkerState.SUCCESS:
             result = event.worker.result
             if isinstance(result, RepositorySummaryState):
-                panel.show_summary(result)
+                if firstrun.is_first_run():
+                    self._onboarding_summary = result
+                    panel.show_onboarding(result)
+                else:
+                    panel.show_summary(result)
             elif isinstance(result, LoadErrorState):
                 panel.show_error(result)
             # None — the load was cancelled; a fresh worker is taking over.

--- a/src/rac/explorer/screens/repository.py
+++ b/src/rac/explorer/screens/repository.py
@@ -20,6 +20,8 @@ from rac.explorer.adapter import ExplorerAdapter
 from rac.explorer.state import LoadErrorState, LoadProgressState, RepositorySummaryState
 from rac.explorer.widgets import RepositoryPanel
 
+from .browser import BrowserScreen
+
 
 class _WorkerCancelToken:
     """Bridges Textual's worker cancellation into the Core CancelToken protocol."""
@@ -33,9 +35,12 @@ class _WorkerCancelToken:
 
 
 class RepositoryScreen(Screen[None]):
-    """Loads the repository off the UI thread and renders its summary."""
+    """The home screen: loads off the UI thread, renders summary + attention."""
 
-    BINDINGS = [Binding("r", "reload", "Reload")]
+    BINDINGS = [
+        Binding("r", "reload", "Reload"),
+        Binding("enter", "browse", "Browse"),
+    ]
 
     def __init__(self, adapter: ExplorerAdapter) -> None:
         super().__init__()
@@ -54,6 +59,11 @@ class RepositoryScreen(Screen[None]):
             LoadProgressState(phase="scan", completed=0, total=None, label="Scanning artifacts")
         )
         self._load_repository()
+
+    def action_browse(self) -> None:
+        browser = self.adapter.browser_state()
+        if browser is not None:
+            self.app.push_screen(BrowserScreen(self.adapter, browser))
 
     @work(thread=True, exclusive=True, group="repository-load")
     def _load_repository(self) -> RepositorySummaryState | LoadErrorState | None:

--- a/src/rac/explorer/state.py
+++ b/src/rac/explorer/state.py
@@ -22,7 +22,7 @@ class LoadProgressState:
 
 @dataclass(frozen=True)
 class RepositorySummaryState:
-    """The repository summary the v0.8.0 shell renders."""
+    """The repository summary the home screen renders."""
 
     directory: str
     artifact_total: int
@@ -32,6 +32,45 @@ class RepositorySummaryState:
     error_count: int
     warning_count: int
     health_score: int
+    # Attention lines (v0.8.1): aggregated counts such as "2 broken
+    # relationships"; empty when the repository needs none.
+    attention: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class ArtifactRow:
+    """One artifact line in the browser or in search results."""
+
+    path: str  # navigation key (opens the context view)
+    id: str
+    type: str
+    title: str | None
+    status_label: str  # e.g. "✓ valid" — text alongside any symbol
+
+
+@dataclass(frozen=True)
+class BrowserState:
+    """The artifact browser: artifacts grouped by type, walk order."""
+
+    directory: str
+    groups: tuple[tuple[str, tuple[ArtifactRow, ...]], ...]  # (type, rows)
+    total: int
+
+
+@dataclass(frozen=True)
+class ContextState:
+    """Everything the context view shows for one artifact."""
+
+    id: str
+    type: str
+    title: str | None
+    path: str
+    aliases: tuple[str, ...]
+    status_label: str
+    missing_recommended: tuple[str, ...]
+    outgoing: tuple[str, ...]  # rendered relationship lines declared here
+    incoming: tuple[str, ...]  # rendered lines for references resolving here
+    diagnostics: tuple[str, ...]  # rendered finding lines
 
 
 @dataclass(frozen=True)

--- a/src/rac/explorer/state.py
+++ b/src/rac/explorer/state.py
@@ -58,6 +58,18 @@ class BrowserState:
 
 
 @dataclass(frozen=True)
+class LookupState:
+    """The outcome of an /open or /find: rows to pick from, or a message.
+
+    One row means an unambiguous answer (open it directly); several rows let
+    the user choose; a message explains an empty or ambiguous outcome.
+    """
+
+    rows: tuple[ArtifactRow, ...]
+    message: str | None = None
+
+
+@dataclass(frozen=True)
 class ContextState:
     """Everything the context view shows for one artifact."""
 

--- a/src/rac/explorer/widgets/__init__.py
+++ b/src/rac/explorer/widgets/__init__.py
@@ -47,6 +47,10 @@ class RepositoryPanel(Static):
                 f"Health         {health}",
             ]
         )
+        if summary.attention:
+            lines.extend(["", "Attention"])
+            lines.extend(f"  ! {line}" for line in summary.attention)
+        lines.extend(["", "Press / for anything · Enter to browse"])
         self.update("\n".join(lines))
 
     def show_error(self, error: LoadErrorState) -> None:

--- a/src/rac/explorer/widgets/__init__.py
+++ b/src/rac/explorer/widgets/__init__.py
@@ -53,6 +53,56 @@ class RepositoryPanel(Static):
         lines.extend(["", "Press / for anything · Enter to browse"])
         self.update("\n".join(lines))
 
+    def show_onboarding(self, summary: RepositorySummaryState) -> None:
+        """The first-run state (v0.8.1): existing, empty, or invalid repository.
+
+        Derived from repository content; Enter always continues into the
+        normal summary (no forced setup, DESIGN-first-run-experience).
+        """
+        lines = ["Welcome to RAC Explorer", "Your product knowledge workspace.", ""]
+        if summary.artifact_total == 0:
+            lines.extend(
+                [
+                    "No RAC artifacts found.",
+                    "",
+                    "Start by:",
+                    "  creating an artifact   rac new requirement <path>",
+                    "  importing a document   rac ingest <file>",
+                    "",
+                    "Press Enter to continue",
+                ]
+            )
+        elif summary.error_count:
+            lines.extend(
+                [
+                    "Repository issues found",
+                    "",
+                    f"  ✗ {summary.error_count} validation errors",
+                    f"  ! {summary.warning_count} warnings",
+                    "",
+                    "Press Enter to open anyway",
+                ]
+            )
+        else:
+            lines.append("Repository found")
+            lines.append("")
+            lines.extend(f"  ✓ {name}  {count}" for name, count in summary.by_type)
+            lines.extend(
+                [
+                    f"  ✓ relationships  {summary.relationship_total}",
+                    "",
+                    "Navigation",
+                    "  /      search and commands",
+                    "  ↑ ↓    move",
+                    "  Enter  open",
+                    "  Esc    back",
+                    "  q      quit",
+                    "",
+                    "Press / for anything · Enter to continue",
+                ]
+            )
+        self.update("\n".join(lines))
+
     def show_error(self, error: LoadErrorState) -> None:
         lines = [f"✗ {error.title}", "", error.detail]
         if error.can_retry:

--- a/src/rac/services/repository.py
+++ b/src/rac/services/repository.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from rac.core.artifacts import spec_for
+from rac.core.classification import missing_sections
 from rac.core.corpus import collect_corpus
 from rac.core.operations import CancelToken, Progress, ProgressCallback, checkpoint
 
@@ -52,6 +54,10 @@ class Artifact:
     A join of the index inventory (identity, type, title, path, aliases) and
     directory validation (``status``: ``valid`` / ``invalid`` / ``skipped``),
     covering every supported type plus ``unknown``.
+
+    ``missing_recommended`` (v0.8.1) lists the schema-recommended sections the
+    artifact does not fill — the same completeness rules ``rac inspect`` and
+    ``rac portfolio`` report; always empty for unknown artifacts.
     """
 
     id: str
@@ -60,6 +66,7 @@ class Artifact:
     path: str
     aliases: tuple[str, ...]
     status: str
+    missing_recommended: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -185,6 +192,14 @@ def load_repository(
     portfolio = portfolio_from_corpus(directory, entries, recursive=recursive)
     phase_done("portfolio")
 
+    missing_by_path: dict[str, tuple[str, ...]] = {}
+    for corpus_entry in entries:
+        spec = spec_for(corpus_entry.artifact_type)
+        if spec is None:
+            continue
+        _, missing_recommended = missing_sections(corpus_entry.product, spec)
+        missing_by_path[str(corpus_entry.path)] = tuple(missing_recommended)
+
     artifacts = [
         Artifact(
             id=entry.id,
@@ -193,6 +208,7 @@ def load_repository(
             path=entry.path,
             aliases=tuple(entry.aliases),
             status=status_by_path[entry.path],
+            missing_recommended=missing_by_path.get(entry.path, ()),
         )
         for entry in index.artifacts
     ]

--- a/src/rac/services/resolve.py
+++ b/src/rac/services/resolve.py
@@ -15,13 +15,36 @@ with sorted path as the tiebreak.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass, field
+from typing import Protocol
 
-from rac.services.index import IndexEntry, build_repository_index
+from rac.services.index import build_repository_index
 
 OUTCOME_RESOLVED = "resolved"
 OUTCOME_NOT_FOUND = "not-found"
 OUTCOME_DUPLICATE = "duplicate"
+
+
+class SearchableArtifact(Protocol):
+    """Anything resolvable/searchable: index entries, repository artifacts.
+
+    Structural (v0.8.1) so consumers holding an already-loaded repository
+    model can reuse the exact `rac resolve` / `rac find` semantics without
+    re-walking the directory (ADR-026).
+    """
+
+    @property
+    def id(self) -> str: ...
+    @property
+    def type(self) -> str: ...
+    @property
+    def title(self) -> str | None: ...
+    @property
+    def path(self) -> str: ...
+    @property
+    def aliases(self) -> Sequence[str]: ...
+
 
 # Match-field priority for search ordering (lower ranks first).
 _RANK_ID = 0
@@ -47,7 +70,7 @@ class ResolvedArtifact:
         }
 
     @classmethod
-    def from_entry(cls, entry: IndexEntry) -> ResolvedArtifact:
+    def from_entry(cls, entry: SearchableArtifact) -> ResolvedArtifact:
         return cls(id=entry.id, type=entry.type, title=entry.title, path=entry.path)
 
 
@@ -104,9 +127,19 @@ def resolve_artifact(directory: str, artifact_id: str, recursive: bool = True) -
     relationship resolution uses. Multiple *distinct files* matching is a
     duplicate, reported with every path and never resolved by order.
     """
+    entries = build_repository_index(directory, recursive=recursive).artifacts
+    return resolve_in_index(entries, artifact_id)
+
+
+def resolve_in_index(entries: Sequence[SearchableArtifact], artifact_id: str) -> ResolutionResult:
+    """Resolve ``artifact_id`` against already-discovered entries (v0.8.1).
+
+    Same outcomes and semantics as :func:`resolve_artifact`; the seam lets a
+    loaded repository model answer lookups without another directory walk.
+    """
     wanted = artifact_id.strip().casefold()
-    matches: list[IndexEntry] = []
-    for entry in build_repository_index(directory, recursive=recursive).artifacts:
+    matches: list[SearchableArtifact] = []
+    for entry in entries:
         if any(alias.casefold() == wanted for alias in entry.aliases):
             matches.append(entry)
     if not matches:
@@ -124,7 +157,7 @@ def resolve_artifact(directory: str, artifact_id: str, recursive: bool = True) -
     )
 
 
-def _match_rank(entry: IndexEntry, needle: str) -> int | None:
+def _match_rank(entry: SearchableArtifact, needle: str) -> int | None:
     """Best match-field rank for ``needle`` in ``entry``, or None for no match."""
     if any(needle in alias.casefold() for alias in entry.aliases):
         return _RANK_ID
@@ -147,9 +180,23 @@ def find_artifacts(
     substring match, results ordered by match-field priority then sorted
     path. An empty result is a valid outcome, not an error.
     """
+    entries = build_repository_index(directory, recursive=recursive).artifacts
+    return search_index(entries, query, artifact_type=artifact_type)
+
+
+def search_index(
+    entries: Sequence[SearchableArtifact],
+    query: str,
+    artifact_type: str | None = None,
+) -> SearchResult:
+    """Search already-discovered entries with `rac find` semantics (v0.8.1).
+
+    Identical matching and ordering to :func:`find_artifacts`; the seam lets
+    a loaded repository model serve searches without another directory walk.
+    """
     needle = query.strip().casefold()
-    ranked: list[tuple[int, str, IndexEntry]] = []
-    for entry in build_repository_index(directory, recursive=recursive).artifacts:
+    ranked: list[tuple[int, str, SearchableArtifact]] = []
+    for entry in entries:
         if artifact_type is not None and entry.type != artifact_type:
             continue
         rank = _match_rank(entry, needle)

--- a/tests/test_explorer_adapter.py
+++ b/tests/test_explorer_adapter.py
@@ -74,6 +74,81 @@ def test_empty_directory_is_a_summary_not_an_error(tmp_path):
     assert result.artifact_total == 0
 
 
+def test_summary_attention_lines_aggregate_findings():
+    result = ExplorerAdapter(str(FIXTURES / "broken_rels")).load()
+    assert isinstance(result, RepositorySummaryState)
+    assert "1 broken relationship" in result.attention
+
+    clean = ExplorerAdapter(str(FIXTURES / "valid_clean")).load()
+    assert isinstance(clean, RepositorySummaryState)
+    assert clean.attention == ()
+
+
+def test_browser_state_requires_a_load():
+    assert ExplorerAdapter(str(FIXTURES / "all_types")).browser_state() is None
+
+
+def test_browser_state_groups_by_type_in_walk_order():
+    adapter = ExplorerAdapter(str(FIXTURES / "all_types"))
+    adapter.load()
+    browser = adapter.browser_state()
+    assert browser is not None
+    assert browser.total == 6
+    assert [group for group, _ in browser.groups] == [
+        "requirement",
+        "decision",
+        "roadmap",
+        "prompt",
+        "design",
+        "unknown",
+    ]
+    assert all(rows for _, rows in browser.groups)
+    [unknown_rows] = [rows for group, rows in browser.groups if group == "unknown"]
+    assert unknown_rows[0].status_label == "– unknown"
+
+
+def test_context_state_renders_resolved_and_incoming_relationships():
+    adapter = ExplorerAdapter(str(FIXTURES / "valid_clean"))
+    adapter.load()
+    assert adapter.repository is not None
+    [req] = adapter.repository.artifacts_of_type("requirement")
+    [adr] = adapter.repository.artifacts_of_type("decision")
+
+    req_context = adapter.context_state(req.path)
+    assert req_context is not None
+    [outgoing] = req_context.outgoing
+    assert outgoing.startswith("Related Decisions → ADR-001")
+    assert (adr.title or "") in outgoing
+    assert req_context.incoming == ()
+    assert req_context.diagnostics == ()
+
+    adr_context = adapter.context_state(adr.path)
+    assert adr_context is not None
+    assert adr_context.outgoing == ()
+    [incoming] = adr_context.incoming
+    assert incoming.startswith("← ")
+    assert "Related Decisions" in incoming
+
+
+def test_context_state_marks_broken_references():
+    adapter = ExplorerAdapter(str(FIXTURES / "broken_rels"))
+    adapter.load()
+    assert adapter.repository is not None
+    [artifact] = adapter.repository.artifacts
+    context = adapter.context_state(artifact.path)
+    assert context is not None
+    [outgoing] = context.outgoing
+    assert "ADR-MISSING" in outgoing
+    assert "✗ relationship target not found" in outgoing
+    assert any("warning" in line for line in context.diagnostics)
+
+
+def test_context_state_unknown_path_returns_none():
+    adapter = ExplorerAdapter(str(FIXTURES / "valid_clean"))
+    adapter.load()
+    assert adapter.context_state("nope.md") is None
+
+
 def test_cancelled_load_returns_none_not_an_error():
     token = CancellationToken()
     adapter = ExplorerAdapter(str(FIXTURES / "all_types"))

--- a/tests/test_explorer_adapter.py
+++ b/tests/test_explorer_adapter.py
@@ -149,6 +149,60 @@ def test_context_state_unknown_path_returns_none():
     assert adapter.context_state("nope.md") is None
 
 
+def test_open_ref_resolves_like_rac_resolve():
+    adapter = ExplorerAdapter(str(FIXTURES / "valid_clean"))
+    adapter.load()
+    lookup = adapter.open_ref("adr-001")
+    assert lookup.message is None
+    [row] = lookup.rows
+    assert row.type == "decision"
+
+    missing = adapter.open_ref("nope-999")
+    assert missing.rows == ()
+    assert missing.message is not None and "Not found" in missing.message
+
+
+def test_open_ref_duplicates_offer_a_choice(tmp_path):
+    doc = (
+        "---\nschema_version: 1\nid: RAC-01JY4M8X2QZ7\ntype: decision\n---\n"
+        "# A Decision\n\n## Context\n\nc\n\n## Decision\n\nd\n\n## Consequences\n\nq\n"
+    )
+    (tmp_path / "a.md").write_text(doc, encoding="utf-8")
+    (tmp_path / "b.md").write_text(doc, encoding="utf-8")
+    adapter = ExplorerAdapter(str(tmp_path))
+    adapter.load()
+    lookup = adapter.open_ref("RAC-01JY4M8X2QZ7")
+    assert len(lookup.rows) == 2
+    assert lookup.message is not None and "Duplicate" in lookup.message
+
+
+def test_search_rows_rank_like_rac_find():
+    adapter = ExplorerAdapter(str(FIXTURES / "all_types"))
+    adapter.load()
+    lookup = adapter.search_rows("md")
+    assert lookup.rows  # path substring matches at minimum
+    empty = adapter.search_rows("zzz-no-such-thing")
+    assert empty.rows == ()
+    assert empty.message is not None and "No matches" in empty.message
+
+
+def test_search_rows_trailing_type_token_filters():
+    adapter = ExplorerAdapter(str(FIXTURES / "all_types"))
+    adapter.load()
+    filtered = adapter.search_rows(". decision")
+    assert filtered.rows
+    assert all(row.type == "decision" for row in filtered.rows)
+
+
+def test_browser_state_type_filter():
+    adapter = ExplorerAdapter(str(FIXTURES / "all_types"))
+    adapter.load()
+    browser = adapter.browser_state("decision")
+    assert browser is not None
+    assert [group for group, _ in browser.groups] == ["decision"]
+    assert browser.total == 1
+
+
 def test_cancelled_load_returns_none_not_an_error():
     token = CancellationToken()
     adapter = ExplorerAdapter(str(FIXTURES / "all_types"))

--- a/tests/test_explorer_app.py
+++ b/tests/test_explorer_app.py
@@ -80,6 +80,44 @@ async def test_reload_binding_recovers_after_repair(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_browse_open_context_and_esc_stack():
+    from rac.explorer.screens.browser import BrowserScreen
+    from rac.explorer.screens.context import ContextScreen
+    from rac.explorer.screens.repository import RepositoryScreen
+
+    app = ExplorerApp(str(FIXTURES / "valid_clean"))
+    async with app.run_test() as pilot:
+        await _settled_panel_text(app, pilot)
+
+        await pilot.press("enter")  # home → browser
+        assert isinstance(app.screen, BrowserScreen)
+
+        await pilot.press("enter")  # first artifact → context view
+        assert isinstance(app.screen, ContextScreen)
+        from textual.widgets import Static
+
+        text = str(app.screen.query_one("#context-panel", Static).content)
+        assert "ID " in text and "Status " in text
+        assert "Completeness  ✓ all recommended sections present" in text
+        assert "Relationships" in text and "Diagnostics" in text
+
+        await pilot.press("escape")  # context → browser
+        assert isinstance(app.screen, BrowserScreen)
+        await pilot.press("escape")  # browser → home
+        assert isinstance(app.screen, RepositoryScreen)
+
+
+@pytest.mark.asyncio
+async def test_home_shows_attention_and_hint():
+    app = ExplorerApp(str(FIXTURES / "broken_rels"))
+    async with app.run_test() as pilot:
+        text = await _settled_panel_text(app, pilot)
+        assert "Attention" in text
+        assert "! 1 broken relationship" in text
+        assert "Press / for anything" in text
+
+
+@pytest.mark.asyncio
 async def test_quit_binding_exits_cleanly():
     app = ExplorerApp(str(FIXTURES / "valid_clean"))
     async with app.run_test() as pilot:

--- a/tests/test_explorer_app.py
+++ b/tests/test_explorer_app.py
@@ -11,10 +11,25 @@ from pathlib import Path
 
 import pytest
 
+from rac.explorer import firstrun
 from rac.explorer.app import ExplorerApp
 from rac.explorer.widgets import RepositoryPanel
 
 FIXTURES = Path(__file__).parent / "fixtures" / "portfolio_summary"
+
+
+@pytest.fixture(autouse=True)
+def onboarded_state(tmp_path_factory, monkeypatch):
+    """Run every app test as a returning user; onboarding tests reset this."""
+    state = tmp_path_factory.mktemp("xdg-state")
+    monkeypatch.setenv("XDG_STATE_HOME", str(state))
+    firstrun.mark_onboarded()
+    return state
+
+
+@pytest.fixture
+def fresh_first_run(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "fresh-state"))
 
 
 async def _settled_panel_text(app: ExplorerApp, pilot) -> str:
@@ -208,6 +223,62 @@ async def test_slash_browse_with_type_filter():
         assert isinstance(app.screen, BrowserScreen)
         artifact_list = app.screen.query_one(OptionList)
         assert artifact_list.option_count == 2  # the type header + one decision
+
+
+def test_first_run_marker_round_trip(fresh_first_run):
+    assert firstrun.is_first_run()
+    firstrun.mark_onboarded()
+    assert not firstrun.is_first_run()
+
+
+@pytest.mark.asyncio
+async def test_first_run_shows_onboarding_then_enter_continues(fresh_first_run):
+    app = ExplorerApp(str(FIXTURES / "valid_clean"))
+    async with app.run_test() as pilot:
+        text = await _settled_panel_text(app, pilot)
+        assert "Welcome to RAC Explorer" in text
+        assert "Repository found" in text
+        assert "✓ relationships  1" in text
+        assert "/      search and commands" in text
+
+        await pilot.press("enter")
+        await pilot.pause()
+        text = str(app.screen.query_one(RepositoryPanel).content)
+        assert "Health" in text  # the normal summary
+    assert not firstrun.is_first_run()  # marker written
+
+
+@pytest.mark.asyncio
+async def test_returning_users_skip_onboarding():
+    app = ExplorerApp(str(FIXTURES / "valid_clean"))
+    async with app.run_test() as pilot:
+        text = await _settled_panel_text(app, pilot)
+        assert "Welcome to RAC Explorer" not in text
+        assert "Health" in text
+
+
+@pytest.mark.asyncio
+async def test_first_run_empty_repository_teaches(fresh_first_run, tmp_path):
+    app = ExplorerApp(str(tmp_path))
+    async with app.run_test() as pilot:
+        text = await _settled_panel_text(app, pilot)
+        assert "No RAC artifacts found." in text
+        assert "rac new" in text and "rac ingest" in text
+
+
+@pytest.mark.asyncio
+async def test_first_run_invalid_repository_opens_anyway(fresh_first_run):
+    app = ExplorerApp(str(FIXTURES / "invalid_known"))
+    async with app.run_test() as pilot:
+        text = await _settled_panel_text(app, pilot)
+        assert "Repository issues found" in text
+        assert "✗ 1 validation errors" in text
+        assert "Press Enter to open anyway" in text
+
+        await pilot.press("enter")
+        await pilot.pause()
+        text = str(app.screen.query_one(RepositoryPanel).content)
+        assert "Health" in text
 
 
 @pytest.mark.asyncio

--- a/tests/test_explorer_app.py
+++ b/tests/test_explorer_app.py
@@ -118,6 +118,99 @@ async def test_home_shows_attention_and_hint():
 
 
 @pytest.mark.asyncio
+async def test_slash_open_navigates_to_context():
+    from rac.explorer.screens.command import CommandScreen
+    from rac.explorer.screens.context import ContextScreen
+
+    app = ExplorerApp(str(FIXTURES / "valid_clean"))
+    async with app.run_test() as pilot:
+        await _settled_panel_text(app, pilot)
+        await pilot.press("/")
+        assert isinstance(app.screen, CommandScreen)
+        await pilot.press(*"open adr-001")
+        await pilot.press("enter")
+        await pilot.pause()
+        assert isinstance(app.screen, ContextScreen)
+        from textual.widgets import Static
+
+        text = str(app.screen.query_one("#context-panel", Static).content)
+        assert "decision" in text
+
+
+@pytest.mark.asyncio
+async def test_slash_bare_text_searches_and_enter_opens():
+    from rac.explorer.screens.command import CommandScreen
+    from rac.explorer.screens.context import ContextScreen
+
+    app = ExplorerApp(str(FIXTURES / "valid_clean"))
+    async with app.run_test() as pilot:
+        await _settled_panel_text(app, pilot)
+        await pilot.press("/")
+        await pilot.press(*"search feature")
+        await pilot.press("enter")
+        await pilot.pause()
+        assert isinstance(app.screen, CommandScreen)  # results listed, surface open
+        await pilot.press("enter")  # open the first (focused) result
+        await pilot.pause()
+        assert isinstance(app.screen, ContextScreen)
+
+
+@pytest.mark.asyncio
+async def test_slash_help_lists_registry_and_esc_closes():
+    from textual.widgets import OptionList
+
+    from rac.explorer.screens.command import CommandScreen
+    from rac.explorer.screens.repository import RepositoryScreen
+
+    app = ExplorerApp(str(FIXTURES / "valid_clean"))
+    async with app.run_test() as pilot:
+        await _settled_panel_text(app, pilot)
+        await pilot.press("/")
+        await pilot.press(*"help")
+        await pilot.press("enter")
+        await pilot.pause()
+        assert isinstance(app.screen, CommandScreen)
+        results = app.screen.query_one(OptionList)
+        assert results.option_count == 6  # the whole registry, nothing more
+        await pilot.press("escape")
+        assert isinstance(app.screen, RepositoryScreen)
+
+
+@pytest.mark.asyncio
+async def test_slash_home_pops_navigation_stack():
+    from rac.explorer.screens.repository import RepositoryScreen
+
+    app = ExplorerApp(str(FIXTURES / "valid_clean"))
+    async with app.run_test() as pilot:
+        await _settled_panel_text(app, pilot)
+        await pilot.press("enter")  # browser
+        await pilot.press("enter")  # context
+        await pilot.press("/")
+        await pilot.press(*"home")
+        await pilot.press("enter")
+        await pilot.pause()
+        assert isinstance(app.screen, RepositoryScreen)
+
+
+@pytest.mark.asyncio
+async def test_slash_browse_with_type_filter():
+    from textual.widgets import OptionList
+
+    from rac.explorer.screens.browser import BrowserScreen
+
+    app = ExplorerApp(str(FIXTURES / "valid_clean"))
+    async with app.run_test() as pilot:
+        await _settled_panel_text(app, pilot)
+        await pilot.press("/")
+        await pilot.press(*"browse decision")
+        await pilot.press("enter")
+        await pilot.pause()
+        assert isinstance(app.screen, BrowserScreen)
+        artifact_list = app.screen.query_one(OptionList)
+        assert artifact_list.option_count == 2  # the type header + one decision
+
+
+@pytest.mark.asyncio
 async def test_quit_binding_exits_cleanly():
     app = ExplorerApp(str(FIXTURES / "valid_clean"))
     async with app.run_test() as pilot:

--- a/tests/test_explorer_cli.py
+++ b/tests/test_explorer_cli.py
@@ -38,12 +38,32 @@ def test_explorer_launches_app_over_directory(tmp_path, monkeypatch):
     assert app.ran
 
 
-def test_explorer_defaults_to_current_directory(tmp_path, monkeypatch):
+def test_explorer_defaults_to_rac_root_when_present(tmp_path, monkeypatch):
+    # ADR-018: rac/ is the conventional knowledge root.
+    monkeypatch.setattr(launch, "_import_app", lambda: _AppSpy)
+    (tmp_path / "rac").mkdir()
+    monkeypatch.chdir(tmp_path)
+    assert main(["explorer"]) == 0
+    [app] = _AppSpy.instances
+    assert app.directory == "rac"
+
+
+def test_explorer_defaults_to_current_directory_without_rac_root(tmp_path, monkeypatch):
     monkeypatch.setattr(launch, "_import_app", lambda: _AppSpy)
     monkeypatch.chdir(tmp_path)
     assert main(["explorer"]) == 0
     [app] = _AppSpy.instances
     assert app.directory == "."
+
+
+def test_explorer_explicit_path_wins_over_rac_root(tmp_path, monkeypatch):
+    monkeypatch.setattr(launch, "_import_app", lambda: _AppSpy)
+    (tmp_path / "rac").mkdir()
+    (tmp_path / "docs").mkdir()
+    monkeypatch.chdir(tmp_path)
+    assert main(["explorer", "docs"]) == 0
+    [app] = _AppSpy.instances
+    assert app.directory == "docs"
 
 
 def test_explorer_top_level_disables_recursion(tmp_path, monkeypatch):

--- a/tests/test_explorer_commands.py
+++ b/tests/test_explorer_commands.py
@@ -1,0 +1,61 @@
+"""Tests for the Explorer command registry and routing (v0.8.1).
+
+Pure unit tests — no Textual, no repository. The `/` surface's contract:
+one registry, search as the fallback route, teaching examples for empty
+input (DESIGN-command-surface).
+"""
+
+from __future__ import annotations
+
+from rac.explorer.commands import EXAMPLES, REGISTRY, SEARCH, parse, suggestions
+
+
+def test_registry_is_the_v081_contract():
+    assert [spec.name for spec in REGISTRY] == ["open", "find", "browse", "home", "help", "quit"]
+    assert all(spec.usage and spec.summary for spec in REGISTRY)
+
+
+def test_health_is_not_discoverable_until_v082():
+    assert "health" not in {spec.name for spec in REGISTRY}
+
+
+def test_registered_command_routes_with_args():
+    invocation = parse("open req-001")
+    assert invocation.command == "open"
+    assert invocation.args == "req-001"
+
+
+def test_leading_slash_and_case_are_tolerated():
+    assert parse("/Open REQ-001").command == "open"
+    assert parse("/Open REQ-001").args == "REQ-001"
+
+
+def test_unregistered_input_is_a_search():
+    invocation = parse("payments retry logic")
+    assert invocation.command == SEARCH
+    assert invocation.args == "payments retry logic"
+
+
+def test_command_name_inside_text_does_not_route():
+    # Only the first word routes; "the open question" is a search.
+    assert parse("the open question").command == SEARCH
+
+
+def test_empty_input_is_an_empty_search():
+    invocation = parse("   ")
+    assert invocation.command == SEARCH
+    assert invocation.args == ""
+
+
+def test_suggestions_prefix_match_on_first_word():
+    assert [s.name for s in suggestions("o")] == ["open"]
+    assert [s.name for s in suggestions("h")] == ["home", "help"]
+    assert suggestions("zzz") == ()
+    assert [s.name for s in suggestions("")] == [s.name for s in REGISTRY]
+
+
+def test_examples_teach_registered_workflows():
+    assert EXAMPLES
+    for example in EXAMPLES:
+        routed = parse(example)
+        assert routed.command in {spec.name for spec in REGISTRY} | {SEARCH}

--- a/tests/test_explorer_isolation.py
+++ b/tests/test_explorer_isolation.py
@@ -59,7 +59,16 @@ def test_adapter_state_and_launch_never_import_textual():
         SRC / "explorer" / "state.py",
         SRC / "explorer" / "adapter.py",
         SRC / "explorer" / "launch.py",
+        SRC / "explorer" / "commands.py",
+        SRC / "explorer" / "firstrun.py",
     ]
     files = [f for f in files if f.exists()]
     assert (SRC / "explorer" / "adapter.py") in files
     assert _violations(files, ("textual",)) == []
+
+
+def test_command_routing_owns_no_intelligence():
+    # DESIGN-command-surface: routing may live in Explorer, answers may not —
+    # the registry module reaches neither Core nor the services.
+    commands = SRC / "explorer" / "commands.py"
+    assert _violations([commands], ("rac.core", "rac.services")) == []

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -58,6 +58,23 @@ def test_unknown_artifacts_are_included_and_skipped():
     assert unknown.status == "skipped"
 
 
+def test_complete_artifacts_have_no_missing_recommended():
+    repo = load("valid_clean")
+    assert all(a.missing_recommended == () for a in repo.artifacts)
+
+
+def test_unknown_artifacts_carry_no_completeness():
+    repo = load("all_types")
+    [unknown] = repo.artifacts_of_type("unknown")
+    assert unknown.missing_recommended == ()
+
+
+def test_missing_recommended_matches_portfolio_completeness():
+    repo = load("all_types")
+    total_missing = sum(len(a.missing_recommended) for a in repo.artifacts)
+    assert total_missing == repo.portfolio.recommended_slots - repo.portfolio.filled_slots
+
+
 # ---------------------------------------------------------------------------
 # Lookup surface for v0.8.1 navigation
 # ---------------------------------------------------------------------------

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -20,6 +20,8 @@ from rac.services.resolve import (
     OUTCOME_RESOLVED,
     find_artifacts,
     resolve_artifact,
+    resolve_in_index,
+    search_index,
 )
 
 CANONICAL_ID = "RAC-01JY4M8X2QZ7"
@@ -164,6 +166,38 @@ def test_search_empty_repository_valid_no_match(tmp_path):
     result = find_artifacts(str(tmp_path), "anything")
     assert result.match_count == 0
     assert result.matches == []
+
+
+# --- index seams (v0.8.1): same semantics without a directory walk --------------
+
+
+def test_resolve_in_index_matches_directory_resolution(repo):
+    from rac.services.index import build_repository_index
+
+    entries = build_repository_index(str(repo)).artifacts
+    for ref in (CANONICAL_ID, "adr-002", "nope"):
+        assert (
+            resolve_in_index(entries, ref).to_dict() == resolve_artifact(str(repo), ref).to_dict()
+        )
+
+
+def test_search_index_matches_directory_search(repo):
+    from rac.services.index import build_repository_index
+
+    entries = build_repository_index(str(repo)).artifacts
+    for query, artifact_type in (("decision", None), ("legacy", "decision"), ("zzz", None)):
+        assert search_index(entries, query, artifact_type=artifact_type).to_dict() == (
+            find_artifacts(str(repo), query, artifact_type=artifact_type).to_dict()
+        )
+
+
+def test_seams_accept_repository_model_artifacts(repo):
+    from rac.services.repository import load_repository
+
+    artifacts = load_repository(str(repo)).artifacts
+    resolved = resolve_in_index(artifacts, CANONICAL_ID)
+    assert resolved.outcome == OUTCOME_RESOLVED
+    assert search_index(artifacts, "legacy").match_count == 1
 
 
 # --- CLI: rac resolve ------------------------------------------------------------


### PR DESCRIPTION
# Summary

Implements `rac/roadmaps/v0.8.x-explorer/v0.8.1-explorer-navigation.md`.

Adds:

- Explorer navigation: an artifact browser grouped by type, an artifact context view (identity, validation state, completeness, relationships, diagnostics), and an Esc-driven screen stack
- The `/` command surface: one modal entry point for search and commands, backed by a single registry (`open`, `find`, `browse`, `home`, `help`, `quit`) where unrecognized input is a search
- A first-run experience derived from repository content (existing / empty / invalid), skipped for returning users via an XDG marker
- `rac explorer` defaulting to the `rac/` root when present (ADR-018)
- Per-artifact completeness on the repository model, index-search seams on the resolve service, 41 new tests, CLI reference / README updates, and changelog entries

# Roadmap / ADR Trace

Roadmap:

- `rac/roadmaps/v0.8.x-explorer/v0.8.1-explorer-navigation.md` (implementation contract pinned in the first commit)

Relevant ADRs and designs:

- ADR-015 — Explorer is a consumer; command routing may live in Explorer, answers may not
- ADR-018 — `rac/` is the canonical knowledge root
- ADR-026 — opaque identity: `/open` resolves canonical IDs and legacy aliases exactly like `rac resolve`
- ADR-028 / DESIGN-visual-system — keyboard-first, no colour-only meaning
- DESIGN-command-surface, DESIGN-first-run-experience

# Scope

## Included

- `rac.services.repository.Artifact.missing_recommended` — completeness from the same single walk, consistent with `rac inspect` and the portfolio ratio
- `rac.services.resolve.resolve_in_index` / `search_index` — exact lookup and search over already-discovered entries, byte-identical semantics to `rac resolve` / `rac find` (equivalence-tested); `SearchableArtifact` is a structural protocol satisfied by both `IndexEntry` and the repository model's `Artifact`
- `rac.explorer.commands` — the pure routing registry; `rac.explorer.firstrun` — the marker module; new `BrowserScreen`, `ContextScreen`, `CommandScreen`
- Home screen: Attention section aggregated from portfolio findings ("2 broken relationships, 1 incomplete artifact" style), "Press / for anything", Enter-to-browse
- Keyboard model: `/` commands, ↑↓ navigate, Enter select, Esc back, `r` reload, `q` quit — no mouse required

## Excluded (deliberately)

- `/health` — not in the registry; v0.8.2 delivers it (the v0.8.1 roadmap example block is illustrative)
- Health scoring detail and attention-item navigation — v0.8.2; recommendations — v0.8.3
- Working import/create flows from the empty state — it teaches `rac new` / `rac ingest`; guided import is v0.8.4
- Workspace persistence beyond the first-run marker: no last-repository/view/artifact restore, no recents, no preferences, no repository chooser — v0.8.6
- Editing or authoring of any kind (ADR-024); relationship traversal views — v0.8.5
- New JSON contracts: existing CLI output is byte-identical (golden battery)

# Product / Architecture Decisions

- Search and commands share the one entry point: only the *first word* routes to a registered command; "the open question" is a search. A leading `/` and any casing are tolerated.
- An action not in the registry is not discoverable (DESIGN-command-surface); the registry is the testable contract (`tests/test_explorer_commands.py` pins it, including `/health`'s absence).
- `/open` outcomes mirror `rac resolve`: one row opens directly, duplicates list every file and force a choice (never resolved by path order), not-found suggests search.
- A trailing word naming an artifact type filters `/find` (`find payments decision`).
- First-run onboarding derives from content, never blocks (Enter always continues), and persists exactly one marker under `$XDG_STATE_HOME/rac/` — failures to write it are tolerated silently (onboarding twice beats crashing on a read-only home).
- `rac explorer` resolves its default at the CLI boundary: `rac/` if present else `.`; explicit paths always win; no other command's default changed.

# User-Facing Contract

## CLI

```bash
rac explorer              # opens rac/ when present, else .
rac explorer docs/        # explicit path wins
```

## Human Output (interactive)

- Home: summary + health label + Attention lines, "Press / for anything · Enter to browse"
- Browser: artifacts grouped by type with text status labels (`✓ valid` / `✗ invalid` / `– unknown`)
- Context: identity, aliases, status, completeness (`! missing recommended: …` or `✓ all recommended sections present`), outgoing relationships with resolved titles, inbound references, diagnostics
- `/`: empty input teaches by example; help lists the registry; results open on Enter

## JSON Output

No changes; no new JSON contracts (the golden battery pins existing output byte-for-byte).

## Exit Codes

Unchanged: `0` session quit · `2` not a directory or missing `explorer` extra.

# Verification

## Ran

```bash
python -m pytest                      # 714 passed (41 new)
python -m ruff check src/ tests/
python -m ruff format --check src/ tests/
python -m mypy src/
rac validate rac/                     # exit 0
rac relationships rac/ --validate     # exit 0
rac review rac/                       # no priority 1–2 findings
```

A headless end-to-end run over `rac/` itself: first-run onboarding (103 artifacts, 117 relationships) → Enter → home with health 75 and attention → `/open adr-015` resolved the legacy alias to its canonical record (completeness, inbound references rendered) → Esc → browser → quit.

## Covered

- Registry routing: command-with-args, leading slash, casing, command-name-inside-text-is-search, empty input, prefix suggestions, `/health` absent
- Seam equivalence: `resolve_in_index`/`search_index` produce identical `to_dict()` payloads to the directory functions across resolved/duplicate/not-found and ranked/filtered/empty cases; repository-model artifacts accepted structurally
- Headless screens: browse → context → Esc stack; `/open` navigation; bare-text search with Enter-opens-result; `/help` listing exactly the registry; `/home` popping the stack; `/browse decision` filtering; attention rendering
- First-run: marker round trip, all three content states, Enter-continues + marker written, returning users skip (autouse fixture runs every other app test as a returning user)
- CLI defaults: `rac/` present, absent, and explicit-path-wins
- Isolation battery extended: `commands.py` and `firstrun.py` import neither Textual nor Core/services

# Review Path

1. `rac/roadmaps/v0.8.x-explorer/v0.8.1-explorer-navigation.md` — the pinned contract
2. `src/rac/services/repository.py`, `src/rac/services/resolve.py` — model and seam additions
3. `src/rac/explorer/commands.py`, `src/rac/explorer/firstrun.py` — the pure Explorer modules
4. `src/rac/explorer/adapter.py`, `state.py` — new state translations (browser, context, lookup, attention)
5. `src/rac/explorer/screens/` — `browser.py`, `context.py`, `command.py`, the `repository.py` home changes; `widgets/` and `app.py`
6. `src/rac/cli.py` — the `rac/` default
7. `tests/` — commands, adapter, app, isolation, resolve, repository
8. `docs/cli.md`, `README.md`, `CHANGELOG.md`

# Notes For Reviewer

- The branch was force-updated onto the rebase-merged `main` before this work began (its previous tip was the merged v0.8.0 history), so the diff is exactly the nine v0.8.1 commits.
- `tests/test_explorer_app.py` carries an autouse fixture pointing `XDG_STATE_HOME` at a pre-onboarded temp dir — anything instantiating `ExplorerApp` outside that file on a fresh machine will see onboarding, which is the intended product behavior.
- Known limitation: attention items on home are display-only; selecting one to jump to the artifact is v0.8.2 scope.

# Implementation Process

Implemented with AI assistance under the roadmap contract.

Final scope, review, and acceptance decisions were made by the maintainer.