### PR TITLE
feat(explorer): v0.8.3 Explorer recommendations — categorized findings with impact and actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ details, release history over commit history.
 
 ### Added
 
+- Explorer recommendations (v0.8.3): `/recommendations` (or `r` from the health
+  view) presents RAC Core's review findings grouped by category (Validation,
+  Relationships, Repository Health, Quality), each with its impact, a suggested
+  `rac` command, and navigation to the affected artifact. Severities map to
+  Critical / Warning / Suggestion. Advisory only — Explorer applies nothing and
+  invents no findings.
 - Explorer health view (v0.8.2): `h` or `/health` opens a repository health
   screen — Core's score with a text label, the four health areas
   (Completeness, Relationships, Validation, Coverage), and a prioritized

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -355,11 +355,17 @@ it shows is also available through `rac portfolio`, `rac index`, `rac resolve`,
 - **Keys:** `/` commands and search · `↑ ↓` navigate · `Enter` select ·
   `Esc` back · `h` health (home) · `r` reload (home) · `q` quit
 - **Commands (`/`):** `open <ref>` · `find <query> [type]` · `browse [type]` ·
-  `health` · `home` · `help` · `quit` — anything else is a search. Lookup resolves
-  canonical IDs and legacy aliases with `rac resolve` / `rac find` semantics.
+  `health` · `recommendations` · `home` · `help` · `quit` — anything else is a
+  search. Lookup resolves canonical IDs and legacy aliases with `rac resolve` /
+  `rac find` semantics.
 - **Health:** `h` or `/health` opens the health view — Core's score with a text
   label, the Completeness / Relationships / Validation / Coverage areas, and a
   prioritized attention list whose items open the affected artifact.
+- **Recommendations:** `/recommendations` (or `r` from the health view) presents
+  Core's review findings grouped by category (Validation, Relationships,
+  Repository Health, Quality), each with its impact, a suggested `rac` command,
+  and navigation to the affected artifact. Advisory only — Explorer applies
+  nothing.
 - **First run:** onboarding derives from repository content (existing, empty, or
   invalid repository) and is skipped for returning users; the completion marker
   under `$XDG_STATE_HOME/rac/` is the only state Explorer persists.

--- a/rac/roadmaps/v0.8.x-explorer/v0.8.3-explorer-recommendations.md
+++ b/rac/roadmaps/v0.8.x-explorer/v0.8.3-explorer-recommendations.md
@@ -67,6 +67,50 @@ From any recommendation, users can open the affected artifact's context view
 and its related artifacts. Acting on recommendations (editor launch, export)
 is delivered by v0.8.4.
 
+## Implementation Contract
+
+The following decisions are pinned for v0.8.3.
+
+### Core Source
+
+- Recommendations are RAC Core's review findings (`rac.services.review`): each
+  carries a priority, a Core-supplied severity, the finding message, a
+  deterministic suggested action, and the affected artifact's path. Explorer
+  presents them; it computes none.
+- A `review_from_portfolio` seam lets Explorer build the review from the
+  already-loaded portfolio (no second walk); `build_review` delegates to it,
+  with byte-identical output (golden battery).
+
+### Presentation (explain before suggesting)
+
+- Each recommendation shows the finding, why it matters (impact), the
+  suggested action, and navigation to the affected artifact. The impact line
+  is fixed presentation copy keyed by the Core finding code — display text, not
+  analysis (the same role as Explorer's existing status and phase labels).
+- Recommendations are grouped by category — Validation, Relationships,
+  Repository Health, Quality — in that fixed order; only categories with
+  findings are shown. Within a category, Core's priority order is preserved.
+
+### Severity
+
+- Core severities map to the three presentation tiers: `error → ✗ Critical`,
+  `warning → ! Warning`, `info → · Suggestion`. Definitions stay in Core.
+
+### Navigation and Command
+
+- `recommendations` joins the command registry (`/recommendations`); the
+  health screen gains an `r` binding to open it. Selecting a recommendation
+  opens the affected artifact's context view (its related artifacts are
+  reachable from there). Acting on a recommendation — editor launch, export —
+  is v0.8.4.
+
+### Scope
+
+- Presentation plus the additive review seam: no JSON contract movement,
+  existing CLI output byte-identical, no AI dependency (ADR-002). Adapter gains
+  `recommendations_state`; `state.py` gains `RecommendationRow` and
+  `RecommendationsState`. The explorer and review batteries absorb the tests.
+
 ## Non-Goals
 
 - Automatic changes or artifact rewriting

--- a/src/rac/explorer/adapter.py
+++ b/src/rac/explorer/adapter.py
@@ -19,6 +19,14 @@ from rac.services.resolve import (
     resolve_in_index,
     search_index,
 )
+from rac.services.review import (
+    ATTENTION_BROKEN_RELATIONSHIP,
+    ATTENTION_INVALID,
+    ATTENTION_MISSING_RECOMMENDED,
+    REVIEW_UNKNOWN_ARTIFACT,
+    ReviewIssue,
+    review_from_portfolio,
+)
 
 from .state import (
     ArtifactRow,
@@ -30,6 +38,8 @@ from .state import (
     LoadErrorState,
     LoadProgressState,
     LookupState,
+    RecommendationRow,
+    RecommendationsState,
     RepositorySummaryState,
     health_label,
 )
@@ -65,6 +75,50 @@ def _area_label(has_findings: bool, *, error: bool = False) -> str:
     if not has_findings:
         return "✓ Healthy"
     return "✗ Error" if error else "! Needs Attention"
+
+
+# The four recommendation categories (DESIGN-recommendations), fixed order.
+_CATEGORY_ORDER = ("Validation", "Relationships", "Repository Health", "Quality")
+
+# Core review finding code → presentation category.
+_CODE_CATEGORY = {
+    ATTENTION_INVALID: "Validation",
+    REVIEW_UNKNOWN_ARTIFACT: "Validation",
+    ATTENTION_BROKEN_RELATIONSHIP: "Relationships",
+    ATTENTION_MISSING_RECOMMENDED: "Quality",
+}
+
+# Core severity → the three presentation tiers (definitions stay in Core).
+_SEVERITY_LABEL = {
+    "error": "✗ Critical",
+    "warning": "! Warning",
+    "info": "· Suggestion",
+}
+
+# "Why it matters" — fixed presentation copy keyed by the Core finding code
+# (display text, like the status and phase labels; not analysis).
+_IMPACT = {
+    ATTENTION_INVALID: "The artifact fails its schema, so tooling and validation cannot trust it.",
+    ATTENTION_BROKEN_RELATIONSHIP: (
+        "A declared reference does not resolve, leaving traceability incomplete."
+    ),
+    ATTENTION_MISSING_RECOMMENDED: (
+        "Recommended sections are empty, weakening the artifact's completeness."
+    ),
+    REVIEW_UNKNOWN_ARTIFACT: "No schema matched, so required structure cannot be checked.",
+}
+
+
+def _recommendation(issue: ReviewIssue) -> RecommendationRow:
+    return RecommendationRow(
+        path=issue.path,
+        identifier=issue.identifier,
+        category=_CODE_CATEGORY.get(issue.code, "Quality"),
+        severity_label=_SEVERITY_LABEL.get(issue.severity, issue.severity),
+        finding=issue.message,
+        impact=_IMPACT.get(issue.code, "This finding affects repository quality."),
+        action=issue.action,
+    )
 
 
 def _row(artifact: Artifact) -> ArtifactRow:
@@ -276,6 +330,30 @@ class ExplorerAdapter:
             score_label=health_label(portfolio.health_score),
             areas=areas,
             attention=attention,
+        )
+
+    def recommendations_state(self) -> RecommendationsState | None:
+        """Recommendations grouped by category, or None before a load (v0.8.3).
+
+        Built from Core's review findings over the loaded portfolio — Explorer
+        adds explanation and grouping, never new findings (ADR-015).
+        """
+        repository = self.repository
+        if repository is None:
+            return None
+        report = review_from_portfolio(
+            repository.directory, repository.portfolio, recursive=repository.recursive
+        )
+        rows = [_recommendation(issue) for issue in report.issues]
+        groups = tuple(
+            (category, tuple(r for r in rows if r.category == category))
+            for category in _CATEGORY_ORDER
+            if any(r.category == category for r in rows)
+        )
+        return RecommendationsState(
+            directory=repository.directory,
+            groups=groups,
+            total=len(rows),
         )
 
     def context_state(self, path: str) -> ContextState | None:

--- a/src/rac/explorer/commands.py
+++ b/src/rac/explorer/commands.py
@@ -40,6 +40,9 @@ REGISTRY: tuple[CommandSpec, ...] = (
     CommandSpec("find", "find <query> [type]", "Search artifacts by ID, title, or path"),
     CommandSpec("browse", "browse [type]", "Browse all artifacts"),
     CommandSpec("health", "health", "Show repository health and attention items"),
+    CommandSpec(
+        "recommendations", "recommendations", "Show recommendations with impact and actions"
+    ),
     CommandSpec("home", "home", "Return to the repository home"),
     CommandSpec("help", "help", "List available commands"),
     CommandSpec("quit", "quit", "Quit the Explorer"),

--- a/src/rac/explorer/screens/command.py
+++ b/src/rac/explorer/screens/command.py
@@ -110,6 +110,15 @@ class CommandScreen(ModalScreen[None]):
 
             self.app.pop_screen()
             self.app.push_screen(HealthScreen(self.adapter, health))
+        elif invocation.command == "recommendations":
+            recommendations = self.adapter.recommendations_state()
+            if recommendations is None:
+                self._set_options([Option("Repository not loaded yet", disabled=True)])
+                return
+            from .recommendations import RecommendationsScreen
+
+            self.app.pop_screen()
+            self.app.push_screen(RecommendationsScreen(self.adapter, recommendations))
         elif invocation.command == "browse":
             artifact_type = invocation.args.casefold() or None
             browser = self.adapter.browser_state(artifact_type)

--- a/src/rac/explorer/screens/health.py
+++ b/src/rac/explorer/screens/health.py
@@ -36,7 +36,10 @@ def render_overview(health: HealthState) -> str:
 class HealthScreen(Screen[None]):
     """Score + areas + a selectable attention list; Esc backs out."""
 
-    BINDINGS = [Binding("escape", "back", "Back")]
+    BINDINGS = [
+        Binding("escape", "back", "Back"),
+        Binding("r", "recommendations", "Recommendations"),
+    ]
 
     def __init__(self, adapter: ExplorerAdapter, health: HealthState) -> None:
         super().__init__()
@@ -72,6 +75,13 @@ class HealthScreen(Screen[None]):
         context = self.adapter.context_state(row.path)
         if context is not None:
             self.app.push_screen(ContextScreen(context))
+
+    def action_recommendations(self) -> None:
+        recommendations = self.adapter.recommendations_state()
+        if recommendations is not None:
+            from .recommendations import RecommendationsScreen
+
+            self.app.push_screen(RecommendationsScreen(self.adapter, recommendations))
 
     def action_back(self) -> None:
         self.app.pop_screen()

--- a/src/rac/explorer/screens/recommendations.py
+++ b/src/rac/explorer/screens/recommendations.py
@@ -1,0 +1,75 @@
+"""Recommendations screen — findings with impact and a suggested action (v0.8.3).
+
+Presents RAC Core's review findings grouped by category, explaining each before
+suggesting an action (DESIGN-recommendations). Explorer applies nothing;
+selecting a recommendation opens the affected artifact's context view.
+"""
+
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.screen import Screen
+from textual.widgets import Footer, Header, OptionList
+from textual.widgets.option_list import Option
+
+from rac.explorer.adapter import ExplorerAdapter
+from rac.explorer.state import RecommendationRow, RecommendationsState
+
+from .context import ContextScreen
+
+
+def _prompt(row: RecommendationRow) -> str:
+    """One recommendation as a multi-line block: finding → impact → action."""
+    return (
+        f"{row.severity_label}  ·  {row.category}\n"
+        f"  {row.identifier}  {row.finding}\n"
+        f"  Impact: {row.impact}\n"
+        f"  Action: {row.action}"
+    )
+
+
+class RecommendationsScreen(Screen[None]):
+    """Category-grouped recommendations; Enter opens the artifact, Esc backs."""
+
+    BINDINGS = [Binding("escape", "back", "Back")]
+
+    def __init__(self, adapter: ExplorerAdapter, recommendations: RecommendationsState) -> None:
+        super().__init__()
+        self.adapter = adapter
+        self.recommendations = recommendations
+        # Selection maps an option index → the affected artifact path; several
+        # recommendations may concern one artifact, so ids must stay unique.
+        self._paths: list[str] = []
+
+    def compose(self) -> ComposeResult:
+        yield Header()
+        options: list[Option | None] = []
+        if self.recommendations.groups:
+            for category, rows in self.recommendations.groups:
+                if options:
+                    options.append(None)
+                options.append(Option(f"{category} ({len(rows)})", id=None, disabled=True))
+                for row in rows:
+                    options.append(Option(_prompt(row), id=str(len(self._paths))))
+                    self._paths.append(row.path)
+        else:
+            options.append(Option("✓ No recommendations", id=None, disabled=True))
+        option_list = OptionList(*options, id="recommendations-list")
+        option_list.border_title = f"Recommendations ({self.recommendations.total})"
+        yield option_list
+        yield Footer()
+
+    def on_mount(self) -> None:
+        if self.recommendations.total:
+            self.query_one(OptionList).focus()
+
+    def on_option_list_option_selected(self, event: OptionList.OptionSelected) -> None:
+        if event.option_id is None:
+            return
+        context = self.adapter.context_state(self._paths[int(event.option_id)])
+        if context is not None:
+            self.app.push_screen(ContextScreen(context))
+
+    def action_back(self) -> None:
+        self.app.pop_screen()

--- a/src/rac/explorer/state.py
+++ b/src/rac/explorer/state.py
@@ -129,6 +129,28 @@ class HealthState:
 
 
 @dataclass(frozen=True)
+class RecommendationRow:
+    """One recommendation: a finding with impact, action, and a target."""
+
+    path: str  # navigation key (opens the affected artifact's context view)
+    identifier: str
+    category: str  # Validation | Relationships | Repository Health | Quality
+    severity_label: str  # "✗ Critical" | "! Warning" | "· Suggestion"
+    finding: str
+    impact: str
+    action: str
+
+
+@dataclass(frozen=True)
+class RecommendationsState:
+    """Recommendations grouped by category, rendered from Core review findings."""
+
+    directory: str
+    groups: tuple[tuple[str, tuple[RecommendationRow, ...]], ...]  # (category, rows)
+    total: int
+
+
+@dataclass(frozen=True)
 class LoadErrorState:
     """A recoverable failure: the shell shows it and offers retry."""
 

--- a/src/rac/services/review.py
+++ b/src/rac/services/review.py
@@ -140,7 +140,18 @@ class ReviewReport:
 def build_review(directory: str, recursive: bool = True) -> ReviewReport:
     """Review ``directory`` and return the prioritized repository report."""
     portfolio = build_portfolio_summary(directory, recursive=recursive)
+    return review_from_portfolio(directory, portfolio, recursive=recursive)
 
+
+def review_from_portfolio(
+    directory: str, portfolio: PortfolioSummary, recursive: bool = True
+) -> ReviewReport:
+    """Build the review from an already-computed portfolio (v0.8.3).
+
+    Same result as :func:`build_review`; the seam lets a consumer holding a
+    loaded repository model (Explorer) reuse Core's review logic without a
+    second walk (ADR-015: the recommendation logic stays here, not in Explorer).
+    """
     issues: list[ReviewIssue] = []
 
     # Findings the portfolio already computed, re-ranked by review priority

--- a/tests/test_explorer_adapter.py
+++ b/tests/test_explorer_adapter.py
@@ -277,6 +277,66 @@ def test_attention_items_link_to_artifacts_and_keep_priority():
     ]
 
 
+def test_recommendations_state_requires_a_load():
+    assert ExplorerAdapter(str(FIXTURES / "broken_rels")).recommendations_state() is None
+
+
+def test_recommendations_mirror_core_review_findings():
+    from rac.services.review import build_review
+
+    adapter = ExplorerAdapter(str(FIXTURES / "broken_rels"))
+    adapter.load()
+    recs = adapter.recommendations_state()
+    assert recs is not None
+    report = build_review(str(FIXTURES / "broken_rels"))
+    # One recommendation per Core review finding — Explorer invents none.
+    assert recs.total == len(report.issues)
+
+
+def test_recommendations_grouped_by_category_in_fixed_order():
+    adapter = ExplorerAdapter(str(FIXTURES / "all_types"))
+    adapter.load()
+    recs = adapter.recommendations_state()
+    assert recs is not None
+    categories = [category for category, _ in recs.groups]
+    order = ["Validation", "Relationships", "Repository Health", "Quality"]
+    # Present categories appear in the fixed canonical order.
+    assert categories == [c for c in order if c in categories]
+    assert all(rows for _, rows in recs.groups)
+
+
+def test_recommendations_explain_before_suggesting():
+    adapter = ExplorerAdapter(str(FIXTURES / "broken_rels"))
+    adapter.load()
+    recs = adapter.recommendations_state()
+    assert recs is not None
+    rows = [r for _, group in recs.groups for r in group]
+    rel = next(r for r in rows if r.category == "Relationships")
+    assert rel.severity_label == "! Warning"
+    assert rel.finding and rel.impact and rel.action
+    assert "traceability" in rel.impact.lower()
+    assert rel.path  # navigable to the affected artifact
+
+
+def test_invalid_artifact_is_critical():
+    adapter = ExplorerAdapter(str(FIXTURES / "invalid_known"))
+    adapter.load()
+    recs = adapter.recommendations_state()
+    assert recs is not None
+    rows = [r for _, group in recs.groups for r in group]
+    validation = next(r for r in rows if r.category == "Validation")
+    assert validation.severity_label == "✗ Critical"
+
+
+def test_clean_repository_has_no_recommendations():
+    adapter = ExplorerAdapter(str(FIXTURES / "valid_clean"))
+    adapter.load()
+    recs = adapter.recommendations_state()
+    assert recs is not None
+    assert recs.total == 0
+    assert recs.groups == ()
+
+
 def test_cancelled_load_returns_none_not_an_error():
     token = CancellationToken()
     adapter = ExplorerAdapter(str(FIXTURES / "all_types"))

--- a/tests/test_explorer_app.py
+++ b/tests/test_explorer_app.py
@@ -186,7 +186,7 @@ async def test_slash_help_lists_registry_and_esc_closes():
         await pilot.pause()
         assert isinstance(app.screen, CommandScreen)
         results = app.screen.query_one(OptionList)
-        assert results.option_count == 7  # the whole registry, nothing more
+        assert results.option_count == 8  # the whole registry, nothing more
         await pilot.press("escape")
         assert isinstance(app.screen, RepositoryScreen)
 
@@ -325,6 +325,42 @@ async def test_health_attention_item_opens_context():
         await pilot.press("h")
         await pilot.pause()
         await pilot.press("enter")  # first attention item (focused)
+        await pilot.pause()
+        assert isinstance(app.screen, ContextScreen)
+
+
+@pytest.mark.asyncio
+async def test_slash_recommendations_opens_screen():
+    from rac.explorer.screens.recommendations import RecommendationsScreen
+
+    app = ExplorerApp(str(FIXTURES / "broken_rels"))
+    async with app.run_test() as pilot:
+        await _settled_panel_text(app, pilot)
+        await pilot.press("/")
+        await pilot.press(*"recommendations")
+        await pilot.press("enter")
+        await pilot.pause()
+        assert isinstance(app.screen, RecommendationsScreen)
+        from textual.widgets import OptionList
+
+        listing = app.screen.query_one(OptionList)
+        assert listing.option_count >= 1  # at least the broken-relationship finding
+
+
+@pytest.mark.asyncio
+async def test_health_r_opens_recommendations_and_item_opens_context():
+    from rac.explorer.screens.context import ContextScreen
+    from rac.explorer.screens.recommendations import RecommendationsScreen
+
+    app = ExplorerApp(str(FIXTURES / "broken_rels"))
+    async with app.run_test() as pilot:
+        await _settled_panel_text(app, pilot)
+        await pilot.press("h")
+        await pilot.pause()
+        await pilot.press("r")  # health → recommendations
+        await pilot.pause()
+        assert isinstance(app.screen, RecommendationsScreen)
+        await pilot.press("enter")  # first recommendation → its artifact
         await pilot.pause()
         assert isinstance(app.screen, ContextScreen)
 

--- a/tests/test_explorer_commands.py
+++ b/tests/test_explorer_commands.py
@@ -10,12 +10,13 @@ from __future__ import annotations
 from rac.explorer.commands import EXAMPLES, REGISTRY, SEARCH, parse, suggestions
 
 
-def test_registry_is_the_v082_contract():
+def test_registry_is_the_v083_contract():
     assert [spec.name for spec in REGISTRY] == [
         "open",
         "find",
         "browse",
         "health",
+        "recommendations",
         "home",
         "help",
         "quit",
@@ -23,10 +24,11 @@ def test_registry_is_the_v082_contract():
     assert all(spec.usage and spec.summary for spec in REGISTRY)
 
 
-def test_health_is_discoverable():
-    assert "health" in {spec.name for spec in REGISTRY}
-    assert parse("health").command == "health"
+def test_health_and_recommendations_are_discoverable():
+    names = {spec.name for spec in REGISTRY}
+    assert "health" in names and "recommendations" in names
     assert parse("/health").command == "health"
+    assert parse("/recommendations").command == "recommendations"
 
 
 def test_registered_command_routes_with_args():

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 
 from rac.cli import main
+from rac.services.portfolio import build_portfolio_summary
 from rac.services.review import (
     PRIORITY_BROKEN_RELATIONSHIP,
     PRIORITY_INVALID_ARTIFACT,
@@ -15,6 +16,7 @@ from rac.services.review import (
     PRIORITY_UNKNOWN_ARTIFACT,
     REVIEW_UNKNOWN_ARTIFACT,
     build_review,
+    review_from_portfolio,
 )
 
 FIXTURES = Path(__file__).parent / "fixtures" / "portfolio_summary"
@@ -22,6 +24,16 @@ FIXTURES = Path(__file__).parent / "fixtures" / "portfolio_summary"
 
 def review(subdir: str, **kwargs):
     return build_review(str(FIXTURES / subdir), **kwargs)
+
+
+def test_review_from_portfolio_matches_build_review():
+    # v0.8.3 seam: the same review, built from an already-computed portfolio.
+    for subdir in ("invalid_known", "broken_rels", "valid_clean", "all_types"):
+        directory = str(FIXTURES / subdir)
+        portfolio = build_portfolio_summary(directory)
+        assert review_from_portfolio(directory, portfolio).to_dict() == (
+            build_review(directory).to_dict()
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# Summary

Implements `rac/roadmaps/v0.8.x-explorer/v0.8.3-explorer-recommendations.md`.

Adds:

- A recommendations view (`/recommendations`, or `r` from the health view): RAC Core's review findings grouped by category, each presenting the finding, why it matters, a suggested action, and navigation to the affected artifact
- Core severities mapped to the three presentation tiers (Critical / Warning / Suggestion)
- A `review_from_portfolio` seam so Explorer reuses Core's review logic over a loaded repository without a second walk

# Roadmap / ADR Trace

Roadmap: `rac/roadmaps/v0.8.x-explorer/v0.8.3-explorer-recommendations.md` (contract pinned in the first commit)

Relevant ADRs and designs:

- ADR-015 — recommendation logic stays in Core; Explorer presents
- ADR-002 — no AI dependency; recommendations come from deterministic review
- ADR-003 — stable finding shapes
- DESIGN-recommendations, DESIGN-health-model

# Scope

## Included

- `rac.services.review.review_from_portfolio` — builds the prioritized review from an already-computed portfolio; `build_review` delegates to it (byte-identical, golden battery)
- `rac.explorer.state.RecommendationRow` / `RecommendationsState`; `ExplorerAdapter.recommendations_state()` — one recommendation per Core review finding, grouped into the four categories in fixed order
- `RecommendationsScreen` (multi-line finding → impact → action blocks); `/recommendations` in the registry; `r` binding on the health screen; selecting a recommendation opens the affected artifact's context view

## Excluded (deliberately)

- Applying changes, rewriting artifacts, or replacing human review (advisory only)
- Recommendation logic in Explorer (ADR-015) — every finding is Core's review output
- AI-dependent behaviour (ADR-002)
- Acting on a recommendation (editor launch, export) — v0.8.4
- No JSON contract movement; existing CLI output byte-identical

# Product / Architecture Decisions

- Recommendations are Core's `ReviewIssue`s. The mapping Explorer owns is presentation only: category (by finding code), severity tier (by Core severity), and a fixed **impact** sentence keyed by the finding code. The impact line is display copy — the same role as Explorer's existing status/phase labels — chosen over adding an `impact` field to Core's review JSON contract (which the roadmap does not call for).
- Category taxonomy is the fixed vocabulary (Validation, Relationships, Repository Health, Quality); only categories with findings render. "Repository Health" has no review-issue source today (orphan/traceability findings are counts, not per-artifact review items), so it appears only if such a finding type is later added to Core.
- Severity tiers map `error → ✗ Critical`, `warning → ! Warning`, `info → · Suggestion`; definitions stay in Core.
- Attention/recommendation lists are keyed by option index, not artifact path, since several findings may concern one artifact and OptionList ids must be unique.

# User-Facing Contract

## CLI / Keys

```bash
rac explorer        # /recommendations, or h then r
```

`/recommendations` (anywhere) · `r` (health view) → recommendations. `Esc` backs out. A recommendation + `Enter` → that artifact's context view.

## Human Output (interactive)

Each recommendation renders as a block:

```
✗ Critical  ·  Validation
  REQ-004  Validation errors: missing-title
  Impact: The artifact fails its schema, so tooling and validation cannot trust it.
  Action: Run: rac validate rac/requirements/req-004.md
```

## JSON Output

No changes; no new contracts.

## Exit Codes

Unchanged: `0` session quit · `2` not a directory or missing `explorer` extra.

# Verification

## Ran

```bash
python -m pytest                      # 733 passed
python -m ruff check src/ tests/
python -m ruff format --check src/ tests/
python -m mypy src/
rac validate rac/                     # exit 0
rac relationships rac/ --validate     # exit 0
rac review rac/                       # no priority 1–2 findings
```

## Covered

- Seam equivalence: `review_from_portfolio(...).to_dict() == build_review(...).to_dict()` across invalid / broken / clean / mixed fixtures
- Adapter: one recommendation per Core review finding; categories present in fixed order; broken-ref recommendation is `! Warning` with a traceability impact and a navigable path; invalid artifact is `✗ Critical`; clean repo yields none
- Screens: `/recommendations` opens the view; `r` from health opens it and a recommendation opens the context view; `/help` lists all 8 registry entries
- Registry: `recommendations` discoverable and parses

# Review Path

1. `rac/roadmaps/v0.8.x-explorer/v0.8.3-explorer-recommendations.md` — the pinned contract
2. `src/rac/services/review.py` — the `review_from_portfolio` seam
3. `src/rac/explorer/adapter.py` — category/severity/impact mapping and `recommendations_state`
4. `src/rac/explorer/screens/recommendations.py` — the screen
5. `src/rac/explorer/commands.py`, `screens/command.py`, `screens/health.py` — `/recommendations` and the `r` binding
6. `tests/` — review, adapter, app, commands
7. `docs/cli.md`, `CHANGELOG.md`

# Notes For Reviewer

- Stacked on v0.8.2 (PR #53); until that merges this PR's diff also shows the v0.8.2 commits. Once #53 merges, this narrows to just the v0.8.3 commits.
- The one judgment call worth your eye: the **impact** sentences are Explorer-side presentation copy keyed by Core finding codes. If you'd rather impact be Core-owned, that's a review-service field addition (a JSON contract change) for a later pass — flagged here rather than done silently.

# Implementation Process

Implemented with AI assistance under the roadmap contract.

Final scope, review, and acceptance decisions were made by the maintainer.