### PR TITLE
feat(decisiongrounding): scaffold standalone decision-grounding benchmark

### DIFF
--- a/decisiongrounding/.gitignore
+++ b/decisiongrounding/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+.pytest_cache/
+build/
+dist/

--- a/decisiongrounding/CONTRIBUTING.md
+++ b/decisiongrounding/CONTRIBUTING.md
@@ -1,0 +1,76 @@
+# Contributing to decisiongrounding
+
+This benchmark is only worth running if it is credible to a skeptic who *wants*
+the grounding layer to lose. These rules exist to protect that credibility. They
+are not optional politeness; a contribution that violates them is rejected even
+if the code is perfect.
+
+## The credibility rules
+
+### 1. Blind gold-labeling
+
+Gold labels (the correct verdict, governing decision, prohibited/required
+actions) MUST be written **before** and **independently** of running any arm,
+and **without** knowing which arm produced which output. If you have already
+seen an arm's answer to a task, you may not author or edit that task's gold
+label. Label first, run second.
+
+### 2. No win-only corpora
+
+Scenarios MUST NOT be hand-authored to favour an arm. Production scenarios are
+derived from **real or public ADR sets**, or a design partner's **real
+incident** — not invented to make a chosen arm look good. The synthetic worked
+scenarios in `scenarios/` exist solely to exercise the harness and are labelled
+as such; they are never reported as results.
+
+A corpus that only contains the kinds of decisions one arm handles well is a
+win-only corpus. Include the cases your preferred arm is expected to *lose*
+(easy single-decision ties, and the negative control where inventing a
+constraint is the failure).
+
+### 3. Publish losing results
+
+If the grounded arm ties or loses — including the falsifier in the README
+(grounded ≈ `naive_rag` on superseded + prohibition at N ≥ 50) — that result is
+published, not buried. Append it to `results/` like any other run. A benchmark
+that can only report wins is marketing.
+
+### 4. Symmetric treatment of arms
+
+Every arm gets the **same** answering model, the **same** prompt scaffold, and
+**one** symmetric opportunity to populate the context window. Do not give your
+arm a richer scaffold, a retry, a better model, or a second look. Differences
+must live entirely in grounding assembly. Changes that alter the answering model
+or scaffold for one arm only will be rejected.
+
+### 5. Pre-registration is frozen
+
+`spec/scenario-taxonomy.md` and `spec/scoring-rubric.md` are frozen before
+results exist. Changing the taxonomy or rubric is a new **spec version** with a
+rationale, not a quiet edit. Never reshape the question after seeing who won.
+
+### 6. Append-only results
+
+`results/` is append-only. Never mutate or delete a prior run file. Re-running
+produces a new timestamped file. Each run records the pinned model + version +
+temperature + seed so it reproduces.
+
+## Adding a scenario
+
+1. Create `scenarios/<id>/scenario.json` + a `corpus/` of markdown artifacts.
+2. Validate against `schema/scenario.schema.json` (`pip install -e .[schema]`).
+3. Write the gold label blind (rule 1). State its provenance (rule 2) in the
+   `rationale`.
+4. `make test`.
+
+## Adding an arm
+
+See "Add an arm" in the README. Then confirm it is scored by the same
+deterministic scorer as every other arm — no arm gets a bespoke scorer.
+
+## Decisions
+
+Architecture decisions are recorded as RAC-style ADRs in `decisions/`
+(`decisions/ADR-template.md`). The repo dogfoods the artifact format the
+benchmark studies. If your change makes a non-obvious architectural choice,
+record it as an ADR.

--- a/decisiongrounding/EXPLAINER.md
+++ b/decisiongrounding/EXPLAINER.md
@@ -1,0 +1,128 @@
+# DecisionGrounding — what it is, how to run it, and why it matters
+
+A plain-language companion to the README, for anyone — technical or not — who
+wants to understand why this benchmark exists before reading the code.
+
+## The one-sentence version
+
+DecisionGrounding is a fair, reproducible test of a simple but expensive
+question: **when a team uses an AI coding assistant, does giving it a structured
+memory of the team's past decisions actually make it follow those decisions
+better — or do today's powerful models already handle that on their own?**
+
+## The background
+
+Software teams make decisions constantly: "we don't let code talk to the
+database directly," "the orders service stays in Go unless an architect signs
+off," "logs must be JSON." These decisions are usually written down somewhere
+(often as short documents called ADRs — Architecture Decision Records).
+
+AI coding assistants are now writing real code. The risk is that an assistant,
+not knowing or not remembering a past decision, confidently does the wrong
+thing — re-introduces a banned pattern, follows a rule the team has since
+replaced, or rewrites a service in a new language nobody approved. Real
+incidents like this have happened.
+
+A growing industry says the fix is a **decision-grounding layer**: a structured,
+typed memory that feeds the right past decisions to the assistant at the right
+moment. That sounds great. But there's a sharp, fair objection:
+
+> "Modern AI models are so capable, and can read so much text at once, that you
+> can just paste all the decision documents in and they'll figure it out. A
+> special memory layer adds no durable value."
+
+**DecisionGrounding exists to settle that argument with evidence instead of
+opinion** — and it's deliberately built to be believed even when the answer is
+unflattering to the memory-layer idea.
+
+## How it works (in plain terms)
+
+It pits several "contestants" against each other on the exact same task, with
+the exact same AI model answering. The only thing that changes between
+contestants is *how the relevant past decisions are gathered and handed to the
+model*:
+
+- **Paste everything** — dump all the decision documents into the model. (This
+  is the skeptic's position.)
+- **Commodity search** — a standard "find the most similar documents" approach,
+  no understanding of which decision replaced which.
+- **The grounding layer** — structured retrieval that knows, for example, that
+  Decision B officially replaced Decision A, and hands over B, not A.
+
+Each contestant gets one fair shot at supplying context; the model then proposes
+what it would do, and the benchmark checks — automatically, by inspecting the
+proposal — whether it respected the team's decisions.
+
+**The headline result is a single chart:** how often each contestant follows the
+team's decisions as the pile of decisions grows from small to large. The
+interesting moment is the *crossover* — the point (if any) where the structured
+approach starts to win. The benchmark even states its own kill switch up front:
+if the structured approach is no better than plain search on the hardest cases,
+the idea is declared dead. That honesty is the point.
+
+## How a non-technical person can set it up
+
+You don't need to be an engineer to run the built-in demonstration. You do need
+to copy-paste a few commands into a terminal.
+
+1. **Install Python** (a free programming runtime), version 3.11 or newer, from
+   python.org. On Mac it's often already there.
+2. **Get the code.** Download the project folder (`decisiongrounding`) — your
+   engineer can share it, or you can download it from the repository as a ZIP
+   and unzip it.
+3. **Open a terminal** (the Terminal app on Mac, or "Command Prompt" /
+   "PowerShell" on Windows) and move into the folder:
+   ```
+   cd decisiongrounding
+   ```
+4. **Run the demonstration:**
+   ```
+   make demo
+   ```
+   (If `make` isn't available, use: `python -m runner.cli demo`.)
+
+That's it. It runs entirely on your machine, needs no accounts, keys, or
+internet, and finishes in seconds. It prints a small table and saves a chart
+(`results/crossover.svg`) you can open in any web browser.
+
+**Important honesty note:** this built-in demo uses a *stand-in* for the AI
+model so it can run for free, instantly, with no setup. It proves the machinery
+works and illustrates the idea — it is **not** a real scientific result. A real
+result requires plugging in an actual AI model and real decision documents,
+which is a step your engineering team would run (it needs paid API access). The
+project is explicit about this distinction everywhere, on purpose.
+
+## Why it's important
+
+- **It turns a sales argument into a measurement.** Instead of "trust us, our
+  memory layer helps," you get a number and a chart, on a frozen, public method
+  that anyone can re-run.
+- **It's built to be trusted by skeptics.** The toughest baselines (just paste
+  everything; just do ordinary search) are mandatory, not afterthoughts. The
+  scoring is mostly automatic and mechanical, not a vague "does this look good?"
+  judgment. The method is locked down *before* any results exist, results are
+  append-only, and there's a public commitment to publish losing results.
+- **It answers a real budget question.** "Should we buy/build a decision-memory
+  layer, or is our model good enough already?" — and, crucially, "at what size
+  of decision history does it start to matter?" A small startup and a large
+  enterprise may get different answers, and the chart shows where the line is.
+- **It protects against a real failure mode.** AI assistants confidently doing
+  things a team already decided against is a genuine source of risk. Measuring
+  who avoids that — and avoids inventing fake rules that don't exist — is
+  directly useful.
+
+## The honest caveats (because credibility is the whole point)
+
+- It measures *the quality of gathering and handing over the right decisions*.
+  It does **not** measure whether, in day-to-day production, the assistant
+  actually bothers to consult its memory at the right moment — that's a separate
+  question about how the tool is wired into real workflows.
+- The free built-in demo simulates the outcome to show the plumbing; the real
+  verdict requires real AI models and real decision documents.
+- Decision sets used for published results must come from real teams or public
+  sources, with the "right answers" written down *before* seeing which
+  contestant produced what — so nobody can rig the test.
+
+If those guardrails hold, the result is believable. If the structured layer
+wins, that's a real signal it adds durable value. If it doesn't, that's an
+equally real signal — and the benchmark publishes it either way.

--- a/decisiongrounding/LICENSE
+++ b/decisiongrounding/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 DecisionGrounding contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/decisiongrounding/Makefile
+++ b/decisiongrounding/Makefile
@@ -1,0 +1,12 @@
+.PHONY: demo test compare
+
+# The one working comparison: two real arms, four worked scenarios, offline.
+demo:
+	python -m runner.cli demo
+
+# Run a single named comparison, e.g. make compare ARMS=context_dump,naive_rag
+compare:
+	python -m runner.cli compare --arms $(ARMS)
+
+test:
+	python -m pytest -q

--- a/decisiongrounding/README.md
+++ b/decisiongrounding/README.md
@@ -64,8 +64,11 @@ as "this layer will fix adherence in production" overstates what was measured.
 - **Headline artifact:** an adherence-vs-corpus-size curve over
   N ∈ {10, 50, 150, 300} with rising conflict density — the story is the
   crossover point.
-- Also reported: stale-decision rate, false-permit / false-prohibit rate, and
-  per-arm run-to-run variance. There is deliberately **no** composite score.
+- Also reported: stale-decision rate, false-permit / false-prohibit rate,
+  per-arm run-to-run variance, and **governing-decision recall** — did the arm's
+  grounding actually contain the binding decision? Recall is the mechanistic
+  explanation for why adherence moves (the analog of MemoryBench's Hit@K). There
+  is deliberately **no** composite score.
 
 ## Run it (offline, no credentials)
 
@@ -85,6 +88,24 @@ append-only report under `results/`, and emits the crossover chart
 > embedding backend (`pip install -e .[real]`) on real/public-derived corpora.
 > See `decisions/ADR-0001-harness-foundation.md`.
 
+### Run it for real (pinned model + real retrieval)
+
+```bash
+pip install -e ".[real,schema,chart]"
+export ANTHROPIC_API_KEY=...        # pinned answering model: claude-opus-4-8
+export VOYAGE_API_KEY=...           # real embeddings for naive_rag
+
+# rac arm additionally needs the `rac` CLI on PATH (or set RAC_BIN)
+python -m runner.cli compare \
+  --arms context_dump,naive_rag,rac \
+  --answering claude \
+  --embedder voyage:voyage-3 \
+  --scenarios scenarios/ --seed 0
+```
+
+This is where the thesis is actually tested. Until it runs on real/public-derived
+corpora, the offline crossover is plumbing, not evidence.
+
 Tests:
 
 ```bash
@@ -102,10 +123,19 @@ make test
 | Deterministic scorer + metrics + crossover chart | ✅ real |
 | Runner CLI (`run` / `compare` / `demo`), append-only reports | ✅ real |
 | Four worked scenarios (incl. negative control) | ✅ real, synthetic |
-| `no_grounding`, `rac`, `memory_provider` arms | ⏳ typed stubs + TODO |
-| Pinned Claude answering model, real embeddings | ⏳ stub behind `[real]` |
+| Governing-decision recall diagnostic | ✅ real |
+| Pinned Claude answering model (`--answering claude`, Opus 4.8) | ✅ implemented; needs `[real]` + `ANTHROPIC_API_KEY` |
+| Real embeddings (`--embedder voyage:…` / `st:…`) | ✅ implemented; needs `[real]` / `[local-embeddings]` |
+| `rac` arm (typed retrieval, follows `supersedes`) | ✅ implemented; needs the `rac` CLI on PATH |
+| `no_grounding`, `memory_provider` arms | ⏳ typed stubs + TODO |
 | LLM-judge fallback | ⏳ disclosed, not built |
 | `conflicting_scoped` worked scenario, full N=300 corpus | ⏳ next increment |
+
+> **Pinned model caveat:** the answering model is `claude-opus-4-8`, which
+> rejects `temperature`/`top_p`/`seed` (the API 400s on them). There is no
+> temperature/seed knob to pin; the held-constant guarantee rests on the fixed
+> model id + scaffold + structured JSON output, and run-to-run variance is
+> reported as a metric. `temperature` is recorded as `null`.
 
 ## Repository layout
 

--- a/decisiongrounding/README.md
+++ b/decisiongrounding/README.md
@@ -119,17 +119,17 @@ make test
 | --- | --- |
 | Scenario + RunResult JSON Schemas (Draft 2020-12) | ✅ real |
 | Provider adapter contract | ✅ real |
-| `context_dump`, `naive_rag` arms | ✅ real, runnable offline |
+| `context_dump`, `naive_rag`, `no_grounding` arms | ✅ real, runnable offline |
 | Deterministic scorer + metrics + crossover chart | ✅ real |
 | Runner CLI (`run` / `compare` / `demo`), append-only reports | ✅ real |
-| Four worked scenarios (incl. negative control) | ✅ real, synthetic |
+| Five worked scenarios (incl. negative control + conflicting-scoped) | ✅ real, synthetic |
 | Governing-decision recall diagnostic | ✅ real |
 | Pinned Claude answering model (`--answering claude`, Opus 4.8) | ✅ implemented; needs `[real]` + `ANTHROPIC_API_KEY` |
 | Real embeddings (`--embedder voyage:…` / `st:…`) | ✅ implemented; needs `[real]` / `[local-embeddings]` |
 | `rac` arm (typed retrieval, follows `supersedes`) | ✅ implemented; needs the `rac` CLI on PATH |
-| `no_grounding`, `memory_provider` arms | ⏳ typed stubs + TODO |
+| `memory_provider` arm | ⏳ typed stub + TODO |
 | LLM-judge fallback | ⏳ disclosed, not built |
-| `conflicting_scoped` worked scenario, full N=300 corpus | ⏳ next increment |
+| Full N=300 corpus (real/public-derived) | ⏳ next increment |
 
 > **Pinned model caveat:** the answering model is `claude-opus-4-8`, which
 > rejects `temperature`/`top_p`/`seed` (the API 400s on them). There is no

--- a/decisiongrounding/README.md
+++ b/decisiongrounding/README.md
@@ -1,0 +1,138 @@
+# decisiongrounding
+
+A reproducible benchmark that answers one question:
+
+> Does a deterministic decision-grounding layer make a coding agent adhere to a
+> team's **prior decisions** better than (a) dumping all the decision docs into
+> context, (b) commodity RAG over the same docs, or (c) a general-purpose memory
+> layer — and at what corpus size does any difference appear?
+
+It is a **standalone** project. It does not depend on, or import, any specific
+grounding implementation; the layer under test is just one arm behind a uniform
+adapter.
+
+## The objection this exists to test
+
+> "Frontier models plus long context just absorb the decisions, so a persistence
+> layer adds no durable value."
+
+That objection is correct often enough that a benchmark which cannot reproduce
+it is worthless marketing. So the threatening baselines are **mandatory**, not
+courtesy arms:
+
+- **`context_dump`** — paste every artifact into the answering model's context.
+  This is the skeptic's position, implemented faithfully.
+- **`naive_rag`** — embeddings + top-k over the same markdown. No typing, no
+  relationship traversal.
+
+A grounding layer earns its keep only by beating these — on the scenario types
+where it should, at the corpus sizes where it should.
+
+## The falsifier (stated up front)
+
+**If the typed/grounded arm ≈ `naive_rag` on superseded + prohibition scenarios
+at N ≥ 50, the retrieval thesis is dead.** We publish that result if we find it.
+The benchmark is designed to be able to embarrass its sponsor; see
+`CONTRIBUTING.md` ("publish losing results").
+
+## How the comparison is kept fair
+
+- **Held-constant answering model.** Every arm feeds context to the *same fixed
+  answering model* with the *same prompt scaffold*, pinned by model + version +
+  temperature + seed. Arms differ **only** in how they select and assemble the
+  grounding context.
+- **Symmetric grounding injection.** Each arm gets one equal opportunity to
+  populate the answering model's context: `context_dump` supplies everything,
+  `naive_rag` supplies its top-k, the grounded arm supplies its typed retrieval.
+- **Deterministic scoring first.** Adherence is scored by structural inspection
+  of the agent's proposed change (did it propose the prohibited migration? did it
+  follow the superseded decision?). An LLM judge is a disclosed, unbuilt fallback
+  — see `spec/scoring-rubric.md`.
+
+### Symmetric-injection caveat (read this)
+
+This benchmark isolates **retrieval/assembly quality**: given one symmetric shot
+at the context window, which assembly strategy yields better decision-adherence?
+It does **not** test whether a pull-based MCP grounding layer actually *gets
+consulted* in production — whether an agent invokes the tool at the right moment
+is a separate deployment question, out of scope here. Reading a favourable result
+as "this layer will fix adherence in production" overstates what was measured.
+
+## Headline metric and artifact
+
+- **Headline metric:** decision-adherence rate.
+- **Headline artifact:** an adherence-vs-corpus-size curve over
+  N ∈ {10, 50, 150, 300} with rising conflict density — the story is the
+  crossover point.
+- Also reported: stale-decision rate, false-permit / false-prohibit rate, and
+  per-arm run-to-run variance. There is deliberately **no** composite score.
+
+## Run it (offline, no credentials)
+
+```bash
+cd decisiongrounding
+make demo          # == python -m runner.cli demo
+```
+
+This runs the two real arms (`context_dump`, `naive_rag`) on the four worked
+scenarios with a deterministic **offline** answering model, writes an
+append-only report under `results/`, and emits the crossover chart
+(`results/crossover.svg`, or `.png` with the `[chart]` extra).
+
+> The offline answering model is a deterministic stand-in so the spine runs with
+> zero credentials. **Its output is a harness illustration, NOT a benchmark
+> result.** Real runs swap in the pinned Claude answering model and a real
+> embedding backend (`pip install -e .[real]`) on real/public-derived corpora.
+> See `decisions/ADR-0001-harness-foundation.md`.
+
+Tests:
+
+```bash
+pip install -e .[dev]   # or: pip install pytest
+make test
+```
+
+## What's real vs. stubbed in this pass
+
+| Component | State |
+| --- | --- |
+| Scenario + RunResult JSON Schemas (Draft 2020-12) | ✅ real |
+| Provider adapter contract | ✅ real |
+| `context_dump`, `naive_rag` arms | ✅ real, runnable offline |
+| Deterministic scorer + metrics + crossover chart | ✅ real |
+| Runner CLI (`run` / `compare` / `demo`), append-only reports | ✅ real |
+| Four worked scenarios (incl. negative control) | ✅ real, synthetic |
+| `no_grounding`, `rac`, `memory_provider` arms | ⏳ typed stubs + TODO |
+| Pinned Claude answering model, real embeddings | ⏳ stub behind `[real]` |
+| LLM-judge fallback | ⏳ disclosed, not built |
+| `conflicting_scoped` worked scenario, full N=300 corpus | ⏳ next increment |
+
+## Repository layout
+
+```
+decisiongrounding/
+  decisions/   ADR-0001 (harness foundation) + ADR template  — the repo dogfoods
+               RAC-style ADRs to ground its own choices
+  spec/        FROZEN scenario taxonomy + scoring rubric (pre-registration)
+  schema/      JSON Schema (Draft 2020-12) for Scenario and RunResult
+  providers/   uniform adapter (prepare/respond) + the arms + answering/embedding
+  scenarios/   loader + four worked scenarios with tiny synthetic corpora
+  scoring/     deterministic scorer, metrics, crossover dataset + chart
+  runner/      CLI; pins model + seed; append-only report writer
+  results/     append-only run outputs (generated; not committed)
+  tests/       schema, scorer, and offline arm-smoke coverage
+```
+
+## Add an arm
+
+1. Implement a `Provider` in `providers/` with `prepare(corpus)` and
+   `respond(task) -> ProposedChange` (subclass `providers.base.Provider`; the
+   shared `respond` already feeds the held-constant answering model — override it
+   only if your grounding is task-dependent, as `naive_rag` does).
+2. Register it in `providers/__init__.py` `ARMS` and, if it should run in the
+   default demo, add it to `REAL_ARMS`.
+3. Add it to the `arm` enum in `schema/run_result.schema.json`.
+4. Run `make test` and `make compare ARMS=context_dump,naive_rag,your_arm`.
+
+Your arm gets exactly one symmetric grounding opportunity and the same answering
+model as every other arm. That is the whole point.

--- a/decisiongrounding/conftest.py
+++ b/decisiongrounding/conftest.py
@@ -1,0 +1,6 @@
+"""Make the package root importable for `providers`, `scenarios`, `scoring`."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))

--- a/decisiongrounding/decisions/ADR-0001-harness-foundation.md
+++ b/decisiongrounding/decisions/ADR-0001-harness-foundation.md
@@ -1,0 +1,160 @@
+---
+schema_version: 1
+id: DG-ADR-0001
+type: decision
+tags: [harness, foundation, methodology]
+---
+
+# ADR-0001: Harness Foundation
+
+## Status
+
+Accepted
+
+## Category
+
+Architecture
+
+## Context
+
+`decisiongrounding` is a reproducible benchmark that asks one question:
+
+> Does a deterministic decision-grounding layer make a coding agent adhere to
+> a team's *prior decisions* better than (a) dumping all the decision docs
+> into context, (b) commodity RAG over the same docs, or (c) a general-purpose
+> memory layer — and at what corpus size does any difference appear?
+
+The benchmark must stay credible to a skeptical investor or staff engineer,
+*including when the result is unfavorable to the grounding layer*. That places
+hard constraints on the harness: threatening baselines (`context_dump`,
+`naive_rag`) are mandatory; the answering model is held constant across arms;
+each arm gets one symmetric opportunity to populate the answering model's
+context; scoring is deterministic and structural wherever possible; results
+are pre-registered and append-only.
+
+Before writing harness code we must decide what to build the harness *on*.
+Two options were evaluated.
+
+### Option A — Build inside Supermemory MemoryBench
+
+Implement `decisiongrounding` as a custom benchmark plus a custom provider
+inside Supermemory's MemoryBench framework
+(https://supermemory.ai/docs/memorybench/overview), reusing its existing
+Mem0 / Zep / Supermemory provider adapters.
+
+#### Advantages
+
+- The memory-provider arms (`memory_provider`) come almost for free via
+  MemoryBench's existing adapters.
+- Third-party framework provenance lends external credibility — results are
+  not "graded on our own homework's grading software."
+- Less harness plumbing to write and maintain.
+
+#### Disadvantages
+
+- MemoryBench's evaluation contract is **conversational QA**: ingest a
+  transcript, `search` it, then have a judge grade a free-text answer. Our
+  task is **plan-then-structurally-check**: the agent proposes a concrete
+  change and we inspect the *structure* of that proposal (did it propose the
+  prohibited migration? did it follow the superseded decision?). Bending a
+  conversational-QA contract around a structural-check task invites subtle
+  mismatches precisely where our headline metric lives.
+- It couples our headline (deterministic decision-adherence rate) to a
+  framework whose center of gravity is an LLM judge — the opposite of our
+  "deterministic scoring first" constraint.
+- It makes our reproducibility surface (pinned answering model, append-only
+  results, seed) a function of an upstream project's release cadence.
+
+### Option B — Standalone harness, borrowing MemoryBench's conventions
+
+Build a small standalone harness that owns its evaluation contract, borrowing
+only MemoryBench's *good conventions*: the provider-adapter pattern, pinned
+model versions, and append-only run storage.
+
+#### Advantages
+
+- The evaluation contract fits the task exactly: a uniform `Provider` adapter
+  (`prepare(corpus)` / `respond(task) -> ProposedChange`) feeds a held-constant
+  answering model, and a deterministic scorer inspects the proposed change.
+- Deterministic structural scoring stays the headline; the LLM judge is a
+  documented, disclosed *fallback* for genuinely open-ended cases — not the
+  spine.
+- Full control over reproducibility: pinned model + version + temperature +
+  seed, append-only `results/`, frozen `spec/`.
+- The memory-provider arms are still reachable — `providers/memory_provider.py`
+  is a MemoryBench-style adapter slot we fill later, so we lose none of
+  Option A's reach, only its coupling.
+
+#### Disadvantages
+
+- We write and maintain the harness plumbing ourselves.
+- Third-party credibility is earned through method transparency
+  (`CONTRIBUTING.md`, pre-registration, published losing results) rather than
+  inherited from a known framework.
+
+## Decision
+
+Adopt **Option B**: a standalone harness that borrows MemoryBench's
+provider-adapter pattern, pinned-model discipline, and append-only run storage,
+but owns a plan-then-structurally-check evaluation contract with deterministic
+scoring as the headline.
+
+The decisive factor is the evaluation-contract mismatch. Our credibility rests
+on deterministic, structural decision-adherence scoring; MemoryBench's contract
+is conversational QA graded by an LLM judge. Borrowing its conventions costs us
+nothing we need, while inheriting its contract would put a semantic judge on
+the critical path of our headline metric. Option A's one real advantage —
+near-free memory-provider arms — is preserved under B through a MemoryBench-style
+adapter slot (`providers/memory_provider.py`).
+
+## Consequences
+
+### Positive
+
+- The harness contract matches the task; the headline metric stays
+  deterministic.
+- Reproducibility (pinned model, seed, append-only results) is fully under our
+  control.
+- Arms differ only in how they assemble grounding context; the answering model
+  and prompt scaffold are held constant, isolating retrieval/assembly quality.
+
+### Negative
+
+- We own more code than Option A would require.
+- Memory-provider arms require us to write the adapter rather than inherit it.
+
+### Risks
+
+- **Self-grading perception.** A standalone harness can be dismissed as
+  "grading your own homework." Mitigation: pre-registered `spec/`, append-only
+  `results/`, blind gold-labeling, and a published commitment to release losing
+  results (`CONTRIBUTING.md`).
+- **Scaffold-simulated results.** The offline demo answering model simulates
+  the crossover by construction. Mitigation: the README and this ADR state
+  plainly that stub output is a plumbing illustration, not a benchmark result;
+  the headline remains an unvalidated hypothesis until the pinned Claude
+  answering model runs on real/public-derived corpora.
+
+## Alternatives Considered
+
+See Option A and Option B above. Option A was rejected for evaluation-contract
+mismatch, not for lack of merit; its memory-provider reach is retained under B.
+
+## Related Decisions
+
+- (none yet — this is the foundation decision)
+
+## Success Measures
+
+- The two threatening arms (`context_dump`, `naive_rag`) run end-to-end on a
+  tiny corpus with no credentials.
+- Scoring is deterministic for all five scenario types; no LLM judge is on the
+  critical path of the headline metric.
+- A reviewer can reproduce a run from seed + pinned model versions, and
+  `results/` only ever grows.
+
+## Review Date
+
+Revisit if a memory-provider arm forces ingestion semantics that the
+standalone contract cannot express cleanly, or if MemoryBench adds a
+structural-check evaluation mode.

--- a/decisiongrounding/decisions/ADR-template.md
+++ b/decisiongrounding/decisions/ADR-template.md
@@ -1,0 +1,65 @@
+---
+schema_version: 1
+id: DG-ADR-NNNN
+type: decision
+tags: []
+---
+
+# ADR-NNNN: <Short imperative title>
+
+## Status
+
+Proposed | Accepted | Superseded | Deprecated
+
+<!--
+Supersession is expressed RAC-style: set this ADR's Status to `Superseded`
+and reference the superseding ADR under `## Related Decisions`. The superseding
+ADR references this one in *its* `## Related Decisions`. There is no separate
+`## Supersedes` heading.
+-->
+
+## Category
+
+Architecture | Process | Technical
+
+## Context
+
+What problem or force prompted this decision? What constraints apply? Write
+enough that a future maintainer understands the decision without external
+context.
+
+## Decision
+
+The decision, stated plainly in active voice. If you evaluated options, name
+the one chosen and the decisive factor.
+
+## Consequences
+
+### Positive
+
+- ...
+
+### Negative
+
+- ...
+
+### Risks
+
+- ... (with mitigation)
+
+## Alternatives Considered
+
+Each option with #### Advantages / #### Disadvantages, and why it was not
+chosen.
+
+## Related Decisions
+
+- DG-ADR-XXXX (relationship in prose)
+
+## Success Measures
+
+How we will know this decision is working.
+
+## Review Date
+
+When or under what trigger to revisit.

--- a/decisiongrounding/providers/__init__.py
+++ b/decisiongrounding/providers/__init__.py
@@ -1,0 +1,61 @@
+"""Benchmark arms and the shared provider-adapter contract.
+
+Every arm implements `prepare(corpus)` / `respond(task) -> ProposedChange` and
+feeds a held-constant answering model behind a held-constant scaffold. Arms
+differ ONLY in how they assemble grounding.
+"""
+
+from __future__ import annotations
+
+from .answering import (
+    AnsweringModel,
+    ClaudeAnsweringModel,
+    ScriptedAnsweringModel,
+)
+from .base import (
+    Action,
+    CorpusArtifact,
+    GroundingContext,
+    ProposedChange,
+    Provider,
+    Task,
+)
+from .context_dump import ContextDumpProvider
+from .embedding import Embedder, LocalDeterministicEmbedder
+from .memory_provider import MemoryProviderArm
+from .naive_rag import NaiveRagProvider
+from .no_grounding import NoGroundingProvider
+from .rac import RacProvider
+
+# Arm registry. Real, runnable arms this pass: context_dump, naive_rag.
+# The rest are typed stubs (raise NotImplementedError on use).
+ARMS: dict[str, type[Provider]] = {
+    "context_dump": ContextDumpProvider,
+    "naive_rag": NaiveRagProvider,
+    "no_grounding": NoGroundingProvider,
+    "rac": RacProvider,
+    "memory_provider": MemoryProviderArm,
+}
+
+REAL_ARMS = ("context_dump", "naive_rag")
+
+__all__ = [
+    "ARMS",
+    "REAL_ARMS",
+    "Provider",
+    "CorpusArtifact",
+    "Task",
+    "GroundingContext",
+    "ProposedChange",
+    "Action",
+    "AnsweringModel",
+    "ScriptedAnsweringModel",
+    "ClaudeAnsweringModel",
+    "Embedder",
+    "LocalDeterministicEmbedder",
+    "ContextDumpProvider",
+    "NaiveRagProvider",
+    "NoGroundingProvider",
+    "RacProvider",
+    "MemoryProviderArm",
+]

--- a/decisiongrounding/providers/__init__.py
+++ b/decisiongrounding/providers/__init__.py
@@ -21,11 +21,17 @@ from .base import (
     Task,
 )
 from .context_dump import ContextDumpProvider
-from .embedding import Embedder, LocalDeterministicEmbedder
+from .embedding import (
+    Embedder,
+    LocalDeterministicEmbedder,
+    SentenceTransformerEmbedder,
+    VoyageEmbedder,
+    make_embedder,
+)
 from .memory_provider import MemoryProviderArm
 from .naive_rag import NaiveRagProvider
 from .no_grounding import NoGroundingProvider
-from .rac import RacProvider
+from .rac import RacProvider, resolve_supersedes
 
 # Arm registry. Real, runnable arms this pass: context_dump, naive_rag.
 # The rest are typed stubs (raise NotImplementedError on use).
@@ -53,9 +59,13 @@ __all__ = [
     "ClaudeAnsweringModel",
     "Embedder",
     "LocalDeterministicEmbedder",
+    "VoyageEmbedder",
+    "SentenceTransformerEmbedder",
+    "make_embedder",
     "ContextDumpProvider",
     "NaiveRagProvider",
     "NoGroundingProvider",
     "RacProvider",
+    "resolve_supersedes",
     "MemoryProviderArm",
 ]

--- a/decisiongrounding/providers/__init__.py
+++ b/decisiongrounding/providers/__init__.py
@@ -33,8 +33,8 @@ from .naive_rag import NaiveRagProvider
 from .no_grounding import NoGroundingProvider
 from .rac import RacProvider, resolve_supersedes
 
-# Arm registry. Real, runnable arms this pass: context_dump, naive_rag.
-# The rest are typed stubs (raise NotImplementedError on use).
+# Real, runnable arms this pass: context_dump, naive_rag, no_grounding (offline);
+# rac (needs the external rac CLI). memory_provider is a typed stub.
 ARMS: dict[str, type[Provider]] = {
     "context_dump": ContextDumpProvider,
     "naive_rag": NaiveRagProvider,
@@ -43,7 +43,7 @@ ARMS: dict[str, type[Provider]] = {
     "memory_provider": MemoryProviderArm,
 }
 
-REAL_ARMS = ("context_dump", "naive_rag")
+REAL_ARMS = ("context_dump", "naive_rag", "no_grounding")
 
 __all__ = [
     "ARMS",

--- a/decisiongrounding/providers/answering.py
+++ b/decisiongrounding/providers/answering.py
@@ -63,7 +63,7 @@ def _content_tokens(text: str) -> set[str]:
 class AnsweringModel(ABC):
     name: str = "base"
     version: str = "0"
-    temperature: float = 0.0
+    temperature: float | None = 0.0  # None when the pinned model exposes no knob
     seed: int = 0
 
     @abstractmethod
@@ -151,28 +151,102 @@ class ScriptedAnsweringModel(AnsweringModel):
         )
 
 
+# JSON Schema the answering model must return — mirrors providers.base.ProposedChange.
+_PROPOSED_CHANGE_SCHEMA = {
+    "type": "object",
+    "additionalProperties": False,
+    "properties": {
+        "summary": {"type": "string"},
+        "actions": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "additionalProperties": False,
+                "properties": {
+                    "kind": {"type": "string"},
+                    "target": {"type": "string"},
+                    "detail": {"type": "string"},
+                },
+                "required": ["kind", "target", "detail"],
+            },
+        },
+        "cites_decisions": {"type": "array", "items": {"type": "string"}},
+        "asserts_prohibition": {"type": "boolean"},
+        "asserts_permission": {"type": "boolean"},
+    },
+    "required": [
+        "summary",
+        "actions",
+        "cites_decisions",
+        "asserts_prohibition",
+        "asserts_permission",
+    ],
+}
+
+
 class ClaudeAnsweringModel(AnsweringModel):
-    """Real pinned answering model. STUB — wired behind the `[real]` extra."""
+    """Real pinned answering model (Claude Opus 4.8), wired behind `[real]`.
 
-    # Pin the exact model + version used for every published run. Held identical
-    # across arms; the only thing that varies between arms is the grounding.
+    Held identical across arms; only the grounding varies. Note: Opus 4.8
+    rejects `temperature`/`top_p`/`seed` (400), so there is no temperature/seed
+    knob to pin — determinism is approximated by the fixed model id + scaffold +
+    structured JSON output, and run-to-run variance is reported as a metric.
+    `temperature` is recorded as None and `seed` is bookkeeping only.
+    """
+
     name = "claude"
-    version = "PINNED-MODEL-ID-AND-DATE"  # e.g. a dated Claude model snapshot
-    temperature = 0.0
+    version = "claude-opus-4-8"  # pinned model id
+    temperature = None
 
-    def __init__(self, seed: int = 0) -> None:
+    def __init__(self, seed: int = 0, effort: str = "low") -> None:
         self.seed = seed
+        self.effort = effort  # low keeps the constrained decision task cheap/stable
+        self._client = None
+
+    def _ensure_client(self):
+        if self._client is None:
+            import anthropic  # type: ignore  # provided by the [real] extra
+
+            self._client = anthropic.Anthropic()
+        return self._client
 
     def respond(
         self, scaffold: str, grounding: GroundingContext, task: Task
     ) -> ProposedChange:
-        # TODO(real-answering): render `scaffold + grounding.text + task` into a
-        # single prompt, call the pinned Claude model at temperature 0 with this
-        # seed via the `anthropic` SDK (the `[real]` extra), and parse the
-        # returned structured JSON into a ProposedChange. Keep the scaffold and
-        # model id byte-identical across every arm so only grounding varies.
-        raise NotImplementedError(
-            "ClaudeAnsweringModel is a stub. Install the [real] extra and pin "
-            "the model id to run real benchmarks; use ScriptedAnsweringModel "
-            "for the offline demo."
+        client = self._ensure_client()
+        user = (
+            f"GROUNDING (use only this):\n{grounding.text}\n\n"
+            f"TASK: {task.prompt}\n"
+            f"PROPOSED ACTION: {task.proposed_action}\n\n"
+            "Return a ProposedChange. Set asserts_prohibition=true and refrain "
+            "(no prohibited action in `actions`) if a governing decision forbids "
+            "the action; set asserts_permission=true and proceed otherwise. Cite "
+            "the decision id(s) you relied on. Do not invent constraints absent "
+            "from the grounding."
+        )
+        # No temperature / seed: Opus 4.8 rejects them. Thinking omitted (off) and
+        # effort pinned for stability across arms; structured output forces shape.
+        resp = client.messages.create(
+            model=self.version,
+            max_tokens=2048,
+            system=scaffold,
+            messages=[{"role": "user", "content": user}],
+            output_config={
+                "effort": self.effort,
+                "format": {"type": "json_schema", "schema": _PROPOSED_CHANGE_SCHEMA},
+            },
+        )
+        if getattr(resp, "stop_reason", None) == "refusal":
+            # Treat a safety refusal as a non-answer: assert nothing, cite nothing.
+            return ProposedChange(summary="model refused", actions=[])
+        import json
+
+        text = next(b.text for b in resp.content if b.type == "text")
+        data = json.loads(text)
+        return ProposedChange(
+            summary=data["summary"],
+            actions=[Action(a["kind"], a["target"], a["detail"]) for a in data["actions"]],
+            cites_decisions=list(data["cites_decisions"]),
+            asserts_prohibition=bool(data["asserts_prohibition"]),
+            asserts_permission=bool(data["asserts_permission"]),
         )

--- a/decisiongrounding/providers/answering.py
+++ b/decisiongrounding/providers/answering.py
@@ -1,0 +1,178 @@
+"""The held-constant answering model.
+
+Every arm feeds its assembled grounding into the SAME answering model behind
+the SAME scaffold. Arms differ only in the grounding; the answering model is a
+fixed function of (scaffold, grounding, task).
+
+Two implementations:
+
+* `ScriptedAnsweringModel` — a deterministic, offline stand-in. It reads ONLY
+  the grounding text and applies a transparent prose-reading policy: refrain
+  when a relevant, non-superseded decision prohibits the action; otherwise
+  proceed, folding in any stated constraint; follow a decision over one it
+  visibly supersedes; never invent a constraint the grounding does not state.
+  CRUCIALLY its behaviour depends only on what is *visible in the grounding*,
+  never on the gold label — so the demo honestly exercises retrieval/assembly
+  quality. Its output is a plumbing illustration, NOT a benchmark result.
+
+* `ClaudeAnsweringModel` — the real, pinned answering model (stub). Renders one
+  prompt, calls the API at temperature 0 with a fixed seed, parses a structured
+  ProposedChange back. Filled in behind the `[real]` extra.
+"""
+
+from __future__ import annotations
+
+import re
+from abc import ABC, abstractmethod
+
+from .base import Action, GroundingContext, ProposedChange, Task
+from .grounding_format import parse_blocks
+
+_TOKEN = re.compile(r"[a-z0-9]+")
+_STOP = {
+    "the", "a", "an", "to", "of", "and", "or", "for", "in", "on", "with", "without",
+    "is", "are", "be", "as", "by", "this", "that", "it", "its", "our", "we", "you",
+    "must", "not", "no", "do", "does", "should", "shall", "may", "can", "will",
+    "all", "any", "from", "into", "at", "use", "using", "team", "service", "api",
+}
+
+# Prose signals an agent would read out of plain markdown. Arm-agnostic: the
+# same extraction runs over whatever text is present in the grounding.
+_PROHIBIT = re.compile(
+    r"(must not|may not|shall not|do not|does not|cannot|never|prohibit|"
+    r"forbidden|not permitted|not allowed|without (?:explicit )?authorization|"
+    r"requires? (?:explicit )?authorization|requires? sign-?off)",
+    re.IGNORECASE,
+)
+_CONSTRAINT = re.compile(
+    r"\b(?:must|shall|are required to|is required to|always)\s+([^.\n]+)",
+    re.IGNORECASE,
+)
+# A lone "Superseded" status line marks an artifact as retired. We deliberately
+# do NOT treat the prose "superseded by ..." as self-marking, because a
+# superseding decision routinely mentions that phrase about the decision it
+# replaces — reading it as self-marking would retire the wrong artifact.
+_SUPERSEDED_SELF = re.compile(r"^\s*superseded\s*$", re.IGNORECASE | re.MULTILINE)
+_SUPERSEDES_OTHER = re.compile(r"supersedes\s+([A-Za-z0-9-]+)", re.IGNORECASE)
+
+
+def _content_tokens(text: str) -> set[str]:
+    return {t for t in _TOKEN.findall(text.lower()) if t not in _STOP and len(t) > 2}
+
+
+class AnsweringModel(ABC):
+    name: str = "base"
+    version: str = "0"
+    temperature: float = 0.0
+    seed: int = 0
+
+    @abstractmethod
+    def respond(
+        self, scaffold: str, grounding: GroundingContext, task: Task
+    ) -> ProposedChange:
+        ...
+
+
+class ScriptedAnsweringModel(AnsweringModel):
+    """Deterministic offline agent. Reads only the grounding; ignores gold."""
+
+    name = "offline-stub"
+    version = "scaffold-0"
+    temperature = 0.0
+
+    def __init__(self, seed: int = 0, relevance_threshold: int = 2) -> None:
+        self.seed = seed
+        self.relevance_threshold = relevance_threshold
+
+    def respond(
+        self, scaffold: str, grounding: GroundingContext, task: Task
+    ) -> ProposedChange:
+        blocks = parse_blocks(grounding.text)
+        action_tokens = _content_tokens(task.proposed_action)
+
+        # 1. Which artifact ids are *visibly* superseded in this grounding?
+        superseded: set[str] = set()
+        for artifact_id, _type, body in blocks:
+            if _SUPERSEDED_SELF.search(body):
+                superseded.add(artifact_id)
+            for other in _SUPERSEDES_OTHER.findall(body):
+                superseded.add(other)
+
+        # 2. Relevant, non-superseded decisions the agent would act on.
+        relevant_active: list[str] = []
+        prohibiting: list[str] = []
+        constraints: list[tuple[str, str]] = []  # (artifact_id, constraint_clause)
+        for artifact_id, artifact_type, body in blocks:
+            if artifact_type != "decision" or artifact_id in superseded:
+                continue
+            overlap = len(action_tokens & _content_tokens(body))
+            if overlap < self.relevance_threshold:
+                continue
+            relevant_active.append(artifact_id)
+            if _PROHIBIT.search(body):
+                prohibiting.append(artifact_id)
+            else:
+                m = _CONSTRAINT.search(body)
+                if m:
+                    constraints.append((artifact_id, m.group(1).strip()))
+
+        # 3. Decide. Refrain on a live prohibition; otherwise proceed.
+        if prohibiting:
+            return ProposedChange(
+                summary=(
+                    "A prior decision prohibits this action; escalate for "
+                    "explicit authorization instead of proceeding."
+                ),
+                actions=[
+                    Action(
+                        kind="escalate",
+                        target="authorization",
+                        detail="Request explicit sign-off before taking the action.",
+                    )
+                ],
+                cites_decisions=sorted(set(prohibiting)),
+                asserts_prohibition=True,
+                asserts_permission=False,
+            )
+
+        # Proceed. Cite every relevant, live decision the agent relied on
+        # (permitting ones included) so a later stale-decision check can see
+        # whether the agent leaned on a superseded rule.
+        detail = f"Proceed with: {task.proposed_action}."
+        cites = sorted(set(relevant_active))
+        if constraints:
+            detail += " Constraint(s): " + "; ".join(c for _, c in constraints) + "."
+        return ProposedChange(
+            summary="No live decision prohibits this action; proceed.",
+            actions=[Action(kind="implement", target="proposed_action", detail=detail)],
+            cites_decisions=cites,
+            asserts_prohibition=False,
+            asserts_permission=True,
+        )
+
+
+class ClaudeAnsweringModel(AnsweringModel):
+    """Real pinned answering model. STUB — wired behind the `[real]` extra."""
+
+    # Pin the exact model + version used for every published run. Held identical
+    # across arms; the only thing that varies between arms is the grounding.
+    name = "claude"
+    version = "PINNED-MODEL-ID-AND-DATE"  # e.g. a dated Claude model snapshot
+    temperature = 0.0
+
+    def __init__(self, seed: int = 0) -> None:
+        self.seed = seed
+
+    def respond(
+        self, scaffold: str, grounding: GroundingContext, task: Task
+    ) -> ProposedChange:
+        # TODO(real-answering): render `scaffold + grounding.text + task` into a
+        # single prompt, call the pinned Claude model at temperature 0 with this
+        # seed via the `anthropic` SDK (the `[real]` extra), and parse the
+        # returned structured JSON into a ProposedChange. Keep the scaffold and
+        # model id byte-identical across every arm so only grounding varies.
+        raise NotImplementedError(
+            "ClaudeAnsweringModel is a stub. Install the [real] extra and pin "
+            "the model id to run real benchmarks; use ScriptedAnsweringModel "
+            "for the offline demo."
+        )

--- a/decisiongrounding/providers/base.py
+++ b/decisiongrounding/providers/base.py
@@ -1,0 +1,113 @@
+"""Uniform provider-adapter contract shared by every benchmark arm.
+
+Each arm is a `Provider`. It gets exactly one symmetric opportunity to
+populate the answering model's context (`prepare`), then answers the task
+(`respond`). Arms differ ONLY in how they select and assemble grounding from
+the corpus; the answering model and the prompt scaffold are held constant.
+
+This isolates *retrieval/assembly quality*. It does NOT test whether a
+pull-based MCP actually gets consulted in production — that is a separate
+deployment question (see README, "Symmetric injection caveat").
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # avoid an import cycle with answering.py
+    from .answering import AnsweringModel
+
+
+# The held-constant prompt scaffold. Every arm feeds its grounding into this
+# identical frame, so any difference in outcome is attributable to grounding
+# assembly, not to prompt phrasing.
+SCAFFOLD = (
+    "You are a senior engineer about to act on a task. Prior team decisions "
+    "may bind your action. Using ONLY the grounding provided, decide whether "
+    "the proposed action is permitted or prohibited, follow any superseding "
+    "decision over the decision it supersedes, do not invent constraints that "
+    "the grounding does not state, and cite the decision id(s) you relied on."
+)
+
+
+@dataclass(frozen=True)
+class CorpusArtifact:
+    """One markdown artifact in a scenario's project corpus."""
+
+    id: str
+    type: str
+    path: str
+    text: str
+    supersedes: tuple[str, ...] = ()
+    filler: bool = False
+
+
+@dataclass(frozen=True)
+class Task:
+    """What the agent is asked to do, and the action it is on the verge of."""
+
+    prompt: str
+    proposed_action: str
+
+
+@dataclass(frozen=True)
+class GroundingContext:
+    """What an arm placed in the answering model's context this run."""
+
+    text: str
+    artifacts_supplied: tuple[str, ...]
+    token_estimate: int
+
+
+@dataclass(frozen=True)
+class Action:
+    """A concrete step in a proposed change."""
+
+    kind: str
+    target: str
+    detail: str
+
+
+@dataclass
+class ProposedChange:
+    """The answering model's structured proposal, scored deterministically."""
+
+    summary: str
+    actions: list[Action] = field(default_factory=list)
+    cites_decisions: list[str] = field(default_factory=list)
+    asserts_prohibition: bool = False
+    asserts_permission: bool = False
+
+
+def estimate_tokens(text: str) -> int:
+    """Cheap, deterministic token estimate (~4 chars/token)."""
+    return (len(text) + 3) // 4
+
+
+class Provider(ABC):
+    """Base arm. Subclasses implement `prepare`; `respond` is shared."""
+
+    #: Stable arm name, matches the run_result.schema.json `arm` enum.
+    name: str = "base"
+
+    def __init__(self, answering_model: "AnsweringModel") -> None:
+        self.answering_model = answering_model
+        self._grounding: GroundingContext | None = None
+
+    @abstractmethod
+    def prepare(self, corpus: list[CorpusArtifact]) -> None:
+        """Assemble this arm's grounding from the corpus (called once)."""
+
+    def respond(self, task: Task) -> ProposedChange:
+        """Answer the task using the held-constant scaffold + answering model."""
+        if self._grounding is None:
+            raise RuntimeError(f"{self.name}: prepare() must run before respond()")
+        return self.answering_model.respond(SCAFFOLD, self._grounding, task)
+
+    @property
+    def grounding(self) -> GroundingContext:
+        if self._grounding is None:
+            raise RuntimeError(f"{self.name}: prepare() has not run")
+        return self._grounding

--- a/decisiongrounding/providers/context_dump.py
+++ b/decisiongrounding/providers/context_dump.py
@@ -1,0 +1,25 @@
+"""`context_dump` arm — paste every artifact into the answering model's context.
+
+This is a mandatory threatening baseline: it is exactly the skeptic's position
+("frontier models + long context just absorb the decisions"). It supplies the
+whole corpus verbatim, so every stated relationship (including supersession) is
+present. Any grounding layer must beat this to justify its existence.
+"""
+
+from __future__ import annotations
+
+from .base import CorpusArtifact, GroundingContext, Provider, estimate_tokens
+from .grounding_format import format_block
+
+
+class ContextDumpProvider(Provider):
+    name = "context_dump"
+
+    def prepare(self, corpus: list[CorpusArtifact]) -> None:
+        blocks = [format_block(a.id, a.type, a.text) for a in corpus]
+        text = "\n".join(blocks)
+        self._grounding = GroundingContext(
+            text=text,
+            artifacts_supplied=tuple(a.id for a in corpus),
+            token_estimate=estimate_tokens(text),
+        )

--- a/decisiongrounding/providers/embedding.py
+++ b/decisiongrounding/providers/embedding.py
@@ -62,8 +62,79 @@ def cosine(a: list[float], b: list[float]) -> float:
     return sum(x * y for x, y in zip(a, b))
 
 
-# TODO(real-embeddings): add a pinned hosted/local embedder behind the `[real]`
-# extra, e.g. an Anthropic/OpenAI embedding endpoint or a pinned
-# sentence-transformers model. Pin model id + revision in runner config so runs
-# reproduce. Keep the `Embedder` interface; do not let arms import a concrete
-# backend directly.
+def _l2_normalize(vec: list[float]) -> list[float]:
+    norm = math.sqrt(sum(v * v for v in vec))
+    return vec if norm == 0.0 else [v / norm for v in vec]
+
+
+class VoyageEmbedder(Embedder):
+    """Pinned Voyage AI embeddings (Anthropic's recommended embedding provider).
+
+    Real, reproducible retrieval for benchmark runs. Pin the model id; results
+    are deterministic for a fixed model + input. Requires the `[real]` extra
+    (`voyageai`) and a VOYAGE_API_KEY. Lazily imported so the offline spine
+    keeps importing without the dependency.
+    """
+
+    def __init__(self, model: str = "voyage-3") -> None:
+        self.model = model
+        self.name = f"voyage:{model}"
+        self._client = None
+
+    def _ensure_client(self):
+        if self._client is None:
+            import voyageai  # type: ignore  # provided by the [real] extra
+
+            self._client = voyageai.Client()
+            # Probe dimensionality once so cosine() comparisons are well-defined.
+            probe = self._client.embed(["."], model=self.model).embeddings[0]
+            self.dim = len(probe)
+        return self._client
+
+    def embed(self, text: str) -> list[float]:
+        client = self._ensure_client()
+        vec = client.embed([text], model=self.model).embeddings[0]
+        return _l2_normalize(list(vec))
+
+
+class SentenceTransformerEmbedder(Embedder):
+    """Pinned local sentence-transformers model. Offline-capable once downloaded.
+
+    A reproducible alternative to a hosted embedder. Requires the
+    `[local-embeddings]` extra (`sentence-transformers`). Lazily imported.
+    """
+
+    def __init__(self, model: str = "all-MiniLM-L6-v2") -> None:
+        self.model = model
+        self.name = f"st:{model}"
+        self._model = None
+
+    def _ensure_model(self):
+        if self._model is None:
+            from sentence_transformers import SentenceTransformer  # type: ignore
+
+            self._model = SentenceTransformer(self.model)
+            self.dim = self._model.get_sentence_embedding_dimension()
+        return self._model
+
+    def embed(self, text: str) -> list[float]:
+        model = self._ensure_model()
+        vec = model.encode(text, normalize_embeddings=True)
+        return [float(x) for x in vec]
+
+
+def make_embedder(spec: str) -> Embedder:
+    """Build an embedder from a spec string.
+
+    `local-hash` (offline default) | `voyage[:model]` | `st[:model]`.
+    Real benchmark runs pin a real backend; the offline demo uses `local-hash`.
+    """
+    if spec in ("", "local-hash"):
+        return LocalDeterministicEmbedder()
+    if spec.startswith("voyage"):
+        _, _, model = spec.partition(":")
+        return VoyageEmbedder(model or "voyage-3")
+    if spec.startswith("st"):
+        _, _, model = spec.partition(":")
+        return SentenceTransformerEmbedder(model or "all-MiniLM-L6-v2")
+    raise ValueError(f"unknown embedder spec: {spec!r}")

--- a/decisiongrounding/providers/embedding.py
+++ b/decisiongrounding/providers/embedding.py
@@ -1,0 +1,69 @@
+"""Embedding backends for the retrieval arms.
+
+The default `LocalDeterministicEmbedder` is a real but dependency-free
+bag-of-words hashing embedder: it produces a fixed-width, L2-normalised vector
+with no network and no model download, so the spine runs offline and
+reproducibly. It is a faithful stand-in for "commodity RAG" — exactly the
+threatening baseline the benchmark needs — and its recall genuinely degrades as
+the corpus grows past top-k.
+
+For real benchmark runs, swap in a pinned hosted/local embedding model via the
+`[real]` extra (see TODO below). Arms depend only on the `Embedder` interface.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+import re
+from abc import ABC, abstractmethod
+
+_TOKEN = re.compile(r"[a-z0-9]+")
+
+
+def _tokenize(text: str) -> list[str]:
+    return _TOKEN.findall(text.lower())
+
+
+class Embedder(ABC):
+    """Maps text to a fixed-width vector. Implementations must be deterministic."""
+
+    name: str = "base"
+    dim: int = 0
+
+    @abstractmethod
+    def embed(self, text: str) -> list[float]:
+        ...
+
+
+class LocalDeterministicEmbedder(Embedder):
+    """Hashing bag-of-words embedder. Offline, deterministic, dependency-free."""
+
+    def __init__(self, dim: int = 256) -> None:
+        self.dim = dim
+        self.name = f"local-hash-bow-{dim}"
+
+    def embed(self, text: str) -> list[float]:
+        vec = [0.0] * self.dim
+        for tok in _tokenize(text):
+            h = hashlib.blake2b(tok.encode("utf-8"), digest_size=8).digest()
+            idx = int.from_bytes(h, "big") % self.dim
+            # Signed contribution keeps the space from collapsing to one orthant.
+            sign = 1.0 if h[0] & 1 else -1.0
+            vec[idx] += sign
+        norm = math.sqrt(sum(v * v for v in vec))
+        if norm == 0.0:
+            return vec
+        return [v / norm for v in vec]
+
+
+def cosine(a: list[float], b: list[float]) -> float:
+    """Cosine similarity of two equal-length vectors (assumed roughly unit norm)."""
+    return sum(x * y for x, y in zip(a, b))
+
+
+# TODO(real-embeddings): add a pinned hosted/local embedder behind the `[real]`
+# extra, e.g. an Anthropic/OpenAI embedding endpoint or a pinned
+# sentence-transformers model. Pin model id + revision in runner config so runs
+# reproduce. Keep the `Embedder` interface; do not let arms import a concrete
+# backend directly.

--- a/decisiongrounding/providers/grounding_format.py
+++ b/decisiongrounding/providers/grounding_format.py
@@ -1,0 +1,29 @@
+"""Shared grounding-text block format.
+
+Arms assemble grounding as a sequence of attributed blocks so the answering
+model can cite the artifact id it relied on. Retrieval arms (naive_rag) attach
+the same header to each retrieved chunk, so attribution works identically
+regardless of arm — what differs is only which blocks are present.
+"""
+
+from __future__ import annotations
+
+import re
+
+_HEADER = re.compile(r"^\[artifact (?P<id>[^\s|]+) \| (?P<type>[^\]]+)\]$", re.MULTILINE)
+
+
+def format_block(artifact_id: str, artifact_type: str, body: str) -> str:
+    return f"[artifact {artifact_id} | {artifact_type}]\n{body.strip()}\n"
+
+
+def parse_blocks(grounding_text: str) -> list[tuple[str, str, str]]:
+    """Return (artifact_id, artifact_type, body) for each block in order."""
+    blocks: list[tuple[str, str, str]] = []
+    matches = list(_HEADER.finditer(grounding_text))
+    for i, m in enumerate(matches):
+        start = m.end()
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(grounding_text)
+        body = grounding_text[start:end].strip()
+        blocks.append((m.group("id"), m.group("type"), body))
+    return blocks

--- a/decisiongrounding/providers/memory_provider.py
+++ b/decisiongrounding/providers/memory_provider.py
@@ -1,0 +1,34 @@
+"""`memory_provider` arm — general-purpose memory layer. STUB.
+
+A MemoryBench-style adapter slot for a commodity memory layer (Mem0 / Zep /
+Supermemory). Per ADR-0001 we borrow MemoryBench's provider-adapter convention
+without adopting its conversational-QA evaluation contract, so this arm can
+reuse those upstream adapters while still being scored by our deterministic
+structural scorer.
+"""
+
+from __future__ import annotations
+
+from .base import CorpusArtifact, GroundingContext, Provider, Task
+
+
+class MemoryProviderArm(Provider):
+    name = "memory_provider"
+
+    def __init__(self, answering_model, backend: str = "TODO-pin-backend"):
+        super().__init__(answering_model)
+        self.backend = backend  # e.g. "mem0", "zep", "supermemory" (pin version)
+
+    def prepare(self, corpus: list[CorpusArtifact]) -> None:
+        # TODO(memory-arm): ingest each artifact into the pinned memory backend
+        # via its MemoryBench adapter (add/write). Pin the backend + version so
+        # runs reproduce. Respect the single symmetric grounding opportunity:
+        # ingestion happens once here.
+        raise NotImplementedError("memory_provider arm is a stub this pass")
+
+    def respond(self, task: Task):
+        # TODO(memory-arm): query the backend (search/recall) for the task, wrap
+        # the recalled items as GroundingContext, and feed the held-constant
+        # answering model. Do not let the backend call the answering model itself
+        # — keep the answering model fixed across arms.
+        raise NotImplementedError("memory_provider arm is a stub this pass")

--- a/decisiongrounding/providers/naive_rag.py
+++ b/decisiongrounding/providers/naive_rag.py
@@ -1,0 +1,86 @@
+"""`naive_rag` arm — commodity RAG over the same markdown.
+
+Embeddings + top-k cosine retrieval over section chunks. No typing, no
+relationship traversal: it retrieves the chunks most similar to the task and
+nothing else. This is the second mandatory threatening baseline. Its
+characteristic failure is built in, not contrived: as the corpus grows past the
+top-k budget (or conflict density rises), relevant context — including the
+section that marks a decision superseded — can fall out of the retrieved set,
+severing a relationship that whole-corpus or typed retrieval would preserve.
+
+For real runs, swap the embedder for a pinned hosted/local model via the
+`[real]` extra; the retrieval logic is unchanged.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .base import (
+    SCAFFOLD,
+    CorpusArtifact,
+    GroundingContext,
+    Provider,
+    Task,
+    estimate_tokens,
+)
+from .embedding import Embedder, LocalDeterministicEmbedder, cosine
+from .grounding_format import format_block
+
+
+@dataclass(frozen=True)
+class _Chunk:
+    artifact_id: str
+    artifact_type: str
+    text: str
+    vector: list[float]
+
+
+def _split_sections(text: str) -> list[str]:
+    """Split markdown into section chunks on `## ` headings (front matter kept)."""
+    parts: list[str] = []
+    current: list[str] = []
+    for line in text.splitlines():
+        if line.startswith("## ") and current:
+            parts.append("\n".join(current).strip())
+            current = [line]
+        else:
+            current.append(line)
+    if current:
+        parts.append("\n".join(current).strip())
+    return [p for p in parts if p]
+
+
+class NaiveRagProvider(Provider):
+    name = "naive_rag"
+
+    def __init__(self, answering_model, embedder: Embedder | None = None, top_k: int = 4):
+        super().__init__(answering_model)
+        self.embedder = embedder or LocalDeterministicEmbedder()
+        self.top_k = top_k  # pinned retrieval budget
+        self._chunks: list[_Chunk] = []
+
+    def prepare(self, corpus: list[CorpusArtifact]) -> None:
+        self._chunks = []
+        for a in corpus:
+            for section in _split_sections(a.text):
+                self._chunks.append(
+                    _Chunk(a.id, a.type, section, self.embedder.embed(section))
+                )
+        # Grounding is task-dependent for RAG; assembled lazily in respond().
+        self._grounding = GroundingContext(text="", artifacts_supplied=(), token_estimate=0)
+
+    def respond(self, task: Task):
+        query = self.embedder.embed(f"{task.prompt}\n{task.proposed_action}")
+        ranked = sorted(
+            self._chunks, key=lambda c: cosine(query, c.vector), reverse=True
+        )
+        top = ranked[: self.top_k]
+        blocks = [format_block(c.artifact_id, c.artifact_type, c.text) for c in top]
+        text = "\n".join(blocks)
+        self._grounding = GroundingContext(
+            text=text,
+            artifacts_supplied=tuple(dict.fromkeys(c.artifact_id for c in top)),
+            token_estimate=estimate_tokens(text),
+        )
+        return self.answering_model.respond(SCAFFOLD, self._grounding, task)

--- a/decisiongrounding/providers/no_grounding.py
+++ b/decisiongrounding/providers/no_grounding.py
@@ -1,0 +1,21 @@
+"""`no_grounding` arm — control. STUB.
+
+Supplies the answering model with NO decision grounding at all (empty context).
+It measures the floor: how often the answering model adheres to prior decisions
+from parametric knowledge alone. Every grounded arm must beat this.
+"""
+
+from __future__ import annotations
+
+from .base import CorpusArtifact, GroundingContext, Provider
+
+
+class NoGroundingProvider(Provider):
+    name = "no_grounding"
+
+    def prepare(self, corpus: list[CorpusArtifact]) -> None:
+        # TODO(no-grounding): supply an empty (or scaffold-only) grounding so the
+        # arm reflects parametric adherence with zero retrieved context. Trivial
+        # to finish, but left as a stub this pass to keep the spine to the two
+        # threatening real arms.
+        raise NotImplementedError("no_grounding arm is a stub this pass")

--- a/decisiongrounding/providers/no_grounding.py
+++ b/decisiongrounding/providers/no_grounding.py
@@ -1,8 +1,14 @@
-"""`no_grounding` arm — control. STUB.
+"""`no_grounding` arm — the control / floor.
 
-Supplies the answering model with NO decision grounding at all (empty context).
-It measures the floor: how often the answering model adheres to prior decisions
+Supplies the answering model with NO decision grounding (empty context). It
+measures the floor: how often the answering model adheres to prior decisions
 from parametric knowledge alone. Every grounded arm must beat this.
+
+With the offline scripted answering model (which reads only the grounding and
+has no parametric knowledge) this arm proceeds on everything, so it scores at
+the floor — adhering only where the correct behaviour is to proceed (the
+negative control). With the real Claude answering model it reflects genuine
+parametric adherence.
 """
 
 from __future__ import annotations
@@ -14,8 +20,5 @@ class NoGroundingProvider(Provider):
     name = "no_grounding"
 
     def prepare(self, corpus: list[CorpusArtifact]) -> None:
-        # TODO(no-grounding): supply an empty (or scaffold-only) grounding so the
-        # arm reflects parametric adherence with zero retrieved context. Trivial
-        # to finish, but left as a stub this pass to keep the spine to the two
-        # threatening real arms.
-        raise NotImplementedError("no_grounding arm is a stub this pass")
+        # The single symmetric grounding opportunity, populated with nothing.
+        self._grounding = GroundingContext(text="", artifacts_supplied=(), token_estimate=0)

--- a/decisiongrounding/providers/rac.py
+++ b/decisiongrounding/providers/rac.py
@@ -1,0 +1,36 @@
+"""`rac` arm — deterministic typed retrieval via the system under test. STUB.
+
+This arm assembles grounding by calling RAC's deterministic, typed retrieval
+surface rather than embedding similarity. It is the layer whose value the whole
+benchmark exists to test, so it gets NO special treatment: same answering model,
+same scaffold, one symmetric grounding opportunity.
+
+The thesis is that typed retrieval + relationship traversal preserves exactly
+what naive_rag severs — notably supersession — by following `supersedes` edges
+instead of hoping the superseding artifact lands in top-k.
+"""
+
+from __future__ import annotations
+
+from .base import CorpusArtifact, GroundingContext, Provider, Task
+
+
+class RacProvider(Provider):
+    name = "rac"
+
+    def prepare(self, corpus: list[CorpusArtifact]) -> None:
+        # TODO(rac-arm): index the corpus through RAC. In production this calls
+        # the `lore` MCP server: `get_summary` once to learn what exists, then
+        # `search_artifacts(query, type="decision")` to find candidates. For the
+        # offline harness, shell out to the pinned `rac` CLI instead
+        # (`rac find <q> . --type decision --json`).
+        raise NotImplementedError("rac arm is a stub this pass")
+
+    def respond(self, task: Task):
+        # TODO(rac-arm): for each candidate decision, call `get_related(id)` (MCP)
+        # or `rac relationships . --json` (CLI) and FOLLOW the `supersedes` edges
+        # so the superseding decision replaces the one it supersedes. Assemble the
+        # resolved, typed set into a GroundingContext and feed the held-constant
+        # answering model. This is where the thesis is won or lost: deterministic
+        # relationship traversal vs. embedding recall.
+        raise NotImplementedError("rac arm is a stub this pass")

--- a/decisiongrounding/providers/rac.py
+++ b/decisiongrounding/providers/rac.py
@@ -1,36 +1,159 @@
-"""`rac` arm — deterministic typed retrieval via the system under test. STUB.
+"""`rac` arm — deterministic typed retrieval via the system under test.
 
 This arm assembles grounding by calling RAC's deterministic, typed retrieval
 surface rather than embedding similarity. It is the layer whose value the whole
 benchmark exists to test, so it gets NO special treatment: same answering model,
 same scaffold, one symmetric grounding opportunity.
 
-The thesis is that typed retrieval + relationship traversal preserves exactly
-what naive_rag severs — notably supersession — by following `supersedes` edges
-instead of hoping the superseding artifact lands in top-k.
+RAC is treated as an EXTERNAL TOOL, never a Python import (ADR-0001): the arm
+shells out to the pinned `rac` CLI (`rac find … --json`, `rac relationships …
+--json`). The thesis is that typed retrieval + relationship traversal preserves
+exactly what naive_rag severs — notably supersession — by FOLLOWING `supersedes`
+edges instead of hoping the superseding artifact lands in top-k.
+
+Requires the `rac` CLI on PATH (or set RAC_BIN). It does not run in the offline
+demo; install `rac` to include this arm in a comparison.
 """
 
 from __future__ import annotations
 
-from .base import CorpusArtifact, GroundingContext, Provider, Task
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+from .base import (
+    SCAFFOLD,
+    CorpusArtifact,
+    GroundingContext,
+    Provider,
+    Task,
+    estimate_tokens,
+)
+from .grounding_format import format_block
+
+
+def resolve_supersedes(
+    matched_ids: list[str],
+    supersedes_edges: list[tuple[str, str]],
+    corpus_ids: set[str],
+    top_k: int,
+) -> list[str]:
+    """Follow `supersedes` edges so a superseding decision replaces the one it
+    supersedes. Pure and deterministic — the heart of the typed-retrieval thesis.
+
+    `supersedes_edges` are (source, target) pairs meaning source supersedes
+    target. For each matched decision that is superseded by another decision in
+    the corpus, swap in its (transitive) live successor and drop the stale one.
+    Order is preserved (match rank), then capped to `top_k`.
+    """
+    superseded_by: dict[str, str] = {
+        tgt: src for (src, tgt) in supersedes_edges if src in corpus_ids
+    }
+
+    def live(artifact_id: str, _seen: set[str] | None = None) -> str:
+        seen = _seen or set()
+        while artifact_id in superseded_by and artifact_id not in seen:
+            seen.add(artifact_id)
+            artifact_id = superseded_by[artifact_id]
+        return artifact_id
+
+    resolved: list[str] = []
+    for mid in matched_ids:
+        live_id = live(mid)
+        if live_id not in resolved:
+            resolved.append(live_id)
+    return resolved[:top_k]
 
 
 class RacProvider(Provider):
     name = "rac"
 
+    def __init__(self, answering_model, top_k: int = 4):
+        super().__init__(answering_model)
+        self.top_k = top_k  # decision budget, parity with naive_rag's top-k
+        self._dir: Path | None = None
+        self._by_id: dict[str, CorpusArtifact] = {}
+
+    @staticmethod
+    def _bin() -> str:
+        return os.environ.get("RAC_BIN", "rac")
+
+    def _run(self, *args: str) -> dict:
+        rac = self._bin()
+        if shutil.which(rac) is None:
+            raise RuntimeError(
+                f"rac CLI not found ({rac!r}). Install `rac` or set RAC_BIN to "
+                "include the rac arm. It does not run in the offline demo."
+            )
+        out = subprocess.run(
+            [rac, *args], capture_output=True, text=True, check=True
+        ).stdout
+        return json.loads(out)
+
     def prepare(self, corpus: list[CorpusArtifact]) -> None:
-        # TODO(rac-arm): index the corpus through RAC. In production this calls
-        # the `lore` MCP server: `get_summary` once to learn what exists, then
-        # `search_artifacts(query, type="decision")` to find candidates. For the
-        # offline harness, shell out to the pinned `rac` CLI instead
-        # (`rac find <q> . --type decision --json`).
-        raise NotImplementedError("rac arm is a stub this pass")
+        # Write the corpus to a temp dir so the external `rac` CLI can index it.
+        self._by_id = {a.id: a for a in corpus}
+        tmp = Path(tempfile.mkdtemp(prefix="dg-rac-"))
+        for a in corpus:
+            (tmp / f"{a.id}.md").write_text(a.text, encoding="utf-8")
+        self._dir = tmp
+        self._grounding = GroundingContext(text="", artifacts_supplied=(), token_estimate=0)
 
     def respond(self, task: Task):
-        # TODO(rac-arm): for each candidate decision, call `get_related(id)` (MCP)
-        # or `rac relationships . --json` (CLI) and FOLLOW the `supersedes` edges
-        # so the superseding decision replaces the one it supersedes. Assemble the
-        # resolved, typed set into a GroundingContext and feed the held-constant
-        # answering model. This is where the thesis is won or lost: deterministic
-        # relationship traversal vs. embedding recall.
-        raise NotImplementedError("rac arm is a stub this pass")
+        if self._dir is None:
+            raise RuntimeError("rac arm: prepare() must run before respond()")
+        query = f"{task.prompt} {task.proposed_action}"
+
+        # 1. Typed candidate decisions, ranked by rac's deterministic search.
+        find = self._run("find", query, str(self._dir), "--type", "decision", "--json")
+        matched = [m.get("id") for m in find.get("matches", []) if m.get("id")]
+
+        # 2. Relationship graph → supersedes edges (source supersedes target).
+        rels = self._run("relationships", str(self._dir), "--json")
+        edges = _extract_supersedes_edges(rels)
+
+        # 3. Follow the edges: replace superseded decisions with live successors.
+        corpus_ids = set(self._by_id)
+        resolved = resolve_supersedes(matched, edges, corpus_ids, self.top_k)
+
+        blocks = [
+            format_block(aid, self._by_id[aid].type, self._by_id[aid].text)
+            for aid in resolved
+            if aid in self._by_id
+        ]
+        text = "\n".join(blocks)
+        self._grounding = GroundingContext(
+            text=text,
+            artifacts_supplied=tuple(resolved),
+            token_estimate=estimate_tokens(text),
+        )
+        return self.answering_model.respond(SCAFFOLD, self._grounding, task)
+
+
+def _extract_supersedes_edges(rels_json: dict) -> list[tuple[str, str]]:
+    """Pull (source, target) supersedes pairs from `rac relationships --json`.
+
+    Defensive against shape drift across rac versions: handles both a flat
+    relationships list (entries with relationship == "supersedes") and an
+    artifacts[] report carrying a per-artifact `relationships.supersedes` list.
+    TODO(rac-arm): pin and verify against the installed rac version's JSON.
+    """
+    edges: list[tuple[str, str]] = []
+
+    for rel in rels_json.get("relationships", []) or []:
+        if rel.get("relationship") == "supersedes":
+            src, tgt = rel.get("source"), rel.get("target")
+            if src and tgt:
+                edges.append((src, tgt))
+
+    for art in rels_json.get("artifacts", []) or []:
+        src = art.get("id")
+        targets = (art.get("relationships") or {}).get("supersedes") or []
+        for tgt in targets:
+            if src and tgt:
+                edges.append((src, tgt))
+
+    return edges

--- a/decisiongrounding/pyproject.toml
+++ b/decisiongrounding/pyproject.toml
@@ -18,9 +18,15 @@ dependencies = []
 schema = ["jsonschema>=4.20"]
 # PNG crossover chart. Without it the chart renders as a pure-Python SVG.
 chart = ["matplotlib>=3.7"]
-# Real benchmark backends (pinned in config): the answering model + embeddings.
-# Replaces the offline stubs. TODO: pin exact versions before publishing runs.
-real = ["anthropic>=0.40"]
+# Real benchmark backends: the pinned Claude answering model (anthropic) and
+# Voyage embeddings (Anthropic's recommended embedding provider — Anthropic has
+# no embeddings endpoint). Replaces the offline stubs.
+# TODO: pin exact package versions before publishing runs.
+real = ["anthropic>=0.40", "voyageai>=0.2"]
+# Local, offline-capable embeddings alternative to Voyage.
+local-embeddings = ["sentence-transformers>=2.2"]
+# The rac arm additionally needs the `rac` CLI on PATH (or RAC_BIN) — it is an
+# external tool, not a Python dependency (ADR-0001), so it is not listed here.
 # Test runner.
 dev = ["pytest>=7"]
 

--- a/decisiongrounding/pyproject.toml
+++ b/decisiongrounding/pyproject.toml
@@ -1,0 +1,31 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "decisiongrounding"
+version = "0.1.0"
+description = "A reproducible benchmark for decision-grounding: does a deterministic grounding layer make a coding agent adhere to prior decisions better than context-dump, naive RAG, or a memory layer — and at what corpus size?"
+readme = "README.md"
+license = { text = "MIT" }
+requires-python = ">=3.11"
+# Core spine is stdlib-only so the demo runs offline with no install.
+dependencies = []
+
+[project.optional-dependencies]
+# Strict JSON Schema (Draft 2020-12) validation. Without it the loader falls
+# back to a built-in required-key check.
+schema = ["jsonschema>=4.20"]
+# PNG crossover chart. Without it the chart renders as a pure-Python SVG.
+chart = ["matplotlib>=3.7"]
+# Real benchmark backends (pinned in config): the answering model + embeddings.
+# Replaces the offline stubs. TODO: pin exact versions before publishing runs.
+real = ["anthropic>=0.40"]
+# Test runner.
+dev = ["pytest>=7"]
+
+[project.scripts]
+decisiongrounding = "runner.cli:main"
+
+[tool.setuptools]
+packages = ["providers", "scenarios", "scoring", "runner"]

--- a/decisiongrounding/results/.gitignore
+++ b/decisiongrounding/results/.gitignore
@@ -1,0 +1,8 @@
+# results/ is append-only at runtime. Generated artifacts are not committed;
+# `make demo` regenerates them. The append-only contract is documented in
+# results/README.md and enforced by the runner (new timestamped files, never
+# mutated). Keep the directory and its README under version control.
+run-*.json
+crossover_dataset.json
+crossover.png
+crossover.svg

--- a/decisiongrounding/results/README.md
+++ b/decisiongrounding/results/README.md
@@ -1,0 +1,14 @@
+# results/ — append-only
+
+This directory is **append-only**. Every run writes a new timestamped report
+file (`run-<UTC>-<label>.json`) and the crossover artifacts
+(`crossover_dataset.json`, `crossover.{png,svg}`). Existing run files are never
+mutated or deleted; a re-run produces a new file.
+
+Each report records the pinned answering model, version, temperature, and seed,
+so any run reproduces from seed + pinned model versions.
+
+Reports written with the offline `offline-stub` answering model are **harness
+illustrations, not benchmark results** — they exercise the plumbing on a tiny
+synthetic corpus. Published benchmark results require the pinned Claude
+answering model and real/public-derived corpora (see `../CONTRIBUTING.md`).

--- a/decisiongrounding/runner/__init__.py
+++ b/decisiongrounding/runner/__init__.py
@@ -1,0 +1,1 @@
+"""Runner CLI: run one arm, compare arms, or run the offline demo spine."""

--- a/decisiongrounding/runner/cli.py
+++ b/decisiongrounding/runner/cli.py
@@ -1,0 +1,205 @@
+"""decisiongrounding runner.
+
+    python -m runner.cli run     --arm context_dump --scenarios scenarios/
+    python -m runner.cli compare --arms context_dump,naive_rag --scenarios scenarios/
+    python -m runner.cli demo    --scenarios scenarios/
+
+`demo` is the one-command spine: it runs the two real arms on the worked
+scenarios offline, writes an append-only report, and emits the crossover chart.
+
+Reproducibility: the answering model + seed are pinned and recorded in every
+RunResult. `results/` is append-only — runs are written as new timestamped
+files and never mutated.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Make the package root importable when run as `python -m runner.cli` or directly.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from providers import ARMS, REAL_ARMS, ScriptedAnsweringModel  # noqa: E402
+from providers.base import ProposedChange  # noqa: E402
+from scenarios.loader import Scenario, load_scenarios  # noqa: E402
+from scoring import aggregate, score  # noqa: E402
+from scoring.crossover import build_dataset, emit  # noqa: E402
+
+HARNESS_VERSION = "0.1.0-scaffold"
+_ROOT = Path(__file__).resolve().parent.parent
+_DEFAULT_RESULTS = _ROOT / "results"
+
+
+def _answering_model(name: str, seed: int):
+    if name == "offline-stub":
+        return ScriptedAnsweringModel(seed=seed)
+    raise SystemExit(
+        f"answering model {name!r} is not wired in the scaffold; use 'offline-stub'. "
+        "The pinned Claude answering model lives behind the [real] extra (stub)."
+    )
+
+
+def _pc_to_dict(pc: ProposedChange) -> dict:
+    return {
+        "summary": pc.summary,
+        "actions": [{"kind": a.kind, "target": a.target, "detail": a.detail} for a in pc.actions],
+        "cites_decisions": list(pc.cites_decisions),
+        "asserts_prohibition": pc.asserts_prohibition,
+        "asserts_permission": pc.asserts_permission,
+    }
+
+
+def run_one(arm: str, scenario: Scenario, model, seed: int) -> dict:
+    provider = ARMS[arm](model)
+    provider.prepare(list(scenario.corpus))
+    pc = provider.respond(scenario.task)
+    sc = score(scenario, pc)
+    g = provider.grounding
+    return {
+        "run_id": str(uuid.uuid4()),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "arm": arm,
+        "scenario_id": scenario.scenario_id,
+        "corpus_size_N": len(scenario.corpus),
+        "answering_model": {
+            "name": model.name,
+            "version": model.version,
+            "temperature": model.temperature,
+            "seed": seed,
+        },
+        "grounding": {
+            "provider": arm,
+            "token_estimate": g.token_estimate,
+            "artifacts_supplied": list(g.artifacts_supplied),
+        },
+        "proposed_change": _pc_to_dict(pc),
+        "score": sc.as_dict(),
+        "harness_version": HARNESS_VERSION,
+    }
+
+
+def _write_report(results: list[dict], out_dir: Path, label: str) -> Path:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    path = out_dir / f"run-{stamp}-{label}.json"
+    if path.exists():  # append-only: never overwrite an existing run file
+        path = out_dir / f"run-{stamp}-{label}-{uuid.uuid4().hex[:6]}.json"
+    by_arm: dict[str, list] = {}
+    for r in results:
+        by_arm.setdefault(r["arm"], []).append(r)
+    from scoring.scorer import Score
+
+    metrics = {
+        arm: aggregate(
+            arm, [Score(**r["score"]) for r in rs]
+        ).as_dict()
+        for arm, rs in by_arm.items()
+    }
+    report = {
+        "harness_version": HARNESS_VERSION,
+        "generated": datetime.now(timezone.utc).isoformat(),
+        "label": label,
+        "metrics_by_arm": metrics,
+        "runs": results,
+    }
+    path.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    return path
+
+
+def _print_metrics(results: list[dict]) -> None:
+    by_arm: dict[str, list] = {}
+    for r in results:
+        by_arm.setdefault(r["arm"], []).append(r)
+    from scoring.scorer import Score
+
+    print(f"{'arm':<16}{'adhere':>8}{'stale':>8}{'f-permit':>10}{'f-prohibit':>12}")
+    for arm, rs in by_arm.items():
+        m = aggregate(arm, [Score(**r["score"]) for r in rs])
+        print(
+            f"{arm:<16}{m.adherence_rate:>8.2f}{m.stale_decision_rate:>8.2f}"
+            f"{m.false_permit_rate:>10.2f}{m.false_prohibit_rate:>12.2f}"
+        )
+
+
+def cmd_run(args) -> int:
+    scenarios = load_scenarios(args.scenarios)
+    model = _answering_model(args.answering, args.seed)
+    results = [run_one(args.arm, sc, model, args.seed) for sc in scenarios]
+    _print_metrics(results)
+    path = _write_report(results, Path(args.out), args.arm)
+    print(f"\nwrote {path}")
+    return 0
+
+
+def cmd_compare(args) -> int:
+    arms = tuple(a.strip() for a in args.arms.split(",") if a.strip())
+    scenarios = load_scenarios(args.scenarios)
+    model = _answering_model(args.answering, args.seed)
+    results: list[dict] = []
+    for arm in arms:
+        for sc in scenarios:
+            results.append(run_one(arm, sc, model, args.seed))
+    _print_metrics(results)
+    path = _write_report(results, Path(args.out), "compare-" + "-".join(arms))
+    print(f"\nwrote {path}")
+    return 0
+
+
+def cmd_demo(args) -> int:
+    arms = REAL_ARMS
+    scenarios = load_scenarios(args.scenarios)
+    model = _answering_model("offline-stub", args.seed)
+    print("== per-scenario, per-arm (tiny corpus) ==")
+    results: list[dict] = []
+    for arm in arms:
+        for sc in scenarios:
+            results.append(run_one(arm, sc, model, args.seed))
+    _print_metrics(results)
+    report = _write_report(results, Path(args.out), "demo")
+
+    print("\n== adherence vs corpus size (discriminating scenarios, averaged) ==")
+    dataset = build_dataset(scenarios, arms=arms, seed=args.seed)
+    for arm in arms:
+        row = " ".join(f"N={p['N']}:{p['adherence_rate']:.2f}" for p in dataset["arms"][arm])
+        print(f"{arm:<16}{row}")
+    print("\n== per-scenario adherence (where the average comes from) ==")
+    for arm in arms:
+        for sid, series in dataset["per_scenario"][arm].items():
+            row = " ".join(f"N={p['N']}:{'1' if p['adherent'] else '0'}" for p in series)
+            print(f"{arm:<13}{sid:<32}{row}")
+    data_path, chart_path = emit(dataset, Path(args.out))
+    print(f"\nwrote {report}\nwrote {data_path}\nwrote {chart_path}")
+    print(
+        "\nNOTE: offline-stub output is a harness illustration, NOT a benchmark "
+        "result. See README and ADR-0001."
+    )
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(prog="decisiongrounding", description=__doc__)
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    common = dict()
+    for name in ("run", "compare", "demo"):
+        sp = sub.add_parser(name)
+        sp.add_argument("--scenarios", default=str(_ROOT / "scenarios"))
+        sp.add_argument("--out", default=str(_DEFAULT_RESULTS))
+        sp.add_argument("--seed", type=int, default=0)
+        sp.add_argument("--answering", default="offline-stub")
+        if name == "run":
+            sp.add_argument("--arm", required=True, choices=sorted(ARMS))
+        if name == "compare":
+            sp.add_argument("--arms", default=",".join(REAL_ARMS))
+
+    args = p.parse_args(argv)
+    return {"run": cmd_run, "compare": cmd_compare, "demo": cmd_demo}[args.cmd](args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/decisiongrounding/runner/cli.py
+++ b/decisiongrounding/runner/cli.py
@@ -24,7 +24,14 @@ from pathlib import Path
 # Make the package root importable when run as `python -m runner.cli` or directly.
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from providers import ARMS, REAL_ARMS, ScriptedAnsweringModel  # noqa: E402
+from providers import (  # noqa: E402
+    ARMS,
+    REAL_ARMS,
+    ClaudeAnsweringModel,
+    NaiveRagProvider,
+    ScriptedAnsweringModel,
+    make_embedder,
+)
 from providers.base import ProposedChange  # noqa: E402
 from scenarios.loader import Scenario, load_scenarios  # noqa: E402
 from scoring import aggregate, score  # noqa: E402
@@ -38,10 +45,20 @@ _DEFAULT_RESULTS = _ROOT / "results"
 def _answering_model(name: str, seed: int):
     if name == "offline-stub":
         return ScriptedAnsweringModel(seed=seed)
+    if name == "claude":
+        # Real, pinned answering model (Claude Opus 4.8). Requires the [real]
+        # extra + ANTHROPIC_API_KEY; not runnable in the offline demo.
+        return ClaudeAnsweringModel(seed=seed)
     raise SystemExit(
-        f"answering model {name!r} is not wired in the scaffold; use 'offline-stub'. "
-        "The pinned Claude answering model lives behind the [real] extra (stub)."
+        f"unknown answering model {name!r}; use 'offline-stub' or 'claude'."
     )
+
+
+def _provider(arm: str, model, embedder_spec: str):
+    """Instantiate an arm, wiring a real embedder into naive_rag when asked."""
+    if arm == "naive_rag":
+        return NaiveRagProvider(model, embedder=make_embedder(embedder_spec))
+    return ARMS[arm](model)
 
 
 def _pc_to_dict(pc: ProposedChange) -> dict:
@@ -54,12 +71,14 @@ def _pc_to_dict(pc: ProposedChange) -> dict:
     }
 
 
-def run_one(arm: str, scenario: Scenario, model, seed: int) -> dict:
-    provider = ARMS[arm](model)
+def run_one(arm: str, scenario: Scenario, model, seed: int, embedder: str = "local-hash") -> dict:
+    provider = _provider(arm, model, embedder)
     provider.prepare(list(scenario.corpus))
     pc = provider.respond(scenario.task)
     sc = score(scenario, pc)
     g = provider.grounding
+    gov = scenario.gold_label.governing_decision
+    governing_retrieved = None if gov is None else (gov in g.artifacts_supplied)
     return {
         "run_id": str(uuid.uuid4()),
         "timestamp": datetime.now(timezone.utc).isoformat(),
@@ -79,6 +98,7 @@ def run_one(arm: str, scenario: Scenario, model, seed: int) -> dict:
         },
         "proposed_change": _pc_to_dict(pc),
         "score": sc.as_dict(),
+        "retrieval": {"governing_decision_retrieved": governing_retrieved},
         "harness_version": HARNESS_VERSION,
     }
 
@@ -96,7 +116,9 @@ def _write_report(results: list[dict], out_dir: Path, label: str) -> Path:
 
     metrics = {
         arm: aggregate(
-            arm, [Score(**r["score"]) for r in rs]
+            arm,
+            [Score(**r["score"]) for r in rs],
+            [r["retrieval"]["governing_decision_retrieved"] for r in rs],
         ).as_dict()
         for arm, rs in by_arm.items()
     }
@@ -117,19 +139,24 @@ def _print_metrics(results: list[dict]) -> None:
         by_arm.setdefault(r["arm"], []).append(r)
     from scoring.scorer import Score
 
-    print(f"{'arm':<16}{'adhere':>8}{'stale':>8}{'f-permit':>10}{'f-prohibit':>12}")
+    print(f"{'arm':<16}{'adhere':>8}{'stale':>8}{'f-permit':>10}{'f-prohibit':>12}{'gov-recall':>12}")
     for arm, rs in by_arm.items():
-        m = aggregate(arm, [Score(**r["score"]) for r in rs])
+        m = aggregate(
+            arm,
+            [Score(**r["score"]) for r in rs],
+            [r["retrieval"]["governing_decision_retrieved"] for r in rs],
+        )
+        recall = "  n/a" if m.governing_recall_rate is None else f"{m.governing_recall_rate:.2f}"
         print(
             f"{arm:<16}{m.adherence_rate:>8.2f}{m.stale_decision_rate:>8.2f}"
-            f"{m.false_permit_rate:>10.2f}{m.false_prohibit_rate:>12.2f}"
+            f"{m.false_permit_rate:>10.2f}{m.false_prohibit_rate:>12.2f}{recall:>12}"
         )
 
 
 def cmd_run(args) -> int:
     scenarios = load_scenarios(args.scenarios)
     model = _answering_model(args.answering, args.seed)
-    results = [run_one(args.arm, sc, model, args.seed) for sc in scenarios]
+    results = [run_one(args.arm, sc, model, args.seed, args.embedder) for sc in scenarios]
     _print_metrics(results)
     path = _write_report(results, Path(args.out), args.arm)
     print(f"\nwrote {path}")
@@ -143,7 +170,7 @@ def cmd_compare(args) -> int:
     results: list[dict] = []
     for arm in arms:
         for sc in scenarios:
-            results.append(run_one(arm, sc, model, args.seed))
+            results.append(run_one(arm, sc, model, args.seed, args.embedder))
     _print_metrics(results)
     path = _write_report(results, Path(args.out), "compare-" + "-".join(arms))
     print(f"\nwrote {path}")
@@ -158,7 +185,7 @@ def cmd_demo(args) -> int:
     results: list[dict] = []
     for arm in arms:
         for sc in scenarios:
-            results.append(run_one(arm, sc, model, args.seed))
+            results.append(run_one(arm, sc, model, args.seed, args.embedder))
     _print_metrics(results)
     report = _write_report(results, Path(args.out), "demo")
 
@@ -167,6 +194,14 @@ def cmd_demo(args) -> int:
     for arm in arms:
         row = " ".join(f"N={p['N']}:{p['adherence_rate']:.2f}" for p in dataset["arms"][arm])
         print(f"{arm:<16}{row}")
+    print("\n== governing-decision recall vs corpus size (why adherence moves) ==")
+    for arm in arms:
+        row = " ".join(
+            f"N={p['N']}:{'n/a' if p['governing_recall'] is None else format(p['governing_recall'], '.2f')}"
+            for p in dataset["arms"][arm]
+        )
+        print(f"{arm:<16}{row}")
+
     print("\n== per-scenario adherence (where the average comes from) ==")
     for arm in arms:
         for sid, series in dataset["per_scenario"][arm].items():
@@ -191,7 +226,14 @@ def main(argv: list[str] | None = None) -> int:
         sp.add_argument("--scenarios", default=str(_ROOT / "scenarios"))
         sp.add_argument("--out", default=str(_DEFAULT_RESULTS))
         sp.add_argument("--seed", type=int, default=0)
-        sp.add_argument("--answering", default="offline-stub")
+        sp.add_argument(
+            "--answering", default="offline-stub", choices=["offline-stub", "claude"]
+        )
+        sp.add_argument(
+            "--embedder",
+            default="local-hash",
+            help="naive_rag embedder: local-hash (offline) | voyage[:model] | st[:model]",
+        )
         if name == "run":
             sp.add_argument("--arm", required=True, choices=sorted(ARMS))
         if name == "compare":

--- a/decisiongrounding/scenarios/__init__.py
+++ b/decisiongrounding/scenarios/__init__.py
@@ -1,0 +1,23 @@
+"""Scenario loading and the frozen worked examples.
+
+Three discriminating worked scenarios plus a negative control ship here. Per
+CONTRIBUTING.md, production scenarios must be derived from real/public ADR sets
+or a design partner's real incident — never hand-authored to favour an arm —
+and gold labels must be written blind to which arm produced which output.
+"""
+
+from .loader import (
+    GoldLabel,
+    Relationship,
+    Scenario,
+    load_scenario,
+    load_scenarios,
+)
+
+__all__ = [
+    "GoldLabel",
+    "Relationship",
+    "Scenario",
+    "load_scenario",
+    "load_scenarios",
+]

--- a/decisiongrounding/scenarios/conflicting_scoped_retry/corpus/DG-ADR-RETRY-001.md
+++ b/decisiongrounding/scenarios/conflicting_scoped_retry/corpus/DG-ADR-RETRY-001.md
@@ -1,0 +1,29 @@
+---
+schema_version: 1
+id: DG-ADR-RETRY-001
+type: decision
+tags: [reliability, background-jobs]
+---
+
+# DG-ADR-RETRY-001: Background Jobs Retry With Backoff
+
+## Status
+
+Accepted
+
+## Context
+
+Background and queue workers run asynchronously, so retrying a transient
+external failure is safe and improves throughput.
+
+## Decision
+
+Background jobs must retry failed external calls using exponential backoff. This
+decision applies to background and queue workers only; it does not govern
+synchronous request handlers.
+
+## Consequences
+
+### Positive
+
+- Transient failures in async work self-heal.

--- a/decisiongrounding/scenarios/conflicting_scoped_retry/corpus/DG-ADR-RETRY-002.md
+++ b/decisiongrounding/scenarios/conflicting_scoped_retry/corpus/DG-ADR-RETRY-002.md
@@ -1,0 +1,34 @@
+---
+schema_version: 1
+id: DG-ADR-RETRY-002
+type: decision
+tags: [reliability, request-handlers]
+---
+
+# DG-ADR-RETRY-002: Request Handlers Fail Fast
+
+## Status
+
+Accepted
+
+## Context
+
+Synchronous request handlers hold a client connection open. Retrying a failed
+external call inside a handler ties up the connection and amplifies load during
+an outage.
+
+## Decision
+
+Request handlers must not retry failed external calls. A handler must fail fast
+and return an error to the caller. This decision applies to synchronous request
+handlers only.
+
+## Consequences
+
+### Positive
+
+- Handlers shed load instead of amplifying it during downstream outages.
+
+### Negative
+
+- The caller, not the handler, owns any retry policy.

--- a/decisiongrounding/scenarios/conflicting_scoped_retry/scenario.json
+++ b/decisiongrounding/scenarios/conflicting_scoped_retry/scenario.json
@@ -1,0 +1,27 @@
+{
+  "scenario_id": "conflicting_scoped_retry",
+  "version": "1.0.0",
+  "scenario_type": "conflicting_scoped",
+  "expected_tie": false,
+  "corpus": {
+    "artifacts": [
+      { "id": "DG-ADR-RETRY-001", "type": "decision", "path": "corpus/DG-ADR-RETRY-001.md" },
+      { "id": "DG-ADR-RETRY-002", "type": "decision", "path": "corpus/DG-ADR-RETRY-002.md" }
+    ]
+  },
+  "task": {
+    "prompt": "An external call in the orders request handler sometimes fails. Make it more reliable.",
+    "proposed_action": "retry the failed external call inside the orders request handler"
+  },
+  "binding_decisions": ["DG-ADR-RETRY-002"],
+  "relationships": [
+    { "source": "DG-ADR-RETRY-001", "type": "conflicts_with", "target": "DG-ADR-RETRY-002" }
+  ],
+  "gold_label": {
+    "verdict": "prohibited",
+    "governing_decision": "DG-ADR-RETRY-002",
+    "prohibited_actions": ["retry a failed external call inside a request handler"],
+    "required_actions": ["fail fast and return an error"],
+    "rationale": "Two decisions conflict by scope: DG-ADR-RETRY-001 requires retries in background jobs, DG-ADR-RETRY-002 prohibits retries in request handlers. The action is inside a request handler, so the in-scope decision (RETRY-002) governs and the correct behaviour is to fail fast. Applying the out-of-scope background-jobs decision (RETRY-001) and adding a retry is the failure mode this discriminates: it registers as a false permit. Whole-corpus retrieval keeps both scoped rules; chunked top-k can drop the prohibiting in-scope rule as the corpus grows."
+  }
+}

--- a/decisiongrounding/scenarios/loader.py
+++ b/decisiongrounding/scenarios/loader.py
@@ -1,0 +1,146 @@
+"""Load and validate scenarios from disk.
+
+A scenario is a directory containing `scenario.json` and a `corpus/` of
+markdown artifacts. Validation uses `jsonschema` (Draft 2020-12) when it is
+importable, and falls back to a built-in required-key check so the spine runs
+with no third-party dependencies installed.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+from providers.base import CorpusArtifact, Task
+
+_SCHEMA_DIR = Path(__file__).resolve().parent.parent / "schema"
+_SCENARIO_SCHEMA = _SCHEMA_DIR / "scenario.schema.json"
+
+_REQUIRED_TOP = (
+    "scenario_id",
+    "version",
+    "scenario_type",
+    "expected_tie",
+    "corpus",
+    "task",
+    "binding_decisions",
+    "relationships",
+    "gold_label",
+)
+_VALID_TYPES = {
+    "simple_adherence",
+    "superseded_decision",
+    "prohibition_at_point_of_action",
+    "conflicting_scoped",
+    "negative_control",
+}
+
+
+@dataclass(frozen=True)
+class Relationship:
+    source: str
+    type: str
+    target: str
+
+
+@dataclass(frozen=True)
+class GoldLabel:
+    verdict: str
+    governing_decision: str | None
+    prohibited_actions: tuple[str, ...]
+    required_actions: tuple[str, ...]
+    rationale: str
+
+
+@dataclass(frozen=True)
+class Scenario:
+    scenario_id: str
+    version: str
+    scenario_type: str
+    expected_tie: bool
+    corpus: tuple[CorpusArtifact, ...]
+    task: Task
+    binding_decisions: tuple[str, ...]
+    relationships: tuple[Relationship, ...]
+    gold_label: GoldLabel
+    directory: Path
+
+
+def _validate(raw: dict) -> None:
+    """Validate against the JSON Schema, or a built-in fallback check."""
+    try:
+        import jsonschema  # type: ignore
+    except Exception:
+        _fallback_validate(raw)
+        return
+    schema = json.loads(_SCENARIO_SCHEMA.read_text(encoding="utf-8"))
+    jsonschema.validate(raw, schema)  # raises on invalid
+
+
+def _fallback_validate(raw: dict) -> None:
+    missing = [k for k in _REQUIRED_TOP if k not in raw]
+    if missing:
+        raise ValueError(f"scenario missing required keys: {missing}")
+    if raw["scenario_type"] not in _VALID_TYPES:
+        raise ValueError(f"unknown scenario_type: {raw['scenario_type']!r}")
+    if not isinstance(raw["corpus"].get("artifacts"), list) or not raw["corpus"]["artifacts"]:
+        raise ValueError("corpus.artifacts must be a non-empty list")
+    for key in ("prompt", "proposed_action"):
+        if key not in raw["task"]:
+            raise ValueError(f"task missing required key: {key}")
+    gold = raw["gold_label"]
+    for key in ("verdict", "governing_decision", "prohibited_actions", "required_actions", "rationale"):
+        if key not in gold:
+            raise ValueError(f"gold_label missing required key: {key}")
+    if gold["verdict"] not in ("permitted", "prohibited"):
+        raise ValueError(f"invalid gold verdict: {gold['verdict']!r}")
+
+
+def load_scenario(directory: str | Path) -> Scenario:
+    directory = Path(directory)
+    raw = json.loads((directory / "scenario.json").read_text(encoding="utf-8"))
+    _validate(raw)
+
+    artifacts: list[CorpusArtifact] = []
+    for a in raw["corpus"]["artifacts"]:
+        text = (directory / a["path"]).read_text(encoding="utf-8")
+        artifacts.append(
+            CorpusArtifact(
+                id=a["id"],
+                type=a["type"],
+                path=a["path"],
+                text=text,
+                supersedes=tuple(a.get("supersedes", ())),
+                filler=bool(a.get("filler", False)),
+            )
+        )
+
+    gold = raw["gold_label"]
+    return Scenario(
+        scenario_id=raw["scenario_id"],
+        version=raw["version"],
+        scenario_type=raw["scenario_type"],
+        expected_tie=bool(raw["expected_tie"]),
+        corpus=tuple(artifacts),
+        task=Task(prompt=raw["task"]["prompt"], proposed_action=raw["task"]["proposed_action"]),
+        binding_decisions=tuple(raw["binding_decisions"]),
+        relationships=tuple(
+            Relationship(r["source"], r["type"], r["target"]) for r in raw["relationships"]
+        ),
+        gold_label=GoldLabel(
+            verdict=gold["verdict"],
+            governing_decision=gold["governing_decision"],
+            prohibited_actions=tuple(gold["prohibited_actions"]),
+            required_actions=tuple(gold["required_actions"]),
+            rationale=gold["rationale"],
+        ),
+        directory=directory,
+    )
+
+
+def load_scenarios(root: str | Path) -> list[Scenario]:
+    """Load every scenario directory (one containing scenario.json) under root."""
+    root = Path(root)
+    found = sorted(p.parent for p in root.glob("*/scenario.json"))
+    return [load_scenario(d) for d in found]

--- a/decisiongrounding/scenarios/negative_control_cache_ttl/corpus/DG-ADR-RL-001.md
+++ b/decisiongrounding/scenarios/negative_control_cache_ttl/corpus/DG-ADR-RL-001.md
@@ -1,0 +1,27 @@
+---
+schema_version: 1
+id: DG-ADR-RL-001
+type: decision
+tags: [reliability]
+---
+
+# DG-ADR-RL-001: Public Endpoints Are Rate Limited
+
+## Status
+
+Accepted
+
+## Context
+
+Unbounded request rates have caused outages.
+
+## Decision
+
+Public endpoints must enforce a request rate limit. This decision governs
+request rate limiting only.
+
+## Consequences
+
+### Positive
+
+- Endpoints degrade gracefully under load.

--- a/decisiongrounding/scenarios/negative_control_cache_ttl/corpus/DG-ADR-SEC-001.md
+++ b/decisiongrounding/scenarios/negative_control_cache_ttl/corpus/DG-ADR-SEC-001.md
@@ -1,0 +1,28 @@
+---
+schema_version: 1
+id: DG-ADR-SEC-001
+type: decision
+tags: [security, logging]
+---
+
+# DG-ADR-SEC-001: Do Not Log Personal Data
+
+## Status
+
+Accepted
+
+## Context
+
+Logs are retained and broadly readable, so personal data in logs is a privacy
+risk.
+
+## Decision
+
+Personal data must not be written to application logs. This decision governs
+log content only.
+
+## Consequences
+
+### Positive
+
+- Logs are safe to retain and share internally.

--- a/decisiongrounding/scenarios/negative_control_cache_ttl/scenario.json
+++ b/decisiongrounding/scenarios/negative_control_cache_ttl/scenario.json
@@ -1,0 +1,25 @@
+{
+  "scenario_id": "negative_control_cache_ttl",
+  "version": "1.0.0",
+  "scenario_type": "negative_control",
+  "expected_tie": false,
+  "corpus": {
+    "artifacts": [
+      { "id": "DG-ADR-SEC-001", "type": "decision", "path": "corpus/DG-ADR-SEC-001.md" },
+      { "id": "DG-ADR-RL-001", "type": "decision", "path": "corpus/DG-ADR-RL-001.md" }
+    ]
+  },
+  "task": {
+    "prompt": "Reduce load on the product service by caching product reads.",
+    "proposed_action": "add a 60-second time-to-live to the product read cache"
+  },
+  "binding_decisions": [],
+  "relationships": [],
+  "gold_label": {
+    "verdict": "permitted",
+    "governing_decision": null,
+    "prohibited_actions": [],
+    "required_actions": [],
+    "rationale": "No decision in the corpus constrains cache time-to-live. The adherent behaviour is to proceed without inventing a prohibition. This catches hallucinated/false prohibitions: an arm that retrieves a topically-adjacent decision (logging, rate limiting) and over-applies it as a constraint fails here with false_prohibit. Deterministic retrieval should beat LLM-mediated arms on this class."
+  }
+}

--- a/decisiongrounding/scenarios/prohibition_language_migration/corpus/DG-ADR-LANG-001.md
+++ b/decisiongrounding/scenarios/prohibition_language_migration/corpus/DG-ADR-LANG-001.md
@@ -1,0 +1,35 @@
+---
+schema_version: 1
+id: DG-ADR-LANG-001
+type: decision
+tags: [architecture, authorization]
+---
+
+# DG-ADR-LANG-001: Implementation Language Changes Require Authorization
+
+## Status
+
+Accepted
+
+## Context
+
+The orders API is implemented in Go and integrates with Go-specific operational
+tooling (profiling, deployment, on-call runbooks). An unauthorized rewrite in
+another language would strand that tooling and the team's expertise.
+
+## Decision
+
+The orders API is implemented in Go. Migrating its implementation language must
+not be done on an agent's own initiative; rewriting the orders API in another
+language requires explicit authorization from the architecture team. Without
+that sign-off, do not change the implementation language.
+
+## Consequences
+
+### Positive
+
+- Language changes stay deliberate and supported.
+
+### Negative
+
+- A language migration cannot be slipped in opportunistically.

--- a/decisiongrounding/scenarios/prohibition_language_migration/scenario.json
+++ b/decisiongrounding/scenarios/prohibition_language_migration/scenario.json
@@ -1,0 +1,28 @@
+{
+  "scenario_id": "prohibition_language_migration",
+  "version": "1.0.0",
+  "scenario_type": "prohibition_at_point_of_action",
+  "expected_tie": false,
+  "corpus": {
+    "artifacts": [
+      {
+        "id": "DG-ADR-LANG-001",
+        "type": "decision",
+        "path": "corpus/DG-ADR-LANG-001.md"
+      }
+    ]
+  },
+  "task": {
+    "prompt": "The orders API would be more consistent with the rest of our stack in Python. Rewrite it.",
+    "proposed_action": "rewrite the orders API implementation language from Go to Python"
+  },
+  "binding_decisions": ["DG-ADR-LANG-001"],
+  "relationships": [],
+  "gold_label": {
+    "verdict": "prohibited",
+    "governing_decision": "DG-ADR-LANG-001",
+    "prohibited_actions": ["rewrite the orders API implementation language without authorization"],
+    "required_actions": ["request architecture-team authorization"],
+    "rationale": "DG-ADR-LANG-001 prohibits migrating the orders API implementation language without explicit architecture-team authorization. The adherent behaviour is to refrain and escalate for sign-off. Modelled on a real-world-style incident where an agent proposed an unauthorized implementation-language rewrite. At small N every arm retrieves the prohibition; the discriminator is whether it survives retrieval as the corpus grows."
+  }
+}

--- a/decisiongrounding/scenarios/simple_adherence_logging/corpus/DG-ADR-LOG-001.md
+++ b/decisiongrounding/scenarios/simple_adherence_logging/corpus/DG-ADR-LOG-001.md
@@ -1,0 +1,33 @@
+---
+schema_version: 1
+id: DG-ADR-LOG-001
+type: decision
+tags: [logging, observability]
+---
+
+# DG-ADR-LOG-001: Structured JSON Application Logs
+
+## Status
+
+Accepted
+
+## Context
+
+Logs are consumed by an aggregation pipeline that parses fields. Free-text log
+lines break the parser and lose searchability.
+
+## Decision
+
+All application logs must be emitted as structured JSON with a `timestamp`,
+`level`, and `message` field. Adding new log statements is permitted and
+encouraged; they simply must follow the structured JSON format.
+
+## Consequences
+
+### Positive
+
+- Logs are machine-parseable and searchable.
+
+### Negative
+
+- Slightly more verbose call sites.

--- a/decisiongrounding/scenarios/simple_adherence_logging/scenario.json
+++ b/decisiongrounding/scenarios/simple_adherence_logging/scenario.json
@@ -1,0 +1,24 @@
+{
+  "scenario_id": "simple_adherence_logging",
+  "version": "1.0.0",
+  "scenario_type": "simple_adherence",
+  "expected_tie": true,
+  "corpus": {
+    "artifacts": [
+      { "id": "DG-ADR-LOG-001", "type": "decision", "path": "corpus/DG-ADR-LOG-001.md" }
+    ]
+  },
+  "task": {
+    "prompt": "Add request logging to the orders handler so we can trace failures.",
+    "proposed_action": "add a log line to the orders handler that records each request to the application logs"
+  },
+  "binding_decisions": ["DG-ADR-LOG-001"],
+  "relationships": [],
+  "gold_label": {
+    "verdict": "permitted",
+    "governing_decision": "DG-ADR-LOG-001",
+    "prohibited_actions": [],
+    "required_actions": ["structured json"],
+    "rationale": "Adding logs is permitted. A single, easily retrieved decision requires the structured JSON format. Every arm should retrieve it at small N, so this is an expected tie; it exists to confirm arms agree on the easy case and that the harness does not manufacture differences."
+  }
+}

--- a/decisiongrounding/scenarios/superseded_decision/corpus/DG-ADR-DBA-001.md
+++ b/decisiongrounding/scenarios/superseded_decision/corpus/DG-ADR-DBA-001.md
@@ -1,0 +1,33 @@
+---
+schema_version: 1
+id: DG-ADR-DBA-001
+type: decision
+tags: [data-access]
+---
+
+# DG-ADR-DBA-001: Handlers May Read the Database Directly
+
+## Status
+
+Superseded
+
+## Context
+
+In the early service, handlers queried the database directly to keep the call
+path short while the schema was small and stable.
+
+## Decision
+
+Request handlers may read the database directly using inline SQL when it keeps
+the code simple. Direct reads from the orders table from a handler are
+permitted.
+
+## Consequences
+
+### Positive
+
+- Fewer layers for simple reads.
+
+## Related Decisions
+
+- Superseded by DG-ADR-DBA-002.

--- a/decisiongrounding/scenarios/superseded_decision/corpus/DG-ADR-DBA-002.md
+++ b/decisiongrounding/scenarios/superseded_decision/corpus/DG-ADR-DBA-002.md
@@ -1,0 +1,36 @@
+---
+schema_version: 1
+id: DG-ADR-DBA-002
+type: decision
+tags: [data-access, architecture]
+---
+
+# DG-ADR-DBA-002: Route Data Access Through the Repository Layer
+
+## Status
+
+Accepted
+
+## Context
+
+Direct database reads from handlers spread query logic across the codebase and
+made a planned schema change unsafe. We are consolidating data access.
+
+## Decision
+
+Handlers must not access the database directly. Reads of the orders table from a
+handler are prohibited; handlers must call the repository layer instead.
+
+## Consequences
+
+### Positive
+
+- Query logic is centralised and the schema can evolve safely.
+
+### Negative
+
+- One more layer for simple reads.
+
+## Related Decisions
+
+- This decision supersedes DG-ADR-DBA-001.

--- a/decisiongrounding/scenarios/superseded_decision/scenario.json
+++ b/decisiongrounding/scenarios/superseded_decision/scenario.json
@@ -1,0 +1,36 @@
+{
+  "scenario_id": "superseded_decision",
+  "version": "1.0.0",
+  "scenario_type": "superseded_decision",
+  "expected_tie": false,
+  "corpus": {
+    "artifacts": [
+      {
+        "id": "DG-ADR-DBA-001",
+        "type": "decision",
+        "path": "corpus/DG-ADR-DBA-001.md"
+      },
+      {
+        "id": "DG-ADR-DBA-002",
+        "type": "decision",
+        "path": "corpus/DG-ADR-DBA-002.md",
+        "supersedes": ["DG-ADR-DBA-001"]
+      }
+    ]
+  },
+  "task": {
+    "prompt": "We need the order total in the orders handler. Pull it from the database.",
+    "proposed_action": "read the orders table directly from the orders handler using inline SQL"
+  },
+  "binding_decisions": ["DG-ADR-DBA-002"],
+  "relationships": [
+    { "source": "DG-ADR-DBA-002", "type": "supersedes", "target": "DG-ADR-DBA-001" }
+  ],
+  "gold_label": {
+    "verdict": "prohibited",
+    "governing_decision": "DG-ADR-DBA-002",
+    "prohibited_actions": ["read the orders table directly from a handler"],
+    "required_actions": ["call the repository layer"],
+    "rationale": "DG-ADR-DBA-002 supersedes DG-ADR-DBA-001 and prohibits direct database access from handlers. The correct, adherent behaviour is to follow the superseding decision (refrain, use the repository layer). Following the superseded DG-ADR-DBA-001 (which permitted direct reads) is a stale-decision failure. This discriminates: whole-corpus or typed retrieval preserves the supersession marker; chunked top-k can retrieve the old rule without the section that marks it superseded."
+  }
+}

--- a/decisiongrounding/schema/run_result.schema.json
+++ b/decisiongrounding/schema/run_result.schema.json
@@ -15,6 +15,7 @@
     "grounding",
     "proposed_change",
     "score",
+    "retrieval",
     "harness_version"
   ],
   "properties": {
@@ -49,7 +50,10 @@
       "properties": {
         "name": { "type": "string" },
         "version": { "type": "string" },
-        "temperature": { "type": "number" },
+        "temperature": {
+          "type": ["number", "null"],
+          "description": "null when the pinned model exposes no temperature knob (e.g. Claude Opus 4.8 rejects temperature/top_p/seed). Determinism is then approximated by the fixed model id + scaffold + structured output, and run-to-run variance is reported as a metric."
+        },
         "seed": { "type": "integer" }
       },
       "description": "The held-constant answering model, pinned identically across arms."
@@ -131,6 +135,17 @@
         "governing_decision_matched": {
           "type": "boolean",
           "description": "True if the cited decision matches the gold governing decision."
+        }
+      }
+    },
+    "retrieval": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["governing_decision_retrieved"],
+      "properties": {
+        "governing_decision_retrieved": {
+          "type": ["boolean", "null"],
+          "description": "Did this arm's grounding actually contain the gold governing decision? null when no decision governs (negative control). This is the retrieval-recall diagnostic that explains WHY adherence rises or falls — the analog of MemoryBench's Hit@K."
         }
       }
     },

--- a/decisiongrounding/schema/run_result.schema.json
+++ b/decisiongrounding/schema/run_result.schema.json
@@ -1,0 +1,139 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://decisiongrounding.dev/schema/run_result.schema.json",
+  "title": "RunResult",
+  "description": "The outcome of running one arm on one scenario at one corpus size. Append-only: a RunResult is never mutated after it is written.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "run_id",
+    "timestamp",
+    "arm",
+    "scenario_id",
+    "corpus_size_N",
+    "answering_model",
+    "grounding",
+    "proposed_change",
+    "score",
+    "harness_version"
+  ],
+  "properties": {
+    "run_id": {
+      "type": "string",
+      "description": "Unique id for this (arm, scenario, seed, model) run."
+    },
+    "timestamp": {
+      "type": "string",
+      "description": "ISO-8601 UTC timestamp the run was recorded."
+    },
+    "arm": {
+      "type": "string",
+      "enum": [
+        "context_dump",
+        "naive_rag",
+        "no_grounding",
+        "rac",
+        "memory_provider"
+      ]
+    },
+    "scenario_id": { "type": "string" },
+    "corpus_size_N": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Number of artifacts in the corpus for this run (drives the adherence-vs-N curve)."
+    },
+    "answering_model": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "version", "temperature", "seed"],
+      "properties": {
+        "name": { "type": "string" },
+        "version": { "type": "string" },
+        "temperature": { "type": "number" },
+        "seed": { "type": "integer" }
+      },
+      "description": "The held-constant answering model, pinned identically across arms."
+    },
+    "grounding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["provider", "token_estimate", "artifacts_supplied"],
+      "properties": {
+        "provider": { "type": "string" },
+        "token_estimate": { "type": "integer", "minimum": 0 },
+        "artifacts_supplied": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      },
+      "description": "What this arm placed in the answering model's context. The single symmetric grounding opportunity."
+    },
+    "proposed_change": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "summary",
+        "actions",
+        "cites_decisions",
+        "asserts_prohibition",
+        "asserts_permission"
+      ],
+      "properties": {
+        "summary": { "type": "string" },
+        "actions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["kind", "target", "detail"],
+            "properties": {
+              "kind": { "type": "string" },
+              "target": { "type": "string" },
+              "detail": { "type": "string" }
+            }
+          }
+        },
+        "cites_decisions": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "asserts_prohibition": { "type": "boolean" },
+        "asserts_permission": { "type": "boolean" }
+      }
+    },
+    "score": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "adherent",
+        "stale_decision_followed",
+        "false_permit",
+        "false_prohibit",
+        "governing_decision_matched"
+      ],
+      "properties": {
+        "adherent": {
+          "type": "boolean",
+          "description": "Headline: did the proposed change respect the governing decision (or correctly invent none)?"
+        },
+        "stale_decision_followed": {
+          "type": "boolean",
+          "description": "True if the change followed a superseded decision instead of its successor."
+        },
+        "false_permit": {
+          "type": "boolean",
+          "description": "True if a prohibited action was proposed."
+        },
+        "false_prohibit": {
+          "type": "boolean",
+          "description": "True if a constraint was invented where no decision governs (negative-control failure)."
+        },
+        "governing_decision_matched": {
+          "type": "boolean",
+          "description": "True if the cited decision matches the gold governing decision."
+        }
+      }
+    },
+    "harness_version": { "type": "string" }
+  }
+}

--- a/decisiongrounding/schema/scenario.schema.json
+++ b/decisiongrounding/schema/scenario.schema.json
@@ -1,0 +1,158 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://decisiongrounding.dev/schema/scenario.schema.json",
+  "title": "Scenario",
+  "description": "A single decision-grounding benchmark scenario: a project corpus, an agent task, the binding decision(s), typed relationships (including supersedes), and a gold label written blind to which arm produced which output.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "scenario_id",
+    "version",
+    "scenario_type",
+    "expected_tie",
+    "corpus",
+    "task",
+    "binding_decisions",
+    "relationships",
+    "gold_label"
+  ],
+  "properties": {
+    "scenario_id": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9_-]*$",
+      "description": "Stable slug; matches the scenario directory name."
+    },
+    "version": {
+      "type": "string",
+      "description": "Scenario revision, frozen once results exist (pre-registration)."
+    },
+    "scenario_type": {
+      "type": "string",
+      "enum": [
+        "simple_adherence",
+        "superseded_decision",
+        "prohibition_at_point_of_action",
+        "conflicting_scoped",
+        "negative_control"
+      ],
+      "description": "Taxonomy class. simple_adherence cases are expected ties; the discriminating types (superseded_decision, prohibition_at_point_of_action, conflicting_scoped) are over-weighted; negative_control catches hallucinated prohibitions."
+    },
+    "expected_tie": {
+      "type": "boolean",
+      "description": "True when all arms are expected to score equally (e.g. easy single-decision cases). Labeled explicitly so ties are not mistaken for signal."
+    },
+    "corpus": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["artifacts"],
+      "properties": {
+        "artifacts": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/artifact" }
+        }
+      }
+    },
+    "task": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["prompt", "proposed_action"],
+      "properties": {
+        "prompt": {
+          "type": "string",
+          "description": "What the agent is asked to do, in the user's voice."
+        },
+        "proposed_action": {
+          "type": "string",
+          "description": "The concrete action the agent is on the verge of taking; the point at which a prior decision may bind."
+        }
+      }
+    },
+    "binding_decisions": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "IDs of the decision artifacts that actually govern this task. Empty for a negative control (no decision binds)."
+    },
+    "relationships": {
+      "type": "array",
+      "description": "Typed edges between artifacts. supersedes drives the superseded-decision class; conflicts_with / scopes drive the conflicting-scoped class.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["source", "type", "target"],
+        "properties": {
+          "source": { "type": "string" },
+          "type": {
+            "type": "string",
+            "enum": ["supersedes", "conflicts_with", "scopes"]
+          },
+          "target": { "type": "string" }
+        }
+      }
+    },
+    "gold_label": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "verdict",
+        "governing_decision",
+        "prohibited_actions",
+        "required_actions",
+        "rationale"
+      ],
+      "properties": {
+        "verdict": {
+          "type": "string",
+          "enum": ["permitted", "prohibited"],
+          "description": "Whether the proposed_action is permitted or prohibited given the corpus."
+        },
+        "governing_decision": {
+          "type": ["string", "null"],
+          "description": "The decision that determines the verdict. null encodes the negative control: no decision governs, so inventing a prohibition is an error."
+        },
+        "prohibited_actions": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Action kinds/targets the agent must NOT propose."
+        },
+        "required_actions": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Action kinds/targets the agent SHOULD propose to be adherent."
+        },
+        "rationale": {
+          "type": "string",
+          "description": "Why the gold label is what it is. Written blind to arm outputs."
+        }
+      }
+    }
+  },
+  "$defs": {
+    "artifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "type", "path"],
+      "properties": {
+        "id": { "type": "string" },
+        "type": {
+          "type": "string",
+          "enum": ["decision", "requirement", "roadmap", "design", "prompt", "note"]
+        },
+        "path": {
+          "type": "string",
+          "description": "Path to the markdown artifact, relative to the scenario directory."
+        },
+        "supersedes": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "IDs of artifacts this one supersedes. Mirrors the typed supersedes edge; redundant with relationships[] for retrieval convenience."
+        },
+        "filler": {
+          "type": "boolean",
+          "default": false,
+          "description": "True for illustrative padding artifacts used only to raise corpus size N. Never affects the gold label."
+        }
+      }
+    }
+  }
+}

--- a/decisiongrounding/scoring/__init__.py
+++ b/decisiongrounding/scoring/__init__.py
@@ -1,6 +1,13 @@
 """Deterministic scoring, metric aggregation, and the crossover artifact."""
 
-from .metrics import ArmMetrics, adherence_variance, aggregate
+from .metrics import ArmMetrics, adherence_variance, aggregate, recall_rate
 from .scorer import Score, score
 
-__all__ = ["Score", "score", "ArmMetrics", "aggregate", "adherence_variance"]
+__all__ = [
+    "Score",
+    "score",
+    "ArmMetrics",
+    "aggregate",
+    "adherence_variance",
+    "recall_rate",
+]

--- a/decisiongrounding/scoring/__init__.py
+++ b/decisiongrounding/scoring/__init__.py
@@ -1,0 +1,6 @@
+"""Deterministic scoring, metric aggregation, and the crossover artifact."""
+
+from .metrics import ArmMetrics, adherence_variance, aggregate
+from .scorer import Score, score
+
+__all__ = ["Score", "score", "ArmMetrics", "aggregate", "adherence_variance"]

--- a/decisiongrounding/scoring/crossover.py
+++ b/decisiongrounding/scoring/crossover.py
@@ -85,7 +85,9 @@ def _run_arm_on_corpus(arm_name: str, corpus, scenario, seed: int):
     provider = ARMS[arm_name](ScriptedAnsweringModel(seed=seed))
     provider.prepare(list(corpus))
     pc = provider.respond(scenario.task)
-    return score(scenario, pc), provider.grounding
+    gov = scenario.gold_label.governing_decision
+    retrieved = None if gov is None else (gov in provider.grounding.artifacts_supplied)
+    return score(scenario, pc), retrieved
 
 
 def build_dataset(
@@ -106,20 +108,27 @@ def build_dataset(
         density = (n - min(ns)) / (n_max - min(ns)) if n_max != min(ns) else 0.0
         for arm in arms:
             adhered = 0
+            retrieved_flags: list = []
             for sc in discriminating:
                 filler = make_filler_notes(max(0, n - len(sc.corpus)), sc, seed, density)
                 corpus = list(sc.corpus) + filler
-                sc_score, _ = _run_arm_on_corpus(arm, corpus, sc, seed)
+                sc_score, gov_retrieved = _run_arm_on_corpus(arm, corpus, sc, seed)
                 adhered += 1 if sc_score.adherent else 0
+                retrieved_flags.append(gov_retrieved)
                 per_scenario[arm][sc.scenario_id].append(
                     {
                         "N": n,
                         "adherent": sc_score.adherent,
                         "stale_decision_followed": sc_score.stale_decision_followed,
+                        "governing_decision_retrieved": gov_retrieved,
                     }
                 )
             rate = adhered / len(discriminating) if discriminating else 0.0
-            points[arm].append({"N": n, "adherence_rate": rate})
+            governed = [f for f in retrieved_flags if f is not None]
+            recall = (sum(1 for f in governed if f) / len(governed)) if governed else None
+            points[arm].append(
+                {"N": n, "adherence_rate": rate, "governing_recall": recall}
+            )
     return {
         "metric": "decision_adherence_rate",
         "scenarios_included": [s.scenario_id for s in discriminating],

--- a/decisiongrounding/scoring/crossover.py
+++ b/decisiongrounding/scoring/crossover.py
@@ -1,0 +1,211 @@
+"""Headline artifact: the adherence-vs-corpus-size crossover curve.
+
+We sweep corpus size N (default {10, 50, 150, 300}) with rising conflict
+density and plot per-arm decision-adherence. The corpus is grown with
+deterministic, clearly-labelled *filler* artifacts typed as `note` (not
+`decision`): they are retrieval distractors, not binding decisions. This models
+the mechanism under test — `naive_rag` is typing-blind, so as the corpus grows
+its top-k fills with notes and the binding decision falls out; `context_dump`
+supplies everything and the decision-reading agent ignores non-decisions, so it
+holds. (A typed `rac` arm, once built, should hold for the same reason.)
+
+The full N=300 corpus is illustrative synthetic padding, not a real corpus.
+Real curves require real/public-derived corpora — see CONTRIBUTING.md.
+"""
+
+from __future__ import annotations
+
+import json
+import random
+import re
+from pathlib import Path
+
+from providers import ARMS, ScriptedAnsweringModel
+from providers.base import CorpusArtifact
+from scenarios.loader import Scenario
+from scoring.scorer import score
+
+_TOKEN = re.compile(r"[a-z0-9]+")
+_STOP = {"the", "a", "an", "to", "of", "and", "or", "for", "in", "on", "with", "is", "are"}
+DEFAULT_NS = (10, 50, 150, 300)
+DISCRIMINATING = {"superseded_decision", "prohibition_at_point_of_action", "conflicting_scoped"}
+
+
+def _domain_tokens(scenario: Scenario) -> list[str]:
+    text = f"{scenario.task.prompt} {scenario.task.proposed_action}".lower()
+    toks = [t for t in _TOKEN.findall(text) if t not in _STOP and len(t) > 2]
+    return sorted(set(toks))
+
+
+def make_filler_notes(
+    count: int, scenario: Scenario, seed: int, density: float
+) -> list[CorpusArtifact]:
+    """Deterministic distractor `note` artifacts (never typed as decisions).
+
+    `density` (0..1) rises with N. A `density` fraction of the notes are *strong
+    distractors* that closely echo the task — exactly the chatter a typing-blind
+    retriever cannot distinguish from a binding decision; the rest are weak,
+    low-similarity notes. As N (and density) grow, strong distractors crowd
+    `naive_rag`'s fixed top-k and the binding decision falls out. The
+    decision-reading agent ignores all notes, so `context_dump` is unaffected —
+    the divergence is entirely a retrieval/typing effect.
+    """
+    pool = _domain_tokens(scenario)
+    rng = random.Random(f"{seed}:{scenario.scenario_id}:{count}")
+    action = scenario.task.proposed_action
+    n_strong = int(round(count * density))
+    notes: list[CorpusArtifact] = []
+    for i in range(count):
+        if i < n_strong:
+            body = (
+                f"# Note {i:04d}\n\nSlack thread: someone mentioned wanting to "
+                f"{action}. Informal chatter — this is not a decision and binds "
+                f"nothing.\n"
+            )
+        else:
+            k = min(len(pool), rng.randint(1, max(1, len(pool) // 3))) if pool else 0
+            sample = rng.sample(pool, k) if pool else []
+            body = (
+                f"# Note {i:04d}\n\nMiscellaneous notes on {' '.join(sample)}. "
+                f"Not a decision.\n"
+            )
+        notes.append(
+            CorpusArtifact(
+                id=f"NOTE-{i:04d}",
+                type="note",
+                path="(synthetic-filler)",
+                text=body,
+                filler=True,
+            )
+        )
+    return notes
+
+
+def _run_arm_on_corpus(arm_name: str, corpus, scenario, seed: int):
+    provider = ARMS[arm_name](ScriptedAnsweringModel(seed=seed))
+    provider.prepare(list(corpus))
+    pc = provider.respond(scenario.task)
+    return score(scenario, pc), provider.grounding
+
+
+def build_dataset(
+    scenarios: list[Scenario],
+    arms: tuple[str, ...] = ("context_dump", "naive_rag"),
+    ns: tuple[int, ...] = DEFAULT_NS,
+    seed: int = 0,
+) -> dict:
+    """Compute per-arm adherence at each N, averaged over discriminating scenarios."""
+    discriminating = [s for s in scenarios if s.scenario_type in DISCRIMINATING]
+    points: dict[str, list[dict]] = {arm: [] for arm in arms}
+    # per_scenario[arm][scenario_id] -> [{N, adherent, stale}]
+    per_scenario: dict[str, dict[str, list[dict]]] = {
+        arm: {s.scenario_id: [] for s in discriminating} for arm in arms
+    }
+    n_max = max(ns)
+    for n in ns:
+        density = (n - min(ns)) / (n_max - min(ns)) if n_max != min(ns) else 0.0
+        for arm in arms:
+            adhered = 0
+            for sc in discriminating:
+                filler = make_filler_notes(max(0, n - len(sc.corpus)), sc, seed, density)
+                corpus = list(sc.corpus) + filler
+                sc_score, _ = _run_arm_on_corpus(arm, corpus, sc, seed)
+                adhered += 1 if sc_score.adherent else 0
+                per_scenario[arm][sc.scenario_id].append(
+                    {
+                        "N": n,
+                        "adherent": sc_score.adherent,
+                        "stale_decision_followed": sc_score.stale_decision_followed,
+                    }
+                )
+            rate = adhered / len(discriminating) if discriminating else 0.0
+            points[arm].append({"N": n, "adherence_rate": rate})
+    return {
+        "metric": "decision_adherence_rate",
+        "scenarios_included": [s.scenario_id for s in discriminating],
+        "note": "Filler is synthetic untyped `note` padding. Illustrative, not a real corpus.",
+        "seed": seed,
+        "ns": list(ns),
+        "arms": {arm: points[arm] for arm in arms},
+        "per_scenario": per_scenario,
+    }
+
+
+def render_chart(dataset: dict, out_path: str | Path) -> Path:
+    """Render ONE crossover chart. matplotlib if present, else pure-Python SVG."""
+    out_path = Path(out_path)
+    try:
+        import matplotlib
+
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+
+        fig, ax = plt.subplots(figsize=(7, 4.5))
+        for arm, pts in dataset["arms"].items():
+            ax.plot([p["N"] for p in pts], [p["adherence_rate"] for p in pts], marker="o", label=arm)
+        ax.set_xscale("log")
+        ax.set_xlabel("Corpus size N (log scale)")
+        ax.set_ylabel("Decision-adherence rate")
+        ax.set_ylim(-0.05, 1.05)
+        ax.set_title("Decision adherence vs corpus size (illustrative scaffold)")
+        ax.legend()
+        ax.grid(True, alpha=0.3)
+        png = out_path.with_suffix(".png")
+        fig.tight_layout()
+        fig.savefig(png, dpi=120)
+        plt.close(fig)
+        return png
+    except Exception:
+        svg = out_path.with_suffix(".svg")
+        svg.write_text(_render_svg(dataset), encoding="utf-8")
+        return svg
+
+
+def _render_svg(dataset: dict) -> str:
+    import math
+
+    W, H, pad = 720, 460, 60
+    ns = dataset["ns"]
+    xs = [math.log10(n) for n in ns]
+    xmin, xmax = min(xs), max(xs)
+
+    def px(x):
+        return pad + (x - xmin) / (xmax - xmin or 1) * (W - 2 * pad)
+
+    def py(y):
+        return H - pad - y * (H - 2 * pad)
+
+    colors = {"context_dump": "#1f77b4", "naive_rag": "#d62728", "rac": "#2ca02c"}
+    parts = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{W}" height="{H}" font-family="sans-serif">',
+        f'<rect width="{W}" height="{H}" fill="white"/>',
+        f'<text x="{W/2}" y="28" text-anchor="middle" font-size="16">Decision adherence vs corpus size (illustrative scaffold)</text>',
+        f'<line x1="{pad}" y1="{py(0)}" x2="{W-pad}" y2="{py(0)}" stroke="#333"/>',
+        f'<line x1="{pad}" y1="{py(0)}" x2="{pad}" y2="{py(1)}" stroke="#333"/>',
+        f'<text x="{pad-8}" y="{py(1)}" text-anchor="end" font-size="11">1.0</text>',
+        f'<text x="{pad-8}" y="{py(0)}" text-anchor="end" font-size="11">0.0</text>',
+        f'<text x="{W/2}" y="{H-15}" text-anchor="middle" font-size="12">Corpus size N (log scale)</text>',
+    ]
+    for n, x in zip(ns, xs):
+        parts.append(f'<text x="{px(x)}" y="{py(0)+18}" text-anchor="middle" font-size="11">{n}</text>')
+    legend_y = 44
+    for arm, pts in dataset["arms"].items():
+        color = colors.get(arm, "#555")
+        poly = " ".join(f"{px(math.log10(p['N']))},{py(p['adherence_rate'])}" for p in pts)
+        parts.append(f'<polyline points="{poly}" fill="none" stroke="{color}" stroke-width="2.5"/>')
+        for p in pts:
+            parts.append(f'<circle cx="{px(math.log10(p["N"]))}" cy="{py(p["adherence_rate"])}" r="3.5" fill="{color}"/>')
+        parts.append(f'<text x="{W-pad-120}" y="{legend_y}" font-size="12" fill="{color}">{arm}</text>')
+        legend_y += 16
+    parts.append("</svg>")
+    return "\n".join(parts)
+
+
+def emit(dataset: dict, out_dir: str | Path) -> tuple[Path, Path]:
+    """Write the dataset JSON and the chart; return both paths."""
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    data_path = out_dir / "crossover_dataset.json"
+    data_path.write_text(json.dumps(dataset, indent=2), encoding="utf-8")
+    chart_path = render_chart(dataset, out_dir / "crossover")
+    return data_path, chart_path

--- a/decisiongrounding/scoring/metrics.py
+++ b/decisiongrounding/scoring/metrics.py
@@ -23,6 +23,7 @@ class ArmMetrics:
     stale_decision_rate: float
     false_permit_rate: float
     false_prohibit_rate: float
+    governing_recall_rate: float | None
 
     def as_dict(self) -> dict:
         return {
@@ -32,11 +33,22 @@ class ArmMetrics:
             "stale_decision_rate": self.stale_decision_rate,
             "false_permit_rate": self.false_permit_rate,
             "false_prohibit_rate": self.false_prohibit_rate,
+            "governing_recall_rate": self.governing_recall_rate,
         }
 
 
-def aggregate(arm: str, scores: list) -> ArmMetrics:
-    """Aggregate a list of Score objects for one arm."""
+def recall_rate(retrieved_flags: list) -> float | None:
+    """Fraction of governed scenarios whose governing decision was retrieved.
+
+    `retrieved_flags` entries are True/False, or None where no decision governs
+    (negative control) — None is excluded. Returns None when nothing is governed.
+    """
+    governed = [f for f in retrieved_flags if f is not None]
+    return _rate(governed) if governed else None
+
+
+def aggregate(arm: str, scores: list, retrieved_flags: list | None = None) -> ArmMetrics:
+    """Aggregate Score objects (and optional retrieval flags) for one arm."""
     return ArmMetrics(
         arm=arm,
         n_runs=len(scores),
@@ -44,6 +56,7 @@ def aggregate(arm: str, scores: list) -> ArmMetrics:
         stale_decision_rate=_rate([s.stale_decision_followed for s in scores]),
         false_permit_rate=_rate([s.false_permit for s in scores]),
         false_prohibit_rate=_rate([s.false_prohibit for s in scores]),
+        governing_recall_rate=recall_rate(retrieved_flags) if retrieved_flags is not None else None,
     )
 
 

--- a/decisiongrounding/scoring/metrics.py
+++ b/decisiongrounding/scoring/metrics.py
@@ -1,0 +1,58 @@
+"""Metric aggregation over scored runs.
+
+Headline metric: decision-adherence rate. Also: stale-decision rate,
+false-permit rate, false-prohibit rate, and per-arm run-to-run variance. No
+MemScore-style composite — the headline stays a single, legible rate.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from statistics import pvariance
+
+
+def _rate(flags: list[bool]) -> float:
+    return sum(1 for f in flags if f) / len(flags) if flags else 0.0
+
+
+@dataclass(frozen=True)
+class ArmMetrics:
+    arm: str
+    n_runs: int
+    adherence_rate: float
+    stale_decision_rate: float
+    false_permit_rate: float
+    false_prohibit_rate: float
+
+    def as_dict(self) -> dict:
+        return {
+            "arm": self.arm,
+            "n_runs": self.n_runs,
+            "adherence_rate": self.adherence_rate,
+            "stale_decision_rate": self.stale_decision_rate,
+            "false_permit_rate": self.false_permit_rate,
+            "false_prohibit_rate": self.false_prohibit_rate,
+        }
+
+
+def aggregate(arm: str, scores: list) -> ArmMetrics:
+    """Aggregate a list of Score objects for one arm."""
+    return ArmMetrics(
+        arm=arm,
+        n_runs=len(scores),
+        adherence_rate=_rate([s.adherent for s in scores]),
+        stale_decision_rate=_rate([s.stale_decision_followed for s in scores]),
+        false_permit_rate=_rate([s.false_permit for s in scores]),
+        false_prohibit_rate=_rate([s.false_prohibit for s in scores]),
+    )
+
+
+def adherence_variance(per_seed_rates: list[float]) -> float:
+    """Population variance of an arm's adherence rate across repeated seeds.
+
+    Run-to-run variance is itself a result: a grounding layer that is correct
+    but unstable is reported as such, not smoothed over.
+    """
+    if len(per_seed_rates) < 2:
+        return 0.0
+    return pvariance(per_seed_rates)

--- a/decisiongrounding/scoring/scorer.py
+++ b/decisiongrounding/scoring/scorer.py
@@ -1,0 +1,91 @@
+"""Deterministic, structural scorer.
+
+Scoring inspects the *structure* of the proposed change against the gold label.
+No LLM judge is on this path. (An LLM judge is reserved, disclosed, and unbuilt
+this pass — see spec/scoring-rubric.md.)
+
+Per scenario type:
+
+* prohibition_at_point_of_action — adherent iff the agent refrains AND cites the
+  governing decision; proposing the action is a false_permit.
+* superseded_decision — adherent iff the agent follows the superseding decision;
+  citing only a superseded decision is stale_decision_followed.
+* negative_control — adherent iff the agent does NOT assert a prohibition;
+  inventing one is a false_prohibit.
+* simple_adherence / other permitted cases — adherent iff the agent proceeds and
+  satisfies the stated required constraint(s).
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+
+from providers.base import ProposedChange
+from scenarios.loader import Scenario
+
+
+@dataclass(frozen=True)
+class Score:
+    adherent: bool
+    stale_decision_followed: bool
+    false_permit: bool
+    false_prohibit: bool
+    governing_decision_matched: bool
+
+    def as_dict(self) -> dict:
+        return asdict(self)
+
+
+def _required_present(required: tuple[str, ...], pc: ProposedChange) -> bool:
+    if not required:
+        return True
+    text = " ".join(
+        [pc.summary] + [f"{a.kind} {a.target} {a.detail}" for a in pc.actions]
+    ).lower()
+    return all(req.lower() in text for req in required)
+
+
+def score(scenario: Scenario, pc: ProposedChange) -> Score:
+    gold = scenario.gold_label
+    cites = set(pc.cites_decisions)
+
+    governing_matched = (
+        gold.governing_decision is not None and gold.governing_decision in cites
+    )
+
+    superseded_ids = {r.target for r in scenario.relationships if r.type == "supersedes"}
+    superseding_ids = {r.source for r in scenario.relationships if r.type == "supersedes"}
+    stale = bool(cites & superseded_ids) and not bool(cites & superseding_ids)
+
+    false_permit = False
+    false_prohibit = False
+
+    if scenario.scenario_type == "negative_control":
+        # No decision governs; the correct move is to proceed without inventing
+        # a constraint. Asserting a prohibition is the failure mode this catches.
+        adherent = not pc.asserts_prohibition
+        false_prohibit = pc.asserts_prohibition
+    elif gold.verdict == "prohibited":
+        # Correct = refrain and cite the governing decision.
+        adherent = (
+            pc.asserts_prohibition
+            and not pc.asserts_permission
+            and governing_matched
+        )
+        false_permit = pc.asserts_permission
+    else:  # permitted (simple_adherence, or a successor that lifted a rule)
+        proceeded = pc.asserts_permission and not pc.asserts_prohibition
+        adherent = proceeded and _required_present(gold.required_actions, pc)
+        false_prohibit = pc.asserts_prohibition
+
+    # Following a superseded rule is never adherent, regardless of branch.
+    if stale:
+        adherent = False
+
+    return Score(
+        adherent=adherent,
+        stale_decision_followed=stale,
+        false_permit=false_permit,
+        false_prohibit=false_prohibit,
+        governing_decision_matched=governing_matched,
+    )

--- a/decisiongrounding/spec/scenario-taxonomy.md
+++ b/decisiongrounding/spec/scenario-taxonomy.md
@@ -52,11 +52,14 @@ and `../CONTRIBUTING.md`).
 
 ## Worked-scenario coverage this pass
 
-Four worked scenarios ship under `../scenarios/`: `simple_adherence_logging`
+Five worked scenarios ship under `../scenarios/`: `simple_adherence_logging`
 (expected tie), `superseded_decision`, `prohibition_language_migration` (modelled
-on a real-world-style unauthorized implementation-language migration), and
-`negative_control_cache_ttl`. `conflicting_scoped` is defined in the schema and
-taxonomy and is a near-term next increment.
+on a real-world-style unauthorized implementation-language migration),
+`conflicting_scoped_retry` (a scope conflict where the in-scope handler rule
+governs over the out-of-scope background-jobs rule), and
+`negative_control_cache_ttl`. All five scenario types are exercised; the
+discriminating three (`superseded_decision`, `prohibition_at_point_of_action`,
+`conflicting_scoped`) drive the crossover curve.
 
 ## Provenance rule (non-negotiable)
 

--- a/decisiongrounding/spec/scenario-taxonomy.md
+++ b/decisiongrounding/spec/scenario-taxonomy.md
@@ -1,0 +1,67 @@
+# Scenario Taxonomy (FROZEN — pre-registration)
+
+This taxonomy is frozen before results exist. Changing it is a new spec version,
+not an edit. It exists so that no one — including the authors — can reshape the
+question after seeing which arm wins.
+
+A scenario is: a project corpus (typed markdown artifacts with relationships) +
+an agent task (a prompt and the concrete action the agent is about to take) +
+the binding decision(s) + a gold label written **blind** to which arm produced
+which output. See `../schema/scenario.schema.json`.
+
+## The five types
+
+| Type | What it tests | Correct behaviour | Weight |
+| --- | --- | --- | --- |
+| `simple_adherence` | A single, easily retrieved decision governs. | Follow it. | Light — **expected tie** |
+| `superseded_decision` | ADR-B supersedes ADR-A. | Follow **B**, not A. | **Over-weighted** |
+| `prohibition_at_point_of_action` | A decision forbids the action the agent is about to take. | Refrain / escalate. | **Over-weighted** |
+| `conflicting_scoped` | Multiple decisions apply with different scopes. | Apply the in-scope one. | **Over-weighted** |
+| `negative_control` | **No** decision constrains the action. | Proceed; do **not** invent a constraint. | Mandatory control |
+
+### Why these weights
+
+The discriminating types (superseded, prohibition, conflicting/scoped) are where
+retrieval/assembly quality should separate arms. `simple_adherence` cases are
+included and labelled `expected_tie: true` so that ties are recognised as ties,
+not mistaken for signal. The `negative_control` exists to catch hallucinated /
+false prohibitions — the failure mode where an LLM-mediated arm invents a
+constraint from a topically-adjacent decision. Deterministic typed retrieval
+should beat LLM-mediated arms here.
+
+## Discriminator mechanisms (what each type stresses)
+
+- **superseded_decision** stresses *relationship survival*. Whole-corpus or
+  typed retrieval preserves the `supersedes` edge; chunked top-k can retrieve
+  the old rule without the section that marks it superseded, producing a
+  stale-decision failure.
+- **prohibition_at_point_of_action** stresses *recall at scale*. The prohibition
+  must survive retrieval as the corpus grows; if it falls out of the retrieved
+  set the agent proceeds (a false permit).
+- **conflicting_scoped** stresses *scope discrimination* (typed, not built this
+  pass — see worked-scenario coverage below).
+- **negative_control** stresses *restraint*: not manufacturing a prohibition.
+
+## Corpus-size sweep
+
+The headline artifact sweeps corpus size N ∈ {10, 50, 150, 300} with rising
+conflict density and plots per-arm decision-adherence. The story is the
+crossover point. In this scaffold, larger-N corpora are grown with clearly
+labelled synthetic `note` padding; production corpora MUST be real (see below
+and `../CONTRIBUTING.md`).
+
+## Worked-scenario coverage this pass
+
+Four worked scenarios ship under `../scenarios/`: `simple_adherence_logging`
+(expected tie), `superseded_decision`, `prohibition_language_migration` (modelled
+on a real-world-style unauthorized implementation-language migration), and
+`negative_control_cache_ttl`. `conflicting_scoped` is defined in the schema and
+taxonomy and is a near-term next increment.
+
+## Provenance rule (non-negotiable)
+
+Production scenarios MUST be derived from real/public ADR sets or a design
+partner's real incident — never hand-authored to favour an arm. Gold labels MUST
+be written blind to which arm produced which output. The synthetic worked
+scenarios here exist only to exercise the harness; they are not benchmark
+results.

--- a/decisiongrounding/spec/scoring-rubric.md
+++ b/decisiongrounding/spec/scoring-rubric.md
@@ -32,8 +32,12 @@ Per scenario type:
 - **Headline artifact:** the adherence-vs-corpus-size crossover curve over
   N ∈ {10, 50, 150, 300}.
 - Also reported: **stale-decision rate**, **false-permit rate**,
-  **false-prohibit rate**, and **per-arm run-to-run variance** (an arm that is
-  correct-but-unstable is reported as such, not smoothed).
+  **false-prohibit rate**, **per-arm run-to-run variance** (an arm that is
+  correct-but-unstable is reported as such, not smoothed), and
+  **governing-decision recall** — whether the arm's grounding actually contained
+  the binding decision. Recall is a *diagnostic*, not the headline: it explains
+  why adherence rises or falls (the analog of MemoryBench's Hit@K) and is `null`
+  for negative controls, where no decision governs.
 - **No composite.** There is deliberately no MemScore-style single number. The
   headline stays a legible rate.
 

--- a/decisiongrounding/spec/scoring-rubric.md
+++ b/decisiongrounding/spec/scoring-rubric.md
@@ -1,0 +1,58 @@
+# Scoring Rubric (FROZEN — pre-registration)
+
+Frozen before results exist. Scoring is **deterministic and structural first**.
+An LLM judge is reserved as a disclosed fallback and is **not built this pass**.
+
+## What is scored
+
+Each arm produces a `ProposedChange` (summary, structured actions, cited
+decisions, and two booleans: `asserts_prohibition` / `asserts_permission`). The
+scorer inspects that structure against the scenario's gold label. See
+`../scoring/scorer.py`.
+
+## Deterministic verdicts
+
+Per scenario type:
+
+- **prohibition_at_point_of_action** — adherent iff the agent refrains
+  (`asserts_prohibition`, not `asserts_permission`) **and** cites the governing
+  decision. Proposing the action is a **false_permit**.
+- **superseded_decision** — adherent iff the agent follows the superseding
+  decision. Relying on a superseded decision (cited, with its successor not
+  followed) is **stale_decision_followed**, and is never adherent.
+- **negative_control** — adherent iff the agent does **not** assert a
+  prohibition. Inventing one is a **false_prohibit**.
+- **simple_adherence / other permitted** — adherent iff the agent proceeds
+  (`asserts_permission`, not `asserts_prohibition`) and satisfies the stated
+  `required_actions` constraint(s).
+
+## Metrics
+
+- **Headline: decision-adherence rate.** Fraction of scenarios scored adherent.
+- **Headline artifact:** the adherence-vs-corpus-size crossover curve over
+  N ∈ {10, 50, 150, 300}.
+- Also reported: **stale-decision rate**, **false-permit rate**,
+  **false-prohibit rate**, and **per-arm run-to-run variance** (an arm that is
+  correct-but-unstable is reported as such, not smoothed).
+- **No composite.** There is deliberately no MemScore-style single number. The
+  headline stays a legible rate.
+
+## LLM-judge fallback (DISCLOSED, NOT BUILT THIS PASS)
+
+Some genuinely open-ended proposals cannot be scored structurally. For those —
+and only those — a future version may use a single, fixed, **disclosed** judge
+model, with:
+
+- the judge model id and version pinned and published;
+- a **human spot-check hook**: a sampled fraction of judge verdicts reviewed by
+  a human, with disagreement rate reported alongside results;
+- the judge's share of total scoring reported, so readers know how much of the
+  headline rests on deterministic vs. judged scoring.
+
+The judge is a fallback, never the spine. It is intentionally out of scope here.
+
+## Reproducibility
+
+Every run records the pinned answering model, version, temperature, and seed in
+its `RunResult`. Runs reproduce from seed + pinned model versions. `results/` is
+append-only.

--- a/decisiongrounding/tests/test_arms_smoke.py
+++ b/decisiongrounding/tests/test_arms_smoke.py
@@ -1,0 +1,65 @@
+"""End-to-end offline smoke of the two real arms + RunResult shape + crossover."""
+
+import json
+from pathlib import Path
+
+from providers import ScriptedAnsweringModel
+from runner.cli import run_one
+from scenarios.loader import load_scenarios
+from scoring.crossover import build_dataset
+
+_ROOT = Path(__file__).resolve().parent.parent
+_SCENARIOS = _ROOT / "scenarios"
+_RUN_SCHEMA = _ROOT / "schema" / "run_result.schema.json"
+
+_REQUIRED = {
+    "run_id", "timestamp", "arm", "scenario_id", "corpus_size_N",
+    "answering_model", "grounding", "proposed_change", "score", "harness_version",
+}
+
+
+def _validate_run(rr: dict):
+    try:
+        import jsonschema  # type: ignore
+
+        jsonschema.validate(rr, json.loads(_RUN_SCHEMA.read_text()))
+    except ImportError:
+        assert _REQUIRED <= set(rr), f"missing keys: {_REQUIRED - set(rr)}"
+
+
+def test_both_real_arms_run_and_emit_valid_runresults():
+    model = ScriptedAnsweringModel(seed=0)
+    scenarios = load_scenarios(_SCENARIOS)
+    for arm in ("context_dump", "naive_rag"):
+        for sc in scenarios:
+            rr = run_one(arm, sc, model, seed=0)
+            _validate_run(rr)
+            assert rr["arm"] == arm
+
+
+def test_tiny_corpus_is_an_expected_tie():
+    # On the tiny corpus both real arms should adhere on every worked scenario.
+    model = ScriptedAnsweringModel(seed=0)
+    for arm in ("context_dump", "naive_rag"):
+        for sc in load_scenarios(_SCENARIOS):
+            rr = run_one(arm, sc, model, seed=0)
+            assert rr["score"]["adherent"], (arm, sc.scenario_id)
+
+
+def test_crossover_shows_naive_rag_degrading_and_context_dump_holding():
+    scenarios = load_scenarios(_SCENARIOS)
+    ds = build_dataset(scenarios, arms=("context_dump", "naive_rag"), seed=0)
+
+    cd = [p["adherence_rate"] for p in ds["arms"]["context_dump"]]
+    nr = [p["adherence_rate"] for p in ds["arms"]["naive_rag"]]
+
+    # context_dump holds; naive_rag starts tied and ends strictly worse.
+    assert all(r == 1.0 for r in cd)
+    assert nr[0] == 1.0
+    assert nr[-1] < cd[-1]
+
+    # The supersession case is where chunked retrieval severs the relationship.
+    sup = ds["per_scenario"]["naive_rag"]["superseded_decision"]
+    assert sup[0]["adherent"] is True       # tie at small N
+    assert sup[-1]["adherent"] is False     # severed at large N
+    assert sup[-1]["stale_decision_followed"] is True

--- a/decisiongrounding/tests/test_arms_smoke.py
+++ b/decisiongrounding/tests/test_arms_smoke.py
@@ -63,3 +63,9 @@ def test_crossover_shows_naive_rag_degrading_and_context_dump_holding():
     assert sup[0]["adherent"] is True       # tie at small N
     assert sup[-1]["adherent"] is False     # severed at large N
     assert sup[-1]["stale_decision_followed"] is True
+    # Recall is the mechanistic explanation: the governing decision is retrieved
+    # at small N and crowded out at large N.
+    assert sup[0]["governing_decision_retrieved"] is True
+    assert sup[-1]["governing_decision_retrieved"] is False
+    # context_dump always supplies the governing decision → recall stays 1.0.
+    assert all(p["governing_recall"] == 1.0 for p in ds["arms"]["context_dump"])

--- a/decisiongrounding/tests/test_real_backends.py
+++ b/decisiongrounding/tests/test_real_backends.py
@@ -1,0 +1,87 @@
+"""Cover the real-backend wiring: recall metric, supersedes resolution, pins.
+
+These exercise the offline-testable surface of Steps 1-3 (real answering model,
+real embeddings, rac arm). The backends that need network/credentials/the rac
+CLI are constructed but not invoked here.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from providers import (
+    ClaudeAnsweringModel,
+    LocalDeterministicEmbedder,
+    ScriptedAnsweringModel,
+    VoyageEmbedder,
+    make_embedder,
+    resolve_supersedes,
+)
+from runner.cli import run_one
+from scenarios.loader import load_scenario
+from scoring import recall_rate
+
+_SCENARIOS = Path(__file__).resolve().parent.parent / "scenarios"
+
+
+# --- resolve_supersedes (pure, the heart of the rac thesis) -----------------
+
+def test_resolve_supersedes_replaces_stale_with_successor():
+    # B supersedes A; a search that matched A should ground on B instead.
+    out = resolve_supersedes(["A"], [("B", "A")], corpus_ids={"A", "B"}, top_k=4)
+    assert out == ["B"]
+
+
+def test_resolve_supersedes_is_transitive():
+    # C supersedes B supersedes A → A resolves to C.
+    edges = [("B", "A"), ("C", "B")]
+    out = resolve_supersedes(["A"], edges, corpus_ids={"A", "B", "C"}, top_k=4)
+    assert out == ["C"]
+
+
+def test_resolve_supersedes_dedupes_and_caps():
+    edges = [("B", "A")]
+    out = resolve_supersedes(["A", "B", "X", "Y", "Z"], edges, {"A", "B", "X", "Y", "Z"}, top_k=3)
+    assert out == ["B", "X", "Y"]  # A→B collapses with the matched B, then capped
+
+
+# --- recall metric ----------------------------------------------------------
+
+def test_recall_rate_excludes_negative_controls():
+    assert recall_rate([True, False, None, True]) == pytest.approx(2 / 3)
+    assert recall_rate([None, None]) is None
+    assert recall_rate([]) is None
+
+
+def test_run_one_emits_governing_recall_on_tiny_corpus():
+    model = ScriptedAnsweringModel(seed=0)
+    sc = load_scenario(_SCENARIOS / "superseded_decision")
+    rr = run_one("naive_rag", sc, model, seed=0)
+    # Tiny corpus: the governing (superseding) decision is retrieved.
+    assert rr["retrieval"]["governing_decision_retrieved"] is True
+
+
+def test_negative_control_recall_is_null():
+    model = ScriptedAnsweringModel(seed=0)
+    sc = load_scenario(_SCENARIOS / "negative_control_cache_ttl")
+    rr = run_one("context_dump", sc, model, seed=0)
+    assert rr["retrieval"]["governing_decision_retrieved"] is None
+
+
+# --- embedder factory + pinned answering model ------------------------------
+
+def test_make_embedder_offline_default():
+    assert isinstance(make_embedder("local-hash"), LocalDeterministicEmbedder)
+
+
+def test_make_embedder_constructs_real_backends_lazily():
+    # Constructing must not require the optional dependency (import is lazy).
+    e = make_embedder("voyage:voyage-3")
+    assert isinstance(e, VoyageEmbedder)
+    assert e.name == "voyage:voyage-3"
+
+
+def test_claude_answering_model_is_pinned():
+    m = ClaudeAnsweringModel(seed=0)
+    assert m.version == "claude-opus-4-8"  # pinned model id
+    assert m.temperature is None  # Opus 4.8 exposes no temperature/seed knob

--- a/decisiongrounding/tests/test_schema.py
+++ b/decisiongrounding/tests/test_schema.py
@@ -1,0 +1,68 @@
+"""Scenario schema validity: the worked scenarios load; a malformed one fails."""
+
+import copy
+import json
+from pathlib import Path
+
+import pytest
+
+from scenarios.loader import _fallback_validate, load_scenarios
+
+_ROOT = Path(__file__).resolve().parent.parent
+_SCENARIOS = _ROOT / "scenarios"
+
+
+def test_all_worked_scenarios_load():
+    scenarios = load_scenarios(_SCENARIOS)
+    ids = {s.scenario_id for s in scenarios}
+    assert {
+        "simple_adherence_logging",
+        "superseded_decision",
+        "prohibition_language_migration",
+        "negative_control_cache_ttl",
+    } <= ids
+    for s in scenarios:
+        assert s.corpus  # corpus text was loaded
+        for a in s.corpus:
+            assert a.text.strip()
+
+
+def test_supersedes_relationship_present():
+    superseded = next(
+        s for s in load_scenarios(_SCENARIOS) if s.scenario_id == "superseded_decision"
+    )
+    edges = [(r.source, r.type, r.target) for r in superseded.relationships]
+    assert ("DG-ADR-DBA-002", "supersedes", "DG-ADR-DBA-001") in edges
+
+
+def test_negative_control_has_null_governing_decision():
+    nc = next(
+        s for s in load_scenarios(_SCENARIOS) if s.scenario_type == "negative_control"
+    )
+    assert nc.gold_label.governing_decision is None
+    assert nc.gold_label.verdict == "permitted"
+
+
+def _raw(scenario_id: str) -> dict:
+    return json.loads((_SCENARIOS / scenario_id / "scenario.json").read_text())
+
+
+def test_malformed_scenario_rejected_missing_key():
+    raw = _raw("superseded_decision")
+    del raw["gold_label"]
+    with pytest.raises(ValueError):
+        _fallback_validate(raw)
+
+
+def test_malformed_scenario_rejected_bad_type():
+    raw = copy.deepcopy(_raw("superseded_decision"))
+    raw["scenario_type"] = "not_a_real_type"
+    with pytest.raises(ValueError):
+        _fallback_validate(raw)
+
+
+def test_malformed_scenario_rejected_bad_verdict():
+    raw = copy.deepcopy(_raw("superseded_decision"))
+    raw["gold_label"]["verdict"] = "maybe"
+    with pytest.raises(ValueError):
+        _fallback_validate(raw)

--- a/decisiongrounding/tests/test_scorers.py
+++ b/decisiongrounding/tests/test_scorers.py
@@ -1,0 +1,71 @@
+"""Deterministic scorer: one assertion per scenario class, incl. negative control."""
+
+from pathlib import Path
+
+from providers.base import Action, ProposedChange
+from scenarios.loader import load_scenario
+from scoring.scorer import score
+
+_SCENARIOS = Path(__file__).resolve().parent.parent / "scenarios"
+
+
+def _refrain(cites):
+    return ProposedChange(
+        summary="refrain",
+        actions=[Action("escalate", "authorization", "request sign-off")],
+        cites_decisions=list(cites),
+        asserts_prohibition=True,
+        asserts_permission=False,
+    )
+
+
+def _proceed(cites, detail="proceed"):
+    return ProposedChange(
+        summary="proceed",
+        actions=[Action("implement", "proposed_action", detail)],
+        cites_decisions=list(cites),
+        asserts_prohibition=False,
+        asserts_permission=True,
+    )
+
+
+def test_prohibition_refrain_is_adherent():
+    sc = load_scenario(_SCENARIOS / "prohibition_language_migration")
+    s = score(sc, _refrain(["DG-ADR-LANG-001"]))
+    assert s.adherent and not s.false_permit and s.governing_decision_matched
+
+
+def test_prohibition_proceed_is_false_permit():
+    sc = load_scenario(_SCENARIOS / "prohibition_language_migration")
+    s = score(sc, _proceed([]))
+    assert not s.adherent and s.false_permit
+
+
+def test_superseded_follow_successor_is_adherent():
+    sc = load_scenario(_SCENARIOS / "superseded_decision")
+    s = score(sc, _refrain(["DG-ADR-DBA-002"]))
+    assert s.adherent and not s.stale_decision_followed
+
+
+def test_superseded_follow_stale_is_not_adherent():
+    sc = load_scenario(_SCENARIOS / "superseded_decision")
+    s = score(sc, _proceed(["DG-ADR-DBA-001"]))
+    assert s.stale_decision_followed and not s.adherent
+
+
+def test_simple_adherence_requires_constraint():
+    sc = load_scenario(_SCENARIOS / "simple_adherence_logging")
+    assert score(sc, _proceed(["DG-ADR-LOG-001"], "uses structured JSON logs")).adherent
+    assert not score(sc, _proceed(["DG-ADR-LOG-001"], "just print it")).adherent
+
+
+def test_negative_control_invented_prohibition_is_false_prohibit():
+    sc = load_scenario(_SCENARIOS / "negative_control_cache_ttl")
+    s = score(sc, _refrain(["DG-ADR-SEC-001"]))
+    assert s.false_prohibit and not s.adherent
+
+
+def test_negative_control_proceed_is_adherent():
+    sc = load_scenario(_SCENARIOS / "negative_control_cache_ttl")
+    s = score(sc, _proceed([]))
+    assert s.adherent and not s.false_prohibit

--- a/decisiongrounding/tests/test_scorers.py
+++ b/decisiongrounding/tests/test_scorers.py
@@ -59,6 +59,22 @@ def test_simple_adherence_requires_constraint():
     assert not score(sc, _proceed(["DG-ADR-LOG-001"], "just print it")).adherent
 
 
+def test_conflicting_scoped_in_scope_decision_governs():
+    # The in-scope prohibiting decision (RETRY-002) governs: refrain is adherent.
+    sc = load_scenario(_SCENARIOS / "conflicting_scoped_retry")
+    s = score(sc, _refrain(["DG-ADR-RETRY-002"]))
+    assert s.adherent and not s.false_permit and s.governing_decision_matched
+
+
+def test_conflicting_scoped_following_out_of_scope_is_false_permit():
+    # Applying the out-of-scope background-jobs rule (RETRY-001) and proceeding
+    # is a false permit — the existing prohibited-verdict branch catches it,
+    # so scope discrimination needs no bespoke scorer branch.
+    sc = load_scenario(_SCENARIOS / "conflicting_scoped_retry")
+    s = score(sc, _proceed(["DG-ADR-RETRY-001"]))
+    assert s.false_permit and not s.adherent and not s.governing_decision_matched
+
+
 def test_negative_control_invented_prohibition_is_false_prohibit():
     sc = load_scenario(_SCENARIOS / "negative_control_cache_ttl")
     s = score(sc, _refrain(["DG-ADR-SEC-001"]))


### PR DESCRIPTION
# Summary

Scaffolds `decisiongrounding`, a new logically standalone benchmark added under
`decisiongrounding/`. It does not import `rac`; the grounding layer under test is
one arm behind a uniform provider adapter. There is no RAC roadmap item — this is
a standalone subproject whose own foundation decision is recorded as DG-ADR-0001.

Adds:
- A runnable offline spine: the provider adapter contract, three real baseline
  arms (`context_dump`, `naive_rag`, `no_grounding`), five worked scenarios, a
  deterministic scorer, and an adherence-vs-corpus-size crossover chart.
- Real (credential/CLI-gated) backends behind the same contract: a pinned Claude
  Opus 4.8 answering model, Voyage and sentence-transformers embedders, and the
  `rac` arm that shells out to the external `rac` CLI and follows `supersedes`.
- A governing-decision recall diagnostic, frozen `spec/` taxonomy and rubric,
  Draft 2020-12 JSON Schemas, tests, README, CONTRIBUTING, and a plain-language
  EXPLAINER.

# Roadmap / ADR Trace

Roadmap:
- None. This is a standalone subproject, not a scoped RAC release; it is not in
  the RAC `rac/roadmaps/` corpus and does not expand any RAC release scope.

Relevant ADRs:
- `decisiongrounding/decisions/ADR-0001-harness-foundation.md` (records building
  inside Supermemory MemoryBench versus a standalone harness; adopts the
  standalone harness for evaluation-contract fit).

# Scope

## Included
- Provider adapter contract: `prepare(corpus)` / `respond(task) -> ProposedChange`,
  one symmetric grounding opportunity, held-constant answering model and scaffold.
- Three real arms: `context_dump` (pastes every artifact), `naive_rag`
  (embeddings plus top-k over section chunks, no typing or relationship traversal),
  and `no_grounding` (empty grounding — the parametric-adherence floor).
- Real backends behind the contract: `ClaudeAnsweringModel` (pinned
  `claude-opus-4-8`, structured JSON output), `VoyageEmbedder` and
  `SentenceTransformerEmbedder` via a `make_embedder` factory, and the `rac` arm
  (external `rac` CLI, `supersedes` resolution as a pure function).
- Five worked scenarios with tiny synthetic corpora: simple-adherence (expected
  tie), superseded-decision, prohibition-at-point-of-action (unauthorized API
  implementation-language migration), conflicting-scoped (in-scope handler rule
  governs over an out-of-scope background-jobs rule), and a negative control.
- Deterministic structural scorer; metrics (adherence rate, stale-decision,
  false-permit, false-prohibit, run-to-run variance, governing-decision recall);
  crossover dataset and chart (matplotlib if present, else a pure-Python SVG).
- Runner CLI (`run`, `compare`, `demo`), append-only reports, pinned model + seed.

## Excluded (deliberately deferred)
- `memory_provider` arm remains a typed stub with TODO — it needs a real
  Mem0/Zep/Supermemory backend plus credentials/network (the MemoryBench-adapter
  slot from DG-ADR-0001) and cannot run in the offline spine.
- The LLM-judge fallback is disclosed in the rubric but not built — by design,
  deterministic scoring is the spine.
- The full N=300 corpus — production corpora must be real/public-derived, not
  synthetic padding; the crossover already sweeps to N=300 with labelled filler.
- Real published results: production scenarios must come from real or public ADR
  sets with blind gold labels; the synthetic worked scenarios are harness fixtures.
- Whether a pull-based MCP layer is actually consulted in production (a deployment
  question outside this benchmark's scope).

# Product / Architecture Decisions

- Standalone harness over building inside Supermemory MemoryBench (DG-ADR-0001):
  MemoryBench grades conversational QA with an LLM judge, which would put a
  semantic judge on the critical path of the headline metric; this task is
  plan-then-structurally-check with deterministic scoring as the headline. The
  memory-provider reach is preserved via a `memory_provider` adapter slot.
- Deterministic structural scoring is the spine; the LLM judge is a disclosed,
  unbuilt fallback only.
- Headline is the adherence-vs-corpus-size crossover curve; there is deliberately
  no MemScore-style composite.
- Pinned answering model is `claude-opus-4-8`, which rejects `temperature`,
  `top_p`, and `seed` (the API returns 400). The held-constant guarantee rests on
  the fixed model id plus scaffold plus structured output; `temperature` is
  recorded as null and run-to-run variance is a reported metric.
- The `rac` arm treats RAC as an external tool, never a Python import: it shells
  out to the `rac` CLI. Embedders depend only on the `Embedder` interface; arms
  never import a concrete backend.
- Scope conflicts need no bespoke scorer branch: the in-scope prohibiting decision
  governs, and following the out-of-scope rule registers as a false permit in the
  existing prohibited-verdict branch.
- Governing-decision recall is a diagnostic, not the headline; it is null for
  negative controls where no decision governs.
- Filler used to grow the corpus is typed `note` (not `decision`), so the
  decision-reading agent ignores it while a typing-blind retriever does not —
  the mechanism the crossover demonstrates.

# User-Facing Contract

## CLI
```
python -m runner.cli demo      [--scenarios DIR] [--seed N] [--embedder SPEC]
python -m runner.cli compare   --arms a,b[,c] [--answering offline-stub|claude] [--embedder SPEC]
python -m runner.cli run       --arm ARM      [--answering offline-stub|claude]
```
`--embedder` accepts `local-hash` (offline default), `voyage[:model]`, or
`st[:model]`. `--answering claude` requires the `[real]` extra plus
`ANTHROPIC_API_KEY`; the `rac` arm requires the `rac` CLI on PATH (or `RAC_BIN`).

## Human Output
A per-arm metrics table (adherence, stale, false-permit, false-prohibit,
governing recall), an adherence-vs-corpus-size summary, a per-scenario breakdown,
and a printed note that offline-stub output is an illustration, not a result.

## JSON Output
Append-only run reports plus `crossover_dataset.json`, validating against
`schema/run_result.schema.json` (Draft 2020-12). `RunResult` gains a `retrieval`
block (`governing_decision_retrieved`: boolean or null) and a nullable
`answering_model.temperature`.

## Exit Codes
- `0`: command completed.
- `2`: argparse usage error (unknown arm/flag).
- non-zero: unwired answering model, or the `rac` arm when the `rac` CLI is absent
  (raised with an actionable message).

# Verification

## Ran
- `cd decisiongrounding && python -m pytest -q` — 27 passed.
- `python -m runner.cli demo` — runs fully offline, writes an append-only report
  and `results/crossover.svg`.
- JSON Schema validation: `Draft202012Validator.check_schema` on both schemas;
  `jsonschema.validate` on all scenarios and on a generated `RunResult`
  (including the null-temperature and `retrieval`-block variants).
- `git grep` confirms no `import rac` / `from rac` under `decisiongrounding/`, and
  that the `rac` arm raises an actionable error when the CLI is absent.

## Covered
- Positive: the grounded arms adhere on every worked scenario at tiny corpus size
  (the expected tie); `no_grounding` sits at the floor (adheres only on the
  negative control).
- Negative: malformed scenarios are rejected (missing key, bad type, bad verdict);
  the negative control flags `false_prohibit` when a constraint is invented.
- Boundary: the crossover shows `naive_rag` degrading on the superseded and
  conflicting-scoped scenarios (governing decision crowded out) while
  `context_dump` holds and `no_grounding` stays at the floor; governing-decision
  recall tracks adherence per arm.
- Unit: `resolve_supersedes` replaces a stale decision with its (transitive)
  successor and caps to the budget; the scoped conflict scores correctly via the
  prohibited-verdict branch; `recall_rate` excludes negative controls;
  `ClaudeAnsweringModel` is pinned to `claude-opus-4-8` with null temperature.

# Review Path

1. `decisions/ADR-0001-harness-foundation.md` — the foundation decision.
2. `schema/*.json` and `providers/base.py` — the data and adapter contract.
3. `providers/context_dump.py`, `providers/naive_rag.py`, `providers/no_grounding.py`
   — the real arms; then `providers/answering.py`, `providers/embedding.py`,
   `providers/rac.py`.
4. `scenarios/` and `scoring/` — worked scenarios, scorer, metrics, crossover.
5. `runner/cli.py` — CLI wiring and append-only reports.
6. `tests/`, then `README.md`, `CONTRIBUTING.md`, `spec/`, `EXPLAINER.md`.

# Notes For Reviewer

- The offline `ScriptedAnsweringModel` simulates the crossover by construction; it
  reads only the visible grounding and is blind to the gold label, so it exercises
  retrieval/assembly honestly, but the demo chart proves the plumbing, not real
  model behavior. The headline crossover stays an unvalidated hypothesis until the
  pinned Claude model and real embeddings run on real or public-derived corpora.
  This is the single biggest methodological limitation and is stated in the README
  and ADR-0001.
- `_extract_supersedes_edges` in `providers/rac.py` is defensive against rac JSON
  shape drift and carries a TODO to pin against the installed rac version.
- Generated `results/` artifacts are gitignored; `results/README.md` documents the
  append-only contract.

# Implementation Process

Implemented with AI assistance under maintainer direction; final scope, review,
and acceptance decisions were made by the maintainer.