### PR TITLE
feat(explorer): v0.8.4 Explorer action workflows — editor launch, guided import, export

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,7 +82,7 @@ jobs:
           - name: repository
             paths: "tests/test_repository.py tests/test_repository_perf.py"
           - name: explorer
-            paths: "tests/test_explorer_adapter.py tests/test_explorer_app.py tests/test_explorer_cli.py tests/test_explorer_commands.py tests/test_explorer_isolation.py"
+            paths: "tests/test_explorer_adapter.py tests/test_explorer_app.py tests/test_explorer_cli.py tests/test_explorer_commands.py tests/test_explorer_editor.py tests/test_explorer_isolation.py"
           - name: relationships
             paths: "tests/test_relationships.py tests/test_relationships_cmd.py tests/test_relationship_validation.py"
           - name: resolve

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ details, release history over commit history.
 
 ### Added
 
+- Explorer action workflows (v0.8.4): open the current artifact in your editor
+  (`e`, via `$VISUAL`/`$EDITOR`; Explorer never edits — ADR-024); a guided
+  `/import <source> [target]` that converts a document through the ingest
+  service, previews the Markdown, and writes only on confirmation (never
+  overwriting); and `x` to export recommendations to a Markdown file with the
+  same preview-and-confirm flow. Conversions report progress.
 - Explorer recommendations (v0.8.3): `/recommendations` (or `r` from the health
   view) presents RAC Core's review findings grouped by category (Validation,
   Relationships, Repository Health, Quality), each with its impact, a suggested

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -355,9 +355,9 @@ it shows is also available through `rac portfolio`, `rac index`, `rac resolve`,
 - **Keys:** `/` commands and search · `↑ ↓` navigate · `Enter` select ·
   `Esc` back · `h` health (home) · `r` reload (home) · `q` quit
 - **Commands (`/`):** `open <ref>` · `find <query> [type]` · `browse [type]` ·
-  `health` · `recommendations` · `home` · `help` · `quit` — anything else is a
-  search. Lookup resolves canonical IDs and legacy aliases with `rac resolve` /
-  `rac find` semantics.
+  `health` · `recommendations` · `import <source> [target]` · `home` · `help` ·
+  `quit` — anything else is a search. Lookup resolves canonical IDs and legacy
+  aliases with `rac resolve` / `rac find` semantics.
 - **Health:** `h` or `/health` opens the health view — Core's score with a text
   label, the Completeness / Relationships / Validation / Coverage areas, and a
   prioritized attention list whose items open the affected artifact.
@@ -365,7 +365,12 @@ it shows is also available through `rac portfolio`, `rac index`, `rac resolve`,
   Core's review findings grouped by category (Validation, Relationships,
   Repository Health, Quality), each with its impact, a suggested `rac` command,
   and navigation to the affected artifact. Advisory only — Explorer applies
-  nothing.
+  nothing. `x` exports them to a Markdown file (preview, then confirm).
+- **Actions:** from an artifact's context view, `e` opens it in your editor
+  (`$VISUAL` / `$EDITOR`; guidance shown if neither is set — Explorer never
+  edits, ADR-024). `/import <source> [target]` converts a document via the
+  ingest service, previews the Markdown, and writes it only after you confirm
+  with `y` (never overwriting). Long conversions report progress.
 - **First run:** onboarding derives from repository content (existing, empty, or
   invalid repository) and is skipped for returning users; the completion marker
   under `$XDG_STATE_HOME/rac/` is the only state Explorer persists.

--- a/rac/roadmaps/v0.8.x-explorer/v0.8.4-explorer-action-workflow.md
+++ b/rac/roadmaps/v0.8.x-explorer/v0.8.4-explorer-action-workflow.md
@@ -84,6 +84,57 @@ Long-running operations display:
 - completion result
 - errors
 
+## Implementation Contract
+
+The following decisions are pinned for v0.8.4.
+
+### Editor Integration
+
+- `rac.explorer.editor` resolves the editor command from `$VISUAL`, then
+  `$EDITOR`; when neither is set it returns guidance rather than guessing.
+  Launch is fire-and-forget (`Popen`) through a module-level runner seam so
+  tests inject a spy and no real editor starts.
+- The context view gains an `e` binding: Open In Editor on the current
+  artifact. The outcome (launched, or guidance when unconfigured) is shown as
+  a text status line.
+- A persisted editor preference and first-run editor selection are deferred to
+  v0.8.6 preferences; v0.8.4 uses the standard `$VISUAL`/`$EDITOR` convention.
+  Terminal editors that need the TUI suspended are a later enhancement; v0.8.4
+  targets GUI editors (Cursor, VS Code, …) per DESIGN-editor-integration.
+
+### Guided Import
+
+- `/import <source> [target]` wraps the Core ingest service: conversion runs in
+  a Textual worker (operation feedback — Converting → Preview → Result), the
+  preview shows the source, converter, target path, and the converted Markdown,
+  and writing requires explicit confirmation (`y`). Import never overwrites an
+  existing file. Output equals `rac ingest` (ADR-015); Explorer owns only the
+  workflow. `import` joins the command registry.
+
+### Change Preview and Confirmation
+
+- Any workflow that can change repository contents previews first and applies
+  only on explicit confirmation; Explorer never silently mutates the
+  repository (ADR-024). Import and recommendation export both use this path.
+
+### Export Finding
+
+- The recommendations screen gains an `x` binding: export the current
+  recommendations to a Markdown file, with the same preview-and-confirm flow.
+
+### Deferred From Initiative 1
+
+- Open Artifact, Show Recommendation, and the relationship view already exist
+  (v0.8.1–v0.8.3); Open Related Artifact and Show Relationship Impact as
+  interactive traversal are delivered by v0.8.5 relationship navigation.
+
+### Scope
+
+- No Core or service changes beyond consuming the existing ingest service; no
+  JSON contract movement; existing CLI output byte-identical. New modules
+  `editor.py`, `screens/confirm.py`, `screens/import_.py`; the explorer battery
+  absorbs the tests.
+
 ## Non-Goals
 
 - Direct artifact editing or content authoring inside Explorer (ADR-024)

--- a/src/rac/explorer/adapter.py
+++ b/src/rac/explorer/adapter.py
@@ -10,8 +10,10 @@ testable without a terminal.
 from __future__ import annotations
 
 from collections.abc import Callable
+from pathlib import Path
 
 from rac.core.operations import CancelToken, OperationCancelled, Progress
+from rac.services.ingest import ConversionError, UnsupportedDocument, ingest
 from rac.services.repository import Artifact, Repository, load_repository
 from rac.services.resolve import (
     OUTCOME_DUPLICATE,
@@ -37,6 +39,7 @@ from .state import (
     ContextState,
     HealthAreaState,
     HealthState,
+    ImportPreview,
     LoadErrorState,
     LoadProgressState,
     LookupState,
@@ -361,6 +364,43 @@ class ExplorerAdapter:
     def open_in_editor(self, path: str) -> EditorOutcome:
         """Open ``path`` in the user's configured editor (v0.8.4, ADR-024)."""
         return editor_mod.open_in_editor(path)
+
+    def import_preview(self, source: str, target: str | None = None) -> ImportPreview | str:
+        """Convert ``source`` via Core ingest for review (v0.8.4).
+
+        Returns an :class:`ImportPreview` to confirm, or an error message
+        string — conversion never raises into the UI (Initiative 5/6). The
+        default target is the source stem as ``.md`` in the current directory;
+        nothing is written here (Initiative 4).
+        """
+        try:
+            result = ingest(source)
+        except UnsupportedDocument as exc:
+            return str(exc)
+        except ConversionError as exc:
+            return f"Could not convert {source}: {exc}"
+        except OSError as exc:
+            return f"Could not read {source}: {exc}"
+        resolved_target = target or f"{Path(source).stem}.md"
+        return ImportPreview(
+            source=source,
+            converter=result.converter,
+            target=resolved_target,
+            markdown=result.markdown,
+        )
+
+    def write_import(self, preview: ImportPreview) -> str:
+        """Write a confirmed import; never overwrites (Initiative 4)."""
+        path = Path(preview.target)
+        if path.exists():
+            return f"Refusing to overwrite existing file: {preview.target}"
+        try:
+            if path.parent != Path():
+                path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(preview.markdown, encoding="utf-8")
+        except OSError as exc:
+            return f"Could not write {preview.target}: {exc}"
+        return f"Imported {preview.source} → {preview.target}"
 
     def context_state(self, path: str) -> ContextState | None:
         """The context view for the artifact at ``path``, or None if unknown."""

--- a/src/rac/explorer/adapter.py
+++ b/src/rac/explorer/adapter.py
@@ -28,6 +28,8 @@ from rac.services.review import (
     review_from_portfolio,
 )
 
+from . import editor as editor_mod
+from .editor import EditorOutcome
 from .state import (
     ArtifactRow,
     AttentionRow,
@@ -355,6 +357,10 @@ class ExplorerAdapter:
             groups=groups,
             total=len(rows),
         )
+
+    def open_in_editor(self, path: str) -> EditorOutcome:
+        """Open ``path`` in the user's configured editor (v0.8.4, ADR-024)."""
+        return editor_mod.open_in_editor(path)
 
     def context_state(self, path: str) -> ContextState | None:
         """The context view for the artifact at ``path``, or None if unknown."""

--- a/src/rac/explorer/adapter.py
+++ b/src/rac/explorer/adapter.py
@@ -389,6 +389,32 @@ class ExplorerAdapter:
             markdown=result.markdown,
         )
 
+    def export_recommendations(self, target: str = "recommendations.md") -> ImportPreview | str:
+        """Render current recommendations as Markdown for export (v0.8.4).
+
+        Returns an :class:`ImportPreview` to confirm and write, or a message
+        when there is nothing to export. Writing goes through
+        :meth:`write_import`, so it previews and never overwrites.
+        """
+        recommendations = self.recommendations_state()
+        if recommendations is None or recommendations.total == 0:
+            return "No recommendations to export"
+        lines = [f"# Recommendations — {recommendations.directory}", ""]
+        for category, rows in recommendations.groups:
+            lines.append(f"## {category}")
+            lines.append("")
+            for row in rows:
+                lines.append(f"- **{row.severity_label}** {row.identifier} — {row.finding}")
+                lines.append(f"  - Impact: {row.impact}")
+                lines.append(f"  - Action: {row.action}")
+            lines.append("")
+        return ImportPreview(
+            source="recommendations",
+            converter="export",
+            target=target,
+            markdown="\n".join(lines),
+        )
+
     def write_import(self, preview: ImportPreview) -> str:
         """Write a confirmed import; never overwrites (Initiative 4)."""
         path = Path(preview.target)

--- a/src/rac/explorer/commands.py
+++ b/src/rac/explorer/commands.py
@@ -43,6 +43,7 @@ REGISTRY: tuple[CommandSpec, ...] = (
     CommandSpec(
         "recommendations", "recommendations", "Show recommendations with impact and actions"
     ),
+    CommandSpec("import", "import <source> [target]", "Convert a document into Markdown"),
     CommandSpec("home", "home", "Return to the repository home"),
     CommandSpec("help", "help", "List available commands"),
     CommandSpec("quit", "quit", "Quit the Explorer"),

--- a/src/rac/explorer/editor.py
+++ b/src/rac/explorer/editor.py
@@ -1,0 +1,69 @@
+"""External editor integration (v0.8.4, DESIGN-editor-integration).
+
+Explorer is not an editor (ADR-024): it locates an artifact and hands it to the
+user's own editor. The editor command is resolved from the standard `$VISUAL`
+then `$EDITOR` environment variables; when neither is set, Explorer offers
+guidance rather than guessing. Launch is fire-and-forget through a module-level
+runner seam, so tests inject a spy and no real editor starts.
+
+A persisted editor preference and first-run editor selection arrive with v0.8.6
+preferences; terminal editors that need the TUI suspended are a later
+enhancement. This module never imports Textual.
+"""
+
+from __future__ import annotations
+
+import os
+import shlex
+import subprocess
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+
+# Runner seam: launch a command, return nothing. Tests monkeypatch this; the
+# default starts the editor detached so the TUI keeps running (GUI editors).
+Runner = Callable[[Sequence[str]], None]
+
+
+def _default_runner(command: Sequence[str]) -> None:  # pragma: no cover - spawns a process
+    subprocess.Popen(command)
+
+
+_RUNNER: Runner = _default_runner
+
+UNCONFIGURED_GUIDANCE = (
+    "No editor configured. Set $VISUAL or $EDITOR (e.g. export EDITOR=code) and try again."
+)
+
+
+@dataclass(frozen=True)
+class EditorOutcome:
+    """The result of an Open In Editor attempt — always a recoverable state."""
+
+    launched: bool
+    message: str
+
+
+def resolve_editor() -> str | None:
+    """The configured editor command, from ``$VISUAL`` then ``$EDITOR``."""
+    for var in ("VISUAL", "EDITOR"):
+        value = os.environ.get(var, "").strip()
+        if value:
+            return value
+    return None
+
+
+def open_in_editor(path: str) -> EditorOutcome:
+    """Launch the configured editor on ``path`` (fire-and-forget).
+
+    Returns guidance instead of raising when no editor is configured or the
+    launch fails, so the interface never crashes (Initiative 5).
+    """
+    editor = resolve_editor()
+    if editor is None:
+        return EditorOutcome(launched=False, message=UNCONFIGURED_GUIDANCE)
+    command = [*shlex.split(editor), path]
+    try:
+        _RUNNER(command)
+    except OSError as exc:
+        return EditorOutcome(launched=False, message=f"Could not launch editor '{editor}': {exc}")
+    return EditorOutcome(launched=True, message=f"Opened {path} in {editor}")

--- a/src/rac/explorer/screens/browser.py
+++ b/src/rac/explorer/screens/browser.py
@@ -52,7 +52,7 @@ class BrowserScreen(Screen[None]):
             return
         context = self.adapter.context_state(event.option_id)
         if context is not None:
-            self.app.push_screen(ContextScreen(context))
+            self.app.push_screen(ContextScreen(self.adapter, context))
 
     def action_back(self) -> None:
         self.app.pop_screen()

--- a/src/rac/explorer/screens/command.py
+++ b/src/rac/explorer/screens/command.py
@@ -148,7 +148,7 @@ class CommandScreen(ModalScreen[None]):
         context = self.adapter.context_state(path)
         if context is not None:
             self.app.pop_screen()
-            self.app.push_screen(ContextScreen(context))
+            self.app.push_screen(ContextScreen(self.adapter, context))
 
     def _pop_to_home(self) -> None:
         from .repository import RepositoryScreen

--- a/src/rac/explorer/screens/command.py
+++ b/src/rac/explorer/screens/command.py
@@ -119,6 +119,17 @@ class CommandScreen(ModalScreen[None]):
 
             self.app.pop_screen()
             self.app.push_screen(RecommendationsScreen(self.adapter, recommendations))
+        elif invocation.command == "import":
+            parts = invocation.args.split()
+            if not parts:
+                self._set_options([Option("Usage: /import <source> [target]", disabled=True)])
+                return
+            source = parts[0]
+            target = parts[1] if len(parts) > 1 else None
+            from .import_ import ImportScreen
+
+            self.app.pop_screen()
+            self.app.push_screen(ImportScreen(self.adapter, source, target))
         elif invocation.command == "browse":
             artifact_type = invocation.args.casefold() or None
             browser = self.adapter.browser_state(artifact_type)

--- a/src/rac/explorer/screens/confirm.py
+++ b/src/rac/explorer/screens/confirm.py
@@ -1,0 +1,47 @@
+"""Confirm-write screen — preview a file write, apply only on confirmation (v0.8.4).
+
+Any workflow that can change repository contents previews first and writes only
+on explicit confirmation (Initiative 4, ADR-024). Used to export findings;
+import has its own conversion step but the same confirm discipline.
+"""
+
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.screen import Screen
+from textual.widgets import Footer, Header, Static
+
+from rac.explorer.adapter import ExplorerAdapter
+from rac.explorer.screens.import_ import ImportScreen
+from rac.explorer.state import ImportPreview
+
+
+class ConfirmWriteScreen(Screen[None]):
+    """Show a write preview; `y` writes (never overwrites), Esc cancels."""
+
+    BINDINGS = [
+        Binding("y", "confirm", "Confirm"),
+        Binding("escape", "back", "Cancel"),
+    ]
+
+    def __init__(self, adapter: ExplorerAdapter, preview: ImportPreview) -> None:
+        super().__init__()
+        self.adapter = adapter
+        self.preview = preview
+        self._done = False
+
+    def compose(self) -> ComposeResult:
+        yield Header()
+        yield Static(ImportScreen._render_preview(self.preview), id="confirm-panel")
+        yield Footer()
+
+    def action_confirm(self) -> None:
+        if self._done:
+            return
+        message = self.adapter.write_import(self.preview)
+        self._done = True
+        self.query_one("#confirm-panel", Static).update(f"{message}\n\nPress Esc to go back.")
+
+    def action_back(self) -> None:
+        self.app.pop_screen()

--- a/src/rac/explorer/screens/context.py
+++ b/src/rac/explorer/screens/context.py
@@ -11,6 +11,7 @@ from textual.binding import Binding
 from textual.screen import Screen
 from textual.widgets import Footer, Header, Static
 
+from rac.explorer.adapter import ExplorerAdapter
 from rac.explorer.state import ContextState
 
 
@@ -53,16 +54,26 @@ def render_context(context: ContextState) -> str:
 class ContextScreen(Screen[None]):
     """Read-only artifact context; editing belongs to external tools (ADR-024)."""
 
-    BINDINGS = [Binding("escape", "back", "Back")]
+    BINDINGS = [
+        Binding("escape", "back", "Back"),
+        Binding("e", "open_in_editor", "Open in editor"),
+    ]
 
-    def __init__(self, context: ContextState) -> None:
+    def __init__(self, adapter: ExplorerAdapter, context: ContextState) -> None:
         super().__init__()
+        self.adapter = adapter
         self.context = context
 
     def compose(self) -> ComposeResult:
         yield Header()
         yield Static(render_context(self.context), id="context-panel")
+        yield Static("", id="context-status")
         yield Footer()
+
+    def action_open_in_editor(self) -> None:
+        # ADR-024: Explorer hands the file to an external editor; it never edits.
+        outcome = self.adapter.open_in_editor(self.context.path)
+        self.query_one("#context-status", Static).update(outcome.message)
 
     def action_back(self) -> None:
         self.app.pop_screen()

--- a/src/rac/explorer/screens/health.py
+++ b/src/rac/explorer/screens/health.py
@@ -74,7 +74,7 @@ class HealthScreen(Screen[None]):
         row = self.health.attention[int(event.option_id)]
         context = self.adapter.context_state(row.path)
         if context is not None:
-            self.app.push_screen(ContextScreen(context))
+            self.app.push_screen(ContextScreen(self.adapter, context))
 
     def action_recommendations(self) -> None:
         recommendations = self.adapter.recommendations_state()

--- a/src/rac/explorer/screens/import_.py
+++ b/src/rac/explorer/screens/import_.py
@@ -1,0 +1,96 @@
+"""Guided import screen — convert, preview, confirm, write (v0.8.4).
+
+Wraps the Core ingest service (DESIGN-import-workflow): conversion runs off the
+UI thread with operation feedback, the converted Markdown is previewed with its
+target path, and nothing is written until the user confirms (Initiative 4).
+Explorer owns the workflow; RAC Core owns the conversion (ADR-015).
+"""
+
+from __future__ import annotations
+
+from textual import work
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.screen import Screen
+from textual.widgets import Footer, Header, Static
+from textual.worker import Worker, WorkerState, get_current_worker
+
+from rac.explorer.adapter import ExplorerAdapter
+from rac.explorer.state import ImportPreview
+
+_PREVIEW_LINES = 20
+
+
+class ImportScreen(Screen[None]):
+    """Converting → Preview (y confirms) → Result. Esc cancels at any point."""
+
+    BINDINGS = [
+        Binding("y", "confirm", "Confirm import"),
+        Binding("escape", "back", "Cancel"),
+    ]
+
+    def __init__(self, adapter: ExplorerAdapter, source: str, target: str | None) -> None:
+        super().__init__()
+        self.adapter = adapter
+        self.source = source
+        self.target = target
+        self.preview: ImportPreview | None = None
+        self._done = False
+
+    def compose(self) -> ComposeResult:
+        yield Header()
+        yield Static(f"Converting {self.source}…", id="import-panel")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        self._convert()
+
+    @work(thread=True, exclusive=True, group="import-convert")
+    def _convert(self) -> ImportPreview | str:
+        worker = get_current_worker()
+        if worker.is_cancelled:  # pragma: no cover - defensive
+            return "Cancelled"
+        return self.adapter.import_preview(self.source, self.target)
+
+    def on_worker_state_changed(self, event: Worker.StateChanged) -> None:
+        if event.worker.group != "import-convert" or event.state != WorkerState.SUCCESS:
+            return
+        result = event.worker.result
+        panel = self.query_one("#import-panel", Static)
+        if isinstance(result, ImportPreview):
+            self.preview = result
+            panel.update(self._render_preview(result))
+        else:  # an error message — recoverable, no write happened
+            self._done = True
+            panel.update(f"✗ Import failed\n\n{result}\n\nPress Esc to go back.")
+
+    @staticmethod
+    def _render_preview(preview: ImportPreview) -> str:
+        body = preview.markdown.splitlines()
+        shown = body[:_PREVIEW_LINES]
+        more = len(body) - len(shown)
+        lines = [
+            "Import Knowledge",
+            "",
+            f"Source     {preview.source}",
+            f"Converter  {preview.converter}",
+            f"Target     {preview.target}",
+            "",
+            "Preview (converted Markdown)",
+            "─" * 40,
+            *shown,
+        ]
+        if more > 0:
+            lines.append(f"… {more} more line(s)")
+        lines.extend(["─" * 40, "", "Press y to write this file · Esc to cancel"])
+        return "\n".join(lines)
+
+    def action_confirm(self) -> None:
+        if self.preview is None or self._done:
+            return
+        message = self.adapter.write_import(self.preview)
+        self._done = True
+        self.query_one("#import-panel", Static).update(f"{message}\n\nPress Esc to go back.")
+
+    def action_back(self) -> None:
+        self.app.pop_screen()

--- a/src/rac/explorer/screens/recommendations.py
+++ b/src/rac/explorer/screens/recommendations.py
@@ -32,7 +32,10 @@ def _prompt(row: RecommendationRow) -> str:
 class RecommendationsScreen(Screen[None]):
     """Category-grouped recommendations; Enter opens the artifact, Esc backs."""
 
-    BINDINGS = [Binding("escape", "back", "Back")]
+    BINDINGS = [
+        Binding("escape", "back", "Back"),
+        Binding("x", "export", "Export"),
+    ]
 
     def __init__(self, adapter: ExplorerAdapter, recommendations: RecommendationsState) -> None:
         super().__init__()
@@ -70,6 +73,14 @@ class RecommendationsScreen(Screen[None]):
         context = self.adapter.context_state(self._paths[int(event.option_id)])
         if context is not None:
             self.app.push_screen(ContextScreen(self.adapter, context))
+
+    def action_export(self) -> None:
+        result = self.adapter.export_recommendations()
+        if isinstance(result, str):
+            return  # nothing to export
+        from .confirm import ConfirmWriteScreen
+
+        self.app.push_screen(ConfirmWriteScreen(self.adapter, result))
 
     def action_back(self) -> None:
         self.app.pop_screen()

--- a/src/rac/explorer/screens/recommendations.py
+++ b/src/rac/explorer/screens/recommendations.py
@@ -69,7 +69,7 @@ class RecommendationsScreen(Screen[None]):
             return
         context = self.adapter.context_state(self._paths[int(event.option_id)])
         if context is not None:
-            self.app.push_screen(ContextScreen(context))
+            self.app.push_screen(ContextScreen(self.adapter, context))
 
     def action_back(self) -> None:
         self.app.pop_screen()

--- a/src/rac/explorer/state.py
+++ b/src/rac/explorer/state.py
@@ -151,6 +151,16 @@ class RecommendationsState:
 
 
 @dataclass(frozen=True)
+class ImportPreview:
+    """A converted document awaiting confirmation before it is written."""
+
+    source: str
+    converter: str
+    target: str
+    markdown: str
+
+
+@dataclass(frozen=True)
 class LoadErrorState:
     """A recoverable failure: the shell shows it and offers retry."""
 

--- a/tests/test_explorer_adapter.py
+++ b/tests/test_explorer_adapter.py
@@ -337,6 +337,62 @@ def test_clean_repository_has_no_recommendations():
     assert recs.groups == ()
 
 
+def test_import_preview_converts_markdown_without_writing(tmp_path):
+    source = tmp_path / "notes.md"
+    source.write_text("# Imported Notes\n\nbody\n", encoding="utf-8")
+    target = tmp_path / "out.md"
+    adapter = ExplorerAdapter(str(tmp_path))
+    preview = adapter.import_preview(str(source), str(target))
+    from rac.explorer.state import ImportPreview
+
+    assert isinstance(preview, ImportPreview)
+    assert preview.converter == "markdown"
+    assert "# Imported Notes" in preview.markdown
+    assert not target.exists()  # preview never writes (Initiative 4)
+
+
+def test_import_preview_matches_rac_ingest(tmp_path):
+    from rac.services.ingest import ingest
+
+    source = tmp_path / "doc.md"
+    source.write_text("# Same As Ingest\n", encoding="utf-8")
+    preview = ExplorerAdapter(str(tmp_path)).import_preview(str(source))
+    from rac.explorer.state import ImportPreview
+
+    assert isinstance(preview, ImportPreview)
+    assert preview.markdown == ingest(str(source)).markdown
+
+
+def test_import_preview_reports_unsupported_type(tmp_path):
+    source = tmp_path / "thing.xyz"
+    source.write_text("data", encoding="utf-8")
+    result = ExplorerAdapter(str(tmp_path)).import_preview(str(source))
+    assert isinstance(result, str)
+    assert "unsupported" in result.lower()
+
+
+def test_import_preview_reports_missing_source(tmp_path):
+    result = ExplorerAdapter(str(tmp_path)).import_preview(str(tmp_path / "nope.md"))
+    assert isinstance(result, str)
+    assert "could not read" in result.lower() or "no such" in result.lower()
+
+
+def test_write_import_writes_and_refuses_overwrite(tmp_path):
+    from rac.explorer.state import ImportPreview
+
+    target = tmp_path / "written.md"
+    preview = ImportPreview(
+        source="src.md", converter="markdown", target=str(target), markdown="# Hi\n"
+    )
+    adapter = ExplorerAdapter(str(tmp_path))
+    message = adapter.write_import(preview)
+    assert "Imported" in message
+    assert target.read_text(encoding="utf-8") == "# Hi\n"
+
+    again = adapter.write_import(preview)
+    assert "Refusing to overwrite" in again
+
+
 def test_cancelled_load_returns_none_not_an_error():
     token = CancellationToken()
     adapter = ExplorerAdapter(str(FIXTURES / "all_types"))

--- a/tests/test_explorer_adapter.py
+++ b/tests/test_explorer_adapter.py
@@ -393,6 +393,24 @@ def test_write_import_writes_and_refuses_overwrite(tmp_path):
     assert "Refusing to overwrite" in again
 
 
+def test_export_recommendations_renders_markdown_without_writing():
+    from rac.explorer.state import ImportPreview
+
+    adapter = ExplorerAdapter(str(FIXTURES / "broken_rels"))
+    adapter.load()
+    result = adapter.export_recommendations()
+    assert isinstance(result, ImportPreview)
+    assert result.converter == "export"
+    assert "# Recommendations" in result.markdown
+    assert "Impact:" in result.markdown and "Action:" in result.markdown
+
+
+def test_export_recommendations_empty_when_clean():
+    adapter = ExplorerAdapter(str(FIXTURES / "valid_clean"))
+    adapter.load()
+    assert adapter.export_recommendations() == "No recommendations to export"
+
+
 def test_cancelled_load_returns_none_not_an_error():
     token = CancellationToken()
     adapter = ExplorerAdapter(str(FIXTURES / "all_types"))

--- a/tests/test_explorer_app.py
+++ b/tests/test_explorer_app.py
@@ -476,6 +476,32 @@ async def test_slash_import_reports_unsupported(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_recommendations_export_previews_then_writes(tmp_path, monkeypatch):
+    from textual.widgets import Static
+
+    from rac.explorer.screens.confirm import ConfirmWriteScreen
+
+    monkeypatch.chdir(tmp_path)  # export defaults to recommendations.md in cwd
+    app = ExplorerApp(str(FIXTURES / "broken_rels"))
+    async with app.run_test() as pilot:
+        await _settled_panel_text(app, pilot)
+        await pilot.press("h")
+        await pilot.pause()
+        await pilot.press("r")  # recommendations
+        await pilot.pause()
+        await pilot.press("x")  # export → confirm screen
+        await pilot.pause()
+        assert isinstance(app.screen, ConfirmWriteScreen)
+        assert not (tmp_path / "recommendations.md").exists()  # preview only
+
+        await pilot.press("y")
+        await pilot.pause()
+        written = (tmp_path / "recommendations.md").read_text(encoding="utf-8")
+        assert "# Recommendations" in written
+        assert "Imported" in str(app.screen.query_one("#confirm-panel", Static).content)
+
+
+@pytest.mark.asyncio
 async def test_quit_binding_exits_cleanly():
     app = ExplorerApp(str(FIXTURES / "valid_clean"))
     async with app.run_test() as pilot:

--- a/tests/test_explorer_app.py
+++ b/tests/test_explorer_app.py
@@ -366,6 +366,46 @@ async def test_health_r_opens_recommendations_and_item_opens_context():
 
 
 @pytest.mark.asyncio
+async def test_context_e_opens_external_editor(monkeypatch):
+    from textual.widgets import Static
+
+    import rac.explorer.editor as editor_mod
+
+    launched: list[list[str]] = []
+    monkeypatch.setattr(editor_mod, "_RUNNER", lambda cmd: launched.append(list(cmd)))
+    monkeypatch.setenv("EDITOR", "code")
+
+    app = ExplorerApp(str(FIXTURES / "valid_clean"))
+    async with app.run_test() as pilot:
+        await _settled_panel_text(app, pilot)
+        await pilot.press("enter")  # browser
+        await pilot.press("enter")  # context
+        await pilot.press("e")
+        await pilot.pause()
+        status = str(app.screen.query_one("#context-status", Static).content)
+        assert "Opened" in status and "code" in status
+        assert launched and launched[0][0] == "code"
+
+
+@pytest.mark.asyncio
+async def test_context_e_without_editor_shows_guidance(monkeypatch):
+    from textual.widgets import Static
+
+    monkeypatch.delenv("VISUAL", raising=False)
+    monkeypatch.delenv("EDITOR", raising=False)
+
+    app = ExplorerApp(str(FIXTURES / "valid_clean"))
+    async with app.run_test() as pilot:
+        await _settled_panel_text(app, pilot)
+        await pilot.press("enter")
+        await pilot.press("enter")
+        await pilot.press("e")
+        await pilot.pause()
+        status = str(app.screen.query_one("#context-status", Static).content)
+        assert "No editor configured" in status
+
+
+@pytest.mark.asyncio
 async def test_quit_binding_exits_cleanly():
     app = ExplorerApp(str(FIXTURES / "valid_clean"))
     async with app.run_test() as pilot:

--- a/tests/test_explorer_app.py
+++ b/tests/test_explorer_app.py
@@ -186,7 +186,7 @@ async def test_slash_help_lists_registry_and_esc_closes():
         await pilot.pause()
         assert isinstance(app.screen, CommandScreen)
         results = app.screen.query_one(OptionList)
-        assert results.option_count == 8  # the whole registry, nothing more
+        assert results.option_count == 9  # the whole registry, nothing more
         await pilot.press("escape")
         assert isinstance(app.screen, RepositoryScreen)
 
@@ -403,6 +403,76 @@ async def test_context_e_without_editor_shows_guidance(monkeypatch):
         await pilot.pause()
         status = str(app.screen.query_one("#context-status", Static).content)
         assert "No editor configured" in status
+
+
+@pytest.mark.asyncio
+async def test_slash_import_previews_then_confirms_write(tmp_path):
+    from textual.widgets import Static
+
+    from rac.explorer.screens.import_ import ImportScreen
+
+    source = tmp_path / "incoming.md"
+    source.write_text("# Imported Doc\n\nhello\n", encoding="utf-8")
+    target = tmp_path / "result.md"
+
+    app = ExplorerApp(str(FIXTURES / "valid_clean"))
+    async with app.run_test() as pilot:
+        await _settled_panel_text(app, pilot)
+        await pilot.press("/")
+        await pilot.press(*f"import {source} {target}")
+        await pilot.press("enter")
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert isinstance(app.screen, ImportScreen)
+        panel = str(app.screen.query_one("#import-panel", Static).content)
+        assert "Preview" in panel and "Imported Doc" in panel
+        assert not target.exists()  # not written until confirmed
+
+        await pilot.press("y")
+        await pilot.pause()
+        assert target.read_text(encoding="utf-8") == "# Imported Doc\n\nhello\n"
+        assert "Imported" in str(app.screen.query_one("#import-panel", Static).content)
+
+
+@pytest.mark.asyncio
+async def test_slash_import_cancel_writes_nothing(tmp_path):
+    from rac.explorer.screens.import_ import ImportScreen
+
+    source = tmp_path / "incoming.md"
+    source.write_text("# Doc\n", encoding="utf-8")
+    target = tmp_path / "result.md"
+
+    app = ExplorerApp(str(FIXTURES / "valid_clean"))
+    async with app.run_test() as pilot:
+        await _settled_panel_text(app, pilot)
+        await pilot.press("/")
+        await pilot.press(*f"import {source} {target}")
+        await pilot.press("enter")
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert isinstance(app.screen, ImportScreen)
+        await pilot.press("escape")  # cancel before confirming
+        await pilot.pause()
+        assert not target.exists()
+
+
+@pytest.mark.asyncio
+async def test_slash_import_reports_unsupported(tmp_path):
+    from textual.widgets import Static
+
+    source = tmp_path / "thing.xyz"
+    source.write_text("x", encoding="utf-8")
+
+    app = ExplorerApp(str(FIXTURES / "valid_clean"))
+    async with app.run_test() as pilot:
+        await _settled_panel_text(app, pilot)
+        await pilot.press("/")
+        await pilot.press(*f"import {source}")
+        await pilot.press("enter")
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        panel = str(app.screen.query_one("#import-panel", Static).content)
+        assert "Import failed" in panel
 
 
 @pytest.mark.asyncio

--- a/tests/test_explorer_commands.py
+++ b/tests/test_explorer_commands.py
@@ -10,13 +10,14 @@ from __future__ import annotations
 from rac.explorer.commands import EXAMPLES, REGISTRY, SEARCH, parse, suggestions
 
 
-def test_registry_is_the_v083_contract():
+def test_registry_is_the_v084_contract():
     assert [spec.name for spec in REGISTRY] == [
         "open",
         "find",
         "browse",
         "health",
         "recommendations",
+        "import",
         "home",
         "help",
         "quit",
@@ -24,11 +25,12 @@ def test_registry_is_the_v083_contract():
     assert all(spec.usage and spec.summary for spec in REGISTRY)
 
 
-def test_health_and_recommendations_are_discoverable():
+def test_action_commands_are_discoverable():
     names = {spec.name for spec in REGISTRY}
-    assert "health" in names and "recommendations" in names
-    assert parse("/health").command == "health"
+    assert {"health", "recommendations", "import"} <= names
     assert parse("/recommendations").command == "recommendations"
+    assert parse("import notes.pdf").command == "import"
+    assert parse("import notes.pdf out.md").args == "notes.pdf out.md"
 
 
 def test_registered_command_routes_with_args():

--- a/tests/test_explorer_editor.py
+++ b/tests/test_explorer_editor.py
@@ -1,0 +1,51 @@
+"""Tests for external editor integration (v0.8.4)."""
+
+from __future__ import annotations
+
+import rac.explorer.editor as editor_mod
+from rac.explorer.editor import open_in_editor, resolve_editor
+
+
+def test_resolve_prefers_visual_then_editor(monkeypatch):
+    monkeypatch.setenv("VISUAL", "code")
+    monkeypatch.setenv("EDITOR", "vim")
+    assert resolve_editor() == "code"
+    monkeypatch.delenv("VISUAL")
+    assert resolve_editor() == "vim"
+
+
+def test_resolve_returns_none_when_unset(monkeypatch):
+    monkeypatch.delenv("VISUAL", raising=False)
+    monkeypatch.delenv("EDITOR", raising=False)
+    assert resolve_editor() is None
+
+
+def test_open_launches_resolved_editor_with_path(monkeypatch):
+    calls: list[list[str]] = []
+    monkeypatch.setattr(editor_mod, "_RUNNER", lambda cmd: calls.append(list(cmd)))
+    monkeypatch.setenv("VISUAL", "code --wait")
+    monkeypatch.delenv("EDITOR", raising=False)
+
+    outcome = open_in_editor("rac/decisions/adr-001.md")
+    assert outcome.launched
+    assert calls == [["code", "--wait", "rac/decisions/adr-001.md"]]
+    assert "adr-001.md" in outcome.message
+
+
+def test_open_without_editor_offers_guidance(monkeypatch):
+    monkeypatch.delenv("VISUAL", raising=False)
+    monkeypatch.delenv("EDITOR", raising=False)
+    outcome = open_in_editor("x.md")
+    assert not outcome.launched
+    assert "$EDITOR" in outcome.message
+
+
+def test_open_handles_launch_failure(monkeypatch):
+    def boom(cmd):
+        raise OSError("no such file")
+
+    monkeypatch.setattr(editor_mod, "_RUNNER", boom)
+    monkeypatch.setenv("EDITOR", "ghost-editor")
+    outcome = open_in_editor("x.md")
+    assert not outcome.launched
+    assert "Could not launch" in outcome.message

--- a/tests/test_explorer_isolation.py
+++ b/tests/test_explorer_isolation.py
@@ -61,6 +61,7 @@ def test_adapter_state_and_launch_never_import_textual():
         SRC / "explorer" / "launch.py",
         SRC / "explorer" / "commands.py",
         SRC / "explorer" / "firstrun.py",
+        SRC / "explorer" / "editor.py",
     ]
     files = [f for f in files if f.exists()]
     assert (SRC / "explorer" / "adapter.py") in files


### PR DESCRIPTION
# Summary

Implements `rac/roadmaps/v0.8.x-explorer/v0.8.4-explorer-action-workflow.md`.

Adds:

- **Editor integration** — `e` from an artifact's context view opens it in the user's editor (`$VISUAL`/`$EDITOR`), launched fire-and-forget; Explorer never edits (ADR-024)
- **Guided import** — `/import <source> [target]` converts a document via the Core ingest service in a worker (operation feedback), previews the Markdown with its target, and writes only after explicit confirmation, never overwriting
- **Export finding** — `x` from the recommendations view exports them to a Markdown file through the same preview-and-confirm path
- A reusable confirm-write screen so every repository-changing workflow previews before applying

# Roadmap / ADR Trace

Roadmap: `rac/roadmaps/v0.8.x-explorer/v0.8.4-explorer-action-workflow.md` (contract pinned in the first commit)

Relevant ADRs and designs:

- ADR-015 — Core owns ingestion; Explorer owns workflow presentation
- ADR-024 — Explorer is not an editor; external tools edit
- ADR-006 — document conversion
- DESIGN-action-workflows, DESIGN-editor-integration, DESIGN-import-workflow

# Scope

## Included

- `rac.explorer.editor` — resolve editor from `$VISUAL` then `$EDITOR`; launch via a module-level runner seam; guidance when unconfigured or on failure (never raises)
- `ExplorerAdapter.open_in_editor`, `import_preview`, `write_import`, `export_recommendations`; `state.ImportPreview`
- `ContextScreen` gains `e` + a status line; `ImportScreen` (convert → preview → confirm → write, worker-driven); `ConfirmWriteScreen` (shared preview/confirm write); `RecommendationsScreen` gains `x`
- `import` joins the command registry; `ContextScreen` now takes the adapter (threaded through all call sites)

## Excluded (deliberately)

- Direct editing/authoring or saving content from Explorer (ADR-024)
- Automated fixes without confirmation; silent mutation
- Persisted editor preference and first-run editor selection — deferred to v0.8.6 preferences; v0.8.4 uses the `$VISUAL`/`$EDITOR` convention
- Terminal editors that require suspending the TUI — a later enhancement; v0.8.4 targets GUI editors per DESIGN-editor-integration
- Open Related Artifact / Show Relationship Impact as interactive traversal — v0.8.5 relationship navigation
- No Core/service changes (consumes existing ingest); no JSON contract movement

# Product / Architecture Decisions

- Editor launch is fire-and-forget (`Popen`) so the TUI keeps running — suited to GUI editors the design emphasizes. The runner is a module seam (`editor._RUNNER`) so tests inject a spy; no real process starts.
- Import default target is the source stem as `.md` in the current directory; an explicit target overrides. `write_import` refuses to overwrite (matching `rac new`'s no-clobber stance) and creates parent directories.
- Import conversion equals `rac ingest` (test asserts `import_preview(...).markdown == ingest(...).markdown`) — Explorer adds only the workflow.
- Conversion runs in a Textual thread worker (operation feedback: Converting → Preview → Result); the write is synchronous and gated on `y`.
- Export reuses the import preview/confirm machinery by producing an `ImportPreview` (`converter="export"`) and writing through `write_import`, so the no-overwrite/preview guarantees hold for it too.

# User-Facing Contract

## CLI / Keys

```bash
rac explorer
# context view:  e → open in $EDITOR
# /import report.docx rac/requirements/new.md   → preview → y to write
# recommendations view: x → export → y to write
```

## Human Output (interactive)

- Editor: a status line — `Opened <path> in <editor>`, or guidance to set `$EDITOR`
- Import: `Converting <source>…`, then a preview block (Source / Converter / Target / converted Markdown) and `Press y to write this file · Esc to cancel`, then the result
- Export: the same preview/confirm block for `recommendations.md`

## JSON Output

No changes; no new contracts.

## Exit Codes

Unchanged: `0` session quit · `2` not a directory or missing `explorer` extra.

# Verification

## Ran

```bash
python -m pytest                      # 751 passed
python -m ruff check src/ tests/
python -m ruff format --check src/ tests/
python -m mypy src/
rac validate rac/                     # exit 0
rac relationships rac/ --validate     # exit 0
rac review rac/                       # no priority 1–2 findings
```

## Covered

- Editor: `$VISUAL` preferred over `$EDITOR`; launch passes `[*shlex.split(cmd), path]` to the runner; unconfigured → guidance; `OSError` → recoverable message; `e` in the context view launches via an injected spy and shows the status, and shows guidance when unset
- Import: preview converts without writing; `import_preview` equals `rac ingest` output; unsupported type and missing source report messages; `write_import` writes then refuses to overwrite; the `/import` flow previews, `y` writes the exact bytes, `Esc` writes nothing, unsupported reports failure
- Export: renders Markdown without writing; empty when clean; the `x` flow previews in `ConfirmWriteScreen` and `y` writes `recommendations.md`
- Registry: `import` discoverable and arg-splitting; `/help` lists all 9 entries
- Isolation battery extended to `editor.py` (no Textual/Core imports)

# Review Path

1. `rac/roadmaps/v0.8.x-explorer/v0.8.4-explorer-action-workflow.md` — the pinned contract
2. `src/rac/explorer/editor.py` — resolution + launch seam
3. `src/rac/explorer/adapter.py` — `open_in_editor`, `import_preview`, `write_import`, `export_recommendations`
4. `src/rac/explorer/screens/import_.py`, `screens/confirm.py` — the worker-driven preview/confirm screens
5. `src/rac/explorer/screens/context.py`, `recommendations.py`, `commands.py`, `screens/command.py` — bindings and routing
6. `tests/` — editor, adapter, app, commands
7. `docs/cli.md`, `CHANGELOG.md`

# Notes For Reviewer

- Stacked on v0.8.2 (PR #53) and v0.8.3 (PR #54); until those merge this PR's diff also shows their commits. Merging in order narrows each.
- `ContextScreen` now requires the adapter (for `e`); all four call sites were updated. No behavior change to existing navigation.
- The largest milestone of the series; editor preference persistence and terminal-editor suspend are explicitly deferred (noted above) rather than half-built.

# Implementation Process

Implemented with AI assistance under the roadmap contract.

Final scope, review, and acceptance decisions were made by the maintainer.