### PR TITLE
feat(relationships): Layer-3 graph integrity — range, acyclicity, all-type status [roadmap:v0.16.0]

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -94,7 +94,7 @@ jobs:
           - name: mcp
             paths: "tests/test_mcp_server.py tests/test_mcp_tools.py tests/test_mcp_isolation.py tests/test_mcp_telemetry.py tests/test_mcp_ping.py"
           - name: relationships
-            paths: "tests/test_relationships.py tests/test_relationships_cmd.py tests/test_relationship_validation.py"
+            paths: "tests/test_relationships.py tests/test_relationships_cmd.py tests/test_relationship_validation.py tests/test_relationship_graph.py tests/test_lifecycle_status.py"
           - name: resolve
             paths: "tests/test_resolve.py"
           - name: review

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ details, release history over commit history.
 
 ### Added
 
+- Relationship-graph integrity (v0.16.0): `rac relationships --validate` now
+  validates the corpus as a graph (ADR-055). A `## Related <Type>` reference that
+  resolves to the wrong artifact type is reported as
+  `relationship-target-type-mismatch` (untyped-document targets are exempt,
+  ADR-010), and a cycle in `supersedes` as `relationship-cycle`. Lifecycle status
+  is generalized to all five artifact types (ADR-051): each type has an optional,
+  validated `## Status` enum and a retired set, so the "nothing live points at a
+  retired artifact" rule (`relationship-target-superseded`) now covers
+  requirements, designs, roadmaps, and prompts, not just decisions — status stays
+  a knowledge lifecycle, never work state (ADR-017). The MCP `get_summary` tool
+  (and `rac portfolio`) gain an additive `validation_status` block reporting the
+  repository gate; the four read-only MCP tools are unchanged in count. The edge
+  vocabulary (`related_*` + `supersedes`) and existing issue codes are unchanged;
+  custom relationship types remain deferred (ADR-052).
+
 - Validation severity overrides + SARIF output (v0.15.2): a repository may declare
   an optional `validation` section in its committed `.rac/config.yaml` to downgrade
   or silence findings — per rule code (`error|warning|off`) and per artifact type

--- a/docs/relationships.md
+++ b/docs/relationships.md
@@ -67,9 +67,41 @@ each problem and exits `1`. The issue codes:
 | `relationship-target-ambiguous` | The referenced id matches more than one artifact. |
 | `relationship-self-reference` | An artifact references itself. |
 | `duplicate-artifact-identifier` | Two artifacts resolve to the same id. |
+| `relationship-edge-unsupported` | A relationship section the artifact's type does not declare. |
+| `relationship-target-type-mismatch` | A reference resolves to the wrong artifact type for the edge. |
+| `relationship-target-superseded` | A live artifact points at a retired (superseded/deprecated) target. |
+| `relationship-cycle` | A cycle in a directional, acyclic edge (`supersedes`). |
 
 Exit codes follow the standard convention: `0` all references valid · `1` issues
 found · `2` path not found.
+
+## Graph integrity
+
+Beyond resolving each reference, `rac relationships --validate` validates the
+corpus *as a graph* (ADR-055). Each relationship kind has a declared schema —
+its target type (**range**), whether it is directional, and whether it may form a
+cycle:
+
+- **Range.** `## Related Decisions` must point at a decision, `## Related
+  Roadmaps` at a roadmap, and so on; `## Supersedes` is decision→decision. A
+  reference that resolves to the wrong *recognized* type is
+  `relationship-target-type-mismatch`. An untyped document target is exempt — it
+  is a legitimate document (ADR-010), owned by referential integrity.
+- **Acyclicity.** `supersedes` is an ordering edge, so a cycle (A supersedes B
+  supersedes A) is illegal and reported as `relationship-cycle`. The undirected
+  `related_*` links never cycle.
+- **Status-consistency.** A live artifact of *any* type must not point at a
+  retired one. Lifecycle status (ADR-051) is an optional `## Status` section per
+  type — decisions/requirements/designs use `Proposed`/`Accepted` (live) and
+  `Superseded`/`Deprecated` (retired); prompts use `Active`/`Deprecated`;
+  roadmaps use `Planned` and `Superseded`/`Abandoned`. A reference to a retired
+  target is `relationship-target-superseded`, except `supersedes` (by which a
+  replacing decision legitimately points at the one it retires).
+
+These checks are deterministic and read the same artifacts you author — no hidden
+graph store (ADR-016). An agent over MCP can read the repository's overall
+validation status from `get_summary` (the `validation_status` block), without a
+fifth tool.
 
 ## Repository consistency
 

--- a/rac/decisions/adr-055-relationship-type-registry-and-graph-integrity.md
+++ b/rac/decisions/adr-055-relationship-type-registry-and-graph-integrity.md
@@ -1,0 +1,124 @@
+---
+schema_version: 1
+id: RAC-KV3WXTPPWR2G
+type: decision
+tags: [relationships, enforcement, graph, schema]
+---
+# ADR-055: A Code-Defined Relationship-Type Registry and Layer-3 Graph Integrity
+
+## Status
+
+Proposed
+
+## Category
+
+Architecture
+
+## Context
+
+ADR-049 names cross-artifact validation as RAC's core, and the relationship
+checks shipped so far — referential integrity, edge-legality (v0.14.0, domain
+only), and decision-only status-consistency (v0.14.1) — cover most of it. But
+the edge rules are *implicit*: legality is derived from each type's
+``ArtifactSpec.optional`` (which sections a type may declare), and there is no
+declarative statement of an edge's target type, directionality, or whether it
+may form a cycle. Three gaps follow: a ``## Related Decisions`` reference that
+resolves to a requirement is accepted silently (no **range** check); a
+``supersedes`` cycle is undetected (no **acyclicity**); and the supersedes
+exemption in the status rule is a hard-coded special case.
+
+This decision interprets the relationship model (ADR-016, which lists "cycles
+where relevant" among the things RAC should report), the enforcement posture
+(ADR-049), and the generalized lifecycle status (ADR-051). It records how RAC
+makes the edge schema declarative and closes the range and acyclicity gaps —
+without the custom-type machinery ADR-052 defers.
+
+## Decision
+
+1. **A code-defined relationship-type registry** (``rac.core.relationship_types``)
+   declares, per built-in edge kind, its ``range`` (allowed target types),
+   ``directional``/``acyclic``/``symmetric`` flags, an ``inverse`` label, a
+   ``forbids_target_status`` flag, and ``cardinality``. The ``related_*`` edges
+   are undirected links whose target must be of the named type; ``supersedes`` is
+   the one directional, acyclic, decision→decision edge.
+
+2. **Domain stays ``ArtifactSpec.optional``** (v0.14.0's recorded source of
+   truth). The registry adds only the *graph* properties; it does not move or
+   duplicate domain legality.
+
+3. **Range is enforced.** A uniquely-resolved reference whose target is a
+   *recognized* artifact of a type outside the edge's ``range`` is reported as
+   ``relationship-target-type-mismatch``. An **untyped** target is exempt
+   (ADR-010): it is a legitimate document, owned by referential integrity, not a
+   range violation.
+
+4. **Acyclicity is enforced** for edge kinds marked ``acyclic`` (today
+   ``supersedes``). A strongly-connected component larger than one node is a
+   cycle and is reported once as ``relationship-cycle`` with the component's
+   paths, deterministically (Tarjan over sorted nodes).
+
+5. **The supersedes exemption becomes data-driven.** The status-consistency rule
+   (generalized to all types by ADR-051) fires for any edge whose
+   ``forbids_target_status`` is true; ``supersedes`` sets it false, replacing the
+   former hard-coded ``section == "supersedes"`` check.
+
+6. **``inverse``/``symmetric``/``cardinality`` are declared but not yet enforced**
+   — they document the graph for display and forward compatibility (a viewer can
+   label inverse edges). Enforcing cardinality or materializing inverse edges is a
+   later, separately recorded decision.
+
+7. **Custom, repo-declared relationship types are deferred** (ADR-052 defers the
+   analogous custom artifact types). The registry is code-defined; a repo-local
+   ``.rac/relationships.yaml`` is explicitly out of scope until a design partner
+   needs it, at which point it is recorded as its own ADR.
+
+## Consequences
+
+### Positive
+
+- The repository is validated *as a graph*: wrong-target-type edges and illegal
+  cycles are caught at write time, in CI — checks no single-file validator has.
+- The edge schema is one declarative source instead of scattered special cases;
+  the supersedes exemption and the new rules all read the registry.
+- Additive (ADR-007): existing relationship codes and their shapes are unchanged;
+  ``relationship-target-type-mismatch`` and ``relationship-cycle`` are new.
+
+### Negative
+
+- Two more relationship rules to keep deterministic and false-positive-free. The
+  untyped-target range exemption is the main judgment call (kept conservative,
+  ADR-016 Risk 4).
+
+### Neutral
+
+- The vocabulary is unchanged (``related_*`` + ``supersedes``); new directional
+  edge types (``depends-on``, ``refines``) remain reserved (ADR-016 Risk 5).
+
+## Alternatives Considered
+
+- **A repo-local ``.rac/relationships.yaml`` registry enabling custom edges now.**
+  Deferred: it is the analog of the custom artifact types ADR-052 deferred;
+  built-in graph integrity is the load-bearing work, custom edges are pull-based.
+- **Add new directional edge types to exercise the rules.** Rejected for now:
+  ADR-016 Risk 5 asks new types be justified by user value; ``supersedes`` and
+  ``related_*`` already demonstrate acyclicity, range, and status-consistency.
+- **Enforce range against untyped targets too.** Rejected: it would fail
+  legitimate references to ADR-010 documents (e.g. loose design notes), an
+  over-strict result; referential integrity already owns those edges.
+- **Keep the supersedes exemption hard-coded.** Rejected: a registry flag makes
+  the exemption declarative and generalizes cleanly with ADR-051.
+
+## Related Decisions
+
+- ADR-049
+- ADR-016
+- ADR-051
+- ADR-052
+- ADR-010
+- ADR-007
+- ADR-002
+
+## Related Requirements
+
+- rac-cross-artifact-enforcement
+- rac-traceability-self-relationships

--- a/rac/requirements/rac-portal-citation-links.md
+++ b/rac/requirements/rac-portal-citation-links.md
@@ -7,7 +7,9 @@ type: requirement
 
 ## Status
 
-Proposed — drafted to open the discussion; nothing here is scheduled.
+Proposed
+
+Drafted to open the discussion; nothing here is scheduled.
 
 ## Problem
 

--- a/rac/roadmaps/future/agent-usage-readback.md
+++ b/rac/roadmaps/future/agent-usage-readback.md
@@ -7,7 +7,9 @@ type: roadmap
 
 ## Status
 
-Considered (unscheduled)
+Planned
+
+Unscheduled — captured as future intent, not yet on a release.
 
 ## Context
 

--- a/rac/roadmaps/v0.16.x-graph-integrity/v0.16.0-relationship-graph-integrity.md
+++ b/rac/roadmaps/v0.16.x-graph-integrity/v0.16.0-relationship-graph-integrity.md
@@ -1,0 +1,154 @@
+---
+schema_version: 1
+id: RAC-KV3WXTPPFPR6
+type: roadmap
+tags: [relationships, enforcement, graph, lifecycle]
+---
+# RAC v0.16.0 — Relationship-Graph Integrity (Layer 3)
+
+## Status
+
+Planned
+
+## Context
+
+ADR-049 makes cross-artifact validation RAC's core, and this milestone opens the
+v0.16.x graph-integrity series with the checks that validate the corpus *as a
+graph* — the differentiator no single-file validator (MADR, dotprompt, OKF) has.
+Referential integrity, edge-legality (domain), and decision-only
+status-consistency already ship. This milestone adds the missing pieces:
+a declarative relationship-type registry, **range** and **acyclicity** checks
+(ADR-055), the generalized all-type status-consistency rule (implementing
+ADR-051), and a validation-status roll-up on the MCP ``get_summary`` tool.
+
+Per ADR-055 and ADR-052, the registry is code-defined and the edge vocabulary is
+unchanged (``related_*`` + ``supersedes``); custom relationship types and new
+directional edges are deferred.
+
+## Outcomes
+
+- A ``## Related <Type>`` reference that resolves to the wrong artifact type, and
+  a cycle in ``supersedes``, are reported with precise, file-named diagnostics and
+  fail ``rac relationships --validate``.
+- A live artifact of *any* type that references a retired artifact of any type is
+  flagged (ADR-051), not only decisions; the ``supersedes`` exemption is
+  data-driven.
+- The MCP ``get_summary`` tool reports repository validation status; the four
+  read-only tools are unchanged in count.
+
+## Initiatives
+
+### Initiative 1 — Relationship-type registry
+
+Add ``rac.core.relationship_types`` (``EdgeSpec`` + ``REGISTRY``) declaring per
+edge kind: ``range``, ``directional``, ``acyclic``, ``symmetric``, ``inverse``,
+``forbids_target_status``, ``cardinality``. Domain stays ``ArtifactSpec.optional``.
+
+### Initiative 2 — Generalized lifecycle status (ADR-051)
+
+Add a ``retired_status`` set and a ``status`` enum to every ``ArtifactSpec``
+(decision unchanged); generalize the metadata check to all types
+(``invalid-<type>-status``); replace ``_is_retired_decision`` with
+``_is_retired_artifact`` reading ``spec.retired_status``. Normalize the two
+free-form corpus status values; backfill stays optional. Status stays an optional,
+validated ``## Status`` body section (ADR-025), never frontmatter or work state.
+
+### Initiative 3 — Range and acyclicity checks
+
+In ``_validate``: report ``relationship-target-type-mismatch`` for a resolved,
+recognized target outside the edge's range (untyped targets exempt, ADR-010); and
+``relationship-cycle`` per strongly-connected component of an acyclic edge kind.
+Drive the status-consistency exemption from ``EdgeSpec.forbids_target_status``.
+
+### Initiative 4 — Validation status in get_summary
+
+``portfolio_from_corpus`` computes the full relationship-validation gate over the
+same snapshot; ``PortfolioSummary`` gains a ``validation_status`` block
+(``artifacts_ok``/``relationships_ok``/``ok``), additive, surfaced by the MCP
+``get_summary`` tool and ``rac portfolio``.
+
+### Initiative 5 — Coverage and docs
+
+Tests for range, cycles, generalized status, per-type status validation, the
+registry, and ``validation_status``; the four-tool guard stays green. Register the
+new test files in the CI battery (ADR-027). Document the edge registry and graph
+checks in ``docs/relationships.md``; CHANGELOG.
+
+## Constraints
+
+- Additive (ADR-007): existing relationship codes, the decision status code, and
+  the JSON contracts are unchanged; new codes and the ``validation_status`` block
+  are added.
+- Determinism (ADR-002): same corpus state, identical findings and ordering
+  (sorted paths; Tarjan over sorted nodes).
+- ADR-052: registry is code-defined; no ``.rac/relationships.yaml``, no custom
+  edge types, no schema dependency.
+- ADR-010 / ADR-025 / ADR-017: status stays optional and body-resident; untyped
+  documents are legitimate (exempt from range); status is knowledge lifecycle,
+  never work state. The MCP surface stays at four read-only tools (ADR-030).
+
+## Non-Goals
+
+- Custom/repo-declared relationship types; new directional edge vocabulary.
+- Enforcing cardinality or materializing inverse edges (declared only).
+- A status backfill of status-less artifacts; templates seeding ``## Status``.
+- Transitive closure / graph queries; a fifth MCP tool.
+
+## Implementation Contract
+
+Pinned for v0.16.0.
+
+### Behaviour
+
+- ``relationship-target-type-mismatch``: a uniquely-resolved reference whose
+  recognized target type is not in the edge's range. Untyped targets are exempt.
+- ``relationship-cycle``: one per SCC (>1 node) of an acyclic edge kind
+  (``supersedes``), carrying the component's sorted paths.
+- ``relationship-target-superseded`` generalizes to all types via
+  ``spec.retired_status`` and ``EdgeSpec.forbids_target_status``; the code and
+  shape are unchanged.
+- ``invalid-<type>-status`` for an out-of-enum status on any type;
+  ``invalid-decision-status`` is unchanged.
+
+### Interface
+
+- No new CLI command or flag. ``rac relationships --validate`` reports the new
+  issues and exits 1 when they occur. ``get_summary`` / ``rac portfolio`` gain an
+  additive ``validation_status`` block.
+
+## Success Measures
+
+- ``rac relationships rac/ --validate`` exits 0; a fixture with a range mismatch
+  or a ``supersedes`` cycle exits 1 with a precise diagnostic.
+- ``rac validate rac/`` exits 0 after the two status normalizations.
+- ``get_summary`` reports ``validation_status``; the four-tool guard holds.
+
+## Risks
+
+- Range over-firing on legitimate references. Mitigated: untyped targets exempt,
+  only recognized wrong-type targets flagged.
+- A second relationship-validation pass in the portfolio summary. Mitigated: it
+  reuses the corpus snapshot (no extra walk) and is paid only on summary/MCP.
+
+## Assumptions
+
+- ``ArtifactSpec.optional`` remains the domain source of truth (v0.14.0).
+- The five artifact types and the ``related_*`` + ``supersedes`` vocabulary
+  remain the relationship surface.
+
+## Related Decisions
+
+- adr-055
+- adr-051
+- adr-049
+- adr-016
+
+## Related Requirements
+
+- rac-cross-artifact-enforcement
+- rac-traceability-self-relationships
+
+## Related Roadmaps
+
+- v0.14.0-enforcement-foundation
+- v0.14.1-status-consistency

--- a/src/rac/core/artifacts.py
+++ b/src/rac/core/artifacts.py
@@ -37,6 +37,11 @@ class ArtifactSpec:
     # A value present in one of these sections that is not in its allowed set is
     # a validation error; a missing section is not (metadata stays optional).
     metadata: dict[str, tuple[str, ...]] = field(default_factory=dict)
+    # Lifecycle status values that mark an artifact as retired (ADR-051): a subset
+    # of ``metadata["status"]``. The single, declarative source of truth the
+    # status-consistency rule reads to decide a target is no longer live. Empty
+    # when the type declares no status enum.
+    retired_status: tuple[str, ...] = ()
     # Short authoring hints per normalized section name, surfaced by `rac improve
     # --template` as guidance comments. Optional; sections without a hint render
     # without one.
@@ -115,6 +120,10 @@ ARTIFACT_SPECS: tuple[ArtifactSpec, ...] = (
             "related designs",
             "related requirements",
         ),
+        # Lifecycle status (ADR-051): optional, validated-if-present. Status stays
+        # a knowledge lifecycle (current vs replaced), never work/delivery state.
+        metadata={"status": ("Proposed", "Accepted", "Superseded", "Deprecated")},
+        retired_status=("Superseded", "Deprecated"),
         descriptions={
             "problem": "The user or business problem this addresses",
             "requirements": "Numbered requirement statements, e.g. [REQ-001] ...",
@@ -176,6 +185,7 @@ ARTIFACT_SPECS: tuple[ArtifactSpec, ...] = (
             "status": ("Proposed", "Accepted", "Superseded", "Deprecated"),
             "category": ("Architecture", "Product", "Process", "Technical", "Other"),
         },
+        retired_status=("Superseded", "Deprecated"),
         descriptions=_relationship_descriptions(
             "supersedes",
             "related requirements",
@@ -224,6 +234,11 @@ ARTIFACT_SPECS: tuple[ArtifactSpec, ...] = (
             "related designs",
             "related roadmaps",
         ),
+        # Lifecycle status (ADR-051): Planned is the live state; Superseded /
+        # Abandoned mark replaced or dropped *intent* — knowledge states, not
+        # delivery tracking (ADR-017). Per-milestone progress stays out.
+        metadata={"status": ("Planned", "Superseded", "Abandoned")},
+        retired_status=("Superseded", "Abandoned"),
         descriptions={
             "outcomes": "The user, business, or operational outcomes this roadmap pursues",
             "initiatives": "The major bodies of work that support those outcomes",
@@ -275,6 +290,9 @@ ARTIFACT_SPECS: tuple[ArtifactSpec, ...] = (
             "related roadmaps",
             "related designs",
         ),
+        # Lifecycle status (ADR-051): Active is the live state, Deprecated retired.
+        metadata={"status": ("Active", "Deprecated")},
+        retired_status=("Deprecated",),
         descriptions={
             "objective": "What this prompt is intended to achieve",
             "input": "The information, context, or source material the prompt expects",
@@ -348,6 +366,9 @@ ARTIFACT_SPECS: tuple[ArtifactSpec, ...] = (
             "related roadmaps",
             "related prompts",
         ),
+        # Lifecycle status (ADR-051): same spine as decisions/requirements.
+        metadata={"status": ("Proposed", "Accepted", "Superseded", "Deprecated")},
+        retired_status=("Superseded", "Deprecated"),
         descriptions={
             "context": "The product area, situation, or experience this design addresses",
             "user need": "The user, audience, task, pain point, or goal this design supports",

--- a/src/rac/core/relationship_types.py
+++ b/src/rac/core/relationship_types.py
@@ -1,0 +1,76 @@
+"""Relationship-type registry — the edge schema for Layer-3 graph integrity (ADR-055).
+
+Edge *legality by source type* (domain) stays where v0.14.0 put it:
+``ArtifactSpec.optional`` (the sections a type may declare). This registry adds
+the *graph* properties of each relationship kind — target type (``range``),
+directionality, acyclicity, and whether the edge forbids a retired target — so
+the Layer-3 checks (range, acyclicity, status-consistency) read one declarative
+source instead of hard-coded special cases.
+
+The registry is **code-defined**. Custom, repo-declared relationship types are
+deferred (ADR-052 defers the analogous custom artifact types); the built-in
+vocabulary is ``rac.services.relationships.RELATIONSHIP_SECTIONS`` keyed in its
+snake_case form (``related_decisions``, ``supersedes``), matching the keys
+``extract_relationships_full`` produces.
+
+``range``, ``acyclic``, and ``forbids_target_status`` are enforced today.
+``symmetric``/``inverse``/``cardinality`` are declared for display and forward
+compatibility (a viewer can label inverse edges) and are not yet enforced.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class EdgeSpec:
+    """The graph schema of one relationship kind."""
+
+    name: str  # snake_case edge key, e.g. "related_decisions", "supersedes"
+    range: tuple[str, ...]  # artifact types a target may be (enforced)
+    directional: bool = False  # supersedes is directional; related_* are not
+    acyclic: bool = False  # cycles are illegal for this kind (enforced)
+    symmetric: bool = True  # an undirected "relates-to" link (declared)
+    inverse: str | None = None  # inverse edge label (declared, display only)
+    # When True, a live source must not point at a retired target via this edge
+    # (the status-consistency rule). supersedes sets False — the replacing
+    # decision legitimately points at the one it retires.
+    forbids_target_status: bool = True
+    cardinality: str = "many"  # declared; not yet enforced
+
+
+def _related(target_type: str) -> EdgeSpec:
+    """An undirected ``related_<type>s`` edge whose range is ``target_type``."""
+    name = f"related_{target_type}s"
+    return EdgeSpec(name=name, range=(target_type,), inverse=name)
+
+
+# Built-in relationship kinds. The five ``related_*`` edges are undirected links
+# whose target must be of the named type; ``supersedes`` is the one directional,
+# acyclic, decision→decision edge, and the only one exempt from the retired-target
+# rule (forbids_target_status=False).
+REGISTRY: dict[str, EdgeSpec] = {
+    spec.name: spec
+    for spec in (
+        _related("requirement"),
+        _related("decision"),
+        _related("roadmap"),
+        _related("prompt"),
+        _related("design"),
+        EdgeSpec(
+            name="supersedes",
+            range=("decision",),
+            directional=True,
+            acyclic=True,
+            symmetric=False,
+            inverse="superseded-by",
+            forbids_target_status=False,
+        ),
+    )
+}
+
+
+def edge_spec(name: str) -> EdgeSpec | None:
+    """The :class:`EdgeSpec` for a snake_case relationship kind, or None."""
+    return REGISTRY.get(name)

--- a/src/rac/core/validation.py
+++ b/src/rac/core/validation.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import re
 from collections import Counter
 
-from .artifacts import spec_for
+from .artifacts import ArtifactSpec, spec_for
 from .classification import classify
 from .identity import identity_conflict
 from .models import Issue, Product
@@ -47,7 +47,35 @@ def validate(product: Product) -> list[Issue]:
         return issues + _validate_prompt(product)
     if artifact_type == "design":
         return issues + _validate_design(product)
+    if artifact_type == "requirement":
+        spec = spec_for("requirement")
+        assert spec is not None  # the requirement spec always exists
+        return issues + _validate_requirement(product) + _validate_status_metadata(product, spec)
+    # Unknown/legacy fallback: requirement rules only, no constrained metadata.
     return issues + _validate_requirement(product)
+
+
+def _validate_status_metadata(product: Product, spec: ArtifactSpec) -> list[Issue]:
+    """Constrained metadata: a present value must be in the type's allowed set.
+
+    Generalised across all artifact types (ADR-051): a missing section is fine —
+    metadata is optional. The issue code is per-type (``invalid-<type>-<field>``)
+    so ``invalid-decision-status`` is unchanged (ADR-007) and other types gain
+    their own codes.
+    """
+    issues: list[Issue] = []
+    for field_name, allowed in spec.metadata.items():
+        body = product.sections.get(field_name, "")
+        value = _first_value(body)
+        if value and not any(value.casefold() == a.casefold() for a in allowed):
+            issues.append(
+                Issue(
+                    "error",
+                    f"invalid-{spec.name}-{field_name}",
+                    f"## {field_name.title()} value {value!r} is not one of: {', '.join(allowed)}.",
+                )
+            )
+    return issues
 
 
 def _validate_metadata(product: Product) -> list[Issue]:
@@ -118,19 +146,9 @@ def _validate_decision(product: Product) -> list[Issue]:
                 )
             )
 
-    # Constrained metadata: a present value must be in the allowed set. A missing
-    # section is fine — metadata is optional (REQ-007).
-    for field_name, allowed in spec.metadata.items():
-        body = product.sections.get(field_name, "")
-        value = _first_value(body)
-        if value and not any(value.casefold() == a.casefold() for a in allowed):
-            issues.append(
-                Issue(
-                    "error",
-                    f"invalid-decision-{field_name}",
-                    f"## {field_name.title()} value {value!r} is not one of: {', '.join(allowed)}.",
-                )
-            )
+    # Constrained metadata (status, category): a present value must be in the
+    # allowed set. A missing section is fine — metadata is optional (REQ-007).
+    issues += _validate_status_metadata(product, spec)
 
     return issues
 
@@ -139,8 +157,9 @@ def _validate_roadmap(product: Product) -> list[Issue]:
     """Validate a Roadmap artifact (REQ-003).
 
     Required sections (Outcomes, Initiatives) must be present; missing recommended
-    sections never fail. Roadmaps carry no constrained metadata (no owners, dates,
-    or status — ADR-017: RAC manages knowledge, not work).
+    sections never fail. Status is an optional, validated lifecycle field
+    (ADR-051: Planned/Superseded/Abandoned) — knowledge currency, never work or
+    delivery state (ADR-017).
     """
     spec = spec_for("roadmap")
     assert spec is not None  # the roadmap spec always exists
@@ -169,6 +188,7 @@ def _validate_roadmap(product: Product) -> list[Issue]:
                 )
             )
 
+    issues += _validate_status_metadata(product, spec)
     return issues
 
 
@@ -176,8 +196,9 @@ def _validate_prompt(product: Product) -> list[Issue]:
     """Validate a Prompt artifact (REQ-006).
 
     Required sections (Objective, Input, Instructions, Output) must be present;
-    missing recommended/optional sections never fail or warn. Prompts carry no
-    metadata and are never executed (REQ-011) — RAC treats them as knowledge.
+    missing recommended/optional sections never fail or warn. Status is an
+    optional, validated lifecycle field (ADR-051: Active/Deprecated); prompts are
+    never executed (REQ-011) — RAC treats them as knowledge.
 
     Section presence is checked against the raw headings, consistent with the
     Decision and Roadmap validators; the Prompt spec's synonyms are a
@@ -210,6 +231,7 @@ def _validate_prompt(product: Product) -> list[Issue]:
                 )
             )
 
+    issues += _validate_status_metadata(product, spec)
     return issues
 
 
@@ -217,8 +239,9 @@ def _validate_design(product: Product) -> list[Issue]:
     """Validate a Design artifact (v0.6.3).
 
     Required sections (Context, User Need, Design, Constraints) must be present;
-    missing recommended/optional sections never fail or warn. Designs carry no
-    metadata and are knowledge artifacts, not UI renderings or component systems.
+    missing recommended/optional sections never fail or warn. Status is an
+    optional, validated lifecycle field (ADR-051); designs are knowledge
+    artifacts, not UI renderings or component systems.
     """
     spec = spec_for("design")
     assert spec is not None  # the design spec always exists
@@ -247,6 +270,7 @@ def _validate_design(product: Product) -> list[Issue]:
                 )
             )
 
+    issues += _validate_status_metadata(product, spec)
     return issues
 
 

--- a/src/rac/output/human.py
+++ b/src/rac/output/human.py
@@ -38,10 +38,12 @@ from rac.services.quickstart import QuickstartResult
 from rac.services.relationships import (
     ISSUE_DUPLICATE_IDENTIFIER,
     ISSUE_EDGE_UNSUPPORTED,
+    ISSUE_RELATIONSHIP_CYCLE,
     ISSUE_SELF_REFERENCE,
     ISSUE_TARGET_AMBIGUOUS,
     ISSUE_TARGET_NOT_FOUND,
     ISSUE_TARGET_SUPERSEDED,
+    ISSUE_TARGET_TYPE_MISMATCH,
     RelationshipReport,
     RelationshipValidation,
 )
@@ -594,6 +596,7 @@ _REF_ISSUE_SUFFIX = {
     ISSUE_TARGET_AMBIGUOUS: "ambiguous",
     ISSUE_SELF_REFERENCE: "self-reference",
     ISSUE_TARGET_SUPERSEDED: "superseded",
+    ISSUE_TARGET_TYPE_MISMATCH: "wrong target type",
 }
 
 
@@ -607,10 +610,12 @@ def render_relationship_validation_human(report: RelationshipValidation) -> str:
 
     duplicates = [i for i in report.issues if i.code == ISSUE_DUPLICATE_IDENTIFIER]
     unsupported = [i for i in report.issues if i.code == ISSUE_EDGE_UNSUPPORTED]
+    cycles = [i for i in report.issues if i.code == ISSUE_RELATIONSHIP_CYCLE]
     references = [
         i
         for i in report.issues
-        if i.code not in (ISSUE_DUPLICATE_IDENTIFIER, ISSUE_EDGE_UNSUPPORTED)
+        if i.code
+        not in (ISSUE_DUPLICATE_IDENTIFIER, ISSUE_EDGE_UNSUPPORTED, ISSUE_RELATIONSHIP_CYCLE)
     ]
 
     if duplicates:
@@ -629,6 +634,13 @@ def render_relationship_validation_human(report: RelationshipValidation) -> str:
                 lines += ["", issue.source_path or "<input>"]
             label = _relationship_label(issue.relationship or "")
             lines.append(_red(f"  ✗ {label} not supported for this artifact type"))
+
+    if cycles:
+        lines += ["", _bold("Relationship Cycles")]
+        for issue in cycles:
+            label = _relationship_label(issue.relationship or "")
+            lines.append(_red(f"✗ {label} cycle:"))
+            lines.extend(f"  - {p}" for p in issue.paths or [])
 
     if references:
         lines += ["", _bold("Broken Relationships")]

--- a/src/rac/services/portfolio.py
+++ b/src/rac/services/portfolio.py
@@ -38,6 +38,7 @@ from .relationships import (
     ISSUE_TARGET_NOT_FOUND,
     RelationshipSummary,
     summary_from_corpus,
+    validation_from_corpus,
 )
 
 # Stable attention codes (part of the JSON contract, ADR-007).
@@ -94,6 +95,11 @@ class PortfolioSummary:
     # ``by_type`` but neither validated nor completeness-scored, so consumers
     # like ``rac review`` need the paths to surface them without a second walk.
     unknown_paths: list[str] = field(default_factory=list)
+    # Full relationship-validation gate result (v0.16.0, additive): whether every
+    # referential, edge-legality, range, status-consistency, and acyclicity check
+    # passes. Distinct from ``relationships.broken`` (referential resolution only),
+    # so the summary can report the same verdict as `rac relationships --validate`.
+    relationships_ok: bool = True
 
     @property
     def total_artifacts(self) -> int:
@@ -147,6 +153,15 @@ class PortfolioSummary:
             "attention": [item.to_dict() for item in self.attention],
             "health": {
                 "score": self.health_score,
+            },
+            # Additive (v0.16.0, ADR-007): the repository validation gate, so an
+            # agent over MCP (`get_summary`) can read pass/fail without a second
+            # tool. ``relationships_ok`` reflects the full relationship-validation
+            # gate (referential + edge-legality + range + status + acyclicity).
+            "validation_status": {
+                "artifacts_ok": self.invalid_artifacts == 0,
+                "relationships_ok": self.relationships_ok,
+                "ok": self.invalid_artifacts == 0 and self.relationships_ok,
             },
         }
 
@@ -236,6 +251,9 @@ def portfolio_from_corpus(
     # Reuses the snapshot (no second walk); per-reference issues become
     # attention items so broken references are surfaced, not just counted.
     rel_summary = summary_from_corpus(entries)
+    # The full relationship-validation gate (additive, v0.16.0): same verdict as
+    # `rac relationships --validate`, over the same snapshot (no extra walk).
+    relationships_ok = validation_from_corpus(directory, entries, recursive=recursive).ok
     for issue in rel_summary.issues:
         source = issue.source_path or ""
         label = (issue.relationship or "").replace("_", " ").title()
@@ -265,4 +283,5 @@ def portfolio_from_corpus(
         relationships=rel_summary,
         attention=attention,
         unknown_paths=unknown_paths,
+        relationships_ok=relationships_ok,
     )

--- a/src/rac/services/relationships.py
+++ b/src/rac/services/relationships.py
@@ -25,6 +25,7 @@ from rac.core.corpus import CorpusEntry, walk_corpus
 from rac.core.identity import artifact_identifier, artifact_identifiers
 from rac.core.markdown import parse_file
 from rac.core.models import Product
+from rac.core.relationship_types import REGISTRY, edge_spec
 
 # The cross-artifact "Related X" sections. These populate the ``relationships``
 # dict in ``rac inspect`` output. ``related designs`` is included so every peer
@@ -312,26 +313,33 @@ ISSUE_SELF_REFERENCE = "relationship-self-reference"
 # Edge-legality (v0.14.0, ADR-049): a relationship section the artifact's type
 # does not declare produces no edge and is reported, not silently dropped.
 ISSUE_EDGE_UNSUPPORTED = "relationship-edge-unsupported"
-# Status-consistency (v0.14.1, ADR-049): a live artifact references a decision the
-# team has retired (Superseded/Deprecated), other than via ``supersedes``.
+# Status-consistency (v0.14.1, ADR-049; generalised in v0.16.0/ADR-051): a live
+# artifact references a target the team has retired, other than via ``supersedes``.
 ISSUE_TARGET_SUPERSEDED = "relationship-target-superseded"
+# Range (v0.16.0, ADR-055): a resolved target whose type is not in the edge's range
+# (e.g. a ``## Related Decisions`` reference that resolves to a requirement).
+ISSUE_TARGET_TYPE_MISMATCH = "relationship-target-type-mismatch"
+# Acyclicity (v0.16.0, ADR-055): a cycle in a directional, acyclic edge kind
+# (``supersedes``), which an ordering/replacement relationship must not contain.
+ISSUE_RELATIONSHIP_CYCLE = "relationship-cycle"
 
-# Decision statuses that mark an artifact as retired (no longer live). Matched
-# case-insensitively against the first line of a decision's ``## Status`` — the
-# same first-line rule ``rac inspect`` uses, inlined to avoid importing
-# ``inspect`` (which imports this module).
-_RETIRED_STATUSES = ("superseded", "deprecated")
 
+def _is_retired_artifact(product: Product, spec: ArtifactSpec | None) -> bool:
+    """True when ``product``'s ``## Status`` is one of its type's retired states.
 
-def _is_retired_decision(product: Product, spec: ArtifactSpec | None) -> bool:
-    """True when ``product`` is a decision whose status is Superseded/Deprecated."""
-    if spec is None or spec.name != "decision":
+    Spec-driven (ADR-051): reads ``spec.retired_status`` rather than a hard-coded
+    set, so every type's retired states are honoured. Matches case-insensitively
+    against the first non-empty status line — the same first-line rule
+    ``rac inspect`` uses, inlined to avoid importing ``inspect`` (which imports
+    this module).
+    """
+    if spec is None or not spec.retired_status:
         return False
     body = product.sections.get("status")
     if not body:
         return False
     first = next((line.strip() for line in body.splitlines() if line.strip()), "")
-    return first.casefold() in _RETIRED_STATUSES
+    return any(first.casefold() == s.casefold() for s in spec.retired_status)
 
 
 @dataclass
@@ -361,6 +369,12 @@ class RelationshipIssue:
             return {
                 "source_path": self.source_path,
                 "relationship": self.relationship,
+                "code": self.code,
+            }
+        if self.code == ISSUE_RELATIONSHIP_CYCLE:
+            return {
+                "relationship": self.relationship,
+                "paths": self.paths,
                 "code": self.code,
             }
         return {
@@ -492,6 +506,89 @@ def _resolve_references(
     return checked, issues, resolved_targets
 
 
+def _acyclic_adjacency(
+    items: list[tuple[str, Product, ArtifactSpec | None]],
+    resolution_index: _IdentIndex,
+    kind: str,
+) -> dict[str, list[str]]:
+    """``{source_path -> sorted unique target paths}`` for edge ``kind``.
+
+    Only uniquely-resolved, non-self edges contribute (self/ambiguous/unresolved
+    are owned by referential integrity), so the graph reflects real directed edges.
+    """
+    adjacency: dict[str, list[str]] = {}
+    for path, product, spec in items:
+        if spec is None:
+            continue
+        targets: set[str] = set()
+        for ref in extract_relationships_full(product, spec).get(kind, []):
+            resolved = [p for p, _ in resolution_index.get(ref.casefold(), [])]
+            if len(resolved) == 1 and resolved[0] != path:
+                targets.add(resolved[0])
+        if targets:
+            adjacency[path] = sorted(targets)
+    return adjacency
+
+
+def _cyclic_components(adjacency: dict[str, list[str]]) -> list[list[str]]:
+    """Strongly-connected components of size > 1, each a sorted node list.
+
+    A cycle exists exactly within an SCC larger than one node (self-loops are
+    already excluded upstream). Deterministic: nodes and neighbours are visited in
+    sorted order (Tarjan), and the components are returned sorted.
+    """
+    indices: dict[str, int] = {}
+    lowlink: dict[str, int] = {}
+    on_stack: set[str] = set()
+    stack: list[str] = []
+    counter = [0]
+    components: list[list[str]] = []
+
+    nodes = sorted(set(adjacency) | {t for ts in adjacency.values() for t in ts})
+
+    def strongconnect(v: str) -> None:
+        indices[v] = lowlink[v] = counter[0]
+        counter[0] += 1
+        stack.append(v)
+        on_stack.add(v)
+        for w in adjacency.get(v, []):
+            if w not in indices:
+                strongconnect(w)
+                lowlink[v] = min(lowlink[v], lowlink[w])
+            elif w in on_stack:
+                lowlink[v] = min(lowlink[v], indices[w])
+        if lowlink[v] == indices[v]:
+            component: list[str] = []
+            while True:
+                w = stack.pop()
+                on_stack.discard(w)
+                component.append(w)
+                if w == v:
+                    break
+            if len(component) > 1:
+                components.append(sorted(component))
+
+    for node in nodes:
+        if node not in indices:
+            strongconnect(node)
+    return sorted(components, key=lambda c: c[0])
+
+
+def _cycle_issues(
+    items: list[tuple[str, Product, ArtifactSpec | None]],
+    resolution_index: _IdentIndex,
+) -> list[RelationshipIssue]:
+    """One ``relationship-cycle`` per cyclic component of each acyclic edge kind."""
+    issues: list[RelationshipIssue] = []
+    for kind in sorted(name for name, edge in REGISTRY.items() if edge.acyclic):
+        adjacency = _acyclic_adjacency(items, resolution_index, kind)
+        for component in _cyclic_components(adjacency):
+            issues.append(
+                RelationshipIssue(code=ISSUE_RELATIONSHIP_CYCLE, relationship=kind, paths=component)
+            )
+    return issues
+
+
 def _validate(
     directory: str,
     items: list[tuple[str, Product, ArtifactSpec | None]],
@@ -526,24 +623,63 @@ def _validate(
             )
 
     resolution_index = _build_resolution_index(items)
-
-    # Status-consistency (v0.14.1, ADR-049): a live artifact must not reference a
-    # retired (Superseded/Deprecated) decision, except via ``supersedes``. Reads
-    # the resolved target's status from the materialised items — no second walk,
-    # no change to _resolve_references (which feeds portfolio accounting).
     by_path = {path: (product, spec) for path, product, spec in items}
+
+    def _resolved(ref: str, source_path: str) -> str | None:
+        """The unique non-self target path for ``ref``, or None.
+
+        Unresolved/ambiguous/self references are owned by referential integrity;
+        the graph checks below only reason about uniquely-resolved edges.
+        """
+        targets = [p for p, _ in resolution_index.get(ref.casefold(), [])]
+        if len(targets) != 1 or targets[0] == source_path:
+            return None
+        return targets[0]
+
+    # Range (v0.16.0, ADR-055): a resolved target whose type is not in the edge's
+    # declared range is an illegal edge — e.g. a ``## Related Decisions`` reference
+    # that resolves to a requirement. Deterministic (sorted-path / spec.optional).
     for path, product, spec in items:
-        if spec is None or _is_retired_decision(product, spec):
+        if spec is None:
+            continue
+        for section, refs in extract_relationships_full(product, spec).items():
+            edge = edge_spec(section)
+            if edge is None:
+                continue
+            for ref in refs:
+                target = _resolved(ref, path)
+                if target is None:
+                    continue
+                _, target_spec = by_path[target]
+                if target_spec is None:
+                    continue  # untyped document (ADR-010) — not a range violation
+                if target_spec.name not in edge.range:
+                    issues.append(
+                        RelationshipIssue(
+                            code=ISSUE_TARGET_TYPE_MISMATCH,
+                            source_path=path,
+                            relationship=section,
+                            target=ref,
+                        )
+                    )
+
+    # Status-consistency (v0.14.1, generalised in v0.16.0/ADR-051): a live artifact
+    # must not reference a retired target, except via an edge that permits it
+    # (``supersedes``, ``forbids_target_status=False``). Reads the resolved
+    # target's status from the materialised items — no second walk.
+    for path, product, spec in items:
+        if spec is None or _is_retired_artifact(product, spec):
             continue  # unknown file, or a retired source (historical chains exempt)
         for section, refs in extract_relationships_full(product, spec).items():
-            if section == "supersedes":
-                continue  # the replacing decision legitimately points at the retired one
+            edge = edge_spec(section)
+            if edge is None or not edge.forbids_target_status:
+                continue  # supersedes legitimately points at the retired one
             for ref in refs:
-                targets = [p for p, _ in resolution_index.get(ref.casefold(), [])]
-                if len(targets) != 1 or targets[0] == path:
-                    continue  # unresolved/ambiguous/self — referential integrity owns it
-                target_product, target_spec = by_path[targets[0]]
-                if _is_retired_decision(target_product, target_spec):
+                target = _resolved(ref, path)
+                if target is None:
+                    continue
+                target_product, target_spec = by_path[target]
+                if _is_retired_artifact(target_product, target_spec):
                     issues.append(
                         RelationshipIssue(
                             code=ISSUE_TARGET_SUPERSEDED,
@@ -552,6 +688,11 @@ def _validate(
                             target=ref,
                         )
                     )
+
+    # Acyclicity (v0.16.0, ADR-055): a cycle in a directional, acyclic edge kind
+    # (today ``supersedes``) is illegal — an ordering/replacement edge must not
+    # form a loop. Reported per strongly-connected component, deterministically.
+    issues.extend(_cycle_issues(items, resolution_index))
 
     checked, ref_issues, _ = _resolve_references(items, resolution_index)
     issues.extend(ref_issues)

--- a/tests/golden/schema_requirement_human.txt
+++ b/tests/golden/schema_requirement_human.txt
@@ -40,3 +40,6 @@ Optional Sections:
       Description: Design artifacts this artifact references
   - Related Requirements
       Description: Requirement artifacts this artifact references
+
+Metadata Fields:
+  - Status: Proposed | Accepted | Superseded | Deprecated

--- a/tests/test_design.py
+++ b/tests/test_design.py
@@ -80,10 +80,13 @@ def test_ui_design_themed_titles_do_not_drive_classification():
     assert classify(parse(requirement_about_ui)).type == "requirement"
 
 
-def test_design_carries_no_metadata():
+def test_design_carries_lifecycle_status():
+    # ADR-051: designs share the decision spine (Proposed/Accepted/Superseded/
+    # Deprecated).
     spec = spec_for("design")
     assert spec is not None
-    assert spec.metadata == {}
+    assert spec.metadata == {"status": ("Proposed", "Accepted", "Superseded", "Deprecated")}
+    assert spec.retired_status == ("Superseded", "Deprecated")
 
 
 # --- validation -------------------------------------------------------------

--- a/tests/test_lifecycle_status.py
+++ b/tests/test_lifecycle_status.py
@@ -1,0 +1,54 @@
+"""Tests for generalized lifecycle status validation (ADR-051).
+
+Status is an optional, validated `## Status` body section on every artifact type.
+A present value outside the type's enum is an error (`invalid-<type>-status`); a
+missing section is fine. The decision code `invalid-decision-status` is unchanged
+(ADR-007).
+"""
+
+from __future__ import annotations
+
+from rac.core.markdown import parse
+from rac.core.validation import validate
+
+REQUIREMENT = "# R\n\n## Problem\n\np\n\n## Requirements\n\n- [REQ-001] do it\n\n## Status\n\n{s}\n"
+ROADMAP = "# R\n\n## Outcomes\n\no\n\n## Initiatives\n\ni\n\n## Status\n\n{s}\n"
+PROMPT = (
+    "# P\n\n## Objective\n\no\n\n## Input\n\ni\n\n## Instructions\n\nx\n\n"
+    "## Output\n\nout\n\n## Status\n\n{s}\n"
+)
+DESIGN = (
+    "# D\n\n## Context\n\nc\n\n## User Need\n\nu\n\n## Design\n\nd\n\n"
+    "## Constraints\n\nk\n\n## Status\n\n{s}\n"
+)
+
+
+def codes(text):
+    return {i.code for i in validate(parse(text))}
+
+
+def test_valid_status_passes_per_type():
+    assert "invalid-requirement-status" not in codes(REQUIREMENT.format(s="Accepted"))
+    assert "invalid-roadmap-status" not in codes(ROADMAP.format(s="Planned"))
+    assert "invalid-prompt-status" not in codes(PROMPT.format(s="Active"))
+    assert "invalid-design-status" not in codes(DESIGN.format(s="Superseded"))
+
+
+def test_out_of_enum_status_fails_per_type():
+    # roadmap has no Accepted; prompt has no Proposed — each is out of enum.
+    assert "invalid-requirement-status" in codes(REQUIREMENT.format(s="Done"))
+    assert "invalid-roadmap-status" in codes(ROADMAP.format(s="Accepted"))
+    assert "invalid-prompt-status" in codes(PROMPT.format(s="Proposed"))
+    assert "invalid-design-status" in codes(DESIGN.format(s="Shipped"))
+
+
+def test_decision_status_code_unchanged():
+    decision = (
+        "# D\n\n## Context\n\nc\n\n## Decision\n\nd\n\n## Consequences\n\nx\n\n## Status\n\nBogus\n"
+    )
+    assert "invalid-decision-status" in codes(decision)
+
+
+def test_missing_status_is_optional():
+    no_status = "# R\n\n## Problem\n\np\n\n## Requirements\n\n- [REQ-001] do it\n"
+    assert not any(c.endswith("-status") for c in codes(no_status))

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -80,10 +80,12 @@ def test_ai_themed_requirement_stays_requirement():
     assert classify(parse(text)).type == "requirement"
 
 
-def test_prompt_carries_no_metadata():
+def test_prompt_carries_lifecycle_status():
+    # ADR-051: prompts use Active (live) / Deprecated (retired).
     spec = spec_for("prompt")
     assert spec is not None
-    assert spec.metadata == {}
+    assert spec.metadata == {"status": ("Active", "Deprecated")}
+    assert spec.retired_status == ("Deprecated",)
 
 
 # --- synonyms (artifact-scoped) ---------------------------------------------

--- a/tests/test_relationship_graph.py
+++ b/tests/test_relationship_graph.py
@@ -1,0 +1,157 @@
+"""Tests for Layer-3 relationship-graph integrity (ADR-055, ADR-051).
+
+Covers the new graph checks — range (wrong target type), acyclicity (supersedes
+cycles), and the generalized all-type status-consistency rule — plus the
+relationship-type registry and the validation_status the portfolio summary
+exposes to the MCP get_summary tool.
+"""
+
+from __future__ import annotations
+
+from rac.core.relationship_types import REGISTRY, edge_spec
+from rac.services.portfolio import build_portfolio_summary
+from rac.services.relationships import (
+    ISSUE_RELATIONSHIP_CYCLE,
+    ISSUE_TARGET_SUPERSEDED,
+    ISSUE_TARGET_TYPE_MISMATCH,
+    validate_relationships,
+)
+
+
+def _write(path, text):
+    path.write_text(text, encoding="utf-8")
+
+
+def _req(title, extra=""):
+    return f"# {title}\n\n## Problem\n\np\n\n## Requirements\n\n- [REQ-001] do the thing\n{extra}\n"
+
+
+def _dec(title, status="Accepted", extra=""):
+    return (
+        f"# {title}\n\n## Context\n\nc\n\n## Decision\n\nd\n\n"
+        f"## Consequences\n\nx\n\n## Status\n\n{status}\n{extra}\n"
+    )
+
+
+def codes(report):
+    return {i.code for i in report.issues}
+
+
+# --- registry ----------------------------------------------------------------
+
+
+def test_registry_declares_built_in_edges():
+    assert set(REGISTRY) == {
+        "related_requirements",
+        "related_decisions",
+        "related_roadmaps",
+        "related_prompts",
+        "related_designs",
+        "supersedes",
+    }
+    supersedes = edge_spec("supersedes")
+    assert supersedes is not None
+    assert supersedes.directional and supersedes.acyclic
+    assert supersedes.forbids_target_status is False  # the exemption is data-driven
+    assert edge_spec("related_decisions").range == ("decision",)
+    assert edge_spec("related_decisions").forbids_target_status is True
+
+
+# --- range -------------------------------------------------------------------
+
+
+def test_range_mismatch_is_flagged(tmp_path):
+    # A requirement declares ## Related Decisions but points at another requirement.
+    _write(tmp_path / "target.md", _req("Target Requirement"))
+    _write(tmp_path / "source.md", _req("Source", "\n## Related Decisions\n\n- target\n"))
+    report = validate_relationships(str(tmp_path))
+    assert ISSUE_TARGET_TYPE_MISMATCH in codes(report)
+    issue = next(i for i in report.issues if i.code == ISSUE_TARGET_TYPE_MISMATCH)
+    assert issue.relationship == "related_decisions"
+    assert issue.target == "target"
+
+
+def test_range_match_passes(tmp_path):
+    _write(tmp_path / "d.md", _dec("A Decision"))
+    _write(tmp_path / "source.md", _req("Source", "\n## Related Decisions\n\n- d\n"))
+    report = validate_relationships(str(tmp_path))
+    assert ISSUE_TARGET_TYPE_MISMATCH not in codes(report)
+
+
+def test_range_exempts_untyped_target(tmp_path):
+    # An untyped document target (ADR-010) is not a range violation.
+    _write(tmp_path / "notes.md", "# Loose Notes\n\njust prose, no schema\n")
+    _write(tmp_path / "source.md", _req("Source", "\n## Related Decisions\n\n- notes\n"))
+    report = validate_relationships(str(tmp_path))
+    assert ISSUE_TARGET_TYPE_MISMATCH not in codes(report)
+
+
+# --- acyclicity --------------------------------------------------------------
+
+
+def test_supersedes_cycle_is_flagged(tmp_path):
+    _write(tmp_path / "a.md", _dec("A", extra="\n## Supersedes\n\n- b\n"))
+    _write(tmp_path / "b.md", _dec("B", extra="\n## Supersedes\n\n- a\n"))
+    report = validate_relationships(str(tmp_path))
+    assert ISSUE_RELATIONSHIP_CYCLE in codes(report)
+    cycle = next(i for i in report.issues if i.code == ISSUE_RELATIONSHIP_CYCLE)
+    assert cycle.relationship == "supersedes"
+    assert sorted(p.rsplit("/", 1)[-1] for p in cycle.paths) == ["a.md", "b.md"]
+
+
+def test_acyclic_supersedes_chain_passes(tmp_path):
+    # a supersedes b supersedes c — a chain, not a cycle.
+    _write(tmp_path / "a.md", _dec("A", extra="\n## Supersedes\n\n- b\n"))
+    _write(tmp_path / "b.md", _dec("B", status="Superseded", extra="\n## Supersedes\n\n- c\n"))
+    _write(tmp_path / "c.md", _dec("C", status="Superseded"))
+    report = validate_relationships(str(tmp_path))
+    assert ISSUE_RELATIONSHIP_CYCLE not in codes(report)
+
+
+# --- generalized status-consistency (ADR-051) --------------------------------
+
+
+def test_live_requirement_referencing_retired_requirement_fails(tmp_path):
+    _write(tmp_path / "old.md", _req("Old", "\n## Status\n\nSuperseded\n"))
+    _write(tmp_path / "live.md", _req("Live", "\n## Related Requirements\n\n- old\n"))
+    report = validate_relationships(str(tmp_path))
+    assert ISSUE_TARGET_SUPERSEDED in codes(report)
+
+
+def test_retired_source_is_exempt(tmp_path):
+    # A retired artifact's own outbound reference is a historical chain, not a fault.
+    _write(tmp_path / "old.md", _req("Old", "\n## Status\n\nSuperseded\n"))
+    _write(
+        tmp_path / "older.md",
+        _req("Older", "\n## Status\n\nSuperseded\n\n## Related Requirements\n\n- old\n"),
+    )
+    report = validate_relationships(str(tmp_path))
+    assert ISSUE_TARGET_SUPERSEDED not in codes(report)
+
+
+def test_supersedes_to_retired_decision_is_exempt(tmp_path):
+    # The replacing decision legitimately points at the one it retires.
+    _write(tmp_path / "old.md", _dec("Old", status="Superseded"))
+    _write(tmp_path / "new.md", _dec("New", extra="\n## Supersedes\n\n- old\n"))
+    report = validate_relationships(str(tmp_path))
+    assert ISSUE_TARGET_SUPERSEDED not in codes(report)
+
+
+# --- validation_status in the summary (MCP get_summary) ----------------------
+
+
+def test_summary_reports_validation_status_ok(tmp_path):
+    _write(tmp_path / "d.md", _dec("A Decision"))
+    payload = build_portfolio_summary(str(tmp_path)).to_dict()
+    assert payload["validation_status"] == {
+        "artifacts_ok": True,
+        "relationships_ok": True,
+        "ok": True,
+    }
+
+
+def test_summary_reports_relationship_failure(tmp_path):
+    _write(tmp_path / "source.md", _req("Source", "\n## Related Decisions\n\n- nope\n"))
+    payload = build_portfolio_summary(str(tmp_path)).to_dict()
+    assert payload["validation_status"]["relationships_ok"] is False
+    assert payload["validation_status"]["ok"] is False

--- a/tests/test_roadmap.py
+++ b/tests/test_roadmap.py
@@ -50,11 +50,13 @@ def test_requirement_does_not_classify_as_roadmap():
     assert inspect_file(fixture_path("valid", "feature.md")).type == "requirement"
 
 
-def test_roadmap_carries_no_metadata():
-    # Roadmap manages knowledge, not work: no status/category/supersedes fields.
+def test_roadmap_carries_lifecycle_status():
+    # ADR-051: status is a knowledge lifecycle (Planned/Superseded/Abandoned),
+    # never work/delivery state; no category or supersedes metadata.
     spec = spec_for("roadmap")
     assert spec is not None
-    assert spec.metadata == {}
+    assert spec.metadata == {"status": ("Planned", "Superseded", "Abandoned")}
+    assert spec.retired_status == ("Superseded", "Abandoned")
 
 
 # --- validation -------------------------------------------------------------

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -103,7 +103,8 @@ def test_schema_json_requirement_shape(capsys):
     ]
     assert "success_metrics" in payload["descriptions"]
     assert "success_metrics" in payload["guidance"]
-    assert payload["metadata"] == {}
+    # ADR-051: requirements gained an optional lifecycle status field.
+    assert payload["metadata"] == {"status": ["Proposed", "Accepted", "Superseded", "Deprecated"]}
 
 
 def test_schema_json_decision_metadata_values(capsys):


### PR DESCRIPTION
# Summary

Implements `rac/roadmaps/v0.16.x-graph-integrity/v0.16.0-relationship-graph-integrity.md`.

Validates the corpus *as a graph* — the differentiator no single-file validator
(MADR, dotprompt, OKF) has. Referential integrity, edge-legality (domain), and
decision-only status-consistency already shipped; this closes the remaining
Layer-3 gaps:

1. **A code-defined relationship-type registry** declaring each edge's target
   type (range), directionality, acyclicity, and retired-target rule.
2. **Range** enforcement (`relationship-target-type-mismatch`) and **acyclicity**
   (`relationship-cycle`) as new checks.
3. **Generalized lifecycle status (ADR-051):** per-type status enums + a retired
   set, so "nothing live points at a retired artifact" covers all five types.
4. **Validation health on the MCP `get_summary` tool** (additive; the four
   read-only tools stay four in count).

# Roadmap / ADR Trace

Roadmap:
- `rac/roadmaps/v0.16.x-graph-integrity/v0.16.0-relationship-graph-integrity.md`

Relevant ADRs:
- `rac/decisions/adr-055-relationship-type-registry-and-graph-integrity.md` (new)
- `rac/decisions/adr-051-lifecycle-status-generalized.md` (implemented here)
- `adr-049` (enforcement is the product), `adr-016` (structural references; "cycles where relevant"), `adr-052` (custom edges deferred), `adr-010` (untyped documents), `adr-017` (knowledge not work), `adr-030` (four MCP tools), `adr-007`/`adr-002`

# Scope

## Included
- `rac.core.relationship_types`: `EdgeSpec` + `REGISTRY` (range / directional /
  acyclic / symmetric / inverse / forbids_target_status / cardinality). Domain
  stays `ArtifactSpec.optional` (v0.14.0).
- Range check (untyped-document targets exempt, ADR-010) and acyclicity (Tarjan
  SCC over `supersedes`).
- ADR-051: `retired_status` + a `status` enum on every spec; metadata validation
  generalized to all types (`invalid-TYPE-status`; `invalid-decision-status`
  unchanged). The `supersedes` exemption is now data-driven.
- `validation_status` block on `PortfolioSummary.to_dict()` → MCP `get_summary`
  and `rac portfolio`.
- Two pre-approved corpus status normalizations (the ADR-051 design named them).

## Excluded (deliberate, recorded)
- Custom/repo-declared relationship types and a `.rac/relationships.yaml` —
  deferred (ADR-052 pattern); the registry is code-defined.
- New directional edge vocabulary (`depends-on`, `refines`, …) — ADR-016 Risk 5.
- Enforcing cardinality or materializing inverse edges (declared only); transitive
  closure / graph queries; a fifth MCP tool; a status backfill of status-less
  artifacts.

# Product / Architecture Decisions

- **Domain stays `spec.optional`; the registry adds only graph properties** — no
  second source of truth for legality.
- **Range exempts untyped targets (ADR-010).** A `## Related Designs` reference to
  a loosely-structured doc that classifies as Unknown is a legitimate document,
  owned by referential integrity — not a range violation. Only a *recognized*
  wrong-type target is flagged. (This surfaced on real corpus links and is the
  conservative, ADR-016-Risk-4 choice.)
- **The supersedes exemption became data-driven** (`forbids_target_status=False`),
  replacing the hard-coded `section == "supersedes"` check and generalizing
  cleanly with ADR-051.
- **`relationships_ok` reflects the full relationship-validation gate**, not just
  referential `broken`, so `get_summary` reports the same verdict as
  `rac relationships --validate`. Computed over the existing snapshot (no extra
  walk); the repository model behind review/watchkeeper is unchanged.

# User-Facing Contract

## CLI
No new command or flag. `rac relationships DIR --validate` reports the new
issues and exits 1 when they occur. New issue codes:

| Code | Meaning |
| --- | --- |
| `relationship-target-type-mismatch` | A reference resolves to the wrong artifact type for the edge. |
| `relationship-cycle` | A cycle in a directional, acyclic edge (`supersedes`). |

`relationship-target-superseded` now covers all five types; `invalid-TYPE-status`
(e.g. `invalid-roadmap-status`) is emitted for an out-of-enum status on any type.

## JSON Output
A `relationship-cycle` issue serializes as `{relationship, paths, code}`; range
mismatches use the existing `{source_path, relationship, target, code}` shape.
`get_summary` / `rac portfolio --json` gain an additive `validation_status`:
`{ "artifacts_ok": bool, "relationships_ok": bool, "ok": bool }`. Existing codes
and shapes are unchanged.

## Exit Codes
- `0`: all references valid and the graph is consistent
- `1`: any relationship issue (referential, edge-legality, range, status, cycle)
- `2`: usage / IO error

# Verification

## Ran
- `rac validate rac/` → exit 0 (175 artifacts, OKF conformant) after the two
  status normalizations.
- `rac relationships rac/ --validate` → 0 issues (654 checked).
- Fixtures: a range mismatch and a `supersedes` cycle each exit 1 with a precise
  file diagnostic; a live→retired edge of a non-decision type fails; a `supersedes`
  edge to a retired decision and a retired source are exempt; an acyclic
  `supersedes` chain passes.
- `rac review rac/` → health 88, no priority 1-2 findings.
- `get_summary` / `rac portfolio --json` carry `validation_status`; the
  `test_factory_registers_exactly_the_four_tools` guard holds.
- `pytest` → 1153 passed (non-TUI) + 105 explorer + the MCP suite; 15 new tests.
  `ruff check` / `ruff format --check` / `mypy src/rac` clean.

## Covered
- Registry shape; range mismatch + match + untyped-target exemption; cycle vs
  acyclic chain; generalized status (live→retired any type, retired-source and
  supersedes exemptions); per-type status validation (valid/invalid/missing;
  decision code unchanged); `validation_status` ok and failure.

# Review Path

1. `src/rac/core/relationship_types.py` — the edge registry.
2. `src/rac/core/artifacts.py` + `validation.py` — ADR-051 status model + check.
3. `src/rac/services/relationships.py` — range, acyclicity (`_cyclic_components`),
   generalized status.
4. `src/rac/services/portfolio.py` + `src/rac/output/human.py` — `validation_status`
   and the new issue rendering.
5. `rac/decisions/adr-055-*.md`, `rac/roadmaps/.../v0.16.0-*.md`.
6. `tests/test_relationship_graph.py`, `tests/test_lifecycle_status.py`, the spec
   test updates, the schema golden, CI battery; `docs/relationships.md`, CHANGELOG.

# Notes For Reviewer

- The range check found real corpus links (roadmaps → `explorer-*` design docs
  that classify as Unknown). These are exempt by design (untyped targets, ADR-010),
  so no corpus change was needed beyond the two status normalizations.
- The custom-relationship-types exit criterion is **deferred on purpose** (ADR-052);
  the registry is code-defined and forward-compatible.
- One pre-existing test, `tests/test_hook.py::test_post_commit_hook_is_advisory_and_runs`,
  is environment-dependent (needs the installed `rac` console script); unrelated.

# Implementation Process

Implemented with AI assistance under the v0.16.0 roadmap contract; final scope —
including the code-defined registry over a repo-local one, keeping the edge
vocabulary, and implementing ADR-051 — review, and acceptance were the maintainer's.