### PR TITLE
docs(roadmap): renumber docs site to v0.11.1 in the portal series [roadmap:v0.11.1]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,5 +20,5 @@ to the corpus artifact and they load through the imports below.
 ## Working corpus
 
 - Current series: `rac/roadmaps/v0.12.x-watchkeeper/` (next up: v0.12.0)
-- Previous series: `rac/roadmaps/v0.11.x-portal/` (complete through v0.11.0)
+- Previous series: `rac/roadmaps/v0.11.x-portal/` (complete through v0.11.1)
 - Decisions (ADRs): `rac/decisions/`

--- a/rac/decisions/adr-042-docs-site-hosting.md
+++ b/rac/decisions/adr-042-docs-site-hosting.md
@@ -127,4 +127,4 @@ by publishing them.
 
 ## Related Roadmaps
 
-- v0.10.7-docs-site
+- v0.11.1-docs-site

--- a/rac/designs/docs-site-scoping.md
+++ b/rac/designs/docs-site-scoping.md
@@ -53,7 +53,8 @@ drift-prevention policy defined here.
 Roadmap placement: the corpus convention is one roadmap artifact per release
 in `rac/roadmaps/v0.10.x-guide/`. Slots v0.10.4–v0.10.6 are taken (the
 "next up: v0.10.4" note in CLAUDE.md is stale), so Phase 2 should target
-**v0.10.7** for this work.
+**v0.11.1** for this work (in the `v0.11.x-portal` series; v0.10.7 was the
+original slot before the v0.11.0 portal release renumbered it).
 
 ## User Need
 
@@ -143,7 +144,7 @@ Every file created or modified:
 | `docs/mcp.md` | modified (link only) | One `../examples/guide/` link becomes an absolute GitHub URL. |
 | `docs/repo-workflow.md` | modified (link only) | One `../rac/decisions/adr-022...` link becomes an absolute GitHub URL. |
 | `docs/testing.md` | modified (links only) | Two `../rac/...` links become absolute GitHub URLs. |
-| `rac/` (Phase 2) | new artifacts | Requirements, relationships, v0.10.7 roadmap entry, and the ADR-022 amendment — scoped in Phase 2, listed here only for traceability. |
+| `rac/` (Phase 2) | new artifacts | Requirements, relationships, v0.11.1 roadmap entry, and the ADR-022 amendment — scoped in Phase 2, listed here only for traceability. |
 
 The seven link conversions across four docs files are the only edits to
 existing docs content, and they change link targets, not prose. No other

--- a/rac/requirements/rac-docs-site-landing-page.md
+++ b/rac/requirements/rac-docs-site-landing-page.md
@@ -94,4 +94,4 @@ front door; this artifact governs that page.
 
 ## Related Roadmaps
 
-- v0.10.7-docs-site
+- v0.11.1-docs-site

--- a/rac/requirements/rac-docs-site-platform.md
+++ b/rac/requirements/rac-docs-site-platform.md
@@ -95,4 +95,4 @@ out of user documentation.
 
 ## Related Roadmaps
 
-- v0.10.7-docs-site
+- v0.11.1-docs-site

--- a/rac/requirements/rac-docs-site-publish-pipeline.md
+++ b/rac/requirements/rac-docs-site-publish-pipeline.md
@@ -87,4 +87,4 @@ navigation or links must never reach production.
 
 ## Related Roadmaps
 
-- v0.10.7-docs-site
+- v0.11.1-docs-site

--- a/rac/requirements/rac-docs-site-readme-doorway.md
+++ b/rac/requirements/rac-docs-site-readme-doorway.md
@@ -88,4 +88,4 @@ README's reduced shape and makes the drift policy enforceable.
 
 ## Related Roadmaps
 
-- v0.10.7-docs-site
+- v0.11.1-docs-site

--- a/rac/roadmaps/v0.11.x-portal/v0.11.1-docs-site.md
+++ b/rac/roadmaps/v0.11.x-portal/v0.11.1-docs-site.md
@@ -3,7 +3,7 @@ schema_version: 1
 id: RAC-KTYXDVA2VG8K
 type: roadmap
 ---
-# RAC v0.10.7 — Lore Docs Site
+# RAC v0.11.1 — Lore Docs Site
 
 ## Status
 
@@ -80,12 +80,15 @@ artifact until deliberately scoped in.
 ## Implementation Contract
 
 New files: `mkdocs.yml`, `.github/workflows/docs.yml`, `docs/index.md`,
-`docs/images/lore-header-light.png`, `docs/images/lore-header-dark.png`.
-Modified files: `README.md`, plus link-only edits to `docs/ecosystem.md`
-(3), `docs/mcp.md` (1), `docs/repo-workflow.md` (1), `docs/testing.md`
-(2). The acceptance criteria of the four requirement artifacts are the
-test plan; `mkdocs build --strict` must exit clean, and the implementation
-PR maps every criterion to pass/fail/blocked.
+`overrides/home.html`, `docs/stylesheets/extra.css`, self-hosted
+JetBrains Mono under `docs/fonts/`, and the vendored brand assets
+`docs/images/lamplighter.png` and `docs/images/favicon.png`. Modified
+files: `README.md`, `.gitignore` (ignore `site/`), plus link-only edits
+to `docs/ecosystem.md` (3), `docs/mcp.md` (1), `docs/repo-workflow.md`
+(1), `docs/testing.md` (2). The acceptance criteria of the four
+requirement artifacts are the test plan; `mkdocs build --strict` must
+exit clean, and the implementation PR maps every criterion to
+pass/fail/blocked.
 
 ## Success Measures
 
@@ -109,8 +112,8 @@ PR maps every criterion to pass/fail/blocked.
 ## Assumptions
 
 - The repository stays public, keeping GitHub Pages available.
-- The v0.10.x series remains the active release line; this item takes the
-  v0.10.7 slot after the delivered v0.10.6.
+- This item ships in the active `v0.11.x-portal` series as v0.11.1, after
+  v0.11.0 (portal export).
 
 ## Related Requirements
 
@@ -131,5 +134,5 @@ PR maps every criterion to pass/fail/blocked.
 
 ## Dependencies
 
-- The existing `docs/` content set (complete as of v0.10.6) and the brand
-  header art in `rac/assets/images/`.
+- The existing `docs/` content set and the lore-web design system
+  (tokens, JetBrains Mono, lamplighter mascot) under `lore-web/`.


### PR DESCRIPTION
# Summary

Renumbers the docs-site roadmap item from `v0.10.7` to **`v0.11.1`**, into the active `v0.11.x-portal` series. It was scoped as v0.10.7 before v0.11.0 (portal export) opened the v0.11.x line.

This is **artifact bookkeeping only — no URLs, no rendering changes.** (The earlier `pyproject.toml` `Homepage` flip was dropped from this PR; the published Homepage stays on the GitHub repo URL until a site URL is decided.)

# Scope

## Included

- Moves `rac/roadmaps/v0.10.x-guide/v0.10.7-docs-site.md` → `rac/roadmaps/v0.11.x-portal/v0.11.1-docs-site.md` (artifact **id unchanged**, `RAC-KTYXDVA2VG8K` — ids are opaque and stable across renames), retitled to "RAC v0.11.1 — Lore Docs Site"
- Updates the `Related Roadmaps` reference (`v0.10.7-docs-site` → `v0.11.1-docs-site`) in the four requirements and ADR-042
- Updates the `v0.10.7` prose mentions in `rac/designs/docs-site-scoping.md` and the `CLAUDE.md` working-corpus pointer (now: v0.11.0 export and v0.11.1 docs site shipped)
- Refreshes the roadmap's Implementation Contract and Dependencies to the **actually shipped** files (`overrides/home.html`, `docs/stylesheets/extra.css`, self-hosted JetBrains Mono, `lamplighter.png`) instead of the superseded `lore-header` art

## Excluded

- **No `pyproject.toml` / Homepage change** — the published URL stays as-is for now (no pointing at a Pages or custom-domain URL yet)
- No code, no docs-site rendering changes
- Roadmap `Status` stays `Planned` to match every other roadmap in the corpus (completion is tracked in CLAUDE.md prose, not the status field)
- The already-merged commit tags still read `[roadmap:v0.10.7]` — frozen history, intentionally left as-is

# Verification

```bash
rac validate rac/                  # PASS — 129 valid, 0 invalid
rac relationships rac/ --validate  # 383 checked, 0 issues
rac resolve v0.11.1-docs-site rac/ # → RAC-KTYXDVA2VG8K (roadmap)
rac review rac/                    # exit 0, no priority 1–2 findings
grep -rn v0.10.7-docs-site rac/    # no matches (all refs updated)
```

# Notes For Reviewer

- Renumber-only; safe to merge whenever. The Homepage/site-URL decision (default `github.io` vs a custom domain like `itsthelore.com`) is parked separately and will land as its own change with a recorded decision when you're ready.

# Implementation Process

Implemented with AI assistance under the roadmap contract. Final scope, review, and acceptance decisions were made by the maintainer.