### PR TITLE
feat(export): add OKF bundle export (rac export --okf) [roadmap:v0.13.6]

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,7 +68,7 @@ jobs:
           - name: diff
             paths: "tests/test_diff.py"
           - name: export
-            paths: "tests/test_export_cmd.py"
+            paths: "tests/test_export_cmd.py tests/test_export_okf.py"
           - name: improve
             paths: "tests/test_improve.py"
           - name: index

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,22 @@ details, release history over commit history.
 
 ### Added
 
+- OKF bundle export (v0.13.6): `rac export <dir> --okf [--out <dir>]` writes a
+  derived Open Knowledge Format (OKF v0.1) bundle — one Markdown file per typed
+  artifact with its OKF `type` projected (decision→ADR, requirement→Requirement,
+  and so on), plus a generated `index.md` (progressive disclosure) and `log.md`
+  (git-derived, date-grouped). Resolved relationships render as `# Citations`
+  body links so they survive for permissive OKF consumers, while the typed front
+  matter and `## Related` sections stay authoritative. Parallel to `--json` and
+  `--html`; existing exports and validation are unchanged. See
+  `docs/okf-profile.md`.
+
 - OKF carrier profile recorded (ADR-048 + `rac-okf-carrier-profile`): RAC
   adopts Google's Open Knowledge Format (OKF v0.1 Draft) as an informative
   carrier profile and a derived export target — never a foundation. RAC repos
   are conformant OKF bundles (RAC `type` maps to OKF `type`: decision→ADR,
-  requirement→Requirement, and so on), and a future derived OKF bundle view
-  joins the JSON/Portal export. RAC's normativity is unchanged — `rac validate`
+  requirement→Requirement, and so on), and the derived OKF bundle view
+  (`rac export --okf`, above) joins the JSON/Portal export. RAC's normativity is unchanged — `rac validate`
   and `rac relationships --validate` keep rejecting what they reject today. The
   profile is documented in `docs/okf-profile.md`; the dependency is informative
   and pinned to OKF v0.1, with no code or package dependency on OKF tooling.

--- a/docs/okf-profile.md
+++ b/docs/okf-profile.md
@@ -14,6 +14,19 @@ scoped by the `rac-okf-carrier-profile` requirement.
 > described in BCP 14 (RFC 2119, RFC 8174) when, and only when, they appear in
 > all capitals.
 
+## Producing a bundle
+
+`rac export <dir> --okf` writes the bundle described here:
+
+```bash
+rac export rac/ --okf --out okf-bundle/
+```
+
+It emits one Markdown file per typed artifact (front matter projecting the OKF
+`type`), plus a generated `index.md` and `log.md`, mirroring the corpus layout.
+The bundle is a derived build artifact, parallel to `rac export --json` and
+`--html`; it never feeds back into RAC.
+
 ## Type mapping (normative)
 
 Every RAC artifact carries a `type` in its front matter. In the OKF bundle view

--- a/rac/requirements/rac-okf-carrier-profile.md
+++ b/rac/requirements/rac-okf-carrier-profile.md
@@ -93,3 +93,7 @@ derived export (REQ-002, REQ-003) follows at the derived-contract band.
 ## Related Requirements
 
 - rac-portal-citation-links
+
+## Related Roadmaps
+
+- v0.13.6-okf-bundle-export

--- a/rac/roadmaps/v0.13.x-welcome/v0.13.6-okf-bundle-export.md
+++ b/rac/roadmaps/v0.13.x-welcome/v0.13.6-okf-bundle-export.md
@@ -1,0 +1,178 @@
+---
+schema_version: 1
+id: RAC-KV2QQPHY9SZ1
+type: roadmap
+---
+# RAC v0.13.6 — OKF Bundle Export
+
+## Status
+
+Planned
+
+## Context
+
+ADR-048 adopts Google's Open Knowledge Format (OKF v0.1 Draft) as an informative
+carrier profile and a **derived export target**, and `rac-okf-carrier-profile`
+scopes the work. This milestone delivers the export half: a new `rac export
+--okf` view that projects the corpus as a conformant OKF bundle, parallel to the
+existing JSON and Portal exports (ADR-007, ADR-014).
+
+The corpus is already OKF-shaped, so the export is additive and reuses the
+existing machinery. `build_corpus_export()` already walks the corpus once,
+classifies artifacts, renders bodies, and resolves relationships — and already
+**excludes Unknown-type files**, exactly the set OKF would have no `type` for.
+The git-derived recency service (ADR-045) and the repository index service supply
+the `log.md` and `index.md` conventions the profile recommends. No validation
+behaviour changes; the bundle is a derived output, never a source format.
+
+This milestone deliberately excludes making `type` mandatory at the source and
+the CI conformance gate (`rac-okf-carrier-profile` REQ-001). That tightens
+validation and revises ADR-025, so it is a separately recorded decision and a
+later fence. Export degrades gracefully without it: untyped documents are simply
+absent from the bundle, as they already are from the JSON export.
+
+## Outcomes
+
+- `rac export <dir> --okf` writes a conformant OKF v0.1 bundle: one Markdown file
+  per typed artifact carrying a projected OKF `type`, plus generated `index.md`
+  and `log.md`.
+- The OKF `type` mirrors the RAC `type` per the ADR-048 mapping
+  (`decision`→`ADR`, `requirement`→`Requirement`, `roadmap`→`Roadmap`,
+  `prompt`→`Prompt`, `design`→`Design`); the RAC `type` stays authoritative.
+- Every relationship that resolves under `rac relationships --validate` appears
+  in the bundle as a body link, so links survive for permissive OKF consumers
+  while the typed front matter remains the source of truth.
+- The existing JSON and HTML exports, and all validation, are byte-for-byte
+  unchanged.
+
+## Initiatives
+
+### Initiative 1 — OKF Bundle Renderer
+
+Add `src/rac/output/okf.py` that turns a `CorpusExport` into an in-memory bundle:
+a mapping of relative bundle paths to file contents. Each artifact becomes a
+Markdown file with OKF front matter (`type` projected via the ADR-048 mapping,
+`id` preserved) and its original body, with a derived `# Citations` / body-link
+block for resolved relationships. The renderer is pure and deterministic
+(artifacts ordered by path, links by target), mirroring `render_export_json`.
+
+### Initiative 2 — Generated index.md and log.md
+
+Generate `index.md` (progressive disclosure: overview, then artifacts grouped by
+type) from the repository index, and `log.md` (date-grouped, newest-first) from
+the git-recency service (ADR-045). Outside a git repository, recency is unknown
+and `log.md` degrades to a stable placeholder rather than failing — no exception
+crosses the boundary, consistent with the recency service's contract.
+
+### Initiative 3 — CLI Surface
+
+Add `--okf` to the `export` mutually-exclusive mode group and `--out` handling so
+`rac export <dir> --okf --out <bundle-dir>` writes the bundle to a directory
+(default `okf-bundle/`). `--json` remains the default; `--okf` and `--html` stay
+mutually exclusive. Exit codes follow the existing export command (`0` success,
+`2` usage/IO error).
+
+### Initiative 4 — Coverage and Documentation
+
+Service-level unit tests for the renderer (type projection, link rendering,
+determinism, Unknown-type exclusion, empty corpus) and a golden bundle over a
+fixture corpus. Update `docs/okf-profile.md` to point at the live command, add a
+CHANGELOG entry, and mark `rac-okf-carrier-profile` REQ-002/003 (and the REQ-005
+conventions) as delivered by this milestone.
+
+## Constraints
+
+- Additive only (ADR-007): no existing export output, CLI flag, JSON field, or
+  validation behaviour changes. `--okf` is a new mode.
+- The bundle is a derived output (ADR-016, ADR-048): RAC front matter and
+  `## Related <Type>` sections stay authoritative; the bundle never becomes a
+  source RAC reads back.
+- No code, package, or network dependency on OKF or Google tooling; the profile
+  stays pinned to OKF v0.1 (ADR-048).
+- Determinism (REQ-Trust-Transparency): same corpus state yields a byte-identical
+  bundle; all ordering is explicit.
+
+## Non-Goals
+
+- Making `type` mandatory at the source or adding a CI OKF-conformance gate
+  (`rac-okf-carrier-profile` REQ-001) — a separate ADR and fence.
+- A round-trip importer that reads an OKF bundle back into RAC; export is one-way.
+- Promoting the OKF bundle to a frozen contract alongside the JSON export — a
+  future ADR if and when it is warranted (ADR-048).
+- Reading or validating bundles produced by other OKF tools.
+
+## Implementation Contract
+
+The following decisions are pinned for v0.13.6.
+
+### CLI
+
+- `rac export <dir> --okf [--out <bundle-dir>]` writes a bundle directory
+  (default `okf-bundle/`). `--okf` joins the existing `--json` / `--html`
+  mutually-exclusive group; `--out` applies to `--html` and `--okf`.
+- An existing `--out` directory is overwritten (exports are build artifacts),
+  matching the `--html` contract.
+
+### Bundle layout
+
+- One file per typed artifact at a path derived from its source path under the
+  bundle root; Unknown-type files are excluded (as in the JSON export).
+- `index.md` at the bundle root; `log.md` at the bundle root.
+- Each artifact file: OKF front matter with the projected `type` and preserved
+  `id`, the original Markdown body, and a derived body-link block for resolved
+  relationships.
+
+### Behaviour
+
+- The OKF `type` is derived from the RAC `type`; an artifact whose RAC `type`
+  has no mapping is not emitted (cannot occur for the five enumerated types).
+- `log.md` uses ISO `YYYY-MM-DD` date grouping, newest-first, from git recency;
+  unknown recency degrades to a placeholder, never an error.
+- JSON/HTML export, `rac validate`, and `rac relationships --validate` are
+  unchanged.
+
+## Success Measures
+
+- `rac export rac/ --okf --out okf-bundle/` produces a bundle whose every
+  artifact file carries a non-empty OKF `type` matching the mapping, plus
+  `index.md` and `log.md`.
+- Each relationship that `rac relationships rac/ --validate` resolves has a
+  corresponding body link in the bundle.
+- Re-running the export on the same corpus state yields a byte-identical bundle
+  (golden test).
+- `rac validate rac/` and `rac relationships rac/ --validate` exit codes and
+  output are unchanged from before the milestone.
+
+## Risks
+
+- Bundle file-path derivation could collide for two artifacts. Mitigated: derive
+  paths from the already-unique source paths and assert uniqueness in the
+  renderer.
+- `log.md` depends on git; in a non-git checkout it would be empty. Mitigated:
+  degrade to a stable placeholder, matching the recency service's no-exception
+  contract.
+- Scope creep toward a frozen contract or a round-trip importer. Mitigated:
+  explicit Non-Goals; the bundle stays a derived, one-way output.
+
+## Assumptions
+
+- `build_corpus_export()` remains the single corpus walk feeding exports; the OKF
+  renderer consumes its `CorpusExport`, adding no second classification path.
+- The git-recency (ADR-045) and index services remain the source of recency and
+  inventory; the OKF generators consume them rather than re-deriving.
+
+## Related Decisions
+
+- adr-048
+- adr-007
+- adr-016
+- adr-045
+- adr-014
+
+## Related Requirements
+
+- rac-okf-carrier-profile
+
+## Related Roadmaps
+
+- v0.13.5-self-type-relationships

--- a/src/rac/cli.py
+++ b/src/rac/cli.py
@@ -15,7 +15,7 @@ Commands:
                     [--no-annotate]
     rac portfolio <directory> [--json] [--top-level]
     rac index [directory] [--json] [--top-level]
-    rac export [directory] [--json | --html] [--out PATH]
+    rac export [directory] [--json | --html | --okf] [--out PATH]
     rac explorer [directory] [--top-level]
     rac mcp [--root PATH] [--telemetry]
     rac mcp-stats [--json | --share]
@@ -42,7 +42,8 @@ Exit codes:
        produced, even from an empty or missing telemetry log; telemetry
        consent shown or changed, including when no endpoint key is
        configured; export payload produced — JSON to stdout, or the
-       --html Portal file written, an empty corpus included; watchkeeper
+       --html Portal file or --okf bundle written, an empty corpus
+       included; watchkeeper
        comparison with nothing requiring attention under the chosen
        --fail-on policy, always with --fail-on none)
     1  validate: errors found; stats: no valid known artifacts; ingest:
@@ -61,7 +62,7 @@ Exit codes:
        refuse-to-overwrite, missing output directory, repository not
        initialized, invalid repository key, explorer extra not installed,
        mcp --root not a directory, skill --dir not a directory, unknown
-       skill name, export --out without --html or unwritable, missing or
+       skill name, export --out without --html/--okf or unwritable, missing or
        corrupt vendored portal shell, watchkeeper revision unknown or
        directory not inside a git repository)
 """
@@ -117,6 +118,7 @@ from rac.services.inspect import build_inspection, inspect_directory
 from rac.services.migrate import migrate_metadata
 from rac.services.portfolio import build_portfolio_summary
 from rac.services.quickstart import DEFAULT_TYPE, CorpusNotEmpty, quickstart
+from rac.services.recency import artifact_recency
 from rac.services.relationships import (
     build_relationship_report,
     build_relationship_report_file,
@@ -484,11 +486,28 @@ def cmd_export(args: argparse.Namespace) -> int:
     if not Path(args.directory).is_dir():
         print(f"rac: not a directory: {args.directory}", file=sys.stderr)
         raise SystemExit(EXIT_USAGE)
-    if args.out is not None and not args.html:
-        print("rac: --out requires --html (--json writes to stdout)", file=sys.stderr)
+    if args.out is not None and not (args.html or args.okf):
+        print("rac: --out requires --html or --okf (--json writes to stdout)", file=sys.stderr)
         raise SystemExit(EXIT_USAGE)
 
     export = build_corpus_export(args.directory)
+
+    # OKF bundle (ADR-048): a derived tree of Markdown files written to a
+    # directory, parallel to the JSON/HTML views. Recency feeds log.md (ADR-045).
+    if args.okf:
+        bundle = outputs.render_okf_bundle(export, artifact_recency(args.directory), args.directory)
+        out = args.out if args.out is not None else "okf-bundle"
+        try:
+            for rel, content in sorted(bundle.items()):
+                dest = Path(out) / rel
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                dest.write_text(content, encoding="utf-8")
+        except OSError as exc:
+            print(f"rac: cannot write {out}: {exc}", file=sys.stderr)
+            raise SystemExit(EXIT_USAGE) from None
+        edges = len(export.relationships)
+        print(f"wrote {out}/ — {export.artifact_count} artifact(s), {edges} relationship(s)")
+        return EXIT_OK
 
     # JSON is the default mode (unlike sibling commands): the payload *is* the
     # product, and stdout keeps it pipeable. --json is an explicit no-op.
@@ -1178,11 +1197,18 @@ def build_parser() -> argparse.ArgumentParser:
         help="Inject the payload into the vendored Portal shell and write one "
         "self-contained HTML file.",
     )
+    export_mode.add_argument(
+        "--okf",
+        action="store_true",
+        help="Write a derived OKF v0.1 bundle (one Markdown file per artifact, "
+        "plus index.md and log.md) to a directory.",
+    )
     p_export.add_argument(
         "--out",
         default=None,
-        help="Where --html writes the Portal (default: lore-export.html). "
-        "Exports are build artifacts: an existing file is overwritten.",
+        help="Where --html writes the Portal (default: lore-export.html) or "
+        "--okf writes the bundle directory (default: okf-bundle). "
+        "Exports are build artifacts: existing output is overwritten.",
     )
     p_export.set_defaults(func=cmd_export)
 

--- a/src/rac/output/__init__.py
+++ b/src/rac/output/__init__.py
@@ -69,6 +69,7 @@ from .json import (
     render_validation_json,
     render_watchkeeper_json,
 )
+from .okf import render_okf_bundle
 from .portal import render_export_html
 from .templates import render_improve_template, render_schema_template
 
@@ -102,6 +103,7 @@ __all__ = [
     "render_migrate_json",
     "render_new_human",
     "render_new_json",
+    "render_okf_bundle",
     "render_portfolio_human",
     "render_portfolio_json",
     "render_quickstart_human",

--- a/src/rac/output/okf.py
+++ b/src/rac/output/okf.py
@@ -1,0 +1,162 @@
+"""OKF bundle export — `rac export --okf` (v0.13.6).
+
+A derived view of the corpus as a conformant Open Knowledge Format (OKF v0.1
+Draft) bundle (ADR-048: OKF is an informative carrier profile and a derived
+export target, never a source format). The bundle is a tree of Markdown files —
+one per typed artifact, plus a generated ``index.md`` and ``log.md`` — returned
+as a ``{relative path: file contents}`` mapping the CLI writes to disk.
+
+Bundle paths are relative to the exported corpus root, so the bundle mirrors the
+corpus layout without leaking the caller's directory. The RAC ``type`` stays
+authoritative; each artifact file projects it to the OKF ``type`` per the
+ADR-048 mapping. Every relationship that resolves (``rac relationships
+--validate``) is rendered as a body link in a derived ``# Citations`` section, so
+links survive for permissive OKF consumers while the typed front matter and
+``## Related <Type>`` sections remain the source of truth.
+
+Determinism (ADR-002, matching ``render_export_json``): artifacts in
+sorted-path order, citations and index entries ordered explicitly, ``log.md``
+grouped by commit date (newest first) then path — the same corpus state yields a
+byte-identical bundle. Recency is derived from git (ADR-045); when git cannot
+answer, ``log.md`` degrades to a placeholder rather than failing.
+"""
+
+from __future__ import annotations
+
+import os
+
+from rac.core.frontmatter import split_frontmatter
+from rac.services.export import CorpusExport, ExportArtifact
+from rac.services.recency import RecencyReport
+
+# RAC ``type`` → OKF ``type`` (ADR-048; docs/okf-profile.md is the normative
+# statement). The five enumerated RAC types map one-to-one; nothing else can
+# appear here because Unknown-type files are excluded from the export.
+OKF_TYPE = {
+    "requirement": "Requirement",
+    "decision": "ADR",
+    "design": "Design",
+    "roadmap": "Roadmap",
+    "prompt": "Prompt",
+}
+
+# Human plural headings for the index, in a fixed disclosure order.
+_INDEX_SECTIONS: tuple[tuple[str, str], ...] = (
+    ("requirement", "Requirements"),
+    ("decision", "Decisions"),
+    ("design", "Designs"),
+    ("roadmap", "Roadmaps"),
+    ("prompt", "Prompts"),
+)
+
+_INDEX_PATH = "index.md"
+_LOG_PATH = "log.md"
+
+
+def _body(path: str) -> str:
+    """The Markdown body after the frontmatter envelope, trailing space trimmed."""
+    with open(path, encoding="utf-8") as fh:
+        text = fh.read()
+    return split_frontmatter(text).body.strip()
+
+
+def _artifact_file(art: ExportArtifact, citations: list[tuple[str, str]]) -> str:
+    """One OKF artifact file: projected front matter, body, derived citations."""
+    lines = [
+        "---",
+        f"type: {OKF_TYPE[art.type]}",
+        f"id: {art.id}",
+        "---",
+        "",
+        _body(art.path),
+    ]
+    if citations:
+        lines += ["", "# Citations", ""]
+        lines += [f"- [{title}]({path})" for title, path in citations]
+    return "\n".join(lines) + "\n"
+
+
+def _citations(
+    art: ExportArtifact,
+    export: CorpusExport,
+    by_id: dict[str, ExportArtifact],
+    rel: dict[str, str],
+) -> list[tuple[str, str]]:
+    """Resolved outgoing relationships as ``(title, bundle path)`` link pairs.
+
+    A relationship resolves exactly when its ``to`` is a canonical id present in
+    the corpus; unresolved references (literal text) carry no link target and are
+    left to the authoritative ``## Related`` sections in the body.
+    """
+    pairs: list[tuple[str, str]] = []
+    for edge in export.relationships:
+        if edge.from_ != art.id:
+            continue
+        target = by_id.get(edge.to)
+        if target is not None:
+            pairs.append((target.title, rel[target.path]))
+    return pairs
+
+
+def _index(export: CorpusExport, rel: dict[str, str]) -> str:
+    """``index.md`` — progressive disclosure: overview, then artifacts by type."""
+    count = export.artifact_count
+    noun = "artifact" if count == 1 else "artifacts"
+    lines = [
+        f"# {export.corpus_name} — Knowledge Index",
+        "",
+        f"A derived OKF bundle of {count} {noun}. The RAC corpus is authoritative;"
+        " this index is a generated entry point.",
+    ]
+    by_type: dict[str, list[ExportArtifact]] = {}
+    for art in export.artifacts:
+        by_type.setdefault(art.type, []).append(art)
+    for type_name, heading in _INDEX_SECTIONS:
+        members = by_type.get(type_name)
+        if not members:
+            continue
+        lines += ["", f"## {heading}", ""]
+        lines += [f"- [{art.title}]({rel[art.path]})" for art in members]
+    return "\n".join(lines) + "\n"
+
+
+def _log(export: CorpusExport, recency: RecencyReport, rel: dict[str, str]) -> str:
+    """``log.md`` — corpus history grouped by commit date, newest first."""
+    last_by_path = {a.path: a.last_committed for a in recency.artifacts}
+    title_by_path = {art.path: art.title for art in export.artifacts}
+
+    dated: dict[str, list[str]] = {}
+    for path, committed in last_by_path.items():
+        if committed is None or path not in title_by_path:
+            continue
+        dated.setdefault(committed.date().isoformat(), []).append(path)
+
+    if not dated:
+        return "# Log\n\n_No commit history available._\n"
+
+    lines = ["# Log"]
+    for day in sorted(dated, reverse=True):
+        lines += ["", f"## {day}", ""]
+        for path in sorted(dated[day]):
+            lines.append(f"- [{title_by_path[path]}]({rel[path]})")
+    return "\n".join(lines) + "\n"
+
+
+def render_okf_bundle(export: CorpusExport, recency: RecencyReport, root: str) -> dict[str, str]:
+    """Project a corpus export as an OKF bundle (``{relative path: contents}``).
+
+    One file per typed artifact at its path relative to ``root`` (the exported
+    corpus directory), plus ``index.md`` and ``log.md`` at the bundle root. Pure
+    and deterministic given the same ``export`` and ``recency``.
+    """
+    rel = {art.path: os.path.relpath(art.path, root) for art in export.artifacts}
+    by_id = {art.id: art for art in export.artifacts}
+    files: dict[str, str] = {}
+    for art in export.artifacts:
+        key = rel[art.path]
+        if key in (_INDEX_PATH, _LOG_PATH):
+            raise ValueError(f"artifact path {key!r} collides with a generated bundle file")
+        files[key] = _artifact_file(art, _citations(art, export, by_id, rel))
+    files[_INDEX_PATH] = _index(export, rel)
+    files[_LOG_PATH] = _log(export, recency, rel)
+    return files

--- a/tests/test_export_okf.py
+++ b/tests/test_export_okf.py
@@ -1,0 +1,196 @@
+"""Tests for the v0.13.6 `rac export --okf` OKF bundle view (ADR-048).
+
+The bundle is a derived OKF v0.1 view of the corpus: one Markdown file per typed
+artifact (front matter projecting the RAC ``type`` to its OKF ``type``), plus a
+generated ``index.md`` and ``log.md``. The renderer is pure and deterministic;
+``log.md`` is fed a synthetic recency here so the tests never depend on git.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime
+
+import pytest
+from conftest import fixture_path
+
+from rac.cli import main
+from rac.core.artifacts import ARTIFACT_SPECS
+from rac.output.okf import OKF_TYPE, render_okf_bundle
+from rac.services.export import build_corpus_export
+from rac.services.recency import ArtifactRecency, RecencyReport
+
+_DAY = datetime(2026, 6, 14, 9, 0, tzinfo=UTC)
+_ROOT = fixture_path("export")
+
+
+def _export():
+    return build_corpus_export(_ROOT)
+
+
+def _bundle(export, recency):
+    return render_okf_bundle(export, recency, _ROOT)
+
+
+def _key(art) -> str:
+    """The artifact's bundle key — its path relative to the corpus root."""
+    return os.path.relpath(art.path, _ROOT)
+
+
+def _recency(export, when=_DAY) -> RecencyReport:
+    """A synthetic recency report giving every exported artifact one date."""
+    return RecencyReport(
+        directory="export",
+        recursive=True,
+        artifacts=[
+            ArtifactRecency(path=a.path, artifact_type=a.type, last_committed=when)
+            for a in export.artifacts
+        ],
+    )
+
+
+# --- renderer ----------------------------------------------------------------
+
+
+def test_bundle_has_index_log_and_one_file_per_artifact():
+    export = _export()
+    bundle = _bundle(export, _recency(export))
+    assert "index.md" in bundle
+    assert "log.md" in bundle
+    artifact_files = [p for p in bundle if p not in ("index.md", "log.md")]
+    assert len(artifact_files) == export.artifact_count
+    assert set(artifact_files) == {_key(a) for a in export.artifacts}
+
+
+def test_bundle_paths_are_relative_to_the_corpus_root():
+    export = _export()
+    bundle = _bundle(export, _recency(export))
+    # No key escapes the bundle root (no absolute paths, no parent traversal).
+    assert all(not os.path.isabs(p) and not p.startswith("..") for p in bundle)
+
+
+def test_okf_type_mapping_covers_every_artifact_type():
+    # If a new RAC type is added without an OKF projection, this fails loudly.
+    assert set(OKF_TYPE) == {spec.name for spec in ARTIFACT_SPECS}
+
+
+def test_artifact_file_projects_okf_front_matter():
+    export = _export()
+    bundle = _bundle(export, _recency(export))
+    for art in export.artifacts:
+        head = bundle[_key(art)].splitlines()[:4]
+        assert head == ["---", f"type: {OKF_TYPE[art.type]}", f"id: {art.id}", "---"]
+
+
+def test_resolved_relationship_renders_as_citation_link():
+    export = _export()
+    bundle = _bundle(export, _recency(export))
+    by_id = {a.id: a for a in export.artifacts}
+    # Derive topology rather than assume it: a source with a resolved out-edge.
+    src_id = next(e.from_ for e in export.relationships if e.to in by_id)
+    src = by_id[src_id]
+    target = next(by_id[e.to] for e in export.relationships if e.from_ == src_id and e.to in by_id)
+    citations = bundle[_key(src)].split("# Citations", 1)[1]
+    assert f"- [{target.title}]({_key(target)})" in citations
+    # Unresolved references never become citation links.
+    unresolved = {e.to for e in export.relationships if e.to not in by_id}
+    assert all(ref not in citations for ref in unresolved)
+
+
+def test_artifact_without_resolved_links_has_no_citations():
+    export = _export()
+    bundle = _bundle(export, _recency(export))
+    by_id = {a.id: a for a in export.artifacts}
+    sources_with_links = {e.from_ for e in export.relationships if e.to in by_id}
+    bare = next((a for a in export.artifacts if a.id not in sources_with_links), None)
+    if bare is None:
+        pytest.skip("fixture has no artifact without resolved outgoing links")
+    assert "# Citations" not in bundle[_key(bare)]
+
+
+def test_unknown_type_files_are_excluded():
+    export = _export()
+    bundle = _bundle(export, _recency(export))
+    assert not any("random-notes" in path for path in bundle)
+
+
+def test_render_is_deterministic():
+    export = _export()
+    recency = _recency(export)
+    assert _bundle(export, recency) == _bundle(export, recency)
+
+
+def test_index_groups_artifacts_by_type():
+    export = _export()
+    index = _bundle(export, _recency(export))["index.md"]
+    assert index.startswith("# export — Knowledge Index")
+    assert "## Decisions" in index
+    assert "## Roadmaps" in index
+    roadmap = next(a for a in export.artifacts if a.type == "roadmap")
+    assert f"- [{roadmap.title}]({_key(roadmap)})" in index
+
+
+def test_log_groups_by_date_newest_first():
+    export = _export()
+    older = datetime(2026, 1, 1, tzinfo=UTC)
+    newer = datetime(2026, 6, 14, tzinfo=UTC)
+    paths = [a.path for a in export.artifacts]
+    recency = RecencyReport(
+        directory="export",
+        recursive=True,
+        artifacts=[
+            ArtifactRecency(path=paths[0], artifact_type="decision", last_committed=newer),
+            *[
+                ArtifactRecency(path=p, artifact_type="decision", last_committed=older)
+                for p in paths[1:]
+            ],
+        ],
+    )
+    log = _bundle(export, recency)["log.md"]
+    assert log.startswith("# Log")
+    assert log.index("## 2026-06-14") < log.index("## 2026-01-01")
+
+
+def test_log_degrades_to_placeholder_without_recency():
+    export = _export()
+    blank = RecencyReport(
+        directory="export",
+        recursive=True,
+        artifacts=[
+            ArtifactRecency(path=a.path, artifact_type=a.type, last_committed=None)
+            for a in export.artifacts
+        ],
+    )
+    assert _bundle(export, blank)["log.md"] == "# Log\n\n_No commit history available._\n"
+
+
+def test_empty_corpus_yields_only_index_and_log(tmp_path):
+    export = build_corpus_export(str(tmp_path))
+    bundle = render_okf_bundle(export, _recency(export), str(tmp_path))
+    assert set(bundle) == {"index.md", "log.md"}
+    assert "0 artifacts" in bundle["index.md"]
+
+
+# --- CLI ---------------------------------------------------------------------
+
+
+def test_export_okf_writes_bundle_to_disk(tmp_path, capsys):
+    out = tmp_path / "bundle"
+    rc = main(["export", fixture_path("export"), "--okf", "--out", str(out)])
+    assert rc == 0
+    assert (out / "index.md").is_file()
+    assert (out / "log.md").is_file()
+    written = capsys.readouterr().out
+    assert "artifact(s)" in written
+
+
+def test_export_okf_and_html_are_mutually_exclusive():
+    with pytest.raises(SystemExit) as exc:
+        main(["export", fixture_path("export"), "--okf", "--html"])
+    assert exc.value.code == 2
+
+
+def test_export_out_requires_a_file_mode():
+    with pytest.raises(SystemExit) as exc:
+        main(["export", fixture_path("export"), "--out", "x"])
+    assert exc.value.code == 2


### PR DESCRIPTION
# Summary

Implements `rac/roadmaps/v0.13.x-welcome/v0.13.6-okf-bundle-export.md` — the
derived **OKF bundle export**, the export half of the OKF carrier profile
(ADR-048, `rac-okf-carrier-profile` REQ-002/003/005).

Adds:
- `rac export DIR --okf [--out OUTDIR]` — a new export mode that writes a
  conformant Open Knowledge Format (OKF v0.1) bundle directory.
- `src/rac/output/okf.py` — a pure, deterministic renderer projecting a
  `CorpusExport` into bundle files.
- A v0.13.6 roadmap contract, renderer + CLI tests, and docs/changelog updates.

# Roadmap / ADR Trace

Roadmap:
- `rac/roadmaps/v0.13.x-welcome/v0.13.6-okf-bundle-export.md` (new)

Relevant ADRs:
- `rac/decisions/adr-048-okf-carrier-profile.md` — OKF is an informative carrier
  profile and a derived export target (the decision this delivers).
- `rac/decisions/adr-007-json-contract-stability.md`,
  `adr-014-viewer-agnostic-knowledge-artifacts.md` — the derived-export posture
  the OKF view parallels.
- `rac/decisions/adr-016-relationships-as-structural-references.md` — typed
  `## Related` sections stay authoritative; the bundle degrades them to body links.
- `rac/decisions/adr-045-git-derived-recency.md` — `log.md` is derived from git.

# Scope

## Included
- `rac export --okf`: one Markdown file per typed artifact with its OKF `type`
  projected (`decision`→`ADR`, `requirement`→`Requirement`, `design`→`Design`,
  `roadmap`→`Roadmap`, `prompt`→`Prompt`); `id` preserved; original body kept.
- A derived `# Citations` block per artifact listing every **resolved**
  relationship as a Markdown body link (unresolved references are left to the
  authoritative `## Related` sections).
- Generated `index.md` (progressive disclosure, artifacts grouped by type) and
  `log.md` (git-derived recency, date-grouped, newest-first).
- Bundle paths relative to the corpus root; deterministic, byte-identical output
  for a given corpus state.

## Excluded (deliberately deferred)
- Making `type` mandatory at the source and a CI OKF-conformance gate
  (`rac-okf-carrier-profile` REQ-001) — that tightens validation and revises
  ADR-025, so it is a separate ADR and a later fence. Export degrades gracefully
  without it: Unknown-type files are excluded, exactly as the JSON export does.
- A round-trip importer (export is one-way) and any promotion of the bundle to a
  frozen contract.

# Product / Architecture Decisions

- **New mode, no change to existing exports.** `--okf` joins the `--json` /
  `--html` mutually-exclusive group; the JSON/HTML payloads, `rac validate`, and
  `rac relationships --validate` are byte-for-byte unchanged.
- **Reuse over reinvention.** The renderer consumes the existing
  `build_corpus_export()` walk plus the index and git-recency services — no
  second classification path, no new git touchpoint.
- **Bundle paths are corpus-root-relative.** Keys and links are
  `os.path.relpath(path, root)`, so the bundle mirrors the corpus layout and the
  CLI can never write outside `--out` (see the bug note below).
- **`log.md` degrades, never fails.** Outside a git repo recency is unknown and
  `log.md` becomes a stable placeholder, matching the recency service's
  no-exception contract (ADR-045).
- **Output directory default is `okf-bundle/`** (parallel to `--html`'s
  `lore-export.html`); existing output is overwritten — exports are build artifacts.

# User-Facing Contract

## CLI
```bash
rac export rac/ --okf --out okf-bundle/
# wrote okf-bundle/ — 159 artifact(s), 542 relationship(s)
```
`--okf` is mutually exclusive with `--json` and `--html`. `--out` applies to
`--html` and `--okf`; using it with neither is a usage error.

## Human Output
One line on success: `wrote DIR/ — N artifact(s), M relationship(s)`.

## JSON Output
Unchanged. `--okf` writes files, not stdout.

## Exit Codes
- `0`: bundle written (an empty corpus still yields `index.md` + `log.md`).
- `2`: not a directory, `--out` without `--html`/`--okf`, or an unwritable target.

# Verification

## Ran
- `python -m pytest tests/test_export_okf.py tests/test_export_cmd.py tests/test_ci_batteries.py`
  → 38 passed. Full suite → 962 passed (the 3 `mcp_stats` goldens fail only
  because the optional `mcp` package cannot install in the authoring container;
  unrelated to this change — CI installs it and runs them).
- `rac validate rac/` → 159/159 valid; `rac relationships rac/ --validate` →
  535+ checked, 0 issues; `rac review rac/` → health 87, 0 priority-1/2 findings.
- `ruff check src/ tests/` and `ruff format --check` clean; `mypy` clean on the
  new module.
- `rac export rac/ --okf` then re-export → byte-identical (determinism).

## Covered
- Positive: type projection for the artifacts present; resolved relationship
  renders as a citation link; index groups by type; log groups by date, newest
  first.
- Negative/boundary: unresolved references are **not** linked; Unknown-type files
  are excluded; empty corpus yields only `index.md` + `log.md`; git-less recency
  degrades to the placeholder; `--okf`/`--html` mutual exclusivity and the
  `--out` guard return exit 2.
- Regression: `test_bundle_paths_are_relative_to_the_corpus_root` pins the
  path-safety fix.

# Review Path

1. `rac/roadmaps/v0.13.x-welcome/v0.13.6-okf-bundle-export.md` — the contract.
2. `src/rac/output/okf.py` — the renderer (type projection, citations, index/log).
3. `src/rac/cli.py` — the `--okf` mode and bundle writing.
4. `tests/test_export_okf.py` + `.github/workflows/tests.yml` — coverage + battery.
5. `docs/okf-profile.md`, `CHANGELOG.md`, the requirement link — delivery record.

# Notes For Reviewer

- **Path-safety bug found and fixed during development.** An earlier renderer
  keyed bundle files by the artifacts' raw paths; with an absolute corpus path,
  `Path(out) / "/abs/path"` discards `out`, and a test wrote projected files over
  three `tests/fixtures/` files. Fixed by emitting corpus-root-relative paths;
  fixtures restored and a regression test added. Worth confirming the relative
  derivation is what you want for the bundle layout.
- The `# Citations` block intentionally **duplicates** the relationship
  information already in the body's `## Related` sections — the former as links
  for OKF consumers, the latter as the authoritative typed references. Flag if
  you'd prefer the OKF view strip the source `## Related` sections instead.
- REQ-001 (`type` required + CI gate) is the deliberate next fence, not part of
  this PR.

# Implementation Process

Implemented with AI assistance under the maintainer's direction and the v0.13.6
roadmap contract; scope, the defer-REQ-001 decision, and acceptance were
maintainer calls.