### PR TITLE
feat(telemetry): opt-in anonymous usage sharing [roadmap:v0.10.6]

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,7 +84,7 @@ jobs:
           - name: explorer
             paths: "tests/test_explorer_adapter.py tests/test_explorer_app.py tests/test_explorer_cli.py tests/test_explorer_commands.py tests/test_explorer_editor.py tests/test_explorer_isolation.py tests/test_explorer_workspace.py"
           - name: mcp
-            paths: "tests/test_mcp_server.py tests/test_mcp_tools.py tests/test_mcp_isolation.py tests/test_mcp_telemetry.py"
+            paths: "tests/test_mcp_server.py tests/test_mcp_tools.py tests/test_mcp_isolation.py tests/test_mcp_telemetry.py tests/test_mcp_ping.py"
           - name: relationships
             paths: "tests/test_relationships.py tests/test_relationships_cmd.py tests/test_relationship_validation.py"
           - name: resolve

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ details, release history over commit history.
 
 ### Added
 
+- Anonymous usage sharing (v0.10.5, opt-in): `rac telemetry on|off|status`
+  and a one-time, TTY-only consent question at `rac init` (default No).
+  With consent, `rac mcp` sends at most one anonymous daily ping — a random
+  install id, the RAC version, and a 30-day active-repo count; never paths,
+  queries, or repository content. The payload is pinned by ADR-041, the
+  network surface is a single module enforced by tests, and a build without
+  an endpoint key sends nothing at all.
+
 - Bundled agent skills (v0.10.5): the package now carries three
   Claude Code skills as resources — `rac-artifacts` (author and maintain
   artifacts with the CLI), `rac-review` (work `rac review` findings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ details, release history over commit history.
 
 ### Added
 
-- Anonymous usage sharing (v0.10.5, opt-in): `rac telemetry on|off|status`
+- Anonymous usage sharing (v0.10.6, opt-in): `rac telemetry on|off|status`
   and a one-time, TTY-only consent question at `rac init` (default No).
   With consent, `rac mcp` sends at most one anonymous daily ping — a random
   install id, the RAC version, and a 30-day active-repo count; never paths,

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Lore asks you to trust it with your product knowledge, so it holds itself to the
 - **No AI in the core.** Retrieval is deterministic: the same repo state and the same query always return the same result. The reasoning is your agent's job; Lore's job is to hand it the facts.
 - **It dogfoods itself.** Lore's own planning corpus under [`rac/`](https://github.com/tcballard/requirements-as-code/tree/main/rac) is validated by RAC in CI — if the tool's rules break the tool's own artifacts, the build fails.
 - **Output is a contract.** Golden tests pin CLI and MCP output; any change to what the tools return is reviewed as a product change.
-- **Telemetry is opt-in, local-only, and content-free.** Nothing is recorded without an explicit flag, events never include your arguments or repository content, and nothing leaves your machine unless you submit a report yourself — Lore contains no network code.
+- **Telemetry is opt-in twice over.** Local recording needs an explicit `--telemetry` flag and never includes your arguments or repository content. Remote sharing is a separate, explicit consent (`rac telemetry on`, or one honest question at `rac init`): one anonymous daily ping — a random install id, the version, and an active-repo count — never paths, queries, or content. `rac telemetry status` shows exactly what is shared, the network surface is a single readable module, and ADR-041 records the decision.
 
 ## Documentation
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -507,6 +507,27 @@ RAC sends nothing itself. `--json` and `--share` are mutually exclusive.
 
 ---
 
+## telemetry
+
+Show or change anonymous usage-sharing consent (ADR-041). With consent on,
+`rac mcp` sends at most one anonymous daily ping — a random install id, the
+version, and an active-repo count; never paths, queries, or repository
+content. Sharing is independent of the local `rac mcp --telemetry` flag.
+
+```bash
+rac telemetry           # status (default): what is shared, and whether sending is possible
+rac telemetry on        # opt in; mints a random install id
+rac telemetry off       # opt out; nothing else changes
+```
+
+`status` also reports when the build has no endpoint key configured — in
+that state nothing is sent even with consent. Consent lives at
+`~/.config/rac/telemetry.json`.
+
+- **Exit codes:** `0` consent shown or changed · `2` invalid action
+
+---
+
 ## new
 
 Create a new artifact from its canonical bundled template, with a
@@ -593,6 +614,11 @@ configuration, not artifact meaning — it never dictates folder structure.
 - **Exit codes:** `0` initialized, or already initialized with the same key
   (idempotent) · `1` a different key is already established (never silently
   rewritten) · `2` invalid key or not a directory
+
+After a successful init on a real terminal, `rac init` asks one one-time
+question — "Share anonymous usage to help shape Lore? [y/N]" — defaulting to
+No. Either answer is persisted, so it is asked at most once per machine; it
+never appears with `--json`, in pipes, or in CI. See `rac telemetry`.
 
 ```bash
 rac init

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,6 +1,6 @@
 # CLI Reference
 
-RAC ships a single command, `rac`, with twenty-one subcommands. This page documents each
+RAC ships a single command, `rac`, with twenty-two subcommands. This page documents each
 one: its purpose, inputs, outputs, and exit codes.
 
 ```bash

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -246,9 +246,10 @@ entire transmission — adding a field requires a new recorded decision
 {
   "api_key": "<public project write key>",
   "event": "lore-daily-ping",
-  "distinct_id": "<random install id>",
   "timestamp": "<ISO 8601 UTC>",
   "properties": {
+    "distinct_id": "<random install id>",
+    "$process_person_profile": false,
     "schema_version": "1",
     "rac_version": "<version>",
     "active_repos": 2
@@ -257,7 +258,9 @@ entire transmission — adding a field requires a new recorded decision
 ```
 
 What the fields are: the install id is a random token minted when you opt in
-(derived from nothing, so it identifies nothing); `active_repos` counts the
+(derived from nothing, so it identifies nothing); `$process_person_profile:
+false` tells PostHog to create no person profile, so the event stays
+anonymous on the receiving side as well; `active_repos` counts the
 distinct repositories Guide served in the last 30 days, tracked locally as
 salted digests in `~/.local/state/rac/active-repos.json` — the salt never
 leaves your machine and only the count is sent. The last-ping marker lives at

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -227,6 +227,50 @@ and timestamps only — and submit it with your own account. RAC never sends
 anything anywhere; building a URL is string formatting, and transmission
 belongs to you and your browser. Submitted reports are public issues.
 
+### Share anonymously (optional)
+
+If you'd rather contribute a signal without writing anything, opt in to an
+anonymous daily ping:
+
+```bash
+rac telemetry on       # opt in (rac init also asks once, on a real terminal)
+rac telemetry status   # exactly what is shared, and whether sending is possible
+rac telemetry off      # stop; nothing else changes
+```
+
+With consent on, `rac mcp` sends at most one ping per 24 hours. This is the
+entire transmission — adding a field requires a new recorded decision
+(ADR-041):
+
+```json
+{
+  "api_key": "<public project write key>",
+  "event": "lore-daily-ping",
+  "distinct_id": "<random install id>",
+  "timestamp": "<ISO 8601 UTC>",
+  "properties": {
+    "schema_version": "1",
+    "rac_version": "<version>",
+    "active_repos": 2
+  }
+}
+```
+
+What the fields are: the install id is a random token minted when you opt in
+(derived from nothing, so it identifies nothing); `active_repos` counts the
+distinct repositories Guide served in the last 30 days, tracked locally as
+salted digests in `~/.local/state/rac/active-repos.json` — the salt never
+leaves your machine and only the count is sent. The last-ping marker lives at
+`~/.local/state/rac/last-ping`; your consent record at
+`~/.config/rac/telemetry.json`.
+
+Sharing is independent of `--telemetry` — each is its own opt-in. When
+sharing is on, the server announces it on stderr at startup; it is never
+silent. The sender is one readable module (`rac/mcp/ping.py`, the only
+network code in RAC): failures are dropped without retries, the socket
+timeout is three seconds, and a build with no endpoint key configured sends
+nothing at all — `rac telemetry status` will say so.
+
 ## 8. Troubleshooting
 
 ### Server not listed in the client

--- a/rac/decisions/adr-040-guide-local-telemetry.md
+++ b/rac/decisions/adr-040-guide-local-telemetry.md
@@ -149,6 +149,9 @@ Opt-in local recording with user-driven sharing is selected.
   structured error code the tools already return.
 - ADR-013 (Git as the state store): the telemetry log is user-machine
   state, not repository state; it never enters the corpus.
+- ADR-041 (anonymous usage ping): amends this decision's "RAC contains
+  no network code" clause — a consented, pinned daily ping ships in
+  v0.10.5; local recording and the user-driven share flow are unchanged.
 
 ## Success Measures
 

--- a/rac/decisions/adr-040-guide-local-telemetry.md
+++ b/rac/decisions/adr-040-guide-local-telemetry.md
@@ -151,7 +151,7 @@ Opt-in local recording with user-driven sharing is selected.
   state, not repository state; it never enters the corpus.
 - ADR-041 (anonymous usage ping): amends this decision's "RAC contains
   no network code" clause — a consented, pinned daily ping ships in
-  v0.10.5; local recording and the user-driven share flow are unchanged.
+  v0.10.6; local recording and the user-driven share flow are unchanged.
 
 ## Success Measures
 

--- a/rac/decisions/adr-041-anonymous-usage-ping.md
+++ b/rac/decisions/adr-041-anonymous-usage-ping.md
@@ -1,0 +1,189 @@
+---
+schema_version: 1
+id: RAC-KTYPAB0HWFJD
+type: decision
+---
+# ADR-041: Anonymous Usage Ping
+
+## Status
+
+Accepted
+
+## Category
+
+Product
+
+## Context
+
+ADR-040 gave Guide local, opt-in, content-free telemetry, with sharing
+as a hand-submitted GitHub issue. That channel works while the
+maintainer can talk to every user; past roughly thirty teams it cannot
+answer the retention question — do installs come back — and no amount
+of local logging will.
+
+ADR-040's decision includes the clause "RAC contains no network code.
+Building a URL is string formatting; transmission belongs to the
+user." The trust-transparency requirement names hosted infrastructure
+a non-goal. RAC's ICP are exactly the engineers who read what a CLI
+phones home; a tool that quietly uploads usage forfeits its trust
+posture on launch day. Any remote signal has to survive that audience
+reading the source.
+
+The decision is the shape of remote telemetry that earns it: opt-in
+twice over, minimal, anonymous, and one readable module wide.
+
+## Decision
+
+RAC sends, with explicit recorded consent and never otherwise, at most
+one anonymous daily ping to PostHog.
+
+- Consent is its own explicit act, separate from the local
+  `--telemetry` flag: an honest one-line question at `rac init`
+  ("Share anonymous usage to help shape Lore? [y/N]") — TTY-gated,
+  default No, asked at most once per machine because either answer is
+  persisted — and a `rac telemetry on|off|status` command to flip or
+  inspect it at any time. This is deliberately the CLI's first
+  interactive prompt: one honest question, never in CI, never twice.
+- The payload is pinned in full; adding a field is a new recorded
+  decision: `api_key` (public project write key), `event`
+  (`lore-daily-ping`), `distinct_id` (install id), `timestamp`
+  (ISO 8601 UTC), `properties.schema_version` (`"1"`),
+  `properties.rac_version`, `properties.active_repos` (int). Never
+  repository contents, paths, artifact text, queries, tool arguments,
+  or anything identifying.
+- The install id is random (`secrets.token_hex(16)`), minted at
+  opt-in and preserved across off-and-on toggles — random beats a
+  salted hash of machine attributes because it derives from nothing.
+- Active repos are counted locally: a salted digest of each served
+  repository root, with a per-install salt that never leaves the
+  machine, pruned to a thirty-day window. Only the count transmits.
+- The sink is PostHog Cloud via one plain stdlib HTTP POST — no SDK
+  dependency. RAC itself still hosts no infrastructure; the
+  third-party-processor trade-off is accepted and recorded here, and
+  the sink is swappable behind one constant.
+- An empty `POSTHOG_API_KEY` constant is a kill switch: nothing sends
+  even with consent, and `rac telemetry status` says so.
+- Fire-and-forget posture: a daemon thread in the `rac mcp` server,
+  one attempt per 24 hours tracked by a local marker, a three-second
+  socket timeout, every exception swallowed, no retries, no queueing.
+  The ping never blocks, delays, or alters a tool call.
+- The network surface of RAC is one module: only the ping module may
+  import `urllib.request`, enforced by the isolation battery.
+
+## Consequences
+
+### Positive
+
+- The retention curve becomes measurable past the scale where every
+  user can be reached individually.
+- The trust story survives scrutiny: opt-in twice over, a pinned
+  content-free payload printed verbatim in the docs, and a network
+  surface one readable file wide.
+- The empty-key kill switch makes every build inert until the
+  PostHog project exists, decoupling code review from data flow.
+
+### Negative
+
+- ADR-040's flat "no network code" claim no longer holds; every
+  honesty surface that quoted it must be rewritten, and the weaker
+  claim ("one module, consent-gated") takes more words to defend.
+- PostHog is a third-party data processor; "we send to PostHog" is a
+  line in the privacy story that a self-hosted collector would avoid.
+- Opt-in data is sparse and self-selected; the curve is a floor, not
+  a census.
+
+### Risks
+
+- Payload creep under product pressure. Mitigation: the battery
+  asserts exact key sets at both payload levels; additions require a
+  new ADR.
+- The consent prompt erodes into a nag. Mitigation: either answer
+  persists; the gate is a file-exists check, pinned by tests.
+- A future contributor adds a network import elsewhere. Mitigation:
+  the isolation rule fails the build.
+
+## Alternatives Considered
+
+### Self-hosted collector
+
+A dead-simple endpoint RAC's maintainer controls.
+
+#### Advantages
+
+- No third-party processor; the strongest possible privacy story.
+
+#### Disadvantages
+
+- There is no lore domain or infrastructure to host it yet, and
+  standing it up delays the signal. Revisit when infrastructure
+  exists; the sink hides behind one constant.
+
+### No remote telemetry ever
+
+Keep the GitHub issue share flow as the only channel.
+
+#### Advantages
+
+- ADR-040's posture survives verbatim.
+
+#### Disadvantages
+
+- Retention is unmeasurable past the hand-callable scale; product
+  investment returns to guesswork exactly when the stakes rise.
+
+### Salted-hashed machine identifier
+
+Derive the install id by hashing hostname or hardware attributes.
+
+#### Advantages
+
+- Survives a deleted consent file.
+
+#### Disadvantages
+
+- Derivable is the opposite of anonymous: a hash of machine
+  attributes can in principle be correlated; a random token cannot.
+  Random wins.
+
+The consented daily ping with a pinned payload is selected.
+
+## Relationship to Other Decisions
+
+- ADR-040 (local telemetry): amended — its "RAC contains no network
+  code" clause narrows to "the network surface is the ping module,
+  and nothing sends without recorded consent". Local recording and
+  the user-driven share flow are unchanged.
+- ADR-032 (stateless reads): untouched — the ping runs outside the
+  request/response contract; nothing it reads or writes ever feeds a
+  tool response, and responses stay byte-identical.
+- ADR-035 (no RAC cloud dependency): honored — the dependency is
+  optional by consent and inert by the kill switch; core
+  functionality never needs it.
+- ADR-013 (Git as the state store): consent and ping state are
+  user-machine state under XDG directories, never repository state.
+
+## Success Measures
+
+- A captured ping matches the pinned payload byte-for-byte and
+  contains no path, salt, or repository content.
+- Declining at `rac init` results in zero network attempts, verified
+  by the battery's wire capture.
+- The isolation battery rejects any network import outside the ping
+  module.
+- A retention curve exists by the first release where opt-in count
+  exceeds what the maintainer can ring individually.
+
+## Review Date
+
+Review when a self-hosted collector becomes practical, when PostHog's
+free tier no longer covers the volume, or when the first product
+question demands a field the pinned payload lacks.
+
+## Related Requirements
+
+- rac-agent-context-guide
+- rac-trust-transparency
+
+## Related Roadmaps
+
+- v0.10.5-anonymous-usage-sharing

--- a/rac/decisions/adr-041-anonymous-usage-ping.md
+++ b/rac/decisions/adr-041-anonymous-usage-ping.md
@@ -46,19 +46,21 @@ one anonymous daily ping to PostHog.
   interactive prompt: one honest question, never in CI, never twice.
 - The payload is pinned in full; adding a field is a new recorded
   decision: `api_key` (public project write key), `event`
-  (`lore-daily-ping`), `distinct_id` (install id), `timestamp`
-  (ISO 8601 UTC), `properties.schema_version` (`"1"`),
-  `properties.rac_version`, `properties.active_repos` (int). Never
-  repository contents, paths, artifact text, queries, tool arguments,
-  or anything identifying.
+  (`lore-daily-ping`), `timestamp` (ISO 8601 UTC), and `properties`
+  carrying `distinct_id` (install id), `$process_person_profile`
+  (`false` — PostHog creates no person profile, so the event stays
+  anonymous on the sink side too), `schema_version` (`"1"`),
+  `rac_version`, and `active_repos` (int). The shape follows PostHog's
+  documented capture contract. Never repository contents, paths,
+  artifact text, queries, tool arguments, or anything identifying.
 - The install id is random (`secrets.token_hex(16)`), minted at
   opt-in and preserved across off-and-on toggles — random beats a
   salted hash of machine attributes because it derives from nothing.
 - Active repos are counted locally: a salted digest of each served
   repository root, with a per-install salt that never leaves the
   machine, pruned to a thirty-day window. Only the count transmits.
-- The sink is PostHog Cloud via one plain stdlib HTTP POST — no SDK
-  dependency. RAC itself still hosts no infrastructure; the
+- The sink is PostHog Cloud (EU region) via one plain stdlib HTTP
+  POST — no SDK dependency. RAC itself still hosts no infrastructure; the
   third-party-processor trade-off is accepted and recorded here, and
   the sink is swappable behind one constant.
 - An empty `POSTHOG_API_KEY` constant is a kill switch: nothing sends

--- a/rac/decisions/adr-041-anonymous-usage-ping.md
+++ b/rac/decisions/adr-041-anonymous-usage-ping.md
@@ -188,4 +188,4 @@ question demands a field the pinned payload lacks.
 
 ## Related Roadmaps
 
-- v0.10.5-anonymous-usage-sharing
+- v0.10.6-anonymous-usage-sharing

--- a/rac/roadmaps/v0.10.x-guide/v0.10.5-anonymous-usage-sharing.md
+++ b/rac/roadmaps/v0.10.x-guide/v0.10.5-anonymous-usage-sharing.md
@@ -132,9 +132,10 @@ The following decisions are pinned for v0.10.5.
 
 The entire transmission, one POST per 24 hours at most:
 `api_key` (public project write key), `event` (`lore-daily-ping`),
-`distinct_id` (random install id), `timestamp` (ISO 8601 UTC), and
-`properties` containing `schema_version` (`"1"`), `rac_version`, and
-`active_repos` (int).
+`timestamp` (ISO 8601 UTC), and `properties` containing `distinct_id`
+(random install id), `$process_person_profile` (`false`, so PostHog
+creates no person profile), `schema_version` (`"1"`), `rac_version`,
+and `active_repos` (int) — PostHog's documented capture shape.
 
 ### State and Config Paths
 

--- a/rac/roadmaps/v0.10.x-guide/v0.10.5-anonymous-usage-sharing.md
+++ b/rac/roadmaps/v0.10.x-guide/v0.10.5-anonymous-usage-sharing.md
@@ -1,0 +1,203 @@
+---
+schema_version: 1
+id: RAC-KTYPAAAN9Q20
+type: roadmap
+---
+# RAC v0.10.5 — Anonymous Usage Sharing
+
+## Status
+
+Planned
+
+## Context
+
+v0.10.4 gave Guide opt-in local telemetry, with hand-submitted GitHub
+issue reports as the only remote channel. That works while every user
+can be reached individually; past roughly thirty teams it cannot
+measure retention, and the product questions shift from "is Guide
+used" to "do installs come back".
+
+ADR-041 settles the phase-2 shape: a consented, anonymous, pinned
+daily ping to PostHog — a random install id, the version, and an
+active-repo count, never repository contents, paths, queries, or
+anything identifying. It deliberately amends ADR-040's "no network
+code" clause while keeping its spirit: the network surface of RAC is
+one readable module, nothing sends without recorded consent, and an
+empty endpoint key keeps every build inert.
+
+This milestone implements that decision: a consent record, the ping
+sender, an honest one-line consent prompt in `rac init` (the CLI's
+first interactive prompt), an explicit `rac telemetry` command, and a
+rewrite of every place the docs currently say nothing leaves the
+machine.
+
+## Outcomes
+
+- `rac init` asks once — "Share anonymous usage to help shape Lore?
+  [y/N]" — only on a real TTY, defaulting No, never blocking CI; the
+  answer persists either way so the question is asked at most once.
+- `rac telemetry on|off|status` flips and inspects consent at any
+  time, showing exactly what is shared.
+- With consent on and an endpoint key configured, `rac mcp` sends at
+  most one ping per 24 hours carrying the install id, version, and
+  active-repo count — nothing else; opt-out or an empty key means
+  silence.
+- Tool responses are byte-identical with sharing on and off; the
+  existing Guide batteries pass unchanged.
+
+## Initiatives
+
+### Initiative 1 — Consent Record (ADR-041)
+
+A stdlib-only consent module outside the server layer: a frozen
+record under the XDG config directory holding the sharing choice, a
+random install id minted at opt-in, a local-only salt for repo
+digests, and the consent timestamp. Corruption-tolerant by the
+Explorer preferences posture; opt-in preserves an existing install id
+across off-and-on toggles so the retention curve stays continuous.
+
+### Initiative 2 — Ping Sender
+
+A stdlib-only sender in the server layer — the only module in RAC
+permitted to import a network client, enforced by the isolation
+battery. A daemon thread started by `rac mcp` when consent is on:
+at most one attempt per 24 hours tracked by a local marker, a short
+socket timeout, every failure swallowed, no retries, and the pinned
+payload as the entire transmission. Active repos are counted from a
+local file of salted path digests pruned to a thirty-day window; only
+the count is sent.
+
+### Initiative 3 — Consent Surfaces
+
+The one-time `rac init` prompt (TTY-gated, default No, skipped with
+`--json` and whenever a record exists) and the `rac telemetry`
+command (`on`, `off`, `status`, defaulting to `status`). Both speak
+plainly about what is and is not sent, and `status` names the
+empty-key state explicitly.
+
+### Initiative 4 — Honesty Surfaces
+
+Every place that currently says nothing leaves the machine is
+rewritten: the README trust bullet, the MCP guide's telemetry
+section, the CLI reference, the changelog, and a one-line amendment
+note in ADR-040 itself.
+
+### Initiative 5 — Contract Battery
+
+A ping battery pins the payload field-for-field, the consent
+round-trip, the 24-hour dedupe, the swallowed-failure no-retry
+posture, the salted-digest privacy of the active-repo file, and the
+TTY gating of the init prompt. A new isolation rule pins the
+strongest claim: network client modules are importable only by the
+ping module.
+
+## Constraints
+
+- The payload is pinned field-for-field; adding a field is a new
+  recorded decision, not a patch (ADR-041).
+- The local salt and raw repository paths are never transmitted; only
+  the active-repo count crosses the wire.
+- The ping never blocks, delays, or alters a tool call; tool
+  responses stay byte-identical (ADR-032 untouched).
+- `urllib.request` is importable only by the ping module, enforced by
+  the isolation battery.
+- Sharing is independent of the local `--telemetry` flag; each is its
+  own opt-in.
+- Consent defaults to No everywhere: empty answers, EOF, non-TTY, and
+  corrupted consent records all mean no sharing.
+
+## Non-Goals
+
+- Opt-out-by-default telemetry, or any prompt that nags twice
+- A second event type, per-tool remote metrics, or latency reporting
+- The PostHog SDK as a dependency; the POST is plain stdlib
+- Retries, offline queueing, or batching of failed pings
+- Transmitting any part of the local telemetry log
+
+## Implementation Contract
+
+The following decisions are pinned for v0.10.5.
+
+### Module Locations
+
+- Consent record and PostHog constants live in `src/rac/consent.py`,
+  outside the server layer, so `rac init` and `rac telemetry` never
+  import the MCP SDK.
+- The sender lives in `src/rac/mcp/ping.py` — the only module in RAC
+  that imports `urllib.request`.
+- The server hook is one call in `run_server`; `build_server` is
+  untouched.
+
+### Ping Payload
+
+The entire transmission, one POST per 24 hours at most:
+`api_key` (public project write key), `event` (`lore-daily-ping`),
+`distinct_id` (random install id), `timestamp` (ISO 8601 UTC), and
+`properties` containing `schema_version` (`"1"`), `rac_version`, and
+`active_repos` (int).
+
+### State and Config Paths
+
+- Consent: `$XDG_CONFIG_HOME/rac/telemetry.json`
+- Last ping marker: `$XDG_STATE_HOME/rac/last-ping`
+- Active repos: `$XDG_STATE_HOME/rac/active-repos.json` (salted
+  digests and dates only)
+
+### CLI and Exit Codes
+
+- `rac telemetry [on | off | status]`: exit 0 for every valid action,
+  including when no endpoint key is configured; invalid actions are
+  argparse usage errors (exit 2).
+- The init prompt never changes `rac init` exit codes or `--json`
+  output.
+
+## Success Measures
+
+- A consenting install produces exactly one ping per day whose body
+  matches the pinned payload byte-for-byte against a captured POST.
+- Declining at `rac init` writes a record and the question is never
+  asked again on that machine.
+- `rac telemetry status` answers "what is shared, where, and is it
+  currently possible" without reading source code.
+- The isolation battery fails any change that adds a network import
+  outside the ping module.
+
+## Risks
+
+- A quiet consent prompt yields few opt-ins. Accepted: the honest
+  prompt is the point; launch messaging can ask, the tool never nags.
+- PostHog as a third-party processor draws scrutiny. Mitigated: the
+  payload is pinned and content-free, the ADR records the trade-off,
+  and the sink is swappable behind one constant.
+- A future field addition erodes the pinned payload. Mitigated: the
+  battery asserts exact key sets at both payload levels; additions
+  require a new ADR.
+
+## Assumptions
+
+- PostHog Cloud's free tier comfortably covers daily pings at any
+  plausible install count.
+- The public project write key is safe to embed (write-only by
+  design); the empty-key kill switch covers builds before the
+  project exists.
+
+## Related Decisions
+
+- ADR-041
+- ADR-040
+- ADR-032
+- ADR-035
+- ADR-027
+
+## Related Designs
+
+- guide-tool-surface
+
+## Related Requirements
+
+- rac-agent-context-guide
+- rac-trust-transparency
+
+## Dependencies
+
+- v0.10.4 local telemetry (consent vocabulary and trust posture)

--- a/rac/roadmaps/v0.10.x-guide/v0.10.6-anonymous-usage-sharing.md
+++ b/rac/roadmaps/v0.10.x-guide/v0.10.6-anonymous-usage-sharing.md
@@ -3,7 +3,7 @@ schema_version: 1
 id: RAC-KTYPAAAN9Q20
 type: roadmap
 ---
-# RAC v0.10.5 — Anonymous Usage Sharing
+# RAC v0.10.6 — Anonymous Usage Sharing
 
 ## Status
 
@@ -116,7 +116,7 @@ ping module.
 
 ## Implementation Contract
 
-The following decisions are pinned for v0.10.5.
+The following decisions are pinned for v0.10.6.
 
 ### Module Locations
 

--- a/src/rac/cli.py
+++ b/src/rac/cli.py
@@ -15,6 +15,7 @@ Commands:
     rac explorer [directory] [--top-level]
     rac mcp [--root PATH] [--telemetry]
     rac mcp-stats [--json | --share]
+    rac telemetry [on | off | status]
     rac new <artifact-type> <output-path> [--json]
     rac templates [--json]
     rac init [directory] [--key KEY] [--json]
@@ -31,7 +32,9 @@ Exit codes:
        matches; migration or dry run completed, even with nothing to migrate;
        explorer session quit by the user; mcp server shutdown on client
        disconnect; skill(s) installed; skills listed; mcp-stats summary
-       produced, even from an empty or missing telemetry log)
+       produced, even from an empty or missing telemetry log; telemetry
+       consent shown or changed, including when no endpoint key is
+       configured)
     1  validate: errors found; stats: no valid known artifacts; ingest:
        conversion failed; relationships --validate: broken/ambiguous/self
        references or duplicate identifiers found; review: invalid artifacts
@@ -55,6 +58,7 @@ import argparse
 import sys
 from pathlib import Path
 
+from rac import consent
 from rac import output as outputs
 from rac.core.classification import score_artifacts
 from rac.core.markdown import parse, parse_file
@@ -560,6 +564,60 @@ def cmd_init(args: argparse.Namespace) -> int:
         print(outputs.render_init_json(result))
     else:
         print(outputs.render_init_human(result))
+        _maybe_ask_usage_sharing()
+    return EXIT_OK
+
+
+def _maybe_ask_usage_sharing() -> None:
+    """Ask the one-time usage-sharing question after a successful init (ADR-041).
+
+    The CLI's only interactive prompt, deliberately narrow: a real TTY on both
+    ends, no ``--json`` (the caller gates that), and no prior answer — either
+    answer is persisted, so the question is asked at most once per machine.
+    Empty input and EOF mean No; CI and pipes never reach ``input()``.
+    """
+    if not (sys.stdin.isatty() and sys.stdout.isatty()) or consent.consent_recorded():
+        return
+    try:
+        answer = input("\nShare anonymous usage to help shape Lore? [y/N] ")
+    except EOFError:
+        answer = ""
+    if answer.strip().lower() in ("y", "yes"):
+        consent.opt_in()
+        print(
+            "Sharing on — one anonymous daily ping. 'rac telemetry status' "
+            "shows exactly what; 'rac telemetry off' stops it."
+        )
+    else:
+        consent.decline()
+
+
+def cmd_telemetry(args: argparse.Namespace) -> int:
+    if args.action == "on":
+        record = consent.opt_in()
+        print(f"Sharing on. Install id: {record.install_id}")
+        print(
+            "One anonymous daily ping: install id, rac version, active-repo "
+            "count. Never paths, queries, or content (ADR-041)."
+        )
+        if not consent.POSTHOG_API_KEY:
+            print("Note: this build has no PostHog key configured; nothing will be sent.")
+    elif args.action == "off":
+        consent.opt_out()
+        print("Sharing off. Nothing will be sent.")
+    else:  # status
+        status = consent.consent_status()
+        print(f"Sharing: {'on' if status.sharing else 'off'}")
+        print(f"Install id: {status.install_id or '(none)'}")
+        print(f"Consented at: {status.consented_at or '(never)'}")
+        print(f"Consent file: {status.path}")
+        if status.sharing:
+            print(
+                "Shared daily: install id, rac version, active-repo count. "
+                "Never paths, queries, or content (ADR-041)."
+            )
+        if not status.endpoint_configured:
+            print("Endpoint key: not configured — nothing is sent.")
     return EXIT_OK
 
 
@@ -919,6 +977,20 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     p_mcp_stats.set_defaults(func=cmd_mcp_stats)
+
+    p_telemetry = sub.add_parser(
+        "telemetry",
+        help="Show or change anonymous usage-sharing consent (ADR-041).",
+        parents=[version_parent],
+    )
+    p_telemetry.add_argument(
+        "action",
+        nargs="?",
+        default="status",
+        choices=["on", "off", "status"],
+        help="on: opt in; off: opt out; status: show consent and what is shared (default).",
+    )
+    p_telemetry.set_defaults(func=cmd_telemetry)
 
     p_new = sub.add_parser(
         "new",

--- a/src/rac/consent.py
+++ b/src/rac/consent.py
@@ -32,12 +32,13 @@ from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 
-# The PostHog capture endpoint and public project write key (ADR-041). An
-# empty key is the kill switch: nothing sends even with consent recorded, and
-# `rac telemetry status` says so. Pre-release task: fill the key in when the
-# PostHog project exists; the sink is swappable behind these two constants.
-POSTHOG_ENDPOINT = "https://us.i.posthog.com/capture/"
-POSTHOG_API_KEY = ""
+# The PostHog capture endpoint (EU region) and public project write key
+# (ADR-041). The key is write-only by design and safe to embed; emptying it
+# is the kill switch — nothing sends even with consent recorded, and
+# `rac telemetry status` says so. The sink is swappable behind these two
+# constants.
+POSTHOG_ENDPOINT = "https://eu.i.posthog.com/capture/"
+POSTHOG_API_KEY = "phc_whK4Ndn7Pae3ZtgNRJWswiafYEyPc9d3eVoFihxzDysZ"
 
 CONSENT_FILENAME = "telemetry.json"
 

--- a/src/rac/consent.py
+++ b/src/rac/consent.py
@@ -1,4 +1,4 @@
-"""Usage-sharing consent — opt-in twice over, anonymous by construction (v0.10.5).
+"""Usage-sharing consent — opt-in twice over, anonymous by construction (v0.10.6).
 
 ADR-041 allows RAC one anonymous daily ping, and only with consent recorded
 here. The record lives as JSON under ``$XDG_CONFIG_HOME/rac/telemetry.json``

--- a/src/rac/consent.py
+++ b/src/rac/consent.py
@@ -1,0 +1,144 @@
+"""Usage-sharing consent — opt-in twice over, anonymous by construction (v0.10.5).
+
+ADR-041 allows RAC one anonymous daily ping, and only with consent recorded
+here. The record lives as JSON under ``$XDG_CONFIG_HOME/rac/telemetry.json``
+with the Explorer-preferences posture: a missing or corrupt file means no
+consent, loading never raises, and saving tolerates filesystem trouble
+silently — a machine where consent cannot be persisted is a machine that
+shares nothing.
+
+The install id is random (``secrets.token_hex(16)``), minted at opt-in and
+preserved across off-and-on toggles so the retention curve stays continuous.
+Random beats a salted hash of machine attributes because it derives from
+nothing (ADR-041). The separate ``salt`` digests repository paths for the
+local active-repo count and never leaves the machine.
+
+Either answer to the ``rac init`` prompt is persisted — including a decline —
+so the question is asked at most once per machine: :func:`consent_recorded`
+is the gate, not the answer.
+
+This module lives outside ``rac.mcp`` because importing that package pays the
+MCP SDK import, and ``rac init`` / ``rac telemetry`` must stay SDK-free. The
+PostHog constants live here for the same reason — they are inert strings; the
+only network code in RAC is :mod:`rac.mcp.ping`.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import secrets
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+# The PostHog capture endpoint and public project write key (ADR-041). An
+# empty key is the kill switch: nothing sends even with consent recorded, and
+# `rac telemetry status` says so. Pre-release task: fill the key in when the
+# PostHog project exists; the sink is swappable behind these two constants.
+POSTHOG_ENDPOINT = "https://us.i.posthog.com/capture/"
+POSTHOG_API_KEY = ""
+
+CONSENT_FILENAME = "telemetry.json"
+
+
+@dataclass(frozen=True)
+class Consent:
+    """The recorded sharing choice; the default is no consent."""
+
+    share_usage: bool = False
+    install_id: str = ""
+    salt: str = ""
+    consented_at: str = ""
+
+
+@dataclass(frozen=True)
+class ConsentStatus:
+    """What `rac telemetry status` reports."""
+
+    sharing: bool
+    install_id: str
+    consented_at: str
+    path: str
+    endpoint_configured: bool
+
+
+def consent_path() -> Path:
+    base = os.environ.get("XDG_CONFIG_HOME") or str(Path.home() / ".config")
+    return Path(base) / "rac" / CONSENT_FILENAME
+
+
+def consent_recorded() -> bool:
+    """True once any answer — including a decline — has been persisted."""
+    return consent_path().is_file()
+
+
+def load_consent() -> Consent:
+    """Read the consent record; any problem means no consent (never raises)."""
+    try:
+        data = json.loads(consent_path().read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return Consent()
+    if not isinstance(data, dict):
+        return Consent()
+    defaults = Consent()
+    return Consent(
+        share_usage=bool(data.get("share_usage", defaults.share_usage)),
+        install_id=str(data.get("install_id", defaults.install_id)),
+        salt=str(data.get("salt", defaults.salt)),
+        consented_at=str(data.get("consented_at", defaults.consented_at)),
+    )
+
+
+def save_consent(consent: Consent) -> None:
+    """Persist the record; tolerates filesystem trouble silently."""
+    path = consent_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(asdict(consent), indent=2) + "\n", encoding="utf-8")
+    except OSError:
+        pass
+
+
+def opt_in() -> Consent:
+    """Record consent, minting ids only where none exist yet."""
+    existing = load_consent()
+    consent = Consent(
+        share_usage=True,
+        install_id=existing.install_id or secrets.token_hex(16),
+        salt=existing.salt or secrets.token_hex(16),
+        consented_at=datetime.now(UTC).isoformat(timespec="seconds").replace("+00:00", "Z"),
+    )
+    save_consent(consent)
+    return consent
+
+
+def opt_out() -> Consent:
+    """Withdraw consent; the ids are kept so a later opt-in stays continuous."""
+    existing = load_consent()
+    consent = Consent(
+        share_usage=False,
+        install_id=existing.install_id,
+        salt=existing.salt,
+        consented_at=existing.consented_at,
+    )
+    save_consent(consent)
+    return consent
+
+
+def decline() -> Consent:
+    """Persist the default no-consent record, making ask-once true."""
+    consent = Consent()
+    save_consent(consent)
+    return consent
+
+
+def consent_status() -> ConsentStatus:
+    consent = load_consent()
+    return ConsentStatus(
+        sharing=consent.share_usage,
+        install_id=consent.install_id,
+        consented_at=consent.consented_at,
+        path=str(consent_path()),
+        endpoint_configured=bool(POSTHOG_API_KEY),
+    )

--- a/src/rac/mcp/ping.py
+++ b/src/rac/mcp/ping.py
@@ -1,0 +1,201 @@
+"""The anonymous daily ping — RAC's entire network surface (v0.10.5).
+
+ADR-041 allows one transmission and pins it in full: with consent recorded
+(:mod:`rac.consent`) and a PostHog key configured, the Guide server sends at
+most one ping per 24 hours carrying a random install id, the RAC version, and
+an active-repo count. Never repository contents, paths, artifact text,
+queries, or tool arguments. Adding a field is a new recorded decision.
+
+This is the only module in RAC permitted to import ``urllib.request`` — the
+isolation battery enforces it — so "what does RAC phone home" is answerable
+by reading one file.
+
+Fire-and-forget posture: a daemon thread started by ``run_server``, a
+three-second socket timeout, every exception swallowed, no retries, no
+queueing. The 24-hour marker is written after each attempt regardless of
+outcome, so a failing endpoint costs one attempt per day, never a storm. The
+ping runs outside the request/response contract (ADR-032): nothing it reads
+or writes ever feeds a tool response.
+
+Active repos are counted locally: each served repository root is recorded as
+a salted digest (the per-install salt from the consent record, never
+transmitted) with a last-seen date, pruned to a thirty-day window. Only the
+count crosses the wire.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import threading
+import time
+import urllib.request
+from datetime import UTC, date, datetime, timedelta
+from pathlib import Path
+
+from rac import __version__
+from rac import consent as consent_record
+from rac.consent import Consent
+
+PING_EVENT = "lore-daily-ping"
+PING_SCHEMA_VERSION = "1"
+PING_INTERVAL_SECONDS = 24 * 3600
+CHECK_INTERVAL_SECONDS = 3600
+SOCKET_TIMEOUT_SECONDS = 3.0
+ACTIVE_WINDOW_DAYS = 30
+
+LAST_PING_FILENAME = "last-ping"
+ACTIVE_REPOS_FILENAME = "active-repos.json"
+
+
+def _state_dir() -> Path:
+    base = os.environ.get("XDG_STATE_HOME") or str(Path.home() / ".local" / "state")
+    return Path(base) / "rac"
+
+
+def repo_digest(root: str, salt: str) -> str:
+    """A salted digest of the resolved repository root; the salt never transmits."""
+    return hashlib.sha256((salt + str(Path(root).resolve())).encode("utf-8")).hexdigest()
+
+
+def record_active_repo(root: str, salt: str) -> None:
+    """Mark ``root`` active today in the local digest file; never raises."""
+    path = _state_dir() / ACTIVE_REPOS_FILENAME
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        data = {}
+    if not isinstance(data, dict):
+        data = {}
+    today = datetime.now(UTC).date()
+    data[repo_digest(root, salt)] = today.isoformat()
+    cutoff = today - timedelta(days=ACTIVE_WINDOW_DAYS)
+    kept = {digest: seen for digest, seen in data.items() if _within_window(seen, cutoff)}
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(kept, indent=2) + "\n", encoding="utf-8")
+    except OSError:
+        pass
+
+
+def active_repo_count() -> int:
+    """Distinct repos seen within the window; any trouble counts as zero."""
+    path = _state_dir() / ACTIVE_REPOS_FILENAME
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return 0
+    if not isinstance(data, dict):
+        return 0
+    cutoff = datetime.now(UTC).date() - timedelta(days=ACTIVE_WINDOW_DAYS)
+    return sum(1 for seen in data.values() if _within_window(seen, cutoff))
+
+
+def _within_window(seen: object, cutoff: date) -> bool:
+    if not isinstance(seen, str):
+        return False
+    parsed = _parse_date(seen)
+    return parsed is not None and parsed >= cutoff
+
+
+def _parse_date(text: str) -> date | None:
+    try:
+        return datetime.strptime(text, "%Y-%m-%d").date()
+    except ValueError:
+        return None
+
+
+def last_ping_at() -> datetime | None:
+    """When the last attempt happened; missing or corrupt means never."""
+    path = _state_dir() / LAST_PING_FILENAME
+    try:
+        text = path.read_text(encoding="utf-8").strip()
+        return datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except (OSError, ValueError):
+        return None
+
+
+def mark_pinged(now: datetime) -> None:
+    """Record the attempt time; never raises."""
+    path = _state_dir() / LAST_PING_FILENAME
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(_iso(now) + "\n", encoding="utf-8")
+    except OSError:
+        pass
+
+
+def should_ping(now: datetime) -> bool:
+    last = last_ping_at()
+    return last is None or (now - last).total_seconds() >= PING_INTERVAL_SECONDS
+
+
+def _iso(now: datetime) -> str:
+    return now.isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def build_payload(install_id: str, active_repos: int, now: datetime) -> dict:
+    """The entire transmission, pinned by ADR-041; additions are a new ADR."""
+    return {
+        "api_key": consent_record.POSTHOG_API_KEY,
+        "event": PING_EVENT,
+        "distinct_id": install_id,
+        "timestamp": _iso(now),
+        "properties": {
+            "schema_version": PING_SCHEMA_VERSION,
+            "rac_version": __version__,
+            "active_repos": active_repos,
+        },
+    }
+
+
+def send_ping(payload: dict) -> None:
+    """One POST, short timeout, every failure swallowed, no retries."""
+    request = urllib.request.Request(
+        consent_record.POSTHOG_ENDPOINT,
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=SOCKET_TIMEOUT_SECONDS):
+            pass
+    except Exception:
+        pass
+
+
+def _tick(install_id: str) -> None:
+    """One loop body: at most one attempt per 24 hours.
+
+    The marker is written after the attempt regardless of outcome — a failing
+    endpoint costs one attempt per day, never a retry storm.
+    """
+    now = datetime.now(UTC)
+    if not should_ping(now):
+        return
+    send_ping(build_payload(install_id, active_repo_count(), now))
+    mark_pinged(now)
+
+
+def start_ping_thread(consent: Consent) -> threading.Thread | None:
+    """Start the daily-ping daemon thread, or return None when nothing may send.
+
+    Requires recorded consent, a minted install id, and a configured key (the
+    empty-key kill switch, ADR-041). The thread dies with the process; there
+    is no shutdown choreography.
+    """
+    if not (consent.share_usage and consent.install_id and consent_record.POSTHOG_API_KEY):
+        return None
+
+    def _loop() -> None:
+        while True:
+            try:
+                _tick(consent.install_id)
+            except Exception:
+                pass
+            time.sleep(CHECK_INTERVAL_SECONDS)
+
+    thread = threading.Thread(target=_loop, daemon=True, name="lore-ping")
+    thread.start()
+    return thread

--- a/src/rac/mcp/ping.py
+++ b/src/rac/mcp/ping.py
@@ -136,13 +136,20 @@ def _iso(now: datetime) -> str:
 
 
 def build_payload(install_id: str, active_repos: int, now: datetime) -> dict:
-    """The entire transmission, pinned by ADR-041; additions are a new ADR."""
+    """The entire transmission, pinned by ADR-041; additions are a new ADR.
+
+    The shape follows PostHog's documented capture contract: ``distinct_id``
+    rides inside ``properties``, and ``$process_person_profile: false`` marks
+    the event anonymous so PostHog creates no person profile — cheaper, and
+    one more enforcement of the anonymity posture.
+    """
     return {
         "api_key": consent_record.POSTHOG_API_KEY,
         "event": PING_EVENT,
-        "distinct_id": install_id,
         "timestamp": _iso(now),
         "properties": {
+            "distinct_id": install_id,
+            "$process_person_profile": False,
             "schema_version": PING_SCHEMA_VERSION,
             "rac_version": __version__,
             "active_repos": active_repos,

--- a/src/rac/mcp/ping.py
+++ b/src/rac/mcp/ping.py
@@ -1,4 +1,4 @@
-"""The anonymous daily ping — RAC's entire network surface (v0.10.5).
+"""The anonymous daily ping — RAC's entire network surface (v0.10.6).
 
 ADR-041 allows one transmission and pins it in full: with consent recorded
 (:mod:`rac.consent`) and a PostHog key configured, the Guide server sends at

--- a/src/rac/mcp/server.py
+++ b/src/rac/mcp/server.py
@@ -26,6 +26,12 @@ classifies the structured payload, and returns it unchanged — tool responses
 are byte-identical with telemetry on and off, and the log is never an input
 to a response. Default is off; nothing is recorded without ``--telemetry``.
 
+Anonymous usage sharing (v0.10.5, ADR-041): with consent recorded via
+``rac telemetry on`` (or the ``rac init`` prompt), ``run_server`` starts the
+daily-ping daemon thread (:mod:`rac.mcp.ping`) — at most one pinned,
+content-free ping per 24 hours, independent of ``--telemetry``, announced on
+stderr. Without consent or without a configured key, nothing sends.
+
 Startup diagnostics (v0.10.1): ``run_server`` writes a one-line notice to
 stderr when the repository root contains no recognized artifacts, so the first
 run against a misconfigured or empty root fails helpfully rather than silently.
@@ -39,8 +45,9 @@ from pathlib import Path
 
 from mcp.server.fastmcp import FastMCP
 
+from rac import consent as consent_record
 from rac.core.corpus import walk_corpus
-from rac.mcp import errors, telemetry
+from rac.mcp import errors, ping, telemetry
 from rac.mcp.budget import DEFAULT_BUDGET, serialize
 from rac.mcp.telemetry import TelemetryRecorder
 from rac.services.index import build_repository_index, index_from_corpus
@@ -276,6 +283,33 @@ def _check_corpus(root: str) -> None:
         pass
 
 
+def _maybe_start_sharing(root: str) -> None:
+    """Start the consented daily ping; absence of consent costs nothing (ADR-041).
+
+    Independent of ``--telemetry`` — each is its own opt-in. stdout belongs to
+    the MCP protocol; the enablement notice goes to stderr, so sharing is
+    announced, never silent.
+    """
+    consent = consent_record.load_consent()
+    if not consent.share_usage:
+        return
+    ping.record_active_repo(root, consent.salt)
+    thread = ping.start_ping_thread(consent)
+    if thread is not None:
+        print(
+            "rac mcp: anonymous usage sharing on — at most one daily ping "
+            "(random install id, rac version, active-repo count; never paths, "
+            "queries, or content). Disable with 'rac telemetry off' (ADR-041).",
+            file=sys.stderr,
+        )
+    else:
+        print(
+            "rac mcp: usage sharing is enabled but this build has no "
+            "PostHog key configured; nothing will be sent.",
+            file=sys.stderr,
+        )
+
+
 def run_server(root: str, budget: int = DEFAULT_BUDGET, telemetry_enabled: bool = False) -> int:
     """Run the Guide server over stdio until the client disconnects.
 
@@ -296,5 +330,6 @@ def run_server(root: str, budget: int = DEFAULT_BUDGET, telemetry_enabled: bool 
             f"(no arguments, no content) to {recorder.path}",
             file=sys.stderr,
         )
+    _maybe_start_sharing(root)
     build_server(root, budget=budget, recorder=recorder).run(transport="stdio")
     return 0

--- a/src/rac/mcp/server.py
+++ b/src/rac/mcp/server.py
@@ -26,7 +26,7 @@ classifies the structured payload, and returns it unchanged — tool responses
 are byte-identical with telemetry on and off, and the log is never an input
 to a response. Default is off; nothing is recorded without ``--telemetry``.
 
-Anonymous usage sharing (v0.10.5, ADR-041): with consent recorded via
+Anonymous usage sharing (v0.10.6, ADR-041): with consent recorded via
 ``rac telemetry on`` (or the ``rac init`` prompt), ``run_server`` starts the
 daily-ping daemon thread (:mod:`rac.mcp.ping`) — at most one pinned,
 content-free ping per 24 hours, independent of ``--telemetry``, announced on

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,3 +16,17 @@ def fixtures_dir() -> Path:
 
 def fixture_path(*parts: str) -> str:
     return str(FIXTURES.joinpath(*parts))
+
+
+@pytest.fixture(autouse=True)
+def _isolated_xdg(tmp_path_factory, monkeypatch):
+    """Point XDG config/state at a temp dir for every test.
+
+    No test may read or write real user state — and with a live PostHog key
+    in source (ADR-041), no test run may ever find a developer's consent
+    record and phone home. Tests that need specific locations still override
+    these variables locally.
+    """
+    base = tmp_path_factory.mktemp("xdg")
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(base / "config"))
+    monkeypatch.setenv("XDG_STATE_HOME", str(base / "state"))

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -116,3 +116,95 @@ def test_cli_init_missing_directory_exit_2(tmp_path, capsys):
     with pytest.raises(SystemExit) as exc:
         main(["init", str(tmp_path / "nope")])
     assert exc.value.code == 2
+
+
+# --- usage-sharing prompt (v0.10.5, ADR-041) ----------------------------------
+
+
+def _tty(monkeypatch, stdin: bool, stdout: bool) -> None:
+    monkeypatch.setattr("sys.stdin.isatty", lambda: stdin)
+    monkeypatch.setattr("sys.stdout.isatty", lambda: stdout)
+
+
+@pytest.fixture()
+def _consent_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+    return tmp_path
+
+
+def test_init_prompt_yes_records_consent(tmp_path, _consent_home, monkeypatch, capsys):
+    from rac import consent
+
+    (tmp_path / "repo").mkdir()
+    _tty(monkeypatch, True, True)
+    monkeypatch.setattr("builtins.input", lambda prompt: "y")
+    assert main(["init", str(tmp_path / "repo")]) == 0
+    record = consent.load_consent()
+    assert record.share_usage is True
+    assert len(record.install_id) == 32
+    assert "rac telemetry status" in capsys.readouterr().out
+
+
+def test_init_prompt_default_no_is_persisted_and_asked_once(tmp_path, _consent_home, monkeypatch):
+    from rac import consent
+
+    (tmp_path / "repo").mkdir()
+    _tty(monkeypatch, True, True)
+    asked = []
+
+    def _input(prompt: str) -> str:
+        asked.append(prompt)
+        return ""
+
+    monkeypatch.setattr("builtins.input", _input)
+    assert main(["init", str(tmp_path / "repo")]) == 0
+    assert len(asked) == 1
+    assert "[y/N]" in asked[0]
+    assert consent.consent_recorded() is True
+    assert consent.load_consent().share_usage is False
+    # The question is never asked twice on the same machine.
+    assert main(["init", str(tmp_path / "repo")]) == 0
+    assert len(asked) == 1
+
+
+def test_init_prompt_eof_means_no(tmp_path, _consent_home, monkeypatch):
+    from rac import consent
+
+    (tmp_path / "repo").mkdir()
+    _tty(monkeypatch, True, True)
+
+    def _eof(prompt: str) -> str:
+        raise EOFError
+
+    monkeypatch.setattr("builtins.input", _eof)
+    assert main(["init", str(tmp_path / "repo")]) == 0
+    assert consent.load_consent().share_usage is False
+
+
+def test_init_never_prompts_without_a_tty(tmp_path, _consent_home, monkeypatch):
+    from rac import consent
+
+    (tmp_path / "repo").mkdir()
+    _tty(monkeypatch, False, False)
+
+    def _forbidden(prompt: str) -> str:  # pragma: no cover - must not run
+        raise AssertionError("input() must not be called without a TTY")
+
+    monkeypatch.setattr("builtins.input", _forbidden)
+    assert main(["init", str(tmp_path / "repo")]) == 0
+    assert consent.consent_recorded() is False
+
+
+def test_init_json_never_prompts(tmp_path, _consent_home, monkeypatch, capsys):
+    from rac import consent
+
+    (tmp_path / "repo").mkdir()
+    _tty(monkeypatch, True, True)
+
+    def _forbidden(prompt: str) -> str:  # pragma: no cover - must not run
+        raise AssertionError("input() must not be called with --json")
+
+    monkeypatch.setattr("builtins.input", _forbidden)
+    assert main(["init", str(tmp_path / "repo"), "--json"]) == 0
+    json.loads(capsys.readouterr().out)  # machine output stays pure JSON
+    assert consent.consent_recorded() is False

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -118,7 +118,7 @@ def test_cli_init_missing_directory_exit_2(tmp_path, capsys):
     assert exc.value.code == 2
 
 
-# --- usage-sharing prompt (v0.10.5, ADR-041) ----------------------------------
+# --- usage-sharing prompt (v0.10.6, ADR-041) ----------------------------------
 
 
 def _tty(monkeypatch, stdin: bool, stdout: bool) -> None:

--- a/tests/test_mcp_isolation.py
+++ b/tests/test_mcp_isolation.py
@@ -74,3 +74,17 @@ def test_only_the_server_package_imports_the_mcp_sdk():
     other = [f for f in SRC.rglob("*.py") if "mcp" not in f.relative_to(SRC).parts]
     assert other
     assert _violations(other, ("mcp",)) == []
+
+
+# Network client modules; the ping module is RAC's entire network surface
+# (ADR-041). ``urllib.parse`` (string formatting for the share URL) is
+# deliberately not in this list.
+NETWORK_MODULES: tuple[str, ...] = ("urllib.request", "http.client")
+
+
+def test_only_the_ping_module_imports_network_modules():
+    # The strongest trust statement in the codebase: "what does RAC phone
+    # home" is answerable by reading one file.
+    files = [f for f in SRC.rglob("*.py") if f != SRC / "mcp" / "ping.py"]
+    assert files
+    assert _violations(files, NETWORK_MODULES) == []

--- a/tests/test_mcp_ping.py
+++ b/tests/test_mcp_ping.py
@@ -44,8 +44,14 @@ from rac.mcp.ping import (
 )
 
 # The pinned payload key sets (ADR-041). Adding a key is a recorded decision.
-PAYLOAD_KEYS = {"api_key", "event", "distinct_id", "timestamp", "properties"}
-PROPERTY_KEYS = {"schema_version", "rac_version", "active_repos"}
+PAYLOAD_KEYS = {"api_key", "event", "timestamp", "properties"}
+PROPERTY_KEYS = {
+    "distinct_id",
+    "$process_person_profile",
+    "schema_version",
+    "rac_version",
+    "active_repos",
+}
 
 NOW = datetime(2026, 6, 12, 12, 0, 0, tzinfo=UTC)
 
@@ -115,7 +121,13 @@ def test_cli_telemetry_on_records_consent_and_prints_install_id(capsys):
     assert record.share_usage is True
     assert record.install_id in out
     assert "Never paths, queries, or content" in out
-    assert "no PostHog key configured" in out  # empty-key build
+    assert "no PostHog key configured" not in out  # the key ships configured
+
+
+def test_cli_telemetry_on_names_the_kill_switch_when_key_is_empty(monkeypatch, capsys):
+    monkeypatch.setattr(consent, "POSTHOG_API_KEY", "")
+    assert main(["telemetry", "on"]) == 0
+    assert "no PostHog key configured" in capsys.readouterr().out
 
 
 def test_cli_telemetry_off_and_default_status(capsys):
@@ -126,7 +138,13 @@ def test_cli_telemetry_off_and_default_status(capsys):
     assert main(["telemetry"]) == 0  # default action is status
     out = capsys.readouterr().out
     assert "Sharing: off" in out
-    assert "not configured" in out
+    assert "not configured" not in out  # the key ships configured
+
+
+def test_cli_telemetry_status_names_the_kill_switch_when_key_is_empty(monkeypatch, capsys):
+    monkeypatch.setattr(consent, "POSTHOG_API_KEY", "")
+    assert main(["telemetry"]) == 0
+    assert "not configured" in capsys.readouterr().out
 
 
 def test_cli_telemetry_invalid_action_is_a_usage_error():
@@ -143,8 +161,10 @@ def test_payload_pinned_key_for_key():
     assert set(payload) == PAYLOAD_KEYS
     assert set(payload["properties"]) == PROPERTY_KEYS
     assert payload["event"] == PING_EVENT
-    assert payload["distinct_id"] == "c" * 32
     assert payload["timestamp"] == "2026-06-12T12:00:00Z"
+    assert payload["properties"]["distinct_id"] == "c" * 32
+    # Anonymous events: PostHog must create no person profile (ADR-041).
+    assert payload["properties"]["$process_person_profile"] is False
     assert payload["properties"]["schema_version"] == "1"
     assert payload["properties"]["rac_version"] == __version__
     assert payload["properties"]["active_repos"] == 2
@@ -238,7 +258,7 @@ def test_no_thread_without_consent_or_install_id_or_key(monkeypatch):
     assert start_ping_thread(Consent()) is None
     assert start_ping_thread(Consent(share_usage=True)) is None  # no install id
     record = consented()
-    assert consent.POSTHOG_API_KEY == ""
+    monkeypatch.setattr(consent, "POSTHOG_API_KEY", "")
     assert start_ping_thread(record) is None  # empty-key kill switch
 
 
@@ -308,7 +328,8 @@ def test_sharing_on_with_key_announces_and_records_the_repo(monkeypatch, tmp_pat
     )
 
 
-def test_sharing_on_without_key_says_nothing_will_be_sent(capsys):
+def test_sharing_on_without_key_says_nothing_will_be_sent(monkeypatch, capsys):
+    monkeypatch.setattr(consent, "POSTHOG_API_KEY", "")
     consented()
     server._maybe_start_sharing(".")
     captured = capsys.readouterr()

--- a/tests/test_mcp_ping.py
+++ b/tests/test_mcp_ping.py
@@ -1,4 +1,4 @@
-"""Anonymous usage ping contracts — consented, pinned, one module wide (v0.10.5).
+"""Anonymous usage ping contracts — consented, pinned, one module wide (v0.10.6).
 
 The battery pins ADR-041's shape: nothing sends without recorded consent and a
 configured key; the payload is the entire transmission, asserted key-for-key

--- a/tests/test_mcp_ping.py
+++ b/tests/test_mcp_ping.py
@@ -1,0 +1,316 @@
+"""Anonymous usage ping contracts — consented, pinned, one module wide (v0.10.5).
+
+The battery pins ADR-041's shape: nothing sends without recorded consent and a
+configured key; the payload is the entire transmission, asserted key-for-key
+at both levels with no path, salt, or content anywhere in it; failures are
+swallowed with exactly one attempt per 24 hours and no retries; the
+active-repo file holds salted digests only; and the consent record tolerates
+corruption by meaning No. The server hook is announced on stderr and is
+independent of the local ``--telemetry`` flag.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from rac import __version__, consent
+from rac.cli import main
+from rac.consent import (
+    Consent,
+    consent_path,
+    consent_recorded,
+    load_consent,
+    opt_in,
+    opt_out,
+    save_consent,
+)
+from rac.mcp import ping, server
+from rac.mcp.ping import (
+    ACTIVE_REPOS_FILENAME,
+    PING_EVENT,
+    SOCKET_TIMEOUT_SECONDS,
+    _tick,
+    active_repo_count,
+    build_payload,
+    mark_pinged,
+    record_active_repo,
+    repo_digest,
+    send_ping,
+    should_ping,
+    start_ping_thread,
+)
+
+# The pinned payload key sets (ADR-041). Adding a key is a recorded decision.
+PAYLOAD_KEYS = {"api_key", "event", "distinct_id", "timestamp", "properties"}
+PROPERTY_KEYS = {"schema_version", "rac_version", "active_repos"}
+
+NOW = datetime(2026, 6, 12, 12, 0, 0, tzinfo=UTC)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_state(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
+
+
+def consented() -> Consent:
+    return opt_in()
+
+
+# --- Consent record -------------------------------------------------------------
+
+
+def test_consent_round_trip_preserves_all_fields():
+    saved = Consent(share_usage=True, install_id="a" * 32, salt="b" * 32, consented_at="t")
+    save_consent(saved)
+    assert load_consent() == saved
+
+
+@pytest.mark.parametrize("content", ["", "not json", "[1, 2]", '"a string"'])
+def test_corrupt_or_non_dict_consent_means_no_consent(content):
+    consent_path().parent.mkdir(parents=True, exist_ok=True)
+    consent_path().write_text(content, encoding="utf-8")
+    assert load_consent() == Consent()
+
+
+def test_missing_consent_file_means_no_consent_and_not_recorded():
+    assert load_consent() == Consent()
+    assert consent_recorded() is False
+
+
+def test_save_over_unwritable_directory_never_raises(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config-file"))
+    (tmp_path / "config-file").write_text("a file, not a directory", encoding="utf-8")
+    save_consent(Consent(share_usage=True))  # must not raise
+
+
+def test_opt_in_mints_ids_and_preserves_them_across_toggles():
+    first = opt_in()
+    assert len(first.install_id) == 32 and len(first.salt) == 32
+    assert first.share_usage is True
+    opt_out()
+    again = opt_in()
+    assert again.install_id == first.install_id
+    assert again.salt == first.salt
+
+
+def test_opt_out_keeps_the_record_and_flips_the_choice():
+    first = opt_in()
+    record = opt_out()
+    assert record.share_usage is False
+    assert record.install_id == first.install_id
+    assert consent_recorded() is True
+
+
+# --- rac telemetry CLI ------------------------------------------------------------
+
+
+def test_cli_telemetry_on_records_consent_and_prints_install_id(capsys):
+    assert main(["telemetry", "on"]) == 0
+    out = capsys.readouterr().out
+    record = load_consent()
+    assert record.share_usage is True
+    assert record.install_id in out
+    assert "Never paths, queries, or content" in out
+    assert "no PostHog key configured" in out  # empty-key build
+
+
+def test_cli_telemetry_off_and_default_status(capsys):
+    main(["telemetry", "on"])
+    capsys.readouterr()
+    assert main(["telemetry", "off"]) == 0
+    assert "Nothing will be sent" in capsys.readouterr().out
+    assert main(["telemetry"]) == 0  # default action is status
+    out = capsys.readouterr().out
+    assert "Sharing: off" in out
+    assert "not configured" in out
+
+
+def test_cli_telemetry_invalid_action_is_a_usage_error():
+    with pytest.raises(SystemExit) as exc:
+        main(["telemetry", "bogus"])
+    assert exc.value.code == 2
+
+
+# --- Payload (the entire transmission, pinned) --------------------------------------
+
+
+def test_payload_pinned_key_for_key():
+    payload = build_payload("c" * 32, 2, NOW)
+    assert set(payload) == PAYLOAD_KEYS
+    assert set(payload["properties"]) == PROPERTY_KEYS
+    assert payload["event"] == PING_EVENT
+    assert payload["distinct_id"] == "c" * 32
+    assert payload["timestamp"] == "2026-06-12T12:00:00Z"
+    assert payload["properties"]["schema_version"] == "1"
+    assert payload["properties"]["rac_version"] == __version__
+    assert payload["properties"]["active_repos"] == 2
+
+
+def test_payload_carries_no_path_salt_or_content(tmp_path):
+    record = consented()
+    record_active_repo(str(tmp_path), record.salt)
+    payload = build_payload(record.install_id, active_repo_count(), NOW)
+    text = json.dumps(payload)
+    assert str(tmp_path) not in text
+    assert record.salt not in text
+    # No value is a filesystem path; the endpoint URL lives outside the body.
+    for value in (*payload.values(), *payload["properties"].values()):
+        assert "/" not in str(value)
+
+
+# --- Wire behavior -----------------------------------------------------------------
+
+
+def test_send_ping_posts_the_payload_to_the_endpoint(monkeypatch):
+    captured = {}
+
+    class _Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+    def _fake_urlopen(request, timeout=None):
+        captured["url"] = request.full_url
+        captured["body"] = json.loads(request.data.decode("utf-8"))
+        captured["content_type"] = request.get_header("Content-type")
+        captured["timeout"] = timeout
+        return _Response()
+
+    monkeypatch.setattr("urllib.request.urlopen", _fake_urlopen)
+    payload = build_payload("d" * 32, 0, NOW)
+    send_ping(payload)
+    assert captured["url"] == consent.POSTHOG_ENDPOINT
+    assert captured["body"] == payload
+    assert captured["content_type"] == "application/json"
+    assert captured["timeout"] == SOCKET_TIMEOUT_SECONDS
+
+
+@pytest.mark.parametrize("error", [OSError("refused"), ValueError("odd"), Exception("boom")])
+def test_failures_swallowed_with_exactly_one_attempt(monkeypatch, error):
+    calls = []
+
+    def _raise(request, timeout=None):
+        calls.append(request)
+        raise error
+
+    monkeypatch.setattr("urllib.request.urlopen", _raise)
+    _tick("e" * 32)  # must not raise
+    assert len(calls) == 1
+    # The marker is written after the failed attempt: no retry within 24h.
+    _tick("e" * 32)
+    assert len(calls) == 1
+
+
+def test_tick_sends_once_per_24_hours(monkeypatch):
+    calls = []
+    monkeypatch.setattr(ping, "send_ping", lambda payload: calls.append(payload))
+    _tick("f" * 32)
+    _tick("f" * 32)
+    assert len(calls) == 1
+
+
+def test_should_ping_honors_the_marker():
+    now = datetime.now(UTC)
+    assert should_ping(now) is True  # no marker
+    mark_pinged(now - timedelta(hours=1))
+    assert should_ping(now) is False
+    mark_pinged(now - timedelta(hours=25))
+    assert should_ping(now) is True
+
+
+def test_corrupt_marker_means_never_pinged(monkeypatch, tmp_path):
+    marker = ping._state_dir() / ping.LAST_PING_FILENAME
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_text("not a timestamp", encoding="utf-8")
+    assert should_ping(datetime.now(UTC)) is True
+
+
+# --- Thread gating ------------------------------------------------------------------
+
+
+def test_no_thread_without_consent_or_install_id_or_key(monkeypatch):
+    assert start_ping_thread(Consent()) is None
+    assert start_ping_thread(Consent(share_usage=True)) is None  # no install id
+    record = consented()
+    assert consent.POSTHOG_API_KEY == ""
+    assert start_ping_thread(record) is None  # empty-key kill switch
+
+
+def test_thread_is_daemon_when_everything_is_configured(monkeypatch):
+    record = consented()
+    monkeypatch.setattr(consent, "POSTHOG_API_KEY", "phc_test")
+    monkeypatch.setattr(ping, "_tick", lambda install_id: None)
+    thread = start_ping_thread(record)
+    assert thread is not None
+    assert thread.daemon is True
+
+
+# --- Active repos --------------------------------------------------------------------
+
+
+def test_active_repo_digests_are_salted_and_paths_never_stored(tmp_path):
+    root = str(tmp_path / "repo")
+    assert repo_digest(root, "salt-a") == repo_digest(root, "salt-a")
+    assert repo_digest(root, "salt-a") != repo_digest(root, "salt-b")
+    record_active_repo(root, "salt-a")
+    record_active_repo(root, "salt-a")  # idempotent
+    assert active_repo_count() == 1
+    stored = (ping._state_dir() / ACTIVE_REPOS_FILENAME).read_text(encoding="utf-8")
+    assert root not in stored
+    assert "salt-a" not in stored
+
+
+def test_active_repos_prune_past_the_window(tmp_path):
+    path = ping._state_dir() / ACTIVE_REPOS_FILENAME
+    path.parent.mkdir(parents=True, exist_ok=True)
+    stale = (datetime.now(UTC).date() - timedelta(days=31)).isoformat()
+    path.write_text(json.dumps({"old" * 16: stale}), encoding="utf-8")
+    assert active_repo_count() == 0
+    record_active_repo(str(tmp_path), "salt")
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert len(data) == 1  # the stale entry was pruned on write
+
+
+def test_corrupt_active_repo_file_counts_zero_and_recovers(tmp_path):
+    path = ping._state_dir() / ACTIVE_REPOS_FILENAME
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("garbage", encoding="utf-8")
+    assert active_repo_count() == 0
+    record_active_repo(str(tmp_path), "salt")
+    assert active_repo_count() == 1
+
+
+# --- Server hook ----------------------------------------------------------------------
+
+
+def test_sharing_off_is_silent(capsys):
+    server._maybe_start_sharing(".")
+    assert capsys.readouterr().err == ""
+
+
+def test_sharing_on_with_key_announces_and_records_the_repo(monkeypatch, tmp_path, capsys):
+    record = consented()
+    monkeypatch.setattr(consent, "POSTHOG_API_KEY", "phc_test")
+    monkeypatch.setattr(ping, "_tick", lambda install_id: None)
+    server._maybe_start_sharing(str(tmp_path))
+    captured = capsys.readouterr()
+    assert captured.out == "", "stdout belongs to the MCP protocol"
+    assert "anonymous usage sharing on" in captured.err
+    assert "rac telemetry off" in captured.err
+    assert repo_digest(str(tmp_path), record.salt) in (
+        (ping._state_dir() / ACTIVE_REPOS_FILENAME).read_text(encoding="utf-8")
+    )
+
+
+def test_sharing_on_without_key_says_nothing_will_be_sent(capsys):
+    consented()
+    server._maybe_start_sharing(".")
+    captured = capsys.readouterr()
+    assert "no PostHog key configured" in captured.err
+    assert "nothing will be sent" in captured.err


### PR DESCRIPTION
# Summary

Implements `rac/roadmaps/v0.10.x-guide/v0.10.6-anonymous-usage-sharing.md`.

Adds:

- Opt-in anonymous remote usage sharing: with explicit consent, `rac mcp` sends at most one daily ping to PostHog (EU) — a random install id, the RAC version, and a 30-day active-repo count; never paths, queries, arguments, or repository content
- Consent surfaces: `rac telemetry on|off|status`, plus the CLI's first interactive prompt — one honest question after a successful `rac init`, TTY-gated, default No, asked at most once per machine
- ADR-041 (amending ADR-040's "no network code" clause), a 31-case ping battery with a new network-isolation rule, suite-wide test hermeticity, and a rewrite of every doc surface that claimed nothing leaves the machine

Note: this milestone was authored as v0.10.5 and renumbered to **v0.10.6** after the bundled-skills milestone (#73) claimed v0.10.5 on main mid-flight; the branch is rebased onto that merge.

# Roadmap / ADR Trace

Roadmap:

- `rac/roadmaps/v0.10.x-guide/v0.10.6-anonymous-usage-sharing.md`

Relevant ADRs:

- `rac/decisions/adr-041-anonymous-usage-ping.md` (new — consented daily ping, pinned payload, PostHog as third-party sink)
- `rac/decisions/adr-040-guide-local-telemetry.md` (amended: one relationship line notes ADR-041 narrows its "RAC contains no network code" clause; local recording and the share-URL flow are unchanged)
- `rac/decisions/adr-032-guide-stateless-reads.md` (untouched — the ping runs outside the request/response contract; tool responses stay byte-identical)
- `rac/decisions/adr-035-byo-ai-credentials.md` (honored — the dependency is optional by consent and inert without a key)

# Scope

## Included

- `src/rac/consent.py` (stdlib-only, outside `rac.mcp` so `rac init`/`rac telemetry` never import the MCP SDK): corruption-tolerant consent record at `~/.config/rac/telemetry.json`; random `secrets.token_hex(16)` install id minted at opt-in and preserved across off→on toggles; a local-only salt for repo digests; persisted declines so the init question is ask-once. The PostHog constants live here (EU capture endpoint plus the public project write key) — blanking the key is a kill switch that disables all sending
- `src/rac/mcp/ping.py` — RAC's entire network surface, the only module permitted to import `urllib.request` (new isolation rule): daemon thread started by `run_server`, at most one attempt per 24h via a local marker, 3-second timeout, every failure swallowed, no retries, payload pinned in full
- Active-repo tracking: salted digests with last-seen dates in `~/.local/state/rac/active-repos.json`, pruned to 30 days; only the count crosses the wire and the salt never does
- Server hook `_maybe_start_sharing` in `run_server` — independent of the local `--telemetry` flag, announced on stderr (stdout stays protocol-only), silent without consent
- Suite-wide hermeticity: an autouse conftest fixture isolates `XDG_CONFIG_HOME`/`XDG_STATE_HOME` for every test, committed before the live key landed — no test run can find a developer's consent record and phone home

## Excluded

- Opt-out-by-default telemetry, or any prompt that asks twice
- A second event type, per-tool remote metrics, latency reporting, or transmitting any part of the local telemetry log — per-tool analytics stay local (`rac mcp-stats`, v0.10.4)
- The PostHog SDK as a dependency; the POST is plain stdlib
- Retries, offline queueing, or batching of failed pings
- A self-hosted collector (no domain/infrastructure yet — recorded as the revisit alternative in ADR-041; the sink hides behind one constant)

# Product / Architecture Decisions

- The payload is the entire transmission and is pinned field-for-field — adding a field is a new ADR, enforced by exact key-set assertions at both payload levels
- The install id is random, not a salted hash of machine attributes: derivable is the opposite of anonymous; a random token derives from nothing (ADR-041 records the reasoning)
- The payload follows PostHog's documented capture contract: `distinct_id` rides inside `properties`, and `"$process_person_profile": false` marks events anonymous so PostHog creates no person profiles — cheaper, and a sink-side enforcement of the anonymity posture
- Consent and the PostHog constants live outside `rac.mcp` because importing that package pays the eager MCP SDK import; the ping module imports them from `rac.consent`
- Sharing is independent of `--telemetry`: each is its own opt-in; consenting without serving sends nothing, and recording locally never implies sharing
- The 24h marker is written after each attempt regardless of outcome — a failing endpoint costs one attempt per day, never a retry storm
- The `rac init` prompt is deliberately the CLI's first interactive prompt; the ADR records the precedent and its gates (TTY both ends, no `--json`, no existing record, EOF/empty means No)

# User-Facing Contract

## CLI

```bash
rac telemetry           # status (default): what is shared, and whether sending is possible
rac telemetry on        # opt in; mints a random install id
rac telemetry off       # opt out
rac init                # asks the one-time consent question on a real terminal
```

## Human Output

- `rac init` (TTY, no prior answer): `Share anonymous usage to help shape Lore? [y/N]` — default No, either answer persisted
- `rac telemetry status`: sharing on/off, install id, consent timestamp and file path, what is shared daily, and an explicit note when no endpoint key is configured (in that state nothing is sent)
- `rac mcp` with consent on announces on stderr: at most one daily ping, what it contains, and how to disable — sharing is never silent

## Wire Contract (the entire transmission)

```json
{
  "api_key": "phc_... (the public project write key)",
  "event": "lore-daily-ping",
  "timestamp": "2026-06-12T20:37:04Z",
  "properties": {
    "distinct_id": "cd03eed3dd98b784834485e27a436914 (random install id)",
    "$process_person_profile": false,
    "schema_version": "1",
    "rac_version": "0.10.6",
    "active_repos": 2
  }
}
```

## Exit Codes

- `0`: telemetry consent shown or changed (`on`/`off`/`status`, including when no key is configured); init behavior unchanged
- `2`: invalid telemetry action (argparse choices)

# Verification

## Ran

```bash
python -m pytest                      # 1040 passed (re-run after rebasing onto the skills merge)
ruff check .                          # clean
mypy                                  # no new errors (51 pre-existing missing-stub noise)
rac validate rac/                     # 120 valid, exit 0
rac relationships rac/ --validate     # 321 checked, 0 issues, exit 0
rac review rac/                       # no priority 1-2 findings
```

Manual end-to-end against a local HTTP sink standing in for PostHog: `rac telemetry on` → `rac mcp` startup produced the stderr notice and exactly one POST whose body matched the pinned payload byte-for-byte (real key, `distinct_id` and `$process_person_profile: false` inside `properties`, `active_repos: 1`); a second startup within 24h sent nothing; after `rac telemetry off` the restart was fully silent; the state file contained only a salted digest, no path.

## Covered

- Consent: round-trip, corruption tolerance (garbage/non-dict/missing → no consent), unwritable-dir saves never raise, ids minted once and preserved across toggles
- Init prompt: shown only on a TTY with no record and no `--json`; `y` records consent; empty/`n`/EOF persist a decline; a second init never asks; non-TTY never reaches `input()`
- Payload: exact key sets pinned at both levels; no value contains a path, the repo root, or the salt; wire capture checks endpoint, JSON body, content type, and the 3s timeout
- Failure posture: raised `urlopen` swallowed with exactly one attempt; marker written after failure (no retry within 24h); `should_ping` honors fresh/stale/corrupt markers
- Gating: no thread without consent, install id, or key; thread is `daemon=True`; `_maybe_start_sharing` silent without consent, announces with key, names the kill switch without one
- Active repos: salted digests differ under different salts, raw paths never stored, 30-day pruning, corrupt file tolerated
- Isolation: network client modules (`urllib.request`, `http.client`) importable only by `rac/mcp/ping.py`; all existing batteries pass unchanged, including the v0.10.4 byte-identical-response guards

# Review Path

1. `rac/decisions/adr-041-anonymous-usage-ping.md` and the roadmap — the contract, including the ADR-040 amendment
2. `src/rac/consent.py` — consent record, ids, kill-switch constants
3. `src/rac/mcp/ping.py` — the one network module: payload, dedupe, failure posture
4. `src/rac/mcp/server.py` (`_maybe_start_sharing`) and `src/rac/cli.py` (`cmd_telemetry`, the init prompt)
5. `tests/test_mcp_ping.py`, `tests/test_init.py`, `tests/test_mcp_isolation.py`, `tests/conftest.py` — the battery, prompt gates, network rule, hermeticity
6. `README.md`, `docs/mcp.md`, `docs/cli.md`, `CHANGELOG.md` — the honesty rewrite

# Notes For Reviewer

- **This PR arms the channel**: the live EU endpoint and project write key are in `src/rac/consent.py`, so once released, consenting installs actually transmit. The key is a public write-only key (standard for client telemetry); blanking it disables all sending. The hermeticity fixture was committed before the key so no point in history has a live key with non-hermetic tests.
- The branch is rebased onto the skills merge (#73); the milestone renumbered v0.10.5 → v0.10.6 in a dedicated commit, and the CLI reference's subcommand count was reconciled (telemetry and skill both landed → twenty-two).
- The README bullet that said "Lore contains no network code" is rewritten — the new claim ("opt-in twice over; the network surface is a single readable module") is the one the code now keeps.
- Data starts flowing only when all four hold: released, user updated, user consented, user runs `rac mcp`. Retention = distinct `distinct_id` per day on the `lore-daily-ping` event.
- Per-tool analytics deliberately stay local; promoting any of them into the ping is a new ADR by construction.

# Implementation Process

Implemented with AI assistance under the roadmap contract.

Final scope, review, and acceptance decisions were made by the maintainer.