### PR TITLE
chore(guide): rename the agent-facing server to lore [release:v0.10.4]

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,6 +1,6 @@
 {
   "mcpServers": {
-    "rac-guide": {
+    "lore": {
       "command": "rac",
       "args": ["mcp", "--root", "."]
     }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Lore
 
+<!-- mcp-name: io.github.tcballard/lore -->
+
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/tcballard/requirements-as-code/main/rac/assets/images/lore-header-dark.png">
   <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/tcballard/requirements-as-code/main/rac/assets/images/lore-header-light.png">
@@ -39,7 +41,7 @@ pip install requirements-as-code
 Claude Code (from your repo root):
 
 ```bash
-claude mcp add rac-guide -- rac mcp
+claude mcp add lore -- rac mcp
 ```
 
 Claude Desktop / Cursor (`mcpServers` in the client config):
@@ -47,7 +49,7 @@ Claude Desktop / Cursor (`mcpServers` in the client config):
 ```json
 {
   "mcpServers": {
-    "rac-guide": { "command": "rac", "args": ["mcp", "--root", "/absolute/path/to/your/repo"] }
+    "lore": { "command": "rac", "args": ["mcp", "--root", "/absolute/path/to/your/repo"] }
   }
 }
 ```

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -26,7 +26,7 @@ path you would pass to `rac validate`.
 **Command form** (adds the server to your Claude Code session):
 
 ```bash
-claude mcp add rac-guide -- rac mcp --root /path/to/your/repo
+claude mcp add lore -- rac mcp --root /path/to/your/repo
 ```
 
 **`.mcp.json` form** — create or edit `.mcp.json` in your project root:
@@ -34,7 +34,7 @@ claude mcp add rac-guide -- rac mcp --root /path/to/your/repo
 ```json
 {
   "mcpServers": {
-    "rac-guide": {
+    "lore": {
       "command": "rac",
       "args": ["mcp", "--root", "/path/to/your/repo"]
     }
@@ -51,7 +51,7 @@ Open `claude_desktop_config.json` (macOS: `~/Library/Application Support/Claude/
 ```json
 {
   "mcpServers": {
-    "rac-guide": {
+    "lore": {
       "command": "rac",
       "args": ["mcp", "--root", "/path/to/your/repo"]
     }
@@ -70,7 +70,7 @@ Create or edit `.cursor/mcp.json` in your project root:
 ```json
 {
   "mcpServers": {
-    "rac-guide": {
+    "lore": {
       "command": "rac",
       "args": ["mcp", "--root", "/path/to/your/repo"]
     }

--- a/examples/guide/demo.md
+++ b/examples/guide/demo.md
@@ -53,13 +53,13 @@ obvious thing, not a trap.
 If you have previously added it, remove it for this run:
 
 ```bash
-claude mcp remove rac-guide
+claude mcp remove lore
 ```
 
 Confirm it is gone:
 
 ```bash
-claude mcp list        # rac-guide must not appear
+claude mcp list        # lore must not appear
 ```
 
 **Run.** From `examples/guide/task/`, start Claude Code and paste the task
@@ -91,7 +91,7 @@ changes to the demo corpus.
 **Command form:**
 
 ```bash
-claude mcp add rac-guide -- rac mcp --root /absolute/path/to/examples/guide
+claude mcp add lore -- rac mcp --root /absolute/path/to/examples/guide
 ```
 
 **`.mcp.json` form** (in the project root):
@@ -99,7 +99,7 @@ claude mcp add rac-guide -- rac mcp --root /absolute/path/to/examples/guide
 ```json
 {
   "mcpServers": {
-    "rac-guide": {
+    "lore": {
       "command": "rac",
       "args": ["mcp", "--root", "/absolute/path/to/examples/guide"]
     }
@@ -110,17 +110,17 @@ claude mcp add rac-guide -- rac mcp --root /absolute/path/to/examples/guide
 Confirm the server is connected before Run 2:
 
 ```bash
-claude mcp list        # rac-guide must appear
+claude mcp list        # lore must appear
 ```
 
-In a Claude Code session, `/mcp` should list `rac-guide` with its four tools:
+In a Claude Code session, `/mcp` should list `lore` with its four tools:
 `get_summary`, `search_artifacts`, `get_artifact`, `get_related`.
 
 ---
 
 ## Run 2 — grounded (RAC Guide connected)
 
-**Setup.** A fresh Claude Code session with `rac-guide` connected (above),
+**Setup.** A fresh Claude Code session with `lore` connected (above),
 started from `examples/guide/task/`.
 
 **Run.** Paste the **same** task prompt. Do not change a word; do not mention
@@ -233,7 +233,7 @@ visible. Shot order per `rac/designs/guide-grounding-demo.md`:
 2. **Ungrounded violation (compressed)** — Run 1: the agent produces the hard
    `DELETE FROM users`. Trim the agent's thinking; keep the resulting diff
    visible.
-3. **The config block** — show adding `rac-guide` (the `claude mcp add` line or
+3. **The config block** — show adding `lore` (the `claude mcp add` line or
    the `.mcp.json` block), then `/mcp` listing the four tools.
 4. **Grounded run** — Run 2: show the `search_artifacts` tool call and its
    result, and the agent's response **citing `ADR-001` / `GUIDE-KTW9YBDWDBFM`**.

--- a/rac/decisions/adr-039-lore-server-identity.md
+++ b/rac/decisions/adr-039-lore-server-identity.md
@@ -1,0 +1,90 @@
+---
+schema_version: 1
+id: RAC-KTY0D0DFTCJA
+type: decision
+---
+# ADR-039: Lore Server Identity
+
+## Status
+
+Accepted
+
+## Category
+
+Product
+
+## Context
+
+ADR-036 named Lore as the product and froze distribution names — the
+PyPI package, the `rac` CLI, and the `rac mcp` command — reserving any
+rename as a separate decision. It did not name the agent-facing server
+identity: the label users type into client configuration, the name the
+server reports in the MCP handshake, the namespace agents see on every
+tool call, and the identity a registry listing carries.
+
+That surface shipped as `rac-guide`, leaking the internal consumer
+codename ("Guide", from ADR-029 through ADR-034) into the product's most
+visible seam — the exact ad-hoc naming drift ADR-036 warns against. The
+mismatch surfaced concretely when preparing the MCP registry submission:
+registering `rac-guide` for a product launched as Lore.
+
+The registry identity is a new surface, not a rename of a shipped one,
+and the installed base is days old: the demo is unrecorded, client
+configurations unverified, and no registry submission exists. The label
+will never be cheaper to settle than now.
+
+## Decision
+
+The agent-facing server identity is `lore`.
+
+- Client configuration label: `claude mcp add lore -- rac mcp`, and
+  `"lore"` as the `mcpServers` key in every documented config block.
+- Server handshake name: the FastMCP server name is `lore`, so client
+  UIs and tool namespaces show `lore`.
+- Registry identity: `io.github.tcballard/lore`, with the matching
+  `mcp-name` ownership marker in the package README.
+- Unchanged, per ADR-036: the `rac mcp` command, the `rac` CLI, the
+  `requirements-as-code` package, all tool names, descriptions, and
+  response contracts. "Guide" remains the internal component name in
+  code, tests, and the corpus.
+- `lore-guide` is not used anywhere: it would introduce a third name
+  when the problem being solved is having two.
+
+## Consequences
+
+### Positive
+
+- One name on every surface an agent or user reads; the registry
+  listing, config blocks, and brand agree.
+- The internal codename stays internal; engine and contract naming stay
+  stable (ADR-036 holds for everything it froze).
+
+### Negative
+
+- Documentation published with v0.10.3 shows `rac-guide`; anyone who
+  configured it keeps a working but differently-labelled server until
+  they re-add it.
+
+### Risks
+
+- Label drift recurs on future surfaces. Mitigated the same way as
+  ADR-036: this decision is the naming reference for agent-facing
+  surfaces.
+
+## Alternatives Considered
+
+### lore-guide
+
+Rejected: carries the internal codename into public view and creates a
+third name to explain alongside Lore and RAC.
+
+### Keep rac-guide
+
+Rejected: registers and advertises an internal codename for a product
+launched as Lore, days before outreach, with nothing depending on the
+old label.
+
+## Related Decisions
+
+- ADR-036
+- ADR-029

--- a/rac/prompts/rac-agent-session-start.md
+++ b/rac/prompts/rac-agent-session-start.md
@@ -23,7 +23,7 @@ Before coding:
 
 Do not implement until I approve the plan.
 
-Grounding (when the `rac-guide` MCP tools are available in your session):
+Grounding (when the `lore` MCP tools are available in your session):
 - Call `get_summary` once at session start to learn what recorded
   knowledge exists.
 - Call `search_artifacts` before designing or implementing; recorded

--- a/server.json
+++ b/server.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+  "name": "io.github.tcballard/lore",
+  "description": "Serve your repo's recorded product knowledge - requirements, decisions (ADRs), designs, roadmaps - to coding agents. Deterministic, read-only.",
+  "repository": {
+    "url": "https://github.com/tcballard/requirements-as-code",
+    "source": "github"
+  },
+  "version": "0.10.4",
+  "packages": [
+    {
+      "registryType": "pypi",
+      "identifier": "requirements-as-code",
+      "version": "0.10.4",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}

--- a/src/rac/mcp/server.py
+++ b/src/rac/mcp/server.py
@@ -46,7 +46,7 @@ from rac.services.resolve import (
     search_index,
 )
 
-SERVER_NAME = "rac-guide"
+SERVER_NAME = "lore"
 
 # --- Verbatim tool descriptions (pinned by guide-tool-surface; ADR-030) ------
 #


### PR DESCRIPTION
# Summary

Settles the agent-facing server identity ahead of the MCP registry submission: the server is `lore`, matching the product name, on every surface an agent or user reads.

Adds:

- ADR-039 (Accepted): the agent-facing identity — client config label, server handshake name, registry name — is `lore`. Everything ADR-036 froze stays frozen: the `rac mcp` command, the `rac` CLI, the `requirements-as-code` package, and all tool names, descriptions, and response contracts. `lore-guide` is recorded as rejected (it would create a third name when the problem was having two); "Guide" remains the internal component name in code, tests, and corpus.
- The rename itself: `SERVER_NAME = "lore"` in `src/rac/mcp/server.py`, plus every documented config block — README, `docs/mcp.md`, `examples/guide/demo.md`, the session-start prompt, and this repo's own `.mcp.json`. Zero `rac-guide` occurrences remain.
- Registry submission assets: `server.json` at the repo root declaring `io.github.tcballard/lore` (PyPI package, stdio transport, v0.10.4), and the `mcp-name: io.github.tcballard/lore` ownership marker as an invisible HTML comment at the top of the README — the marker PyPI ownership validation requires once a release carries it.

# Roadmap / ADR Trace

Decisions:

- `rac/decisions/adr-039-lore-server-identity.md` (new, Accepted)
- `rac/decisions/adr-036-lore-product-identity.md` — scoped against explicitly; its distribution-name freeze holds
- `rac/decisions/adr-029-guide-delivery-surface.md` — delivery mechanics unchanged

Roadmap: completes the registry-submission preparation from `v0.10.2-guide-grounding-demo.md` Initiative 5 (the submission itself is a human step).

# Scope

## Included

- Label-level rename only: handshake name, config keys, docs, registry manifest, ownership marker

## Excluded

- No tool surface, contract, CLI, or package changes; no behavior changes of any kind (the suite passes untouched — no test pinned the old label)
- The registry publish itself (`mcp-publisher login github` then `mcp-publisher publish` is a maintainer device-flow step, after the v0.10.4 release puts the marker on PyPI)
- A `uvx` runtime hint in `server.json` (deferred per ADR-029; revisit if `mcp-publisher` validation suggests it)

# Verification

```bash
python -m pytest -q                    # 934 passed, untouched by the rename
python -m ruff check src/ tests/      # clean
python -m mypy src/                    # no issues
rac validate rac/                      # 104 valid, 0 invalid
rac relationships rac/ --validate      # 0 issues
rac review rac/                        # no priority 1-2 findings
python -c "import json; json.load(open('server.json'))"
grep -rn "rac-guide" src/ tests/ docs/ examples/ README.md .mcp.json   # no matches
```

The renamed server was exercised live in an agent session via the project `.mcp.json` (`get_artifact` retrieved ADR-036 through the running server while this decision was being made).

# Review Path

1. `rac/decisions/adr-039-lore-server-identity.md` — the decision and its scope boundary against ADR-036
2. `src/rac/mcp/server.py` — the one-line handshake rename
3. `README.md`, `docs/mcp.md`, `examples/guide/demo.md`, `.mcp.json`, `rac/prompts/rac-agent-session-start.md` — config blocks
4. `server.json` — the registry manifest

# Notes For Reviewer

- Sequencing after merge: tag `v0.10.4` and publish the Release (PyPI then carries both the ownership marker and the banner-rendering fix from the previous PR), then `mcp-publisher publish`. Registry validation fails until the marker is live on PyPI.
- v0.10.3's published docs show `rac-guide`; anyone who configured that label keeps a working server under the old name until they re-add it — noted in ADR-039's consequences.

# Implementation Process

Implemented with AI assistance under the roadmap contract. Final scope, review, and acceptance decisions were made by the maintainer.