### PR TITLE
feat(validate): OKF v0.1 conformance as a write-time gate [roadmap:v0.15.1]

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,7 +56,7 @@ jobs:
         # enforced by tests/test_ci_batteries.py in the core battery.
         battery:
           - name: core
-            paths: "tests/test_validate.py tests/test_parser.py tests/test_schema.py tests/test_identity.py tests/test_frontmatter.py tests/test_metadata_identity.py tests/test_idgen.py tests/test_ci_batteries.py tests/test_corpus.py tests/test_operations.py"
+            paths: "tests/test_validate.py tests/test_okf_conformance.py tests/test_parser.py tests/test_schema.py tests/test_identity.py tests/test_frontmatter.py tests/test_metadata_identity.py tests/test_idgen.py tests/test_ci_batteries.py tests/test_corpus.py tests/test_operations.py"
           - name: cli
             paths: "tests/test_cli.py"
           - name: compare

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ details, release history over commit history.
 
 ### Added
 
+- OKF v0.1 conformance check (v0.15.1): `rac validate <dir>` now enforces OKF
+  conformance as a write-time gate, not just on export. It reports, per typed
+  artifact, `okf-unmapped-type` (a `type` with no OKF mapping) and
+  `okf-reserved-filename-collision` (a typed artifact named `index.md`/`log.md`),
+  and fails the run when the corpus could not produce a conformant bundle. Untyped
+  documents are excluded (ADR-010); the directory `validate` JSON gains an additive
+  `okf` section (no `schema_version` bump). Per ADR-052, `rac-core` stays the
+  code-defined OKF-superset envelope — no JSON Schema files, no new dependency.
+
 - OKF frontmatter superset (v0.15.0): RAC artifacts may now declare an optional
   `tags: [...]` list (the OKF-reserved descriptive field ADR-025 anticipated),
   validated for shape and additive — no `schema_version` bump. `rac export --okf`

--- a/docs/okf-profile.md
+++ b/docs/okf-profile.md
@@ -67,6 +67,33 @@ type: decision
 presents, in the OKF bundle view, as `type: ADR` — the same file, the same body,
 a derived front-matter projection.
 
+## Checking conformance (write-time gate)
+
+Conformance is enforced, not just produced on export. Running `rac validate` over
+a corpus checks OKF v0.1 conformance as part of the run (ADR-048, ADR-049):
+
+```bash
+rac validate rac/
+# … PASS  rac/ — N artifact(s) checked: N valid, 0 invalid. OKF v0.1: conformant.
+```
+
+The check is deterministic and per-artifact. It reports, with a file-named,
+fixable diagnostic, and fails the `validate` exit code:
+
+| Code | Meaning |
+| --- | --- |
+| `okf-unmapped-type` | a typed artifact whose `type` has no OKF mapping (it would be silently dropped from the bundle) |
+| `okf-reserved-filename-collision` | a typed artifact named `index.md` or `log.md`, which OKF reserves for generated entry points |
+
+Untyped documents are excluded (ADR-010): they are legitimately skipped and the
+bundle already omits them, so an `index.md`/`log.md` that is an untyped entry
+point is recognized, never flagged. Referential integrity ("links resolve") stays
+with `rac relationships --validate`. The directory `validate` JSON carries an
+additive `okf` section (ADR-007). Per ADR-052, `rac-core` — the OKF-superset
+frontmatter envelope (`schema_version`, `id`, `type`, `relationships`, `tags`) —
+is defined in code and enforced this way; RAC ships no JSON Schema `rac-core` file
+and takes no schema-validation dependency.
+
 ## Conventions (recommended)
 
 Where RAC has gaps, a RAC repository SHOULD adopt the following OKF conventions.

--- a/rac/decisions/adr-052-rac-core-okf-superset-conformance.md
+++ b/rac/decisions/adr-052-rac-core-okf-superset-conformance.md
@@ -1,0 +1,127 @@
+---
+schema_version: 1
+id: RAC-KV3P8MSKB276
+type: decision
+tags: [okf, interop, schema, enforcement]
+---
+# ADR-052: rac-core Is the Code-Defined OKF-Superset Envelope, Conformance Enforced at Write Time
+
+## Status
+
+Proposed
+
+## Category
+
+Architecture
+
+## Context
+
+A hardening brief proposed founding RAC's extensibility on an authoritative
+JSON Schema 2020-12 `rac-core` (every type composing it via `allOf`), with
+`type` and `title` as required frontmatter, stored timestamps, an OKF
+conformance gate over every file, and a codemod across the corpus. Taken
+literally that is a large, partly-destructive change — and it collides with
+decisions RAC has already recorded:
+
+- **Mandatory `type`** contradicts ADR-010 (untyped documents are legitimate and
+  deliberately skipped).
+- **Frontmatter `title`/`description`** contradict ADR-025 (title is H1-derived;
+  product reasoning stays in the body).
+- **Stored `timestamp`** contradicts ADR-045 (recency is git-derived, never
+  stored in source).
+- **A full OKF superset + codemod** is exactly what ADR-050 considered and
+  rejected, adopting only the conflict-free `tags` field.
+- **JSON Schema files as the source of truth** cuts against ADR-049, which names
+  the per-type schema *table stakes* and the cross-artifact graph the product —
+  and against the working reality that the frontmatter envelope is already
+  defined in code (`core/frontmatter.py`, `core/metadata.py`) and exercised by
+  the full test suite.
+
+What is *genuinely* missing is small. ADR-048 requires every RAC repository to
+be a conformant OKF v0.1 bundle, but conformance was only ever a side-effect of
+`rac export --okf`; nothing failed CI when the corpus could not produce a
+conformant bundle. This decision records how RAC closes that gap without
+adopting the conflicting machinery above.
+
+## Decision
+
+1. **`rac-core` is the existing code-defined frontmatter envelope**, not a new
+   JSON Schema artifact. The reserved fields — `schema_version`, `id`, `type`,
+   `relationships`, `tags` (ADR-025, ADR-050) — are a strict superset of OKF's
+   reserved set, validated in `core/frontmatter.py`. "Validates against rac-core"
+   means the envelope, *when present*, parses clean; legacy artifacts without
+   frontmatter stay valid (ADR-025) and untyped documents stay legitimate
+   (ADR-010). No `allOf` composition, no JSON Schema dialect, no new dependency.
+
+2. **OKF v0.1 conformance becomes a write-time gate** in `rac validate`
+   (`services/okf_conformance.py`, Layer 0). Over a corpus it checks, per typed
+   artifact, that the `type` maps to an OKF type and that no typed artifact
+   occupies a reserved filename (`index.md`/`log.md`). Untyped documents are
+   excluded (ADR-010). Referential integrity ("links resolve") remains owned by
+   `rac relationships --validate` and is not duplicated here.
+
+3. **The RAC→OKF type mapping and reserved filenames live once in `core/okf.py`**
+   and are shared by the bundle export and the conformance check (ADR-002: one
+   deterministic source of truth).
+
+4. **No mandatory fields, no codemod, no stored dates.** ADR-010, ADR-025, and
+   ADR-045 stand unchanged. The conformance result is additive to the directory
+   `validate` JSON contract (ADR-007); no `schema_version` bump.
+
+5. **Custom JSON Schema dialects/vocabularies remain deferred** (post-PMF); if a
+   design partner ever needs repo-local custom types, schema composition over
+   this code-defined core is the intended path and will be recorded as its own
+   ADR — never a silent edit to an accepted decision.
+
+## Consequences
+
+### Positive
+
+- OKF conformance (ADR-048) is now enforced deterministically in CI, not merely
+  produced on export — consistent with ADR-049's "enforcement is the product".
+- The change is additive and small: a new check plus a shared constants module,
+  reusing existing parsing and the directory-validate surface. Every recorded
+  decision is preserved; no artifact changes shape.
+- Future type additions cannot silently fall out of the OKF bundle — an unmapped
+  type fails conformance with a file-named diagnostic.
+
+### Negative
+
+- rac-core is documented in code and ADRs rather than a publishable JSON Schema
+  file, so external JSON Schema tooling cannot consume it directly today. A
+  derived schema export is left as a future, pull-based option.
+
+### Neutral
+
+- The conformance check overlaps in spirit with `rac export --okf`'s exclusion
+  of untyped files; the export stays the derived view, the check the write-time
+  gate.
+
+## Alternatives Considered
+
+- **Authoritative JSON Schema 2020-12 `rac-core` + `allOf`, mandatory
+  `type`/`title`, stored timestamps, codemod (the brief's literal path).**
+  Rejected: conflicts with ADR-010, ADR-025, ADR-045, ADR-050, and the
+  table-stakes posture of ADR-049; large and partly destructive for marginal
+  gain over the code-defined envelope RAC already enforces.
+- **A derived `rac-core` JSON Schema generated from the code spec (like the OKF
+  export).** Deferred, not rejected: useful for external tooling, but not
+  required to close the conformance gap; recordable later if demand appears.
+- **Leave OKF conformance as an export-only side-effect.** Rejected: ADR-048
+  requires conformance and ADR-049 requires it be enforced; an unenforced
+  guarantee drifts.
+
+## Related Decisions
+
+- ADR-048
+- ADR-049
+- ADR-050
+- ADR-025
+- ADR-010
+- ADR-045
+- ADR-007
+
+## Related Requirements
+
+- rac-okf-carrier-profile
+- rac-cross-artifact-enforcement

--- a/rac/roadmaps/v0.15.x-interop/v0.15.1-okf-conformance-check.md
+++ b/rac/roadmaps/v0.15.x-interop/v0.15.1-okf-conformance-check.md
@@ -1,0 +1,133 @@
+---
+schema_version: 1
+id: RAC-KV3P8MSKWE9P
+type: roadmap
+tags: [okf, interop, enforcement]
+---
+# RAC v0.15.1 — OKF v0.1 Conformance Check
+
+## Status
+
+Planned
+
+## Context
+
+ADR-048 requires every RAC repository to be a conformant OKF v0.1 bundle, and
+ADR-049 makes deterministic, CI-enforced validation RAC's core. Yet conformance
+existed only as a side-effect of `rac export --okf`: nothing failed when a corpus
+could not produce a conformant bundle. This milestone closes that gap by turning
+OKF conformance into a write-time gate in `rac validate`, and records the
+schema-foundation posture (rac-core stays the code-defined OKF-superset envelope,
+not JSON Schema files) in ADR-052.
+
+Per ADR-052, this is additive and conflict-free: no mandatory frontmatter, no
+stored timestamps, no codemod (ADR-010, ADR-025, ADR-045 stand). Untyped
+documents are excluded from the check exactly as they are from the bundle.
+
+## Outcomes
+
+- `rac validate <dir>` reports OKF v0.1 conformance and fails the run when the
+  corpus is not conformant, with a file-named, coded, fixable diagnostic.
+- The RAC→OKF type mapping and OKF reserved filenames live once in `core/okf.py`,
+  shared by the bundle export and the conformance check.
+- The directory `validate` JSON gains an additive `okf` section (ADR-007); no
+  `schema_version` bump; existing output is otherwise unchanged.
+
+## Initiatives
+
+### Initiative 1 — Shared OKF constants
+
+Lift the RAC→OKF `type` map into `core/okf.py` and add the OKF reserved filename
+set (`index.md`, `log.md`). The bundle export imports the map from there; nothing
+in its output changes.
+
+### Initiative 2 — Conformance check + validate gate
+
+Add `services/okf_conformance.py` with `check_okf_conformance(directory, entries)`
+returning a report of findings: `okf-unmapped-type` (a typed artifact whose type
+has no OKF mapping) and `okf-reserved-filename-collision` (a typed artifact at a
+reserved filename). Untyped documents are excluded (ADR-010). Fold the result into
+directory `validate` — additive JSON `okf` section, a human conformance line, and
+the run's exit code.
+
+### Initiative 3 — Coverage and docs
+
+Golden (clean corpus and the real `rac/` corpus pass), adversarial (reserved-name
+collision; a type with no OKF mapping), and negative-boundary (untyped documents
+and untyped reserved entry points are not flagged) tests, plus a rac-core
+envelope assertion over the corpus. Refresh the `validate` goldens for the
+additive output and update `docs/okf-profile.md`.
+
+## Constraints
+
+- Additive (ADR-007): optional `okf` section; existing `validate` JSON keys,
+  codes, and single-file output are unchanged; no `schema_version` bump.
+- ADR-010: `type` stays optional; untyped documents are excluded, never failed.
+- ADR-025 / ADR-045: no mandatory frontmatter, no stored timestamps, no codemod.
+- ADR-052: rac-core stays the code-defined OKF-superset envelope; no JSON Schema
+  files and no new dependency.
+- Determinism (ADR-002): same corpus state yields the same findings and exit code,
+  offline.
+
+## Non-Goals
+
+- JSON Schema 2020-12 `rac-core` files, `allOf` composition, or custom dialects.
+- Mandatory `type`/`title`, frontmatter timestamps, or any corpus migration.
+- A new MCP tool, or any change to the four read-only tools.
+- Per-type standards enforcement (29148/EARS/MADR/dotprompt) — later releases.
+
+## Implementation Contract
+
+The following are pinned for v0.15.1.
+
+### Behaviour
+
+- `check_okf_conformance` emits `okf-unmapped-type` and
+  `okf-reserved-filename-collision`, file-named, only for typed artifacts.
+- `rac validate <dir>` exits non-zero when conformance fails; the conformant
+  corpus stays green. Single-file `rac validate` is unchanged (no corpus, no
+  conformance pass).
+- Referential integrity stays with `rac relationships --validate`; it is not
+  duplicated by the conformance check.
+
+### Interface
+
+- No new CLI command or flag. Directory `validate` JSON gains an additive `okf`
+  object; human output gains an `OKF v0.1:` summary clause and per-finding lines.
+
+## Success Measures
+
+- `rac validate rac/` reports `OKF v0.1: conformant.` and exits 0.
+- A fixture corpus with a typed `index.md` fails with
+  `okf-reserved-filename-collision` and a precise path.
+- Re-running validation on an unchanged corpus is byte-identical.
+
+## Risks
+
+- Folding conformance into the default `validate` gate could surface a latent
+  non-conformance in an adopter's repo. Mitigated: warnings-style framing in
+  docs, untyped documents excluded, and the only error conditions are genuine
+  bundle-breakers (unmapped type, reserved-name collision).
+
+## Assumptions
+
+- ADR-048 remains the OKF carrier-profile contract and ADR-052 the
+  schema-foundation posture.
+- The five enumerated artifact types continue to map one-to-one to OKF types.
+
+## Related Decisions
+
+- adr-052
+- adr-048
+- adr-049
+- adr-050
+
+## Related Requirements
+
+- rac-okf-carrier-profile
+- rac-cross-artifact-enforcement
+
+## Related Roadmaps
+
+- v0.15.0-okf-frontmatter-superset
+- v0.13.6-okf-bundle-export

--- a/src/rac/core/okf.py
+++ b/src/rac/core/okf.py
@@ -1,0 +1,28 @@
+"""OKF v0.1 carrier-profile constants (ADR-048).
+
+The RAC ``type`` → OKF ``type`` mapping and OKF's reserved filenames live here,
+in core, so the OKF bundle export (``output/okf.py``) and the write-time OKF
+conformance check (``services/okf_conformance.py``) share one definition
+(ADR-002: a single deterministic source of truth). ADR-048 makes OKF an
+informative carrier profile; these constants are the checkable part of it.
+"""
+
+from __future__ import annotations
+
+# RAC ``type`` → OKF ``type`` (ADR-048; docs/okf-profile.md is the normative
+# statement). The five enumerated RAC types map one-to-one. A registered RAC type
+# absent here is an OKF conformance error, never a silent drop from the bundle.
+OKF_TYPE = {
+    "requirement": "Requirement",
+    "decision": "ADR",
+    "design": "Design",
+    "roadmap": "Roadmap",
+    "prompt": "Prompt",
+}
+
+# OKF reserves these filenames for generated entry points: ``index.md`` for
+# progressive disclosure and ``log.md`` for chronological history. A *typed
+# artifact* at one of these paths would collide with the generated bundle file
+# (a conformance error); an *untyped* document at index.md/log.md is a legitimate
+# reserved entry point and is left alone (ADR-010).
+RESERVED_FILENAMES = ("index.md", "log.md")

--- a/src/rac/output/human.py
+++ b/src/rac/output/human.py
@@ -147,13 +147,30 @@ def render_validate_dir_human(result: DirectoryValidation) -> str:
             lines.append(f"          {issue.message}")
         lines.append("")
 
+    # OKF v0.1 conformance findings (ADR-048): listed like invalid artifacts so a
+    # conformance-only failure is just as actionable as a per-file one.
+    okf = result.okf
+    if okf is not None and okf.findings:
+        for finding in okf.findings:
+            lines.append(_red(_bold(f"FAIL  {finding.path}")) + "  (OKF conformance)")
+            lines.append(f"  {_red('error')}   [{finding.code}] {finding.path}")
+            lines.append(f"          {finding.message}")
+            lines.append("")
+
     skipped = f", {result.skipped} skipped (unknown type)" if result.skipped else ""
     verdict = _green("PASS") if result.ok else _red("FAIL")
-    lines.append(
+    summary = (
         f"{verdict}  {result.directory} — "
         f"{result.checked} artifact(s) checked: "
         f"{result.valid} valid, {result.invalid} invalid{skipped}."
     )
+    if okf is not None:
+        summary += (
+            " OKF v0.1: conformant."
+            if okf.ok
+            else f" OKF v0.1: {len(okf.findings)} conformance issue(s)."
+        )
+    lines.append(summary)
     if result.checked == 0 and result.skipped == 0:
         lines += ["", EMPTY_CORPUS_HINT]
     return "\n".join(lines)

--- a/src/rac/output/okf.py
+++ b/src/rac/output/okf.py
@@ -26,19 +26,14 @@ from __future__ import annotations
 import os
 
 from rac.core.frontmatter import split_frontmatter
+from rac.core.okf import OKF_TYPE
 from rac.services.export import CorpusExport, ExportArtifact
 from rac.services.recency import RecencyReport
 
-# RAC ``type`` → OKF ``type`` (ADR-048; docs/okf-profile.md is the normative
-# statement). The five enumerated RAC types map one-to-one; nothing else can
-# appear here because Unknown-type files are excluded from the export.
-OKF_TYPE = {
-    "requirement": "Requirement",
-    "decision": "ADR",
-    "design": "Design",
-    "roadmap": "Roadmap",
-    "prompt": "Prompt",
-}
+# RAC ``type`` → OKF ``type`` is defined once in ``rac.core.okf`` (ADR-048) and
+# re-exported here for the bundle renderer and its existing importers. Unknown-
+# type files are excluded from the export, so every ``art.type`` resolves.
+__all__ = ["OKF_TYPE", "render_okf_bundle"]
 
 # Human plural headings for the index, in a fixed disclosure order.
 _INDEX_SECTIONS: tuple[tuple[str, str], ...] = (

--- a/src/rac/services/okf_conformance.py
+++ b/src/rac/services/okf_conformance.py
@@ -1,0 +1,112 @@
+"""OKF v0.1 conformance — the write-time gate (ADR-048, ADR-049).
+
+ADR-048 requires every RAC repository to be a conformant OKF v0.1 bundle, and
+ADR-049 makes deterministic, CI-enforced validation RAC's core. Until now
+conformance was only a side-effect of ``rac export --okf``; this check makes it
+a write-time gate, surfaced through ``rac validate`` over a corpus.
+
+The check is deterministic and per-artifact (Layer 0). It runs over the same
+corpus snapshot as directory validation and reports, with file-named
+diagnostics and stable codes:
+
+- ``okf-unmapped-type`` — a typed RAC artifact whose ``type`` has no OKF mapping.
+  Guards future type additions: a new type added without an OKF mapping fails
+  here instead of being silently excluded from the bundle.
+- ``okf-reserved-filename-collision`` — a typed artifact whose filename is an OKF
+  reserved entry point (``index.md``/``log.md``), which would collide with the
+  generated bundle file.
+
+Untyped documents are excluded (ADR-010): they are legitimately skipped and the
+OKF bundle already omits them, so ``index.md``/``log.md`` that are untyped
+documents are recognized reserved entry points, never findings.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+
+from rac.core.artifacts import spec_for
+from rac.core.corpus import CorpusEntry
+from rac.core.okf import OKF_TYPE, RESERVED_FILENAMES
+
+# Stable finding codes (part of the JSON contract, ADR-007).
+CODE_UNMAPPED_TYPE = "okf-unmapped-type"
+CODE_RESERVED_FILENAME = "okf-reserved-filename-collision"
+
+
+@dataclass
+class OkfFinding:
+    """One OKF conformance finding, file-named for actionable diagnostics."""
+
+    code: str
+    path: str
+    message: str
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass
+class OkfConformanceReport:
+    """Repository OKF v0.1 conformance result (additive to directory validate)."""
+
+    directory: str
+    recursive: bool
+    artifacts_checked: int
+    findings: list[OkfFinding]
+
+    @property
+    def ok(self) -> bool:
+        return not self.findings
+
+    def to_dict(self) -> dict:
+        return {
+            "conformant": self.ok,
+            "artifacts_checked": self.artifacts_checked,
+            "findings": [f.to_dict() for f in self.findings],
+        }
+
+
+def check_okf_conformance(
+    directory: str, entries: list[CorpusEntry], recursive: bool = True
+) -> OkfConformanceReport:
+    """Check OKF v0.1 conformance over an already-walked corpus snapshot.
+
+    Deterministic: entries arrive in sorted path order, so findings do too. Only
+    typed artifacts are checked; untyped documents are excluded (ADR-010), which
+    also exempts untyped ``index.md``/``log.md`` reserved entry points.
+    """
+    findings: list[OkfFinding] = []
+    checked = 0
+    for entry in entries:
+        artifact_type = entry.artifact_type
+        if spec_for(artifact_type) is None:
+            continue
+        checked += 1
+        path = str(entry.path)
+        if artifact_type not in OKF_TYPE:
+            findings.append(
+                OkfFinding(
+                    CODE_UNMAPPED_TYPE,
+                    path,
+                    f"artifact type {artifact_type!r} has no OKF type mapping; add "
+                    f"it to rac.core.okf.OKF_TYPE so the artifact is carried in the "
+                    f"OKF bundle (ADR-048)",
+                )
+            )
+        if entry.path.name in RESERVED_FILENAMES:
+            findings.append(
+                OkfFinding(
+                    CODE_RESERVED_FILENAME,
+                    path,
+                    f"a typed artifact named {entry.path.name!r} collides with the "
+                    f"generated OKF bundle entry point; rename the file — OKF "
+                    f"reserves index.md and log.md (ADR-048)",
+                )
+            )
+    return OkfConformanceReport(
+        directory=directory,
+        recursive=recursive,
+        artifacts_checked=checked,
+        findings=findings,
+    )

--- a/src/rac/services/validate.py
+++ b/src/rac/services/validate.py
@@ -19,6 +19,8 @@ from rac.core.corpus import CorpusEntry, walk_corpus
 from rac.core.models import Issue
 from rac.core.validation import has_errors, validate
 
+from .okf_conformance import OkfConformanceReport, check_okf_conformance
+
 # Stable per-file statuses (part of the JSON contract, ADR-007).
 STATUS_VALID = "valid"
 STATUS_INVALID = "invalid"
@@ -54,6 +56,9 @@ class DirectoryValidation:
     directory: str
     recursive: bool
     files: list[FileValidation]
+    # OKF v0.1 conformance over the same snapshot (ADR-048, Layer 0). Additive
+    # (ADR-007): optional so other constructors stay valid; folded into ``ok``.
+    okf: OkfConformanceReport | None = None
 
     @property
     def checked(self) -> int:
@@ -73,10 +78,13 @@ class DirectoryValidation:
 
     @property
     def ok(self) -> bool:
-        return self.invalid == 0
+        # A run passes only when every artifact validates *and* the corpus is OKF
+        # v0.1 conformant (ADR-048). Conformance is treated as ok when not
+        # computed, so single-purpose constructions are unaffected.
+        return self.invalid == 0 and (self.okf is None or self.okf.ok)
 
     def to_dict(self) -> dict:
-        return {
+        payload = {
             "schema_version": "1",
             "directory": self.directory,
             "recursive": self.recursive,
@@ -90,6 +98,10 @@ class DirectoryValidation:
             "valid": self.ok,
             "files": [f.to_dict() for f in self.files],
         }
+        # Additive (ADR-007): OKF v0.1 conformance, present when computed.
+        if self.okf is not None:
+            payload["okf"] = self.okf.to_dict()
+        return payload
 
 
 def validate_directory(directory: str, recursive: bool = True) -> DirectoryValidation:
@@ -135,4 +147,5 @@ def validate_corpus(
                 issues=issues,
             )
         )
-    return DirectoryValidation(directory=directory, recursive=recursive, files=files)
+    okf = check_okf_conformance(directory, entries, recursive=recursive)
+    return DirectoryValidation(directory=directory, recursive=recursive, files=files, okf=okf)

--- a/tests/fixtures/okf_conformance/clean/adr.md
+++ b/tests/fixtures/okf_conformance/clean/adr.md
@@ -1,0 +1,18 @@
+---
+schema_version: 1
+id: RAC-KTQ63DPSMF19
+type: decision
+---
+# A Clean Decision
+
+## Context
+
+A typed artifact that maps to an OKF type.
+
+## Decision
+
+Stay conformant.
+
+## Consequences
+
+The bundle carries it.

--- a/tests/fixtures/okf_conformance/clean/notes.md
+++ b/tests/fixtures/okf_conformance/clean/notes.md
@@ -1,0 +1,4 @@
+# Planning Notes
+
+Loose planning thoughts that match no artifact schema — a legitimate untyped
+document (ADR-010), excluded from the OKF bundle and from conformance.

--- a/tests/fixtures/okf_conformance/reserved_collision/index.md
+++ b/tests/fixtures/okf_conformance/reserved_collision/index.md
@@ -1,0 +1,18 @@
+---
+schema_version: 1
+id: RAC-KTQ63DPSMF19
+type: decision
+---
+# A Decision At A Reserved Path
+
+## Context
+
+This typed artifact is named index.md, an OKF reserved entry point.
+
+## Decision
+
+It would collide with the generated bundle index.
+
+## Consequences
+
+Conformance must flag it.

--- a/tests/fixtures/okf_conformance/reserved_ok/index.md
+++ b/tests/fixtures/okf_conformance/reserved_ok/index.md
@@ -1,0 +1,6 @@
+# Knowledge Index
+
+An untyped index.md entry point — recognized as an OKF reserved file, never a
+conformance finding (it is not a typed artifact).
+
+- a link to somewhere

--- a/tests/golden/validate_dir_human.txt
+++ b/tests/golden/validate_dir_human.txt
@@ -2,4 +2,4 @@ FAIL  tests/fixtures/portfolio/broken.md  (Requirement)
   error   [missing-title] tests/fixtures/portfolio/broken.md
           File has no top-level # title.
 
-FAIL  tests/fixtures/portfolio — 4 artifact(s) checked: 3 valid, 1 invalid.
+FAIL  tests/fixtures/portfolio — 4 artifact(s) checked: 3 valid, 1 invalid. OKF v0.1: conformant.

--- a/tests/golden/validate_dir_json.txt
+++ b/tests/golden/validate_dir_json.txt
@@ -80,5 +80,10 @@
         }
       ]
     }
-  ]
+  ],
+  "okf": {
+    "conformant": true,
+    "artifacts_checked": 4,
+    "findings": []
+  }
 }

--- a/tests/test_okf_conformance.py
+++ b/tests/test_okf_conformance.py
@@ -1,0 +1,131 @@
+"""Tests for OKF v0.1 conformance — the write-time gate (ADR-048).
+
+Covers the golden (a clean corpus passes), the adversarial cases (a typed
+artifact at a reserved filename, and a registered type with no OKF mapping), and
+the negative boundary (untyped documents and untyped reserved entry points are
+never flagged — ADR-010). The CLI is checked end-to-end through ``rac validate``.
+"""
+
+from __future__ import annotations
+
+import json
+
+from conftest import fixture_path
+
+import rac.services.okf_conformance as okf_mod
+from rac.cli import main
+from rac.core.corpus import walk_corpus
+from rac.services.okf_conformance import (
+    CODE_RESERVED_FILENAME,
+    CODE_UNMAPPED_TYPE,
+    check_okf_conformance,
+)
+
+
+def _report(*parts):
+    directory = fixture_path(*parts)
+    entries = list(walk_corpus(directory))
+    return check_okf_conformance(directory, entries)
+
+
+def codes(report):
+    return {f.code for f in report.findings}
+
+
+# --- golden -----------------------------------------------------------------
+
+
+def test_clean_corpus_is_conformant():
+    report = _report("okf_conformance", "clean")
+    assert report.ok
+    assert report.findings == []
+    # The typed decision is checked; the untyped document is excluded (ADR-010).
+    assert report.artifacts_checked == 1
+
+
+def test_real_corpus_is_okf_conformant():
+    # Release A exit criterion: a RAC repository passes OKF v0.1 conformance.
+    entries = list(walk_corpus("rac"))
+    report = check_okf_conformance("rac", entries)
+    assert report.ok, [f.to_dict() for f in report.findings]
+    assert report.artifacts_checked > 0
+
+
+def test_every_corpus_artifact_satisfies_rac_core():
+    # Release A exit criterion: every existing RAC artifact validates against the
+    # rac-core frontmatter envelope. In RAC's idiom the envelope is optional but
+    # validated-when-present (ADR-025): legacy artifacts without frontmatter stay
+    # valid (ADR-010), and any present envelope must parse clean (no metadata
+    # issues). This is what "validates against rac-core" means here — not the
+    # mandatory-id/type/title shape the brief illustrated.
+    for entry in walk_corpus("rac"):
+        assert entry.product.metadata_issues == [], (
+            entry.path,
+            entry.product.metadata_issues,
+        )
+
+
+# --- adversarial ------------------------------------------------------------
+
+
+def test_typed_artifact_at_reserved_filename_is_flagged():
+    report = _report("okf_conformance", "reserved_collision")
+    assert not report.ok
+    assert CODE_RESERVED_FILENAME in codes(report)
+    finding = next(f for f in report.findings if f.code == CODE_RESERVED_FILENAME)
+    assert finding.path.endswith("index.md")
+    assert "index.md" in finding.message
+
+
+def test_registered_type_without_okf_mapping_is_flagged(monkeypatch):
+    # Simulate a future type registered without an OKF mapping: the bundle would
+    # silently drop it, so conformance must flag it instead.
+    trimmed = {k: v for k, v in okf_mod.OKF_TYPE.items() if k != "decision"}
+    monkeypatch.setattr(okf_mod, "OKF_TYPE", trimmed)
+    report = _report("okf_conformance", "clean")
+    assert not report.ok
+    assert CODE_UNMAPPED_TYPE in codes(report)
+    finding = next(f for f in report.findings if f.code == CODE_UNMAPPED_TYPE)
+    assert "decision" in finding.message
+
+
+# --- negative boundary (ADR-010) --------------------------------------------
+
+
+def test_untyped_reserved_entry_point_is_not_flagged():
+    report = _report("okf_conformance", "reserved_ok")
+    assert report.ok
+    assert report.artifacts_checked == 0  # the untyped index.md is excluded
+
+
+# --- CLI end-to-end ---------------------------------------------------------
+
+
+def test_cli_reports_conformant_corpus(capsys):
+    rc = main(["validate", fixture_path("okf_conformance", "clean")])
+    assert rc == 0
+    assert "OKF v0.1: conformant." in capsys.readouterr().out
+
+
+def test_cli_fails_on_reserved_filename_collision(capsys):
+    rc = main(["validate", fixture_path("okf_conformance", "reserved_collision")])
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert CODE_RESERVED_FILENAME in out
+    assert "OKF conformance" in out
+
+
+def test_cli_json_carries_okf_section(capsys):
+    rc = main(["validate", fixture_path("okf_conformance", "reserved_collision"), "--json"])
+    assert rc == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["valid"] is False
+    assert payload["okf"]["conformant"] is False
+    assert payload["okf"]["findings"][0]["code"] == CODE_RESERVED_FILENAME
+
+
+def test_cli_json_clean_corpus_okf_conformant(capsys):
+    rc = main(["validate", fixture_path("okf_conformance", "clean"), "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["okf"] == {"conformant": True, "artifacts_checked": 1, "findings": []}


### PR DESCRIPTION
# Summary

Implements `rac/roadmaps/v0.15.x-interop/v0.15.1-okf-conformance-check.md`.

Makes OKF v0.1 conformance a write-time gate in `rac validate`, instead of a
side-effect that only appeared on `rac export --okf`. ADR-048 requires every RAC
repository to be a conformant OKF bundle and ADR-049 requires that to be
enforced; until now nothing failed CI when a corpus could not produce a
conformant bundle.

Adds:
- A repository-level OKF conformance check folded into the directory form of
  `rac validate`.
- An additive `okf` section in the directory-validate JSON, a human `OKF v0.1:`
  summary line, and conformance participation in the exit code.
- ADR-052 recording that `rac-core` is the code-defined OKF-superset frontmatter
  envelope (not a JSON Schema file), plus golden/adversarial/boundary tests,
  fixtures, and docs.

# Roadmap / ADR Trace

Roadmap:
- `rac/roadmaps/v0.15.x-interop/v0.15.1-okf-conformance-check.md`

Relevant ADRs:
- `rac/decisions/adr-052-rac-core-okf-superset-conformance.md` (new)
- `rac/decisions/adr-048-okf-carrier-profile.md` (conformance requirement)
- `rac/decisions/adr-049-enforcement-is-the-product.md` (enforce, don't just emit)
- `rac/decisions/adr-050-okf-frontmatter-superset.md`, `adr-010`, `adr-025`,
  `adr-045` (the boundaries this change deliberately respects)
- `rac/decisions/adr-007-json-contract-stability.md` (additive JSON)

# Scope

## Included
- `check_okf_conformance(directory, entries)` over a corpus snapshot, reporting,
  per typed artifact: `okf-unmapped-type` (a `type` with no OKF mapping) and
  `okf-reserved-filename-collision` (a typed artifact named `index.md`/`log.md`).
- The directory form of `rac validate` runs the check, surfaces it in human +
  JSON output, and fails the exit code when the corpus is not conformant.
- The RAC-to-OKF type map and OKF reserved filenames lifted into
  `rac/core/okf.py`, shared by the bundle export and the conformance check.

## Excluded (deliberate)
- No JSON Schema 2020-12 `rac-core` file, no `allOf` composition, no custom
  schema dialects, no new schema-validation dependency (ADR-052).
- No mandatory frontmatter `type`/`title`, no stored timestamps, no corpus
  codemod — these conflict with ADR-010, ADR-025, ADR-045, ADR-050.
- Untyped documents are not checked or failed (ADR-010); they are excluded from
  the OKF bundle and from conformance.
- Referential integrity (whether links resolve) stays with
  `rac relationships --validate`; it is not duplicated here.
- No new MCP tool; the four read-only tools are untouched.

# Product / Architecture Decisions

- `rac-core` is documented as the existing code-defined frontmatter envelope
  (`schema_version`/`id`/`type`/`relationships`/`tags`), a strict superset of
  OKF's reserved fields. "Validates against rac-core" means the envelope, when
  present, parses clean; legacy artifacts without frontmatter stay valid. This
  was chosen over an authoritative JSON Schema because the envelope is already
  enforced in code and the literal JSON-Schema/mandatory-field path collides
  with five recorded ADRs; ADR-052 records the trade-off.
- Conformance is checked on the same corpus snapshot directory validation
  already walks (one walk, ADR-002 determinism), so it adds no second traversal.
- The directory-validate JSON gains an additive `okf` key rather than a new
  command or a `schema_version` bump (ADR-007).
- The unmapped-type code exists to guard future type additions: a sixth artifact
  type added without an OKF mapping fails conformance with a file-named
  diagnostic instead of being silently dropped from the bundle.

# User-Facing Contract

## CLI
No new command or flag. Running `rac validate` against a directory now also
reports OKF conformance.

## Human Output
The directory summary line gains a clause, e.g.
`... 170 valid, 0 invalid. OKF v0.1: conformant.` A non-conformant corpus lists
each finding as a `FAIL ... (OKF conformance)` block with the code, path, and a
fix hint, and the run prints `OKF v0.1: N conformance issue(s).`

## JSON Output
Additive top-level `okf` object on directory `rac validate --json`, with fields
`conformant` (bool), `artifacts_checked` (int), and `findings` (a list of
`code`/`path`/`message` objects). Existing keys (`schema_version`, `summary`,
`valid`, `files`) are unchanged. Single-file `rac validate` output is unchanged
(no corpus, no conformance pass).

## Exit Codes
- `0`: every artifact valid and the corpus OKF-conformant
- `1`: any invalid artifact or any OKF conformance finding
- `2`: usage / IO error (unchanged)

# Verification

## Ran
- `rac validate rac/` reports `OKF v0.1: conformant.`, exit 0 (170 typed
  artifacts checked, 15 untyped documents skipped).
- `rac validate tests/fixtures/okf_conformance/reserved_collision/` exits 1 with
  `okf-reserved-filename-collision`.
- `rac relationships rac/ --validate` reports 0 issues (615 relationships).
- `rac review rac/` reports health 88/100, no priority 1-2 findings.
- `pytest` reports 1117 passed in the non-TUI suite plus 105 explorer tests
  passing; 10 new conformance tests; `validate_dir` goldens refreshed.
- `ruff check` / `ruff format --check` clean on all changed files.

## Covered
- Golden: `tests/fixtures/okf_conformance/clean/` (typed artifact + untyped
  document) and the real `rac/` corpus both report conformant.
- Adversarial: typed `index.md` triggers `okf-reserved-filename-collision`; a
  type whose OKF mapping is removed triggers `okf-unmapped-type`.
- Boundary: an untyped `index.md` entry point and untyped documents are not
  flagged (`artifacts_checked == 0`).
- Contract: rac-core envelope assertion over the whole corpus; CLI human + JSON
  asserted for both conformant and non-conformant corpora.

# Review Path

1. `src/rac/core/okf.py` — shared type map + reserved filenames.
2. `src/rac/services/okf_conformance.py` — the check and its report shape.
3. `src/rac/services/validate.py` — how conformance folds into `ok`/`to_dict`.
4. `src/rac/output/human.py` — the human conformance rendering.
5. `rac/decisions/adr-052-*.md` and `rac/roadmaps/.../v0.15.1-*.md`.
6. `tests/test_okf_conformance.py`, `tests/fixtures/okf_conformance/`, goldens,
   CI battery entry; `docs/okf-profile.md` and `CHANGELOG.md`.

# Notes For Reviewer

- One pre-existing test, `tests/test_hook.py::test_post_commit_hook_is_advisory_and_runs`,
  is environment-dependent (it shells out to the installed `rac` console script);
  it is unrelated to this change.
- `rac/decisions/adr-035-byo-ai-credentials.md` is the one typed artifact with no
  frontmatter block (legacy form, valid per ADR-025); the rac-core test treats a
  present envelope as the contract, so this stays valid rather than forcing a
  backfill. A follow-up could add its frontmatter, but that is out of scope here.

# Implementation Process

Implemented with AI assistance under the v0.15.1 roadmap contract; final scope,
the decision to take the repo-idiomatic path over the literal JSON-Schema
rebuild (ADR-052), review, and acceptance were the maintainer's.