### PR TITLE
test(explorer): deflake the mascot animation test

### DIFF
--- a/tests/test_explorer_app.py
+++ b/tests/test_explorer_app.py
@@ -1046,10 +1046,19 @@ async def test_mascot_animates_only_with_animations_on(fresh_first_run):
         await _settled_panel_text(app, pilot)
         home = app.screen.query_one(HomeView)
         art = app.screen.query_one("#mascot", Static)
-        before = str(art.content)
-        home._tick_mascot()  # advance a frame deterministically
+
+        # Animations on: cycling the frames moves the lantern. Sample across
+        # full cycles rather than asserting a single tick — a background timer
+        # also advances the frame and some sequences repeat one (the DISCOVERY
+        # pulse is ✶ ✦ ✶), so a lone tick can land on an identical frame.
+        home.show_mascot(mascot.SEARCHING)
         await pilot.pause()
-        assert str(art.content) != before  # the lantern moved
+        seen = set()
+        for _ in range(len(mascot.frames(mascot.SEARCHING)) * 2):
+            seen.add(str(art.content))
+            home._tick_mascot()
+            await pilot.pause()
+        assert len(seen) > 1  # the lantern moved through distinct frames
 
         # With animations off the figure holds its first frame.
         from dataclasses import replace


### PR DESCRIPTION
# Summary

Deflakes one Explorer test that fails intermittently in CI.

`tests/test_explorer_app.py::test_mascot_animates_only_with_animations_on`
asserted that a single `_tick_mascot()` changed the rendered mascot figure.
That assertion is racy:

- A background `set_interval(0.6s, _tick_mascot)` is already advancing the
  frame, so the figure captured as "before" lands on a nondeterministic frame.
- The `DISCOVERY` sequence repeats a frame — the pulse is `✶ ✦ ✶`, so frames
  0 and 2 are identical.

When "before" lands on the last `✶` and the single manual tick advances to the
first `✶`, the figure is unchanged and the assertion fails. This surfaced on
`main` as CI run #47 (`coverage`, report-only): `1 failed, 1119 passed`, both
sides of the assertion the `✶` frame.

# Scope

## Included

- Rewrite the "animations on" half to drive a known distinct-frame state
  (`SEARCHING`, frames `◈ ◇ ◆`), sample the figure across two full cycles, and
  assert more than one distinct frame is seen — robust to the background timer
  and to repeated frames.

## Excluded

- No production code change. The mascot widget, frames, timer, and the
  `interaction` behaviour are untouched.
- The "animations off holds the first frame" half of the test is unchanged.
- No change to any other test.

# Verification

## Ran

```bash
# the previously-flaky test, 25 consecutive runs
for i in $(seq 1 25); do pytest -q \
  tests/test_explorer_app.py::test_mascot_animates_only_with_animations_on; done
# → 25 passed, 0 failed

pytest -q tests/test_explorer_app.py -k mascot   # 10 passed
ruff check tests/test_explorer_app.py
ruff format --check tests/test_explorer_app.py
```

## Covered

- Animations on: cycling produces more than one distinct figure (sampled over
  two full frame cycles, so neither the background timer nor a repeated frame
  can make it flake).
- Animations off: a tick still holds the first frame (unchanged).

# Notes For Reviewer

- The flake predates and is independent of the v0.8.12/v0.8.13 work; it is a
  test-determinism issue, not a product bug — the animation behaviour is
  correct.
- The job that caught it (`coverage`) is report-only and non-gating, which is
  why it did not block merges.