### PR TITLE
feat(explorer): v0.8.2 Explorer health — health view, four areas, navigable attention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ details, release history over commit history.
 
 ### Added
 
+- Explorer health view (v0.8.2): `h` or `/health` opens a repository health
+  screen — Core's score with a text label, the four health areas
+  (Completeness, Relationships, Validation, Coverage), and a prioritized
+  attention list whose items open the affected artifact's context view.
+  Explorer adds no scoring; every value comes from existing Core results.
 - Explorer navigation (v0.8.1): browse every artifact grouped by type, open
   any artifact's context view (identity, validation state, completeness,
   relationships, diagnostics), and reach anything through the `/` command

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -339,10 +339,11 @@ rac index rac/ --json
 ## explorer
 
 Launch the interactive terminal Explorer — browse every artifact, inspect any
-of them in context, and reach anything through the `/` command surface, without
-memorizing RAC commands. The home view shows the repository summary, health
-score, and attention items; health detail and recommendations arrive in later
-v0.8.x releases.
+of them in context, assess repository health, and reach anything through the `/`
+command surface, without memorizing RAC commands. The home view shows the
+repository summary and attention items; the health view (`h` or `/health`)
+breaks health into four areas and links each attention item to the artifact it
+concerns. Recommendations arrive in later v0.8.x releases.
 
 Explorer is a presentation layer over the same services the CLI uses: everything
 it shows is also available through `rac portfolio`, `rac index`, `rac resolve`,
@@ -352,10 +353,13 @@ it shows is also available through `rac portfolio`, `rac index`, `rac resolve`,
   (ADR-018), else the current directory; scanned recursively for `*.md`.
 - **Options:** `--top-level` · `--recursive` (no `--json`: the surface is interactive)
 - **Keys:** `/` commands and search · `↑ ↓` navigate · `Enter` select ·
-  `Esc` back · `r` reload (home) · `q` quit
+  `Esc` back · `h` health (home) · `r` reload (home) · `q` quit
 - **Commands (`/`):** `open <ref>` · `find <query> [type]` · `browse [type]` ·
-  `home` · `help` · `quit` — anything else is a search. Lookup resolves
+  `health` · `home` · `help` · `quit` — anything else is a search. Lookup resolves
   canonical IDs and legacy aliases with `rac resolve` / `rac find` semantics.
+- **Health:** `h` or `/health` opens the health view — Core's score with a text
+  label, the Completeness / Relationships / Validation / Coverage areas, and a
+  prioritized attention list whose items open the affected artifact.
 - **First run:** onboarding derives from repository content (existing, empty, or
   invalid repository) and is skipped for returning users; the completion marker
   under `$XDG_STATE_HOME/rac/` is the only state Explorer persists.

--- a/rac/roadmaps/v0.8.x-explorer/v0.8.2-explorer-health.md
+++ b/rac/roadmaps/v0.8.x-explorer/v0.8.2-explorer-health.md
@@ -94,6 +94,56 @@ Health states carry text labels alongside any colour or symbol:
 
 Meaning never depends on colour alone.
 
+## Implementation Contract
+
+The following decisions are pinned for v0.8.2.
+
+### Health Screen
+
+- A `HealthScreen` renders Core's health score, an overall status label, the
+  four health areas (Completeness, Relationships, Validation, Coverage), and a
+  prioritized, selectable attention list. Reachable from the home screen via
+  `h` and from anywhere via `/health`; Esc pops back to home.
+- Every value is read from the already-loaded repository model and its
+  `PortfolioSummary` — no second walk, no Explorer-side scoring.
+
+### Area Status (no invented thresholds)
+
+- Each area's ✓ / ! / ✗ status derives from Core facts, not Explorer
+  thresholds: Validation is ✗ Error when invalid artifacts exist; Completeness
+  is ! Needs Attention when recommended sections are unfilled; Relationships is
+  ! Needs Attention when references are broken; Coverage is ! Needs Attention
+  when artifacts are orphaned. An area with no findings is ✓ Healthy.
+- The overall score band label (`health_label`) is shared with the home
+  summary so the two screens never disagree.
+
+### Attention Items
+
+- The attention list is the portfolio's `attention` items in their existing
+  deterministic priority order (errors before warnings, then path, then code).
+- Each item carries its severity label and the affected artifact's path;
+  selecting one opens that artifact's context view (closing v0.8.1's
+  display-only limitation).
+
+### Command Surface
+
+- `health` joins the v0.8.1 registry; `/health` opens the health screen. The
+  registry contract test flips from pinning `/health` absent to pinning it
+  present.
+
+### Accessibility
+
+- Status everywhere carries a text label beside its symbol
+  (`✓ Healthy` / `! Needs Attention` / `✗ Error`); meaning never depends on
+  colour (ADR-028, DESIGN-visual-system).
+
+### Scope
+
+- Presentation only: no Core or service changes, no JSON contract movement,
+  existing CLI output byte-identical. Adapter gains `health_state`; `state.py`
+  gains `HealthState`, `HealthAreaState`, `AttentionRow`. No new test files or
+  CI battery changes — the explorer battery absorbs the coverage.
+
 ## Non-Goals
 
 - New health intelligence or scoring algorithms in Explorer (ADR-015)

--- a/src/rac/explorer/adapter.py
+++ b/src/rac/explorer/adapter.py
@@ -22,12 +22,16 @@ from rac.services.resolve import (
 
 from .state import (
     ArtifactRow,
+    AttentionRow,
     BrowserState,
     ContextState,
+    HealthAreaState,
+    HealthState,
     LoadErrorState,
     LoadProgressState,
     LookupState,
     RepositorySummaryState,
+    health_label,
 )
 
 # Presentation labels for the analysis phases that follow the scan.
@@ -54,6 +58,13 @@ def _plural(count: int, noun: str) -> str:
 
 def _status_label(status: str) -> str:
     return _STATUS_LABELS.get(status, status)
+
+
+def _area_label(has_findings: bool, *, error: bool = False) -> str:
+    """A health area's status from a Core fact (no Explorer thresholds)."""
+    if not has_findings:
+        return "✓ Healthy"
+    return "✗ Error" if error else "! Needs Attention"
 
 
 def _row(artifact: Artifact) -> ArtifactRow:
@@ -209,6 +220,63 @@ class ExplorerAdapter:
         if not rows:
             return LookupState(rows=(), message=f"No matches for '{args.strip()}'")
         return LookupState(rows=rows)
+
+    def health_state(self) -> HealthState | None:
+        """The repository health screen, or None before a load (v0.8.2).
+
+        Every value is read from the loaded portfolio summary; Explorer adds
+        no scoring (ADR-015). Area status derives from Core facts, not from
+        Explorer-invented thresholds.
+        """
+        repository = self.repository
+        if repository is None:
+            return None
+        portfolio = repository.portfolio
+        rel = portfolio.relationships
+
+        completeness_pct = round(portfolio.completeness * 100)
+        coverage_pct = round(rel.coverage * 100)
+        areas = (
+            HealthAreaState(
+                name="Completeness",
+                status_label=_area_label(portfolio.filled_slots < portfolio.recommended_slots),
+                detail=(
+                    f"{completeness_pct}% "
+                    f"({portfolio.filled_slots}/{portfolio.recommended_slots} recommended sections)"
+                ),
+            ),
+            HealthAreaState(
+                name="Relationships",
+                status_label=_area_label(rel.broken > 0),
+                detail=f"{rel.valid} resolved, {rel.broken} broken of {rel.total}",
+            ),
+            HealthAreaState(
+                name="Validation",
+                status_label=_area_label(portfolio.invalid_artifacts > 0, error=True),
+                detail=f"{portfolio.valid_artifacts} valid, {portfolio.invalid_artifacts} invalid",
+            ),
+            HealthAreaState(
+                name="Coverage",
+                status_label=_area_label(rel.orphaned > 0),
+                detail=f"{coverage_pct}% of artifacts linked, {rel.orphaned} orphaned",
+            ),
+        )
+        attention = tuple(
+            AttentionRow(
+                path=item.path,
+                identifier=item.identifier,
+                severity_label="✗ error" if item.severity == "error" else "! warning",
+                message=item.message,
+            )
+            for item in portfolio.attention
+        )
+        return HealthState(
+            directory=repository.directory,
+            score=portfolio.health_score,
+            score_label=health_label(portfolio.health_score),
+            areas=areas,
+            attention=attention,
+        )
 
     def context_state(self, path: str) -> ContextState | None:
         """The context view for the artifact at ``path``, or None if unknown."""

--- a/src/rac/explorer/commands.py
+++ b/src/rac/explorer/commands.py
@@ -35,11 +35,11 @@ class Invocation:
     args: str
 
 
-# The v0.8.1 registry. /health arrives with v0.8.2 (its roadmap owns it).
 REGISTRY: tuple[CommandSpec, ...] = (
     CommandSpec("open", "open <ref>", "Open an artifact by ID or alias"),
     CommandSpec("find", "find <query> [type]", "Search artifacts by ID, title, or path"),
     CommandSpec("browse", "browse [type]", "Browse all artifacts"),
+    CommandSpec("health", "health", "Show repository health and attention items"),
     CommandSpec("home", "home", "Return to the repository home"),
     CommandSpec("help", "help", "List available commands"),
     CommandSpec("quit", "quit", "Quit the Explorer"),

--- a/src/rac/explorer/screens/command.py
+++ b/src/rac/explorer/screens/command.py
@@ -101,6 +101,15 @@ class CommandScreen(ModalScreen[None]):
             self._show_help()
         elif invocation.command == "home":
             self._pop_to_home()
+        elif invocation.command == "health":
+            health = self.adapter.health_state()
+            if health is None:
+                self._set_options([Option("Repository not loaded yet", disabled=True)])
+                return
+            from .health import HealthScreen
+
+            self.app.pop_screen()
+            self.app.push_screen(HealthScreen(self.adapter, health))
         elif invocation.command == "browse":
             artifact_type = invocation.args.casefold() or None
             browser = self.adapter.browser_state(artifact_type)

--- a/src/rac/explorer/screens/health.py
+++ b/src/rac/explorer/screens/health.py
@@ -1,0 +1,77 @@
+"""Health screen — repository health at a glance (v0.8.2).
+
+Renders Core's score, the four health areas, and a prioritized attention list
+(DESIGN-health-model). Explorer calculates nothing here; selecting an
+attention item opens the affected artifact's context view, and Esc backs out.
+"""
+
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.screen import Screen
+from textual.widgets import Footer, Header, OptionList, Static
+from textual.widgets.option_list import Option
+
+from rac.explorer.adapter import ExplorerAdapter
+from rac.explorer.state import HealthState
+
+from .context import ContextScreen
+
+
+def render_overview(health: HealthState) -> str:
+    """The score and the four areas as terminal-readable text."""
+    lines = [
+        f"Repository Health  {health.directory}",
+        "",
+        f"Score   {health.score} / 100   {health.score_label}",
+        "",
+        "Areas",
+    ]
+    for area in health.areas:
+        lines.append(f"  {area.status_label:<18} {area.name:<14} {area.detail}")
+    return "\n".join(lines)
+
+
+class HealthScreen(Screen[None]):
+    """Score + areas + a selectable attention list; Esc backs out."""
+
+    BINDINGS = [Binding("escape", "back", "Back")]
+
+    def __init__(self, adapter: ExplorerAdapter, health: HealthState) -> None:
+        super().__init__()
+        self.adapter = adapter
+        self.health = health
+
+    def compose(self) -> ComposeResult:
+        yield Header()
+        yield Static(render_overview(self.health), id="health-overview")
+        # Options are keyed by list index, not artifact path: several findings
+        # may concern the same artifact, and OptionList ids must be unique.
+        options: list[Option] = []
+        if self.health.attention:
+            for i, row in enumerate(self.health.attention):
+                options.append(
+                    Option(f"{row.severity_label}  {row.identifier}  {row.message}", id=str(i))
+                )
+        else:
+            options.append(Option("✓ Nothing needs attention", disabled=True))
+        attention = OptionList(*options, id="attention-list")
+        attention.border_title = "Attention"
+        yield attention
+        yield Footer()
+
+    def on_mount(self) -> None:
+        if self.health.attention:
+            self.query_one(OptionList).focus()
+
+    def on_option_list_option_selected(self, event: OptionList.OptionSelected) -> None:
+        if event.option_id is None:
+            return
+        row = self.health.attention[int(event.option_id)]
+        context = self.adapter.context_state(row.path)
+        if context is not None:
+            self.app.push_screen(ContextScreen(context))
+
+    def action_back(self) -> None:
+        self.app.pop_screen()

--- a/src/rac/explorer/screens/repository.py
+++ b/src/rac/explorer/screens/repository.py
@@ -22,6 +22,7 @@ from rac.explorer.state import LoadErrorState, LoadProgressState, RepositorySumm
 from rac.explorer.widgets import RepositoryPanel
 
 from .browser import BrowserScreen
+from .health import HealthScreen
 
 
 class _WorkerCancelToken:
@@ -41,6 +42,7 @@ class RepositoryScreen(Screen[None]):
     BINDINGS = [
         Binding("r", "reload", "Reload"),
         Binding("enter", "browse", "Browse"),
+        Binding("h", "health", "Health"),
     ]
 
     def __init__(self, adapter: ExplorerAdapter) -> None:
@@ -73,6 +75,13 @@ class RepositoryScreen(Screen[None]):
         browser = self.adapter.browser_state()
         if browser is not None:
             self.app.push_screen(BrowserScreen(self.adapter, browser))
+
+    def action_health(self) -> None:
+        if self._onboarding_summary is not None:
+            return  # finish onboarding (Enter) before opening sub-screens
+        health = self.adapter.health_state()
+        if health is not None:
+            self.app.push_screen(HealthScreen(self.adapter, health))
 
     @work(thread=True, exclusive=True, group="repository-load")
     def _load_repository(self) -> RepositorySummaryState | LoadErrorState | None:

--- a/src/rac/explorer/state.py
+++ b/src/rac/explorer/state.py
@@ -10,6 +10,19 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 
+def health_label(score: int) -> str:
+    """The overall health band label for ``score`` (text beside the symbol).
+
+    Shared by the home summary and the health screen so they never disagree
+    (ADR-028: meaning never depends on colour alone).
+    """
+    if score >= 80:
+        return "✓ Healthy"
+    if score >= 50:
+        return "! Needs Attention"
+    return "✗ Unhealthy"
+
+
 @dataclass(frozen=True)
 class LoadProgressState:
     """One progress update while the repository loads."""
@@ -83,6 +96,36 @@ class ContextState:
     outgoing: tuple[str, ...]  # rendered relationship lines declared here
     incoming: tuple[str, ...]  # rendered lines for references resolving here
     diagnostics: tuple[str, ...]  # rendered finding lines
+
+
+@dataclass(frozen=True)
+class HealthAreaState:
+    """One health area (Completeness, Relationships, Validation, Coverage)."""
+
+    name: str
+    status_label: str  # "✓ Healthy" | "! Needs Attention" | "✗ Error"
+    detail: str  # Core facts, e.g. "92% (110/120 recommended sections)"
+
+
+@dataclass(frozen=True)
+class AttentionRow:
+    """One prioritized attention item, linked to the artifact it concerns."""
+
+    path: str  # navigation key (opens the context view)
+    identifier: str
+    severity_label: str  # "✗ error" | "! warning"
+    message: str
+
+
+@dataclass(frozen=True)
+class HealthState:
+    """The repository health screen, rendered entirely from Core results."""
+
+    directory: str
+    score: int
+    score_label: str
+    areas: tuple[HealthAreaState, ...]
+    attention: tuple[AttentionRow, ...]
 
 
 @dataclass(frozen=True)

--- a/src/rac/explorer/widgets/__init__.py
+++ b/src/rac/explorer/widgets/__init__.py
@@ -8,16 +8,16 @@ from __future__ import annotations
 
 from textual.widgets import Static
 
-from rac.explorer.state import LoadErrorState, LoadProgressState, RepositorySummaryState
+from rac.explorer.state import (
+    LoadErrorState,
+    LoadProgressState,
+    RepositorySummaryState,
+    health_label,
+)
 
-
-def _health_label(score: int) -> str:
-    # Labels alongside the number — never colour-only meaning (ADR-028).
-    if score >= 80:
-        return "✓ Healthy"
-    if score >= 50:
-        return "! Needs attention"
-    return "✗ Unhealthy"
+# Re-exported under the historical name used by home rendering and tests; the
+# single definition lives in rac.explorer.state so the health screen agrees.
+_health_label = health_label
 
 
 class RepositoryPanel(Static):

--- a/tests/test_explorer_adapter.py
+++ b/tests/test_explorer_adapter.py
@@ -203,6 +203,80 @@ def test_browser_state_type_filter():
     assert browser.total == 1
 
 
+def test_health_state_requires_a_load():
+    assert ExplorerAdapter(str(FIXTURES / "valid_clean")).health_state() is None
+
+
+def test_health_state_mirrors_portfolio_score():
+    adapter = ExplorerAdapter(str(FIXTURES / "valid_clean"))
+    adapter.load()
+    health = adapter.health_state()
+    assert health is not None
+    assert adapter.repository is not None
+    assert health.score == adapter.repository.portfolio.health_score
+    assert health.score_label  # text label beside the number
+
+
+def test_health_state_lists_the_four_areas():
+    adapter = ExplorerAdapter(str(FIXTURES / "valid_clean"))
+    adapter.load()
+    health = adapter.health_state()
+    assert health is not None
+    assert [a.name for a in health.areas] == [
+        "Completeness",
+        "Relationships",
+        "Validation",
+        "Coverage",
+    ]
+    assert all(a.status_label and a.detail for a in health.areas)
+
+
+def test_clean_repository_areas_are_healthy():
+    adapter = ExplorerAdapter(str(FIXTURES / "valid_clean"))
+    adapter.load()
+    health = adapter.health_state()
+    assert health is not None
+    by_name = {a.name: a for a in health.areas}
+    assert by_name["Relationships"].status_label == "✓ Healthy"
+    assert by_name["Validation"].status_label == "✓ Healthy"
+    assert health.attention == ()
+
+
+def test_broken_relationships_mark_the_relationships_area():
+    adapter = ExplorerAdapter(str(FIXTURES / "broken_rels"))
+    adapter.load()
+    health = adapter.health_state()
+    assert health is not None
+    by_name = {a.name: a for a in health.areas}
+    assert by_name["Relationships"].status_label == "! Needs Attention"
+    assert "1 broken" in by_name["Relationships"].detail
+
+
+def test_invalid_artifacts_mark_validation_as_error():
+    adapter = ExplorerAdapter(str(FIXTURES / "invalid_known"))
+    adapter.load()
+    health = adapter.health_state()
+    assert health is not None
+    by_name = {a.name: a for a in health.areas}
+    assert by_name["Validation"].status_label == "✗ Error"
+
+
+def test_attention_items_link_to_artifacts_and_keep_priority():
+    adapter = ExplorerAdapter(str(FIXTURES / "broken_rels"))
+    adapter.load()
+    health = adapter.health_state()
+    assert health is not None
+    assert adapter.repository is not None
+    assert health.attention
+    # Every attention row points at a real artifact (navigable to its context).
+    paths = {a.path for a in adapter.repository.artifacts}
+    assert all(row.path in paths for row in health.attention)
+    # Order matches the portfolio's prioritized attention list verbatim.
+    assert [row.message for row in health.attention] == [
+        item.message for item in adapter.repository.portfolio.attention
+    ]
+
+
 def test_cancelled_load_returns_none_not_an_error():
     token = CancellationToken()
     adapter = ExplorerAdapter(str(FIXTURES / "all_types"))

--- a/tests/test_explorer_app.py
+++ b/tests/test_explorer_app.py
@@ -186,7 +186,7 @@ async def test_slash_help_lists_registry_and_esc_closes():
         await pilot.pause()
         assert isinstance(app.screen, CommandScreen)
         results = app.screen.query_one(OptionList)
-        assert results.option_count == 6  # the whole registry, nothing more
+        assert results.option_count == 7  # the whole registry, nothing more
         await pilot.press("escape")
         assert isinstance(app.screen, RepositoryScreen)
 
@@ -279,6 +279,54 @@ async def test_first_run_invalid_repository_opens_anyway(fresh_first_run):
         await pilot.pause()
         text = str(app.screen.query_one(RepositoryPanel).content)
         assert "Health" in text
+
+
+@pytest.mark.asyncio
+async def test_h_binding_opens_health_screen():
+    from textual.widgets import Static
+
+    from rac.explorer.screens.health import HealthScreen
+    from rac.explorer.screens.repository import RepositoryScreen
+
+    app = ExplorerApp(str(FIXTURES / "valid_clean"))
+    async with app.run_test() as pilot:
+        await _settled_panel_text(app, pilot)
+        await pilot.press("h")
+        assert isinstance(app.screen, HealthScreen)
+        overview = str(app.screen.query_one("#health-overview", Static).content)
+        assert "Score" in overview
+        assert "Completeness" in overview and "Coverage" in overview
+        assert "✓ Healthy" in overview
+        await pilot.press("escape")
+        assert isinstance(app.screen, RepositoryScreen)
+
+
+@pytest.mark.asyncio
+async def test_slash_health_opens_health_screen():
+    from rac.explorer.screens.health import HealthScreen
+
+    app = ExplorerApp(str(FIXTURES / "valid_clean"))
+    async with app.run_test() as pilot:
+        await _settled_panel_text(app, pilot)
+        await pilot.press("/")
+        await pilot.press(*"health")
+        await pilot.press("enter")
+        await pilot.pause()
+        assert isinstance(app.screen, HealthScreen)
+
+
+@pytest.mark.asyncio
+async def test_health_attention_item_opens_context():
+    from rac.explorer.screens.context import ContextScreen
+
+    app = ExplorerApp(str(FIXTURES / "broken_rels"))
+    async with app.run_test() as pilot:
+        await _settled_panel_text(app, pilot)
+        await pilot.press("h")
+        await pilot.pause()
+        await pilot.press("enter")  # first attention item (focused)
+        await pilot.pause()
+        assert isinstance(app.screen, ContextScreen)
 
 
 @pytest.mark.asyncio

--- a/tests/test_explorer_app.py
+++ b/tests/test_explorer_app.py
@@ -56,7 +56,7 @@ def test_summary_states_meaning_in_text_not_colour_alone():
     from rac.explorer.widgets import _health_label
 
     assert _health_label(90) == "✓ Healthy"
-    assert _health_label(60) == "! Needs attention"
+    assert _health_label(60) == "! Needs Attention"
     assert _health_label(10) == "✗ Unhealthy"
 
 

--- a/tests/test_explorer_commands.py
+++ b/tests/test_explorer_commands.py
@@ -10,13 +10,23 @@ from __future__ import annotations
 from rac.explorer.commands import EXAMPLES, REGISTRY, SEARCH, parse, suggestions
 
 
-def test_registry_is_the_v081_contract():
-    assert [spec.name for spec in REGISTRY] == ["open", "find", "browse", "home", "help", "quit"]
+def test_registry_is_the_v082_contract():
+    assert [spec.name for spec in REGISTRY] == [
+        "open",
+        "find",
+        "browse",
+        "health",
+        "home",
+        "help",
+        "quit",
+    ]
     assert all(spec.usage and spec.summary for spec in REGISTRY)
 
 
-def test_health_is_not_discoverable_until_v082():
-    assert "health" not in {spec.name for spec in REGISTRY}
+def test_health_is_discoverable():
+    assert "health" in {spec.name for spec in REGISTRY}
+    assert parse("health").command == "health"
+    assert parse("/health").command == "health"
 
 
 def test_registered_command_routes_with_args():
@@ -49,7 +59,8 @@ def test_empty_input_is_an_empty_search():
 
 def test_suggestions_prefix_match_on_first_word():
     assert [s.name for s in suggestions("o")] == ["open"]
-    assert [s.name for s in suggestions("h")] == ["home", "help"]
+    assert [s.name for s in suggestions("h")] == ["health", "home", "help"]
+    assert [s.name for s in suggestions("he")] == ["health", "help"]
     assert suggestions("zzz") == ()
     assert [s.name for s in suggestions("")] == [s.name for s in REGISTRY]
 


### PR DESCRIPTION
# Summary

Implements `rac/roadmaps/v0.8.x-explorer/v0.8.2-explorer-health.md`.

Adds:

- A health view (`h` from home, `/health` from anywhere): Core's health score with a text label, the four health areas (Completeness, Relationships, Validation, Coverage), and a prioritized attention list
- Attention items that link to the artifact they concern — selecting one opens its context view, closing v0.8.1's display-only limitation
- `health` joins the command registry; adapter `health_state` and three state types; no Core, service, or JSON changes

# Roadmap / ADR Trace

Roadmap: `rac/roadmaps/v0.8.x-explorer/v0.8.2-explorer-health.md` (contract pinned in the first commit)

Relevant ADRs and designs:

- ADR-015 — Explorer surfaces Core intelligence; it calculates no health
- ADR-003 — stable diagnostic/attention shapes
- DESIGN-health-model, DESIGN-visual-system

# Scope

## Included

- `rac.explorer.state.HealthState` / `HealthAreaState` / `AttentionRow`; the score band label `health_label` moved to `state` so home and the health screen never disagree
- `ExplorerAdapter.health_state()` — reads the loaded `PortfolioSummary`; area status derives from Core facts (invalid → Validation `✗ Error`; unfilled recommended → Completeness `! Needs Attention`; broken refs → Relationships `! Needs Attention`; orphaned → Coverage `! Needs Attention`; otherwise `✓ Healthy`)
- `HealthScreen` (overview + selectable attention list); `h` binding on home; `/health` routing in the command surface
- Attention list keyed by index, not path (several findings may concern one artifact; OptionList ids must be unique)

## Excluded (deliberately)

- New health intelligence or scoring in Explorer (ADR-015) — every value is Core's
- Recommendations presentation — v0.8.3; suggested actions on attention items — v0.8.3
- Automatic remediation
- No new JSON contracts; existing CLI output byte-identical (golden battery)

# Product / Architecture Decisions

- Area status is fact-based, never an Explorer-invented threshold: an area is `✗ Error` only with error-severity findings, `! Needs Attention` with warning-severity findings, `✓ Healthy` with none.
- The overall score band label is shared between home and health so the two screens always agree; this replaced the v0.8.1 duplicate (home's `_health_label` now re-exports the shared function — its one pinned string changed from "Needs attention" to "Needs Attention").
- The attention list preserves the portfolio's existing deterministic priority order (errors before warnings, then path, then code) verbatim — Explorer does not re-sort.
- `/health` is now discoverable; the registry contract test flipped from pinning its absence (v0.8.1) to pinning its presence.

# User-Facing Contract

## CLI / Keys

```bash
rac explorer        # h opens health; / then "health" does the same
```

`h` (home) · `/health` (anywhere) → health view. `Esc` backs out. Attention item + `Enter` → that artifact's context view.

## Human Output (interactive)

- Health overview: `Score  75 / 100  ! Needs Attention`, then the four areas each with `✓/!/✗` + label + Core detail (e.g. `Completeness  92% (110/120 recommended sections)`)
- Attention list: `! warning  REQ-004  Missing recommended sections: …`, prioritized, each selectable

## JSON Output

No changes; no new contracts.

## Exit Codes

Unchanged: `0` session quit · `2` not a directory or missing `explorer` extra.

# Verification

## Ran

```bash
python -m pytest                      # 724 passed
python -m ruff check src/ tests/
python -m ruff format --check src/ tests/
python -m mypy src/
rac validate rac/                     # exit 0
rac relationships rac/ --validate     # exit 0
rac review rac/                       # no priority 1–2 findings
```

## Covered

- Adapter `health_state`: score mirrors portfolio; the four areas present; clean repo all `✓ Healthy` with empty attention; broken refs mark Relationships `! Needs Attention`; invalid artifacts mark Validation `✗ Error`; attention rows carry real artifact paths in the portfolio's exact priority order
- Screens: `h` opens health and Esc returns; `/health` opens it; an attention item opens the context view; `/help` lists all 7 registry entries
- Registry: `health` discoverable, `/health` parses; prefix suggestions updated (`h` → health/home/help)

# Review Path

1. `rac/roadmaps/v0.8.x-explorer/v0.8.2-explorer-health.md` — the pinned contract
2. `src/rac/explorer/state.py` — new state types + shared `health_label`
3. `src/rac/explorer/adapter.py` — `health_state` and fact-based area derivation
4. `src/rac/explorer/screens/health.py` — the screen
5. `src/rac/explorer/screens/repository.py`, `commands.py`, `screens/command.py` — `h` binding and `/health` routing
6. `tests/` — adapter, app, commands
7. `docs/cli.md`, `CHANGELOG.md`

# Notes For Reviewer

- This PR is stacked on the v0.8.0/v0.8.1 line already in `main`; its diff is exactly the six v0.8.2 commits.
- Part of a v0.8.2–v0.8.6 speed-run: sibling PRs follow, intended to merge in order. Each is stacked on the previous, so once this merges the next PR's diff narrows to just its milestone.
- The only changed pre-existing string is home's health label casing ("Needs attention" → "Needs Attention"), now sourced from the shared `health_label`.

# Implementation Process

Implemented with AI assistance under the roadmap contract.

Final scope, review, and acceptance decisions were made by the maintainer.