### PR TITLE
docs(decisions): record OKF as an informative carrier profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ details, release history over commit history.
 
 ### Added
 
+- OKF carrier profile recorded (ADR-046 + `rac-okf-carrier-profile`): RAC
+  adopts Google's Open Knowledge Format (OKF v0.1 Draft) as an informative
+  carrier profile and a derived export target — never a foundation. RAC repos
+  are conformant OKF bundles (RAC `type` maps to OKF `type`: decision→ADR,
+  requirement→Requirement, and so on), and a future derived OKF bundle view
+  joins the JSON/Portal export. RAC's normativity is unchanged — `rac validate`
+  and `rac relationships --validate` keep rejecting what they reject today. The
+  profile is documented in `docs/okf-profile.md`; the dependency is informative
+  and pinned to OKF v0.1, with no code or package dependency on OKF tooling.
+
 - Watchkeeper GitHub Action and reusable workflow (v0.12.3): a composite
   `action.yml` at the repository root (`uses:
   tcballard/requirements-as-code@<tag>`) and a callable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ details, release history over commit history.
 
 ### Added
 
-- OKF carrier profile recorded (ADR-046 + `rac-okf-carrier-profile`): RAC
+- OKF carrier profile recorded (ADR-048 + `rac-okf-carrier-profile`): RAC
   adopts Google's Open Knowledge Format (OKF v0.1 Draft) as an informative
   carrier profile and a derived export target — never a foundation. RAC repos
   are conformant OKF bundles (RAC `type` maps to OKF `type`: decision→ADR,

--- a/docs/okf-profile.md
+++ b/docs/okf-profile.md
@@ -1,0 +1,116 @@
+# OKF Profile
+
+RAC stores product knowledge the same way [Google Cloud's Open Knowledge Format
+(OKF)](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
+does — a Git tree of Markdown files with YAML front matter. This page is RAC's
+**informative profile** of OKF **v0.1 Draft**: it defines how a RAC repository
+presents itself as a conformant OKF bundle. It is a derived, interoperability
+view; RAC Core and `rac validate` remain the source of truth, and adopting this
+profile loosens none of RAC's guarantees. The decision behind it is
+[ADR-046](https://github.com/tcballard/requirements-as-code/blob/main/rac/decisions/adr-046-okf-carrier-profile.md),
+scoped by the `rac-okf-carrier-profile` requirement.
+
+> The key words MUST, SHOULD, and MAY in this document are to be interpreted as
+> described in BCP 14 (RFC 2119, RFC 8174) when, and only when, they appear in
+> all capitals.
+
+## Type mapping (normative)
+
+Every RAC artifact carries a `type` in its front matter. In the OKF bundle view
+each artifact MUST present a non-empty OKF `type`, mapped from its RAC `type`:
+
+| RAC `type`    | OKF `type`    |
+| ------------- | ------------- |
+| `requirement` | `Requirement` |
+| `decision`    | `ADR`         |
+| `roadmap`     | `Roadmap`     |
+| `prompt`      | `Prompt`      |
+| `design`      | `Design`      |
+
+The RAC `type` is authoritative; the OKF `type` is derived from it. A RAC
+artifact MUST NOT present an empty or unmapped OKF `type`.
+
+### Worked example
+
+A RAC decision artifact:
+
+```yaml
+---
+schema_version: 1
+id: RAC-KV2KWK55FC49
+type: decision
+---
+# ADR-046: OKF as an Informative Carrier Profile
+```
+
+presents, in the OKF bundle view, as `type: ADR` — the same file, the same body,
+a derived front-matter projection.
+
+## Conventions (recommended)
+
+Where RAC has gaps, a RAC repository SHOULD adopt the following OKF conventions.
+Each is a derived output generated from the corpus, never a hand-maintained
+source file.
+
+### `index.md` — progressive disclosure
+
+An OKF bundle SHOULD ship an `index.md` entry point that discloses the corpus in
+layers: an overview, then the artifact types, then individual artifacts. It is
+the front door for a human or agent that has never seen the bundle.
+
+```markdown
+# Knowledge Index
+
+## Decisions
+- [ADR-046: OKF as an Informative Carrier Profile](rac/decisions/adr-046-okf-carrier-profile.md)
+  — RAC adopts OKF as an informative carrier profile and derived export target.
+
+## Requirements
+- [REQ-OKF-Carrier-Profile](rac/requirements/rac-okf-carrier-profile.md)
+  — conformance, derived bundle export, and the no-loosening invariant.
+```
+
+### `log.md` — date-grouped history
+
+An OKF bundle SHOULD ship a `log.md` recording how the corpus evolved, grouped
+by date, newest-first. RAC derives this from Git history of the `rac/` tree
+(consistent with ADR-045: recency is derived from Git, not stored in front
+matter), so it never drifts from reality.
+
+```markdown
+# Log
+
+## 2026-06-14
+- Added ADR-046 (OKF as an informative carrier profile).
+- Added REQ-OKF-Carrier-Profile (conformance, profile, and bundle export).
+```
+
+### `# Citations` — body references
+
+Where a RAC artifact wants a human-facing list of what it draws on, it SHOULD use
+a `# Citations` body section. This complements — and never replaces — RAC's typed
+`## Related <Type>` structural references, which remain the machine-resolved,
+validated edges (see [relationships](relationships.md) and ADR-016). In the
+derived OKF view, each resolved structural relationship also appears as a body
+link, so the relationship survives for permissive OKF consumers.
+
+```markdown
+# Citations
+
+- [ADR-016: Relationships as Explicit Structural References](rac/decisions/adr-016-relationships-as-structural-references.md)
+- [ADR-007: JSON Contract Stability](rac/decisions/adr-007-json-contract-stability.md)
+```
+
+## Status of this profile
+
+The dependency on OKF is **informative and pinned to OKF v0.1**. RAC takes no
+code, package, or network dependency on OKF or Google tooling. OKF is a pre-1.0,
+single-vendor draft; if it diverges materially at 1.0, RAC can re-pin or drop the
+profile without touching Core. Promoting the OKF bundle to a frozen RAC contract
+(alongside the JSON/Portal export) would extend RAC's stability obligations and
+is therefore a future, separately recorded ADR — not a change to this page.
+
+## See also
+
+- [relationships.md](relationships.md) — how RAC's typed structural references work.
+- [artifacts.md](artifacts.md) — artifact types and identity.

--- a/docs/okf-profile.md
+++ b/docs/okf-profile.md
@@ -7,7 +7,7 @@ does — a Git tree of Markdown files with YAML front matter. This page is RAC's
 presents itself as a conformant OKF bundle. It is a derived, interoperability
 view; RAC Core and `rac validate` remain the source of truth, and adopting this
 profile loosens none of RAC's guarantees. The decision behind it is
-[ADR-046](https://github.com/tcballard/requirements-as-code/blob/main/rac/decisions/adr-046-okf-carrier-profile.md),
+[ADR-048](https://github.com/tcballard/requirements-as-code/blob/main/rac/decisions/adr-048-okf-carrier-profile.md),
 scoped by the `rac-okf-carrier-profile` requirement.
 
 > The key words MUST, SHOULD, and MAY in this document are to be interpreted as
@@ -40,7 +40,7 @@ schema_version: 1
 id: RAC-KV2KWK55FC49
 type: decision
 ---
-# ADR-046: OKF as an Informative Carrier Profile
+# ADR-048: OKF as an Informative Carrier Profile
 ```
 
 presents, in the OKF bundle view, as `type: ADR` — the same file, the same body,
@@ -62,7 +62,7 @@ the front door for a human or agent that has never seen the bundle.
 # Knowledge Index
 
 ## Decisions
-- [ADR-046: OKF as an Informative Carrier Profile](rac/decisions/adr-046-okf-carrier-profile.md)
+- [ADR-048: OKF as an Informative Carrier Profile](rac/decisions/adr-048-okf-carrier-profile.md)
   — RAC adopts OKF as an informative carrier profile and derived export target.
 
 ## Requirements
@@ -81,7 +81,7 @@ matter), so it never drifts from reality.
 # Log
 
 ## 2026-06-14
-- Added ADR-046 (OKF as an informative carrier profile).
+- Added ADR-048 (OKF as an informative carrier profile).
 - Added REQ-OKF-Carrier-Profile (conformance, profile, and bundle export).
 ```
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,6 +34,7 @@ nav:
   - Watchkeeper: watchkeeper.md
   - Artifacts: artifacts.md
   - Relationships: relationships.md
+  - OKF Profile: okf-profile.md
   - Repository Workflow: repo-workflow.md
   - Examples: examples.md
   - Ecosystem: ecosystem.md

--- a/rac/decisions/adr-046-okf-carrier-profile.md
+++ b/rac/decisions/adr-046-okf-carrier-profile.md
@@ -1,0 +1,136 @@
+---
+schema_version: 1
+id: RAC-KV2KWK55FC49
+type: decision
+---
+# ADR-046: OKF as an Informative Carrier Profile
+
+## Status
+
+Proposed
+
+## Category
+
+Architecture
+
+## Context
+
+Google Cloud has published the Open Knowledge Format (OKF) — `okf/SPEC.md`,
+v0.1 Draft — in the `GoogleCloudPlatform/knowledge-catalog` samples repository.
+OKF and RAC independently arrived at the same carrier: a Git tree of Markdown
+files with YAML front matter, human-readable and reviewable in a pull request.
+For interop that convergence is a gift; RAC artifacts are already shaped like
+OKF bundles.
+
+But OKF is the inverse of RAC exactly where RAC's value lives:
+
+- **Permissive consumption.** OKF consumers MUST NOT reject a bundle for missing
+  fields, an unknown `type`, unknown keys, or broken links. RAC is
+  schema-normative: `rac validate` rejects malformed artifacts, and `rac
+  relationships --validate` rejects broken or ambiguous references.
+- **Untyped links.** In OKF the relationship kind lives in prose. In RAC,
+  relationships are explicit structural references declared in `## Related
+  <Type>` sections, resolved against artifact identity and validated (ADR-016).
+  They are not as richly typed as a labelled-edge graph, but they are *typed by
+  target type and machine-resolved* — the opposite of prose.
+- **Free `type`.** OKF's `type` is an unregistered free string. RAC has five
+  enumerated artifact types (`requirement`, `decision`, `roadmap`, `prompt`,
+  `design`) that drive classification and validation.
+- **No findings model.** OKF defines no review or findings output. RAC ships
+  `rac review` / `rac watchkeeper` with a deterministic, prioritised findings
+  model.
+- **Maturity.** OKF is a pre-1.0, single-vendor draft. RAC's contracts are
+  governed and stability-tested (ADR-007).
+
+The question is how RAC should relate to OKF without surrendering any of the
+properties above. Founding RAC on OKF would dissolve typed structural references
+(ADR-016) and the strict consumption model that make RAC trustworthy. Ignoring
+OKF would forfeit cheap interoperability and a second, independent validation of
+RAC's carrier — for the sake of one field (`type`) RAC almost already emits.
+
+This decision interprets the artifact model (ADR-004), its metadata contract
+(ADR-025), and the derived-contract posture behind the JSON/Portal export
+(ADR-007, ADR-014); it must respect the relationship model (ADR-016) and the
+Git-native carrier (ADR-013).
+
+## Decision
+
+RAC adopts OKF as an **informative carrier profile** and a **derived export
+target** — never a foundation. RAC Core remains the single source of truth.
+Specifically:
+
+1. **Conformance.** Every RAC repository MUST be a conformant OKF v0.1 bundle.
+   Every artifact MUST carry a non-empty `type`. The OKF bundle view maps RAC's
+   `type` to OKF's `type`: `requirement` → `Requirement`, `decision` → `ADR`,
+   `design` → `Design`, `roadmap` → `Roadmap`, `prompt` → `Prompt`.
+
+2. **Conventions (SHOULD).** Where RAC has gaps, it SHOULD adopt OKF's
+   conventions: an `index.md` progressive-disclosure entry point, a date-grouped
+   `log.md` corpus history (derived from Git, consistent with ADR-045), and a
+   `# Citations` body convention for human-facing references.
+
+3. **Derived contract.** The OKF bundle view MUST be a *derived* contract,
+   parallel to the existing JSON/Portal export (ADR-007), not a new source
+   format. RAC's typed front matter and `## Related <Type>` sections stay
+   authoritative; in the OKF view, structural relationships degrade gracefully to
+   derived body links.
+
+4. **No loosening.** RAC's normativity MUST NOT be loosened to accommodate OKF.
+   `rac validate` keeps rejecting what it rejects today; `rac relationships
+   --validate` keeps rejecting broken and ambiguous references; structural
+   references are not replaced by prose links (ADR-016 stands unchanged).
+
+5. **Informative, pinned dependency.** The dependency on OKF is informative and
+   pinned to OKF v0.1. RAC takes no code, package, or network dependency on OKF
+   or Google tooling. The single-vendor, pre-1.0 risk is accepted and tracked;
+   any move to treat the OKF bundle as a frozen contract is reassessed at OKF 1.0
+   and recorded as a *new* ADR (the governed change path), never a silent edit
+   to an accepted decision.
+
+## Consequences
+
+### Positive
+
+- RAC gains cheap, standards-aligned interop: a RAC repo is readable by any OKF
+  consumer, and OKF tooling becomes a second, independent check on RAC's carrier.
+- The work is additive and small — RAC already emits almost everything OKF asks
+  for; the gap is a guaranteed non-empty `type` and a derived bundle view.
+- RAC's strict guarantees are untouched; nothing a user relies on for trust
+  changes.
+
+### Negative
+
+- RAC carries an OKF profile and a derived export to keep in step with a pre-1.0
+  spec that may change under it.
+- The mapping (`decision` ↔ `ADR`, etc.) is one more contract surface to test and
+  document.
+
+### Neutral
+
+- The SHOULD conventions (`index.md`, `log.md`, `# Citations`) are recorded as
+  intent here; whether and when to implement their generators is scoped by the
+  related requirement and fenced to a future release.
+- If OKF diverges materially at 1.0, RAC can drop or re-pin the profile without
+  touching Core — the dependency is informative by construction.
+
+## Alternatives Considered
+
+- **Found RAC on OKF.** Rejected. OKF's permissive consumption and prose links
+  are incompatible with RAC's reason to exist: it would destroy the typed
+  structural-reference model (ADR-016) and the strict validation users trust.
+- **Ignore OKF entirely.** Rejected. RAC already produces an OKF-shaped tree;
+  declining the profile forfeits free interoperability and an external validation
+  of the carrier for the cost of a single guaranteed field.
+
+## Related Decisions
+
+- ADR-004
+- ADR-025
+- ADR-016
+- ADR-007
+- ADR-014
+- ADR-013
+
+## Related Requirements
+
+- rac-okf-carrier-profile

--- a/rac/decisions/adr-048-okf-carrier-profile.md
+++ b/rac/decisions/adr-048-okf-carrier-profile.md
@@ -3,7 +3,7 @@ schema_version: 1
 id: RAC-KV2KWK55FC49
 type: decision
 ---
-# ADR-046: OKF as an Informative Carrier Profile
+# ADR-048: OKF as an Informative Carrier Profile
 
 ## Status
 

--- a/rac/requirements/rac-okf-carrier-profile.md
+++ b/rac/requirements/rac-okf-carrier-profile.md
@@ -1,0 +1,95 @@
+---
+schema_version: 1
+id: RAC-KV2KYJ60TJ1C
+type: requirement
+---
+# REQ-OKF-Carrier-Profile
+
+> The key words MUST, MUST NOT, SHOULD, SHOULD NOT, and MAY in this document are
+> to be interpreted as described in BCP 14 (RFC 2119, RFC 8174) when, and only
+> when, they appear in all capitals.
+
+## Status
+
+Proposed
+
+## Problem
+
+RAC stores product knowledge as a Git tree of typed Markdown artifacts with YAML
+front matter. Google Cloud's Open Knowledge Format (OKF v0.1 Draft) describes the
+same carrier and is gaining tooling, so a RAC repository is *almost* an OKF
+bundle already. The gap is small but real: OKF requires every artifact to carry a
+non-empty `type`, and RAC's `type` is currently optional in front matter. Without
+a guaranteed `type` and a derived bundle view, RAC forfeits free
+interoperability and an independent, external validation of its carrier — for the
+cost of a single field. ADR-046 decides RAC adopts OKF as an informative carrier
+profile and derived export target; this requirement scopes that adoption as
+checkable behaviour without loosening any RAC guarantee.
+
+## Requirements
+
+- [REQ-001] Every RAC artifact MUST carry a non-empty `type` drawn from the enumerated set (`requirement`, `decision`, `roadmap`, `prompt`, `design`), so that a RAC repository is a conformant OKF v0.1 bundle.
+
+- [REQ-002] RAC MUST provide a derived OKF bundle view that maps RAC `type` to OKF `type` (`requirement`→`Requirement`, `decision`→`ADR`, `design`→`Design`, `roadmap`→`Roadmap`, `prompt`→`Prompt`); the OKF view MUST be a derived contract parallel to the JSON/Portal export (ADR-007), never a new source format, with RAC front matter and `## Related <Type>` sections remaining authoritative.
+
+- [REQ-003] In the derived OKF view, each resolved structural relationship MUST appear as a body link, so that relationship information survives for permissive OKF consumers while the typed sections stay the source of truth.
+
+- [REQ-004] RAC normativity MUST NOT be loosened to satisfy OKF: `rac validate` and `rac relationships --validate` MUST keep rejecting exactly what they reject today, and structural references MUST NOT be replaced by prose links (ADR-016).
+
+- [REQ-005] RAC SHOULD adopt OKF's progressive-disclosure `index.md`, date-grouped `log.md` history (derived from Git per ADR-045), and `# Citations` body convention where RAC has gaps; the dependency on OKF MUST remain informative and pinned to OKF v0.1, with no code, package, or network dependency on OKF or Google tooling.
+
+## Acceptance Criteria
+
+- `rac validate rac/` reports zero artifacts with a missing or empty `type`.
+- A derived OKF export emits one bundle entry per artifact, each with an OKF
+  `type` equal to the mapped RAC `type` for all five types.
+- For every relationship that `rac relationships --validate` resolves, the
+  derived OKF view contains a corresponding body link to the target.
+- Re-running `rac validate` and `rac relationships --validate` before and after
+  the OKF work yields identical exit codes and findings on the same corpus state
+  (no loosening).
+- The repository declares no build, runtime, or test dependency on any OKF or
+  Google package, and the OKF profile cites OKF v0.1 explicitly.
+
+## Success Metrics
+
+- A RAC repository passes an independent OKF v0.1 conformance check unmodified.
+- The OKF export and the JSON/Portal export agree on artifact identity, `type`,
+  and resolved relationships for the same corpus.
+
+## Risks
+
+- OKF is a pre-1.0, single-vendor draft; its conventions may change. Mitigated by
+  keeping the dependency informative and pinned, and reassessing at OKF 1.0 via a
+  new ADR (ADR-046, decision point 5).
+- Treating the OKF bundle as a frozen contract would extend RAC's stability
+  obligations (ADR-007). Mitigated by keeping the OKF view a derived contract and
+  routing any promotion to a frozen contract through a new ADR.
+
+## Assumptions
+
+- The relationship model stays "structural references in Markdown sections"
+  (ADR-016); this requirement concerns conformance and export, not the mechanism.
+- The base metadata contract (ADR-025) can guarantee a non-empty `type` without
+  otherwise changing front matter; the precise mechanism is implementation,
+  scoped to a future release.
+
+## Priority
+
+This sits in the same band as the JSON/derived-contract work it parallels
+(ADR-007): valuable interoperability that is additive and non-blocking, below
+RAC's core validation guarantees. The conformance field (REQ-001) is the
+higher-priority half because it is a one-field change that unlocks the rest; the
+derived export (REQ-002, REQ-003) follows at the derived-contract band.
+
+## Related Decisions
+
+- ADR-046
+- ADR-004
+- ADR-016
+- ADR-007
+- ADR-014
+
+## Related Requirements
+
+- rac-portal-citation-links

--- a/rac/requirements/rac-okf-carrier-profile.md
+++ b/rac/requirements/rac-okf-carrier-profile.md
@@ -22,7 +22,7 @@ bundle already. The gap is small but real: OKF requires every artifact to carry 
 non-empty `type`, and RAC's `type` is currently optional in front matter. Without
 a guaranteed `type` and a derived bundle view, RAC forfeits free
 interoperability and an independent, external validation of its carrier — for the
-cost of a single field. ADR-046 decides RAC adopts OKF as an informative carrier
+cost of a single field. ADR-048 decides RAC adopts OKF as an informative carrier
 profile and derived export target; this requirement scopes that adoption as
 checkable behaviour without loosening any RAC guarantee.
 
@@ -61,7 +61,7 @@ checkable behaviour without loosening any RAC guarantee.
 
 - OKF is a pre-1.0, single-vendor draft; its conventions may change. Mitigated by
   keeping the dependency informative and pinned, and reassessing at OKF 1.0 via a
-  new ADR (ADR-046, decision point 5).
+  new ADR (ADR-048, decision point 5).
 - Treating the OKF bundle as a frozen contract would extend RAC's stability
   obligations (ADR-007). Mitigated by keeping the OKF view a derived contract and
   routing any promotion to a frozen contract through a new ADR.
@@ -84,7 +84,7 @@ derived export (REQ-002, REQ-003) follows at the derived-contract band.
 
 ## Related Decisions
 
-- ADR-046
+- ADR-048
 - ADR-004
 - ADR-016
 - ADR-007


### PR DESCRIPTION
# Summary

Records RAC's adoption of Google's Open Knowledge Format (OKF v0.1 Draft) as an
**informative carrier profile and a derived export target — never a foundation**.
This is an authoring-only change: it adds the decision, the requirement that
scopes the work, and the profile documentation. No implementation code changes.

Adds:
- `ADR-048` — the decision and its rationale, alternatives, and consequences.
- `rac-okf-carrier-profile` — the requirement: five BCP-14 MUST/SHOULD clauses
  with machine-checkable acceptance criteria; the traceable parent for the
  future implementation.
- `docs/okf-profile.md` — the normative `type` mapping plus the `index.md`,
  `log.md`, and `# Citations` conventions, with worked examples; wired into the
  MkDocs nav.
- A `CHANGELOG.md` (Unreleased) note recording the adoption.

# Roadmap / ADR Trace

Roadmap:
- None. This is an ad-hoc decision-recording change; the requirement
  `rac/requirements/rac-okf-carrier-profile.md` is itself the traceable parent
  for the implementation work, which will be version-fenced in a future roadmap.

Relevant ADRs:
- `rac/decisions/adr-048-okf-carrier-profile.md` (new — the decision)
- `rac/decisions/adr-004-artifact-model.md`, `adr-025-hybrid-artifact-metadata.md`
  (the artifact model and metadata contract this interprets)
- `rac/decisions/adr-007-json-contract-stability.md`,
  `adr-014-viewer-agnostic-knowledge-artifacts.md` (derived-contract posture)
- `rac/decisions/adr-016-relationships-as-structural-references.md`,
  `adr-013-leverage-existing-source-control-systems.md` (constraints respected)

# Scope

## Included
- The OKF decision (ADR-048), as a `type: decision` artifact that passes
  `rac validate`.
- The requirement (`rac-okf-carrier-profile`), with acceptance criteria that
  name the future checks (non-empty enumerated `type`; derived OKF view mapping
  RAC `type` → OKF `type`; resolved relationships rendered as body links; no
  loosening of `rac validate` / `rac relationships --validate`).
- The profile doc with the normative mapping table and one worked example per
  convention, pinned to OKF v0.1.
- Structural relationship edges among the new and existing artifacts (the new
  ADR↔requirement pair plus links to ADR-004/007/013/014/016/025), all resolving
  under `rac relationships --validate`.

## Excluded (deliberately deferred to a later, separately scoped session)
- Any schema or base-model change to guarantee a non-empty `type`.
- The `rac export okf` bundle exporter and the `index.md` / `log.md` generators.
- A CI conformance gate.
- Any promotion of the OKF bundle to a **frozen** RAC contract (that requires a
  new ADR — the governed change path — not an edit here).

# Product / Architecture Decisions

- **Encoded against RAC's real model, not the task's assumed one.** The
  originating task described a non-existent layout (`knowledge/`, JSON
  `schemas/`, `docs/spec/`, `$schema`/`artifactType`/`owners` front matter,
  `decided-by`/`depends-on` edges, `REQ-00NN` IDs). The decision *substance* is
  preserved; the encoding uses RAC's actual contract: `schema_version`/`id`/
  `type` front matter, `## Related (Type)` structural references, slug filenames.
- **`type` mapping is `decision`→`ADR`, `requirement`→`Requirement`,
  `roadmap`→`Roadmap`, `prompt`→`Prompt`, `design`→`Design`.** RAC `type` is
  authoritative; the OKF `type` is derived.
- **The OKF bundle view is a derived contract**, parallel to the JSON/Portal
  export (ADR-007), not a new source format. Typed front matter and the
  `## Related` sections stay authoritative; relationships degrade to body links
  in the view.
- **No loosening.** `rac validate` and `rac relationships --validate` keep
  rejecting exactly what they reject today (REQ-004 / ADR-016 unchanged).
- **`adr-007-json-contract-stability` was not edited.** Accepted ADRs are not
  amended in place (clean-break, ADR-023); the dependency is recorded from the
  requirement instead.
- **ADR numbered 048.** main's v0.13.x work took 046 (CLI usage telemetry) and
  047 (agent guidance as prompts) during this branch's life; the renumber is a
  dedicated `chore(decisions)` commit, mirroring main's own renumber convention.

# User-Facing Contract

## CLI
No CLI commands added or changed.

## Human Output
No change to any command's terminal output.

## JSON Output
No change. (The future OKF export will add an additive view; it is out of scope
here.)

## Exit Codes
Unchanged.

The only user-facing addition is documentation: a new **OKF Profile** page in the
docs site nav.

# Verification

## Ran
- `rac validate rac/` → `PASS — 158 artifact(s) checked: 158 valid, 0 invalid`.
- `rac relationships rac/ --validate` → `Relationships Checked: 535 · Validation
  Issues: 0` (the new ADR↔requirement edges and all six related-decision links
  resolve uniquely; no dangling edges).
- `rac review rac/` → health 87/100; 99 findings, **0 at priority 1–2** (all
  pre-existing priority 3–4 advisories on unrelated artifacts).
- `rac validate rac/decisions/adr-048-okf-carrier-profile.md` and the requirement
  individually → PASS.

## Covered
- Positive: both new artifacts classify as their declared type and satisfy their
  required sections (ADR: Context/Decision/Consequences; REQ:
  Problem/Requirements/Acceptance criteria).
- Boundary: `[REQ-NNN]` clauses are single-line (the validator flags wrapped
  continuation lines as missing IDs — caught and fixed during authoring).
- Graph: the decision→decision edges rely on the v0.13.5 schema addition
  (`related decisions` on decisions); confirmed they materialize as real edges,
  not silently-dropped prose.

Note: `pytest` is not installed in this authoring environment, so the unit suite
was not run locally. This change touches no Python code — only artifacts, docs,
nav, and changelog — so the corpus gates above are the relevant verification; CI
runs the full suite on this PR.

# Review Path

1. `rac/decisions/adr-048-okf-carrier-profile.md` — the decision and its framing.
2. `rac/requirements/rac-okf-carrier-profile.md` — the normative clauses and
   acceptance criteria that scope the implementation.
3. `docs/okf-profile.md` + `mkdocs.yml` — the normative mapping and conventions.
4. `CHANGELOG.md` — the Unreleased note.

# Notes For Reviewer

- The originating task's premise didn't match this repository; the re-mapping
  decision and its rationale are documented in the ADR's Context and in the
  Product/Architecture Decisions section above. Worth a sanity check that the
  re-mapping faithfully preserves the intended decision.
- `adr-007` is intentionally untouched; if you'd prefer the OKF bundle recorded
  as a first-class frozen contract now, that's a separate ADR rather than an
  edit here.
- Known limitation: the OKF spec is referenced as informative and pinned to
  v0.1; it was not re-fetched during authoring, so the conventions are stated as
  SHOULDs against OKF's general model. Re-pin at OKF 1.0.

# Implementation Process

Authored with AI assistance under the maintainer's direction; the re-mapping to
RAC's real model, the no-loosening constraints, and final acceptance were
maintainer decisions.