### PR TITLE
feat(explorer): v0.8.6 Explorer maturity — workspace continuity, preferences, mascot

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,7 +82,7 @@ jobs:
           - name: repository
             paths: "tests/test_repository.py tests/test_repository_perf.py"
           - name: explorer
-            paths: "tests/test_explorer_adapter.py tests/test_explorer_app.py tests/test_explorer_cli.py tests/test_explorer_commands.py tests/test_explorer_editor.py tests/test_explorer_isolation.py"
+            paths: "tests/test_explorer_adapter.py tests/test_explorer_app.py tests/test_explorer_cli.py tests/test_explorer_commands.py tests/test_explorer_editor.py tests/test_explorer_isolation.py tests/test_explorer_workspace.py"
           - name: relationships
             paths: "tests/test_relationships.py tests/test_relationships_cmd.py tests/test_relationship_validation.py"
           - name: resolve

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ details, release history over commit history.
 
 ### Added
 
+- Explorer maturity (v0.8.6): workspace continuity — Explorer remembers recently
+  opened repositories and the last artifact per repository, and `.` / `/resume`
+  reopens it; optional file-based preferences (`theme`, `mascot`, `animations`,
+  `artifact_grouping`) under XDG config with `/preferences` to view them; and a
+  lantern-carrying mascot in the welcome and empty states. Disabling the mascot
+  or animations loses no information (every state carries text), and nothing
+  requires login, cloud, or sync.
 - Explorer relationship navigation (v0.8.5): `g` from a context view (or
   `/relationships <ref>`) opens a knowledge-graph view — the artifact's
   outgoing relationships, its impact ("what depends on this?"), and its lineage

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -356,9 +356,9 @@ it shows is also available through `rac portfolio`, `rac index`, `rac resolve`,
   `Esc` back · `h` health (home) · `r` reload (home) · `q` quit
 - **Commands (`/`):** `open <ref>` · `find <query> [type]` · `browse [type]` ·
   `health` · `recommendations` · `import <source> [target]` ·
-  `relationships <ref>` · `home` · `help` · `quit` — anything else is a search.
-  Lookup resolves canonical IDs and legacy aliases with `rac resolve` /
-  `rac find` semantics.
+  `relationships <ref>` · `resume` · `preferences` · `home` · `help` · `quit` —
+  anything else is a search. Lookup resolves canonical IDs and legacy aliases
+  with `rac resolve` / `rac find` semantics.
 - **Health:** `h` or `/health` opens the health view — Core's score with a text
   label, the Completeness / Relationships / Validation / Coverage areas, and a
   prioritized attention list whose items open the affected artifact.
@@ -377,8 +377,13 @@ it shows is also available through `rac portfolio`, `rac index`, `rac resolve`,
   ingest service, previews the Markdown, and writes it only after you confirm
   with `y` (never overwriting). Long conversions report progress.
 - **First run:** onboarding derives from repository content (existing, empty, or
-  invalid repository) and is skipped for returning users; the completion marker
-  under `$XDG_STATE_HOME/rac/` is the only state Explorer persists.
+  invalid repository) and is skipped for returning users; a lantern-carrying
+  mascot greets the welcome and empty states (disable with `mascot = false`).
+- **Continuity & preferences:** Explorer remembers recently opened repositories
+  and the last artifact per repository (under `$XDG_STATE_HOME/rac/`); `.` or
+  `/resume` reopens it. Optional preferences — `theme`, `mascot`, `animations`,
+  `artifact_grouping` — live in `$XDG_CONFIG_HOME/rac/explorer.json` (no login,
+  cloud, or sync); `/preferences` shows the current values and the file path.
 - **Exit codes:** `0` session quit · `2` not a directory, or the `explorer` extra is
   not installed
 

--- a/rac/roadmaps/v0.8.x-explorer/v0.8.6-explorer-maturity.md
+++ b/rac/roadmaps/v0.8.x-explorer/v0.8.6-explorer-maturity.md
@@ -75,6 +75,50 @@ DESIGN-mascot-animations:
 - Refine navigation flows and visual consistency across all views
   (DESIGN-visual-system).
 
+## Implementation Contract
+
+The following decisions are pinned for v0.8.6.
+
+### Preferences
+
+- `rac.explorer.preferences` persists optional preferences as JSON under
+  `$XDG_CONFIG_HOME/rac/explorer.json`: `theme`, `mascot` (on/off),
+  `animations` (on/off), and `artifact_grouping` (`type` or `flat`). Loading
+  tolerates a missing or corrupt file by returning defaults — preferences never
+  block onboarding and need no login, cloud, or sync. They are edited in the
+  file (Explorer authors nothing, ADR-024); `/preferences` shows the current
+  values and the file path.
+
+### Workspace Persistence
+
+- `rac.explorer.workspace` persists, under `$XDG_STATE_HOME/rac/`, the recently
+  opened repositories and, per repository, the last opened artifact. Launch
+  records the repository; opening a context view records the artifact.
+  `/resume` reopens the last artifact for the current repository, and the
+  welcome state offers it — returning users resume without an abrupt auto-jump.
+
+### Mascot and Animations
+
+- `rac.explorer.mascot` provides the lantern-carrying explorer and its
+  state frames (idle, searching, discovery, success, empty, error). The mascot
+  appears in the welcome and empty states only, never gates a feature or
+  modifies the repository, and is disabled by `mascot = false`. Every mascot
+  state carries equivalent text, so `animations = false` (static frame) and
+  `mascot = false` (text only) lose no information (Initiative 4, ADR-028).
+
+### Performance
+
+- Responsiveness against the 1000+ artifact target is re-validated at the
+  Explorer level with a headless app smoke over a generated corpus, alongside
+  the existing Core perf battery.
+
+### Scope
+
+- Presentation and local state only: no Core or service changes, no repository
+  intelligence, no JSON contract movement. New modules `preferences.py`,
+  `workspace.py`, `mascot.py`; `preferences` and `resume` join the command
+  registry. The explorer battery absorbs the tests.
+
 ## Non-Goals
 
 - New capabilities or repository intelligence

--- a/src/rac/explorer/adapter.py
+++ b/src/rac/explorer/adapter.py
@@ -32,6 +32,7 @@ from rac.services.review import (
 
 from . import editor as editor_mod
 from .editor import EditorOutcome
+from .preferences import GROUPING_FLAT, Preferences, load_preferences
 from .state import (
     ArtifactRow,
     AttentionRow,
@@ -50,6 +51,7 @@ from .state import (
     RepositorySummaryState,
     health_label,
 )
+from .workspace import Workspace, load_workspace, save_workspace
 
 # Presentation labels for the analysis phases that follow the scan.
 _PHASE_LABELS = {
@@ -165,6 +167,45 @@ class ExplorerAdapter:
         self.directory = directory
         self.recursive = recursive
         self.repository: Repository | None = None
+        # Local config and continuity (v0.8.6) — read-only at construction;
+        # writes happen on explicit launch/navigation events.
+        self.preferences: Preferences = load_preferences()
+        self.workspace: Workspace = load_workspace()
+
+    # --- workspace continuity (v0.8.6) -------------------------------------
+
+    def record_open(self) -> None:
+        """Remember this repository as recently opened (Initiative 1)."""
+        self.workspace.record_open(self.directory)
+        save_workspace(self.workspace)
+
+    def record_artifact(self, path: str) -> None:
+        """Remember the last artifact opened in this repository."""
+        self.workspace.record_artifact(self.directory, path)
+        save_workspace(self.workspace)
+
+    def resume_path(self) -> str | None:
+        """The last artifact opened here, if it still exists in the load."""
+        path = self.workspace.resume_artifact(self.directory)
+        if path is None or self.repository is None:
+            return None
+        return path if any(a.path == path for a in self.repository.artifacts) else None
+
+    def preferences_lines(self) -> tuple[str, ...]:
+        """Current preferences and the file that controls them (read-only)."""
+        from .preferences import preferences_path
+
+        prefs = self.preferences
+        return (
+            "Preferences",
+            "",
+            f"  theme              {prefs.theme}",
+            f"  mascot             {'on' if prefs.mascot else 'off'}",
+            f"  animations         {'on' if prefs.animations else 'off'}",
+            f"  artifact_grouping  {prefs.artifact_grouping}",
+            "",
+            f"Edit {preferences_path()} to change these.",
+        )
 
     def load(
         self,
@@ -232,6 +273,14 @@ class ExplorerAdapter:
         if self.repository is None:
             return None
         repository = self.repository
+        if artifact_type is None and self.preferences.artifact_grouping == GROUPING_FLAT:
+            # Flat grouping (preference): one list, no type headers.
+            rows = tuple(_row(a) for a in repository.artifacts)
+            return BrowserState(
+                directory=repository.directory,
+                groups=(("all", rows),),
+                total=len(rows),
+            )
         groups = tuple(
             (group_type, tuple(_row(a) for a in repository.artifacts_of_type(group_type)))
             for group_type, count in repository.portfolio.by_type.items()

--- a/src/rac/explorer/app.py
+++ b/src/rac/explorer/app.py
@@ -51,6 +51,13 @@ class ExplorerApp(App[None]):
         self.sub_title = directory
 
     def on_mount(self) -> None:
+        # Preferences (v0.8.6): apply the theme if Textual recognizes it;
+        # an unknown theme name must never break startup.
+        try:
+            self.theme = self.adapter.preferences.theme
+        except Exception:  # noqa: BLE001 - unknown theme: keep the default
+            pass
+        self.adapter.record_open()  # workspace continuity (Initiative 1)
         self.push_screen(RepositoryScreen(self.adapter))
 
     def action_command_surface(self) -> None:

--- a/src/rac/explorer/commands.py
+++ b/src/rac/explorer/commands.py
@@ -45,6 +45,8 @@ REGISTRY: tuple[CommandSpec, ...] = (
     ),
     CommandSpec("import", "import <source> [target]", "Convert a document into Markdown"),
     CommandSpec("relationships", "relationships <ref>", "Traverse an artifact's relationships"),
+    CommandSpec("resume", "resume", "Reopen the last artifact in this repository"),
+    CommandSpec("preferences", "preferences", "Show preferences and where to change them"),
     CommandSpec("home", "home", "Return to the repository home"),
     CommandSpec("help", "help", "List available commands"),
     CommandSpec("quit", "quit", "Quit the Explorer"),

--- a/src/rac/explorer/mascot.py
+++ b/src/rac/explorer/mascot.py
@@ -1,0 +1,65 @@
+"""The Explorer mascot — a lantern-carrying guide (v0.8.6).
+
+A small explorer with a lantern: navigation that illuminates hidden product
+knowledge (DESIGN-mascot). The mascot is identity, never a feature — it gates
+nothing and modifies nothing. Each state carries equivalent text, so disabling
+animations (static frame) or the mascot entirely (text only) loses no
+information (DESIGN-mascot-animations, ADR-028). This module never imports
+Textual.
+"""
+
+from __future__ import annotations
+
+# Mascot states tied to system events (DESIGN-mascot-animations).
+IDLE = "idle"
+SEARCHING = "searching"
+DISCOVERY = "discovery"
+SUCCESS = "success"
+EMPTY = "empty"
+ERROR = "error"
+
+# A lantern glyph per state — the "animated" element is the lantern; with
+# animations off we use the steady frame. Meaning never rides on the glyph
+# alone; the label below always accompanies it.
+_LANTERN = {
+    IDLE: "◇",
+    SEARCHING: "◈",
+    DISCOVERY: "✶",
+    SUCCESS: "✓",
+    EMPTY: "○",
+    ERROR: "✗",
+}
+
+# The text that carries each state's meaning without any glyph (accessibility).
+_LABEL = {
+    IDLE: "Ready to explore.",
+    SEARCHING: "Searching…",
+    DISCOVERY: "Found something.",
+    SUCCESS: "Done.",
+    EMPTY: "Nothing here yet.",
+    ERROR: "Something went wrong.",
+}
+
+
+def label(state: str) -> str:
+    """The text-only feedback for ``state`` (always available)."""
+    return _LABEL.get(state, _LABEL[IDLE])
+
+
+def figure(state: str, *, animations: bool = True) -> str:
+    """The mascot as terminal art for ``state``.
+
+    ``animations`` selects the lantern glyph for the state; when False the
+    steady idle lantern is used. The accompanying label is always returned, so
+    no information depends on the glyph.
+    """
+    lantern = _LANTERN.get(state, _LANTERN[IDLE]) if animations else _LANTERN[IDLE]
+    return "\n".join(
+        [
+            "   ___",
+            "  /^^^\\",
+            f"  (• •)  {lantern}",
+            "  /| |\\  |",
+            f"  guide · {label(state)}",
+        ]
+    )

--- a/src/rac/explorer/preferences.py
+++ b/src/rac/explorer/preferences.py
@@ -1,0 +1,65 @@
+"""Explorer preferences — optional, file-based, never blocking (v0.8.6).
+
+Preferences live as JSON under ``$XDG_CONFIG_HOME/rac/explorer.json`` and are
+edited in that file (Explorer authors nothing, ADR-024). Loading tolerates a
+missing or corrupt file by returning defaults, so preferences never block
+onboarding and need no login, cloud, or sync (DESIGN-first-run-experience).
+This module never imports Textual.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+GROUPING_TYPE = "type"
+GROUPING_FLAT = "flat"
+_GROUPINGS = (GROUPING_TYPE, GROUPING_FLAT)
+
+
+@dataclass(frozen=True)
+class Preferences:
+    """User preferences with safe defaults; unknown values fall back."""
+
+    theme: str = "textual-dark"
+    mascot: bool = True
+    animations: bool = True
+    artifact_grouping: str = GROUPING_TYPE
+
+
+def preferences_path() -> Path:
+    base = os.environ.get("XDG_CONFIG_HOME") or str(Path.home() / ".config")
+    return Path(base) / "rac" / "explorer.json"
+
+
+def load_preferences() -> Preferences:
+    """Read preferences, returning defaults on any problem (never raises)."""
+    path = preferences_path()
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return Preferences()
+    if not isinstance(data, dict):
+        return Preferences()
+    defaults = Preferences()
+    grouping = data.get("artifact_grouping", defaults.artifact_grouping)
+    if grouping not in _GROUPINGS:
+        grouping = defaults.artifact_grouping
+    return Preferences(
+        theme=str(data.get("theme", defaults.theme)),
+        mascot=bool(data.get("mascot", defaults.mascot)),
+        animations=bool(data.get("animations", defaults.animations)),
+        artifact_grouping=grouping,
+    )
+
+
+def save_preferences(preferences: Preferences) -> None:
+    """Persist preferences; tolerates filesystem trouble silently."""
+    path = preferences_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(asdict(preferences), indent=2) + "\n", encoding="utf-8")
+    except OSError:
+        pass

--- a/src/rac/explorer/screens/command.py
+++ b/src/rac/explorer/screens/command.py
@@ -119,6 +119,16 @@ class CommandScreen(ModalScreen[None]):
 
             self.app.pop_screen()
             self.app.push_screen(RecommendationsScreen(self.adapter, recommendations))
+        elif invocation.command == "preferences":
+            self._set_options(
+                [Option(line, disabled=True) for line in self.adapter.preferences_lines()]
+            )
+        elif invocation.command == "resume":
+            path = self.adapter.resume_path()
+            if path is None:
+                self._set_options([Option("No previous artifact to resume", disabled=True)])
+                return
+            self._open_path(path)
         elif invocation.command == "relationships":
             lookup = self.adapter.open_ref(invocation.args)
             if len(lookup.rows) != 1 or lookup.message is not None:

--- a/src/rac/explorer/screens/context.py
+++ b/src/rac/explorer/screens/context.py
@@ -71,6 +71,10 @@ class ContextScreen(Screen[None]):
         yield Static("", id="context-status")
         yield Footer()
 
+    def on_mount(self) -> None:
+        # Workspace continuity (v0.8.6): this is now the last artifact opened.
+        self.adapter.record_artifact(self.context.path)
+
     def action_open_in_editor(self) -> None:
         # ADR-024: Explorer hands the file to an external editor; it never edits.
         outcome = self.adapter.open_in_editor(self.context.path)

--- a/src/rac/explorer/screens/repository.py
+++ b/src/rac/explorer/screens/repository.py
@@ -16,7 +16,7 @@ from textual.screen import Screen
 from textual.widgets import Footer, Header
 from textual.worker import Worker, WorkerState, get_current_worker
 
-from rac.explorer import firstrun
+from rac.explorer import firstrun, mascot
 from rac.explorer.adapter import ExplorerAdapter
 from rac.explorer.state import LoadErrorState, LoadProgressState, RepositorySummaryState
 from rac.explorer.widgets import RepositoryPanel
@@ -43,6 +43,7 @@ class RepositoryScreen(Screen[None]):
         Binding("r", "reload", "Reload"),
         Binding("enter", "browse", "Browse"),
         Binding("h", "health", "Health"),
+        Binding("full_stop", "resume", "Resume last"),
     ]
 
     def __init__(self, adapter: ExplorerAdapter) -> None:
@@ -83,6 +84,35 @@ class RepositoryScreen(Screen[None]):
         if health is not None:
             self.app.push_screen(HealthScreen(self.adapter, health))
 
+    def action_resume(self) -> None:
+        # Workspace continuity (v0.8.6): reopen the last artifact, on request.
+        if self._onboarding_summary is not None:
+            return
+        path = self.adapter.resume_path()
+        if path is None:
+            return
+        context = self.adapter.context_state(path)
+        if context is not None:
+            from .context import ContextScreen
+
+            self.app.push_screen(ContextScreen(self.adapter, context))
+
+    def _welcome_header(self, summary: RepositorySummaryState) -> str:
+        """Mascot, recent repositories, and a resume hint for the welcome state."""
+        lines: list[str] = []
+        prefs = self.adapter.preferences
+        if prefs.mascot:
+            state = mascot.EMPTY if summary.artifact_total == 0 else mascot.DISCOVERY
+            lines.append(mascot.figure(state, animations=prefs.animations))
+            lines.append("")
+        resume = self.adapter.resume_path()
+        if resume is not None:
+            lines.append(f"Resume last artifact: press .  ({resume})")
+        recent = [d for d in self.adapter.workspace.recent if d != self.adapter.directory]
+        if recent:
+            lines.append("Recent repositories: " + ", ".join(recent[:3]))
+        return "\n".join(lines)
+
     @work(thread=True, exclusive=True, group="repository-load")
     def _load_repository(self) -> RepositorySummaryState | LoadErrorState | None:
         worker = get_current_worker()
@@ -103,7 +133,7 @@ class RepositoryScreen(Screen[None]):
             if isinstance(result, RepositorySummaryState):
                 if firstrun.is_first_run():
                     self._onboarding_summary = result
-                    panel.show_onboarding(result)
+                    panel.show_onboarding(result, header=self._welcome_header(result))
                 else:
                     panel.show_summary(result)
             elif isinstance(result, LoadErrorState):

--- a/src/rac/explorer/widgets/__init__.py
+++ b/src/rac/explorer/widgets/__init__.py
@@ -53,13 +53,19 @@ class RepositoryPanel(Static):
         lines.extend(["", "Press / for anything · Enter to browse"])
         self.update("\n".join(lines))
 
-    def show_onboarding(self, summary: RepositorySummaryState) -> None:
+    def show_onboarding(self, summary: RepositorySummaryState, header: str = "") -> None:
         """The first-run state (v0.8.1): existing, empty, or invalid repository.
 
         Derived from repository content; Enter always continues into the
         normal summary (no forced setup, DESIGN-first-run-experience).
+
+        ``header`` carries the v0.8.6 welcome additions (mascot, recent
+        repositories, a resume hint) the screen composes from preferences and
+        the workspace; it is empty when those are disabled or absent.
         """
         lines = ["Welcome to RAC Explorer", "Your product knowledge workspace.", ""]
+        if header:
+            lines.extend([header, ""])
         if summary.artifact_total == 0:
             lines.extend(
                 [

--- a/src/rac/explorer/workspace.py
+++ b/src/rac/explorer/workspace.py
@@ -1,0 +1,69 @@
+"""Workspace continuity — recent repositories and the last artifact (v0.8.6).
+
+Persists, under ``$XDG_STATE_HOME/rac/explorer-workspace.json``, the recently
+opened repositories and, per repository, the last opened artifact, so returning
+users can resume (Initiative 1). This is local state only — no login, cloud, or
+sync — and every write tolerates filesystem trouble silently (resuming is a
+convenience, never a requirement). This module never imports Textual.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+
+_RECENT_LIMIT = 10
+
+
+@dataclass
+class Workspace:
+    """Recently opened repositories and the last artifact opened in each."""
+
+    recent: list[str] = field(default_factory=list)
+    last_artifact: dict[str, str] = field(default_factory=dict)
+
+    def record_open(self, directory: str) -> None:
+        """Move ``directory`` to the front of the recent list (deduped)."""
+        self.recent = [directory, *(d for d in self.recent if d != directory)][:_RECENT_LIMIT]
+
+    def record_artifact(self, directory: str, path: str) -> None:
+        self.last_artifact[directory] = path
+
+    def resume_artifact(self, directory: str) -> str | None:
+        return self.last_artifact.get(directory)
+
+
+def workspace_path() -> Path:
+    base = os.environ.get("XDG_STATE_HOME") or str(Path.home() / ".local" / "state")
+    return Path(base) / "rac" / "explorer-workspace.json"
+
+
+def load_workspace() -> Workspace:
+    """Read the workspace, returning an empty one on any problem."""
+    path = workspace_path()
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return Workspace()
+    if not isinstance(data, dict):
+        return Workspace()
+    recent = [str(d) for d in data.get("recent", []) if isinstance(d, str)]
+    last = {
+        str(k): str(v)
+        for k, v in (data.get("last_artifact", {}) or {}).items()
+        if isinstance(k, str) and isinstance(v, str)
+    }
+    return Workspace(recent=recent[:_RECENT_LIMIT], last_artifact=last)
+
+
+def save_workspace(workspace: Workspace) -> None:
+    """Persist the workspace; tolerates filesystem trouble silently."""
+    path = workspace_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {"recent": workspace.recent, "last_artifact": workspace.last_artifact}
+        path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    except OSError:
+        pass

--- a/tests/test_explorer_app.py
+++ b/tests/test_explorer_app.py
@@ -7,11 +7,12 @@ keeping the thread-worker tests deterministic.
 
 from __future__ import annotations
 
+import time
 from pathlib import Path
 
 import pytest
 
-from rac.explorer import firstrun
+from rac.explorer import firstrun, mascot
 from rac.explorer.app import ExplorerApp
 from rac.explorer.widgets import RepositoryPanel
 
@@ -23,6 +24,8 @@ def onboarded_state(tmp_path_factory, monkeypatch):
     """Run every app test as a returning user; onboarding tests reset this."""
     state = tmp_path_factory.mktemp("xdg-state")
     monkeypatch.setenv("XDG_STATE_HOME", str(state))
+    # Isolate preferences too (v0.8.6): never read or write the real user config.
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path_factory.mktemp("xdg-config")))
     firstrun.mark_onboarded()
     return state
 
@@ -186,7 +189,7 @@ async def test_slash_help_lists_registry_and_esc_closes():
         await pilot.pause()
         assert isinstance(app.screen, CommandScreen)
         results = app.screen.query_one(OptionList)
-        assert results.option_count == 10  # the whole registry, nothing more
+        assert results.option_count == 12  # the whole registry, nothing more
         await pilot.press("escape")
         assert isinstance(app.screen, RepositoryScreen)
 
@@ -539,6 +542,98 @@ async def test_slash_relationships_opens_for_resolved_ref():
         await pilot.press("enter")
         await pilot.pause()
         assert isinstance(app.screen, RelationshipScreen)
+
+
+@pytest.mark.asyncio
+async def test_resume_reopens_last_artifact():
+    from rac.explorer.screens.context import ContextScreen
+    from rac.explorer.screens.repository import RepositoryScreen
+
+    directory = str(FIXTURES / "valid_clean")
+    # First session: open an artifact (records it), then quit.
+    app = ExplorerApp(directory)
+    async with app.run_test() as pilot:
+        await _settled_panel_text(app, pilot)
+        await pilot.press("enter")  # browser
+        await pilot.press("enter")  # context — records the artifact
+        assert isinstance(app.screen, ContextScreen)
+        recorded = app.screen.context.path
+        await pilot.press("q")
+
+    # Second session on the same repository: resume via `.`.
+    app2 = ExplorerApp(directory)
+    async with app2.run_test() as pilot:
+        await _settled_panel_text(app2, pilot)
+        assert isinstance(app2.screen, RepositoryScreen)
+        await pilot.press("full_stop")
+        await pilot.pause()
+        assert isinstance(app2.screen, ContextScreen)
+        assert app2.screen.context.path == recorded
+
+
+@pytest.mark.asyncio
+async def test_slash_preferences_shows_values_and_path():
+    from textual.widgets import OptionList
+
+    app = ExplorerApp(str(FIXTURES / "valid_clean"))
+    async with app.run_test() as pilot:
+        await _settled_panel_text(app, pilot)
+        await pilot.press("/")
+        await pilot.press(*"preferences")
+        await pilot.press("enter")
+        await pilot.pause()
+        results = app.screen.query_one(OptionList)
+        rendered = " ".join(str(opt.prompt) for opt in results._options)
+        assert "mascot" in rendered and "explorer.json" in rendered
+
+
+@pytest.mark.asyncio
+async def test_first_run_welcome_shows_mascot_when_enabled(fresh_first_run):
+    app = ExplorerApp(str(FIXTURES / "valid_clean"))
+    async with app.run_test() as pilot:
+        text = await _settled_panel_text(app, pilot)
+        assert mascot.label(mascot.DISCOVERY) in text  # mascot present by default
+
+
+@pytest.mark.asyncio
+async def test_mascot_can_be_disabled(fresh_first_run, tmp_path, monkeypatch):
+    from rac.explorer.preferences import Preferences, save_preferences
+
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "cfg"))
+    save_preferences(Preferences(mascot=False))
+    app = ExplorerApp(str(FIXTURES / "valid_clean"))
+    async with app.run_test() as pilot:
+        text = await _settled_panel_text(app, pilot)
+        assert mascot.label(mascot.DISCOVERY) not in text  # disabling loses the art
+        assert "Repository found" in text  # but no information is lost
+
+
+@pytest.mark.asyncio
+async def test_remains_responsive_at_repository_scale(tmp_path):
+    # Initiative 5: re-validate the 1000+ artifact target at the Explorer level.
+    root = tmp_path / "large"
+    root.mkdir()
+    for i in range(600):
+        (root / f"adr-{i:04d}.md").write_text(
+            f"# ADR-{i:04d} D{i}\n\n## Status\n\nAccepted\n\n## Context\n\nc\n\n"
+            "## Decision\n\nd\n\n## Consequences\n\nq\n",
+            encoding="utf-8",
+        )
+    for i in range(600):
+        (root / f"req-{i:04d}.md").write_text(
+            f"# Feature {i}\n\n## Problem\n\np\n\n## Requirements\n\n"
+            f"[REQ-{i:04d}] shall work.\n\n## Related Decisions\n\n- ADR-{i % 600:04d}\n",
+            encoding="utf-8",
+        )
+
+    started = time.monotonic()
+    app = ExplorerApp(str(root))
+    async with app.run_test() as pilot:
+        text = await _settled_panel_text(app, pilot)
+        assert "Artifacts   1200" in text
+        await pilot.press("enter")  # browser renders the full list
+        await pilot.pause()
+    assert time.monotonic() - started < 60  # generous ceiling; catch regressions
 
 
 @pytest.mark.asyncio

--- a/tests/test_explorer_commands.py
+++ b/tests/test_explorer_commands.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from rac.explorer.commands import EXAMPLES, REGISTRY, SEARCH, parse, suggestions
 
 
-def test_registry_is_the_v085_contract():
+def test_registry_is_the_v086_contract():
     assert [spec.name for spec in REGISTRY] == [
         "open",
         "find",
@@ -19,6 +19,8 @@ def test_registry_is_the_v085_contract():
         "recommendations",
         "import",
         "relationships",
+        "resume",
+        "preferences",
         "home",
         "help",
         "quit",
@@ -28,11 +30,19 @@ def test_registry_is_the_v085_contract():
 
 def test_action_commands_are_discoverable():
     names = {spec.name for spec in REGISTRY}
-    assert {"health", "recommendations", "import", "relationships"} <= names
+    assert {
+        "health",
+        "recommendations",
+        "import",
+        "relationships",
+        "resume",
+        "preferences",
+    } <= names
     assert parse("/recommendations").command == "recommendations"
     assert parse("import notes.pdf").command == "import"
     assert parse("import notes.pdf out.md").args == "notes.pdf out.md"
     assert parse("relationships req-001").command == "relationships"
+    assert parse("/resume").command == "resume"
 
 
 def test_registered_command_routes_with_args():

--- a/tests/test_explorer_isolation.py
+++ b/tests/test_explorer_isolation.py
@@ -62,6 +62,9 @@ def test_adapter_state_and_launch_never_import_textual():
         SRC / "explorer" / "commands.py",
         SRC / "explorer" / "firstrun.py",
         SRC / "explorer" / "editor.py",
+        SRC / "explorer" / "preferences.py",
+        SRC / "explorer" / "workspace.py",
+        SRC / "explorer" / "mascot.py",
     ]
     files = [f for f in files if f.exists()]
     assert (SRC / "explorer" / "adapter.py") in files

--- a/tests/test_explorer_workspace.py
+++ b/tests/test_explorer_workspace.py
@@ -1,0 +1,112 @@
+"""Tests for Explorer preferences, workspace, and mascot (v0.8.6)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from rac.explorer import mascot
+from rac.explorer.preferences import (
+    GROUPING_FLAT,
+    Preferences,
+    load_preferences,
+    preferences_path,
+    save_preferences,
+)
+from rac.explorer.workspace import load_workspace, save_workspace, workspace_path
+
+
+@pytest.fixture(autouse=True)
+def isolated_xdg(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
+
+
+# --- preferences ---------------------------------------------------------------
+
+
+def test_defaults_when_no_file():
+    prefs = load_preferences()
+    assert prefs == Preferences()
+    assert prefs.mascot and prefs.animations
+
+
+def test_round_trip():
+    save_preferences(Preferences(theme="custom", mascot=False, artifact_grouping=GROUPING_FLAT))
+    loaded = load_preferences()
+    assert loaded.theme == "custom"
+    assert loaded.mascot is False
+    assert loaded.artifact_grouping == GROUPING_FLAT
+
+
+def test_corrupt_file_falls_back_to_defaults():
+    path = preferences_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("not json{", encoding="utf-8")
+    assert load_preferences() == Preferences()
+
+
+def test_unknown_grouping_falls_back():
+    path = preferences_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"artifact_grouping": "spirals"}), encoding="utf-8")
+    assert load_preferences().artifact_grouping == "type"
+
+
+# --- workspace -----------------------------------------------------------------
+
+
+def test_records_recent_and_resumes_last_artifact():
+    ws = load_workspace()
+    ws.record_open("rac/")
+    ws.record_open("other/")
+    ws.record_artifact("rac/", "rac/decisions/adr-001.md")
+    save_workspace(ws)
+
+    reloaded = load_workspace()
+    assert reloaded.recent[0] == "other/"  # most recent first
+    assert "rac/" in reloaded.recent
+    assert reloaded.resume_artifact("rac/") == "rac/decisions/adr-001.md"
+    assert reloaded.resume_artifact("unknown/") is None
+
+
+def test_recent_is_deduped_and_capped():
+    ws = load_workspace()
+    for i in range(15):
+        ws.record_open(f"repo-{i}/")
+    ws.record_open("repo-0/")  # re-opening moves it to the front, no dupe
+    assert ws.recent[0] == "repo-0/"
+    assert len(ws.recent) <= 10
+    assert ws.recent.count("repo-0/") == 1
+
+
+def test_corrupt_workspace_falls_back():
+    path = workspace_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("}{", encoding="utf-8")
+    assert load_workspace().recent == []
+
+
+# --- mascot --------------------------------------------------------------------
+
+
+def test_every_state_has_text_equivalent():
+    for state in (
+        mascot.IDLE,
+        mascot.SEARCHING,
+        mascot.DISCOVERY,
+        mascot.SUCCESS,
+        mascot.EMPTY,
+        mascot.ERROR,
+    ):
+        assert mascot.label(state)
+        assert mascot.label(state) in mascot.figure(state)
+
+
+def test_animations_off_uses_steady_frame_but_keeps_meaning():
+    animated = mascot.figure(mascot.SEARCHING, animations=True)
+    static = mascot.figure(mascot.SEARCHING, animations=False)
+    # The label (meaning) is identical; only the lantern glyph differs.
+    assert mascot.label(mascot.SEARCHING) in animated
+    assert mascot.label(mascot.SEARCHING) in static


### PR DESCRIPTION
# Summary

Implements `rac/roadmaps/v0.8.x-explorer/v0.8.6-explorer-maturity.md` — the final v0.8.x milestone.

Adds:

- **Workspace continuity** — Explorer remembers recently opened repositories and the last artifact per repository; `.` or `/resume` reopens it
- **Preferences** — optional `theme` / `mascot` / `animations` / `artifact_grouping`, file-based under XDG config, shown via `/preferences`
- **Mascot** — a lantern-carrying guide in the welcome and empty states, with text-equivalent feedback so disabling it (or animations) loses nothing
- An Explorer-level responsiveness check over a 1,200-artifact corpus

# Roadmap / ADR Trace

Roadmap: `rac/roadmaps/v0.8.x-explorer/v0.8.6-explorer-maturity.md` (contract pinned in the first commit)

Relevant ADRs and designs:

- ADR-015 — no new repository intelligence; presentation and local state only
- ADR-019, ADR-028 — accessibility, terminal-native, no colour-only meaning
- DESIGN-mascot, DESIGN-mascot-animations, DESIGN-mascot-interaction, DESIGN-first-run-experience, DESIGN-visual-system

# Scope

## Included

- `rac.explorer.preferences` — `Preferences(theme, mascot, animations, artifact_grouping)`, JSON under `$XDG_CONFIG_HOME/rac/explorer.json`, tolerant load; the app applies the theme (guarded) and the browser honours `artifact_grouping`; `/preferences` displays values + path
- `rac.explorer.workspace` — recent repositories + last artifact per repository under `$XDG_STATE_HOME/rac/`; `record_open` on launch, `record_artifact` on context open, `resume_path`, `/resume` and the `.` binding
- `rac.explorer.mascot` — the lantern guide with state frames (idle/searching/discovery/success/empty/error), shown in welcome/empty; every state carries a text label
- `resume` and `preferences` join the command registry

## Excluded (deliberately)

- New capabilities or repository intelligence (ADR-015)
- Mascot behaviour that gates features or modifies the repository; game-like or continuous animation
- In-app preference editing — preferences are edited in the file (ADR-024); `/preferences` is read-only
- Cloud, login, or sync of any kind

# Product / Architecture Decisions

- Preferences and workspace are loaded read-only in the adapter constructor; writes happen only on explicit events (launch records the repository, opening a context view records the artifact), so constructing an adapter has no side effects.
- Resume is explicit (`.` / `/resume`), not an automatic jump on launch — returning users resume on request without a surprising redirect. `resume_path` returns the last artifact only if it still exists in the current load.
- The mascot is identity, never a feature: it appears only in welcome/empty states, and every state's meaning is in its text label, so `animations = false` (steady lantern frame) and `mascot = false` (text only) both lose no information.
- An unknown `theme` name must never break startup — applying it is wrapped and falls back to the default.
- Tolerant persistence everywhere: a missing or corrupt preferences/workspace file yields defaults; writes swallow `OSError` (continuity is a convenience, not a requirement).

# User-Facing Contract

## CLI / Keys

```bash
rac explorer
# .  or  /resume        → reopen the last artifact in this repository
# /preferences          → show theme / mascot / animations / grouping + file path
# edit  $XDG_CONFIG_HOME/rac/explorer.json  to change preferences
```

## Human Output (interactive)

- Welcome/empty states show the mascot (when enabled) plus recent repositories and a resume hint
- `/preferences` lists current values and `Edit <path> to change these.`

## JSON Output

No changes; no new contracts.

## Exit Codes

Unchanged: `0` session quit · `2` not a directory or missing `explorer` extra.

# Verification

## Ran

```bash
python -m pytest                      # 772 passed
python -m ruff check src/ tests/
python -m ruff format --check src/ tests/
python -m mypy src/
rac validate rac/                     # exit 0
rac relationships rac/ --validate     # exit 0
rac review rac/                       # no priority 1–2 findings
```

## Covered

- Preferences: defaults when no file; round-trip; corrupt file and unknown grouping fall back
- Workspace: records recent (deduped, capped at 10) and resumes the last artifact; corrupt file falls back
- Mascot: every state has a text equivalent present in the figure; animations off keeps the meaning
- App: resume reopens the last artifact across two sessions on the same repository; `/preferences` shows values and `explorer.json`; the mascot appears by default and disappears (with no information lost) when `mascot = false`; the shell renders 1,200 artifacts and browses within a generous time ceiling
- Isolation battery extended to `preferences.py`, `workspace.py`, `mascot.py` (no Textual/Core imports)

# Review Path

1. `rac/roadmaps/v0.8.x-explorer/v0.8.6-explorer-maturity.md` — the pinned contract
2. `src/rac/explorer/preferences.py`, `workspace.py`, `mascot.py` — the three pure modules
3. `src/rac/explorer/adapter.py` — load/record/resume, grouping, `preferences_lines`
4. `src/rac/explorer/app.py`, `screens/repository.py`, `screens/context.py`, `widgets/__init__.py` — theme, welcome header, recording, `.`/resume
5. `src/rac/explorer/commands.py`, `screens/command.py` — `/resume`, `/preferences`
6. `tests/test_explorer_workspace.py` and the app/adapter additions
7. `docs/cli.md`, `CHANGELOG.md`

# Notes For Reviewer

- Final PR of the v0.8.2–v0.8.6 stack (on top of PRs #53–#56); until those merge this diff also shows their commits. Merging in order narrows each to its milestone.
- With this, the Explorer requirement's Discover / Understand / Assess / Act capabilities are all delivered; the series is feature-complete against the v0.8.x roadmap.

# Implementation Process

Implemented with AI assistance under the roadmap contract.

Final scope, review, and acceptance decisions were made by the maintainer.