### PR TITLE
feat(review): v0.8.11 — Core-owned impact text and the first-run editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ details, release history over commit history.
 
 ### Added
 
+- Review impact and the first-run editor (v0.8.11): every `rac review`
+  finding now carries an `impact` sentence — why it matters — owned by Core
+  and present in the JSON contract (additive field; `schema_version`
+  unchanged), so the CLI, automation, and the Explorer all read identical
+  text. Explorer onboarding gains one optional editor step after the
+  welcome: Enter accepts (an empty value keeps the `$VISUAL`/`$EDITOR`
+  fallback), typing persists the `editor` preference, Esc skips — and
+  returning users never see it.
+
 - Explorer creation, stats, and the directory view (v0.8.10): the sidebar
   now mirrors the repository's actual directory structure by default —
   directories as collapsible nodes (name, trailing `/`, artifact count),

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -277,10 +277,13 @@ Findings are grouped by priority, highest impact first:
 | 4 | Missing recommended information | no — advisory |
 
 Every finding carries a concrete suggested action (`rac validate <file>`,
-`rac relationships <dir> --validate`, `rac improve <file> --template`, …), and
+`rac relationships <dir> --validate`, `rac improve <file> --template`, …) and
+an `impact` sentence explaining why it matters (additive in v0.8.11), and
 the report ends with the same health score `portfolio` computes. The `--json`
 form is a stable contract (`schema_version: "1"`) with `ok`, `artifacts`,
-`validation`, `relationships`, `health`, `issues[]`, and `actions[]`.
+`validation`, `relationships`, `health`, `issues[]` (each with `priority`,
+`severity`, `path`, `identifier`, `code`, `message`, `action`, `impact`),
+and `actions[]`.
 
 `review` composes the same analysis `portfolio` runs; use `portfolio` for a
 one-screen summary and `review` when you want the prioritized worklist.
@@ -436,6 +439,9 @@ it shows is also available through `rac portfolio`, `rac index`, `rac resolve`,
   invalid repository) and is skipped for returning users; a lantern-carrying
   mascot animates in the welcome, empty, and loading states (static with
   `animations = off`, hidden with `mascot = off` — no information is lost).
+  One optional editor step follows the welcome: Enter accepts (an empty
+  value keeps the `$VISUAL`/`$EDITOR` fallback), typing sets the `editor`
+  preference, Esc skips — `/settings` can change it any time.
 - **Settings & continuity:** `/settings` changes everything in place — theme
   (default `rac-lantern`; Enter cycles every Textual theme with live
   preview), mascot, animations, artifact grouping (`folders` default), and

--- a/rac/roadmaps/future/explorer-followups.md
+++ b/rac/roadmaps/future/explorer-followups.md
@@ -6,6 +6,10 @@ not lost; neither is a defect.
 
 ## 1. Recommendation "impact" copy lives in Explorer, not Core
 
+**Scoped into v0.8.11** (explorer-followups): `ReviewIssue` gains an
+additive `impact` field owned by Core; the Explorer renders it and drops
+its own copy.
+
 Deferred from v0.8.3 (recommendations).
 
 Today each recommendation's *impact* line ("why it matters") is fixed
@@ -25,10 +29,10 @@ service grows or another consumer needs impact.
 
 ## 2. Editor preference persistence and terminal-editor support
 
-**Landing in v0.8.8** (explorer-command-palette): the `editor` preference in
+**Landed in v0.8.8** (explorer-command-palette): the `editor` preference in
 `/settings` with preference → `$VISUAL` → `$EDITOR` resolution, and a
-suspend/resume path for terminal editors. The first-run editor prompt
-remains deferred.
+suspend/resume path for terminal editors. The remaining piece — the
+first-run editor prompt — is **scoped into v0.8.11** (explorer-followups).
 
 Deferred from v0.8.4 (action workflows) and v0.8.6 (preferences).
 
@@ -51,6 +55,7 @@ behind editor-type detection.
 
 ## References
 
+- rac/roadmaps/v0.8.x-explorer/v0.8.11-explorer-followups.md
 - rac/roadmaps/v0.8.x-explorer/v0.8.3-explorer-recommendations.md
 - rac/roadmaps/v0.8.x-explorer/v0.8.4-explorer-action-workflow.md
 - rac/roadmaps/v0.8.x-explorer/v0.8.6-explorer-maturity.md

--- a/rac/roadmaps/v0.8.x-explorer/v0.8.11-explorer-followups.md
+++ b/rac/roadmaps/v0.8.x-explorer/v0.8.11-explorer-followups.md
@@ -1,0 +1,143 @@
+---
+schema_version: 1
+id: RAC-KTW06NWH56R9
+type: roadmap
+---
+# RAC v0.8.11 — Explorer Follow-ups: Core-Owned Impact and First-Run Editor
+
+## Status
+
+Planned
+
+## Context
+
+Two deliberate deferrals from the v0.8.x series are recorded in
+`rac/roadmaps/future/explorer-followups.md`; with the workspace, command
+surface, live reload, and creation flows complete (v0.8.7–v0.8.10), this
+item retires both.
+
+First, every recommendation's *impact* sentence ("why it matters") is
+Explorer-authored presentation copy in `rac.explorer.adapter`, keyed by
+Core's finding codes. That kept v0.8.3 presentation-only, but it leaves
+`rac review` JSON consumers without impact text and the copy outside the
+validated corpus. The fix follows ADR-015's own ordering — service, then
+CLI, then JSON, then Explorer: Core owns the impact text on `ReviewIssue`,
+and the Explorer renders it instead of its own.
+
+Second, the editor preference and terminal-editor support landed in v0.8.8,
+but a fresh user is never offered an editor: onboarding is a welcome screen
+only, and the preference hides in `/settings`. The first-run prompt the
+deferral note called for closes the loop.
+
+## Outcomes
+
+- Impact text becomes repository intelligence: every `rac review` consumer
+  — JSON, CLI, CI, the Explorer — reads the same Core-owned "why it
+  matters" sentence for a finding.
+- The Explorer carries no finding copy of its own; the adapter renders
+  Core's fields verbatim (ADR-015 fully honored for recommendations).
+- A first-run user leaves onboarding with a working editor: prompted once,
+  prefilled from the environment, skippable, persisted — and never asked
+  again.
+
+## Initiatives
+
+### Initiative 1 — Core-Owned Impact Text
+
+`ReviewIssue` gains an additive `impact` field with Core-owned per-code
+text, carried through `to_dict` as an additive JSON-contract change
+(ADR-007; `schema_version` stays 1 — fields are additive and gated). The
+review service's human rendering may surface it where useful; the Explorer
+adapter deletes its `_IMPACT` table and renders Core's sentence. Unknown
+codes carry a generic impact in Core, so the field is always present.
+
+### Initiative 2 — First-Run Editor Prompt
+
+Onboarding gains one optional step after the welcome: an editor prompt
+prefilled from `$VISUAL` / `$EDITOR`, where Enter accepts (an empty value
+keeps the environment fallback), editing the line sets the preference, and
+Esc skips. The choice persists through the existing `save_preferences`
+path; returning users — anyone past first run — never see the step.
+`/settings` remains the place to change it later.
+
+## Implementation Contract
+
+The following decisions are pinned for v0.8.11.
+
+### Impact
+
+- `rac.services.review.ReviewIssue` gains `impact: str`; the per-code text
+  moves from `rac.explorer.adapter._IMPACT` to the review service, with a
+  generic sentence for unrecognized codes. `to_dict` adds the key —
+  additive only; no existing field changes, no schema_version bump.
+- The Explorer adapter's `_recommendation` reads `issue.impact`; the
+  `_IMPACT` table is deleted (clean break, ADR-023). Golden files and JSON
+  contract tests absorb the new key.
+
+### First-run prompt
+
+- The prompt is one onboarding state owned by the home view (no new
+  screens); it appears only when `firstrun.is_first_run()` and writes only
+  `explorer.json` (ADR-024). Resolution display reuses
+  `editor.resolve_editor`; an accepted empty value stores `""` (the
+  environment fallback), matching `/settings` semantics.
+
+### Scope
+
+- No new dependencies. The review JSON change is the only Core movement;
+  it is additive and documented in the CLI reference. Explorer battery and
+  review/golden batteries absorb all tests.
+
+## Non-Goals
+
+- Changing impact severities, priorities, codes, or actions — only the
+  impact sentence moves.
+- A schema_version bump — the field is additive (ADR-007).
+- Editor validation or detection beyond what v0.8.8 shipped — the prompt
+  stores a command, it does not verify one.
+- Re-prompting existing users — the first-run marker already gates it.
+
+## Success Measures
+
+- `rac review --json` carries an `impact` for every issue, and the
+  Explorer shows byte-identical impact text to the JSON output.
+- `grep _IMPACT src/rac/explorer/` finds nothing.
+- A fresh user who accepts the prompt has `editor` persisted in
+  `explorer.json` and `e` works immediately; a user who skips sees the
+  same behavior as today.
+
+## Assumptions
+
+- The review service remains the single producer of findings; no other
+  consumer holds finding copy that would also need moving.
+- The first-run marker (`explorer-first-run`) remains the onboarding gate.
+
+## Risks
+
+- Golden-file churn: adding a JSON key touches review goldens; the change
+  is mechanical but must be reviewed as contract movement, not noise.
+- Impact copy becomes API: once in JSON, wording changes are observable to
+  consumers; text edits should be deliberate.
+- An onboarding step risks friction; one prefilled, skippable line bounds
+  it, and Esc preserves today's behavior exactly.
+
+## Related Decisions
+
+- ADR-007
+- ADR-015
+- ADR-023
+- ADR-024
+
+## Related Designs
+
+- explorer-recommendations
+- explorer-editor-integrations
+- explorer-first-run-experience
+
+## Related Requirements
+
+- rac-product-knowledge-navigator-explorer
+
+## Dependencies
+
+- v0.8.10 explorer creation, stats, and directory view

--- a/src/rac/explorer/adapter.py
+++ b/src/rac/explorer/adapter.py
@@ -128,19 +128,6 @@ _SEVERITY_LABEL = {
     "info": "· Suggestion",
 }
 
-# "Why it matters" — fixed presentation copy keyed by the Core finding code
-# (display text, like the status and phase labels; not analysis).
-_IMPACT = {
-    ATTENTION_INVALID: "The artifact fails its schema, so tooling and validation cannot trust it.",
-    ATTENTION_BROKEN_RELATIONSHIP: (
-        "A declared reference does not resolve, leaving traceability incomplete."
-    ),
-    ATTENTION_MISSING_RECOMMENDED: (
-        "Recommended sections are empty, weakening the artifact's completeness."
-    ),
-    REVIEW_UNKNOWN_ARTIFACT: "No schema matched, so required structure cannot be checked.",
-}
-
 
 def _recommendation(issue: ReviewIssue) -> RecommendationRow:
     return RecommendationRow(
@@ -149,7 +136,8 @@ def _recommendation(issue: ReviewIssue) -> RecommendationRow:
         category=_CODE_CATEGORY.get(issue.code, "Quality"),
         severity_label=_SEVERITY_LABEL.get(issue.severity, issue.severity),
         finding=issue.message,
-        impact=_IMPACT.get(issue.code, "This finding affects repository quality."),
+        # Core owns the impact sentence (v0.8.11) — the adapter renders it.
+        impact=issue.impact,
         action=issue.action,
     )
 

--- a/src/rac/explorer/widgets/__init__.py
+++ b/src/rac/explorer/widgets/__init__.py
@@ -111,6 +111,27 @@ class RepositoryPanel(Static):
             )
         self.update("\n".join(lines))
 
+    def show_editor_prompt(self, resolved: str | None) -> None:
+        """The optional first-run editor step (v0.8.11).
+
+        One prefilled, skippable line: Enter accepts (empty keeps the
+        $VISUAL/$EDITOR fallback), typing sets the preference, Esc skips —
+        `/settings` can change it any time (DESIGN-editor-integration).
+        """
+        detected = f"Detected from environment: {resolved}" if resolved else "None detected"
+        self.update(
+            "\n".join(
+                [
+                    "Choose your editor",
+                    "",
+                    "  `e` opens artifacts in your own editor.",
+                    f"  {detected}",
+                    "",
+                    "  Enter accepts · type a command to set one · Esc skips",
+                ]
+            )
+        )
+
     def show_error(self, error: LoadErrorState) -> None:
         lines = [f"✗ {error.title}", "", error.detail]
         if error.can_retry:

--- a/src/rac/explorer/widgets/views.py
+++ b/src/rac/explorer/widgets/views.py
@@ -242,6 +242,8 @@ class HomeView(Vertical):
         # The summary held back while first-run onboarding is on screen;
         # Enter dismisses onboarding and reveals it (no forced setup).
         self._onboarding_summary: RepositorySummaryState | None = None
+        # The optional editor step between welcome and summary (v0.8.11).
+        self._prompting_editor = False
         self._mascot_state: str | None = None
         self._mascot_frame = 0
 
@@ -250,6 +252,12 @@ class HomeView(Vertical):
         art.display = False
         yield art
         yield RepositoryPanel(id="repository-panel")
+        editor_input = Input(
+            placeholder="Editor command, e.g. code or vim — empty keeps $VISUAL/$EDITOR",
+            id="firstrun-editor",
+        )
+        editor_input.display = False
+        yield editor_input
 
     def on_mount(self) -> None:
         self.set_interval(0.6, self._tick_mascot)
@@ -331,13 +339,41 @@ class HomeView(Vertical):
 
     def action_continue(self) -> None:
         if self._onboarding_summary is not None:
-            summary, self._onboarding_summary = self._onboarding_summary, None
-            firstrun.mark_onboarded()
-            self.remove_class("welcome")
-            self.panel.show_summary(summary)
-            self._mascot_for_summary(summary)
+            if not self._prompting_editor:
+                # The optional editor step (v0.8.11): one prefilled,
+                # skippable line between the welcome and the summary.
+                self._prompting_editor = True
+                self.panel.show_editor_prompt(editor_mod.resolve_editor(""))
+                field = self.query_one("#firstrun-editor", Input)
+                field.display = True
+                field.focus()
             return
         self.post_message(BrowseRequested())
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        event.stop()
+        # Enter accepts: an empty value stores "" — the $VISUAL/$EDITOR
+        # fallback — matching /settings semantics (ADR-024: explorer.json only).
+        self.adapter.save_preferences(replace(self.adapter.preferences, editor=event.value.strip()))
+        self._finish_onboarding()
+
+    def on_key(self, event: events.Key) -> None:
+        # Esc skips the editor step without writing anything; today's
+        # behavior exactly. Only intercepted while the prompt is up.
+        if event.key == "escape" and self._prompting_editor:
+            event.stop()
+            self._finish_onboarding()
+
+    def _finish_onboarding(self) -> None:
+        summary, self._onboarding_summary = self._onboarding_summary, None
+        self._prompting_editor = False
+        self.query_one("#firstrun-editor", Input).display = False
+        firstrun.mark_onboarded()
+        self.remove_class("welcome")
+        self.focus()
+        if summary is not None:
+            self.panel.show_summary(summary)
+            self._mascot_for_summary(summary)
 
 
 class ContextView(Vertical):

--- a/src/rac/services/review.py
+++ b/src/rac/services/review.py
@@ -47,6 +47,27 @@ _ATTENTION_PRIORITY = {
     ATTENTION_MISSING_RECOMMENDED: PRIORITY_MISSING_RECOMMENDED,
 }
 
+# "Why it matters" per finding code (v0.8.11) — Core owns the impact text so
+# every consumer (JSON, CLI, Explorer) reads the same sentence. Moved here
+# from the Explorer adapter; an unrecognized code gets the generic sentence,
+# so the field is always present.
+_GENERIC_IMPACT = "This finding affects repository quality."
+_IMPACT = {
+    ATTENTION_INVALID: "The artifact fails its schema, so tooling and validation cannot trust it.",
+    ATTENTION_BROKEN_RELATIONSHIP: (
+        "A declared reference does not resolve, leaving traceability incomplete."
+    ),
+    ATTENTION_MISSING_RECOMMENDED: (
+        "Recommended sections are empty, weakening the artifact's completeness."
+    ),
+    REVIEW_UNKNOWN_ARTIFACT: "No schema matched, so required structure cannot be checked.",
+}
+
+
+def impact_for(code: str) -> str:
+    """The Core-owned impact sentence for a finding ``code``."""
+    return _IMPACT.get(code, _GENERIC_IMPACT)
+
 
 @dataclass
 class ReviewIssue:
@@ -59,6 +80,7 @@ class ReviewIssue:
     code: str
     message: str
     action: str  # a runnable command or concrete edit
+    impact: str  # why it matters (v0.8.11; additive JSON field, ADR-007)
 
     def to_dict(self) -> dict:
         return {
@@ -69,6 +91,7 @@ class ReviewIssue:
             "code": self.code,
             "message": self.message,
             "action": self.action,
+            "impact": self.impact,
         }
 
 
@@ -175,6 +198,7 @@ def review_from_portfolio(
                 code=item.code,
                 message=item.message,
                 action=action,
+                impact=impact_for(item.code),
             )
         )
 
@@ -190,6 +214,7 @@ def review_from_portfolio(
                 code=REVIEW_UNKNOWN_ARTIFACT,
                 message="No artifact schema matched this document.",
                 action=f"Run: rac inspect {path} (see rac schema --list)",
+                impact=impact_for(REVIEW_UNKNOWN_ARTIFACT),
             )
         )
 

--- a/tests/golden/review_json.txt
+++ b/tests/golden/review_json.txt
@@ -37,7 +37,8 @@
       "identifier": "broken",
       "code": "invalid-artifact",
       "message": "Validation errors: missing-title",
-      "action": "Run: rac validate tests/fixtures/portfolio/broken.md"
+      "action": "Run: rac validate tests/fixtures/portfolio/broken.md",
+      "impact": "The artifact fails its schema, so tooling and validation cannot trust it."
     },
     {
       "priority": 4,
@@ -46,7 +47,8 @@
       "identifier": "broken",
       "code": "missing-recommended-sections",
       "message": "Missing recommended sections: Success Metrics, Risks, Assumptions",
-      "action": "Run: rac improve tests/fixtures/portfolio/broken.md --template"
+      "action": "Run: rac improve tests/fixtures/portfolio/broken.md --template",
+      "impact": "Recommended sections are empty, weakening the artifact's completeness."
     },
     {
       "priority": 4,
@@ -55,7 +57,8 @@
       "identifier": "feature_a",
       "code": "missing-recommended-sections",
       "message": "Missing recommended sections: Assumptions",
-      "action": "Run: rac improve tests/fixtures/portfolio/feature_a.md --template"
+      "action": "Run: rac improve tests/fixtures/portfolio/feature_a.md --template",
+      "impact": "Recommended sections are empty, weakening the artifact's completeness."
     },
     {
       "priority": 4,
@@ -64,7 +67,8 @@
       "identifier": "feature_b",
       "code": "missing-recommended-sections",
       "message": "Missing recommended sections: Success Metrics, Risks, Assumptions",
-      "action": "Run: rac improve tests/fixtures/portfolio/feature_b.md --template"
+      "action": "Run: rac improve tests/fixtures/portfolio/feature_b.md --template",
+      "impact": "Recommended sections are empty, weakening the artifact's completeness."
     },
     {
       "priority": 4,
@@ -73,7 +77,8 @@
       "identifier": "feature_c",
       "code": "missing-recommended-sections",
       "message": "Missing recommended sections: Success Metrics, Risks, Assumptions",
-      "action": "Run: rac improve tests/fixtures/portfolio/sub/feature_c.md --template"
+      "action": "Run: rac improve tests/fixtures/portfolio/sub/feature_c.md --template",
+      "impact": "Recommended sections are empty, weakening the artifact's completeness."
     }
   ],
   "actions": [

--- a/tests/test_explorer_app.py
+++ b/tests/test_explorer_app.py
@@ -905,6 +905,13 @@ async def test_first_run_shows_onboarding_then_enter_continues(fresh_first_run):
 
         await pilot.press("enter")
         await pilot.pause()
+        # The optional editor step (v0.8.11): one prefilled, skippable line.
+        text = str(app.screen.query_one(RepositoryPanel).content)
+        assert "Choose your editor" in text
+        assert firstrun.is_first_run()  # not onboarded until the step ends
+
+        await pilot.press("enter")  # accept: empty keeps the env fallback
+        await pilot.pause()
         text = str(app.screen.query_one(RepositoryPanel).content)
         assert "Health" in text  # the normal summary
     assert not firstrun.is_first_run()  # marker written
@@ -937,7 +944,8 @@ async def test_first_run_invalid_repository_opens_anyway(fresh_first_run):
         assert "✗ 1 validation errors" in text
         assert "Press Enter to open anyway" in text
 
-        await pilot.press("enter")
+        await pilot.press("enter")  # welcome → editor step
+        await pilot.press("enter")  # accept the editor default
         await pilot.pause()
         text = str(app.screen.query_one(RepositoryPanel).content)
         assert "Health" in text
@@ -1851,3 +1859,65 @@ async def test_stats_command_renders_the_dashboard():
         await pilot.press("escape")
         await pilot.pause()
         assert app.screen.current_view == "view-home"
+
+
+# --- first-run editor prompt (v0.8.11) --------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_first_run_editor_prompt_persists_a_typed_command(fresh_first_run):
+    from rac.explorer.preferences import load_preferences
+
+    app = ExplorerApp(str(FIXTURES / "valid_clean"))
+    async with app.run_test() as pilot:
+        await _settled_panel_text(app, pilot)
+        await pilot.press("enter")  # welcome → editor step
+        await pilot.pause()
+        assert app.focused is app.screen.query_one("#firstrun-editor", Input)
+
+        await pilot.press(*"code --wait")
+        await pilot.press("enter")
+        await pilot.pause()
+        assert load_preferences().editor == "code --wait"
+        assert not firstrun.is_first_run()
+        text = str(app.screen.query_one(RepositoryPanel).content)
+        assert "Health" in text  # onboarding finished into the summary
+
+
+@pytest.mark.asyncio
+async def test_first_run_editor_prompt_empty_enter_keeps_the_fallback(fresh_first_run):
+    from rac.explorer.preferences import load_preferences
+
+    app = ExplorerApp(str(FIXTURES / "valid_clean"))
+    async with app.run_test() as pilot:
+        await _settled_panel_text(app, pilot)
+        await pilot.press("enter", "enter")  # welcome → step → accept empty
+        await pilot.pause()
+        assert load_preferences().editor == ""  # the $VISUAL/$EDITOR fallback
+        assert not firstrun.is_first_run()
+
+
+@pytest.mark.asyncio
+async def test_first_run_editor_prompt_esc_skips_without_writing(fresh_first_run, monkeypatch):
+    from rac.explorer.preferences import preferences_path
+
+    app = ExplorerApp(str(FIXTURES / "valid_clean"))
+    async with app.run_test() as pilot:
+        await _settled_panel_text(app, pilot)
+        await pilot.press("enter")  # welcome → editor step
+        await pilot.press("escape")  # skip
+        await pilot.pause()
+        assert not preferences_path().exists()  # nothing written
+        assert not firstrun.is_first_run()  # but onboarding completed
+        text = str(app.screen.query_one(RepositoryPanel).content)
+        assert "Health" in text
+        assert not app.screen.query_one("#firstrun-editor", Input).display
+
+
+@pytest.mark.asyncio
+async def test_returning_users_never_see_the_editor_prompt():
+    app = ExplorerApp(str(FIXTURES / "valid_clean"))
+    async with app.run_test() as pilot:
+        text = await _settled_panel_text(app, pilot)
+        assert "Choose your editor" not in text
+        assert not app.screen.query_one("#firstrun-editor", Input).display

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -187,7 +187,9 @@ def test_cli_json_contract(capsys):
             "code",
             "message",
             "action",
+            "impact",
         }
+        assert issue["impact"]  # Core-owned, always present (v0.8.11)
     assert rc in (0, 1)
 
 
@@ -215,3 +217,15 @@ def test_top_level_flag(capsys):
 def test_empty_directory_reviews_ok(tmp_path, capsys):
     assert main(["review", str(tmp_path)]) == 0
     assert "Nothing needs attention" in capsys.readouterr().out
+
+
+def test_impact_is_core_owned_and_always_present():
+    # v0.8.11: the "why it matters" sentence is repository intelligence,
+    # not viewer copy — every consumer reads the same text.
+    from rac.services.review import impact_for
+
+    report = build_review(str(FIXTURES / "invalid_known"))
+    assert report.issues
+    for issue in report.issues:
+        assert issue.impact == impact_for(issue.code)
+    assert impact_for("some-future-code") == "This finding affects repository quality."


### PR DESCRIPTION
# Summary

Implements `rac/roadmaps/v0.8.x-explorer/v0.8.11-explorer-followups.md` — both deliberate deferrals recorded in `rac/roadmaps/future/explorer-followups.md` during the v0.8.x series, retired in one item.

Adds:

- An additive `impact` field on `ReviewIssue` — the "why it matters" sentence — owned by Core and carried through the `rac review` JSON contract, so the CLI, automation, and the Explorer all read identical text; the Explorer's own impact copy table is deleted
- An optional first-run editor step in Explorer onboarding: prefilled from the environment, Enter accepts (empty keeps the `$VISUAL`/`$EDITOR` fallback), typing persists the `editor` preference, Esc skips — returning users never see it
- The v0.8.11 contract artifact, updated deferral note, docs, regenerated review golden, tests, and the changelog entry

# Roadmap / ADR Trace

Roadmap:

- `rac/roadmaps/v0.8.x-explorer/v0.8.11-explorer-followups.md`
- `rac/roadmaps/future/explorer-followups.md` (both sections now point at this item)

Relevant ADRs:

- ADR-007 — the JSON change is additive only: a new key on each issue, no existing field changes, `schema_version` stays at 1
- `rac/decisions/adr-015-explorer-as-consumer.md` — impact text becomes repository intelligence in the service layer; the Explorer renders it instead of authoring it (the deferral existed precisely because v0.8.3 was scoped presentation-only)
- `rac/decisions/adr-023-clean-break-internal-refactors.md` — the adapter's `_IMPACT` table is deleted, not shimmed
- `rac/decisions/adr-024-rac-not-content-store.md` — the first-run step writes only `explorer.json`, and only on accept

# Scope

## Included

- `rac.services.review`: `_IMPACT` per-code map plus `impact_for(code)` with a generic fallback (the sentence: This finding affects repository quality.), so the field is always present, including for future codes; both issue-construction sites set it
- `ReviewIssue.impact` + the `to_dict` key; the Explorer adapter's `_recommendation` reads `issue.impact`
- `HomeView` onboarding gains the editor step: prompt panel showing the environment-resolved editor, an input revealed on the welcome's Enter, accept/skip paths, and the first-run marker written when the step ends either way
- Contract test pins the new issue key; `tests/golden/review_json.txt` regenerated (diff verified to be purely the additive `impact` entries)

## Excluded

- Human-output changes for `rac review` — the impact sentence is in the JSON contract and the Explorer; threading it into the CLI's human rendering is deliberately untouched to keep golden churn at one file (available any time the human format gets a pass)
- Impact wording changes — the sentences moved verbatim from the Explorer; now that they're API, edits are deliberate contract changes
- Editor command validation — the prompt stores a command, it does not verify one (same as `/settings`, per the contract's non-goals)
- Re-prompting existing users — the existing first-run marker gates the step

# Product / Architecture Decisions

- "Prefilled from the environment" is implemented as the prompt *displaying* the resolved editor with an empty input beneath: accepting empty stores the empty string (the explicit keep-the-fallback value `/settings` already uses), which avoids freezing today's `$EDITOR` into the preferences file as a snapshot
- Esc writes nothing at all — skip is byte-identical to pre-v0.8.11 behavior (verified: no `explorer.json` is created)
- `impact_for` is exported so consumers and tests can assert text equality with the service rather than duplicating strings

# User-Facing Contract

## CLI

No command surface changes.

## Human Output

`rac review`'s human output is unchanged. Explorer onboarding gains one optional screen (Choose your editor) on first run only.

## JSON Output

Each entry in `rac review --json`'s `issues[]` gains one additive key, `impact` — why the finding matters; always present, generic for unknown codes. `schema_version` remains at 1 (additive, ADR-007). All other fields unchanged.

## Exit Codes

Unchanged.

# Verification

## Ran

```bash
pytest --ignore=tests/test_ingest.py   # 844 passed
ruff check .
ruff format --check .
python -m mypy src/                     # clean
rac validate rac/                       # PASS — 86 valid, 0 invalid
rac relationships rac/ --validate       # 0 issues (167 checked)
rac review rac/                         # no priority 1–2 findings
```

`tests/test_ingest.py` exclusion is the known container `cryptography` issue, unrelated to this diff.

## Covered

- Impact: every issue's `impact` equals `impact_for(issue.code)`; unknown codes get the generic sentence; the JSON contract test pins the key set including `impact`; the golden pins the exact serialized output
- First-run prompt: typed command persists to preferences and finishes onboarding; empty Enter stores the empty string (fallback semantics); Esc skips with no preferences file written; returning users never see the prompt; the two pre-existing onboarding flows updated for the extra Enter
- Explorer recommendations still render impact text — now sourced from Core (`grep _IMPACT src/rac/explorer/` finds nothing)

# Review Path

1. `src/rac/services/review.py` — the `_IMPACT` map, `impact_for`, the field, both construction sites
2. `src/rac/explorer/adapter.py` — `_recommendation` reads Core's sentence; the copy table is gone
3. `src/rac/explorer/widgets/views.py` (`HomeView`) and `widgets/__init__.py` (`show_editor_prompt`) — the onboarding step
4. `tests/test_review.py`, `tests/golden/review_json.txt`, the first-run sections of `tests/test_explorer_app.py`
5. `docs/cli.md` (review JSON contract + first-run bullet), the roadmap contract, the updated deferral note, `CHANGELOG.md`

# Notes For Reviewer

- The golden diff looks larger than it is: every issue object gains the `impact` line and the preceding `action` line gains a comma — nothing else moved
- This closes out `rac/roadmaps/future/explorer-followups.md`; after merge, both of its sections describe shipped work
- The impact sentences are now observable API — future wording edits should be treated as contract changes

# Implementation Process

Implemented with AI assistance under the roadmap contract. Final scope, review, and acceptance decisions were made by the maintainer.