### PR TITLE
docs(release): Lore product identity and the v0.10.3 search contract [roadmap:v0.10.3]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,6 @@ to the corpus artifact and they load through the imports below.
 
 ## Working corpus
 
-- Current series: `rac/roadmaps/v0.10.x-guide/` (next up: v0.10.0)
+- Current series: `rac/roadmaps/v0.10.x-guide/` (next up: v0.10.3)
 - Previous series: `rac/roadmaps/v0.8.x-explorer/` (complete through v0.8.10)
 - Decisions (ADRs): `rac/decisions/`

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Requirements as Code
+# Lore
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="rac/assets/images/lore-header-dark.png">
@@ -6,180 +6,118 @@
   <img alt="Lore — agents that know why. Deterministic. Read-only. No RAG, no guessing." src="rac/assets/images/lore-header-light.png">
 </picture>
 
-[![CI](https://github.com/tcballard/requirements-as-code/actions/workflows/ci.yml/badge.svg)](https://github.com/tcballard/requirements-as-code/actions/workflows/ci.yml)
-[![PyPI](https://img.shields.io/pypi/v/requirements-as-code)](https://pypi.org/project/requirements-as-code/)
+[![CI](https://github.com/tcballard/requirements-as-code/actions/workflows/ci.yml/badge.svg)](https://github.com/tcballard/requirements-as-code/actions/workflows/ci.yml) [![PyPI](https://img.shields.io/pypi/v/requirements-as-code)](https://pypi.org/project/requirements-as-code/)
 
-> **Treat product knowledge like source code.**
+> **Give your coding agent the decisions your team already made — so it stops re-doing things you ruled out.**
 
-RAC is a command-line tool for managing requirements, decisions, roadmaps, prompts,
-and design artifacts as plain Markdown, right inside your Git repository.
+Your agent reintroduces an approach you rejected months ago. It rebuilds something you deliberately removed. The decision was written down — in an ADR nobody, human or agent, ever reopened.
+
+Lore stores your requirements, decisions, designs, and roadmaps as typed Markdown in your repo, and serves them to Claude Code, Cursor, and Claude Desktop over MCP. The agent cites your decisions instead of violating them.
+
+No AI in the core. No inference. No guessing. Just your team's recorded knowledge, in your Git, handed to the agent that needs it.
+
+Lore is built on **RAC — Requirements as Code** — the open-source engine underneath. For now the package, CLI, and MCP server all ship under the `rac` name:
+
+```bash
+pip install requirements-as-code
+```
+
+> 📺 **[90-second demo](#)** — watch an agent violate a decision, then respect it. *(link on launch)*
+
+## Grounding your agent (start here)
+
+Lore ships a read-only MCP server. Point your agent at your repo and it can search, retrieve, and traverse your recorded knowledge mid-task.
+
+**1. Install**
 
 ```bash
 pip install requirements-as-code
 ```
 
-## What is RAC?
+**2. Connect your agent**
 
-The code is structured, the tests are automated, the infrastructure is versioned —
-but the *reasoning* behind what you build is scattered across documents, tickets,
-chats, and AI conversations. RAC brings that knowledge back into the repository.
-
-You write product thinking in Markdown; RAC validates it, inspects it, and connects
-it — so it stays durable, reviewable, and usable as context for both humans and AI.
-No proprietary formats, no hosted platform, no lock-in.
-
-## Who is it for?
-
-- **Software and product teams** who want the *why* behind their software versioned
-  alongside the code.
-- **AI-native teams** who need structured, durable context instead of more scattered
-  chat history.
-
-## Install
-
-Requires Python 3.11+.
+Claude Code (from your repo root):
 
 ```bash
-pip install requirements-as-code
-# or
-uv tool install requirements-as-code
+claude mcp add rac-guide -- rac mcp
 ```
 
-## Quick Start
+Claude Desktop / Cursor (`mcpServers` in the client config):
+
+```json
+{
+  "mcpServers": {
+    "rac-guide": { "command": "rac", "args": ["mcp", "--root", "/absolute/path/to/your/repo"] }
+  }
+}
+```
+
+**3. Ask, and watch it ground**
+
+> *"Should I add a hard delete to the user model?"*
+
+The agent calls Lore, finds your soft-delete decision, cites it by ID, and proposes the compliant change — instead of reintroducing the thing you removed on purpose.
+
+The server exposes four read-only tools: `get_artifact`, `search_artifacts`, `get_related`, `get_summary`. It never writes to your repo.
+
+▶ **Full walkthrough + runnable example: [examples/guide/](https://github.com/tcballard/requirements-as-code/tree/main/examples/guide)**
+
+## Why this works
+
+The code is structured, the tests are automated, the infrastructure is versioned — but the *reasoning* behind what you build is scattered across tickets, chats, and dead docs. Agents can't act on what they can't read, so they re-litigate settled decisions.
+
+Lore puts that reasoning back in the repo as typed, connected artifacts, then serves it to the agent through a deterministic interface. You write the decision once, in Markdown; RAC validates it, links it, and makes it retrievable — durable context for both humans and AI, with no proprietary format and no hosted platform.
+
+## Who it's for
+
+- **Teams running coding agents heavily** (Claude Code, Cursor) who are tired of the agent ignoring decisions the team already made.
+- **Teams who already write ADRs** and want those decisions to actually shape what the agent does.
+- **Anyone who wants the *why* behind their software versioned alongside the code.**
+
+## Authoring artifacts (the RAC CLI)
+
+The MCP server is only as good as what it serves. RAC's CLI is how you write and maintain that knowledge — and how you enforce it in CI.
 
 ```bash
-rac validate requirement.md   # check one artifact
-rac validate rac/             # check every artifact in a directory
-rac inspect requirement.md    # see its type and completeness
-rac stats rac/                # summarize a directory of artifacts
-rac review rac/               # full repository review, worst problems first
+rac validate rac/          # check every artifact in a directory
+rac inspect requirement.md # see its type and completeness
+rac review rac/            # full repository review, worst problems first
 ```
 
-New to RAC? Walk through your first artifact in five minutes:
-**[docs/quickstart.md](docs/quickstart.md)**.
+New to Lore? Author your first artifact in five minutes: **[docs/quickstart.md](https://github.com/tcballard/requirements-as-code/blob/main/docs/quickstart.md)**.
 
-## Supported Artifact Types
+### Supported artifact types
 
 - **Requirements** — what needs to exist
 - **Decisions** — why choices were made (ADRs)
+- **Designs** — product experience thinking
 - **Roadmaps** — where the product is heading
 - **Prompts** — reusable AI collaboration patterns
-- **Designs** — product experience thinking
 
-Everything stays plain Markdown — see **[docs/artifacts.md](docs/artifacts.md)**.
+Everything stays plain Markdown — see **[docs/artifacts.md](https://github.com/tcballard/requirements-as-code/blob/main/docs/artifacts.md)**.
+
+## How Lore earns trust
+
+Lore asks you to trust it with your product knowledge, so it holds itself to the same standard it applies to your repository:
+
+- **The MCP server is read-only by construction.** It cannot create, modify, or delete files in your repo — enforced in code and verified by tests, not by convention.
+- **No AI in the core.** Retrieval is deterministic: the same repo state and the same query always return the same result. The reasoning is your agent's job; Lore's job is to hand it the facts.
+- **It dogfoods itself.** Lore's own planning corpus under [`rac/`](https://github.com/tcballard/requirements-as-code/tree/main/rac) is validated by RAC in CI — if the tool's rules break the tool's own artifacts, the build fails.
+- **Output is a contract.** Golden tests pin CLI and MCP output; any change to what the tools return is reviewed as a product change.
 
 ## Documentation
 
-- [Quickstart](docs/quickstart.md) — install and try RAC in five minutes
-- [CLI reference](docs/cli.md) — every command, flag, and exit code
-- [Artifact types](docs/artifacts.md) — the five types and their sections
-- [Relationships](docs/relationships.md) — link artifacts and validate the links
-- [Repository workflow](docs/repo-workflow.md) — organize a repo with RAC
-- [Guide (MCP server)](docs/mcp.md) — connect coding agents to your repository
-- [Testing & contributing](docs/testing.md) — local setup and verification
-- [Examples](docs/examples.md) — small, realistic artifacts
+- [Quickstart](https://github.com/tcballard/requirements-as-code/blob/main/docs/quickstart.md) — install and author your first artifact
+- [MCP server](https://github.com/tcballard/requirements-as-code/blob/main/docs/mcp.md) — tools, client configuration, examples
+- [CLI reference](https://github.com/tcballard/requirements-as-code/blob/main/docs/cli.md) — every command, flag, and exit code
+- [Artifact types](https://github.com/tcballard/requirements-as-code/blob/main/docs/artifacts.md) — the five types and their sections
+- [Relationships](https://github.com/tcballard/requirements-as-code/blob/main/docs/relationships.md) — link artifacts and validate the links
 
-## RAC Guide — MCP server for coding agents
+Requires Python 3.11+. `uv tool install requirements-as-code` also works.
 
-RAC Guide is an MCP server that serves your repository's requirements,
-decisions, designs, and roadmaps to coding agents as callable tools, so
-recorded decisions are respected instead of rediscovered. A single
-`pip install` is all that is needed — no separate package, no extra flag.
+## Project status
 
-```bash
-rac mcp                   # serve the current directory
-rac mcp --root path/to/repo
-```
-
-### Configure your client
-
-**Claude Code**
-
-```bash
-claude mcp add rac-guide -- rac mcp --root /path/to/your/repo
-```
-
-Or add to `.mcp.json` in your project root:
-
-```json
-{
-  "mcpServers": {
-    "rac-guide": {
-      "command": "rac",
-      "args": ["mcp", "--root", "/path/to/your/repo"]
-    }
-  }
-}
-```
-
-<!-- TODO: verify against Claude Code <version> before release -->
-
-**Claude Desktop** — add to `claude_desktop_config.json`:
-
-```json
-{
-  "mcpServers": {
-    "rac-guide": {
-      "command": "rac",
-      "args": ["mcp", "--root", "/path/to/your/repo"]
-    }
-  }
-}
-```
-
-<!-- TODO: verify against Claude Desktop <version> before release -->
-
-**Cursor** — add to `.cursor/mcp.json` in your project:
-
-```json
-{
-  "mcpServers": {
-    "rac-guide": {
-      "command": "rac",
-      "args": ["mcp", "--root", "/path/to/your/repo"]
-    }
-  }
-}
-```
-
-<!-- TODO: verify against Cursor <version> before release -->
-
-Want to try Guide against a ready-made corpus before pointing it at your own
-repository? See **[examples/guide/](examples/guide/)**.
-
-Full onboarding path, troubleshooting, and first-question walkthrough:
-**[docs/mcp.md](docs/mcp.md)**.
-
-## How RAC earns trust
-
-RAC asks you to trust it with your product knowledge, so it holds itself to the
-same standard it applies to your repository:
-
-- **It dogfoods itself.** RAC's own planning corpus under [`rac/`](rac/) is
-  validated by RAC in CI (`rac validate rac/`, `rac relationships rac/ --validate`,
-  `rac review rac/`) — if the tool's rules break the tool's own artifacts, the
-  build fails.
-- **Output is a contract.** Golden tests pin the CLI's human and JSON output
-  byte-for-byte; any change to what RAC prints is reviewed as a product change.
-- **JSON is versioned.** Machine-readable output carries a `schema_version` and
-  only changes additively.
-
-## Project Status
-
-RAC is early and evolving quickly. A terminal Explorer ships alongside the
-CLI — browse the artifact tree, read documents with their references as
-navigable links, assess repository health, and reach anything from the `/`
-command palette:
-
-![RAC Explorer reading an artifact: the sidebar, tabbed context panel, and status line under the rac-lantern theme](docs/images/explorer-hero.svg)
-
-```bash
-pip install 'requirements-as-code[explorer]'
-rac explorer
-```
-
-Contributions, ideas, and experiments are welcome — see
-[CONTRIBUTING.md](CONTRIBUTING.md).
+Lore is early and evolving quickly. The MCP server ships today; feedback from teams running agents in anger is exactly what shapes what comes next. Contributions, ideas, and experiments welcome — see [CONTRIBUTING.md](https://github.com/tcballard/requirements-as-code/blob/main/CONTRIBUTING.md).
 
 ## License
 

--- a/rac/decisions/adr-036-lore-product-identity.md
+++ b/rac/decisions/adr-036-lore-product-identity.md
@@ -1,0 +1,97 @@
+---
+schema_version: 1
+id: RAC-KTXSTGNKHHVX
+type: decision
+---
+# ADR-036: Lore Product Identity
+
+## Status
+
+Accepted
+
+## Category
+
+Product
+
+## Context
+
+The v0.10.x launch positions the agent-grounding capability as a product
+with its own name: Lore, "agents that know why". The README, header
+banner, and outreach materials lead with that name.
+
+Underneath it, everything ships as RAC — Requirements as Code: the PyPI
+package (`requirements-as-code`), the CLI (`rac`), the MCP server
+(`rac mcp`), the artifact model, and this corpus itself. Renaming those
+surfaces at launch would break install instructions, client
+configurations, pinned contracts, and muscle memory, for no user benefit.
+
+Without a recorded naming structure, the two names will drift: new
+documentation, tool text, and conversations will each pick a name ad hoc,
+and the first question outreach generates — "what is Lore, and what is
+RAC?" — has no corpus answer for Guide to serve.
+
+## Decision
+
+Lore is the product. RAC is the engine.
+
+- **Lore** names the product: the experience of a coding agent grounded
+  in a team's recorded knowledge — the corpus conventions, the MCP
+  serving surface, and the launch narrative. Marketing-facing material
+  (README lead, banner, demo, announcement) leads with Lore.
+- **RAC — Requirements as Code** names the open-source engine: the
+  artifact model, validation, relationships, services, CLI, and MCP
+  server implementation. Technical documentation, contracts, and code
+  keep the RAC name.
+- **Distribution names are unchanged for now.** The PyPI package stays
+  `requirements-as-code`; the CLI command and MCP server stay `rac` /
+  `rac mcp`; internal consumer naming (Guide, Explorer) is unchanged.
+  Renaming any shipped surface is a separate, future decision with its
+  own migration plan — it does not follow implicitly from this one.
+- Where both names appear, the relationship is stated once, in this
+  form: "Lore is built on RAC — Requirements as Code — the open-source
+  engine underneath."
+
+## Consequences
+
+### Positive
+
+- The product can carry a brandable, memorable name without breaking any
+  shipped surface, install path, or pinned contract.
+- One recorded answer to "Lore vs RAC" exists, and Guide can serve it.
+- Engine naming stays stable for contracts, tests, and integrations.
+
+### Negative
+
+- Two names must be explained wherever newcomers land; every major
+  entry point needs the one-line relationship statement.
+- Search and discovery split across two names until the brand settles.
+
+### Risks
+
+- Drift: future surfaces pick a name ad hoc. Mitigated by treating this
+  decision as the naming reference for new material.
+- A future package or CLI rename, if ever chosen, invalidates published
+  configuration blocks and documentation; that cost belongs to the
+  future decision, not this one.
+
+## Alternatives Considered
+
+### Rename everything to Lore at launch
+
+Rejected: breaks install instructions, verified client configuration
+blocks, and the pinned tool surface days before outreach, and couples a
+brand experiment to a contract migration.
+
+### Launch with the RAC name only
+
+Rejected: the engine name describes the mechanism, not the outcome. The
+launch story — agents that know why — is a product claim, and a product
+claim warrants a product name that can outlive implementation details.
+
+## Related Decisions
+
+- ADR-029
+
+## Related Roadmaps
+
+- v0.10.2-guide-grounding-demo

--- a/rac/decisions/adr-037-token-boundary-search-matching.md
+++ b/rac/decisions/adr-037-token-boundary-search-matching.md
@@ -1,0 +1,97 @@
+---
+schema_version: 1
+id: RAC-KTXTAF6ZKDK8
+type: decision
+---
+# ADR-037: Token-Boundary Search Matching
+
+## Status
+
+Proposed
+
+## Category
+
+Technical
+
+## Context
+
+Artifact search — `rac find` on the CLI and `search_artifacts` on the
+Guide tool surface — matches by case-insensitive substring over
+identifiers, titles, and paths. Substring matching produces false
+positives at word boundaries: a query for `lore` matches every Explorer
+artifact, because "lore" is a substring of "Explorer". The collision now
+involves the product name itself.
+
+Search quality became a product surface when Guide shipped: an agent
+that receives noisy matches burns context triaging them, and an agent
+that learns the tool is noisy stops calling it. The grounding
+measurement (eight-of-ten decision-ID citations) depends directly on
+retrieval precision.
+
+The `guide-tool-surface` design pinned v1 search as exactly
+`find_artifacts` semantics. Changing how matching works is therefore a
+deliberate contract change, not a bug fix, and is recorded as one.
+
+## Decision
+
+Search matching moves from raw substring to token-boundary matching.
+
+- Identifiers, titles, and paths are tokenized on non-alphanumeric
+  boundaries and lowercase-to-uppercase transitions (camelCase splits).
+- A query term matches a token case-insensitively when it equals the
+  token or is a prefix of it: `relation` matches `relationships`;
+  `lore` matches `Lore` but not `Explorer`.
+- Multi-term queries require every term to match (AND semantics).
+- The ranking ladder is unchanged: identifier matches rank above title
+  matches above path matches, with sorted path as the tiebreak.
+- One Core implementation serves both `rac find` and
+  `search_artifacts`; their results never diverge.
+- Golden and contract tests are re-pinned to the new semantics, the
+  change is announced as a behavior change in the release notes, and
+  the grounding measurement is re-run after it lands.
+
+## Consequences
+
+### Positive
+
+- Word-boundary false positives disappear; precision improves for every
+  query without any new dependency.
+- Prefix matching preserves the partial-word ergonomics users already
+  rely on.
+- Matching stays deterministic and explainable in one sentence.
+
+### Negative
+
+- Existing queries can return fewer results than before; any workflow
+  that depended on mid-word substring hits breaks.
+- Golden tests and the pinned search contract must be re-pinned in the
+  same change.
+
+### Risks
+
+- Tokenization rules accrete special cases over time. Mitigated by
+  keeping the rule set small, documented in one place, and pinned by
+  boundary tests — including `lore` versus `Explorer` as a named
+  regression case.
+
+## Alternatives Considered
+
+### Keep substring matching
+
+Rejected: the false-positive class now collides with the product name,
+and precision failures directly suppress agent tool use.
+
+### Fuzzy or edit-distance matching
+
+Rejected: deterministic in the technical sense but unexplainable in
+practice; ranking ceases to be a one-sentence contract and golden tests
+become brittle.
+
+## Related Decisions
+
+- ADR-007
+- ADR-038
+
+## Related Designs
+
+- guide-tool-surface

--- a/rac/decisions/adr-037-token-boundary-search-matching.md
+++ b/rac/decisions/adr-037-token-boundary-search-matching.md
@@ -7,7 +7,7 @@ type: decision
 
 ## Status
 
-Proposed
+Accepted
 
 ## Category
 

--- a/rac/decisions/adr-038-body-text-search-tier.md
+++ b/rac/decisions/adr-038-body-text-search-tier.md
@@ -1,0 +1,114 @@
+---
+schema_version: 1
+id: RAC-KTXTAG63E89H
+type: decision
+---
+# ADR-038: Body-Text Search Tier
+
+## Status
+
+Proposed
+
+## Category
+
+Technical
+
+## Context
+
+v1 search deliberately matches metadata fields only — identifier,
+title, and path — and the `guide-tool-surface` design records body-text
+matching as an open question for a later version. The miss is real: a
+decision whose title does not carry the query keyword is invisible to
+search even when its body settles the question, and the agent falls
+back to the grepping behaviour Guide exists to replace.
+
+The cost side has already been paid. The corpus walk reads every
+artifact's content to parse it, so body text is available in the same
+snapshot search already uses, and the per-response budget (ADR-033)
+already bounds what any response can spend of the agent's context.
+
+The boundary that must not move: retrieval stays exact and
+deterministic. The agent is the semantic layer (ADR-034) — it
+reformulates queries; Core never guesses.
+
+## Decision
+
+Body text joins search as the lowest-ranked matching tier.
+
+- The ranking ladder extends to: identifier, then title, then path,
+  then section heading, then body — ties broken by sorted path, exactly
+  the existing pattern.
+- Matching uses the token-boundary semantics of ADR-037; multi-term
+  queries require every term to match, anywhere in the artifact's
+  matchable fields.
+- Body and heading matches carry additive snippet fields in search
+  responses — the matching line's text and its section heading — so an
+  agent can judge relevance without spending a `get_artifact` per
+  candidate. Snippet fields follow the additive rules of ADR-007 and
+  truncate as whole items under the existing response budget.
+- The implementation lives in Core and serves `rac find` and
+  `search_artifacts` identically (ADR-031).
+- No embeddings, semantic scoring, stemming, or synonym expansion in
+  Core — ever, under this decision. Query reformulation belongs to the
+  consuming agent; the tool description may suggest retrying a missed
+  search with a synonym, which is a description-contract revision that
+  can be measured (the `guide-tool-surface` measurement protocol).
+
+## Consequences
+
+### Positive
+
+- Recall reaches the artifacts whose bodies, not titles, answer the
+  query — the common case for decisions on large corpora.
+- Snippets let the agent triage matches cheaply, reducing total context
+  spent per grounded answer.
+- The ranking ladder remains a one-sentence, golden-testable contract.
+
+### Negative
+
+- Common words match many artifacts; responses grow and truncate more
+  often. Mitigated by AND semantics, tier ranking, and the budget.
+- Search output gains fields; the search contract grows and must stay
+  pinned.
+
+### Risks
+
+- Corpus growth makes in-memory body matching slow. The corpus-snapshot
+  seam remains the optimization point, per the ADR-032 posture:
+  optimize when a real user reports it, without breaking determinism.
+- Snippet extraction rules (line boundaries, length) accrete edge
+  cases. Mitigated by whole-line snippets only, pinned by contract
+  tests.
+
+## Alternatives Considered
+
+### Embedding or RAG-based retrieval
+
+Rejected: breaks byte-stable determinism (ADR-032), adds a model
+dependency to a deterministic core, and falsifies the product's "no
+RAG, no guessing" claim. Semantic flexibility is the agent's job
+(ADR-034).
+
+### Opaque lexical scoring (BM25-style)
+
+Rejected: deterministic given a fixed corpus, but the ranking stops
+being explainable or stable under corpus growth, and golden tests pin
+it poorly. A tiered ladder is worth more than a better score.
+
+### Remain metadata-only
+
+Rejected: the misses push agents back to grepping, which is the
+behaviour Guide exists to replace.
+
+## Related Decisions
+
+- ADR-007
+- ADR-031
+- ADR-032
+- ADR-033
+- ADR-034
+- ADR-037
+
+## Related Designs
+
+- guide-tool-surface

--- a/rac/decisions/adr-038-body-text-search-tier.md
+++ b/rac/decisions/adr-038-body-text-search-tier.md
@@ -7,7 +7,7 @@ type: decision
 
 ## Status
 
-Proposed
+Accepted
 
 ## Category
 

--- a/rac/roadmaps/v0.10.x-guide/v0.10.3-search-quality.md
+++ b/rac/roadmaps/v0.10.x-guide/v0.10.3-search-quality.md
@@ -1,0 +1,184 @@
+---
+schema_version: 1
+id: RAC-KTXTGSJJSW5Y
+type: roadmap
+---
+# RAC v0.10.3 — Search Quality
+
+## Status
+
+Planned
+
+## Context
+
+v0.10.0 made search a product surface: `search_artifacts` is the tool an
+agent reaches for before implementing, and the grounding claim depends on
+what it returns. Two recorded weaknesses remain. Substring matching
+produces word-boundary false positives — a query for `lore` matches every
+Explorer artifact, a collision that now involves the product name — and
+metadata-only matching misses artifacts whose bodies, not titles, answer
+the query, pushing agents back toward the grepping behaviour Guide
+replaces.
+
+ADR-037 and ADR-038 settle both: token-boundary matching, and a body-text
+tier with snippets. This milestone implements the pair as one deliberate,
+announced contract change to search semantics. It lands before the demo
+recording, so the launch measurement runs once, against the improved
+search.
+
+## Outcomes
+
+- A query matches on token boundaries: `lore` returns Lore artifacts and
+  no Explorer artifacts; `relation` still finds `relationships`.
+- Body and section-heading text participate in matching as the
+  lowest-ranked tiers, and body/heading matches carry snippet fields an
+  agent can triage without retrieving each candidate.
+- `rac find` and `search_artifacts` return identical results from one
+  Core implementation, re-pinned by goldens and contract tests.
+- The grounding measurement re-runs against the new semantics and meets
+  the eight-of-ten gate before the demo is recorded.
+
+## Initiatives
+
+### Initiative 1 — Token-Boundary Matching (ADR-037)
+
+Replace substring matching in the Core search implementation with
+tokenized matching: split identifiers, titles, paths, and headings on
+non-alphanumeric boundaries and camelCase transitions; match query terms
+case-insensitively as whole tokens or token prefixes; require every term
+of a multi-term query to match. The ranking ladder and sorted-path
+tiebreak are unchanged.
+
+### Initiative 2 — Body-Text Tier with Snippets (ADR-038)
+
+Extend matching to section headings and body text as the lowest tiers of
+the ladder: identifier, title, path, heading, body. Source heading and
+body text from the corpus snapshot the search path already consumes —
+no second walk. Heading and body matches add additive snippet fields
+(matching line text plus its section heading) to search responses,
+following ADR-007's additive rules and truncating as whole items under
+the response budget.
+
+### Initiative 3 — Contract Re-Pinning
+
+Re-pin golden output, CLI JSON, and the `mcp` battery's search contract
+tests to the new semantics in the same change, with `lore` versus
+`Explorer` as a named regression test. Revise the `guide-tool-surface`
+design: the body-text open question is settled, and the search response
+shape gains the snippet fields.
+
+### Initiative 4 — Measurement Re-Run
+
+Re-run the ten-run grounding measurement after the change lands
+(ADR-037 requirement). The demo recording happens after this gate
+passes, so launch assets reflect shipped behaviour.
+
+## Constraints
+
+- One matching implementation in Core serves CLI and Guide; the server
+  layer gains no search logic (ADR-031).
+- Matching stays deterministic and tiered; no embeddings, fuzzy
+  matching, stemming, synonym expansion, or opaque scoring (ADR-038).
+- Existing response shapes change only additively (ADR-007); the
+  semantics change is announced in release notes as a behavior change.
+- Guide tool descriptions are unchanged; description revisions, if the
+  measurement demands them, follow the design's own protocol.
+- One corpus walk per Guide tool call is preserved (v0.10.x precedent).
+
+## Non-Goals
+
+- Semantic, embedding, or RAG-based retrieval (ADR-038)
+- Stemming, plural folding, or synonym normalization
+- Search configuration flags or per-call ranking options
+- Performance optimization beyond the existing corpus-snapshot seam
+- Pagination or cursoring; the response budget remains the cap
+
+## Implementation Contract
+
+The following decisions are pinned for v0.10.3.
+
+### Module Locations
+
+- Tokenization and matching live with the existing search implementation
+  in `src/rac/services/resolve.py` (`_match_rank`, `search_index`,
+  `find_artifacts`); one implementation, no consumer-side variants.
+- Heading and body text reach search through the corpus snapshot
+  (`walk_corpus` / the index built from it); if the searchable entry
+  model must grow fields, it grows in Core.
+
+### Semantics
+
+- Tokens split on non-alphanumeric boundaries and lowercase-to-uppercase
+  transitions; comparison is casefolded.
+- A term matches a token by equality or prefix.
+- Multi-term queries: every term must match somewhere in the artifact's
+  matchable fields; the artifact ranks by the best field any term hit.
+- Ladder: identifier, title, path, heading, body; ties break by sorted
+  path. Empty results remain a valid outcome.
+
+### Response Shape
+
+- Search match entries gain optional additive fields for heading/body
+  matches: the matched section heading and the matching line's text.
+  Field names are pinned in the revised `guide-tool-surface` design
+  before implementation; identifier/title/path-matched entries are
+  byte-identical to today's shape.
+
+### Testing
+
+- Boundary battery: `lore` excludes Explorer artifacts (named
+  regression); prefix matching; camelCase splits; multi-term AND;
+  heading and body tier ordering; snippet truncation under small
+  budgets; CLI/Guide equivalence on the same fixture state.
+- Goldens and `mcp` contract tests re-pinned in the same commit as the
+  semantics change; every new test file joins exactly one battery
+  (ADR-027).
+
+## Success Measures
+
+- `rac find lore rac/` returns only Lore-related artifacts on the
+  dogfood corpus.
+- A fixture decision whose body, but not title, contains the query term
+  is found, with its snippet, by both `rac find` and `search_artifacts`.
+- Tool and CLI search output remain byte-identical to each other for
+  identical state and query.
+- The ten-run grounding measurement passes at eight or better after the
+  change, before the demo recording.
+
+## Risks
+
+- Re-pinned goldens mask unintended result changes. Mitigated by the
+  named boundary cases and by reviewing golden diffs as product changes.
+- Snippet fields push more responses into truncation. Mitigated by
+  whole-item truncation and the existing budget contract tests.
+- Tokenization edge cases (digits, unicode) accrete rules. Mitigated by
+  keeping the rule set in one documented place with boundary tests.
+
+## Assumptions
+
+- The corpus snapshot's parsed model exposes section headings and body
+  lines without re-reading files.
+- Current corpus scale keeps in-memory body matching within interactive
+  latency; the corpus-snapshot seam remains the optimization point.
+
+## Related Decisions
+
+- ADR-037
+- ADR-038
+- ADR-007
+- ADR-027
+- ADR-031
+- ADR-033
+
+## Related Designs
+
+- guide-tool-surface
+
+## Related Requirements
+
+- rac-agent-context-guide
+
+## Dependencies
+
+- v0.10.0 server and tool surface
+- v0.10.2 measurement protocol (the re-run gate)


### PR DESCRIPTION
# Summary

Documentation-and-decisions follow-up to the v0.10.x merge: positions Lore as the product, records the naming and search-quality decisions, and pins the v0.10.3 implementation contract.

Adds:

- README rewritten around the grounding story: Lore is the product, RAC — Requirements as Code — is the open-source engine underneath; the package, CLI, and MCP server keep the `rac` name for now
- ADR-036 (Accepted): the Lore product identity — names, the canonical relationship statement, and the explicit rule that renaming any shipped surface is a separate future decision
- ADR-037 (Accepted): token-boundary search matching, replacing raw substring matching (the `lore` vs `Explorer` collision becomes a named regression case)
- ADR-038 (Accepted): body-text search tier with additive snippet fields; embeddings, fuzzy matching, stemming, and opaque scoring permanently rejected for Core
- `rac/roadmaps/v0.10.x-guide/v0.10.3-search-quality.md`: the pinned implementation contract for both ADRs — one Core matching implementation, additive response fields, re-pinned goldens, and a measurement re-run gating the demo recording
- Working corpus pointer in CLAUDE.md moved to v0.10.3

# Roadmap / ADR Trace

Roadmap:

- `rac/roadmaps/v0.10.x-guide/v0.10.3-search-quality.md` (new)

Decisions:

- `rac/decisions/adr-036-lore-product-identity.md` (new, Accepted)
- `rac/decisions/adr-037-token-boundary-search-matching.md` (new, Accepted)
- `rac/decisions/adr-038-body-text-search-tier.md` (new, Accepted)

# Scope

## Included

- README repositioning and factual corrections: the shipped tool name is `get_summary` (an earlier draft said `get_repository_summary`), config blocks use the `rac-guide` server label consistent with `docs/mcp.md` and `demo.md`, and the Claude Desktop / Cursor block carries an absolute `--root` (GUI clients do not spawn servers with the repo as working directory)
- The three decision artifacts and the roadmap contract

## Excluded

- Any implementation of the search changes (that is v0.10.3 work, gated on this contract)
- Any rename of the package, CLI, or MCP server (explicitly reserved by ADR-036)
- The demo recording and measurement (happen after v0.10.3 lands, per the roadmap's sequencing)

# Verification

```bash
rac validate rac/                      # 103 valid, 0 invalid
rac relationships rac/ --validate      # 0 issues
rac review rac/                        # no priority 1-2 findings
```

All artifact IDs minted via `rac new`; ADR-036/037/038 resolve by alias; relationship sections cross-link the decisions, the design, and the roadmap.

# Review Path

1. `README.md` — the Lore/RAC framing
2. `rac/decisions/adr-036-lore-product-identity.md`
3. `rac/decisions/adr-037-*.md`, `adr-038-*.md` — the search semantics decisions
4. `rac/roadmaps/v0.10.x-guide/v0.10.3-search-quality.md` — the implementation contract
5. `CLAUDE.md` — corpus pointer

# Notes For Reviewer

- ADR-037 makes the search semantics change an announced behavior change: goldens re-pin in the implementing PR, and the grounding measurement re-runs before the demo is recorded — the roadmap sequences the recording after that gate.
- The README's 90-second demo link is still a placeholder anchor by design; it is filled at launch.

# Implementation Process

Implemented with AI assistance under the roadmap contract. Final scope, review, and acceptance decisions were made by the maintainer.