### PR TITLE
feat(explorer): v0.8.5 Explorer relationship navigation — traverse, impact, lineage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ details, release history over commit history.
 
 ### Added
 
+- Explorer relationship navigation (v0.8.5): `g` from a context view (or
+  `/relationships <ref>`) opens a knowledge-graph view — the artifact's
+  outgoing relationships, its impact ("what depends on this?"), and its lineage
+  (Supersedes / Superseded By). Connected artifacts are selectable, so the graph
+  can be traversed one hop at a time. Rendered from Core's relationship model;
+  Explorer infers nothing.
 - Explorer action workflows (v0.8.4): open the current artifact in your editor
   (`e`, via `$VISUAL`/`$EDITOR`; Explorer never edits — ADR-024); a guided
   `/import <source> [target]` that converts a document through the ingest

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -355,9 +355,10 @@ it shows is also available through `rac portfolio`, `rac index`, `rac resolve`,
 - **Keys:** `/` commands and search · `↑ ↓` navigate · `Enter` select ·
   `Esc` back · `h` health (home) · `r` reload (home) · `q` quit
 - **Commands (`/`):** `open <ref>` · `find <query> [type]` · `browse [type]` ·
-  `health` · `recommendations` · `import <source> [target]` · `home` · `help` ·
-  `quit` — anything else is a search. Lookup resolves canonical IDs and legacy
-  aliases with `rac resolve` / `rac find` semantics.
+  `health` · `recommendations` · `import <source> [target]` ·
+  `relationships <ref>` · `home` · `help` · `quit` — anything else is a search.
+  Lookup resolves canonical IDs and legacy aliases with `rac resolve` /
+  `rac find` semantics.
 - **Health:** `h` or `/health` opens the health view — Core's score with a text
   label, the Completeness / Relationships / Validation / Coverage areas, and a
   prioritized attention list whose items open the affected artifact.
@@ -366,6 +367,10 @@ it shows is also available through `rac portfolio`, `rac index`, `rac resolve`,
   Repository Health, Quality), each with its impact, a suggested `rac` command,
   and navigation to the affected artifact. Advisory only — Explorer applies
   nothing. `x` exports them to a Markdown file (preview, then confirm).
+- **Relationships:** `g` from a context view (or `/relationships <ref>`) opens
+  the knowledge-graph view — the artifact's outgoing relationships, its impact
+  ("what depends on this?"), and its lineage. Connected artifacts are
+  selectable, so you can traverse the graph one hop at a time; `Esc` unwinds.
 - **Actions:** from an artifact's context view, `e` opens it in your editor
   (`$VISUAL` / `$EDITOR`; guidance shown if neither is set — Explorer never
   edits, ADR-024). `/import <source> [target]` converts a document via the

--- a/rac/roadmaps/v0.8.x-explorer/v0.8.5-explorer-relationship-navigation.md
+++ b/rac/roadmaps/v0.8.x-explorer/v0.8.5-explorer-relationship-navigation.md
@@ -85,6 +85,46 @@ Requirement
 Relationship views prioritize terminal readability over graphical
 complexity. No interactive canvas or web-style graph editor.
 
+## Implementation Contract
+
+The following decisions are pinned for v0.8.5.
+
+### Source
+
+- Every relationship view renders the loaded repository model's `Relationship`
+  objects (source, kind, raw target, resolved path, issue) — the same data
+  `rac relationships` reports (ADR-016). Explorer traverses; it infers no
+  relationships and edits none (ADR-015).
+
+### Relationship Screen
+
+- A `RelationshipScreen` for an artifact shows three sections: its outgoing
+  relationships (with resolved titles, or a `✗ unresolved` marker), its impact
+  ("what depends on this?" — the artifacts whose references resolve to it), and
+  its lineage (Supersedes / Superseded By). The connected, resolved artifacts
+  form one selectable list; opening one shows its context view, and `g` from
+  there reopens relationships — traversal continues, Esc unwinds.
+- Reachable with `g` from the context view and via `/relationships <ref>`.
+
+### Traceability and Lineage
+
+- Traceability (ADR-020) is the same outgoing/incoming traversal followed from a
+  requirement; no separate engine. Lineage covers Supersedes and Superseded By;
+  Created/Updated timestamps are not modelled by Core and are out of scope.
+
+### Rendering
+
+- Terminal-readable text only — no canvas or graph editor (Initiative 5).
+  Status carries text labels beside symbols (ADR-028).
+
+### Scope
+
+- Presentation over the existing model: no Core or service changes, no JSON
+  contract movement, existing CLI output byte-identical. Adapter gains
+  `relationships_view`; `state.py` gains `RelationshipLink` and
+  `RelationshipsView`; `relationships` joins the command registry. The explorer
+  battery absorbs the tests.
+
 ## Non-Goals
 
 - Manual relationship editing inside Explorer (relationships are authored in

--- a/src/rac/explorer/adapter.py
+++ b/src/rac/explorer/adapter.py
@@ -45,6 +45,8 @@ from .state import (
     LookupState,
     RecommendationRow,
     RecommendationsState,
+    RelationshipLink,
+    RelationshipsView,
     RepositorySummaryState,
     health_label,
 )
@@ -427,6 +429,75 @@ class ExplorerAdapter:
         except OSError as exc:
             return f"Could not write {preview.target}: {exc}"
         return f"Imported {preview.source} → {preview.target}"
+
+    def relationships_view(self, path: str) -> RelationshipsView | None:
+        """The knowledge-graph view for the artifact at ``path`` (v0.8.5).
+
+        Renders the loaded model's relationships — outgoing edges, impact
+        (artifacts that depend on this one), and lineage (Supersedes /
+        Superseded By). Explorer traverses; it infers nothing (ADR-016).
+        """
+        repository = self.repository
+        if repository is None:
+            return None
+        artifact = next((a for a in repository.artifacts if a.path == path), None)
+        if artifact is None:
+            return None
+        titles = {a.path: (a.title or a.id) for a in repository.artifacts}
+
+        def label(kind: str) -> str:
+            return kind.replace("_", " ").title()
+
+        outgoing: list[RelationshipLink] = []
+        lineage: list[str] = []
+        for rel in repository.relationships:
+            if rel.source_path != path:
+                continue
+            if rel.resolved_path is not None:
+                outgoing.append(
+                    RelationshipLink(
+                        kind=label(rel.relationship),
+                        label=titles[rel.resolved_path],
+                        target_path=rel.resolved_path,
+                        navigable=True,
+                    )
+                )
+                if rel.relationship == "supersedes":
+                    lineage.append(f"Supersedes → {titles[rel.resolved_path]}")
+            else:
+                phrase = (rel.issue or "unresolved").replace("-", " ").replace("_", " ")
+                outgoing.append(
+                    RelationshipLink(
+                        kind=label(rel.relationship),
+                        label=f"{rel.target} (✗ {phrase})",
+                        target_path="",
+                        navigable=False,
+                    )
+                )
+
+        impact: list[RelationshipLink] = []
+        for rel in repository.relationships:
+            if rel.resolved_path != path:
+                continue
+            impact.append(
+                RelationshipLink(
+                    kind=label(rel.relationship),
+                    label=titles.get(rel.source_path, rel.source_path),
+                    target_path=rel.source_path,
+                    navigable=True,
+                )
+            )
+            if rel.relationship == "supersedes":
+                lineage.append(f"Superseded By ← {titles.get(rel.source_path, rel.source_path)}")
+
+        return RelationshipsView(
+            id=artifact.id,
+            title=artifact.title,
+            path=artifact.path,
+            outgoing=tuple(outgoing),
+            impact=tuple(impact),
+            lineage=tuple(lineage),
+        )
 
     def context_state(self, path: str) -> ContextState | None:
         """The context view for the artifact at ``path``, or None if unknown."""

--- a/src/rac/explorer/commands.py
+++ b/src/rac/explorer/commands.py
@@ -44,6 +44,7 @@ REGISTRY: tuple[CommandSpec, ...] = (
         "recommendations", "recommendations", "Show recommendations with impact and actions"
     ),
     CommandSpec("import", "import <source> [target]", "Convert a document into Markdown"),
+    CommandSpec("relationships", "relationships <ref>", "Traverse an artifact's relationships"),
     CommandSpec("home", "home", "Return to the repository home"),
     CommandSpec("help", "help", "List available commands"),
     CommandSpec("quit", "quit", "Quit the Explorer"),

--- a/src/rac/explorer/screens/command.py
+++ b/src/rac/explorer/screens/command.py
@@ -119,6 +119,19 @@ class CommandScreen(ModalScreen[None]):
 
             self.app.pop_screen()
             self.app.push_screen(RecommendationsScreen(self.adapter, recommendations))
+        elif invocation.command == "relationships":
+            lookup = self.adapter.open_ref(invocation.args)
+            if len(lookup.rows) != 1 or lookup.message is not None:
+                self._show_lookup(lookup)
+                return
+            view = self.adapter.relationships_view(lookup.rows[0].path)
+            if view is None:
+                self._set_options([Option("Repository not loaded yet", disabled=True)])
+                return
+            from .relationships import RelationshipScreen
+
+            self.app.pop_screen()
+            self.app.push_screen(RelationshipScreen(self.adapter, view))
         elif invocation.command == "import":
             parts = invocation.args.split()
             if not parts:

--- a/src/rac/explorer/screens/context.py
+++ b/src/rac/explorer/screens/context.py
@@ -57,6 +57,7 @@ class ContextScreen(Screen[None]):
     BINDINGS = [
         Binding("escape", "back", "Back"),
         Binding("e", "open_in_editor", "Open in editor"),
+        Binding("g", "relationships", "Relationships"),
     ]
 
     def __init__(self, adapter: ExplorerAdapter, context: ContextState) -> None:
@@ -74,6 +75,13 @@ class ContextScreen(Screen[None]):
         # ADR-024: Explorer hands the file to an external editor; it never edits.
         outcome = self.adapter.open_in_editor(self.context.path)
         self.query_one("#context-status", Static).update(outcome.message)
+
+    def action_relationships(self) -> None:
+        view = self.adapter.relationships_view(self.context.path)
+        if view is not None:
+            from .relationships import RelationshipScreen
+
+            self.app.push_screen(RelationshipScreen(self.adapter, view))
 
     def action_back(self) -> None:
         self.app.pop_screen()

--- a/src/rac/explorer/screens/relationships.py
+++ b/src/rac/explorer/screens/relationships.py
@@ -1,0 +1,86 @@
+"""Relationship screen — traverse the knowledge graph (v0.8.5).
+
+Renders an artifact's outgoing relationships, its impact (what depends on it),
+and its lineage, all from the loaded repository model (ADR-016). Connected
+artifacts are selectable: opening one shows its context view, from which `g`
+reopens this screen — traversal continues across the graph, Esc unwinds.
+Terminal-readable text only; no canvas (Initiative 5).
+"""
+
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.screen import Screen
+from textual.widgets import Footer, Header, OptionList, Static
+from textual.widgets.option_list import Option
+
+from rac.explorer.adapter import ExplorerAdapter
+from rac.explorer.state import RelationshipsView
+
+
+def render_sections(view: RelationshipsView) -> str:
+    """Outgoing / Impact / Lineage as terminal-readable text."""
+    lines = [view.title or view.id, "", "Relationships"]
+    if view.outgoing:
+        lines.extend(f"  {link.kind} → {link.label}" for link in view.outgoing)
+    else:
+        lines.append("  none declared")
+
+    lines.extend(["", "Impact (what depends on this)"])
+    if view.impact:
+        lines.extend(f"  ← {link.label} ({link.kind})" for link in view.impact)
+    else:
+        lines.append("  nothing depends on this artifact")
+
+    lines.extend(["", "Lineage"])
+    if view.lineage:
+        lines.extend(f"  {line}" for line in view.lineage)
+    else:
+        lines.append("  no recorded supersession")
+    return "\n".join(lines)
+
+
+class RelationshipScreen(Screen[None]):
+    """Connected artifacts are selectable; `g`/Enter continues the traversal."""
+
+    BINDINGS = [Binding("escape", "back", "Back")]
+
+    def __init__(self, adapter: ExplorerAdapter, view: RelationshipsView) -> None:
+        super().__init__()
+        self.adapter = adapter
+        self.view = view
+        # Navigable connected artifacts (outgoing resolved + impact sources),
+        # keyed by option index so duplicate paths stay unique.
+        self._paths: list[str] = []
+
+    def compose(self) -> ComposeResult:
+        yield Header()
+        yield Static(render_sections(self.view), id="relationship-panel")
+        options: list[Option] = []
+        for link in (*self.view.outgoing, *self.view.impact):
+            if link.navigable:
+                options.append(Option(f"{link.kind}: {link.label}", id=str(len(self._paths))))
+                self._paths.append(link.target_path)
+        if not options:
+            options.append(Option("No connected artifacts to open", id=None, disabled=True))
+        connected = OptionList(*options, id="connected-list")
+        connected.border_title = "Open connected artifact"
+        yield connected
+        yield Footer()
+
+    def on_mount(self) -> None:
+        if self._paths:
+            self.query_one(OptionList).focus()
+
+    def on_option_list_option_selected(self, event: OptionList.OptionSelected) -> None:
+        if event.option_id is None:
+            return
+        context = self.adapter.context_state(self._paths[int(event.option_id)])
+        if context is not None:
+            from .context import ContextScreen
+
+            self.app.push_screen(ContextScreen(self.adapter, context))
+
+    def action_back(self) -> None:
+        self.app.pop_screen()

--- a/src/rac/explorer/state.py
+++ b/src/rac/explorer/state.py
@@ -151,6 +151,28 @@ class RecommendationsState:
 
 
 @dataclass(frozen=True)
+class RelationshipLink:
+    """One edge in the knowledge graph, rendered for the terminal."""
+
+    kind: str  # e.g. "Related Decisions", "Supersedes"
+    label: str  # the connected artifact's title/id, or the raw reference text
+    target_path: str  # the artifact to navigate to ("" when unresolved)
+    navigable: bool
+
+
+@dataclass(frozen=True)
+class RelationshipsView:
+    """An artifact's relationships: outgoing edges, impact, and lineage."""
+
+    id: str
+    title: str | None
+    path: str
+    outgoing: tuple[RelationshipLink, ...]
+    impact: tuple[RelationshipLink, ...]  # what depends on this artifact
+    lineage: tuple[str, ...]  # Supersedes / Superseded By lines
+
+
+@dataclass(frozen=True)
 class ImportPreview:
     """A converted document awaiting confirmation before it is written."""
 

--- a/tests/test_explorer_adapter.py
+++ b/tests/test_explorer_adapter.py
@@ -411,6 +411,64 @@ def test_export_recommendations_empty_when_clean():
     assert adapter.export_recommendations() == "No recommendations to export"
 
 
+def test_relationships_view_outgoing_resolves_targets():
+    adapter = ExplorerAdapter(str(FIXTURES / "valid_clean"))
+    adapter.load()
+    assert adapter.repository is not None
+    [req] = adapter.repository.artifacts_of_type("requirement")
+    [adr] = adapter.repository.artifacts_of_type("decision")
+    view = adapter.relationships_view(req.path)
+    assert view is not None
+    [link] = view.outgoing
+    assert link.kind == "Related Decisions"
+    assert link.navigable and link.target_path == adr.path
+
+
+def test_relationships_view_impact_is_what_depends_on_this():
+    adapter = ExplorerAdapter(str(FIXTURES / "valid_clean"))
+    adapter.load()
+    assert adapter.repository is not None
+    [req] = adapter.repository.artifacts_of_type("requirement")
+    [adr] = adapter.repository.artifacts_of_type("decision")
+    view = adapter.relationships_view(adr.path)
+    assert view is not None
+    assert view.outgoing == ()  # the ADR declares no outgoing references
+    [dependent] = view.impact
+    assert dependent.target_path == req.path
+    assert dependent.navigable
+
+
+def test_relationships_view_marks_unresolved_targets():
+    adapter = ExplorerAdapter(str(FIXTURES / "broken_rels"))
+    adapter.load()
+    assert adapter.repository is not None
+    [artifact] = adapter.repository.artifacts
+    view = adapter.relationships_view(artifact.path)
+    assert view is not None
+    [link] = view.outgoing
+    assert not link.navigable
+    assert "✗" in link.label
+
+
+def test_relationships_view_impact_matches_model():
+    adapter = ExplorerAdapter(str(FIXTURES / "valid_clean"))
+    adapter.load()
+    assert adapter.repository is not None
+    for artifact in adapter.repository.artifacts:
+        view = adapter.relationships_view(artifact.path)
+        assert view is not None
+        expected = {
+            rel.source_path
+            for rel in adapter.repository.relationships
+            if rel.resolved_path == artifact.path
+        }
+        assert {link.target_path for link in view.impact} == expected
+
+
+def test_relationships_view_requires_a_load():
+    assert ExplorerAdapter(str(FIXTURES / "valid_clean")).relationships_view("x.md") is None
+
+
 def test_cancelled_load_returns_none_not_an_error():
     token = CancellationToken()
     adapter = ExplorerAdapter(str(FIXTURES / "all_types"))

--- a/tests/test_explorer_app.py
+++ b/tests/test_explorer_app.py
@@ -186,7 +186,7 @@ async def test_slash_help_lists_registry_and_esc_closes():
         await pilot.pause()
         assert isinstance(app.screen, CommandScreen)
         results = app.screen.query_one(OptionList)
-        assert results.option_count == 9  # the whole registry, nothing more
+        assert results.option_count == 10  # the whole registry, nothing more
         await pilot.press("escape")
         assert isinstance(app.screen, RepositoryScreen)
 
@@ -499,6 +499,46 @@ async def test_recommendations_export_previews_then_writes(tmp_path, monkeypatch
         written = (tmp_path / "recommendations.md").read_text(encoding="utf-8")
         assert "# Recommendations" in written
         assert "Imported" in str(app.screen.query_one("#confirm-panel", Static).content)
+
+
+@pytest.mark.asyncio
+async def test_context_g_opens_relationships_and_traverses():
+    from textual.widgets import Static
+
+    from rac.explorer.screens.context import ContextScreen
+    from rac.explorer.screens.relationships import RelationshipScreen
+
+    app = ExplorerApp(str(FIXTURES / "valid_clean"))
+    async with app.run_test() as pilot:
+        await _settled_panel_text(app, pilot)
+        await pilot.press("enter")  # home → browser
+        await pilot.press("enter")  # first artifact → context
+        assert isinstance(app.screen, ContextScreen)
+        await pilot.press("g")
+        await pilot.pause()
+        assert isinstance(app.screen, RelationshipScreen)
+        panel = str(app.screen.query_one("#relationship-panel", Static).content)
+        assert "Relationships" in panel and "Impact" in panel and "Lineage" in panel
+        # Traverse to a connected artifact, then back out.
+        await pilot.press("enter")
+        await pilot.pause()
+        assert isinstance(app.screen, ContextScreen)
+        await pilot.press("escape")
+        assert isinstance(app.screen, RelationshipScreen)
+
+
+@pytest.mark.asyncio
+async def test_slash_relationships_opens_for_resolved_ref():
+    from rac.explorer.screens.relationships import RelationshipScreen
+
+    app = ExplorerApp(str(FIXTURES / "valid_clean"))
+    async with app.run_test() as pilot:
+        await _settled_panel_text(app, pilot)
+        await pilot.press("/")
+        await pilot.press(*"relationships adr-001")
+        await pilot.press("enter")
+        await pilot.pause()
+        assert isinstance(app.screen, RelationshipScreen)
 
 
 @pytest.mark.asyncio

--- a/tests/test_explorer_commands.py
+++ b/tests/test_explorer_commands.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from rac.explorer.commands import EXAMPLES, REGISTRY, SEARCH, parse, suggestions
 
 
-def test_registry_is_the_v084_contract():
+def test_registry_is_the_v085_contract():
     assert [spec.name for spec in REGISTRY] == [
         "open",
         "find",
@@ -18,6 +18,7 @@ def test_registry_is_the_v084_contract():
         "health",
         "recommendations",
         "import",
+        "relationships",
         "home",
         "help",
         "quit",
@@ -27,10 +28,11 @@ def test_registry_is_the_v084_contract():
 
 def test_action_commands_are_discoverable():
     names = {spec.name for spec in REGISTRY}
-    assert {"health", "recommendations", "import"} <= names
+    assert {"health", "recommendations", "import", "relationships"} <= names
     assert parse("/recommendations").command == "recommendations"
     assert parse("import notes.pdf").command == "import"
     assert parse("import notes.pdf out.md").args == "notes.pdf out.md"
+    assert parse("relationships req-001").command == "relationships"
 
 
 def test_registered_command_routes_with_args():


### PR DESCRIPTION
# Summary

Implements `rac/roadmaps/v0.8.x-explorer/v0.8.5-explorer-relationship-navigation.md`.

Adds:

- A relationship view (`g` from a context view, or `/relationships <ref>`): an artifact's outgoing relationships, its impact ("what depends on this?"), and its lineage (Supersedes / Superseded By)
- Graph traversal — connected artifacts are selectable, opening their context view, from which `g` reopens relationships; `Esc` unwinds
- All rendered from the loaded repository model; Explorer infers nothing (ADR-016)

# Roadmap / ADR Trace

Roadmap: `rac/roadmaps/v0.8.x-explorer/v0.8.5-explorer-relationship-navigation.md` (contract pinned in the first commit)

Relevant ADRs and designs:

- ADR-015 — relationship intelligence stays in Core
- ADR-016 — relationships are authored in artifacts; Explorer reads, never edits or infers
- ADR-020 — the requirement → implements/constrains/expresses traceability graph
- DESIGN-knowledge-graph

# Scope

## Included

- `rac.explorer.state.RelationshipLink` / `RelationshipsView`; `ExplorerAdapter.relationships_view(path)` built from the model's `Relationship` objects
- `RelationshipScreen` — Relationships / Impact / Lineage sections plus a selectable list of connected (resolved) artifacts; `g` binding on the context view; `/relationships <ref>` routing (resolves the ref, then opens the view)

## Excluded (deliberately)

- Manual relationship editing or inference (ADR-016, ADR-015)
- Created/Updated lineage timestamps — not modelled by Core; lineage covers Supersedes / Superseded By only
- Any graphical canvas or web-style graph editor (Initiative 5) — terminal-readable text only
- No Core/service changes; no JSON contract movement

# Product / Architecture Decisions

- The view is derived entirely from `repository.relationships`: outgoing edges are relationships whose source is this artifact (resolved to a title, or marked `✗ unresolved`); impact is relationships whose resolved target is this artifact (the dependents); lineage filters `supersedes` in both directions. A test asserts the impact set equals the model's incoming-resolved references.
- Traceability (ADR-020) needs no separate engine — it is the same outgoing/incoming traversal followed from a requirement.
- The connected-artifact list is keyed by option index (a path can appear via several edges; OptionList ids must be unique), reusing the pattern from health/recommendations.
- `g` (context) and `/relationships <ref>` both open the same screen; the command resolves the ref with `rac resolve` semantics first, surfacing not-found / duplicate like `/open`.

# User-Facing Contract

## CLI / Keys

```bash
rac explorer
# context view:  g → relationships;  Enter on a connected artifact → its context → g → …
# /relationships adr-015
```

## Human Output (interactive)

```
ADR-015: Consumers before Interfaces

Relationships
  none declared

Impact (what depends on this)
  ← Explorer Command Surface (Related Decisions)
  ← Explorer Health (Related Decisions)

Lineage
  no recorded supersession
```

## JSON Output

No changes; no new contracts.

## Exit Codes

Unchanged: `0` session quit · `2` not a directory or missing `explorer` extra.

# Verification

## Ran

```bash
python -m pytest                      # 758 passed
python -m ruff check src/ tests/
python -m ruff format --check src/ tests/
python -m mypy src/
rac validate rac/                     # exit 0
rac relationships rac/ --validate     # exit 0
rac review rac/                       # no priority 1–2 findings
```

## Covered

- Adapter: outgoing resolves to the target artifact path; impact is the set of dependents (asserted equal to the model's incoming-resolved references for every artifact); unresolved targets are non-navigable and marked `✗`; None before a load
- Screens: `g` opens the relationship view (Relationships/Impact/Lineage sections), selecting a connected artifact opens its context view and `Esc` returns — traversal both ways; `/relationships <ref>` opens it for a resolved ref
- Registry: `relationships` discoverable; `/help` lists all 10 entries

# Review Path

1. `rac/roadmaps/v0.8.x-explorer/v0.8.5-explorer-relationship-navigation.md` — the pinned contract
2. `src/rac/explorer/adapter.py` — `relationships_view` (outgoing / impact / lineage derivation)
3. `src/rac/explorer/screens/relationships.py` — the screen and traversal
4. `src/rac/explorer/screens/context.py`, `commands.py`, `screens/command.py` — `g` binding and `/relationships`
5. `tests/` — adapter, app, commands
6. `docs/cli.md`, `CHANGELOG.md`

# Notes For Reviewer

- Stacked on v0.8.2–v0.8.4 (PRs #53–#55); until those merge this PR's diff also shows their commits. Merging in order narrows each.
- Closes the v0.8.1/v0.8.4 deferral of Open Related Artifact / Show Relationship Impact.

# Implementation Process

Implemented with AI assistance under the roadmap contract.

Final scope, review, and acceptance decisions were made by the maintainer.