### PR TITLE
feat(relationships): cross-artifact enforcement + OKF frontmatter superset [roadmap:v0.14.0,v0.14.1,v0.15.0]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ details, release history over commit history.
 
 ### Added
 
+- Status-consistency validation (v0.14.1): `rac relationships --validate` now
+  reports a relationship from a live artifact to a decision the team has retired
+  (`Superseded` or `Deprecated`) as `relationship-target-superseded` — so nothing
+  live points at a superseded artifact. The `supersedes` edge by which a replacing
+  decision references the one it replaces is exempt, as is a reference from a
+  retired decision (historical chains). Decision-only for now, since lifecycle
+  status lives on decisions. Existing issue codes are unchanged.
+
 - Edge-legality validation (v0.14.0): `rac relationships --validate` now reports a
   `## Related <Type>` (or `## Supersedes`) section that the artifact's type does
   not support, instead of silently dropping it. Such a section produces no graph

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ details, release history over commit history.
 
 ### Added
 
+- OKF frontmatter superset (v0.15.0): RAC artifacts may now declare an optional
+  `tags: [...]` list (the OKF-reserved descriptive field ADR-025 anticipated),
+  validated for shape and additive — no `schema_version` bump. `rac export --okf`
+  carries `tags` from source plus `created`/`updated` derived from git history
+  (first and last commit) in each bundle artifact, so the OKF bundle is
+  timestamped while the source stays date-free (recency is git-derived, ADR-045).
+  RAC deliberately does not add frontmatter `title`/`description` or make `type`
+  mandatory (ADR-050). The JSON export contract is unchanged.
+
 - Status-consistency validation (v0.14.1): `rac relationships --validate` now
   reports a relationship from a live artifact to a decision the team has retired
   (`Superseded` or `Deprecated`) as `relationship-target-superseded` — so nothing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ details, release history over commit history.
 
 ### Added
 
+- Edge-legality validation (v0.14.0): `rac relationships --validate` now reports a
+  `## Related <Type>` (or `## Supersedes`) section that the artifact's type does
+  not support, instead of silently dropping it. Such a section produces no graph
+  edge today; the new `relationship-edge-unsupported` issue surfaces it (and fails
+  the validate exit code) so authors learn the link did nothing. Opens the
+  enforcement series that makes deterministic cross-artifact validation RAC's core
+  (ADR-049). Existing relationship issue codes are unchanged.
+
 - OKF bundle export (v0.13.6): `rac export <dir> --okf [--out <dir>]` writes a
   derived Open Knowledge Format (OKF v0.1) bundle — one Markdown file per typed
   artifact with its OKF `type` projected (decision→ADR, requirement→Requirement,

--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ rac export rac/ --html --out lore-export.html    # the Portal, one file
 - **Teams who already write ADRs** and want those decisions to actually shape what the agent does.
 - **Anyone who wants the *why* behind their software versioned alongside the code.**
 
+## How it relates to OKF
+
+Google's Open Knowledge Format (OKF) standardises the *carrier* — a Git tree of Markdown with YAML front matter — and is deliberately permissive: an OKF consumer must not reject a bundle for missing fields, unknown types, or broken links. RAC writes that same carrier and adds what OKF leaves to the consumer: **write-time enforcement** in CI. `rac validate` and `rac relationships --validate` reject malformed artifacts, broken or ambiguous links, references to superseded decisions, and relationship edges a type does not support — deterministically, before the knowledge lands. OKF is read-optimised interchange; RAC is write-time enforcement, and `rac export --okf` turns any RAC repo into a conformant OKF bundle — so the two compose rather than compete.
+
 ## Documentation
 
 **Full documentation: <https://tcballard.github.io/requirements-as-code/>**

--- a/docs/index.md
+++ b/docs/index.md
@@ -67,6 +67,10 @@ Comparison sources, verified 2026-06-12:
 - Lore / RAC cells: this repository (README, docs/, rac/).
 -->
 
+## How this relates to OKF
+
+Google's Open Knowledge Format (OKF) standardises the *carrier* — a Git tree of Markdown with YAML front matter — and is deliberately permissive: consumers must not reject a bundle for missing fields, unknown types, or broken links. OKF says *"if you can `cat` it, you can read it."* RAC says *"and CI guarantees the file is well-formed, the decision is consistent, and nothing points at a superseded artifact."* OKF is read-time interchange; RAC is **write-time enforcement** — deterministic, cross-artifact validation (referential integrity, status-consistency, illegal-edge detection) that fails your build before bad knowledge lands. A RAC repo *is* a conformant OKF bundle (`rac export --okf`), so you get the interchange for free and keep the enforcement OKF leaves out (ADR-048, ADR-049).
+
 ## How Lore earns trust
 
 Lore asks you to trust it with your product knowledge, so it holds itself to the same standard it applies to your repository:

--- a/docs/index.md
+++ b/docs/index.md
@@ -71,6 +71,28 @@ Comparison sources, verified 2026-06-12:
 
 Google's Open Knowledge Format (OKF) standardises the *carrier* — a Git tree of Markdown with YAML front matter — and is deliberately permissive: consumers must not reject a bundle for missing fields, unknown types, or broken links. OKF says *"if you can `cat` it, you can read it."* RAC says *"and CI guarantees the file is well-formed, the decision is consistent, and nothing points at a superseded artifact."* OKF is read-time interchange; RAC is **write-time enforcement** — deterministic, cross-artifact validation (referential integrity, status-consistency, illegal-edge detection) that fails your build before bad knowledge lands. A RAC repo *is* a conformant OKF bundle (`rac export --okf`), so you get the interchange for free and keep the enforcement OKF leaves out (ADR-048, ADR-049).
 
+| Dimension | Lore / RAC | OKF (v0.1 Draft) |
+| --- | --- | --- |
+| Validation time | Write-time: `rac validate` and `rac relationships --validate` fail CI before the knowledge lands | Read-time: consumers "MUST NOT reject a bundle" for missing optional fields or unknown `type`, and "MUST tolerate broken links" |
+| Links | Typed `## Related` structural references, resolved and validated — broken, ambiguous, superseded-target, and unsupported edges are errors | Untyped: the relationship kind "is conveyed by the surrounding prose, not by the link itself" |
+| `type` field | Five enumerated types that drive classification and validation | A free string — "Type values are not registered centrally" |
+| Cross-artifact checks | Referential integrity, status-consistency, edge-legality — enforced deterministically in CI | None defined; consumption is permissive by design |
+| Maturity | Governed corpus; CLI and MCP output is a stability-tested contract | "Version 0.1 — Draft"; a single-vendor (Google Cloud) initiative |
+| Interoperability | `rac export --okf` emits a conformant OKF bundle | The shared carrier RAC writes |
+
+<!--
+OKF comparison source, verified 2026-06-14:
+- OKF — https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md
+  (SPEC.md, "Version 0.1 — Draft"): consumers "MUST NOT reject a bundle because
+  of: Missing optional frontmatter fields / Unknown `type` values / Unknown
+  additional frontmatter keys" and "MUST tolerate broken links"; the relationship
+  kind "is conveyed by the surrounding prose, not by the link itself"; "Type
+  values are not registered centrally". A Google Cloud Platform initiative
+  (single-vendor), openly published on GitHub.
+- Lore / RAC cells: this repository — `rac validate`, `rac relationships
+  --validate`, `rac export --okf`, and ADR-016 / ADR-048 / ADR-049.
+-->
+
 ## How Lore earns trust
 
 Lore asks you to trust it with your product knowledge, so it holds itself to the same standard it applies to your repository:

--- a/docs/okf-profile.md
+++ b/docs/okf-profile.md
@@ -27,6 +27,14 @@ It emits one Markdown file per typed artifact (front matter projecting the OKF
 The bundle is a derived build artifact, parallel to `rac export --json` and
 `--html`; it never feeds back into RAC.
 
+Each bundle artifact also carries OKF's descriptive fields where RAC has them
+(ADR-050): `tags` projected from the source frontmatter (a RAC artifact MAY
+declare `tags: [...]`), and `created`/`updated` derived from git history — first
+and last commit. Timestamps are never stored in the source frontmatter; recency
+is git-derived (ADR-045), so the source stays date-free while the bundle is fully
+timestamped. RAC does not project a frontmatter `title` (it derives from the H1)
+or a `description`.
+
 ## Type mapping (normative)
 
 Every RAC artifact carries a `type` in its front matter. In the OKF bundle view

--- a/rac/decisions/adr-049-enforcement-is-the-product.md
+++ b/rac/decisions/adr-049-enforcement-is-the-product.md
@@ -1,0 +1,117 @@
+---
+schema_version: 1
+id: RAC-KV3FZJNRVNPE
+type: decision
+---
+# ADR-049: Write-Time Cross-Artifact Enforcement Is RAC's Core
+
+## Status
+
+Proposed
+
+## Category
+
+Product
+
+## Context
+
+Google Cloud published the Open Knowledge Format (OKF) — a Git tree of Markdown
+with YAML front matter, backed by a hyperscaler and reference implementations.
+Per-type schemas are being standardised too: MADR for decisions, dotprompt for
+prompts. Between them, two layers RAC once looked distinctive for are being
+commoditised in front of us:
+
+- the **carrier** (a markdown-and-front-matter bundle) — now OKF, with
+  zero-tooling adoption;
+- the **per-artifact schema** (what fields a decision or prompt should carry) —
+  now MADR/dotprompt and similar.
+
+This sharpens, rather than answers, the platform-absorption objection: "a model
+that eats the markdown" now has a Google-blessed, zero-tooling format to eat, and
+the per-file shapes are converging on community standards. If RAC's pitch rests
+on the file format or the per-type schema, it is defending ground that is being
+levelled.
+
+What none of those layers do — and what RAC already does — is validate the corpus
+*as a graph*, deterministically, at write time, in CI: that every reference
+resolves, that nothing points at a decision the team has superseded, that a
+declared relationship is actually a legal edge rather than silently inert prose.
+OKF is explicitly permissive (consumers MUST NOT reject on broken links or
+unknown types); MADR/dotprompt validate a single file in isolation. Cross-artifact
+referential integrity, status-consistency, and illegal-edge detection are RAC's
+alone.
+
+This decision interprets the relationship model (ADR-016) and the
+intelligence-not-content-store boundary (ADR-024), and follows the OKF carrier
+profile (ADR-048) by stating what RAC keeps when the carrier is shared.
+
+## Decision
+
+RAC's core product is **deterministic, CI-enforced, cross-artifact validation** —
+write-time enforcement of the corpus as a graph. The carrier (now OKF) and the
+per-type schemas (now MADR/dotprompt and peers) are **table stakes**: RAC stays
+compatible with them and treats them as interchange, not as the differentiator.
+
+Concretely, the product is the enforcement surface, in priority order:
+
+1. **Referential integrity** — every relationship resolves to exactly one
+   existing artifact (already shipped: broken, ambiguous, self-reference, and
+   duplicate-identifier detection).
+2. **Status-consistency** — no live artifact may point at a superseded or
+   deprecated target (beginning decision-only, where lifecycle status exists).
+3. **Edge-legality** — a declared relationship that is not a legal edge for the
+   source type is surfaced as a finding, never silently dropped.
+
+These checks are deterministic (same corpus state, same result; ADR-002), live in
+RAC Core, and gate CI through `rac validate` / `rac relationships --validate` /
+`rac watchkeeper`. Roadmap priority follows this decision: enforcement
+capabilities lead; carrier and schema work are sequenced as interop, not as the
+headline.
+
+The positioning line, to be reflected on public surfaces: OKF says "if you can
+`cat` it, you can read it"; RAC says "and CI guarantees the file is well-formed,
+the decision is consistent, and nothing points at a superseded artifact." OKF is
+read-time interchange; RAC is write-time enforcement.
+
+## Consequences
+
+### Positive
+
+- A defensible, single-sentence differentiator that does not depend on owning the
+  file format or the per-file schema.
+- Clear roadmap prioritisation: cross-artifact enforcement rules are first-class
+  product work, not validation housekeeping.
+- Aligns with where RAC already invests (ADR-016, the review/watchkeeper model).
+
+### Negative
+
+- RAC must actually deliver the enforcement rules it now claims as the product
+  (status-consistency and edge-legality are not yet implemented).
+- Leaning into graph enforcement raises the bar for determinism and false-positive
+  discipline on every new rule.
+
+### Neutral
+
+- Schema and carrier compatibility (OKF, and any future MADR/dotprompt alignment)
+  remain supported and tested — as table stakes, deliberately not as the pitch.
+
+## Alternatives Considered
+
+- **Compete on the carrier or the per-type schema.** Rejected: both are being
+  commoditised by a hyperscaler and community standards; defending them is a
+  losing position and is not where RAC's value lives.
+- **Leave enforcement as an unstated capability.** Rejected: without naming it as
+  the product, roadmap priority and public positioning keep drifting toward
+  format/schema parity, the exact ground being levelled.
+
+## Related Decisions
+
+- ADR-016
+- ADR-024
+- ADR-048
+
+## Related Requirements
+
+- rac-cross-artifact-enforcement
+- rac-growth-positioning
+- rac-repository-review-mode

--- a/rac/decisions/adr-050-okf-frontmatter-superset.md
+++ b/rac/decisions/adr-050-okf-frontmatter-superset.md
@@ -1,0 +1,103 @@
+---
+schema_version: 1
+id: RAC-KV3JY2CHGGRY
+type: decision
+tags: [okf, interop, metadata]
+---
+# ADR-050: OKF-Reserved Frontmatter — Adopt tags, Derive Timestamps from Git
+
+## Status
+
+Proposed
+
+## Category
+
+Technical
+
+## Context
+
+OKF reserves a small set of descriptive front-matter fields: `type`, `title`,
+`description`, `tags`, and a `timestamp`. Making a RAC repository a richer OKF
+bundle invites adopting them as a superset on top of RAC's strict `id`/`type`/
+typed relationships. But three of the five collide with decisions RAC has already
+recorded, so this is not the near-zero change it first appears:
+
+- **`type` (made mandatory on every file)** conflicts with ADR-010 (Documents Are
+  Not Artifacts): untyped documents are legitimate and deliberately skipped. The
+  15 currently-unclassified files are real planning docs; forcing a type would
+  make them validated artifacts that then fail for missing sections. OKF-bundle
+  validity already comes from `rac export --okf`, which excludes documents.
+- **`created`/`updated` stored in frontmatter** conflicts with ADR-045 (recency is
+  derived from git, not stored): a hand-maintained date drifts and pushes toward
+  the work-status modelling ADR-017 rejects.
+- **`title`/`description` in frontmatter** collide with RAC's H1-derived title and
+  body conventions (ADR-025), requiring conflict-detection rules for marginal gain.
+
+Only `tags` is free of conflict — and ADR-025 already reserved it ("Frontmatter,
+if later supported"). This decision adopts the conflict-free subset and resolves
+the timestamp tension by deriving timestamps in the *export* rather than storing
+them in the source.
+
+## Decision
+
+1. **Adopt `tags`** as an optional frontmatter field: a list of non-empty string
+   labels, validated for shape only, never a source of product reasoning. No
+   `schema_version` bump — this matches how `id`, `type`, and `relationships` were
+   added as optional fields at `schema_version: 1`; the addition is additive and
+   backward-compatible.
+2. **Derive OKF timestamps from git.** `rac export --okf` projects `created`
+   (first commit) and `updated` (last commit) into each bundle artifact's front
+   matter, derived from git history (ADR-045). They are never stored in the source
+   frontmatter, so the source stays date-free and the bundle is fully timestamped
+   for OKF consumers.
+3. **Do not adopt `title`/`description` in frontmatter** (they conflict with the
+   H1 title and body conventions; revisit only if OKF `description` interop
+   demands it).
+4. **Do not make `type` mandatory** at the source (ADR-010 stands; documents are
+   legitimate). OKF-bundle validity is delivered by `rac export --okf`, which
+   already excludes untyped documents.
+
+## Consequences
+
+### Positive
+
+- RAC artifacts gain OKF's `tags` for agent filtering and sorting, and the OKF
+  bundle carries `type` + `tags` + `created`/`updated` — four of OKF's five
+  reserved fields — with no conflict against any recorded decision.
+- The source corpus stays free of drift-prone dates (ADR-045) and free of forced
+  typing (ADR-010); both guarantees are preserved.
+
+### Negative
+
+- The OKF bundle's `title` still derives from the H1 (no frontmatter `title`), and
+  `description` is absent — slightly less than a full OKF superset.
+- The OKF export does two git lookups per artifact (first and last commit), paid
+  only on `rac export --okf`, not on the validation or cadence paths.
+
+### Neutral
+
+- `tags` are descriptive only; they do not participate in classification,
+  relationships, or review scoring.
+
+## Alternatives Considered
+
+- **Full OKF superset (add `title`/`description`, mandatory `type`, frontmatter
+  timestamps).** Rejected: conflicts with ADR-010, ADR-045, and the ADR-025 title
+  conventions; high cost for marginal interop gain.
+- **Store `created`/`updated` in frontmatter.** Rejected: contradicts ADR-045;
+  deriving them in the export gives OKF consumers the same data without the drift.
+- **A `schema_version` bump gating the new field.** Rejected: inconsistent with how
+  RAC has added optional fields, and unnecessary for an additive optional field.
+
+## Related Decisions
+
+- ADR-025
+- ADR-048
+- ADR-045
+- ADR-010
+- ADR-007
+- ADR-017
+
+## Related Requirements
+
+- rac-okf-carrier-profile

--- a/rac/requirements/rac-cross-artifact-enforcement.md
+++ b/rac/requirements/rac-cross-artifact-enforcement.md
@@ -1,0 +1,92 @@
+---
+schema_version: 1
+id: RAC-KV3G0KY6Y4NM
+type: requirement
+---
+# REQ-Cross-Artifact-Enforcement
+
+> The key words MUST, MUST NOT, SHOULD, SHOULD NOT, and MAY in this document are
+> to be interpreted as described in BCP 14 (RFC 2119, RFC 8174) when, and only
+> when, they appear in all capitals.
+
+## Status
+
+Proposed
+
+## Problem
+
+The markdown carrier (OKF) and per-type schemas (MADR, dotprompt) are being
+commoditised. The capability that stays RAC's alone — and that nothing in that
+landscape provides — is deterministic, CI-enforced validation of the corpus as a
+graph (ADR-049). Today RAC enforces only part of it: references must resolve
+(`rac relationships --validate`), but two graph-level guarantees a reader expects
+from "the decision is consistent" are missing:
+
+- **Status-consistency.** A live artifact can reference a decision the team has
+  marked `Superseded` or `Deprecated`, and nothing flags it — the corpus silently
+  points at retired knowledge.
+- **Edge-legality.** A `## Related <Type>` section that the source type's schema
+  does not consume is silently dropped: it renders as prose, passes validation,
+  and produces zero edges with no warning (the same silent-failure class recorded
+  in `rac-traceability-self-relationships` REQ-003).
+
+This requirement makes cross-artifact enforcement an explicit, named product
+surface and closes those two gaps.
+
+## Requirements
+
+- [REQ-001] RAC MUST treat cross-artifact validation as a first-class, deterministic, CI-gated product surface: every rule yields the same findings for the same corpus state, runs in RAC Core, and influences `rac validate` / `rac relationships --validate` / `rac watchkeeper` exit codes and verdicts.
+
+- [REQ-002] Referential integrity MUST remain enforced: a relationship reference that resolves to no artifact, to more than one artifact, to itself, or that collides on a duplicate identifier is a validation issue (already shipped; retained as the foundation).
+
+- [REQ-003] Status-consistency MUST be enforced for decisions: a relationship whose resolved target is a decision with status `Superseded` or `Deprecated` is a validation issue, EXCEPT the `supersedes` relationship by which the replacing decision points at the one it replaces. The check MUST be deterministic and reuse the existing status canonicalisation.
+
+- [REQ-004] Edge-legality MUST be surfaced, not silent: a `## Related <Type>` section present on an artifact whose type does not declare that relationship (so it produces no edge) MUST be reported as a finding rather than dropped silently. This satisfies `rac-traceability-self-relationships` REQ-003.
+
+- [REQ-005] New enforcement findings MUST distinguish themselves with stable issue codes and MUST NOT loosen or rename existing relationship issue codes (ADR-007 contract stability).
+
+## Acceptance Criteria
+
+- `rac relationships rac/ --validate` exits `0` on the clean corpus and `1` on a fixture that references a `Superseded` decision from a non-`supersedes` edge.
+- The `supersedes` edge from a replacing decision to the decision it supersedes does NOT raise the status-consistency issue.
+- A fixture artifact carrying a `## Related <Type>` section its type does not declare produces an edge-legality finding (not a silent drop) and is visible in `rac relationships`/`rac validate` output.
+- Every new issue has a stable, documented code; existing codes
+  (`relationship-target-not-found`, `relationship-target-ambiguous`,
+  `relationship-self-reference`, `duplicate-artifact-identifier`) are unchanged.
+- `rac validate rac/`, `rac relationships rac/ --validate`, and `rac review rac/`
+  stay green on the corpus after the rules ship.
+
+## Success Metrics
+
+- A corpus that points at a superseded decision fails CI deterministically rather
+  than drifting unnoticed.
+- The count of silently-dropped relationship sections across the corpus reaches
+  zero (each is either a real edge or a surfaced finding).
+
+## Risks
+
+- Over-strict status-consistency could flag legitimate historical references.
+  Mitigated by the explicit `supersedes` exception and by scoping to decisions
+  first (where lifecycle status exists), generalising only if warranted.
+- Edge-legality could fire on intentional prose headings that merely resemble a
+  relationship section. Mitigated by matching only the canonical
+  `## Related <Type>` section names already used by the parser.
+
+## Assumptions
+
+- The relationship model stays "structural references in Markdown sections"
+  (ADR-016); this requirement adds graph-level checks, not a new mechanism.
+- Lifecycle status remains decision-only for now (a later, separately scoped
+  decision may generalise it).
+
+## Related Decisions
+
+- ADR-049
+- ADR-016
+- ADR-007
+- ADR-024
+
+## Related Requirements
+
+- rac-repository-review-mode
+- rac-traceability-self-relationships

--- a/rac/requirements/rac-cross-artifact-enforcement.md
+++ b/rac/requirements/rac-cross-artifact-enforcement.md
@@ -90,3 +90,8 @@ surface and closes those two gaps.
 
 - rac-repository-review-mode
 - rac-traceability-self-relationships
+
+## Related Roadmaps
+
+- v0.14.0-enforcement-foundation
+- v0.14.1-status-consistency

--- a/rac/requirements/rac-growth-positioning.md
+++ b/rac/requirements/rac-growth-positioning.md
@@ -3,7 +3,7 @@ schema_version: 1
 id: RAC-KTYB8944G7TN
 type: requirement
 ---
-# Growth Positioning: Relating Lore/RAC to Spec-Driven Development Tools
+# Growth Positioning: Relating Lore/RAC to Spec-Driven Development Tools and OKF
 
 ## Status
 
@@ -25,6 +25,16 @@ RAC manages the *requirements* as a durable, versioned, governed corpus
 that persists across changes. RAC is the layer above SDD tools, not a
 competitor to them.
 
+A second category now needs the same treatment. Google's Open Knowledge
+Format (OKF) standardises the *carrier* RAC already writes — a Git tree
+of Markdown with YAML front matter — and is deliberately permissive,
+where RAC is enforcing. Without a recorded answer, evaluators may read
+RAC as redundant with a hyperscaler-blessed format, missing that the two
+sit at different layers: OKF is read-time interchange; RAC adds
+deterministic write-time enforcement in CI and exports a conformant OKF
+bundle. That relationship is complementary and must be stated as such
+(ADR-048, ADR-049).
+
 ## Requirements
 
 - [REQ-001] The README shall contain a single `##` section, placed below the fold (after the "Who it's for" section and never above the Lore lead), that relates Lore/RAC to spec-driven development tools and states the layer-above thesis: SDD tools manage the change and treat requirements as ephemeral inputs; RAC manages requirements as a durable, versioned corpus that persists across changes, a layer above SDD tools rather than a competitor to them.
@@ -32,6 +42,8 @@ competitor to them.
 - [REQ-003] The section shall contain a comparison table whose rows are capability dimensions (requirement persistence, change management, traceability, tool coupling, install footprint), restricted to rows for which every column's claim has been verified.
 - [REQ-004] Every claim in the comparison table shall be verifiable from the named tool's own repository or documentation, with the source URLs recorded in an HTML comment adjacent to the table.
 - [REQ-005] The section shall frame the relationship as complementary — Lore/RAC owns a different layer — and shall contain no claim that Lore or RAC is better than any named tool, and no claim that cannot be verified.
+- [REQ-006] The README shall contain a single `##` section, below the fold, that relates Lore/RAC to Google's Open Knowledge Format (OKF), naming OKF explicitly and stating the complementary thesis: OKF standardises the read-time carrier and is permissive, while RAC adds deterministic write-time enforcement in CI, and a RAC repository exports a conformant OKF bundle via `rac export --okf`.
+- [REQ-007] The OKF section shall frame the relationship as complementary (the two compose rather than compete), contain no claim that Lore or RAC is better than OKF, and make only verifiable claims — OKF's permissive consumption model traceable to its spec, and RAC's enforcement traceable to `rac validate` / `rac relationships --validate` behaviour.
 
 ## Success Metrics
 
@@ -70,3 +82,5 @@ competitor to them.
 ## Related Decisions
 
 - adr-036
+- adr-048
+- adr-049

--- a/rac/roadmaps/v0.14.x-enforcement/v0.14.0-enforcement-foundation.md
+++ b/rac/roadmaps/v0.14.x-enforcement/v0.14.0-enforcement-foundation.md
@@ -1,0 +1,134 @@
+---
+schema_version: 1
+id: RAC-KV3G1RJ3CJ3R
+type: roadmap
+---
+# RAC v0.14.0 — Edge-Legality Enforcement
+
+## Status
+
+Planned
+
+## Context
+
+ADR-049 names deterministic, CI-enforced cross-artifact validation as RAC's core
+product, and `rac-cross-artifact-enforcement` scopes the rules. This milestone
+opens the v0.14.x enforcement series with the first rule beyond referential
+integrity: edge-legality.
+
+Today a `## Related <Type>` (or `## Supersedes`) section on an artifact whose type
+does not declare that relationship is parsed away to nothing — it renders as
+prose, passes validation, and produces zero edges with no warning. That silent
+failure was recorded in `rac-traceability-self-relationships` REQ-003 and is
+`rac-cross-artifact-enforcement` REQ-004. This milestone surfaces it as a
+validation issue (`relationship-edge-unsupported`) so authors learn the link did
+nothing instead of believing it resolved.
+
+Status-consistency (REQ-003 of the enforcement requirement) needs the resolved
+target's type and status at validation time and ships next, in v0.14.1; this
+milestone does not add that plumbing because edge-legality does not need it — the
+check is entirely a property of the source artifact and its own schema.
+
+## Outcomes
+
+- A relationship section the source type's schema does not support is reported as
+  a validation issue instead of being silently dropped, and fails the
+  `rac relationships --validate` exit code.
+- The new finding is deterministic, carried in both human and JSON output, and
+  gated in CI through the existing dogfood relationship check.
+- Referential integrity and all existing relationship issue codes are unchanged;
+  the corpus stays green (it has no unsupported sections).
+
+## Initiatives
+
+### Initiative 1 — Edge-legality / no-silent-drop
+
+Detect relationship sections present (with at least one reference) in an
+artifact's Markdown whose name its type's `spec.optional` does not include, and
+emit a new issue, `relationship-edge-unsupported`, naming the source and the
+offending section. Recognise only the canonical `## Related <Type>` / `supersedes`
+section names the parser already knows, so prose headings that merely resemble a
+relationship section do not trip it.
+
+### Initiative 2 — Output and coverage
+
+Render the new finding under its own "Unsupported Relationships" group in human
+output and as a `{source_path, relationship, code}` object in JSON. Add
+negative/boundary tests (a legal edge, an unsupported `## Related <Type>`, a
+non-decision declaring `## Supersedes`, the CLI exit code, the JSON shape).
+
+## Constraints
+
+- Deterministic (ADR-002): same corpus state, identical findings and ordering
+  (artifacts in sorted-path order, sections in canonical `RELATIONSHIP_SECTIONS`
+  order).
+- Additive (ADR-007): existing relationship issue codes
+  (`relationship-target-not-found`, `relationship-target-ambiguous`,
+  `relationship-self-reference`, `duplicate-artifact-identifier`) are unchanged;
+  the new code is added, not substituted. `supersedes` semantics are untouched.
+- Structural references stay the mechanism (ADR-016); this adds a graph-legality
+  check over the same parsed sections.
+
+## Non-Goals
+
+- Status-consistency (the superseded-target rule) — that is v0.14.1, with the
+  target-metadata threading it needs.
+- Generalising lifecycle status beyond decisions.
+- Richer typed edge labels beyond the target-type vocabulary (ADR-016 reserves).
+- Auto-repairing or rewriting offending sections.
+
+## Implementation Contract
+
+The following decisions are pinned for v0.14.0.
+
+### Behaviour
+
+- A relationship section present on an artifact but absent from that artifact
+  type's `spec.optional` raises one `relationship-edge-unsupported` issue per
+  offending section, carrying the source path and the snake_case section name; it
+  is not counted as a checked reference (it produces no edge).
+- Referential-integrity issue codes and their output are unchanged.
+
+### Interface
+
+- `rac relationships <dir> --validate` reports the new issue under an
+  "Unsupported Relationships" group and exits `1` when it occurs; `0` when the
+  corpus is clean. Human and JSON outputs both carry it.
+
+## Success Measures
+
+- `rac relationships rac/ --validate` exits `0` on the corpus and `1` on a fixture
+  whose artifact declares a relationship section its type does not support.
+- The count of silently-dropped relationship sections is observable (each is now
+  either a real edge or a surfaced finding).
+- No existing relationship-validation output changes except by the additive new
+  issue.
+
+## Risks
+
+- Edge-legality could over-fire on intentional prose headings. Mitigated by
+  matching only canonical section names already recognised by the parser.
+- A consumer might assume only the four legacy issue codes. Mitigated: the code is
+  additive and documented; existing codes and their `to_dict` shapes are unchanged.
+
+## Assumptions
+
+- `spec.optional` remains the source of truth for which relationship sections a
+  type may declare (`src/rac/core/artifacts.py`).
+- `validate_relationships` / `validation_from_corpus` remain the validation entry
+  points feeding `rac relationships --validate`, `rac review`, and `rac watchkeeper`.
+
+## Related Decisions
+
+- adr-049
+- adr-016
+- adr-007
+
+## Related Requirements
+
+- rac-cross-artifact-enforcement
+- rac-traceability-self-relationships
+
+## Related Roadmaps
+
+- v0.13.6-okf-bundle-export

--- a/rac/roadmaps/v0.14.x-enforcement/v0.14.1-status-consistency.md
+++ b/rac/roadmaps/v0.14.x-enforcement/v0.14.1-status-consistency.md
@@ -1,0 +1,131 @@
+---
+schema_version: 1
+id: RAC-KV3GREQKTMVB
+type: roadmap
+---
+# RAC v0.14.1 — Status Consistency
+
+## Status
+
+Planned
+
+## Context
+
+ADR-049 makes deterministic cross-artifact validation RAC's core, and
+`rac-cross-artifact-enforcement` REQ-003 scopes status-consistency: a live
+artifact must not point at a decision the team has retired. v0.14.0 surfaced
+illegal edges; this milestone adds the second enforcement rule — the one behind
+the positioning line "nothing points at a superseded artifact."
+
+Lifecycle status exists only on decisions today (`Proposed`/`Accepted`/
+`Superseded`/`Deprecated`), so the rule is decision-targeted: a resolved
+relationship whose target is a decision with status `Superseded` or `Deprecated`
+is a validation issue — except the `supersedes` edge by which a replacing
+decision legitimately points at the one it replaces. A source that is itself a
+retired decision is exempt: the rule is about *live* knowledge referencing dead
+knowledge, not historical chains between retired decisions.
+
+The check needs the resolved target's type and status at validation time.
+`_validate` already materialises the corpus items, so it can index them by path
+and read the target's status in a single self-contained pass — no change to the
+shared `_resolve_references` (which feeds `rac portfolio`) and no second walk.
+
+## Outcomes
+
+- A relationship resolving to a `Superseded`/`Deprecated` decision is reported as
+  `relationship-target-superseded` and fails `rac relationships --validate`,
+  except the `supersedes` edge.
+- A retired decision's own outbound references do not trigger the rule (not live).
+- Referential integrity, edge-legality, and all existing issue codes are
+  unchanged; the corpus stays green (no decision is currently retired).
+
+## Initiatives
+
+### Initiative 1 — Status-consistency rule
+
+In `_validate`, index items by path and, for each resolved (uniquely-matched,
+non-self) reference from a live source, emit `relationship-target-superseded` when
+the target is a decision whose status is `Superseded`/`Deprecated` and the edge is
+not `supersedes`. Determine retired status inline (first non-empty line of the
+decision's `## Status`), without importing `inspect` (it imports this module).
+
+### Initiative 2 — Output, wiring, coverage
+
+Render the finding in human output (a reference-style "✗ <target> superseded"
+line) and JSON (`{source_path, relationship, target, code}`). Confirm it flows
+through the existing `validate → exit code → watchkeeper` chain. Tests: a live
+artifact referencing a superseded decision fails; the `supersedes` edge to that
+decision does not; a deprecated target also fails; a retired-source reference is
+exempt; CLI exit code and JSON shape.
+
+## Constraints
+
+- Deterministic (ADR-002): same corpus state, identical findings and ordering.
+- Additive (ADR-007): existing relationship issue codes are unchanged; the new
+  code is added. `supersedes` semantics are untouched.
+- Decision-only: the rule applies where lifecycle status exists; generalising
+  status to other types is out of scope (a later, separately scoped decision).
+- No change to `_resolve_references` or `summarize_relationships` — portfolio's
+  resolution accounting stays exactly as it is.
+
+## Non-Goals
+
+- Generalising lifecycle status to requirements, roadmaps, prompts, or designs.
+- Flagging references *from* a retired decision (historical chains are exempt).
+- Treating `Proposed` as retired — only `Superseded`/`Deprecated` are retired.
+- A `rac review`/portfolio "broken" reclassification — status-consistency is a
+  `--validate` finding, like edge-legality.
+
+## Implementation Contract
+
+The following decisions are pinned for v0.14.1.
+
+### Behaviour
+
+- A uniquely-resolved, non-self relationship from a live source whose target is a
+  decision with status `Superseded` or `Deprecated` raises one
+  `relationship-target-superseded` issue (source path, snake section name, raw
+  reference), unless the edge is `supersedes`.
+- "Live source" excludes a decision whose own status is `Superseded`/`Deprecated`.
+- Edge-legality and referential-integrity issue codes and output are unchanged.
+
+### Interface
+
+- `rac relationships <dir> --validate` reports the new issue and exits `1` when it
+  occurs. Human and JSON outputs both carry it.
+
+## Success Measures
+
+- `rac relationships rac/ --validate` stays `0` on the corpus and returns `1` on a
+  fixture where a live artifact references a superseded decision.
+- The `supersedes` edge from the replacing decision to the superseded one does not
+  raise the issue.
+- A `Deprecated` decision target is treated identically to `Superseded`.
+
+## Risks
+
+- Over-strict: flagging legitimate historical references. Mitigated by the
+  `supersedes` exception and the retired-source exemption.
+- Reading status inline could drift from the canonical spelling. Mitigated by
+  matching only the retired values case-insensitively on the first status line,
+  the same first-line rule `inspect` uses.
+
+## Assumptions
+
+- Lifecycle status remains decision-only (`spec.metadata["status"]`).
+- `_validate` remains the single place that assembles relationship-validation
+  issues from the materialised corpus items.
+
+## Related Decisions
+
+- adr-049
+- adr-016
+- adr-007
+
+## Related Requirements
+
+- rac-cross-artifact-enforcement
+
+## Related Roadmaps
+
+- v0.14.0-enforcement-foundation

--- a/rac/roadmaps/v0.15.x-interop/v0.15.0-okf-frontmatter-superset.md
+++ b/rac/roadmaps/v0.15.x-interop/v0.15.0-okf-frontmatter-superset.md
@@ -1,0 +1,128 @@
+---
+schema_version: 1
+id: RAC-KV3JZ2085R29
+type: roadmap
+tags: [okf, interop]
+---
+# RAC v0.15.0 — OKF Frontmatter Superset (tags + git-derived timestamps)
+
+## Status
+
+Planned
+
+## Context
+
+ADR-050 adopts the conflict-free subset of OKF's reserved descriptive front
+matter so a RAC bundle carries more of what OKF consumers expect, without
+breaking any recorded decision. This milestone delivers it, opening the v0.15.x
+interop series (distinct from v0.14.x enforcement).
+
+Two parts. First, RAC recognises an optional `tags` field in source frontmatter —
+a list of labels (ADR-025 reserved it). Second, `rac export --okf` projects
+`created`/`updated` into each bundle artifact, derived from git history (ADR-045),
+so the bundle is timestamped while the source stays date-free. Per ADR-050, RAC
+does not add `title`/`description` to frontmatter and does not make `type`
+mandatory (ADR-010 keeps documents legitimate; OKF validity already comes from the
+export, which excludes them).
+
+## Outcomes
+
+- A RAC artifact may declare `tags: [...]`; `rac validate` accepts it and rejects
+  malformed values. No `schema_version` bump — additive, like `id`/`type`/
+  `relationships` before it.
+- `rac export --okf` carries `tags` (from source) and `created`/`updated` (from
+  git) in each artifact's front matter, present-only and deterministic.
+- The source corpus stays free of stored dates (ADR-045) and forced typing
+  (ADR-010); existing validation and the JSON export are unchanged.
+
+## Initiatives
+
+### Initiative 1 — Recognise `tags` in frontmatter
+
+Add `tags` to the supported frontmatter fields and validate it as a list of
+non-empty strings (`invalid-metadata-field` otherwise). Carry it on
+`ArtifactMetadata`. Timestamps are deliberately not added to the frontmatter
+schema.
+
+### Initiative 2 — Git-derived timestamps in the OKF export
+
+Extend the git-recency service with a first-commit lookup (gated by a
+`with_creation` flag so the cadence path is unaffected) and project
+`created`/`updated` into each OKF artifact's front matter, alongside `tags` from
+source. Present-only; absent when git cannot answer.
+
+### Initiative 3 — Coverage and docs
+
+Frontmatter tests (valid/invalid tags, timestamps not supported), export tests
+(tags from source, created/updated from git), and `docs/okf-profile.md` updated
+to document the now-supported fields and the git-derived timestamps.
+
+## Constraints
+
+- Additive (ADR-007): `tags` is optional; no `schema_version` bump; existing
+  frontmatter fields, validation codes, and the JSON export are unchanged.
+- ADR-045: timestamps are git-derived, never stored in source frontmatter.
+- ADR-010: `type` stays optional; documents remain legitimate.
+- ADR-025: `title`/`description` are not added (H1/body conventions stand).
+- Determinism (ADR-002): the bundle stays byte-identical for a given git state.
+
+## Non-Goals
+
+- Frontmatter `title`/`description`, or any conflict-resolution rules for them.
+- Mandatory `type` or a CI conformance gate over untyped documents.
+- Storing dates in source frontmatter.
+- Exposing `tags`/timestamps in the JSON export contract (a later, versioned
+  decision if wanted).
+
+## Implementation Contract
+
+The following decisions are pinned for v0.15.0.
+
+### Behaviour
+
+- `tags` is an optional list of non-empty strings; malformed values raise
+  `invalid-metadata-field`. It is carried on `ArtifactMetadata.tags`.
+- `rac export --okf` projects, present-only, per artifact: `created` (first
+  commit), `updated` (last commit), and `tags` (from source).
+- `rac validate`, `rac relationships --validate`, the JSON/HTML export, and the
+  cadence/recency path are unchanged in output.
+
+### Interface
+
+- No CLI surface change. `rac new` templates are unchanged (no `tags` by default).
+
+## Success Measures
+
+- A `tags`-bearing artifact validates clean and its tags appear in the OKF bundle.
+- `rac export rac/ --okf` carries `created`/`updated` on every artifact in a git
+  checkout, and re-export is byte-identical.
+- A source `created:`/`updated:` field is rejected as an unsupported frontmatter
+  field (ADR-045 upheld).
+
+## Risks
+
+- Two git lookups per artifact on export. Mitigated: gated behind `with_creation`,
+  paid only on `rac export --okf`, never on validate/review/cadence.
+- `tags` could be mistaken for a classification or relationship signal. Mitigated:
+  it is descriptive only, documented as such, and not consumed by analysis.
+
+## Assumptions
+
+- ADR-025 remains the frontmatter contract; this extends its reserved-field set by
+  one (`tags`) as it anticipated.
+- The git-recency service (ADR-045) remains the single home for git timestamps.
+
+## Related Decisions
+
+- adr-050
+- adr-025
+- adr-045
+- adr-048
+
+## Related Requirements
+
+- rac-okf-carrier-profile
+
+## Related Roadmaps
+
+- v0.13.6-okf-bundle-export

--- a/src/rac/cli.py
+++ b/src/rac/cli.py
@@ -495,7 +495,8 @@ def cmd_export(args: argparse.Namespace) -> int:
     # OKF bundle (ADR-048): a derived tree of Markdown files written to a
     # directory, parallel to the JSON/HTML views. Recency feeds log.md (ADR-045).
     if args.okf:
-        bundle = outputs.render_okf_bundle(export, artifact_recency(args.directory), args.directory)
+        recency = artifact_recency(args.directory, with_creation=True)
+        bundle = outputs.render_okf_bundle(export, recency, args.directory)
         out = args.out if args.out is not None else "okf-bundle"
         try:
             for rel, content in sorted(bundle.items()):

--- a/src/rac/core/frontmatter.py
+++ b/src/rac/core/frontmatter.py
@@ -32,8 +32,11 @@ _DELIMITER = "---"
 _CLOSERS = ("---", "...")
 
 # The complete frontmatter field schema. One canonical location per field
-# (ADR-025): anything else is invalid-metadata-field, not ignored.
-_SUPPORTED_FIELDS = ("schema_version", "id", "type", "relationships")
+# (ADR-025): anything else is invalid-metadata-field, not ignored. ``tags`` is
+# the OKF-reserved descriptive field ADR-025 reserved and ADR-050 adopts —
+# optional, additive, validated for shape only. Timestamps are deliberately
+# absent: recency is git-derived, never stored in frontmatter (ADR-045).
+_SUPPORTED_FIELDS = ("schema_version", "id", "type", "relationships", "tags")
 
 
 class _StrictLoader(yaml.SafeLoader):
@@ -211,10 +214,29 @@ def parse_frontmatter(raw: str) -> tuple[ArtifactMetadata | None, list[Issue]]:
                 kind: [normalize_id(t) for t in targets] for kind, targets in relationships.items()
             }
 
+    tags = _parse_tags(data, issues)
+
     metadata = ArtifactMetadata(
         schema_version=schema_version if isinstance(schema_version, int) else 0,
         id=artifact_id,
         type=artifact_type,
         relationships=parsed_relationships,
+        tags=tags,
     )
     return metadata, issues
+
+
+def _parse_tags(data: dict, issues: list[Issue]) -> list[str]:
+    """Validate the optional ``tags`` field — a list of non-empty strings."""
+    tags = data.get("tags")
+    if tags is None:
+        return []
+    if not isinstance(tags, list) or not all(isinstance(t, str) and t.strip() for t in tags):
+        issues.append(
+            _issue(
+                "invalid-metadata-field",
+                "frontmatter field 'tags' must be a list of non-empty strings",
+            )
+        )
+        return []
+    return [t.strip() for t in tags]

--- a/src/rac/core/metadata.py
+++ b/src/rac/core/metadata.py
@@ -53,4 +53,8 @@ class ArtifactMetadata:
     id: str | None = None
     type: str | None = None
     relationships: dict[str, list[str]] = field(default_factory=dict)
+    # OKF-reserved descriptive labels (ADR-050): optional, additive, never a
+    # source of product reasoning. ADR-025 reserved ``tags``. Timestamps stay out
+    # of frontmatter — recency is git-derived (ADR-045).
+    tags: list[str] = field(default_factory=list)
     provenance: str = PROVENANCE_FRONTMATTER

--- a/src/rac/output/human.py
+++ b/src/rac/output/human.py
@@ -41,6 +41,7 @@ from rac.services.relationships import (
     ISSUE_SELF_REFERENCE,
     ISSUE_TARGET_AMBIGUOUS,
     ISSUE_TARGET_NOT_FOUND,
+    ISSUE_TARGET_SUPERSEDED,
     RelationshipReport,
     RelationshipValidation,
 )
@@ -570,11 +571,12 @@ def render_relationships_human(report: RelationshipReport) -> str:
 
 # --- relationship validation -------------------------------------------------
 
-# Suffix shown after a broken reference, per issue code.
+# Suffix shown after a flagged reference, per issue code.
 _REF_ISSUE_SUFFIX = {
     ISSUE_TARGET_NOT_FOUND: "not found",
     ISSUE_TARGET_AMBIGUOUS: "ambiguous",
     ISSUE_SELF_REFERENCE: "self-reference",
+    ISSUE_TARGET_SUPERSEDED: "superseded",
 }
 
 

--- a/src/rac/output/human.py
+++ b/src/rac/output/human.py
@@ -37,6 +37,7 @@ from rac.services.portfolio import PortfolioSummary
 from rac.services.quickstart import QuickstartResult
 from rac.services.relationships import (
     ISSUE_DUPLICATE_IDENTIFIER,
+    ISSUE_EDGE_UNSUPPORTED,
     ISSUE_SELF_REFERENCE,
     ISSUE_TARGET_AMBIGUOUS,
     ISSUE_TARGET_NOT_FOUND,
@@ -586,7 +587,12 @@ def render_relationship_validation_human(report: RelationshipValidation) -> str:
     ]
 
     duplicates = [i for i in report.issues if i.code == ISSUE_DUPLICATE_IDENTIFIER]
-    references = [i for i in report.issues if i.code != ISSUE_DUPLICATE_IDENTIFIER]
+    unsupported = [i for i in report.issues if i.code == ISSUE_EDGE_UNSUPPORTED]
+    references = [
+        i
+        for i in report.issues
+        if i.code not in (ISSUE_DUPLICATE_IDENTIFIER, ISSUE_EDGE_UNSUPPORTED)
+    ]
 
     if duplicates:
         lines += ["", _bold("Duplicate Identifiers")]
@@ -594,6 +600,16 @@ def render_relationship_validation_human(report: RelationshipValidation) -> str:
             count = len(issue.paths or [])
             lines.append(_red(f"✗ {issue.identifier} ({count} files)"))
             lines.extend(f"  - {p}" for p in issue.paths or [])
+
+    if unsupported:
+        lines += ["", _bold("Unsupported Relationships")]
+        current_source = None
+        for issue in unsupported:
+            if issue.source_path != current_source:
+                current_source = issue.source_path
+                lines += ["", issue.source_path or "<input>"]
+            label = _relationship_label(issue.relationship or "")
+            lines.append(_red(f"  ✗ {label} not supported for this artifact type"))
 
     if references:
         lines += ["", _bold("Broken Relationships")]

--- a/src/rac/output/okf.py
+++ b/src/rac/output/okf.py
@@ -60,16 +60,26 @@ def _body(path: str) -> str:
     return split_frontmatter(text).body.strip()
 
 
-def _artifact_file(art: ExportArtifact, citations: list[tuple[str, str]]) -> str:
-    """One OKF artifact file: projected front matter, body, derived citations."""
-    lines = [
-        "---",
-        f"type: {OKF_TYPE[art.type]}",
-        f"id: {art.id}",
-        "---",
-        "",
-        _body(art.path),
-    ]
+def _artifact_file(
+    art: ExportArtifact,
+    citations: list[tuple[str, str]],
+    created: str | None,
+    updated: str | None,
+) -> str:
+    """One OKF artifact file: projected front matter, body, derived citations.
+
+    OKF-reserved descriptive fields (ADR-050), projected present-only so the
+    bundle stays minimal and deterministic: ``tags`` from the source frontmatter,
+    ``created``/``updated`` derived from git (never stored in source, ADR-045).
+    """
+    front = ["---", f"type: {OKF_TYPE[art.type]}", f"id: {art.id}"]
+    if created is not None:
+        front.append(f"created: {created}")
+    if updated is not None:
+        front.append(f"updated: {updated}")
+    if art.tags:
+        front.append(f"tags: [{', '.join(art.tags)}]")
+    lines = [*front, "---", "", _body(art.path)]
     if citations:
         lines += ["", "# Citations", ""]
         lines += [f"- [{title}]({path})" for title, path in citations]
@@ -151,12 +161,16 @@ def render_okf_bundle(export: CorpusExport, recency: RecencyReport, root: str) -
     """
     rel = {art.path: os.path.relpath(art.path, root) for art in export.artifacts}
     by_id = {art.id: art for art in export.artifacts}
+    recency_by_path = {a.path: a for a in recency.artifacts}
     files: dict[str, str] = {}
     for art in export.artifacts:
         key = rel[art.path]
         if key in (_INDEX_PATH, _LOG_PATH):
             raise ValueError(f"artifact path {key!r} collides with a generated bundle file")
-        files[key] = _artifact_file(art, _citations(art, export, by_id, rel))
+        record = recency_by_path.get(art.path)
+        created = record.first_committed.isoformat() if record and record.first_committed else None
+        updated = record.last_committed.isoformat() if record and record.last_committed else None
+        files[key] = _artifact_file(art, _citations(art, export, by_id, rel), created, updated)
     files[_INDEX_PATH] = _index(export, rel)
     files[_LOG_PATH] = _log(export, recency, rel)
     return files

--- a/src/rac/services/export.py
+++ b/src/rac/services/export.py
@@ -73,6 +73,10 @@ class ExportArtifact:
     title: str
     path: str
     body_html: str
+    # OKF-reserved descriptive labels (ADR-050). Carried for the OKF bundle
+    # projection; deliberately *not* in ``to_dict`` — the JSON contract (ADR-007)
+    # is unchanged until a versioned addition is decided.
+    tags: list[str] = field(default_factory=list)
 
     def to_dict(self) -> dict:
         return {
@@ -183,6 +187,7 @@ def build_corpus_export(directory: str, recursive: bool = True) -> CorpusExport:
         canonical_by_path[path] = canonical
         if spec is None:
             continue  # unknown files are not exported
+        meta = entry.product.metadata
         artifacts.append(
             ExportArtifact(
                 id=canonical,
@@ -192,6 +197,7 @@ def build_corpus_export(directory: str, recursive: bool = True) -> CorpusExport:
                 title=entry.product.title or canonical,
                 path=path,
                 body_html=_render_body(path, md),
+                tags=meta.tags if meta else [],
             )
         )
 

--- a/src/rac/services/recency.py
+++ b/src/rac/services/recency.py
@@ -42,21 +42,17 @@ def _repository_root(directory: str) -> str | None:
     return result.stdout.strip()
 
 
-def _last_committed(repo_root: str, path: str) -> datetime | None:
-    """Commit time of the most recent change to ``path``, or ``None``.
-
-    Uses ``git log -1 --format=%cI`` (ISO-8601, timezone-aware). An empty
-    result means the file is untracked or uncommitted.
-    """
+def _pathspec(repo_root: str, path: str) -> str:
+    """``path`` relative to ``repo_root`` for git, or absolute if outside it."""
     abspath = Path(path).resolve()
     try:
-        pathspec = str(abspath.relative_to(Path(repo_root).resolve()))
+        return str(abspath.relative_to(Path(repo_root).resolve()))
     except ValueError:  # path lies outside the work tree; pass it through
-        pathspec = str(abspath)
-    result = _run_git(["log", "-1", "--format=%cI", "--", pathspec], cwd=repo_root)
-    if result is None or result.returncode != 0:
-        return None
-    stamp = result.stdout.strip()
+        return str(abspath)
+
+
+def _parse_stamp(stamp: str) -> datetime | None:
+    stamp = stamp.strip()
     if not stamp:
         return None
     try:
@@ -65,13 +61,50 @@ def _last_committed(repo_root: str, path: str) -> datetime | None:
         return None
 
 
+def _last_committed(repo_root: str, path: str) -> datetime | None:
+    """Commit time of the most recent change to ``path``, or ``None``.
+
+    Uses ``git log -1 --format=%cI`` (ISO-8601, timezone-aware). An empty
+    result means the file is untracked or uncommitted.
+    """
+    result = _run_git(
+        ["log", "-1", "--format=%cI", "--", _pathspec(repo_root, path)], cwd=repo_root
+    )
+    if result is None or result.returncode != 0:
+        return None
+    return _parse_stamp(result.stdout)
+
+
+def _first_committed(repo_root: str, path: str) -> datetime | None:
+    """Commit time of the earliest change to ``path``, or ``None``.
+
+    ``git log --reverse --format=%cI`` lists oldest first; the first line is the
+    creation commit. Used only for the OKF export's ``created`` field, never on
+    the cadence path.
+    """
+    result = _run_git(
+        ["log", "--reverse", "--format=%cI", "--", _pathspec(repo_root, path)], cwd=repo_root
+    )
+    if result is None or result.returncode != 0:
+        return None
+    for line in result.stdout.splitlines():
+        if line.strip():
+            return _parse_stamp(line)
+    return None
+
+
 @dataclass
 class ArtifactRecency:
-    """One artifact's last-authored time, or ``None`` when git does not know."""
+    """One artifact's authored times, or ``None`` when git does not know.
+
+    ``first_committed`` (creation) is populated only when recency is requested
+    ``with_creation`` — the OKF export needs it; the cadence path does not.
+    """
 
     path: str
     artifact_type: str
     last_committed: datetime | None
+    first_committed: datetime | None = None
 
 
 @dataclass
@@ -118,13 +151,16 @@ class RecencyReport:
         }
 
 
-def artifact_recency(directory: str, recursive: bool = True) -> RecencyReport:
+def artifact_recency(
+    directory: str, recursive: bool = True, with_creation: bool = False
+) -> RecencyReport:
     """Recency for every recognised artifact under ``directory``.
 
-    Derives each artifact's last-committed time from git. Outside a git
-    repository, or for untracked files, the time is ``None`` ("unknown") — no
-    exception crosses the boundary. Unknown-type documents are excluded;
-    recency is about product-knowledge artifacts.
+    Derives each artifact's last-committed time from git (and its first-committed
+    time when ``with_creation`` — one extra git call per file, used only by the
+    OKF export). Outside a git repository, or for untracked files, the time is
+    ``None`` ("unknown") — no exception crosses the boundary. Unknown-type
+    documents are excluded; recency is about product-knowledge artifacts.
     """
     index = build_repository_index(directory, recursive=recursive)
     entries = [e for e in index.artifacts if e.type != "unknown"]
@@ -133,7 +169,17 @@ def artifact_recency(directory: str, recursive: bool = True) -> RecencyReport:
     artifacts: list[ArtifactRecency] = []
     for entry in entries:
         last = _last_committed(repo_root, entry.path) if repo_root is not None else None
+        first = (
+            _first_committed(repo_root, entry.path)
+            if with_creation and repo_root is not None
+            else None
+        )
         artifacts.append(
-            ArtifactRecency(path=entry.path, artifact_type=entry.type, last_committed=last)
+            ArtifactRecency(
+                path=entry.path,
+                artifact_type=entry.type,
+                last_committed=last,
+                first_committed=first,
+            )
         )
     return RecencyReport(directory=directory, recursive=recursive, artifacts=artifacts)

--- a/src/rac/services/relationships.py
+++ b/src/rac/services/relationships.py
@@ -130,6 +130,25 @@ def present_relationship_sections(product: Product, spec: ArtifactSpec) -> list[
     return present
 
 
+def unsupported_relationship_sections(product: Product, spec: ArtifactSpec) -> list[str]:
+    """Relationship sections ``product`` declares that its type does not support.
+
+    A ``## Related <Type>`` / ``## Supersedes`` section present with at least one
+    reference whose name is *not* in this type's ``spec.optional`` produces no edge
+    today and is silently dropped (ADR-049 edge-legality;
+    ``rac-cross-artifact-enforcement`` REQ-004). Returns the canonical section
+    names in :data:`RELATIONSHIP_SECTIONS` order so the finding is deterministic.
+    """
+    unsupported: list[str] = []
+    for section in RELATIONSHIP_SECTIONS:
+        if section in spec.optional:
+            continue
+        body = product.sections.get(section)
+        if body and parse_references(body):
+            unsupported.append(section)
+    return unsupported
+
+
 # --- Repository-level relationship inspection (v0.7.1) -----------------------
 #
 # `rac relationships <path>` discovers the explicit relationships declared across
@@ -290,6 +309,9 @@ ISSUE_DUPLICATE_IDENTIFIER = "duplicate-artifact-identifier"
 ISSUE_TARGET_NOT_FOUND = "relationship-target-not-found"
 ISSUE_TARGET_AMBIGUOUS = "relationship-target-ambiguous"
 ISSUE_SELF_REFERENCE = "relationship-self-reference"
+# Edge-legality (v0.14.0, ADR-049): a relationship section the artifact's type
+# does not declare produces no edge and is reported, not silently dropped.
+ISSUE_EDGE_UNSUPPORTED = "relationship-edge-unsupported"
 
 
 @dataclass
@@ -313,6 +335,12 @@ class RelationshipIssue:
             return {
                 "identifier": self.identifier,
                 "paths": self.paths,
+                "code": self.code,
+            }
+        if self.code == ISSUE_EDGE_UNSUPPORTED:
+            return {
+                "source_path": self.source_path,
+                "relationship": self.relationship,
                 "code": self.code,
             }
         return {
@@ -463,6 +491,19 @@ def _validate(
         issues.append(
             RelationshipIssue(code=ISSUE_DUPLICATE_IDENTIFIER, identifier=display, paths=dup_paths)
         )
+
+    # Edge-legality (v0.14.0, ADR-049): report relationship sections an artifact's
+    # type does not declare instead of silently dropping them. Deterministic —
+    # items in sorted-path order, sections in canonical RELATIONSHIP_SECTIONS order.
+    for path, product, spec in items:
+        if spec is None:
+            continue
+        for section in unsupported_relationship_sections(product, spec):
+            issues.append(
+                RelationshipIssue(
+                    code=ISSUE_EDGE_UNSUPPORTED, source_path=path, relationship=_snake(section)
+                )
+            )
 
     checked, ref_issues, _ = _resolve_references(items, _build_resolution_index(items))
     issues.extend(ref_issues)

--- a/src/rac/services/relationships.py
+++ b/src/rac/services/relationships.py
@@ -312,6 +312,26 @@ ISSUE_SELF_REFERENCE = "relationship-self-reference"
 # Edge-legality (v0.14.0, ADR-049): a relationship section the artifact's type
 # does not declare produces no edge and is reported, not silently dropped.
 ISSUE_EDGE_UNSUPPORTED = "relationship-edge-unsupported"
+# Status-consistency (v0.14.1, ADR-049): a live artifact references a decision the
+# team has retired (Superseded/Deprecated), other than via ``supersedes``.
+ISSUE_TARGET_SUPERSEDED = "relationship-target-superseded"
+
+# Decision statuses that mark an artifact as retired (no longer live). Matched
+# case-insensitively against the first line of a decision's ``## Status`` — the
+# same first-line rule ``rac inspect`` uses, inlined to avoid importing
+# ``inspect`` (which imports this module).
+_RETIRED_STATUSES = ("superseded", "deprecated")
+
+
+def _is_retired_decision(product: Product, spec: ArtifactSpec | None) -> bool:
+    """True when ``product`` is a decision whose status is Superseded/Deprecated."""
+    if spec is None or spec.name != "decision":
+        return False
+    body = product.sections.get("status")
+    if not body:
+        return False
+    first = next((line.strip() for line in body.splitlines() if line.strip()), "")
+    return first.casefold() in _RETIRED_STATUSES
 
 
 @dataclass
@@ -505,7 +525,35 @@ def _validate(
                 )
             )
 
-    checked, ref_issues, _ = _resolve_references(items, _build_resolution_index(items))
+    resolution_index = _build_resolution_index(items)
+
+    # Status-consistency (v0.14.1, ADR-049): a live artifact must not reference a
+    # retired (Superseded/Deprecated) decision, except via ``supersedes``. Reads
+    # the resolved target's status from the materialised items — no second walk,
+    # no change to _resolve_references (which feeds portfolio accounting).
+    by_path = {path: (product, spec) for path, product, spec in items}
+    for path, product, spec in items:
+        if spec is None or _is_retired_decision(product, spec):
+            continue  # unknown file, or a retired source (historical chains exempt)
+        for section, refs in extract_relationships_full(product, spec).items():
+            if section == "supersedes":
+                continue  # the replacing decision legitimately points at the retired one
+            for ref in refs:
+                targets = [p for p, _ in resolution_index.get(ref.casefold(), [])]
+                if len(targets) != 1 or targets[0] == path:
+                    continue  # unresolved/ambiguous/self — referential integrity owns it
+                target_product, target_spec = by_path[targets[0]]
+                if _is_retired_decision(target_product, target_spec):
+                    issues.append(
+                        RelationshipIssue(
+                            code=ISSUE_TARGET_SUPERSEDED,
+                            source_path=path,
+                            relationship=section,
+                            target=ref,
+                        )
+                    )
+
+    checked, ref_issues, _ = _resolve_references(items, resolution_index)
     issues.extend(ref_issues)
 
     return RelationshipValidation(

--- a/tests/test_export_okf.py
+++ b/tests/test_export_okf.py
@@ -78,8 +78,52 @@ def test_artifact_file_projects_okf_front_matter():
     export = _export()
     bundle = _bundle(export, _recency(export))
     for art in export.artifacts:
-        head = bundle[_key(art)].splitlines()[:4]
-        assert head == ["---", f"type: {OKF_TYPE[art.type]}", f"id: {art.id}", "---"]
+        lines = bundle[_key(art)].splitlines()
+        assert lines[0] == "---"
+        front = lines[1 : lines.index("---", 1)]
+        assert f"type: {OKF_TYPE[art.type]}" in front
+        assert f"id: {art.id}" in front
+        # _recency supplies a last-commit time, so `updated` is projected.
+        assert any(line.startswith("updated: ") for line in front)
+
+
+def test_created_and_updated_projected_from_git_recency():
+    export = _export()
+    recency = RecencyReport(
+        directory="export",
+        recursive=True,
+        artifacts=[
+            ArtifactRecency(
+                path=a.path,
+                artifact_type=a.type,
+                last_committed=datetime(2026, 6, 14, tzinfo=UTC),
+                first_committed=datetime(2026, 1, 1, tzinfo=UTC),
+            )
+            for a in export.artifacts
+        ],
+    )
+    front = render_okf_bundle(export, recency, _ROOT)[_key(export.artifacts[0])]
+    assert "created: 2026-01-01T00:00:00+00:00" in front
+    assert "updated: 2026-06-14T00:00:00+00:00" in front
+
+
+def test_tags_projected_from_source(tmp_path):
+    (tmp_path / "adr-001.md").write_text(
+        "---\nschema_version: 1\ntype: decision\ntags: [okf, interop]\n---\n"
+        "# A\n\n## Context\nc\n\n## Decision\nd\n\n## Consequences\nq\n",
+        encoding="utf-8",
+    )
+    export = build_corpus_export(str(tmp_path))
+    recency = RecencyReport(
+        directory=str(tmp_path),
+        recursive=True,
+        artifacts=[
+            ArtifactRecency(path=a.path, artifact_type=a.type, last_committed=None)
+            for a in export.artifacts
+        ],
+    )
+    bundle = render_okf_bundle(export, recency, str(tmp_path))
+    assert "tags: [okf, interop]" in bundle["adr-001.md"]
 
 
 def test_resolved_relationship_renders_as_citation_link():

--- a/tests/test_frontmatter.py
+++ b/tests/test_frontmatter.py
@@ -203,3 +203,34 @@ def test_validation_surfaces_unterminated_frontmatter():
     text = "---\nschema_version: 1\n# T\n\n## Problem\n\np\n\n## Requirements\n\n[REQ-001] x\n"
     issues = validate(parse(text))
     assert "malformed-frontmatter" in [i.code for i in issues]
+
+
+# --- tags (OKF-reserved descriptive field, ADR-050) -------------------------
+
+
+def test_parse_tags_accepted():
+    md, issues = parse_frontmatter("schema_version: 1\ntype: decision\ntags: [okf, interop]")
+    assert _codes(issues) == []
+    assert md.tags == ["okf", "interop"]
+
+
+def test_parse_tags_absent_is_empty():
+    md, issues = parse_frontmatter("schema_version: 1\ntype: decision")
+    assert _codes(issues) == []
+    assert md.tags == []
+
+
+def test_parse_tags_must_be_list_of_nonempty_strings():
+    _, issues = parse_frontmatter("schema_version: 1\ntags: [okf, '']")
+    assert "invalid-metadata-field" in _codes(issues)
+
+
+def test_parse_tags_rejects_scalar():
+    _, issues = parse_frontmatter("schema_version: 1\ntags: okf")
+    assert "invalid-metadata-field" in _codes(issues)
+
+
+def test_timestamps_are_not_supported_frontmatter():
+    # Recency is git-derived (ADR-045); created/updated are not frontmatter fields.
+    _, issues = parse_frontmatter("schema_version: 1\ncreated: 2026-06-14")
+    assert "invalid-metadata-field" in _codes(issues)

--- a/tests/test_relationship_validation.py
+++ b/tests/test_relationship_validation.py
@@ -20,6 +20,7 @@ from rac.core.classification import classify
 from rac.core.markdown import parse_file
 from rac.services.relationships import (
     ISSUE_DUPLICATE_IDENTIFIER,
+    ISSUE_EDGE_UNSUPPORTED,
     ISSUE_SELF_REFERENCE,
     ISSUE_TARGET_AMBIGUOUS,
     ISSUE_TARGET_NOT_FOUND,
@@ -264,3 +265,68 @@ def test_non_validate_inspection_still_works(capsys):
     out = capsys.readouterr().out
     assert "Files Inspected:" in out
     assert "Validation Issues" not in out
+
+
+# --- edge-legality / no silent drop (v0.14.0, ADR-049) ----------------------
+
+_DESIGN = "# {t}\n\n## Context\n\nc\n\n## User Need\n\nn\n\n## Design\n\nd\n\n## Constraints\n\nk\n"
+
+
+def test_unsupported_relationship_section_is_reported(tmp_path):
+    # A design's schema does not declare `related designs`; today that section
+    # is silently dropped. v0.14.0 surfaces it as a finding.
+    (tmp_path / "a.md").write_text(_DESIGN.format(t="A"), encoding="utf-8")
+    (tmp_path / "b.md").write_text(
+        _DESIGN.format(t="B") + "\n## Related Designs\n\n- a\n", encoding="utf-8"
+    )
+    report = validate_relationships(str(tmp_path))
+    assert not report.ok
+    codes = [i.code for i in report.issues]
+    assert codes.count(ISSUE_EDGE_UNSUPPORTED) == 1
+    issue = next(i for i in report.issues if i.code == ISSUE_EDGE_UNSUPPORTED)
+    assert issue.source_path.endswith("b.md")
+    assert issue.relationship == "related_designs"
+    # It is not counted as a resolved/broken reference — it produces no edge.
+    assert report.relationships_checked == 0
+
+
+def test_supersedes_on_non_decision_is_unsupported(tmp_path):
+    # `supersedes` is decision-only; a roadmap declaring it is an illegal edge.
+    (tmp_path / "v2.md").write_text(
+        _ROADMAP.format(t="Two") + "\n## Supersedes\n\n- v1\n", encoding="utf-8"
+    )
+    report = validate_relationships(str(tmp_path))
+    assert [i.code for i in report.issues] == [ISSUE_EDGE_UNSUPPORTED]
+
+
+def test_supported_relationship_section_is_not_flagged(tmp_path):
+    # A decision MAY declare `related decisions`; it must not be edge-unsupported.
+    (tmp_path / "adr-001.md").write_text(_DECISION.format(t="A1"), encoding="utf-8")
+    (tmp_path / "adr-002.md").write_text(
+        _DECISION.format(t="A2") + "\n## Related Decisions\n\n- adr-001\n", encoding="utf-8"
+    )
+    report = validate_relationships(str(tmp_path))
+    assert report.ok
+    assert ISSUE_EDGE_UNSUPPORTED not in [i.code for i in report.issues]
+
+
+def test_unsupported_section_fails_cli(tmp_path):
+    (tmp_path / "b.md").write_text(
+        _DESIGN.format(t="B") + "\n## Related Designs\n\n- a\n", encoding="utf-8"
+    )
+    assert main(["relationships", str(tmp_path), "--validate"]) == 1
+
+
+def test_unsupported_section_in_json_output(tmp_path, capsys):
+    (tmp_path / "b.md").write_text(
+        _DESIGN.format(t="B") + "\n## Related Designs\n\n- a\n", encoding="utf-8"
+    )
+    main(["relationships", str(tmp_path), "--validate", "--json"])
+    payload = json.loads(capsys.readouterr().out)
+    issue = next(i for i in payload["issues"] if i["code"] == ISSUE_EDGE_UNSUPPORTED)
+    assert issue == {
+        "source_path": issue["source_path"],
+        "relationship": "related_designs",
+        "code": ISSUE_EDGE_UNSUPPORTED,
+    }
+    assert "target" not in issue  # no resolved target for a structural finding

--- a/tests/test_relationship_validation.py
+++ b/tests/test_relationship_validation.py
@@ -24,6 +24,7 @@ from rac.services.relationships import (
     ISSUE_SELF_REFERENCE,
     ISSUE_TARGET_AMBIGUOUS,
     ISSUE_TARGET_NOT_FOUND,
+    ISSUE_TARGET_SUPERSEDED,
     validate_relationships,
     validate_relationships_file,
 )
@@ -330,3 +331,78 @@ def test_unsupported_section_in_json_output(tmp_path, capsys):
         "code": ISSUE_EDGE_UNSUPPORTED,
     }
     assert "target" not in issue  # no resolved target for a structural finding
+
+
+# --- status consistency / superseded targets (v0.14.1, ADR-049) -------------
+
+
+def _decision(title, status, extra=""):
+    return _DECISION.format(t=title) + f"\n## Status\n\n{status}\n" + extra
+
+
+def test_reference_to_superseded_decision_is_reported(tmp_path):
+    (tmp_path / "adr-001.md").write_text(_decision("Old", "Superseded"), encoding="utf-8")
+    (tmp_path / "req-001.md").write_text(
+        "# R\n\n## Problem\n\np\n\n## Requirements\n\n- [REQ-001] x\n\n"
+        "## Related Decisions\n\n- adr-001\n",
+        encoding="utf-8",
+    )
+    report = validate_relationships(str(tmp_path))
+    assert not report.ok
+    issue = next(i for i in report.issues if i.code == ISSUE_TARGET_SUPERSEDED)
+    assert issue.source_path.endswith("req-001.md")
+    assert issue.relationship == "related_decisions"
+    assert issue.target == "adr-001"
+
+
+def test_supersedes_edge_to_superseded_decision_is_allowed(tmp_path):
+    # The replacing decision points at the one it supersedes — that is the one
+    # edge allowed to reference a Superseded decision.
+    (tmp_path / "adr-001.md").write_text(_decision("Old", "Superseded"), encoding="utf-8")
+    (tmp_path / "adr-002.md").write_text(
+        _decision("New", "Accepted", "\n## Supersedes\n\n- adr-001\n"), encoding="utf-8"
+    )
+    report = validate_relationships(str(tmp_path))
+    assert report.ok
+    assert ISSUE_TARGET_SUPERSEDED not in [i.code for i in report.issues]
+
+
+def test_deprecated_target_is_reported(tmp_path):
+    (tmp_path / "adr-001.md").write_text(_decision("Old", "Deprecated"), encoding="utf-8")
+    (tmp_path / "adr-002.md").write_text(
+        _decision("Live", "Accepted", "\n## Related Decisions\n\n- adr-001\n"), encoding="utf-8"
+    )
+    report = validate_relationships(str(tmp_path))
+    assert [i.code for i in report.issues] == [ISSUE_TARGET_SUPERSEDED]
+
+
+def test_retired_source_reference_is_exempt(tmp_path):
+    # A retired decision referencing another retired decision is a historical
+    # chain, not live knowledge pointing at dead knowledge — not flagged.
+    (tmp_path / "adr-001.md").write_text(_decision("Old", "Superseded"), encoding="utf-8")
+    (tmp_path / "adr-002.md").write_text(
+        _decision("Older", "Superseded", "\n## Related Decisions\n\n- adr-001\n"),
+        encoding="utf-8",
+    )
+    report = validate_relationships(str(tmp_path))
+    assert report.ok
+
+
+def test_accepted_target_is_not_flagged(tmp_path):
+    (tmp_path / "adr-001.md").write_text(_decision("Live", "Accepted"), encoding="utf-8")
+    (tmp_path / "adr-002.md").write_text(
+        _decision("Also", "Accepted", "\n## Related Decisions\n\n- adr-001\n"), encoding="utf-8"
+    )
+    report = validate_relationships(str(tmp_path))
+    assert report.ok
+
+
+def test_superseded_target_fails_cli_with_suffix(tmp_path, capsys):
+    (tmp_path / "adr-001.md").write_text(_decision("Old", "Superseded"), encoding="utf-8")
+    (tmp_path / "req-001.md").write_text(
+        "# R\n\n## Problem\n\np\n\n## Requirements\n\n- [REQ-001] x\n\n"
+        "## Related Decisions\n\n- adr-001\n",
+        encoding="utf-8",
+    )
+    assert main(["relationships", str(tmp_path), "--validate"]) == 1
+    assert "✗ adr-001 superseded" in capsys.readouterr().out


### PR DESCRIPTION
# Summary

Makes deterministic, CI-enforced **cross-artifact validation** RAC's stated
product (ADR-049), builds the two enforcement rules that were missing, and adds
the conflict-free slice of the OKF frontmatter superset. Three workstreams, each
recorded as RAC artifacts and shipped in version-fenced roadmaps.

Adds:
- **Positioning (ADR-049):** write-time cross-artifact enforcement is RAC's core;
  carrier (OKF) and per-type schema (MADR/dotprompt) are table stakes.
- **v0.14.0 edge-legality:** a relationship section a type does not support is
  reported (`relationship-edge-unsupported`), not silently dropped.
- **v0.14.1 status-consistency:** a live artifact referencing a Superseded or
  Deprecated decision is reported (`relationship-target-superseded`).
- **v0.15.0 interop:** an optional `tags` frontmatter field, and `rac export
  --okf` carrying `tags` + git-derived `created`/`updated` per artifact.

# Roadmap / ADR Trace

Roadmaps:
- `rac/roadmaps/v0.14.x-enforcement/v0.14.0-enforcement-foundation.md`
- `rac/roadmaps/v0.14.x-enforcement/v0.14.1-status-consistency.md`
- `rac/roadmaps/v0.15.x-interop/v0.15.0-okf-frontmatter-superset.md`

Relevant ADRs:
- `adr-049-enforcement-is-the-product.md` (new) and `adr-050-okf-frontmatter-superset.md` (new)
- Respected: `adr-016` (structural references), `adr-024` (intelligence, not content
  store), `adr-048` (OKF carrier), `adr-007` (contract stability), `adr-010`
  (documents are not artifacts), `adr-045` (git-derived recency), `adr-017`,
  `adr-025`.

Requirement: `rac/requirements/rac-cross-artifact-enforcement.md` (new).

# Scope

## Included
- Two new relationship-validation rules, both deterministic and CI-gated through
  the existing `validate / relationships --validate / watchkeeper` chain:
  - **edge-legality:** report (not drop) a `## Related (Type)` / `## Supersedes`
    section absent from the source type's `spec.optional`.
  - **status-consistency:** report a uniquely-resolved, non-self relationship from
    a *live* source to a Superseded/Deprecated decision — except the `supersedes`
    edge, and exempting retired-source historical chains. Decision-only (status
    lives on decisions today).
- An optional `tags` frontmatter field (list of non-empty strings), additive, no
  `schema_version` bump.
- `rac export --okf` projecting `tags` (source) and `created`/`updated` (git first
  and last commit, via a gated `with_creation` recency lookup) per bundle artifact.
- The positioning thesis recorded (ADR-049) and a "How this relates to OKF"
  section in `docs/index.md`.

## Excluded (deliberately, with reasons recorded in ADR-049 / ADR-050)
- Mandatory `type` on every file — conflicts with ADR-010 (documents are
  legitimate). OKF-bundle validity already comes from `rac export --okf`, which
  excludes documents.
- Frontmatter `created`/`updated` — conflicts with ADR-045 (recency is git-derived,
  not stored). The timestamps are derived in the export instead.
- Frontmatter `title`/`description` — collide with the H1/body conventions (ADR-025).
- Generalising lifecycle status beyond decisions; richer typed edge labels
  (ADR-016 reserves); exposing `tags`/timestamps in the JSON export contract.

# Product / Architecture Decisions

- **Two recorded-decision conflicts were surfaced and resolved, not overridden.**
  "Mandatory type" hit ADR-010, and "store created/updated" hit ADR-045. Both were
  redirected: OKF validity via the export (already excludes documents), and
  timestamps derived from git in the bundle. ADR-049/ADR-050 record the reasoning.
- **No change to `_resolve_references` or portfolio accounting.** Both new rules
  are added in `_validate` over the already-materialised corpus items — no second
  walk, no perturbation of referential-integrity resolution or `rac portfolio`
  counts.
- **`tags` added at `schema_version: 1`** (no bump), matching how `id`, `type`, and
  `relationships` were introduced as optional fields. A bump would force every file
  to redeclare v2 to add a tag.
- **First-commit lookup is gated.** `artifact_recency(..., with_creation=True)` is
  used only by `rac export --okf`; the cadence/review path is unchanged (one git
  call per artifact, as before).
- **Existing issue codes and the JSON export are unchanged** (ADR-007). New issue
  codes are additive; `tags`/timestamps are not in any JSON `to_dict`.

# User-Facing Contract

## CLI
```bash
rac relationships rac/ --validate   # now also: edge-legality + status-consistency
rac export rac/ --okf --out okf-bundle/   # bundle artifacts carry tags + created/updated
```
A RAC artifact MAY now declare `tags: [a, b]` in frontmatter.

## Human Output
`rac relationships --validate` gains an "Unsupported Relationships" group
(edge-legality) and a "superseded" suffix on a flagged reference
(status-consistency).

## JSON Output
Additive only: two new issue codes (`relationship-edge-unsupported`,
`relationship-target-superseded`) in `rac relationships --validate --json`. The
`rac export` JSON payload, `rac inspect`, and the recency JSON are unchanged.

## Exit Codes
Unchanged: `rac relationships --validate` exits `1` when any issue (old or new)
is present, `0` when clean.

# Verification

## Ran
- `python -m pytest tests/test_relationship_validation.py tests/test_export_okf.py
  tests/test_frontmatter.py tests/test_recency.py tests/test_cadence.py
  tests/test_review.py tests/test_dogfood.py tests/test_ci_batteries.py
  tests/test_golden.py` → 185 passed (the 3 `mcp_stats` goldens fail only because
  the optional `mcp` package cannot install in the authoring container — CI runs
  them).
- `rac validate rac/` → 165/165 valid; `rac relationships rac/ --validate` → 581
  checked, 0 issues; `rac review rac/` → health 88, 0 priority-1/2.
- `ruff check src/ tests/` and `ruff format --check` clean; `mypy src/` clean (the
  one local error was the missing `types-PyYAML` stub on `frontmatter.py`'s
  pre-existing `import yaml`, not introduced here).
- `rac export rac/ --okf` then re-export → byte-identical (timestamps from a fixed
  git state stay deterministic).

## Covered
- edge-legality: an unsupported `## Related Designs` on a design and `## Supersedes`
  on a roadmap are reported; a legal `## Related Decisions` on a decision is not;
  CLI exit code and JSON shape.
- status-consistency: a live reference to a Superseded (and Deprecated) decision is
  flagged; the `supersedes` edge and a retired-source reference are exempt; an
  Accepted target is not flagged.
- tags: valid/invalid tags; `created`/`updated` rejected as frontmatter fields
  (ADR-045 upheld). export: tags from source, created/updated from git recency.
- Corpus probes confirmed both rules fire on zero existing artifacts (no Superseded
  decisions; no unsupported sections), so the corpus stays green.

# Review Path

1. `rac/decisions/adr-049-...` + `adr-050-...` — the two decisions, including the
   conflict resolutions.
2. `src/rac/services/relationships.py` — both new rules in `_validate`
   (`_is_retired_decision`, `unsupported_relationship_sections`).
3. `src/rac/services/recency.py` + `src/rac/output/okf.py` + `src/rac/services/export.py`
   — git-derived timestamps and tags projection.
4. `src/rac/core/frontmatter.py` + `metadata.py` — `tags` recognition.
5. `tests/test_relationship_validation.py`, `tests/test_export_okf.py`,
   `tests/test_frontmatter.py` — coverage.
6. `docs/index.md`, `docs/okf-profile.md`, `CHANGELOG.md`, the requirement and
   roadmaps — record and positioning.

# Notes For Reviewer

- The strong "a RAC repo is a valid OKF bundle at the source" claim is deliberately
  not pursued — it requires mandatory typing, which ADR-010 forbids. The export
  path delivers OKF validity without that conflict; this is recorded, not glossed.
- README hero copy and the `rac-growth-positioning` requirement were left unedited;
  ADR-049 + the `docs/index.md` section carry the thesis. Wording for those public
  surfaces is left for the maintainer.
- Status-consistency is decision-only by design; generalising lifecycle status to
  all types is recorded as out of scope (a later, separate decision).

# Implementation Process

Implemented with AI assistance under the maintainer's direction and the v0.14.x /
v0.15.0 roadmap contracts; scope, the two conflict resolutions (ADR-010, ADR-045),
and acceptance were maintainer calls.