### PR TITLE
feat(search): token-boundary matching and body-text tier [roadmap:v0.10.3]

### DIFF
--- a/rac/designs/guide-tool-surface.md
+++ b/rac/designs/guide-tool-surface.md
@@ -100,10 +100,23 @@ Description (verbatim):
 > matching artifact IDs, types, titles, and paths; use get_artifact to read
 > a match.
 
-Search uses the exact semantics of `rac find`: case-insensitive substring
-matching over identifiers, title, and path, ordered by match-field priority
-with sorted path as tiebreak. v1 adds no semantics beyond what
-`find_artifacts` does today.
+Search uses the exact semantics of `rac find`: token-boundary matching over
+identifiers, title, path, section headings, and body text, ordered by
+match-field priority with sorted path as tiebreak (ADR-037, ADR-038). One
+Core implementation serves `rac find` and `search_artifacts` identically.
+
+Tokenization splits matchable text on non-alphanumeric boundaries and on
+lowercase-to-uppercase (camelCase) transitions; comparison is casefolded. A
+query term matches a token by equality or prefix — `relation` matches
+`relationships`, `lore` matches `Lore` but not `Explorer`. Queries tokenize
+by the same rules, so `soft-delete` becomes the terms `soft` and `delete`.
+Multi-term queries require every term to match somewhere in the artifact's
+matchable fields (AND); the artifact ranks by the best field any term hit.
+
+The ranking ladder is five tiers: identifier, then title, then path, then
+section heading, then body — ties broken by sorted path. Heading and body
+text reach search through the corpus snapshot the walk already produces; no
+second walk and no re-read of files.
 
 Response (`SearchResult.to_dict`):
 
@@ -118,6 +131,32 @@ Response (`SearchResult.to_dict`):
   ]
 }
 ```
+
+Identifier-, title-, and path-matched entries carry exactly the four fields
+above — byte-identical to v1. A heading- or body-matched entry additionally
+carries two pinned, additive snippet fields (ADR-007):
+
+```json
+{
+  "id": "...",
+  "type": "...",
+  "title": "...",
+  "path": "...",
+  "section": "...",
+  "snippet": "..."
+}
+```
+
+- `section` is the matched section heading text, exactly as stored in the
+  document (the `##` heading of the section the hit falls under).
+- `snippet` is the matching line's text, a whole stored line — never a
+  fragment. For an artifact with several heading/body hits, the snippet is
+  the first matching line in document order (deterministic).
+
+Snippet fields appear only on heading/body matches; they are absent (not
+null) on metadata matches. They ride inside their match entry, so the
+whole-item truncation of the response budget (ADR-033) drops a snippet only
+by dropping its entire entry.
 
 ### get_related
 
@@ -307,9 +346,6 @@ Description text is written for the deciding agent:
 
 ## Open Questions
 
-- Whether `search_artifacts` should also match body text in a later version;
-  v1 deliberately pins metadata-field matching (id, title, path) as
-  `find_artifacts` does today.
 - Whether `get_artifact` content should offer a metadata-only mode once
   budgets meet very large artifacts.
 - Whether error text should embed the follow-up suggestion or leave it to
@@ -327,6 +363,8 @@ Description text is written for the deciding agent:
 - ADR-033
 - ADR-007
 - ADR-026
+- ADR-037
+- ADR-038
 
 ## Related Roadmaps
 

--- a/src/rac/core/markdown.py
+++ b/src/rac/core/markdown.py
@@ -16,7 +16,7 @@ import re
 from markdown_it import MarkdownIt
 
 from .frontmatter import parse_frontmatter, split_frontmatter
-from .models import Issue, MalformedRequirement, Product, Requirement
+from .models import Issue, MalformedRequirement, Product, Requirement, SearchSection
 
 # A requirement line: a leading ``[...]`` ID token followed by description text.
 # We capture anything inside the brackets so we can distinguish a *malformed* ID
@@ -98,6 +98,10 @@ def parse(text: str, source_path: str = "") -> Product:
     extra_title_lines: list[int] = []
     section: str | None = None  # current tracked section key, or None/"other"
     current_h2: str | None = None  # normalized heading of the current ## section
+    # Searchable sections in document order, original heading/line text preserved
+    # (v0.10.3): the source of snippet text for body-tier search.
+    search_sections: list[SearchSection] = []
+    current_search: SearchSection | None = None
 
     problem_lines: list[str] = []
     requirement_lines: list[tuple[str, int]] = []
@@ -123,12 +127,17 @@ def parse(text: str, source_path: str = "") -> Product:
                     extra_title_lines.append((tok.map[0] + 1 + offset) if tok.map else 0)
                 section = None  # content directly under the title is ignored
                 current_h2 = None
+                current_search = None
             elif tok.tag == "h2":
                 normalized = _normalize_heading(heading_text)
                 current_h2 = normalized
                 # Record the heading immediately so empty sections still appear
                 # in product.sections (classification keys off heading presence).
                 section_bodies.setdefault(normalized, [])
+                # Searchable section carries the heading text exactly as stored,
+                # so body-tier snippets render the document's own heading.
+                current_search = SearchSection(heading=heading_text.strip())
+                search_sections.append(current_search)
                 key = _SECTIONS.get(normalized)
                 section = key
                 if key is not None:
@@ -150,6 +159,8 @@ def parse(text: str, source_path: str = "") -> Product:
                 stripped = raw.strip()
                 if stripped:
                     section_bodies.setdefault(current_h2, []).append(stripped)
+                    if current_search is not None:
+                        current_search.lines.append(stripped)
 
         if section is None or section == "other":
             continue
@@ -189,6 +200,7 @@ def parse(text: str, source_path: str = "") -> Product:
         success_metrics=metric_lines,
         risks=risk_lines,
         sections=sections,
+        search_sections=search_sections,
         has_problem_section=has["problem"],
         has_requirements_section=has["requirements"],
         has_metrics_section=has["success_metrics"],

--- a/src/rac/core/models.py
+++ b/src/rac/core/models.py
@@ -44,6 +44,21 @@ class MalformedRequirement:
 
 
 @dataclass
+class SearchSection:
+    """One ``##`` section's searchable content, original text preserved (v0.10.3).
+
+    Distinct from :attr:`Product.sections` (casefolded heading -> joined body):
+    search needs the heading and body lines *as stored* so snippets render the
+    document's own text. ``heading`` is the ``##`` heading exactly as written;
+    ``lines`` are the section's non-blank body lines, each stripped of
+    surrounding whitespace, in document order.
+    """
+
+    heading: str
+    lines: list[str] = field(default_factory=list)
+
+
+@dataclass
 class Product:
     """The structured representation of a single requirement file."""
 
@@ -61,6 +76,11 @@ class Product:
     # types: classification, inspection metadata, and validation read from here
     # rather than re-parsing the Markdown.
     sections: dict[str, str] = field(default_factory=dict)
+    # Searchable section content with original heading/line text (v0.10.3,
+    # additive): the source of snippet text for body-tier search matches. Kept
+    # separate from ``sections`` (which casefolds headings and joins bodies for
+    # classification and validation) so search renders the document's own text.
+    search_sections: list[SearchSection] = field(default_factory=list)
     # Distinguish "section absent" from "section present but empty".
     has_problem_section: bool = False
     has_requirements_section: bool = False

--- a/src/rac/output/human.py
+++ b/src/rac/output/human.py
@@ -808,7 +808,15 @@ def render_find_human(result: SearchResult) -> str:
         return f"No artifacts match {result.query!r}."
     id_w = max(len(m.id) for m in result.matches)
     type_w = max(len(m.type) for m in result.matches)
-    lines = [f"{m.id:<{id_w}}  {m.type:<{type_w}}  {m.title or '—'}" for m in result.matches]
+    lines: list[str] = []
+    for m in result.matches:
+        lines.append(f"{m.id:<{id_w}}  {m.type:<{type_w}}  {m.title or '—'}")
+        # Heading/body matches carry a snippet; show the matched section and line
+        # indented under the row so an agent or reader can triage without opening
+        # the file (ADR-038). Metadata matches have no snippet and stay one line.
+        if m.snippet is not None:
+            section = f"{m.section}: " if m.section else ""
+            lines.append(f"{' ' * id_w}  {' ' * type_w}  ↳ {section}{m.snippet}")
     lines.append("")
     lines.append(f"{result.match_count} match(es) for {result.query!r}.")
     return "\n".join(lines)

--- a/src/rac/services/index.py
+++ b/src/rac/services/index.py
@@ -21,6 +21,7 @@ from dataclasses import dataclass, field
 from rac.core.artifacts import spec_for
 from rac.core.corpus import CorpusEntry, walk_corpus
 from rac.core.identity import artifact_identifier, artifact_identifiers
+from rac.core.models import SearchSection
 
 
 @dataclass
@@ -39,6 +40,12 @@ class IndexEntry:
     # Every identifier the artifact answers to, canonical first (v0.7.12,
     # additive): legacy aliases keep resolving during identity migration.
     aliases: list[str] = field(default_factory=list)
+    # Searchable section headings and body lines, original text preserved
+    # (v0.10.3): the body/heading tiers of `rac find` and their snippets read
+    # from here, sourced from the same corpus walk — never a second read. Not
+    # serialized: the index JSON contract is unchanged (id/type/title/path/
+    # aliases only).
+    search_sections: list[SearchSection] = field(default_factory=list)
 
     def to_dict(self) -> dict:
         return {
@@ -102,6 +109,7 @@ def index_from_corpus(
                 title=product.title,
                 path=str(path),
                 aliases=artifact_identifiers(product, spec, str(path)),
+                search_sections=product.search_sections,
             )
         )
     return RepositoryIndex(directory=directory, recursive=recursive, artifacts=artifacts)

--- a/src/rac/services/repository.py
+++ b/src/rac/services/repository.py
@@ -19,6 +19,7 @@ from dataclasses import dataclass
 from rac.core.artifacts import spec_for
 from rac.core.classification import missing_sections
 from rac.core.corpus import collect_corpus
+from rac.core.models import SearchSection
 from rac.core.operations import CancelToken, Progress, ProgressCallback, checkpoint
 
 from .index import index_from_corpus
@@ -67,6 +68,10 @@ class Artifact:
     aliases: tuple[str, ...]
     status: str
     missing_recommended: tuple[str, ...] = ()
+    # Searchable section headings/body lines, original text preserved (v0.10.3):
+    # lets the repository model serve body-tier `rac find` searches through the
+    # shared resolver seam without a second walk. Not part of any JSON contract.
+    search_sections: tuple[SearchSection, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -209,6 +214,7 @@ def load_repository(
             aliases=tuple(entry.aliases),
             status=status_by_path[entry.path],
             missing_recommended=missing_by_path.get(entry.path, ()),
+            search_sections=tuple(entry.search_sections),
         )
         for entry in index.artifacts
     ]

--- a/src/rac/services/resolve.py
+++ b/src/rac/services/resolve.py
@@ -7,18 +7,27 @@ consume these same functions, so lookup behavior cannot fork per consumer
 (ADR-015, ADR-026).
 
 Exact resolution has exactly three outcomes — resolved, not found, duplicate —
-and a duplicate is never silently resolved by path order. Search is
-deterministic: case-insensitive substring matching over identifiers, title,
-and path, ordered by match-field priority (id, then title, then filename/path)
-with sorted path as the tiebreak.
+and a duplicate is never silently resolved by path order. Resolution stays
+exact-match against an artifact's identifier set.
+
+Search (v0.10.3, ADR-037/ADR-038) is deterministic, tiered, token-boundary
+matching: identifiers, title, path, section headings, and body text are
+tokenized on non-alphanumeric boundaries and camelCase transitions; a query
+term matches a token by casefolded equality or prefix; a multi-term query
+requires every term to match somewhere in the artifact (AND). Matches rank by
+the best field any term hit — identifier, then title, then path, then heading,
+then body — with sorted path as the tiebreak. Heading and body matches carry
+snippet fields (the matched heading and the matching line, as stored).
 """
 
 from __future__ import annotations
 
+import re
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Protocol
 
+from rac.core.models import SearchSection
 from rac.services.index import build_repository_index
 
 OUTCOME_RESOLVED = "resolved"
@@ -44,34 +53,95 @@ class SearchableArtifact(Protocol):
     def path(self) -> str: ...
     @property
     def aliases(self) -> Sequence[str]: ...
+    @property
+    def search_sections(self) -> Sequence[SearchSection]: ...
 
 
-# Match-field priority for search ordering (lower ranks first).
+# Match-field priority for search ordering (lower ranks first); the ladder
+# pinned by ADR-037/ADR-038: id, then title, then path, then heading, then body.
 _RANK_ID = 0
 _RANK_TITLE = 1
 _RANK_PATH = 2
+_RANK_HEADING = 3
+_RANK_BODY = 4
+
+# A token is a maximal run that is neither a non-alphanumeric boundary nor a
+# camelCase transition. We split on both: ``_TOKEN_SPLIT`` breaks on runs of
+# non-alphanumerics, then ``_CAMEL_SPLIT`` breaks lowercase->uppercase seams.
+_NON_ALNUM_RE = re.compile(r"[^0-9A-Za-z]+")
+_CAMEL_RE = re.compile(r"(?<=[a-z])(?=[A-Z])")
+
+
+def tokenize(text: str) -> list[str]:
+    """Split ``text`` into casefolded match tokens (ADR-037).
+
+    Tokens break on non-alphanumeric boundaries and on lowercase-to-uppercase
+    (camelCase) transitions: ``soft-delete`` -> ``[soft, delete]``,
+    ``relationships`` -> ``[relationships]``, ``Explorer`` -> ``[explorer]``,
+    ``camelCase`` -> ``[camel, case]``. Empty pieces are dropped.
+    """
+    tokens: list[str] = []
+    for piece in _NON_ALNUM_RE.split(text):
+        if not piece:
+            continue
+        for sub in _CAMEL_RE.split(piece):
+            if sub:
+                tokens.append(sub.casefold())
+    return tokens
+
+
+def _term_hits_tokens(term: str, tokens: Sequence[str]) -> bool:
+    """True when ``term`` equals or is a prefix of any token (ADR-037)."""
+    return any(token == term or token.startswith(term) for token in tokens)
 
 
 @dataclass
 class ResolvedArtifact:
-    """The canonical answer to "what artifact is this ID?" (ADR-026)."""
+    """The canonical answer to "what artifact is this ID?" (ADR-026).
+
+    ``section`` and ``snippet`` (v0.10.3, additive) carry the matched section
+    heading and matching line for heading/body search matches; both stay None
+    for resolution and for id/title/path search matches, and are absent (not
+    null) from ``to_dict`` then — the metadata-match shape is byte-identical to
+    pre-v0.10.3 (ADR-007).
+    """
 
     id: str
     type: str
     title: str | None
     path: str
+    section: str | None = None
+    snippet: str | None = None
 
     def to_dict(self) -> dict:
-        return {
+        payload = {
             "id": self.id,
             "type": self.type,
             "title": self.title,
             "path": self.path,
         }
+        if self.section is not None:
+            payload["section"] = self.section
+        if self.snippet is not None:
+            payload["snippet"] = self.snippet
+        return payload
 
     @classmethod
-    def from_entry(cls, entry: SearchableArtifact) -> ResolvedArtifact:
-        return cls(id=entry.id, type=entry.type, title=entry.title, path=entry.path)
+    def from_entry(
+        cls,
+        entry: SearchableArtifact,
+        *,
+        section: str | None = None,
+        snippet: str | None = None,
+    ) -> ResolvedArtifact:
+        return cls(
+            id=entry.id,
+            type=entry.type,
+            title=entry.title,
+            path=entry.path,
+            section=section,
+            snippet=snippet,
+        )
 
 
 @dataclass
@@ -157,15 +227,87 @@ def resolve_in_index(entries: Sequence[SearchableArtifact], artifact_id: str) ->
     )
 
 
-def _match_rank(entry: SearchableArtifact, needle: str) -> int | None:
-    """Best match-field rank for ``needle`` in ``entry``, or None for no match."""
-    if any(needle in alias.casefold() for alias in entry.aliases):
-        return _RANK_ID
-    if entry.title and needle in entry.title.casefold():
-        return _RANK_TITLE
-    if needle in entry.path.casefold():
-        return _RANK_PATH
-    return None
+@dataclass
+class _Match:
+    """A search hit: the winning tier plus snippet text for heading/body tiers."""
+
+    rank: int
+    section: str | None = None
+    snippet: str | None = None
+
+
+def _id_tokens(entry: SearchableArtifact) -> list[str]:
+    tokens: list[str] = []
+    for alias in entry.aliases:
+        tokens.extend(tokenize(alias))
+    return tokens
+
+
+def _match_entry(entry: SearchableArtifact, terms: Sequence[str]) -> _Match | None:
+    """Best tiered match for an AND query, or None when a term matches nothing.
+
+    Every term of ``terms`` must match somewhere in the artifact's matchable
+    fields (id, title, path, headings, body); the artifact then ranks by the
+    best (lowest) tier *any* term hit (ADR-037). For a heading/body win, the
+    snippet is the first matching line in document order — the heading itself
+    for a heading hit, the body line for a body hit (ADR-038, deterministic).
+    """
+    id_tokens = _id_tokens(entry)
+    title_tokens = tokenize(entry.title or "")
+    path_tokens = tokenize(entry.path)
+
+    # Per term: does any term hit each metadata tier? (AND requires every term
+    # match *somewhere*; ranking uses the best tier any *single* term reached.)
+    matched_terms = set()
+    best_rank: int | None = None
+
+    def consider(rank: int, tokens: Sequence[str]) -> None:
+        nonlocal best_rank
+        for term in terms:
+            if _term_hits_tokens(term, tokens):
+                matched_terms.add(term)
+                if best_rank is None or rank < best_rank:
+                    best_rank = rank
+
+    consider(_RANK_ID, id_tokens)
+    consider(_RANK_TITLE, title_tokens)
+    consider(_RANK_PATH, path_tokens)
+
+    # Heading/body tiers, with the snippet captured at the first matching line
+    # in document order. Headings rank above body; within each, document order.
+    heading_hit: tuple[str, str] | None = None  # (section_heading, snippet_line)
+    body_hit: tuple[str, str] | None = None
+    for sec in entry.search_sections:
+        heading_tokens = tokenize(sec.heading)
+        for term in terms:
+            if _term_hits_tokens(term, heading_tokens):
+                matched_terms.add(term)
+                if heading_hit is None:
+                    heading_hit = (sec.heading, sec.heading)
+        for line in sec.lines:
+            line_tokens = tokenize(line)
+            for term in terms:
+                if _term_hits_tokens(term, line_tokens):
+                    matched_terms.add(term)
+                    if body_hit is None:
+                        body_hit = (sec.heading, line)
+
+    if heading_hit is not None and (best_rank is None or _RANK_HEADING < best_rank):
+        best_rank = _RANK_HEADING
+    if body_hit is not None and (best_rank is None or _RANK_BODY < best_rank):
+        best_rank = _RANK_BODY
+
+    # AND semantics: every term must have matched at least one field.
+    if any(term not in matched_terms for term in terms):
+        return None
+    if best_rank is None:
+        return None
+
+    if best_rank == _RANK_HEADING and heading_hit is not None:
+        return _Match(rank=best_rank, section=heading_hit[0], snippet=heading_hit[1])
+    if best_rank == _RANK_BODY and body_hit is not None:
+        return _Match(rank=best_rank, section=body_hit[0], snippet=body_hit[1])
+    return _Match(rank=best_rank)
 
 
 def find_artifacts(
@@ -174,11 +316,12 @@ def find_artifacts(
     artifact_type: str | None = None,
     recursive: bool = True,
 ) -> SearchResult:
-    """Search artifacts under ``directory`` by id, title, filename, or path.
+    """Search artifacts under ``directory`` by id, title, path, heading, or body.
 
-    Deterministic and explainable (no ranking heuristics): case-insensitive
-    substring match, results ordered by match-field priority then sorted
-    path. An empty result is a valid outcome, not an error.
+    Deterministic and explainable (no ranking heuristics): token-boundary
+    matching (ADR-037), the five-tier ladder with body text (ADR-038), results
+    ordered by match-field priority then sorted path. An empty result is a
+    valid outcome, not an error.
     """
     entries = build_repository_index(directory, recursive=recursive).artifacts
     return search_index(entries, query, artifact_type=artifact_type)
@@ -194,17 +337,21 @@ def search_index(
     Identical matching and ordering to :func:`find_artifacts`; the seam lets
     a loaded repository model serve searches without another directory walk.
     """
-    needle = query.strip().casefold()
-    ranked: list[tuple[int, str, SearchableArtifact]] = []
-    for entry in entries:
-        if artifact_type is not None and entry.type != artifact_type:
-            continue
-        rank = _match_rank(entry, needle)
-        if rank is not None:
-            ranked.append((rank, entry.path, entry))
+    terms = tokenize(query)
+    ranked: list[tuple[int, str, SearchableArtifact, _Match]] = []
+    if terms:  # an all-punctuation query tokenizes to nothing: no matches.
+        for entry in entries:
+            if artifact_type is not None and entry.type != artifact_type:
+                continue
+            match = _match_entry(entry, terms)
+            if match is not None:
+                ranked.append((match.rank, entry.path, entry, match))
     ranked.sort(key=lambda r: (r[0], r[1]))
     return SearchResult(
         query=query,
         artifact_type=artifact_type,
-        matches=[ResolvedArtifact.from_entry(e) for _, _, e in ranked],
+        matches=[
+            ResolvedArtifact.from_entry(e, section=m.section, snippet=m.snippet)
+            for _, _, e, m in ranked
+        ],
     )

--- a/tests/golden/find_human.txt
+++ b/tests/golden/find_human.txt
@@ -1,3 +1,5 @@
-RAC-01JY4M8X2QZ7  decision  Markdown Is the Canonical Source Format
+RAC-01JY4M8X2QZ7     decision  Markdown Is the Canonical Source Format
+v0-canonical-format  roadmap   Canonical Format Roadmap
+                               ↳ Initiatives: Adopt Markdown everywhere.
 
-1 match(es) for 'markdown'.
+2 match(es) for 'markdown'.

--- a/tests/golden/find_json.txt
+++ b/tests/golden/find_json.txt
@@ -2,13 +2,21 @@
   "schema_version": "1",
   "query": "markdown",
   "type": null,
-  "match_count": 1,
+  "match_count": 2,
   "matches": [
     {
       "id": "RAC-01JY4M8X2QZ7",
       "type": "decision",
       "title": "Markdown Is the Canonical Source Format",
       "path": "tests/fixtures/resolve/markdown-first.md"
+    },
+    {
+      "id": "v0-canonical-format",
+      "type": "roadmap",
+      "title": "Canonical Format Roadmap",
+      "path": "tests/fixtures/resolve/v0-canonical-format.md",
+      "section": "Initiatives",
+      "snippet": "Adopt Markdown everywhere."
     }
   ]
 }

--- a/tests/test_dogfood.py
+++ b/tests/test_dogfood.py
@@ -106,6 +106,23 @@ def test_demo_keywords_surface_the_decision():
         assert DEMO_DECISION_ID in ids, f"{query!r} did not surface {DEMO_DECISION_ID}: {ids}"
 
 
+def test_lore_does_not_match_explorer_artifacts():
+    """Named regression (ADR-037): `lore` is a substring of "Explorer" but not a
+    token prefix of it. On the dogfood corpus — which carries both Lore and many
+    Explorer artifacts — `rac find lore` must return only Lore-related artifacts
+    and never an Explorer one."""
+    result = find_artifacts(CORPUS, "lore")
+    assert result.match_count > 0  # the Lore product-identity artifacts exist
+    leaked = [m.path for m in result.matches if "explorer" in m.path.casefold()]
+    assert leaked == [], f"`lore` leaked Explorer artifacts: {leaked}"
+    # Every match is genuinely Lore-related: the token appears in its content.
+    for m in result.matches:
+        text = Path(m.path).read_text(encoding="utf-8").casefold()
+        from rac.services.resolve import tokenize
+
+        assert "lore" in tokenize(text), f"{m.path} matched 'lore' without a lore token"
+
+
 def test_demo_decision_resolves_with_content():
     """get_artifact's resolver finds the decision and its content carries the
     hard-DELETE prohibition the grounded agent must cite."""

--- a/tests/test_explorer_adapter.py
+++ b/tests/test_explorer_adapter.py
@@ -236,7 +236,11 @@ def test_search_rows_rank_like_rac_find():
 def test_search_rows_trailing_type_token_filters():
     adapter = ExplorerAdapter(str(FIXTURES / "all_types"))
     adapter.load()
-    filtered = adapter.search_rows(". decision")
+    # "all" is a token of every artifact's path (the all_types fixture dir); the
+    # trailing "decision" filters to the one decision. Token-boundary matching
+    # (ADR-037) replaced substring matching, so a punctuation-only query no
+    # longer means "match everything" — the query must carry a real token.
+    filtered = adapter.search_rows("all decision")
     assert filtered.rows
     assert all(row.type == "decision" for row in filtered.rows)
 

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -129,6 +129,47 @@ def test_search_artifacts_empty_result_is_not_an_error():
     assert "error" not in payload
 
 
+def test_search_artifacts_body_match_carries_snippet():
+    # `tightly` appears only in the requirement's body ("Services are tightly
+    # coupled"). The body tier (ADR-038) surfaces it with section + snippet, and
+    # the tool payload is byte-identical to the CLI's find JSON.
+    payload = call(CORPUS, "search_artifacts", {"query": "tightly"})
+    assert payload["match_count"] == 1
+    match = payload["matches"][0]
+    assert match["id"] == REQ
+    assert match["section"] == "Problem"
+    assert match["snippet"] == "Services are tightly coupled."
+    cli = json.loads(json_output.render_find_json(find_artifacts(CORPUS, "tightly")))
+    assert payload == cli
+
+
+def test_search_artifacts_metadata_match_omits_snippet_fields():
+    # A title match (no body hit) keeps the four-field metadata shape exactly
+    # (ADR-007): no section/snippet keys appear.
+    payload = call(CORPUS, "search_artifacts", {"query": "decoupled", "type": "requirement"})
+    assert [m["id"] for m in payload["matches"]] == [REQ]
+    assert list(payload["matches"][0]) == ["id", "type", "title", "path"]
+
+
+def test_search_snippet_match_truncates_as_whole_item():
+    # A snippet-bearing match truncates as one whole item under a small budget:
+    # the snippet rides inside its entry, so it is never split mid-element.
+    full = call(CORPUS, "search_artifacts", {"query": "services"})
+    assert full["match_count"] >= 2 and "truncated" not in full
+    budget = 220
+    payload = call(CORPUS, "search_artifacts", {"query": "services"}, budget=budget)
+    assert payload["truncated"] is True
+    assert payload["match_count"] == full["match_count"]
+    assert len(payload["matches"]) < full["match_count"]
+    # Every kept entry is structurally complete: either a metadata shape or a
+    # metadata-plus-snippet shape, never a fragment.
+    for m in payload["matches"]:
+        assert {"id", "type", "title", "path"} <= set(m)
+        assert set(m) <= {"id", "type", "title", "path", "section", "snippet"}
+        if "snippet" in m or "section" in m:
+            assert "section" in m and "snippet" in m
+
+
 # --- get_related -------------------------------------------------------------
 
 

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -168,6 +168,153 @@ def test_search_empty_repository_valid_no_match(tmp_path):
     assert result.matches == []
 
 
+# --- token-boundary battery (v0.10.3, ADR-037/ADR-038) --------------------------
+
+
+def test_tokenize_splits_on_boundaries_and_camelcase():
+    from rac.services.resolve import tokenize
+
+    assert tokenize("soft-delete") == ["soft", "delete"]
+    assert tokenize("relationships") == ["relationships"]
+    assert tokenize("Explorer") == ["explorer"]
+    assert tokenize("camelCaseWord") == ["camel", "case", "word"]
+    assert tokenize("adr-002-legacy.md") == ["adr", "002", "legacy", "md"]
+    assert tokenize("...") == []
+
+
+def test_prefix_matching_finds_whole_token(repo):
+    # `relation` must match a `relationships` token by prefix (ADR-037).
+    (repo / "decisions" / "relationships.md").write_text(
+        LEGACY_DECISION.replace("A Legacy Decision", "Relationship Validation"),
+        encoding="utf-8",
+    )
+    matches = find_artifacts(str(repo), "relation").matches
+    assert any(m.path.endswith("relationships.md") for m in matches)
+
+
+def test_word_boundary_excludes_substring_false_positive(repo):
+    # `lore` is a substring of "Explorer" but not a token prefix of it; the
+    # named regression (lore vs Explorer) lives in test_dogfood against the
+    # dogfood corpus. Here the unit form: a mid-word substring no longer hits.
+    (repo / "decisions" / "explorer.md").write_text(
+        LEGACY_DECISION.replace("A Legacy Decision", "The Explorer Surface"),
+        encoding="utf-8",
+    )
+    matches = find_artifacts(str(repo), "lore").matches
+    assert not any("explorer" in m.path.casefold() for m in matches)
+    assert not any((m.title or "").casefold().find("explorer") >= 0 for m in matches)
+
+
+def test_camelcase_split_is_searchable(repo):
+    (repo / "decisions" / "camel.md").write_text(
+        LEGACY_DECISION.replace("A Legacy Decision", "Use camelCase Identifiers"),
+        encoding="utf-8",
+    )
+    # `camel` and `case` are separate tokens after the camelCase split.
+    assert find_artifacts(str(repo), "camel").match_count >= 1
+    assert any(m.path.endswith("camel.md") for m in find_artifacts(str(repo), "case").matches)
+
+
+def test_multi_term_requires_every_term(repo):
+    (repo / "decisions" / "ab.md").write_text(
+        LEGACY_DECISION.replace("A Legacy Decision", "Alpha Bravo Decision"),
+        encoding="utf-8",
+    )
+    # Both terms present -> match; one term absent -> no match (AND semantics).
+    assert any(m.path.endswith("ab.md") for m in find_artifacts(str(repo), "alpha bravo").matches)
+    assert not any(
+        m.path.endswith("ab.md") for m in find_artifacts(str(repo), "alpha charlie").matches
+    )
+
+
+def test_tier_ordering_id_title_path_heading_body(tmp_path):
+    # Five artifacts, each making "needle" match at exactly one tier; the result
+    # order must be id, title, path, heading, body (ADR-038 ladder). Sorted-path
+    # tiebreak is irrelevant here — every artifact wins at a distinct tier.
+    base = (
+        "---\nschema_version: 1\nid: {id}\ntype: decision\n---\n"
+        "# {title}\n\n## Status\n\nAccepted\n\n## Category\n\nArchitecture\n\n"
+        "## {heading}\n\n{body}\n\n## Decision\n\nd\n\n## Consequences\n\nq\n"
+    )
+    # id tier: a legacy artifact whose filename stem (its identifier) carries the
+    # token. Path also carries it, but the id tier (rank 0) is the win.
+    (tmp_path / "needle-by-id.md").write_text(
+        "# Aaa\n\n## Context\n\nx\n\n## Decision\n\nd\n\n## Consequences\n\nq\n",
+        encoding="utf-8",
+    )
+    # title tier: token only in the title.
+    (tmp_path / "btitle.md").write_text(
+        base.format(id="RAC-TIT000000001", title="Needle Title", heading="Context", body="x"),
+        encoding="utf-8",
+    )
+    # path tier: token only in a directory component (not the stem, not id/title).
+    (tmp_path / "needledir").mkdir()
+    (tmp_path / "needledir" / "plain.md").write_text(
+        base.format(id="RAC-PTH000000001", title="Ccc", heading="Context", body="x"),
+        encoding="utf-8",
+    )
+    # heading tier: token only in a section heading.
+    (tmp_path / "dhead.md").write_text(
+        base.format(id="RAC-HED000000001", title="Ddd", heading="Needle Heading", body="x"),
+        encoding="utf-8",
+    )
+    # body tier: token only in body text.
+    (tmp_path / "ebody.md").write_text(
+        base.format(id="RAC-BOD000000001", title="Eee", heading="Context", body="needle in body"),
+        encoding="utf-8",
+    )
+    matches = find_artifacts(str(tmp_path), "needle").matches
+    order = [m.path.split("/")[-1] for m in matches]
+    assert order == ["needle-by-id.md", "btitle.md", "plain.md", "dhead.md", "ebody.md"]
+    # Only the heading and body matches carry snippets.
+    by_name = {m.path.split("/")[-1]: m for m in matches}
+    assert by_name["needle-by-id.md"].snippet is None
+    assert by_name["btitle.md"].snippet is None
+    assert by_name["plain.md"].snippet is None
+    assert by_name["dhead.md"].section == "Needle Heading"
+    assert by_name["ebody.md"].snippet == "needle in body"
+
+
+def test_body_only_match_carries_snippet(tmp_path):
+    # A decision whose body, not its title/path/id, holds the query term is
+    # found, with the section heading and matching line as its snippet (ADR-038).
+    (tmp_path / "dec.md").write_text(
+        "---\nschema_version: 1\nid: RAC-BODYONLY0001\ntype: decision\n---\n"
+        "# Unrelated Title\n\n## Status\n\nAccepted\n\n## Category\n\nArchitecture\n\n"
+        "## Context\n\nThe payments gateway must stay idempotent.\n\n"
+        "## Decision\n\nd\n\n## Consequences\n\nq\n",
+        encoding="utf-8",
+    )
+    matches = find_artifacts(str(tmp_path), "idempotent").matches
+    assert len(matches) == 1
+    m = matches[0]
+    assert m.section == "Context"
+    assert m.snippet == "The payments gateway must stay idempotent."
+    # The snippet fields ride inside the match dict (additive, ADR-007).
+    assert m.to_dict()["section"] == "Context"
+    assert m.to_dict()["snippet"] == "The payments gateway must stay idempotent."
+
+
+def test_metadata_match_has_no_snippet_fields(repo):
+    # An id/title/path match's dict is byte-identical to the pre-v0.10.3 shape.
+    match = find_artifacts(str(repo), CANONICAL_ID).matches[0]
+    assert match.section is None and match.snippet is None
+    assert set(match.to_dict()) == {"id", "type", "title", "path"}
+
+
+def test_body_snippet_is_first_matching_line_in_document_order(tmp_path):
+    (tmp_path / "dec.md").write_text(
+        "---\nschema_version: 1\nid: RAC-FIRSTLINE01\ntype: decision\n---\n"
+        "# T\n\n## Status\n\nAccepted\n\n## Category\n\nArchitecture\n\n"
+        "## Context\n\nFirst widget line.\nSecond widget line.\n\n"
+        "## Decision\n\nThird widget line.\n\n## Consequences\n\nq\n",
+        encoding="utf-8",
+    )
+    match = find_artifacts(str(tmp_path), "widget").matches[0]
+    assert match.section == "Context"
+    assert match.snippet == "First widget line."
+
+
 # --- index seams (v0.8.1): same semantics without a directory walk --------------
 
 


### PR DESCRIPTION
# Summary

Implements `rac/roadmaps/v0.10.x-guide/v0.10.3-search-quality.md`.

Adds:

- Token-boundary search matching (ADR-037): matchable text and queries tokenize on non-alphanumeric boundaries and camelCase transitions; terms match tokens by equality or prefix; multi-term queries are AND. The word-boundary false-positive class is gone — `lore` no longer matches Explorer artifacts.
- Body-text search tier with snippets (ADR-038): the ranking ladder extends to identifier, title, path, section heading, body; heading/body matches carry pinned additive `section` and `snippet` fields so an agent can triage matches without retrieving each candidate.
- Revised `guide-tool-surface` design: the body-text open question is settled and the snippet field shape was pinned before any code landed.
- Re-pinned goldens, a named `lore`-vs-`Explorer` regression test, and a token-boundary test battery (+13 tests, 934 total).

# Roadmap / ADR Trace

Roadmap:

- `rac/roadmaps/v0.10.x-guide/v0.10.3-search-quality.md`

Relevant ADRs:

- `rac/decisions/adr-037-token-boundary-search-matching.md` — the matching semantics
- `rac/decisions/adr-038-body-text-search-tier.md` — the body tier, snippets, and the permanent rejection of embeddings/fuzzy/scoring
- `rac/decisions/adr-007-json-contract-stability.md` — additive response rules
- `rac/decisions/adr-031`, `adr-032`, `adr-033` — consumer boundary, statelessness, response budget

Design: `rac/designs/guide-tool-surface.md` (revised in this PR, first commit).

# Scope

## Included

- One Core matching engine in `rac.services.resolve` (`tokenize`, five-tier `_match_entry`, rewritten `search_index`) serving `rac find` and `search_artifacts` identically
- Body/heading text sourced from the corpus snapshot via a new `Product.search_sections` structure that preserves original heading and line text (the existing `sections` map is lossy — casefolded/joined — and untouched, since other consumers depend on it); no file re-reads, exactly one corpus walk per `search_artifacts` call (regression-pinned)
- `rac find` human output shows snippets indented under heading/body-matched rows
- Index/repository entry models grow `search_sections` internally; the index JSON contract (`to_dict`) is unchanged

## Excluded

- Semantic, embedding, or RAG-based retrieval; stemming; synonyms; fuzzy matching; opaque scoring (ADR-038, permanent for Core)
- Search configuration flags, pagination, or per-call ranking options
- Tool description changes (pinned verbatim; unchanged)
- The measurement re-run and demo recording (human-only; the roadmap gates the recording on the re-run)

# Product / Architecture Decisions

- **This is a deliberate, announced behavior change to search semantics**, not a bug fix: results differ from v0.10.0 wherever substring matching produced word-boundary hits. Goldens were re-pinned in the same change set and each diff reviewed as a product change (e.g. a fixture roadmap now matches `markdown` via its body line "Adopt Markdown everywhere", with snippet — intended body-tier behavior).
- Empty and punctuation-only queries now match nothing (they tokenize to zero terms). Previously the empty substring matched everything. One Explorer adapter test relied on a lone dot as an accidental match-all (every path contains `.md`); it was updated to use a real token — the wildcard was never a documented feature.
- Snippet fields appear only on heading/body matches and are absent (not null) on identifier/title/path matches, which remain byte-identical to v1 — the additive rule of ADR-007 applied strictly.
- Snippet determinism: first matching line in document order, whole stored lines only; snippets ride inside match entries so the existing whole-item truncation covers them without new budget logic.
- Resolution (`rac resolve`, `get_artifact`, `get_related`) is untouched: alias matching stays exact; only search matching changed.

# User-Facing Contract

## CLI

`rac find` interface unchanged. Human output gains an indented `↳ Section: line` row under heading/body matches.

## JSON Output

Search match entries (CLI `--json` and `search_artifacts`, identical):

```json
{"id": "...", "type": "...", "title": "...", "path": "...", "section": "...", "snippet": "..."}
```

`section`/`snippet` present only on heading/body matches. All other shapes unchanged.

## Exit Codes

Unchanged.

# Verification

## Ran

```bash
python -m pytest -q                                   # 934 passed (+13)
python -m ruff check src/ tests/                      # clean
python -m ruff format --check src/ tests/             # clean
python -m mypy src/                                   # no issues, 64 files
rac validate rac/                                     # exit 0
rac relationships rac/ --validate                     # exit 0
rac review rac/                                       # no priority 1-2 findings
rac find lore rac/                                    # only Lore artifacts, zero Explorer
rac find "delete user" examples/guide                 # demo decision still top match
```

Plus a live stdio MCP client: `search_artifacts("lore")` returned exactly the five Lore-related artifacts (title matches without snippets, body matches with), byte-equal to `rac find lore --json`.

## Covered

- Named regression: `lore` excludes Explorer artifacts on the dogfood corpus
- Tokenization boundaries: prefix matching, camelCase splits, multi-term AND, casefolding
- Tier ordering across all five tiers; body-only matches found with snippets; snippet truncation under small budgets
- CLI/Guide byte-equivalence for identical state and query
- Dogfood demo searchability tests pass UNCHANGED (`delete user`, `delete`, `soft-delete` still surface the demo decision — `soft-delete` tokenizes to [soft, delete] under AND)
- One corpus walk per `search_artifacts` call; `get_related`'s one-walk regression still passes

# Review Path

1. `rac/designs/guide-tool-surface.md` — the revised search contract (read first; the code implements this)
2. `src/rac/services/resolve.py` — tokenizer, tiers, snippet capture
3. `src/rac/core/models.py`, `core/markdown.py`, `services/index.py`, `services/repository.py` — `search_sections` plumbing
4. `src/rac/output/human.py` — snippet display
5. `tests/test_resolve.py`, `test_dogfood.py`, `test_mcp_tools.py`, `tests/golden/` — the re-pinned contracts

# Notes For Reviewer

- The golden diffs are the semantics change made visible — review them as product behavior, not noise.
- Release notes for v0.10.3 should announce: token-boundary matching (results differ from substring), body-text matching with snippets, and empty/punctuation-only queries returning no matches.
- Per the roadmap, the 10-run grounding measurement re-runs after this merges, and the demo recording happens after that gate passes.

# Implementation Process

Implemented with AI assistance under the roadmap contract. Final scope, review, and acceptance decisions were made by the maintainer.