### PR TITLE
feat(skill): add rac-import single-document import skill

### DIFF
--- a/.claude/skills/rac-import/SKILL.md
+++ b/.claude/skills/rac-import/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: rac-import
+description: Reformat ONE existing document (a decision, requirement, design, roadmap, or prompt) into ONE valid RAC (requirements-as-code) artifact, with a mandatory human-review step before any file is written and `rac validate` as the deterministic close. Use when a user wants to import a single existing decision or document into a project's rac/ directory. Single-document only — for multi-format or bulk conversion use the rac-ingest skill.
+---
+
+# RAC single-document import
+
+Reshape one existing document into one valid RAC artifact. You propose; the
+human ratifies; `rac validate` is the deterministic check. This skill never
+adds AI to the RAC core — it runs in the coding agent and uses the `rac` CLI.
+
+## Hard constraints
+
+- **One document in, one artifact out.** If asked to import a directory, a
+  whole wiki, or several documents at once, stop and explain that this skill
+  handles exactly one document → one artifact by design. For multi-format or
+  bulk conversion, point the user to the `rac-ingest` skill.
+- **The schema is not yours to invent.** Read the real shape with
+  `rac schema <type>` (and `rac schema` for the list of recognised types).
+  Use the real section names, the real five artifact types, and the real
+  `## Related <Type>` relationship sections. Never guess or hard-code a field,
+  type, or relationship kind. If you cannot run `rac schema`, stop and say so.
+- **Human review is mandatory and explicit (before any file is written).**
+  Present the draft and require the user to confirm or correct **(a) the
+  artifact type, (b) the title, and (c) each relationship** before you write
+  anything. Relationships are *suggestions to confirm*, never silently
+  asserted. The `id` is minted by `rac new` (opaque, system-assigned) — never
+  hand-write or choose it; show it after.
+- **Close on deterministic validation.** After writing, run `rac validate`.
+  If it fails, show the errors and offer to fix them, then re-validate. Never
+  leave an invalid artifact behind.
+- **No invention.** Reformat only what the source says. Do not invent context,
+  consequences, rationale, or requirements. Where a required section has no
+  source material, flag the gap and ask the user — do not fill it with
+  plausible-sounding text.
+
+## 1. Get the source
+
+Ask the user for the one document — pasted text or a file path — and, if it is
+not obvious, what kind of decision or requirement it represents. If they offer
+more than one document or a directory, apply the single-document constraint
+above before going further.
+
+## 2. Convert (only if not already Markdown)
+
+```bash
+rac ingest decision.docx          # preview Markdown on stdout
+```
+
+`rac ingest <file>` converts DOCX / PDF / HTML / PPTX / XLSX / Markdown to
+Markdown text, preserving structure — it does not judge whether the result is a
+valid artifact. Pasted Markdown needs no conversion. Rich formats need the
+optional extras (`pip install 'requirements-as-code[ingest]'`, `[ingest-pdf]`,
+`[ingest-office]`); the command names the missing extra when one is needed.
+
+## 3. Choose the type and read its real schema
+
+Pick the type with the user (or cross-check with `rac inspect <file>`, which
+infers type from `##` headings and reports confidence). Then read the actual
+contract:
+
+```bash
+rac schema                     # the recognised artifact types
+rac schema decision            # required / recommended / optional sections, and
+                               # any controlled values (e.g. Status, Category)
+rac schema decision --json     # the same, machine-readable
+```
+
+Map the source onto *these* section names. Do not introduce sections the schema
+does not define.
+
+## 4. Draft the artifact
+
+Reshape the source content under the type's real headings. Keep the author's
+own wording where it fits. For each **required** section the source does not
+cover, leave it clearly marked as a gap to raise with the user — do not invent
+content. (Requirements use testable `- [REQ-001] ...` lines under
+`## Requirements`; a `## Status` value, when present, must be one of the
+controlled values `rac schema` lists for that type.)
+
+> Normative language: writing requirements with BCP-14 keywords (MUST / SHOULD /
+> MAY) is good practice, but note that `rac validate` does not yet enforce them.
+> It does warn on vague verbs (support, handle, allow, enable) in requirements.
+
+## 5. Review gate — confirm before writing
+
+Present, in the conversation (not as a file yet):
+
+- the **draft** artifact;
+- a short summary: the **chosen type**, the **proposed title**, and any
+  **relationships the source explicitly names** (never relationships inferred by
+  scanning the repository — that is out of scope);
+- every **gap** where a required section had no source material.
+
+Ask the user to confirm or correct the type, the title, and each relationship.
+Verify any relationship target actually resolves before proposing it:
+
+```bash
+rac resolve <id> rac/
+rac find "<text>" rac/
+```
+
+Do not write a file until the user has confirmed.
+
+## 6. Write, then validate
+
+On confirmation, scaffold the file (this mints the id and writes the canonical
+template — it never overwrites an existing file), then replace the template body
+with the confirmed content:
+
+```bash
+rac new decision rac/decisions/<slug>.md
+```
+
+Write artifacts only inside the host project's RAC directory (`rac/` by default;
+confirm the path if the project keeps them elsewhere) under the matching
+subfolder (`rac/decisions/`, `rac/requirements/`, `rac/roadmaps/`,
+`rac/prompts/`, `rac/designs/`). If the project has no `.rac/config.yaml`, run
+`rac init` once at the project root first. Keep the `##` headings and the
+frontmatter block intact; never edit the minted `id`.
+
+Then close on validation:
+
+```bash
+rac validate rac/decisions/<slug>.md
+```
+
+Treat errors as blocking — show them, offer fixes, and re-run until it exits 0.
+`rac improve <file> --template` prints section stubs when the content exists to
+fill a missing recommended section. If the artifact links to others, finish with
+`rac relationships rac/ --validate`.
+
+## Out of scope
+
+- Bulk or batch import, directory crawling, or "migrate my whole wiki" (one
+  document → one artifact only; use `rac-ingest` for broader conversion).
+- Inferring relationships by scanning the repository — only the links the source
+  document itself names, each confirmed by the user.
+- Auto-committing the new artifact without the human-review step.
+- Inventing facts, context, or rationale not present in the source.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,25 @@ rac review rac/            # full repository review, worst problems first
 rac export rac/ --html --out lore-export.html    # the Portal, one file
 ```
 
+## Importing an existing decision
+
+Already have decisions in Confluence, Notion, or loose Markdown? The `rac-import`
+agent skill turns **one** existing document into **one** valid RAC artifact, with
+a human-review step before anything is written.
+
+```bash
+rac skill install rac-import   # installs into .claude/skills/ (Claude Code / Cursor auto-discover)
+```
+
+Then ask your agent, in plain language: *"import this decision doc into RAC"*
+(paste the text or give a path). The skill reads the real schema with
+`rac schema`, drafts the artifact from **only** what your document says, and
+shows you the proposed **type, title, and any relationships to confirm or
+correct** before it writes a file. It scaffolds with `rac new` (which mints the
+id), then closes on `rac validate` — and offers fixes if validation fails, so it
+never leaves an invalid artifact behind. It is single-document by design; for
+multi-format or bulk conversion use the `rac-ingest` skill.
+
 ## Who it's for
 
 - **Teams running coding agents heavily** (Claude Code, Cursor) who are tired of the agent ignoring decisions the team already made.

--- a/rac/requirements/rac-growth-agent-skill.md
+++ b/rac/requirements/rac-growth-agent-skill.md
@@ -38,6 +38,8 @@ code.claude.com/docs/en/skills). RAC should ship one.
 
 - [REQ-008] Every bundled skill is installable by name (`rac skill install <name>`), all bundled skills install together when no name is given (refusing all-or-nothing if any target exists), `rac skill list` enumerates them, and each skill carries its own packaged-resource/dogfood byte-equality test.
 
+- [REQ-009] A bundled single-document import skill (`rac-import`) reshapes one existing document into one valid RAC artifact: it reads the real schema with `rac schema`, drafts only from source content (flagging required sections the source does not cover, never fabricating), requires explicit human confirmation of the artifact type, title, and any relationships before any file is written, scaffolds with `rac new` (which mints the id), and closes on `rac validate`. It is single-document by scope (refusing batch/directory/wiki import and pointing to `rac-ingest`), proposes relationships only from links the source itself names, and adds no AI to RAC core.
+
 ## Success Metrics
 
 - The skill file exists at the documented path and is valid per the
@@ -72,6 +74,7 @@ code.claude.com/docs/en/skills). RAC should ship one.
 - v1.4-claude-skills
 - v0.10.5-bundled-agent-skill
 - v0.10.5-review-and-ingest-skills
+- v0.17.0-single-document-import-skill
 
 ## Related Requirements
 

--- a/rac/roadmaps/v0.17.x-onboarding/v0.17.0-single-document-import-skill.md
+++ b/rac/roadmaps/v0.17.x-onboarding/v0.17.0-single-document-import-skill.md
@@ -1,0 +1,92 @@
+---
+schema_version: 1
+id: RAC-KV3ZT2CXHG6G
+type: roadmap
+tags: [skills, onboarding, adoption]
+---
+# v0.17.0 — Single-Document Import Skill
+
+## Status
+
+Planned
+
+## Context
+
+A common adoption blocker is the on-ramp: new users have existing decisions in
+Confluence, Notion, or loose Markdown and no guided way to get one into RAC
+format. The `rac-ingest` skill converts and can mint identity across a whole
+directory, but it is broad and unguided. This milestone adds a focused,
+human-in-the-loop sibling for the most common first step — turning one existing
+document into one valid artifact — opening a v0.17.x onboarding series.
+
+## Outcomes
+
+- An agent in a host project has a bundled procedure to reshape exactly one
+  existing document into one valid RAC artifact, with an explicit human-review
+  step before any file is written and `rac validate` as the deterministic close.
+- The skill adds no AI to RAC core: it proposes, the human ratifies, and the
+  deterministic CLI checks. It reuses the released command surface only.
+- The bundled skill set grows to four without weakening the install or
+  byte-equality contracts.
+
+## Initiatives
+
+- Bundle `rac-import` alongside the existing skills, packaged identically
+  (resource under `rac.skills`, byte-identical dogfood copy under
+  `.claude/skills/`, per-skill sync test). Its procedure: take one document
+  (paste or path); convert non-Markdown via `rac ingest`; choose the type and
+  read its real shape with `rac schema <type>`; draft only from source content,
+  flagging required sections the source does not cover; present the draft and
+  require the user to confirm the type, title, and any relationships before
+  writing; scaffold with `rac new` (which mints the id); then close on
+  `rac validate`, offering fixes until it exits 0.
+- Single-document by scope: the skill refuses a directory, a wiki, or several
+  documents and points to `rac-ingest` for broader conversion. Relationships are
+  suggestions the source itself names, each confirmed with `rac resolve` /
+  `rac find` — never inferred by scanning the repository.
+- Describe released CLI behaviour only: `rac ingest`, `rac schema`, `rac inspect`,
+  `rac new`, `rac validate`, `rac resolve`, `rac find`. Normative-language
+  conventions (BCP-14) are authoring guidance, not a check the skill claims,
+  because `rac validate` does not enforce them yet.
+- Document the on-ramp in the README ("Importing an existing decision") and
+  refresh the skill list/install goldens for the new entry.
+
+## Success Measures
+
+- `rac skill install rac-import` writes `.claude/skills/rac-import/SKILL.md`;
+  `rac skill list` enumerates it; re-running install exits 1 and writes nothing.
+- The packaged skill is byte-identical to its dogfood copy (enforced by test).
+- Following the skill, three realistic messy source documents (a decision, a
+  requirement, a design) each produce an artifact that passes `rac validate`,
+  faithful to the source with no invented facts.
+- pytest, `rac validate rac/`, and `rac relationships rac/ --validate` pass.
+
+## Assumptions
+
+- Project-level skills (`.claude/skills/`) remain the documented discovery path.
+- The host project has the `rac` CLI installed; the skill does not manage install.
+
+## Risks
+
+- Overlap with `rac-ingest` could confuse users. Mitigated: the descriptions and
+  the skill body state the single-document, human-reviewed scope and cross-refer
+  `rac-ingest` for broader conversion.
+- Skill prose drifts from CLI behaviour as commands evolve; the sync tests catch
+  drift between copies but not against the CLI itself.
+
+## Related Decisions
+
+- adr-003
+- adr-007
+- adr-021
+
+## Related Requirements
+
+- rac-growth-agent-skill
+- rac-growth-adoption
+
+## Related Roadmaps
+
+- v0.10.5-review-and-ingest-skills
+- v0.10.5-bundled-agent-skill
+- v1.4-claude-skills

--- a/src/rac/core/skills.py
+++ b/src/rac/core/skills.py
@@ -43,6 +43,10 @@ BUNDLED_SKILLS = (
         name="rac-ingest",
         description="Convert legacy documents into valid, linked RAC artifacts.",
     ),
+    SkillSpec(
+        name="rac-import",
+        description="Reformat one document into one valid RAC artifact, with human review.",
+    ),
 )
 
 

--- a/src/rac/skills/rac-import/SKILL.md
+++ b/src/rac/skills/rac-import/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: rac-import
+description: Reformat ONE existing document (a decision, requirement, design, roadmap, or prompt) into ONE valid RAC (requirements-as-code) artifact, with a mandatory human-review step before any file is written and `rac validate` as the deterministic close. Use when a user wants to import a single existing decision or document into a project's rac/ directory. Single-document only — for multi-format or bulk conversion use the rac-ingest skill.
+---
+
+# RAC single-document import
+
+Reshape one existing document into one valid RAC artifact. You propose; the
+human ratifies; `rac validate` is the deterministic check. This skill never
+adds AI to the RAC core — it runs in the coding agent and uses the `rac` CLI.
+
+## Hard constraints
+
+- **One document in, one artifact out.** If asked to import a directory, a
+  whole wiki, or several documents at once, stop and explain that this skill
+  handles exactly one document → one artifact by design. For multi-format or
+  bulk conversion, point the user to the `rac-ingest` skill.
+- **The schema is not yours to invent.** Read the real shape with
+  `rac schema <type>` (and `rac schema` for the list of recognised types).
+  Use the real section names, the real five artifact types, and the real
+  `## Related <Type>` relationship sections. Never guess or hard-code a field,
+  type, or relationship kind. If you cannot run `rac schema`, stop and say so.
+- **Human review is mandatory and explicit (before any file is written).**
+  Present the draft and require the user to confirm or correct **(a) the
+  artifact type, (b) the title, and (c) each relationship** before you write
+  anything. Relationships are *suggestions to confirm*, never silently
+  asserted. The `id` is minted by `rac new` (opaque, system-assigned) — never
+  hand-write or choose it; show it after.
+- **Close on deterministic validation.** After writing, run `rac validate`.
+  If it fails, show the errors and offer to fix them, then re-validate. Never
+  leave an invalid artifact behind.
+- **No invention.** Reformat only what the source says. Do not invent context,
+  consequences, rationale, or requirements. Where a required section has no
+  source material, flag the gap and ask the user — do not fill it with
+  plausible-sounding text.
+
+## 1. Get the source
+
+Ask the user for the one document — pasted text or a file path — and, if it is
+not obvious, what kind of decision or requirement it represents. If they offer
+more than one document or a directory, apply the single-document constraint
+above before going further.
+
+## 2. Convert (only if not already Markdown)
+
+```bash
+rac ingest decision.docx          # preview Markdown on stdout
+```
+
+`rac ingest <file>` converts DOCX / PDF / HTML / PPTX / XLSX / Markdown to
+Markdown text, preserving structure — it does not judge whether the result is a
+valid artifact. Pasted Markdown needs no conversion. Rich formats need the
+optional extras (`pip install 'requirements-as-code[ingest]'`, `[ingest-pdf]`,
+`[ingest-office]`); the command names the missing extra when one is needed.
+
+## 3. Choose the type and read its real schema
+
+Pick the type with the user (or cross-check with `rac inspect <file>`, which
+infers type from `##` headings and reports confidence). Then read the actual
+contract:
+
+```bash
+rac schema                     # the recognised artifact types
+rac schema decision            # required / recommended / optional sections, and
+                               # any controlled values (e.g. Status, Category)
+rac schema decision --json     # the same, machine-readable
+```
+
+Map the source onto *these* section names. Do not introduce sections the schema
+does not define.
+
+## 4. Draft the artifact
+
+Reshape the source content under the type's real headings. Keep the author's
+own wording where it fits. For each **required** section the source does not
+cover, leave it clearly marked as a gap to raise with the user — do not invent
+content. (Requirements use testable `- [REQ-001] ...` lines under
+`## Requirements`; a `## Status` value, when present, must be one of the
+controlled values `rac schema` lists for that type.)
+
+> Normative language: writing requirements with BCP-14 keywords (MUST / SHOULD /
+> MAY) is good practice, but note that `rac validate` does not yet enforce them.
+> It does warn on vague verbs (support, handle, allow, enable) in requirements.
+
+## 5. Review gate — confirm before writing
+
+Present, in the conversation (not as a file yet):
+
+- the **draft** artifact;
+- a short summary: the **chosen type**, the **proposed title**, and any
+  **relationships the source explicitly names** (never relationships inferred by
+  scanning the repository — that is out of scope);
+- every **gap** where a required section had no source material.
+
+Ask the user to confirm or correct the type, the title, and each relationship.
+Verify any relationship target actually resolves before proposing it:
+
+```bash
+rac resolve <id> rac/
+rac find "<text>" rac/
+```
+
+Do not write a file until the user has confirmed.
+
+## 6. Write, then validate
+
+On confirmation, scaffold the file (this mints the id and writes the canonical
+template — it never overwrites an existing file), then replace the template body
+with the confirmed content:
+
+```bash
+rac new decision rac/decisions/<slug>.md
+```
+
+Write artifacts only inside the host project's RAC directory (`rac/` by default;
+confirm the path if the project keeps them elsewhere) under the matching
+subfolder (`rac/decisions/`, `rac/requirements/`, `rac/roadmaps/`,
+`rac/prompts/`, `rac/designs/`). If the project has no `.rac/config.yaml`, run
+`rac init` once at the project root first. Keep the `##` headings and the
+frontmatter block intact; never edit the minted `id`.
+
+Then close on validation:
+
+```bash
+rac validate rac/decisions/<slug>.md
+```
+
+Treat errors as blocking — show them, offer fixes, and re-run until it exits 0.
+`rac improve <file> --template` prints section stubs when the content exists to
+fill a missing recommended section. If the artifact links to others, finish with
+`rac relationships rac/ --validate`.
+
+## Out of scope
+
+- Bulk or batch import, directory crawling, or "migrate my whole wiki" (one
+  document → one artifact only; use `rac-ingest` for broader conversion).
+- Inferring relationships by scanning the repository — only the links the source
+  document itself names, each confirmed by the user.
+- Auto-committing the new artifact without the human-review step.
+- Inventing facts, context, or rationale not present in the source.

--- a/tests/golden/skill_install_human.txt
+++ b/tests/golden/skill_install_human.txt
@@ -1,5 +1,6 @@
 Installed rac-artifacts skill: .claude/skills/rac-artifacts/SKILL.md
 Installed rac-review skill: .claude/skills/rac-review/SKILL.md
 Installed rac-ingest skill: .claude/skills/rac-ingest/SKILL.md
+Installed rac-import skill: .claude/skills/rac-import/SKILL.md
 
 Claude Code discovers skills automatically from .claude/skills/ in the project.

--- a/tests/golden/skill_install_json.txt
+++ b/tests/golden/skill_install_json.txt
@@ -13,6 +13,10 @@
     {
       "skill": "rac-ingest",
       "path": ".claude/skills/rac-ingest/SKILL.md"
+    },
+    {
+      "skill": "rac-import",
+      "path": ".claude/skills/rac-import/SKILL.md"
     }
   ]
 }

--- a/tests/golden/skill_list_human.txt
+++ b/tests/golden/skill_list_human.txt
@@ -3,3 +3,4 @@ Bundled agent skills:
 - rac-artifacts  Author and maintain RAC Markdown artifacts with the rac CLI.
 - rac-review     Review a RAC corpus and work findings worst-first.
 - rac-ingest     Convert legacy documents into valid, linked RAC artifacts.
+- rac-import     Reformat one document into one valid RAC artifact, with human review.

--- a/tests/golden/skill_list_json.txt
+++ b/tests/golden/skill_list_json.txt
@@ -12,6 +12,10 @@
     {
       "skill": "rac-ingest",
       "description": "Convert legacy documents into valid, linked RAC artifacts."
+    },
+    {
+      "skill": "rac-import",
+      "description": "Reformat one document into one valid RAC artifact, with human review."
     }
   ]
 }

--- a/tests/test_skill.py
+++ b/tests/test_skill.py
@@ -32,7 +32,7 @@ from rac.services.skill import SkillFileExists, install_skills
 REPO_ROOT = Path(__file__).parent.parent
 GOLDEN_DIR = Path(__file__).parent / "golden"
 
-SKILL_NAMES = ["rac-artifacts", "rac-review", "rac-ingest"]
+SKILL_NAMES = ["rac-artifacts", "rac-review", "rac-ingest", "rac-import"]
 
 
 def dogfood_path(name: str) -> Path:


### PR DESCRIPTION
# Summary

Adds a new bundled agent skill, **`rac-import`**, that reshapes ONE existing
document into ONE valid RAC artifact, with a mandatory human-review step before
anything is written and `rac validate` as the deterministic close. It runs inside
the coding agent (Claude Code / Cursor) and uses only the `rac` CLI — it adds no
AI to the RAC core.

Adds:
- `src/rac/skills/rac-import/SKILL.md` + a byte-identical dogfood copy at
  `.claude/skills/rac-import/SKILL.md`, registered in `BUNDLED_SKILLS`.
- A README "Importing an existing decision" section.
- Refreshed skill list/install goldens; the registry-order test updated.
- Corpus dogfood: a v0.17.0 onboarding-series roadmap item recording the skill,
  and REQ-009 on `rac-growth-agent-skill` capturing its contract.

Screenshots (skill list/install, one doc before/after, and `rac validate` PASS)
will be attached as a comment.

# Scope

## Included
- A focused, single-document, human-in-the-loop sibling of `rac-ingest`.
- The skill reads the real schema with `rac schema`, scaffolds with `rac new`
  (which mints the id), and closes on `rac validate`.
- Recorded in the corpus the RAC way (roadmap + requirement line), so the skill is
  traceable, and `rac validate` / `rac relationships --validate` stay green.

## Excluded (by design — the skill refuses these)
- Bulk/batch import, directory crawling, or whole-wiki migration (one document →
  one artifact; `rac-ingest` covers broader/multi-format conversion).
- Inferring relationships by scanning the repo (only links the source names,
  each user-confirmed).
- Auto-committing without the human-review step; inventing facts not in the source.

# How it satisfies the hard constraints

1. **Single-doc only** — the skill refuses a directory/wiki/multiple docs and
   points to `rac-ingest`.
2. **Schema is not invented** — it reads `rac schema TYPE` for the real section
   names, the five real types, and the `## Related TYPE` vocabulary. RAC has no
   JSON Schema files (the schema is code-defined and surfaced by `rac schema`), so
   the skill reads the command, not a `.json` file.
3. **Human review is mandatory and explicit** — it presents the draft and requires
   the user to confirm/correct the type, the title, and each relationship before a
   file is written. Relationships are suggestions to confirm, verified with
   `rac resolve`/`rac find`, never asserted. The id is system-minted by `rac new`
   (ADR-026), shown but never hand-written.
4. **Closes on validation** — after writing it runs `rac validate`, shows errors,
   offers fixes, and re-runs until exit 0; it never leaves an invalid artifact.
5. **No fabrication** — it reformats only what the source says and flags any
   required section the source does not cover, rather than filling it in.

Note: BCP-14 (MUST/SHOULD) and EARS are not enforced by `rac validate` today, so
the skill treats normative keywords as authoring guidance, not a check it claims.

# Verification

## Ran
- `rac skill list` shows `rac-import`; `rac skill install rac-import` writes
  `.claude/skills/rac-import/SKILL.md`.
- **Worked demo** (throwaway workspace, not committed): three realistic messy
  source docs — a decision, a requirement, a design — taken through the skill's
  flow produced three artifacts; `rac validate rac/` →
  **valid, OKF v0.1 conformant**; each classified as the intended type
  (decision 1.00, requirement 0.71, design 0.69), faithful to the source with no
  invented facts.
- Corpus stays clean with the new artifacts: `rac validate rac/` → 176 valid, 0
  invalid; `rac relationships rac/ --validate` → 0 issues; `rac review rac/` →
  health 88, no priority 1-2.
- `pytest` → green (incl. the skill byte-identity, registry-order, and the four
  refreshed list/install goldens); `ruff check` / `ruff format --check` clean.

# Review Path

1. `src/rac/skills/rac-import/SKILL.md` — the skill contract and runtime steps.
2. `src/rac/core/skills.py` — the `BUNDLED_SKILLS` registry entry.
3. `tests/test_skill.py` + `tests/golden/skill_*` — name list + refreshed goldens.
4. `README.md` — the "Importing an existing decision" usage note.
5. `rac/roadmaps/v0.17.x-onboarding/v0.17.0-single-document-import-skill.md` and
   `rac/requirements/rac-growth-agent-skill.md` (REQ-009) — the corpus record.

# Notes For Reviewer

- The dogfood copy (`.claude/skills/rac-import/SKILL.md`) must stay byte-identical
  to the packaged source — a test enforces it.
- `rac-import` overlaps `rac-ingest` deliberately: this is the constrained,
  human-reviewed, single-document path; `rac-ingest` remains the general,
  multi-format, can-mint-across-a-directory tool. The skill cross-references it.
- The roadmap opens a `v0.17.x-onboarding` series; rename/re-slot if you'd prefer
  a different version fence.

# Implementation Process

Implemented with AI assistance; final scope — a new focused skill over extending
`rac-ingest`, the name `rac-import`, the demonstrate-only worked examples, and
recording the skill in the corpus — and acceptance were the maintainer's.