### PR TITLE
docs(decisions): generalized lifecycle status — decision + design

### DIFF
--- a/rac/decisions/adr-051-lifecycle-status-generalized.md
+++ b/rac/decisions/adr-051-lifecycle-status-generalized.md
@@ -1,0 +1,122 @@
+---
+schema_version: 1
+id: RAC-KV3MPPW4XGFP
+type: decision
+tags: [lifecycle, status, enforcement]
+---
+# ADR-051: Lifecycle Status Is Knowledge Lifecycle, Generalized Across All Artifact Types
+
+## Status
+
+Proposed
+
+## Category
+
+Architecture
+
+## Context
+
+Lifecycle `status` is decision-only today: the decision spec declares
+`metadata={"status": ("Proposed", "Accepted", "Superseded", "Deprecated")}`,
+validated from a `## Status` body section; the other four types declare no enum.
+Two consequences follow. The v0.14.1 status-consistency rule
+(`rac-cross-artifact-enforcement` REQ-003) can only flag references to retired
+*decisions*, so "nothing live points at a superseded artifact" holds for one of
+five types. And the corpus already uses status informally and inconsistently —
+requirements as prose `Proposed`/`Accepted`, roadmaps as `Planned`, prompts and
+designs not at all — so the convention exists without a contract.
+
+The design `generalized-lifecycle-status` works out the *how*. This ADR records
+the *decision* and, critically, the boundary that keeps it from drifting into the
+project-management modelling ADR-017 rejects.
+
+## Decision
+
+1. **Generalize lifecycle status to all five artifact types**, declared per-type
+   via `ArtifactSpec.metadata["status"]` on a shared `Proposed → live → retired`
+   spine. Decisions are unchanged. The enums are:
+
+   | Type | Live | Retired |
+   | --- | --- | --- |
+   | decision | `Proposed`, `Accepted` | `Superseded`, `Deprecated` |
+   | requirement | `Proposed`, `Accepted` | `Superseded`, `Deprecated` |
+   | design | `Proposed`, `Accepted` | `Superseded`, `Deprecated` |
+   | prompt | `Active` | `Deprecated` |
+   | roadmap | `Planned` | `Superseded`, `Abandoned` |
+
+2. **Status means knowledge lifecycle, never work status (binding, interprets
+   ADR-017).** It answers "is this the team's current position, or has it been
+   replaced?" — not "is someone building it?". The states `In Progress`,
+   `In Review`, `Blocked`, `Done`, `Shipped`, `Assigned`, and any date or
+   workflow-owner field are out of scope and MUST NOT be added as status. For
+   roadmaps specifically, `Planned` denotes current intent and `Superseded`/
+   `Abandoned` denote replaced or dropped intent — knowledge states, not delivery
+   tracking; per-milestone delivery progress stays out.
+
+3. **Each spec declares a `retired_status` set** (a subset of its status enum) as
+   the single source of truth for terminality. The status-consistency rule
+   generalizes from `_is_retired_decision` to `_is_retired_artifact`, reading
+   `spec.retired_status`, so a live artifact of any type that references any
+   retired artifact is reported `relationship-target-superseded`. The `supersedes`
+   exception and the retired-source exemption are unchanged.
+
+4. **Status stays an optional, validated `## Status` body section** (ADR-025): not
+   frontmatter, validated only when present, so the artifacts with no status keep
+   validating and only a value outside the type's enum is an error.
+
+5. **Additive (ADR-007).** The decision status enum, the
+   `relationship-target-superseded` code, and its shape are unchanged; the rule's
+   reach widens. The two existing free-form status values are normalized to enum
+   values as part of delivery.
+
+## Consequences
+
+### Positive
+
+- The "nothing live points at a retired artifact" guarantee covers all five types,
+  not just decisions.
+- Agents and `rac` can tell a current artifact from a replaced one uniformly.
+- The change is mostly declarative data on each `ArtifactSpec` plus a one-line
+  predicate swap, reusing existing validation machinery — no per-type branching.
+
+### Negative
+
+- Five lifecycles to maintain, each a place the ADR-017 boundary must be guarded
+  on every future change.
+- A small migration: two free-form status values to normalize; optional backfill
+  of status-less artifacts.
+
+### Neutral
+
+- Status remains optional; artifacts without a `## Status` section stay valid.
+- Templates for the four types MAY later seed a `## Status` section; not required.
+
+## Alternatives Considered
+
+- **One shared status vocabulary for all types.** Rejected: a roadmap is `Planned`,
+  not `Accepted`; forcing one vocabulary erases real lifecycle differences.
+- **Exclude roadmaps as too work-adjacent.** Considered seriously (the sharpest
+  ADR-017 case) and rejected: `Planned → Superseded/Abandoned` is a defensible
+  *knowledge* lifecycle, and a uniform model across all five types is worth more
+  than carving out one. The boundary is held by excluding delivery states, not by
+  excluding the type.
+- **Status in frontmatter.** Rejected: contradicts ADR-025.
+- **Keep status decision-only.** Rejected: that is the enforcement gap.
+- **Make status required.** Rejected: forces a disruptive backfill and fights
+  ADR-010; optional-but-validated delivers the value without it.
+
+## Related Decisions
+
+- ADR-017
+- ADR-025
+- ADR-049
+- ADR-007
+- ADR-016
+
+## Related Requirements
+
+- rac-cross-artifact-enforcement
+
+## Related Designs
+
+- generalized-lifecycle-status

--- a/rac/designs/generalized-lifecycle-status.md
+++ b/rac/designs/generalized-lifecycle-status.md
@@ -1,0 +1,184 @@
+---
+schema_version: 1
+id: RAC-KV3MG0SDPPWC
+type: design
+tags: [lifecycle, status, enforcement]
+---
+# Design: Generalized Lifecycle Status Across Artifact Types
+
+## Context
+
+Lifecycle `status` is decision-only today. The decision spec declares
+`metadata={"status": ("Proposed", "Accepted", "Superseded", "Deprecated")}`,
+canonicalised from a `## Status` body section (ADR-025) and validated by
+`canonical_value`. The other four types declare no status enum.
+
+Two pressures make this a gap rather than a choice:
+
+- **Enforcement is half-covered.** The v0.14.1 status-consistency rule
+  (`rac-cross-artifact-enforcement` REQ-003) flags a live artifact that references
+  a *retired decision*, but a retired *requirement*, *design*, *roadmap*, or
+  *prompt* is invisible to it. "Nothing points at a superseded artifact" only
+  holds for one of five types.
+- **The corpus already does it informally.** An audit of `rac/` shows
+  requirements using `Proposed`/`Accepted` as prose (20 Proposed, 1 Accepted, 1
+  free-form, 19 with no `## Status`), roadmaps using `Planned` (39 Planned, 1
+  `Considered (unscheduled)`, 13 with none), and prompts/designs using nothing.
+  The convention exists; it is just unvalidated and inconsistent.
+
+The mechanism to close the gap already exists and is generic — `ArtifactSpec.metadata`,
+`canonical_value`, and `_validate` work for any type. What is missing is the
+*model*: which states each type has, which of them mean "retired," and how the
+enforcement rule reads them — all without crossing ADR-017 (RAC manages
+knowledge, not work).
+
+## User Need
+
+A reader, an agent over MCP, and CI all need to know, for **any** artifact, whether
+it is current or retired — so that:
+
+- a maintainer is warned when a live requirement, design, or roadmap still points
+  at superseded knowledge, not only when a decision does;
+- an agent retrieving context can tell a current artifact from a replaced one;
+- `rac` can report drift uniformly instead of decision-only.
+
+The need is *knowledge lifecycle* ("is this artifact still the team's current
+position?"), explicitly not *work status* ("is someone building it?").
+
+## Design
+
+### 1. Per-type status enums on a shared spine
+
+Each `ArtifactSpec` declares its own `metadata["status"]` enum. The vocabularies
+differ because the lifecycles differ, but they share a spine —
+`Proposed → live → retired` — so a single notion of "retired" generalises.
+
+| Type | Live states | Retired states |
+| --- | --- | --- |
+| decision | `Proposed`, `Accepted` | `Superseded`, `Deprecated` |
+| requirement | `Proposed`, `Accepted` | `Superseded`, `Deprecated` |
+| design | `Proposed`, `Accepted` | `Superseded`, `Deprecated` |
+| prompt | `Active` | `Deprecated` |
+| roadmap | `Planned` | `Superseded`, `Abandoned` |
+
+Decisions are unchanged. The deliberately excluded states are the work/delivery
+ones — `In Progress`, `In Review`, `Blocked`, `Done`, `Shipped`, `Assigned` — which
+would pull RAC into project management (ADR-017). "Retired" means *replaced or no
+longer endorsed*, never *finished*.
+
+### 2. A declared "retired" set per spec
+
+The status enum alone does not say which values are terminal. Each spec gains a
+small, explicit retired-set (e.g. `retired_status={"Superseded", "Deprecated"}`),
+a subset of its `metadata["status"]`. This is the single source of truth the
+enforcement rule reads, so "retired" is never inferred from a string convention.
+
+### 3. Status stays an optional, validated `## Status` section
+
+Status remains a Markdown body section (ADR-025), not frontmatter. It stays
+**optional** and **validated-if-present** — exactly the decision contract today —
+so the 30-plus artifacts with no status keep validating, and only a *malformed*
+status (a value outside the type's enum) is an error. This keeps migration
+friction near zero.
+
+### 4. Generalized status-consistency
+
+The v0.14.1 rule changes from decision-specific to type-generic:
+`_is_retired_decision(product, spec)` becomes `_is_retired_artifact(product, spec)`,
+which reads the first `## Status` line and tests it against `spec.retired_status`.
+Everything else in the rule is unchanged: the `supersedes` exception, the
+retired-source exemption, and the "uniquely-resolved, non-self" guard all still
+hold. The result: a live artifact of any type that references *any* retired
+artifact is reported as `relationship-target-superseded`.
+
+### 5. Migration
+
+- Normalise the two free-form values (`Considered (unscheduled)`,
+  `Proposed — drafted to open the discussion…`) to enum values, or add the values
+  to the enums if they are wanted.
+- Backfilling the ~32 status-less artifacts is optional (status stays optional);
+  it can be done lazily as artifacts are touched.
+- `rac new` templates for requirement/roadmap/design/prompt MAY gain a `## Status`
+  section seeded with the type's first live state, so new artifacts adopt it.
+
+## Constraints
+
+- **ADR-017 (knowledge, not work).** Status captures knowledge currency only.
+  No work/delivery/assignment states, no dates, no owners-as-workflow. This is the
+  binding constraint and the design's main risk surface.
+- **ADR-025 (hybrid metadata).** Status stays a `## Status` body section, never
+  frontmatter.
+- **ADR-007 (contract stability).** Additive: the decision status enum and its
+  validation are unchanged; new enums are added; status stays optional. The
+  `relationship-target-superseded` code and shape are unchanged — only its reach
+  widens.
+- **Spec-driven (no per-type branching).** New behaviour comes from data on each
+  `ArtifactSpec`, not from `if artifact_type == ...` in the rule.
+- **Determinism (ADR-002).** Same corpus state, same findings.
+
+## Rationale
+
+Per-type enums beat one shared vocabulary because the lifecycles genuinely differ
+— a roadmap is `Planned`, not `Accepted`; a prompt is `Active`, not `Proposed`.
+A shared *retired-classification* on top of them is what the enforcement rule
+needs, so the graph guarantee generalises without flattening the vocabularies.
+Keeping status optional preserves ADR-010's spirit (not everything must be fully
+specified) and avoids a disruptive backfill. Reusing the existing
+metadata/`canonical_value` machinery means the change is mostly data plus a
+one-line predicate swap in the rule.
+
+## Alternatives
+
+- **One shared status vocabulary for all types.** Rejected: forces unnatural
+  values (a roadmap that is "Accepted"?) and erases real lifecycle differences.
+- **Status in frontmatter.** Rejected: contradicts ADR-025 (status is a body
+  section) and reopens the conflict-detection problem.
+- **Keep status decision-only (status quo).** Rejected: leaves the enforcement
+  guarantee covering one of five types — the gap this design closes.
+- **Make status required.** Rejected: forces a backfill of 30-plus artifacts and
+  fights ADR-010; optional-but-validated delivers the value without the friction.
+- **Infer "retired" from a hard-coded string set in the rule.** Rejected: a
+  per-spec `retired_status` keeps the model declarative and spec-driven.
+
+## Accessibility
+
+Status values stay human-readable words in plain Markdown (no codes or colour
+dependence), legible in any text editor and in `rac inspect`/review output —
+consistent with RAC's viewer-agnostic, plain-text model (ADR-014).
+
+## Style Guidance
+
+Follow the existing decision convention exactly: a `## Status` section whose first
+non-empty line is one enum value, title-cased. New per-type enums reuse the
+decision spelling where a value is shared (`Proposed`, `Accepted`, `Superseded`,
+`Deprecated`).
+
+## Open Questions
+
+- **Roadmap lifecycle vs ADR-017 — the crux.** A roadmap is inherently about
+  intended work, so even `Planned` leans delivery-ward. Is `Planned → Superseded /
+  Abandoned` a defensible *knowledge* lifecycle, or should roadmaps be excluded
+  from status generalisation and rely on the `archive/` directory convention
+  instead? This question most needs a decision.
+- **Do requirements/designs need a "delivered/met" state?** It is the most useful
+  and the most ADR-017-dangerous addition; the table above omits it deliberately.
+- **Should generalising status be ratified by an ADR?** It touches the artifact
+  model and the ADR-017 boundary, so an ADR (not just this design) likely should
+  record the "status is knowledge lifecycle, never work status" rule before
+  implementation.
+- **Backfill now or lazily?** And should the four templates gain a seeded
+  `## Status` section?
+- **Version fence.** Which release carries this (a v0.14.2 enforcement follow-on,
+  or its own series)?
+
+## Related Requirements
+
+- rac-cross-artifact-enforcement
+
+## Related Decisions
+
+- adr-049
+- adr-017
+- adr-025
+- adr-016
+- adr-007

--- a/rac/designs/generalized-lifecycle-status.md
+++ b/rac/designs/generalized-lifecycle-status.md
@@ -155,17 +155,13 @@ decision spelling where a value is shared (`Proposed`, `Accepted`, `Superseded`,
 
 ## Open Questions
 
-- **Roadmap lifecycle vs ADR-017 — the crux.** A roadmap is inherently about
-  intended work, so even `Planned` leans delivery-ward. Is `Planned → Superseded /
-  Abandoned` a defensible *knowledge* lifecycle, or should roadmaps be excluded
-  from status generalisation and rely on the `archive/` directory convention
-  instead? This question most needs a decision.
+Resolved by ADR-051: roadmaps are **in** the model (`Planned → Superseded /
+Abandoned` as a knowledge lifecycle, delivery states excluded), and the
+"status is knowledge lifecycle, never work status" boundary is ratified by that
+ADR rather than left to this design. Remaining:
+
 - **Do requirements/designs need a "delivered/met" state?** It is the most useful
   and the most ADR-017-dangerous addition; the table above omits it deliberately.
-- **Should generalising status be ratified by an ADR?** It touches the artifact
-  model and the ADR-017 boundary, so an ADR (not just this design) likely should
-  record the "status is knowledge lifecycle, never work status" rule before
-  implementation.
 - **Backfill now or lazily?** And should the four templates gain a seeded
   `## Status` section?
 - **Version fence.** Which release carries this (a v0.14.2 enforcement follow-on,
@@ -177,6 +173,7 @@ decision spelling where a value is shared (`Proposed`, `Accepted`, `Superseded`,
 
 ## Related Decisions
 
+- adr-051
 - adr-049
 - adr-017
 - adr-025


### PR DESCRIPTION
# Summary

Records the decision and design for **generalizing lifecycle `status` beyond
decisions to all five artifact types**, so the v0.14.1 status-consistency
guarantee ("nothing live points at a retired artifact") can cover every type, not
just decisions. This is a decision-of-record + design PR; no code changes.

Adds:
- `rac/decisions/adr-051-lifecycle-status-generalized.md` — the decision.
- `rac/designs/generalized-lifecycle-status.md` — the mechanism (the how).

# Roadmap / ADR Trace

- ADR-051 (new) ratifies the model; the design works out the how.
- Interprets/respects: `adr-017` (knowledge, not work — the binding boundary),
  `adr-025` (status is a body section, not frontmatter), `adr-007` (additive),
  `adr-016`, `adr-049`, `adr-010`.
- Implementation parent: `rac/requirements/rac-cross-artifact-enforcement.md` REQ-003.

# Scope

## Decided (ADR-051)
- Generalize `status` to all five types via per-type `ArtifactSpec` enums on a
  shared `Proposed -> live -> retired` spine (decisions unchanged):
  requirement/design `Proposed, Accepted | Superseded, Deprecated`; prompt
  `Active | Deprecated`; roadmap `Planned | Superseded, Abandoned`.
- **Status means knowledge lifecycle, never work status** (interprets ADR-017):
  `In Progress`, `In Review`, `Blocked`, `Done`, `Shipped`, `Assigned`, dates, and
  workflow owners are out of scope. Roadmaps are deliberately included, with
  delivery states excluded, after weighing the ADR-017 tension.
- Each spec declares a `retired_status` set; the status-consistency rule
  generalizes `_is_retired_decision` to `_is_retired_artifact` over it. The
  `supersedes` exception and retired-source exemption are unchanged.
- Status stays an optional, validated `## Status` section (ADR-025); additive
  (ADR-007); two free-form corpus values normalized on delivery.

## Not in this PR (deliberately)
- The implementation (the four enums + `retired_status` + the one-line predicate
  swap + tests) — a tidy, version-fenced follow-on driven by the requirement.
- Three open questions the design records: a "delivered/met" state for
  requirements/designs (the next ADR-017 judgment call), backfill-now-vs-lazily +
  templates, and the version fence.

# Verification

- `rac validate rac/` -> 168/168 valid; `rac relationships rac/ --validate` -> 598
  checked, 0 issues. The ADR and design link each other and resolve both ways.
- Both artifacts dogfood the new `tags` field (`lifecycle, status, enforcement`).

# Review Path

1. `rac/decisions/adr-051-lifecycle-status-generalized.md` — the decision, the
   per-type table, and the ADR-017 boundary.
2. `rac/designs/generalized-lifecycle-status.md` — the corpus audit that motivates
   it, the mechanism, alternatives, and remaining open questions.

# Notes For Reviewer

- The sharpest call was roadmaps: a roadmap is inherently about intended work, so
  even `Planned` leans delivery-ward. The decision keeps roadmaps in with a
  knowledge lifecycle (`Planned -> Superseded/Abandoned`) and holds the ADR-017
  line by excluding delivery states, not by excluding the type — flagged here in
  case you want the opposite.
- The "delivered/met" state for requirements/designs is left open on purpose; it
  is the most useful and the most ADR-017-dangerous addition.

# Implementation Process

Drafted collaboratively with AI assistance under the maintainer's direction; the
roadmap-inclusion call and the knowledge-not-work boundary were maintainer
decisions.