### PR TITLE
docs(roadmap): capture deferred Explorer follow-ups

### DIFF
--- a/rac/roadmaps/future/explorer-followups.md
+++ b/rac/roadmaps/future/explorer-followups.md
@@ -1,0 +1,52 @@
+# Explorer Follow-ups (deferred from v0.8.x)
+
+Informal scoping note. Two design decisions were made deliberately during the
+v0.8.x Explorer series and flagged for a later pass. Captured here so they are
+not lost; neither is a defect.
+
+## 1. Recommendation "impact" copy lives in Explorer, not Core
+
+Deferred from v0.8.3 (recommendations).
+
+Today each recommendation's *impact* line ("why it matters") is fixed
+presentation copy keyed by the Core finding code, held in
+`rac.explorer.adapter` alongside the other display labels. The finding,
+severity, action, and path all come from Core's review service; only the
+impact sentence is Explorer-authored.
+
+This kept v0.8.3 presentation-only and avoided changing a JSON contract the
+roadmap did not call for. The trade-off: a CLI/JSON consumer of `rac review`
+does not see the impact text, and the copy is not validated as corpus content.
+
+Follow-up option: add an additive `impact` field to `ReviewIssue` (a versioned
+JSON-contract change, ADR-007), with Core owning the per-code text. Explorer
+would then render Core's impact rather than its own. Worth doing if the review
+service grows or another consumer needs impact.
+
+## 2. Editor preference persistence and terminal-editor support
+
+Deferred from v0.8.4 (action workflows) and v0.8.6 (preferences).
+
+`rac explorer` resolves the editor from `$VISUAL` / `$EDITOR` and launches it
+fire-and-forget (`Popen`), which suits GUI editors (Cursor, VS Code, …) per
+DESIGN-editor-integration. Two pieces were left out:
+
+- A persisted editor preference and first-run editor selection. The
+  preferences file (v0.8.6) already has a home for it
+  (`$XDG_CONFIG_HOME/rac/explorer.json`); adding an `editor` key plus a
+  first-run prompt is the natural extension.
+- Terminal editors (vim, neovim, emacs -nw) that need the TUI suspended while
+  the editor owns the terminal, then resumed on exit. This requires
+  `App.suspend()` handling and is a larger interaction change than the
+  fire-and-forget GUI path.
+
+Follow-up option: extend `rac.explorer.preferences` with an `editor` setting
+and offer it during first run; add a suspend/resume path for terminal editors
+behind editor-type detection.
+
+## References
+
+- rac/roadmaps/v0.8.x-explorer/v0.8.3-explorer-recommendations.md
+- rac/roadmaps/v0.8.x-explorer/v0.8.4-explorer-action-workflow.md
+- rac/roadmaps/v0.8.x-explorer/v0.8.6-explorer-maturity.md
+- rac/designs/explorer-editor-integrations.md


### PR DESCRIPTION
# Summary

Captures, as an informal future-scoping note under `rac/roadmaps/future/`, two design decisions made deliberately during the v0.8.x Explorer series and flagged for a later pass. Neither is a defect; this is housekeeping so the follow-ups are tracked rather than buried in merged PR descriptions (#54, #55).

# What it records

1. **Recommendation "impact" copy lives in Explorer, not Core** (deferred from v0.8.3). The impact sentence is Explorer-authored presentation copy keyed by the Core finding code; finding/severity/action/path all come from Core's review service. Follow-up option noted: add an additive `impact` field to `ReviewIssue` (a versioned JSON-contract change, ADR-007) so Core owns it and CLI/JSON consumers see it.
2. **Editor preference persistence + terminal-editor support** (deferred from v0.8.4 / v0.8.6). The editor is resolved from `$VISUAL`/`$EDITOR` and launched fire-and-forget (GUI editors). Follow-up options noted: a persisted `editor` preference + first-run selection (the v0.8.6 preferences file already has a home for it), and TUI suspend/resume for terminal editors.

# Verification

- The note classifies as `unknown` (confidence 0.0), exactly like the existing `rac/roadmaps/future/` notes, so it is skipped by validation and disturbs no contract.
- `rac validate rac/` exit 0 · `rac relationships rac/ --validate` exit 0 · `rac review rac/` no priority 1–2 findings · `tests/test_dogfood.py` passes.

# Notes For Reviewer

- Single doc file; no code, no behavior change.
- Branched off `main` after the full v0.8.x series merged — standalone, not stacked.

# Implementation Process

Implemented with AI assistance.

Final scope, review, and acceptance decisions were made by the maintainer.