### PR TITLE
feat(validate): severity overrides + SARIF output [roadmap:v0.15.2]

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,7 +56,7 @@ jobs:
         # enforced by tests/test_ci_batteries.py in the core battery.
         battery:
           - name: core
-            paths: "tests/test_validate.py tests/test_okf_conformance.py tests/test_parser.py tests/test_schema.py tests/test_identity.py tests/test_frontmatter.py tests/test_metadata_identity.py tests/test_idgen.py tests/test_ci_batteries.py tests/test_corpus.py tests/test_operations.py"
+            paths: "tests/test_validate.py tests/test_okf_conformance.py tests/test_overrides.py tests/test_sarif.py tests/test_parser.py tests/test_schema.py tests/test_identity.py tests/test_frontmatter.py tests/test_metadata_identity.py tests/test_idgen.py tests/test_ci_batteries.py tests/test_corpus.py tests/test_operations.py"
           - name: cli
             paths: "tests/test_cli.py"
           - name: compare

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ details, release history over commit history.
 
 ### Added
 
+- Validation severity overrides + SARIF output (v0.15.2): a repository may declare
+  an optional `validation` section in its committed `.rac/config.yaml` to downgrade
+  or silence findings — per rule code (`error|warning|off`) and per artifact type
+  (`error|warning` ceiling), with the per-rule entry winning over the type ceiling.
+  This makes warnings-first onboarding possible: a team can point `rac validate` at
+  a legacy repo, keep CI green, and tighten the gate over time. Overrides apply to
+  `rac validate` only (review/watchkeeper/portfolio are unchanged); an absent
+  section is a no-op, so the default gate stays strict. Also adds
+  `rac validate <dir> --sarif`, emitting a deterministic, offline SARIF 2.1.0
+  document (core validation + OKF conformance findings) for GitHub Code Scanning;
+  `--sarif` is mutually exclusive with `--json` and applies to directory validation.
+
 - OKF v0.1 conformance check (v0.15.1): `rac validate <dir>` now enforces OKF
   conformance as a write-time gate, not just on export. It reports, per typed
   artifact, `okf-unmapped-type` (a `type` with no OKF mapping) and

--- a/docs/examples/rac-validate.sarif.json
+++ b/docs/examples/rac-validate.sarif.json
@@ -1,0 +1,98 @@
+{
+  "version": "2.1.0",
+  "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "rac",
+          "informationUri": "https://github.com/tcballard/requirements-as-code",
+          "version": "0.15.2",
+          "rules": [
+            {
+              "id": "ambiguous-verb"
+            },
+            {
+              "id": "invalid-decision-status"
+            },
+            {
+              "id": "missing-risks"
+            },
+            {
+              "id": "missing-success-metrics"
+            }
+          ]
+        }
+      },
+      "results": [
+        {
+          "ruleId": "invalid-decision-status",
+          "level": "error",
+          "message": {
+            "text": "## Status value 'Draft' is not one of: Proposed, Accepted, Superseded, Deprecated."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "rac/decisions/adr-bad-status.md"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "missing-risks",
+          "level": "warning",
+          "message": {
+            "text": "No ## Risks section (optional, but recommended)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "rac/requirements/feature.md"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "missing-success-metrics",
+          "level": "warning",
+          "message": {
+            "text": "No ## Success Metrics section (optional, but recommended)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "rac/requirements/feature.md"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "ambiguous-verb",
+          "level": "warning",
+          "message": {
+            "text": "REQ-001 uses ambiguous verb(s) (support); be more specific."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "rac/requirements/feature.md"
+                },
+                "region": {
+                  "startLine": 7
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -1,0 +1,76 @@
+# Validation: overrides & SARIF
+
+`rac validate` is RAC's write-time gate: it fails when any artifact carries an
+error-severity finding, and (over a directory) when the corpus is not a
+conformant OKF v0.1 bundle. Two features make that gate adoptable in CI on a
+real, pre-existing repository.
+
+## Severity overrides (warnings-first onboarding)
+
+Pointing `rac validate` at a legacy corpus for the first time can surface many
+pre-existing findings at once. Rather than fail the build on all of them, a
+repository can downgrade or silence specific findings in its committed
+`.rac/config.yaml`, then tighten the gate over time. The decision behind this is
+[ADR-053](https://github.com/tcballard/requirements-as-code/blob/main/rac/decisions/adr-053-validation-severity-overrides.md).
+
+Add an optional `validation` section:
+
+```yaml
+repository_key: RAC
+
+validation:
+  rules:                 # rule code -> error | warning | off
+    ambiguous-verb: off
+    too-many-requirements: warning
+  types:                 # artifact type -> error | warning  (a ceiling)
+    roadmap: warning
+```
+
+- **`rules`** sets a finding's severity by its stable code (the `[code]` shown in
+  `rac validate` output, e.g. `invalid-decision-status`). `off` suppresses the
+  finding entirely.
+- **`types`** caps a whole artifact type at `error` or `warning`. A `warning`
+  ceiling downgrades that type's errors so they no longer fail the run.
+- **Precedence:** a per-rule entry is more specific and **wins** over the
+  per-type ceiling — so a downgraded type can still force one rule back to
+  `error`.
+
+The config is committed and versioned, so CI and every teammate share the same
+policy (a per-developer file would not keep CI green). Determinism holds: the
+same corpus *and config* yield the same findings and exit code. An absent
+`validation` section is a pure no-op — the default gate is strict.
+
+Overrides apply to `rac validate` only; `rac review`, `rac watchkeeper`, and
+`rac portfolio` report the corpus as authored.
+
+A typical onboarding path: start by capping noisy types to `warning`, get CI
+green, then remove entries (or restore `error`) rule-by-rule as the corpus is
+cleaned up.
+
+## SARIF output for GitHub Code Scanning
+
+`rac validate <dir> --sarif` emits a [SARIF 2.1.0](https://json-schema.org/)
+document covering core validation findings and OKF conformance findings, so a CI
+job can upload it and have GitHub Code Scanning annotate findings inline on a
+pull request. The decision behind this is
+[ADR-054](https://github.com/tcballard/requirements-as-code/blob/main/rac/decisions/adr-054-sarif-validation-output.md).
+
+```bash
+rac validate rac/ --sarif > rac.sarif
+```
+
+- `--sarif` is mutually exclusive with `--json`, and applies to directory
+  validation only (single-file `--sarif` is a usage error).
+- Severity maps to the SARIF `level` (`error`/`warning`); suppressed (`off`)
+  findings never appear. A finding's line becomes a `region` when known.
+- Output is deterministic and offline: results are sorted, no timestamps are
+  emitted, and the same corpus state produces a byte-identical document.
+
+The exit code is unchanged by the output format: `rac validate` still exits `1`
+when an error-severity finding remains after overrides, and `0` otherwise.
+
+## See also
+
+- [CLI Reference](cli.md) — all `rac validate` flags and exit codes.
+- [OKF Profile](okf-profile.md) — the conformance findings SARIF also reports.
+- [Repository Workflow](repo-workflow.md) — `rac init` and `.rac/config.yaml`.

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -69,6 +69,11 @@ rac validate rac/ --sarif > rac.sarif
 The exit code is unchanged by the output format: `rac validate` still exits `1`
 when an error-severity finding remains after overrides, and `0` otherwise.
 
+A worked example of the output is checked in at
+[`docs/examples/rac-validate.sarif.json`](examples/rac-validate.sarif.json): one
+`error` (an out-of-enum decision status), two recommended-section `warning`s, and
+a line-anchored `ambiguous-verb` finding (note the `region.startLine`).
+
 ## See also
 
 - [CLI Reference](cli.md) — all `rac validate` flags and exit codes.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,6 +34,7 @@ nav:
   - Watchkeeper: watchkeeper.md
   - Artifacts: artifacts.md
   - Relationships: relationships.md
+  - Validation: validation.md
   - OKF Profile: okf-profile.md
   - Repository Workflow: repo-workflow.md
   - Examples: examples.md

--- a/rac/decisions/adr-053-validation-severity-overrides.md
+++ b/rac/decisions/adr-053-validation-severity-overrides.md
@@ -1,0 +1,125 @@
+---
+schema_version: 1
+id: RAC-KV3SME4EAE84
+type: decision
+tags: [validation, enforcement, onboarding, config]
+---
+# ADR-053: Validation Severity Overrides via .rac/config.yaml (Warnings-First Onboarding)
+
+## Status
+
+Proposed
+
+## Category
+
+Architecture
+
+## Context
+
+RAC's validation severities are fixed in code: each rule emits `error` or
+`warning`, and a directory `rac validate` fails when any artifact carries an
+error (ADR-049 makes that gate the product). That is correct for a corpus RAC
+grew with, but hostile to adoption: a team pointing `rac validate` at a legacy
+repository for the first time is failed on hundreds of pre-existing findings at
+once. The brief that scopes this series makes *warnings-first onboarding* a
+requirement — a team must be able to start with findings as warnings and tighten
+the gate over time.
+
+RAC already has a committed, discoverable repository config — `.rac/config.yaml`,
+established by `rac init` and resolved by `load_repository_config` (ADR-026). The
+question is how to express per-repository severity policy without (a) loosening
+the default gate, (b) breaking determinism (ADR-002), or (c) drifting toward the
+custom-type JSON-Schema registry ADR-052 deferred.
+
+## Decision
+
+1. **A `validation` section in `.rac/config.yaml`** carries optional severity
+   overrides. It is committed and versioned, so CI and every teammate share the
+   same policy — a per-developer local file would not keep CI green and is not
+   offered.
+
+   ```yaml
+   validation:
+     rules:                 # rule code -> error | warning | off
+       ambiguous-verb: off
+       too-many-requirements: warning
+     types:                 # artifact type -> error | warning  (a ceiling)
+       roadmap: warning
+   ```
+
+2. **Two granularities.** A per-rule-code entry sets a finding's severity by its
+   stable code (`error`/`warning`/`off`); a per-type entry caps a whole artifact
+   type at `error` or `warning`. `off` (rule-only) suppresses the finding.
+
+3. **Precedence: rule beats type.** A per-type `warning` ceiling downgrades that
+   type's `error` findings to `warning`; a per-rule-code entry is more specific
+   and wins, so a downgraded type can still force one rule back to `error`. This
+   is a pure post-processing pass (`rac.core.overrides.apply_overrides`) applied
+   before status and exit code are computed, so a downgraded type or rule keeps
+   the run green.
+
+4. **Scope: the `rac validate` entrypoints only.** Overrides apply to directory
+   and single-file `rac validate` (core findings and OKF conformance findings,
+   which gain a `severity`). The repository model behind `review`, `watchkeeper`,
+   and `portfolio` is unchanged (it validates with no overrides), so those
+   surfaces keep reporting the corpus as authored.
+
+5. **Determinism preserved (ADR-002).** The overrides live in a committed file,
+   so the same repository state yields the same findings and exit code. Malformed
+   shapes or unknown severity values are a hard error
+   (`MalformedRepositoryConfig`), never silently ignored. (YAML resolves the bare
+   word `off` to a boolean; the loader coerces it back so authors need not quote
+   it.)
+
+6. **Not a registry or a dialect.** This is a flat, hand-managed severity map —
+   not a JSON-Schema vocabulary and not the custom-type registry ADR-052 defers.
+   The per-type knob keys on any type string, so it is forward-compatible with a
+   future custom-type registry without anticipating one.
+
+## Consequences
+
+### Positive
+
+- Warnings-first onboarding: a team can adopt RAC on a legacy repo with CI green
+  from day one, then tighten the gate rule-by-rule or type-by-type.
+- Policy is shared and reviewable (committed config), not per-developer drift.
+- Reuses the existing config file and discovery walk; no new file, no dependency.
+
+### Negative
+
+- Validation severity is now influenced by repository config, so reproducing a
+  result requires the `.rac/config.yaml` as well as the artifacts. Mitigated: the
+  config is committed and versioned, so determinism holds.
+- A team could over-suppress and hollow out the gate. Mitigated: overrides are
+  visible in the committed config and in `rac validate` output; the default
+  (no `validation` section) is the strict gate.
+
+### Neutral
+
+- `review`/`watchkeeper`/`portfolio` deliberately ignore overrides; whether they
+  should honour them is a separate, later decision.
+
+## Alternatives Considered
+
+- **A per-developer, git-ignored local override file.** Rejected: it would not
+  keep CI green for the team, which is the whole point of warnings-first.
+- **A new dedicated `.rac/overrides.cfg` file.** Rejected: a second config file
+  and parser for no benefit over a section in the existing `.rac/config.yaml`.
+- **A global `--strict`/`--lenient` flag instead of config.** Rejected: too
+  coarse (no per-rule/per-type control) and not shared with CI by default.
+- **Per-rule severity baked into a custom-type JSON-Schema registry.** Rejected:
+  that is the machinery ADR-052 deferred; overrides need none of it.
+
+## Related Decisions
+
+- ADR-049
+- ADR-052
+- ADR-026
+- ADR-002
+- ADR-007
+- ADR-010
+
+## Related Requirements
+
+- rac-cross-artifact-enforcement
+- rac-growth-adoption

--- a/rac/decisions/adr-054-sarif-validation-output.md
+++ b/rac/decisions/adr-054-sarif-validation-output.md
@@ -1,0 +1,98 @@
+---
+schema_version: 1
+id: RAC-KV3SME4ESBPA
+type: decision
+tags: [validation, ci, interop, output]
+---
+# ADR-054: SARIF as a Derived Validation Output for CI Code Scanning
+
+## Status
+
+Proposed
+
+## Category
+
+Architecture
+
+## Context
+
+RAC's enforcement is the product (ADR-049), but its only machine output is the
+JSON validation contract (ADR-007), which GitHub's PR review surface does not
+render natively. The Static Analysis Results Interchange Format (SARIF 2.1.0) is
+the format GitHub Code Scanning ingests to annotate findings inline on a pull
+request diff — the distribution surface a CI-enforced validator needs to be
+visible where review happens.
+
+RAC's findings are already SARIF-shaped: a core `Issue` carries a stable `code`,
+a `severity`, a `message`, and an optional `line`, anchored to a file path; OKF
+conformance findings carry a code, path, message, and (after ADR-053) a severity.
+What is missing is a renderer and a CLI surface.
+
+## Decision
+
+1. **`rac validate <dir> --sarif`** emits a SARIF 2.1.0 document for the corpus,
+   covering both core validation findings and OKF conformance findings in one
+   run (`tool.driver.name = "rac"`). It is mutually exclusive with `--json`.
+   SARIF is a repository-scan artifact; there is no single-file SARIF surface
+   (single-file `--sarif` is a usage error).
+
+2. **A derived contract, parallel to JSON (ADR-007).** SARIF is a presentation of
+   the same `DirectoryValidation` result, never a new source of truth. Severity
+   maps to SARIF `level` (`error`/`warning`); a finding's `line` becomes a
+   `region` when present, omitted for file-level findings; suppressed (`off`)
+   findings — already dropped by the override pass (ADR-053) — never appear.
+
+3. **Deterministic and offline (ADR-002).** Results are sorted by
+   `(uri, startLine, ruleId, message)`, the declared `rules` are the sorted set
+   of observed codes, and no timestamps are emitted, so the same corpus state
+   yields a byte-identical document. The only build-derived field is the tool
+   version, which reflects the installed package.
+
+4. **Emission here, upload later.** This decision delivers valid SARIF emission.
+   Wrapping it in a GitHub Action that uploads the file and annotates the PR is a
+   later, separately scoped piece of work; relationship-validation SARIF is
+   likewise deferred (the relationship report is a distinct model).
+
+## Consequences
+
+### Positive
+
+- RAC findings can be surfaced inline on a PR by GitHub Code Scanning, making the
+  write-time gate visible where reviewers work.
+- Reuses existing finding data with no model change beyond ADR-053's severity on
+  OKF findings; no new dependency.
+
+### Negative
+
+- SARIF is a second machine-output surface to keep stable as findings evolve.
+  Mitigated: it is a thin, derived projection with deterministic ordering and
+  structural tests.
+
+### Neutral
+
+- Relationship-validation findings and the GitHub Action wrapper are out of scope
+  here and tracked separately.
+
+## Alternatives Considered
+
+- **GitHub workflow-command annotations (`::error file=...`) instead of SARIF.**
+  Rejected as the contract: ephemeral, not stored as code-scanning alerts, and
+  log-scoped. RAC already has a workflow-annotation path for watchkeeper; SARIF
+  is the durable, reviewable surface.
+- **Extend the JSON contract instead of adding SARIF.** Rejected: GitHub does not
+  ingest RAC's JSON; SARIF is the lingua franca for code scanning.
+- **A single combined output for validate + relationships.** Deferred: the
+  relationship report is a separate model; folding it in is future work.
+
+## Related Decisions
+
+- ADR-049
+- ADR-007
+- ADR-053
+- ADR-002
+- ADR-048
+
+## Related Requirements
+
+- rac-cross-artifact-enforcement
+- rac-growth-adoption

--- a/rac/roadmaps/v0.15.x-interop/v0.15.2-validation-overrides-and-sarif.md
+++ b/rac/roadmaps/v0.15.x-interop/v0.15.2-validation-overrides-and-sarif.md
@@ -1,0 +1,144 @@
+---
+schema_version: 1
+id: RAC-KV3SME4EYF2E
+type: roadmap
+tags: [validation, ci, onboarding, interop]
+---
+# RAC v0.15.2 — Validation Severity Overrides + SARIF Output
+
+## Status
+
+Planned
+
+## Context
+
+ADR-049 makes the write-time validation gate RAC's product, but two things keep
+it from being adoptable in CI on a real repository. First, severities are fixed
+in code, so a team pointing `rac validate` at a legacy corpus is failed on
+hundreds of pre-existing findings at once — there is no warnings-first onramp.
+Second, RAC emits only its JSON contract, which GitHub's PR surface does not
+render, so findings are invisible where review happens.
+
+This milestone delivers both, in RAC's idiom and without the custom-type
+JSON-Schema registry ADR-052 deferred: a `validation` section in the committed
+`.rac/config.yaml` for per-rule and per-type severity overrides (ADR-053), and a
+`rac validate --sarif` output for GitHub Code Scanning (ADR-054).
+
+## Outcomes
+
+- A repository may downgrade or suppress findings — per rule code and per
+  artifact type — via `.rac/config.yaml`, so CI can be green from day one and
+  tightened over time. Default behaviour (no `validation` section) is unchanged.
+- `rac validate <dir> --sarif` emits a deterministic, offline SARIF 2.1.0
+  document covering core validation and OKF conformance findings.
+- `review`, `watchkeeper`, and `portfolio` are unchanged; overrides scope to the
+  `rac validate` entrypoints only.
+
+## Initiatives
+
+### Initiative 1 — Severity override model and loader
+
+Add `rac.core.overrides` (the pure `SeverityOverrides` model, `resolve_severity`,
+`apply_overrides`) and a `load_overrides` reader on `.rac/config.yaml` (reusing
+the discovery walk extracted as `find_config_file`). Precedence: per-type ceiling
+first, per-rule-code wins; `off` suppresses. Malformed shapes are a hard error.
+
+### Initiative 2 — Thread overrides through validate
+
+`validate_directory` loads the repository's overrides and applies them to each
+file's findings and to OKF conformance (OKF findings gain a `severity`), before
+status and exit code are computed. Single-file `rac validate` applies overrides
+discovered from the file's directory. `validate_corpus` defaults to no overrides
+so the repository model behind review/watchkeeper/portfolio is unchanged.
+
+### Initiative 3 — SARIF output
+
+Add `rac.output.sarif.render_validate_sarif` and a `--sarif` flag (mutually
+exclusive with `--json`) emitting SARIF 2.1.0 for directory validation. Severity
+maps to `level`; line to `region` when present; results sorted deterministically;
+no timestamps. Single-file `--sarif` is a usage error.
+
+### Initiative 4 — Coverage and docs
+
+Unit tests (precedence, suppression, the YAML `off` coercion, malformed-config
+errors), end-to-end `rac validate` tests (downgrade keeps CI green, rule beats
+type ceiling, OKF finding downgradable), and SARIF structural + determinism
+tests. Register the new test files in the CI battery (ADR-027). Document the
+`validation` config section and `--sarif`; add a CHANGELOG entry.
+
+## Constraints
+
+- Additive (ADR-007): the directory `validate` JSON gains no breaking change; an
+  absent `validation` section is a pure no-op; existing codes and exit semantics
+  are unchanged when no overrides are declared.
+- Determinism (ADR-002): overrides live in a committed file; SARIF is
+  byte-identical for a given corpus state and build.
+- ADR-052: no JSON-Schema custom-type registry, no `allOf`, no schema dependency.
+- ADR-049: the default gate is not loosened; overrides are an explicit,
+  committed, reviewable opt-in.
+
+## Non-Goals
+
+- A custom-type registry or repo-local schema files (ADR-052; deferred).
+- Relationship-validation overrides or relationship SARIF (different report
+  model; a later decision).
+- A GitHub Action wrapper that uploads SARIF and annotates the PR (later work).
+- Overrides influencing `review`/`watchkeeper`/`portfolio`.
+
+## Implementation Contract
+
+Pinned for v0.15.2.
+
+### Behaviour
+
+- `validation.rules` maps a rule code to `error|warning|off`; `validation.types`
+  maps an artifact type to `error|warning`. Per-rule wins over the per-type
+  ceiling; `off` suppresses. Unknown values raise `MalformedRepositoryConfig`.
+- `rac validate <dir>` applies overrides before computing the exit code, so a
+  downgraded type/rule keeps the run green. Single-file `rac validate` applies
+  overrides from the file's directory.
+- `rac validate <dir> --sarif` emits SARIF 2.1.0 (core + OKF findings),
+  deterministic and offline; `--sarif` with a file or `-` is a usage error.
+
+### Interface
+
+- New `--sarif` flag on `validate`, mutually exclusive with `--json`. No other
+  CLI surface change. `.rac/config.yaml` gains an optional `validation` section.
+
+## Success Measures
+
+- A corpus that fails `rac validate` by default exits 0 once a type or rule is
+  downgraded in `.rac/config.yaml`, and the change is visible in the committed
+  config.
+- `rac validate rac/` is unchanged (the repo declares no overrides).
+- `rac validate <fixture> --sarif` produces valid SARIF that re-renders
+  byte-identically.
+
+## Risks
+
+- Teams could over-suppress and hollow out the gate. Mitigated: overrides are
+  committed, reviewable, and shown in output; the default is the strict gate.
+- SARIF is a second machine surface to keep stable. Mitigated: it is a thin
+  derived projection with deterministic ordering and structural tests.
+
+## Assumptions
+
+- `.rac/config.yaml` (ADR-026) remains the repository config home.
+- The five artifact types and their rule codes remain the validation surface;
+  the per-type knob keys on any type string for forward compatibility.
+
+## Related Decisions
+
+- adr-053
+- adr-054
+- adr-052
+- adr-049
+
+## Related Requirements
+
+- rac-cross-artifact-enforcement
+- rac-growth-adoption
+
+## Related Roadmaps
+
+- v0.15.1-okf-conformance-check

--- a/src/rac/cli.py
+++ b/src/rac/cli.py
@@ -1,7 +1,7 @@
 """Command-line interface for RAC.
 
 Commands:
-    rac validate <file.md | dir | -> [--json] [--top-level]
+    rac validate <file.md | dir | -> [--json | --sarif] [--top-level]
     rac diff <old.md> <new.md> [--json]
     rac stats <directory> [--json]
     rac ingest <file> [-o OUT | --stdout] [--force] [--json]
@@ -75,7 +75,7 @@ from pathlib import Path
 
 from rac import consent
 from rac import output as outputs
-from rac.core.classification import score_artifacts
+from rac.core.classification import classify, score_artifacts
 from rac.core.hooks import (
     DEFAULT_STYLE,
     HookNotFound,
@@ -85,6 +85,7 @@ from rac.core.hooks import (
 )
 from rac.core.markdown import parse, parse_file
 from rac.core.models import Product
+from rac.core.overrides import apply_overrides
 from rac.core.schema import available_schemas, schema_reference
 from rac.core.skills import SkillNotFound, SkillResourceMissing, skill_specs
 from rac.core.templates import (
@@ -113,6 +114,7 @@ from rac.services.init import (
     MalformedRepositoryConfig,
     RepositoryKeyConflict,
     init_repository,
+    load_overrides,
 )
 from rac.services.inspect import build_inspection, inspect_directory
 from rac.services.migrate import migrate_metadata
@@ -170,14 +172,23 @@ def cmd_validate(args: argparse.Namespace) -> int:
     # legacy requirement fallback applies only to explicit single-file input.
     if args.file != "-" and Path(args.file).is_dir():
         result = validate_directory(args.file, recursive=not args.top_level)
-        if args.json:
+        if args.sarif:
+            print(outputs.render_validate_sarif(result))
+        elif args.json:
             print(outputs.render_validate_dir_json(result))
         else:
             print(outputs.render_validate_dir_human(result))
         return EXIT_OK if result.ok else EXIT_VALIDATION_FAILED
 
+    if args.sarif:
+        # SARIF is a repository-scan artifact for CI code scanning (ADR-054);
+        # there is no single-file SARIF surface.
+        print("rac: --sarif applies to directory validation", file=sys.stderr)
+        raise SystemExit(EXIT_USAGE)
+
     product = _read_validate_input(args.file)
-    issues = validate(product)
+    start = "." if args.file == "-" else str(Path(args.file).parent)
+    issues = apply_overrides(validate(product), classify(product).type, load_overrides(start))
     if args.json:
         print(outputs.render_validation_json(product, issues))
     else:
@@ -879,8 +890,14 @@ def build_parser() -> argparse.ArgumentParser:
         "file",
         help="A Markdown artifact file, a directory, or '-' to read from stdin.",
     )
-    p_validate.add_argument(
+    p_validate_format = p_validate.add_mutually_exclusive_group()
+    p_validate_format.add_argument(
         "--json", action="store_true", help="Emit JSON instead of human-readable text."
+    )
+    p_validate_format.add_argument(
+        "--sarif",
+        action="store_true",
+        help="Emit SARIF 2.1.0 for GitHub Code Scanning (directory validation only).",
     )
     p_validate.add_argument(
         "--top-level",

--- a/src/rac/core/overrides.py
+++ b/src/rac/core/overrides.py
@@ -1,0 +1,88 @@
+"""Validation severity overrides — warnings-first onboarding (ADR-053).
+
+A team adopting RAC on a legacy repository should not have CI fail on hundreds of
+pre-existing findings. A repository may declare an optional ``validation`` section
+in the committed ``.rac/config.yaml`` to downgrade or silence specific findings —
+per rule code and per artifact type — so the gate can be tightened over time
+rather than all at once. The loader lives in :mod:`rac.services.init` (which owns
+``.rac/config.yaml``); this module is the pure model and application logic.
+
+Determinism (ADR-002) is preserved: the overrides live in a committed, versioned
+file, so the same repository state yields the same findings and exit code. This
+is *not* a JSON-Schema dialect or a custom-type registry (ADR-052 defers those);
+it is a flat, hand-managed severity map applied as a pure post-processing pass.
+
+Config shape::
+
+    validation:
+      rules:                 # rule code -> error | warning | off
+        ambiguous-verb: off
+        too-many-requirements: warning
+      types:                 # artifact type -> error | warning  (a ceiling)
+        roadmap: warning
+
+Precedence: a per-type ``warning`` ceiling downgrades that type's ``error``
+findings to ``warning``; a per-rule-code entry is more specific and wins over the
+ceiling (so a downgraded type can still force one rule back to ``error``).
+``off`` suppresses the finding entirely.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+from typing import cast
+
+from .models import Issue, Severity
+
+# Severities a rule may be mapped to; ``off`` suppresses the finding.
+RULE_VALUES = ("error", "warning", "off")
+# A whole type may be capped to error/warning, but not silenced wholesale.
+TYPE_VALUES = ("error", "warning")
+
+
+@dataclass(frozen=True)
+class SeverityOverrides:
+    """Per-rule and per-type severity overrides from ``.rac/config.yaml``."""
+
+    rules: dict[str, str] = field(default_factory=dict)
+    types: dict[str, str] = field(default_factory=dict)
+
+    @property
+    def is_empty(self) -> bool:
+        return not self.rules and not self.types
+
+
+EMPTY = SeverityOverrides()
+
+
+def resolve_severity(base: str, code: str, artifact_type: str, overrides: SeverityOverrides) -> str:
+    """The effective severity of a finding after overrides: error|warning|off.
+
+    Pure. ``base`` is the finding's intrinsic severity; the per-type ceiling is
+    applied first, then the more specific per-rule-code entry wins.
+    """
+    sev = base
+    if overrides.types.get(artifact_type) == "warning" and sev == "error":
+        sev = "warning"
+    rule = overrides.rules.get(code)
+    if rule is not None:
+        sev = rule
+    return sev
+
+
+def apply_overrides(
+    issues: list[Issue], artifact_type: str, overrides: SeverityOverrides
+) -> list[Issue]:
+    """Return ``issues`` with overridden severities; ``off`` findings dropped.
+
+    A no-op when ``overrides`` is empty, so the default path is unchanged.
+    """
+    if overrides.is_empty:
+        return issues
+    out: list[Issue] = []
+    for issue in issues:
+        sev = resolve_severity(issue.severity, issue.code, artifact_type, overrides)
+        if sev == "off":
+            continue
+        out.append(issue if sev == issue.severity else replace(issue, severity=cast(Severity, sev)))
+    return out

--- a/src/rac/output/__init__.py
+++ b/src/rac/output/__init__.py
@@ -71,6 +71,7 @@ from .json import (
 )
 from .okf import render_okf_bundle
 from .portal import render_export_html
+from .sarif import render_validate_sarif
 from .templates import render_improve_template, render_schema_template
 
 __all__ = [
@@ -132,6 +133,7 @@ __all__ = [
     "render_unknown_schema",
     "render_validate_dir_human",
     "render_validate_dir_json",
+    "render_validate_sarif",
     "render_validation_human",
     "render_validation_json",
     "render_watchkeeper_github",

--- a/src/rac/output/sarif.py
+++ b/src/rac/output/sarif.py
@@ -1,0 +1,84 @@
+"""SARIF rendering for `rac validate` — CI code scanning (ADR-054).
+
+SARIF 2.1.0 is the format GitHub Code Scanning ingests to annotate a pull
+request inline. `rac validate <dir> --sarif` emits one SARIF run covering both
+core validation findings and OKF conformance findings, so a CI job can upload it
+and surface RAC's findings on the diff.
+
+The output is a *derived* machine contract, parallel to the JSON export (ADR-007),
+and fully deterministic and offline (ADR-002): the tool version comes from the
+installed package, results are sorted by ``(uri, line, ruleId)``, and no
+timestamps are emitted, so the same corpus state yields a byte-identical document.
+"""
+
+from __future__ import annotations
+
+import json
+
+from rac import __version__
+from rac.services.validate import DirectoryValidation
+
+_SCHEMA = "https://json.schemastore.org/sarif-2.1.0.json"
+_INFORMATION_URI = "https://github.com/tcballard/requirements-as-code"
+
+# SARIF `level` is a closed set; RAC severities map one-to-one. Suppressed
+# (``off``) findings never reach here — they are dropped before rendering.
+_LEVEL = {"error": "error", "warning": "warning"}
+
+
+def _result(rule_id: str, level: str, message: str, uri: str, line: int | None) -> dict:
+    location: dict = {"physicalLocation": {"artifactLocation": {"uri": uri}}}
+    if line is not None:
+        location["physicalLocation"]["region"] = {"startLine": line}
+    return {
+        "ruleId": rule_id,
+        "level": _LEVEL.get(level, "warning"),
+        "message": {"text": message},
+        "locations": [location],
+    }
+
+
+def render_validate_sarif(result: DirectoryValidation) -> str:
+    """Render a directory validation result as a SARIF 2.1.0 document."""
+    results: list[dict] = []
+    for file in result.files:
+        for issue in file.issues:
+            results.append(
+                _result(issue.code, issue.severity, issue.message, file.path, issue.line)
+            )
+    if result.okf is not None:
+        for finding in result.okf.findings:
+            results.append(
+                _result(finding.code, finding.severity, finding.message, finding.path, None)
+            )
+
+    # Deterministic ordering (ADR-002): a line of 0 sorts file-level findings
+    # ahead of line-anchored ones for the same file, then by rule then message.
+    results.sort(
+        key=lambda r: (
+            r["locations"][0]["physicalLocation"]["artifactLocation"]["uri"],
+            r["locations"][0]["physicalLocation"].get("region", {}).get("startLine", 0),
+            r["ruleId"],
+            r["message"]["text"],
+        )
+    )
+
+    rules = [{"id": code} for code in sorted({r["ruleId"] for r in results})]
+    document = {
+        "version": "2.1.0",
+        "$schema": _SCHEMA,
+        "runs": [
+            {
+                "tool": {
+                    "driver": {
+                        "name": "rac",
+                        "informationUri": _INFORMATION_URI,
+                        "version": __version__,
+                        "rules": rules,
+                    }
+                },
+                "results": results,
+            }
+        ],
+    }
+    return json.dumps(document, indent=2)

--- a/src/rac/services/init.py
+++ b/src/rac/services/init.py
@@ -20,6 +20,8 @@ from pathlib import Path
 
 import yaml
 
+from rac.core.overrides import EMPTY, RULE_VALUES, TYPE_VALUES, SeverityOverrides
+
 # Repository key contract (v0.7.11): uppercase alphanumeric, leading letter,
 # 2-10 characters. The key is the human-recognizable ID prefix, e.g. RAC.
 KEY_RE = re.compile(r"^[A-Z][A-Z0-9]{1,9}$")
@@ -109,14 +111,74 @@ def _read_config(config_path: Path) -> RepositoryConfig:
     return RepositoryConfig(repository_key=key, config_path=str(config_path))
 
 
-def load_repository_config(start_dir: str) -> RepositoryConfig | None:
-    """The nearest ``.rac/config.yaml`` at or above ``start_dir``, or None."""
+def find_config_file(start_dir: str) -> Path | None:
+    """The nearest ``.rac/config.yaml`` at or above ``start_dir``, or None.
+
+    The shared discovery walk: identity (``load_repository_config``) and the
+    validation overrides loader both resolve the same file from any
+    subdirectory of an initialized repository.
+    """
     current = Path(start_dir).resolve()
     for directory in (current, *current.parents):
         config_path = directory / CONFIG_DIR / CONFIG_FILE
         if config_path.is_file():
-            return _read_config(config_path)
+            return config_path
     return None
+
+
+def load_repository_config(start_dir: str) -> RepositoryConfig | None:
+    """The nearest ``.rac/config.yaml`` at or above ``start_dir``, or None."""
+    config_path = find_config_file(start_dir)
+    return _read_config(config_path) if config_path is not None else None
+
+
+def load_overrides(start_dir: str) -> SeverityOverrides:
+    """Read the ``validation`` severity overrides from the nearest config (ADR-053).
+
+    Returns :data:`~rac.core.overrides.EMPTY` when there is no config file or no
+    ``validation`` section. Malformed shapes or unknown severity values raise
+    :class:`MalformedRepositoryConfig` — overrides are never silently ignored.
+    """
+    config_path = find_config_file(start_dir)
+    if config_path is None:
+        return EMPTY
+    try:
+        data = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise MalformedRepositoryConfig(str(config_path), f"invalid YAML: {exc}") from exc
+    section = data.get("validation") if isinstance(data, dict) else None
+    if section is None:
+        return EMPTY
+    if not isinstance(section, dict):
+        raise MalformedRepositoryConfig(str(config_path), "'validation' must be a mapping")
+    rules = _parse_severity_map(config_path, section.get("rules"), "validation.rules", RULE_VALUES)
+    types = _parse_severity_map(config_path, section.get("types"), "validation.types", TYPE_VALUES)
+    return SeverityOverrides(rules=rules, types=types)
+
+
+def _parse_severity_map(
+    config_path: Path, value: object, where: str, allowed: tuple[str, ...]
+) -> dict[str, str]:
+    """Validate one ``{name: severity}`` mapping, or empty when absent."""
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise MalformedRepositoryConfig(str(config_path), f"'{where}' must be a mapping")
+    parsed: dict[str, str] = {}
+    for name, sev in value.items():
+        # YAML 1.1 resolves the bare word ``off`` to ``False`` (likewise on/yes/no
+        # to booleans). ``off`` is the natural suppression keyword, so coerce a
+        # bool back to text rather than forcing users to quote it; the membership
+        # check below rejects ``on``/``yes`` (True) where they are not allowed.
+        if isinstance(sev, bool):
+            sev = "off" if sev is False else "on"
+        if not isinstance(name, str) or not isinstance(sev, str) or sev not in allowed:
+            raise MalformedRepositoryConfig(
+                str(config_path),
+                f"'{where}.{name}' must map a name to one of {', '.join(allowed)}",
+            )
+        parsed[name] = sev
+    return parsed
 
 
 def init_repository(directory: str, key: str = DEFAULT_KEY) -> InitResult:

--- a/src/rac/services/okf_conformance.py
+++ b/src/rac/services/okf_conformance.py
@@ -28,6 +28,7 @@ from dataclasses import asdict, dataclass
 from rac.core.artifacts import spec_for
 from rac.core.corpus import CorpusEntry
 from rac.core.okf import OKF_TYPE, RESERVED_FILENAMES
+from rac.core.overrides import EMPTY, SeverityOverrides, resolve_severity
 
 # Stable finding codes (part of the JSON contract, ADR-007).
 CODE_UNMAPPED_TYPE = "okf-unmapped-type"
@@ -36,11 +37,17 @@ CODE_RESERVED_FILENAME = "okf-reserved-filename-collision"
 
 @dataclass
 class OkfFinding:
-    """One OKF conformance finding, file-named for actionable diagnostics."""
+    """One OKF conformance finding, file-named for actionable diagnostics.
+
+    ``severity`` defaults to ``error`` but is subject to the repository's
+    severity overrides (ADR-053), so a team can downgrade a conformance code or a
+    type during onboarding.
+    """
 
     code: str
     path: str
     message: str
+    severity: str = "error"
 
     def to_dict(self) -> dict:
         return asdict(self)
@@ -57,7 +64,9 @@ class OkfConformanceReport:
 
     @property
     def ok(self) -> bool:
-        return not self.findings
+        # Conformant when no finding remains at error severity (overrides may
+        # downgrade findings to warning, or suppress them, during onboarding).
+        return not any(f.severity == "error" for f in self.findings)
 
     def to_dict(self) -> dict:
         return {
@@ -68,13 +77,17 @@ class OkfConformanceReport:
 
 
 def check_okf_conformance(
-    directory: str, entries: list[CorpusEntry], recursive: bool = True
+    directory: str,
+    entries: list[CorpusEntry],
+    recursive: bool = True,
+    overrides: SeverityOverrides = EMPTY,
 ) -> OkfConformanceReport:
     """Check OKF v0.1 conformance over an already-walked corpus snapshot.
 
     Deterministic: entries arrive in sorted path order, so findings do too. Only
     typed artifacts are checked; untyped documents are excluded (ADR-010), which
-    also exempts untyped ``index.md``/``log.md`` reserved entry points.
+    also exempts untyped ``index.md``/``log.md`` reserved entry points. Severity
+    overrides (ADR-053) may downgrade or suppress a finding by code or type.
     """
     findings: list[OkfFinding] = []
     checked = 0
@@ -85,24 +98,26 @@ def check_okf_conformance(
         checked += 1
         path = str(entry.path)
         if artifact_type not in OKF_TYPE:
-            findings.append(
-                OkfFinding(
-                    CODE_UNMAPPED_TYPE,
-                    path,
-                    f"artifact type {artifact_type!r} has no OKF type mapping; add "
-                    f"it to rac.core.okf.OKF_TYPE so the artifact is carried in the "
-                    f"OKF bundle (ADR-048)",
-                )
+            _add(
+                findings,
+                CODE_UNMAPPED_TYPE,
+                path,
+                f"artifact type {artifact_type!r} has no OKF type mapping; add "
+                f"it to rac.core.okf.OKF_TYPE so the artifact is carried in the "
+                f"OKF bundle (ADR-048)",
+                artifact_type,
+                overrides,
             )
         if entry.path.name in RESERVED_FILENAMES:
-            findings.append(
-                OkfFinding(
-                    CODE_RESERVED_FILENAME,
-                    path,
-                    f"a typed artifact named {entry.path.name!r} collides with the "
-                    f"generated OKF bundle entry point; rename the file — OKF "
-                    f"reserves index.md and log.md (ADR-048)",
-                )
+            _add(
+                findings,
+                CODE_RESERVED_FILENAME,
+                path,
+                f"a typed artifact named {entry.path.name!r} collides with the "
+                f"generated OKF bundle entry point; rename the file — OKF "
+                f"reserves index.md and log.md (ADR-048)",
+                artifact_type,
+                overrides,
             )
     return OkfConformanceReport(
         directory=directory,
@@ -110,3 +125,18 @@ def check_okf_conformance(
         artifacts_checked=checked,
         findings=findings,
     )
+
+
+def _add(
+    findings: list[OkfFinding],
+    code: str,
+    path: str,
+    message: str,
+    artifact_type: str,
+    overrides: SeverityOverrides,
+) -> None:
+    """Append a finding at its overridden severity; ``off`` suppresses it."""
+    severity = resolve_severity("error", code, artifact_type, overrides)
+    if severity == "off":
+        return
+    findings.append(OkfFinding(code, path, message, severity=severity))

--- a/src/rac/services/validate.py
+++ b/src/rac/services/validate.py
@@ -17,8 +17,10 @@ from dataclasses import asdict, dataclass
 from rac.core.artifacts import spec_for
 from rac.core.corpus import CorpusEntry, walk_corpus
 from rac.core.models import Issue
+from rac.core.overrides import EMPTY, SeverityOverrides, apply_overrides
 from rac.core.validation import has_errors, validate
 
+from .init import load_overrides
 from .okf_conformance import OkfConformanceReport, check_okf_conformance
 
 # Stable per-file statuses (part of the JSON contract, ADR-007).
@@ -111,16 +113,25 @@ def validate_directory(directory: str, recursive: bool = True) -> DirectoryValid
     result — and everything rendered from it — is deterministic.
     """
     entries = list(walk_corpus(directory, recursive=recursive))
-    return validate_corpus(directory, entries, recursive=recursive)
+    overrides = load_overrides(directory)
+    return validate_corpus(directory, entries, recursive=recursive, overrides=overrides)
 
 
 def validate_corpus(
-    directory: str, entries: list[CorpusEntry], recursive: bool = True
+    directory: str,
+    entries: list[CorpusEntry],
+    recursive: bool = True,
+    overrides: SeverityOverrides = EMPTY,
 ) -> DirectoryValidation:
     """Validate an already-walked corpus snapshot (v0.8.0).
 
     Same result as :func:`validate_directory`; the snapshot lets one walk
     feed several analyses (repository model, future incremental refresh).
+    Severity overrides (ADR-053) default to :data:`~rac.core.overrides.EMPTY` so
+    consumers that hold their own snapshot (the repository model behind review /
+    watchkeeper / portfolio) are unchanged; ``validate_directory`` loads the
+    repository's overrides and passes them. Overrides are applied before status
+    and exit code are computed, so a downgraded type or rule keeps the run green.
     """
     files: list[FileValidation] = []
     for entry in entries:
@@ -138,7 +149,7 @@ def validate_corpus(
                 )
             )
             continue
-        issues = validate(product)
+        issues = apply_overrides(validate(product), artifact_type, overrides)
         files.append(
             FileValidation(
                 path=str(path),
@@ -147,5 +158,5 @@ def validate_corpus(
                 issues=issues,
             )
         )
-    okf = check_okf_conformance(directory, entries, recursive=recursive)
+    okf = check_okf_conformance(directory, entries, recursive=recursive, overrides=overrides)
     return DirectoryValidation(directory=directory, recursive=recursive, files=files, okf=okf)

--- a/tests/test_overrides.py
+++ b/tests/test_overrides.py
@@ -1,0 +1,155 @@
+"""Tests for validation severity overrides — warnings-first onboarding (ADR-053).
+
+Covers the pure model (`resolve_severity`/`apply_overrides`), the config loader
+(`load_overrides` over `.rac/config.yaml`, including the YAML `off`->False
+coercion and malformed-config errors), and end-to-end behaviour through
+`rac validate`: a corpus that fails by default goes green once a type or rule is
+downgraded, precedence (rule beats the type ceiling), suppression, and that an
+absent `validation` section is a pure no-op.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rac.cli import main
+from rac.core.models import Issue
+from rac.core.overrides import EMPTY, SeverityOverrides, apply_overrides, resolve_severity
+from rac.services.init import MalformedRepositoryConfig, load_overrides
+
+# A decision that classifies (context/decision/consequences/status) but carries an
+# out-of-enum status, so it fails with `invalid-decision-status` by default.
+BAD_DECISION = """\
+---
+schema_version: 1
+id: RAC-KTQ63DPSMF19
+type: decision
+---
+# A Decision With A Bad Status
+
+## Context
+c
+
+## Decision
+d
+
+## Consequences
+x
+
+## Status
+Bogus
+"""
+
+
+def _repo(tmp_path, config: str, artifact: str = BAD_DECISION):
+    (tmp_path / ".rac").mkdir()
+    (tmp_path / ".rac" / "config.yaml").write_text(config, encoding="utf-8")
+    (tmp_path / "d.md").write_text(artifact, encoding="utf-8")
+    return str(tmp_path)
+
+
+# --- pure model --------------------------------------------------------------
+
+
+def test_resolve_severity_precedence():
+    ov = SeverityOverrides(rules={"x": "error"}, types={"decision": "warning"})
+    # Type ceiling downgrades, but the per-rule entry is more specific and wins.
+    assert resolve_severity("error", "x", "decision", ov) == "error"
+    assert resolve_severity("error", "y", "decision", ov) == "warning"
+    assert resolve_severity("error", "y", "requirement", ov) == "error"
+
+
+def test_apply_overrides_empty_is_noop():
+    issues = [Issue("error", "a", "m"), Issue("warning", "b", "m")]
+    assert apply_overrides(issues, "decision", EMPTY) is issues
+
+
+def test_apply_overrides_downgrades_and_suppresses():
+    issues = [Issue("error", "a", "m", 3), Issue("error", "b", "m")]
+    ov = SeverityOverrides(rules={"a": "warning", "b": "off"})
+    out = apply_overrides(issues, "decision", ov)
+    assert [(i.code, i.severity) for i in out] == [("a", "warning")]
+    assert out[0].line == 3  # other fields preserved
+
+
+# --- loader ------------------------------------------------------------------
+
+
+def test_load_overrides_absent_config_is_empty(tmp_path):
+    assert load_overrides(str(tmp_path)).is_empty
+
+
+def test_load_overrides_no_validation_section_is_empty(tmp_path):
+    repo = _repo(tmp_path, "repository_key: RAC\n")
+    assert load_overrides(repo).is_empty
+
+
+def test_load_overrides_parses_rules_and_types(tmp_path):
+    cfg = (
+        "repository_key: RAC\nvalidation:\n"
+        "  rules:\n    ambiguous-verb: off\n"
+        "  types:\n    roadmap: warning\n"
+    )
+    repo = _repo(tmp_path, cfg)
+    ov = load_overrides(repo)
+    assert ov.rules == {"ambiguous-verb": "off"}  # YAML `off` coerced from False
+    assert ov.types == {"roadmap": "warning"}
+
+
+def test_load_overrides_rejects_unknown_severity(tmp_path):
+    repo = _repo(tmp_path, "repository_key: RAC\nvalidation:\n  rules:\n    x: loud\n")
+    with pytest.raises(MalformedRepositoryConfig, match="error, warning, off"):
+        load_overrides(repo)
+
+
+def test_load_overrides_rejects_off_for_whole_type(tmp_path):
+    # `off` is not allowed for a whole type (only error|warning).
+    repo = _repo(tmp_path, "repository_key: RAC\nvalidation:\n  types:\n    decision: off\n")
+    with pytest.raises(MalformedRepositoryConfig, match="error, warning"):
+        load_overrides(repo)
+
+
+# --- end to end through `rac validate` ---------------------------------------
+
+
+def test_validate_fails_without_overrides(tmp_path, capsys):
+    repo = _repo(tmp_path, "repository_key: RAC\n")
+    assert main(["validate", repo]) == 1
+    assert "1 invalid" in capsys.readouterr().out
+
+
+def test_type_downgrade_keeps_ci_green(tmp_path, capsys):
+    repo = _repo(tmp_path, "repository_key: RAC\nvalidation:\n  types:\n    decision: warning\n")
+    assert main(["validate", repo]) == 0
+    assert "1 valid, 0 invalid" in capsys.readouterr().out
+
+
+def test_rule_suppression_keeps_ci_green(tmp_path):
+    repo = _repo(
+        tmp_path, "repository_key: RAC\nvalidation:\n  rules:\n    invalid-decision-status: off\n"
+    )
+    assert main(["validate", repo]) == 0
+
+
+def test_rule_overrides_type_ceiling(tmp_path):
+    cfg = (
+        "repository_key: RAC\nvalidation:\n  types:\n    decision: warning\n"
+        "  rules:\n    invalid-decision-status: error\n"
+    )
+    repo = _repo(tmp_path, cfg)
+    assert main(["validate", repo]) == 1  # rule forces error back, type cap loses
+
+
+def test_okf_finding_is_downgradable(tmp_path):
+    # A typed artifact named index.md triggers okf-reserved-filename-collision.
+    (tmp_path / ".rac").mkdir()
+    (tmp_path / "index.md").write_text(BAD_DECISION.replace("Bogus", "Accepted"), encoding="utf-8")
+    cfg_path = tmp_path / ".rac" / "config.yaml"
+    cfg_path.write_text("repository_key: RAC\n", encoding="utf-8")
+    assert main(["validate", str(tmp_path)]) == 1  # collision fails by default
+    cfg_path.write_text(
+        "repository_key: RAC\nvalidation:\n  rules:\n"
+        "    okf-reserved-filename-collision: warning\n",
+        encoding="utf-8",
+    )
+    assert main(["validate", str(tmp_path)]) == 0  # downgraded -> conformant

--- a/tests/test_sarif.py
+++ b/tests/test_sarif.py
@@ -1,0 +1,116 @@
+"""Tests for SARIF validation output — CI code scanning (ADR-054).
+
+Structural and determinism checks rather than a committed byte-golden (the tool
+version is build-derived). Covers the SARIF 2.1.0 envelope, that core validation
+and OKF findings both appear, the severity->level mapping, region presence only
+for line-anchored findings, and that suppressed (`off`) findings never render.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from rac.cli import main
+from rac.output import render_validate_sarif
+from rac.services.validate import validate_directory
+
+BAD_DECISION = """\
+---
+schema_version: 1
+id: RAC-KTQ63DPSMF19
+type: decision
+---
+# Bad Status
+
+## Context
+c
+
+## Decision
+d
+
+## Consequences
+x
+
+## Status
+Bogus
+"""
+
+
+def _sarif_for(tmp_path) -> dict:
+    (tmp_path / "d.md").write_text(BAD_DECISION, encoding="utf-8")
+    # index.md (typed) also yields an OKF reserved-filename finding.
+    (tmp_path / "index.md").write_text(BAD_DECISION.replace("Bogus", "Accepted"), encoding="utf-8")
+    result = validate_directory(str(tmp_path))
+    return json.loads(render_validate_sarif(result))
+
+
+def test_sarif_envelope(tmp_path):
+    doc = _sarif_for(tmp_path)
+    assert doc["version"] == "2.1.0"
+    assert "$schema" in doc
+    driver = doc["runs"][0]["tool"]["driver"]
+    assert driver["name"] == "rac"
+    assert isinstance(driver["version"], str) and driver["version"]
+
+
+def test_sarif_covers_core_and_okf_findings(tmp_path):
+    doc = _sarif_for(tmp_path)
+    rule_ids = {r["ruleId"] for r in doc["runs"][0]["results"]}
+    assert "invalid-decision-status" in rule_ids  # core validation
+    assert "okf-reserved-filename-collision" in rule_ids  # OKF conformance
+    # Declared rules mirror the observed codes.
+    declared = {r["id"] for r in doc["runs"][0]["tool"]["driver"]["rules"]}
+    assert rule_ids <= declared
+
+
+def test_sarif_levels_and_regions(tmp_path):
+    doc = _sarif_for(tmp_path)
+    for r in doc["runs"][0]["results"]:
+        assert r["level"] in ("error", "warning")
+        loc = r["locations"][0]["physicalLocation"]
+        assert loc["artifactLocation"]["uri"]
+        # OKF findings are file-level (no region); core findings may carry a line.
+        if "region" in loc:
+            assert loc["region"]["startLine"] >= 1
+
+
+def test_sarif_deterministic(tmp_path):
+    (tmp_path / "d.md").write_text(BAD_DECISION, encoding="utf-8")
+    result = validate_directory(str(tmp_path))
+    assert render_validate_sarif(result) == render_validate_sarif(result)
+
+
+def test_sarif_omits_suppressed_findings(tmp_path):
+    (tmp_path / ".rac").mkdir()
+    (tmp_path / ".rac" / "config.yaml").write_text(
+        "repository_key: RAC\nvalidation:\n  rules:\n    invalid-decision-status: off\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "d.md").write_text(BAD_DECISION, encoding="utf-8")
+    doc = json.loads(render_validate_sarif(validate_directory(str(tmp_path))))
+    rule_ids = {r["ruleId"] for r in doc["runs"][0]["results"]}
+    assert "invalid-decision-status" not in rule_ids
+
+
+def test_cli_sarif_directory(tmp_path, capsys):
+    (tmp_path / "d.md").write_text(BAD_DECISION, encoding="utf-8")
+    rc = main(["validate", str(tmp_path), "--sarif"])
+    assert rc == 1
+    doc = json.loads(capsys.readouterr().out)
+    assert doc["version"] == "2.1.0"
+
+
+def test_cli_sarif_rejected_for_single_file(tmp_path, capsys):
+    f = tmp_path / "d.md"
+    f.write_text(BAD_DECISION, encoding="utf-8")
+    with pytest.raises(SystemExit) as exc:
+        main(["validate", str(f), "--sarif"])
+    assert exc.value.code == 2  # EXIT_USAGE
+    assert "directory validation" in capsys.readouterr().err
+
+
+def test_cli_json_and_sarif_mutually_exclusive(tmp_path):
+    with pytest.raises(SystemExit):
+        main(["validate", str(tmp_path), "--json", "--sarif"])


### PR DESCRIPTION
# Summary

Implements `rac/roadmaps/v0.15.x-interop/v0.15.2-validation-overrides-and-sarif.md`.

Makes RAC's write-time validation gate adoptable in CI on a real repository. Two
additions:

1. **Severity overrides (warnings-first onboarding).** A repository may declare a
   `validation` section in its committed `.rac/config.yaml` to downgrade or
   silence findings — per rule code and per artifact type — so a team can point
   `rac validate` at a legacy corpus, keep CI green, and tighten the gate over
   time. The default (no section) is the strict gate, unchanged.
2. **SARIF output.** `rac validate DIR --sarif` emits a deterministic, offline
   SARIF 2.1.0 document (core validation + OKF conformance findings) for GitHub
   Code Scanning.

# Roadmap / ADR Trace

Roadmap:
- `rac/roadmaps/v0.15.x-interop/v0.15.2-validation-overrides-and-sarif.md`

Relevant ADRs:
- `rac/decisions/adr-053-validation-severity-overrides.md` (new) — the override model
- `rac/decisions/adr-054-sarif-validation-output.md` (new) — SARIF as a derived CI output
- `rac/decisions/adr-052-rac-core-okf-superset-conformance.md` — custom-type registry stays deferred
- `rac/decisions/adr-049-enforcement-is-the-product.md`, `adr-026` (`.rac/config.yaml`), `adr-002` (determinism), `adr-007` (additive JSON)

# Scope

## Included
- `rac.core.overrides`: `SeverityOverrides`, `resolve_severity`, `apply_overrides`
  (per-type ceiling first, per-rule-code wins, `off` suppresses) — a pure pass.
- `load_overrides` over `.rac/config.yaml` (reusing the extracted
  `find_config_file`), with the YAML `off` -> `False` coercion and a hard error on
  malformed shapes.
- OKF findings gain a `severity` and flow through the same overrides.
- `rac validate` applies overrides before status/exit (directory and single-file).
- `rac.output.sarif.render_validate_sarif` + a `--sarif` flag (mutually exclusive
  with `--json`, directory-only).
- A worked SARIF example checked in under `docs/examples/` and a `docs/validation.md` guide.

## Excluded (deliberate, recorded)
- The custom-type JSON-Schema registry / `allOf` / a schema dependency — deferred
  per ADR-052. The per-type knob keys on any type string, so it is
  forward-compatible without building the registry now.
- Relationship-validation overrides and relationship SARIF (a distinct report
  model) — noted for later.
- The GitHub Action that uploads SARIF and annotates the PR — Release E.
- Overrides do not affect `review` / `watchkeeper` / `portfolio`.

# Product / Architecture Decisions

- **Overrides live in the committed `.rac/config.yaml`, not a per-developer file**
  — warnings-first only works if CI and teammates share the policy. Reuses the
  existing config and discovery walk; no new file, no dependency.
- **Precedence: per-rule beats the per-type ceiling**, so a downgraded type can
  still force one rule back to `error`. `off` (rule-only) suppresses.
- **Determinism preserved (ADR-002):** overrides are committed and versioned, so
  the same corpus + config yields the same findings and exit code. Malformed
  config is a hard `MalformedRepositoryConfig`, never silently ignored.
- **SARIF is a derived contract (ADR-007), parallel to JSON** — never a source of
  truth; deterministic ordering and no timestamps make it byte-stable.
- **Scope discipline:** `validate_corpus` defaults to no overrides, so the
  repository model behind review/watchkeeper/portfolio is unchanged.

# User-Facing Contract

## CLI
- New `--sarif` on `rac validate` (mutually exclusive with `--json`, directory
  only; single-file `--sarif` is a usage error).
- `.rac/config.yaml` gains an optional `validation` section:
  ```yaml
  validation:
    rules:                 # rule code -> error | warning | off
      ambiguous-verb: off
      too-many-requirements: warning
    types:                 # artifact type -> error | warning  (a ceiling)
      roadmap: warning
  ```

## Human / JSON Output
Unchanged in shape. Overrides change which findings are present and their
severities (and therefore the pass/fail verdict); an absent `validation` section
is a pure no-op.

## SARIF Output
`rac validate DIR --sarif` emits SARIF 2.1.0. `ruleId` = finding code, `level`
= severity (`error`/`warning`), `region.startLine` when a line is known, omitted
for file-level findings; suppressed (`off`) findings never appear. Worked example
at `docs/examples/rac-validate.sarif.json`:

```json
{
  "version": "2.1.0",
  "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
  "runs": [
    {
      "tool": { "driver": { "name": "rac", "version": "0.15.2", "rules": [
        { "id": "ambiguous-verb" }, { "id": "invalid-decision-status" },
        { "id": "missing-risks" }, { "id": "missing-success-metrics" }
      ] } },
      "results": [
        {
          "ruleId": "invalid-decision-status",
          "level": "error",
          "message": { "text": "## Status value 'Draft' is not one of: Proposed, Accepted, Superseded, Deprecated." },
          "locations": [ { "physicalLocation": { "artifactLocation": { "uri": "rac/decisions/adr-bad-status.md" } } } ]
        },
        {
          "ruleId": "ambiguous-verb",
          "level": "warning",
          "message": { "text": "REQ-001 uses ambiguous verb(s) (support); be more specific." },
          "locations": [ { "physicalLocation": {
            "artifactLocation": { "uri": "rac/requirements/feature.md" },
            "region": { "startLine": 7 }
          } } ]
        }
      ]
    }
  ]
}
```
(Two `missing-*` warnings elided here for brevity; the full document is the
checked-in example.)

## Exit Codes
- `0`: every artifact valid (after overrides) and the corpus OKF-conformant
- `1`: any error-severity finding remains, or OKF non-conformance
- `2`: usage / IO error (incl. single-file `--sarif`, or `--json` plus `--sarif`)

# Verification

## Ran
- `rac validate rac/` → exit 0, OKF conformant (173 artifacts) — unchanged (the
  repo declares no overrides).
- Fixture corpus: fails by default; goes exit 0 when a type or a rule is
  downgraded; a per-rule `error` overrides a per-type `warning` ceiling; an OKF
  finding is downgradable.
- `rac validate DIR --sarif` → valid SARIF, byte-identical on re-render.
- `rac relationships rac/ --validate` → 0 issues; `rac review rac/` → health 88,
  no priority 1-2 findings.
- `pytest` → 1138 passed in the non-TUI suite (+105 explorer); 29 new tests.
- `ruff check` / `ruff format --check` / `mypy src/rac` all clean.

## Covered
- Overrides: `resolve_severity`/`apply_overrides` precedence and suppression;
  loader parsing incl. the YAML `off` coercion and malformed-config errors;
  end-to-end downgrade-keeps-CI-green, rule-beats-type, OKF downgradable.
- SARIF: 2.1.0 envelope, core + OKF coverage, `level` mapping, region only for
  line-anchored findings, determinism, suppressed findings omitted, CLI guards.

# Review Path

1. `src/rac/core/overrides.py` — the pure model and application.
2. `src/rac/services/init.py` — `load_overrides` + shared `find_config_file`.
3. `src/rac/services/okf_conformance.py` / `validate.py` — threading + OKF severity.
4. `src/rac/output/sarif.py` — the renderer.
5. `src/rac/cli.py` — `--sarif` flag and single-file overrides wiring.
6. `rac/decisions/adr-053-*.md`, `adr-054-*.md`, `rac/roadmaps/.../v0.15.2-*.md`.
7. `tests/test_overrides.py`, `tests/test_sarif.py`, CI battery; `docs/validation.md`
   + `docs/examples/rac-validate.sarif.json`; CHANGELOG.

# Notes For Reviewer

- The custom-type registry exit criterion from the brief is **deferred on
  purpose** (ADR-052); the per-type knob is forward-compatible.
- One pre-existing test, `tests/test_hook.py::test_post_commit_hook_is_advisory_and_runs`,
  is environment-dependent (needs the installed `rac` console script); unrelated
  to this change.

# Implementation Process

Implemented with AI assistance under the v0.15.2 roadmap contract; final scope —
including the choice of a committed `.rac/config.yaml` overrides section over a
custom-type registry — review, and acceptance were the maintainer's.