### PR TITLE
chore(guide): ground the workspace and fix README badges [release:v0.10.3]

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "rac-guide": {
+      "command": "rac",
+      "args": ["mcp", "--root", "."]
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Lore
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="rac/assets/images/lore-header-dark.png">
-  <source media="(prefers-color-scheme: light)" srcset="rac/assets/images/lore-header-light.png">
-  <img alt="Lore — agents that know why. Deterministic. Read-only. No RAG, no guessing." src="rac/assets/images/lore-header-light.png">
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/tcballard/requirements-as-code/main/rac/assets/images/lore-header-dark.png">
+  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/tcballard/requirements-as-code/main/rac/assets/images/lore-header-light.png">
+  <img alt="Lore — agents that know why. Deterministic. Read-only. No RAG, no guessing." src="https://raw.githubusercontent.com/tcballard/requirements-as-code/main/rac/assets/images/lore-header-light.png">
 </picture>
 
-[![CI](https://github.com/tcballard/requirements-as-code/actions/workflows/ci.yml/badge.svg)](https://github.com/tcballard/requirements-as-code/actions/workflows/ci.yml) [![PyPI](https://img.shields.io/pypi/v/requirements-as-code)](https://pypi.org/project/requirements-as-code/)
+[![CI](https://github.com/tcballard/requirements-as-code/actions/workflows/ci.yml/badge.svg)](https://github.com/tcballard/requirements-as-code/actions/workflows/ci.yml) [![PyPI](https://img.shields.io/pypi/v/requirements-as-code)](https://pypi.org/project/requirements-as-code/) [![Python](https://img.shields.io/pypi/pyversions/requirements-as-code)](https://pypi.org/project/requirements-as-code/) [![License: MIT](https://img.shields.io/pypi/l/requirements-as-code)](https://github.com/tcballard/requirements-as-code/blob/main/LICENSE)
 
 > **Give your coding agent the decisions your team already made — so it stops re-doing things you ruled out.**
 

--- a/rac/prompts/rac-agent-session-start.md
+++ b/rac/prompts/rac-agent-session-start.md
@@ -23,6 +23,18 @@ Before coding:
 
 Do not implement until I approve the plan.
 
+Grounding (when the `rac-guide` MCP tools are available in your session):
+- Call `get_summary` once at session start to learn what recorded
+  knowledge exists.
+- Call `search_artifacts` before designing or implementing; recorded
+  decisions take precedence over conventions inferred from the code.
+- When an artifact ID is mentioned, call `get_artifact`; call
+  `get_related` before changing anything an artifact covers.
+- Cite decisions by ID. If a task conflicts with a recorded decision,
+  say so and stop — do not silently override it.
+Without the tools, the same knowledge lives under `rac/`; use the
+`rac` CLI (`find`, `resolve`, `relationships`) instead.
+
 Testing:
 - Add negative boundary tests for each new artifact type.
 - Test that adjacent artifact types do not misclassify as each other.


### PR DESCRIPTION
# Summary

Two small post-release items: the workspace grounds its own agents, and the README's badges and PyPI rendering are corrected.

Adds:

- Checked-in `.mcp.json` serving the dogfood corpus through `rac-guide` (`rac mcp --root .`) — the team setup documented in `docs/mcp.md` §6, applied to this repository
- Grounding guidance in `rac/prompts/rac-agent-session-start.md` (imported by CLAUDE.md every session): `get_summary` at session start, `search_artifacts` before implementing, cite decisions by ID, surface conflicts instead of overriding — with a CLI fallback for sessions without MCP tools
- README: banner image URLs are now absolute (the README is the PyPI long description, where relative paths do not resolve — the banner was broken on pypi.org), and Python-version + license badges join the existing CI and PyPI badges

# Scope

## Included

- `.mcp.json`, the session-start prompt artifact, README badge row and banner URLs

## Excluded

- No code, tool surface, or contract changes
- No new badges with low-signal numbers (downloads deferred until they flatter)

# Verification

```bash
rac validate rac/                      # 103 valid, 0 invalid (the prompt edit is a validated artifact)
rac relationships rac/ --validate      # 0 issues
rac review rac/                        # no priority 1-2 findings
python -c "import json; json.load(open('.mcp.json'))"
```

The PyPI long description for 0.10.3 was checked directly: it carries the relative banner paths this PR fixes. The PyPI *version* badge markup was verified correct — it is dynamic (shields.io reads PyPI live, which already serves 0.10.3); any stale display is shields/GitHub-camo caching that clears on its own.

# Notes For Reviewer

- The next release's long description will render the banner; the already-published 0.10.3 page keeps the broken image (PyPI descriptions are immutable per release).
- Remote agent sessions load MCP servers at session start, so `.mcp.json` benefits the next session, not a running one; the prompt's CLI fallback covers that case.

# Implementation Process

Implemented with AI assistance under the roadmap contract. Final scope, review, and acceptance decisions were made by the maintainer.