### PR TITLE
feat(validate): per-type standards enforcement (29148/EARS/BCP-14) [roadmap:v0.17.1]

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,7 +56,7 @@ jobs:
         # enforced by tests/test_ci_batteries.py in the core battery.
         battery:
           - name: core
-            paths: "tests/test_validate.py tests/test_okf_conformance.py tests/test_overrides.py tests/test_sarif.py tests/test_parser.py tests/test_schema.py tests/test_identity.py tests/test_frontmatter.py tests/test_metadata_identity.py tests/test_idgen.py tests/test_ci_batteries.py tests/test_corpus.py tests/test_operations.py"
+            paths: "tests/test_validate.py tests/test_okf_conformance.py tests/test_overrides.py tests/test_requirement_standards.py tests/test_sarif.py tests/test_parser.py tests/test_schema.py tests/test_identity.py tests/test_frontmatter.py tests/test_metadata_identity.py tests/test_idgen.py tests/test_ci_batteries.py tests/test_corpus.py tests/test_operations.py"
           - name: cli
             paths: "tests/test_cli.py"
           - name: compare

--- a/.rac/config.yaml
+++ b/.rac/config.yaml
@@ -1,1 +1,14 @@
 repository_key: RAC
+
+# Warnings-first onboarding (ADR-053), dogfooded: RAC's own corpus predates the
+# v0.17.1 requirement-quality checks (29148 / EARS / BCP-14, ADR-056), so they are
+# disabled here pending incremental cleanup. The checks ship at full strength for
+# adopting repositories; this is the same gradient a new adopter would use to take
+# RAC's gate green on day one and tighten over time.
+validation:
+  rules:
+    requirement-normative-keyword: off   # BCP-14: lowercase shall/should (error)
+    requirement-not-singular: off        # 29148: one normative statement per line
+    requirement-non-ears: off            # EARS: a line with no SHALL/SHOULD/MAY
+    requirement-ears-clause: off         # EARS: "If …" without a "then" response
+    roadmap-no-advancement-link: off     # roadmap links no requirement/decision

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ details, release history over commit history.
 
 ### Added
 
+- Per-type standards enforcement (v0.17.1): `rac validate` now lints requirement
+  *quality* against the standards RAC cites — BCP-14 keyword discipline
+  (`requirement-normative-keyword`, error: only uppercase MUST/SHALL/SHOULD/MAY are
+  normative), ISO 29148 singularity (`requirement-not-singular`, warning), and EARS
+  (`requirement-non-ears` / `requirement-ears-clause`, warnings). Roadmaps gain an
+  optional, validated `## Horizon` (now/next/later or a quarter) and an
+  advancement-linkage warning. All checks are deterministic (no AI in core) and
+  overridable per the v0.15.2 model. Severity overrides are now **repository-wide**
+  (ADR-053 revised): a rule downgraded in `.rac/config.yaml` is downgraded for
+  `rac review`/`watchkeeper`/`portfolio` too, not only `rac validate` — so a
+  warnings-first policy is consistent across every surface.
+
 - Relationship-graph integrity (v0.16.0): `rac relationships --validate` now
   validates the corpus as a graph (ADR-055). A `## Related <Type>` reference that
   resolves to the wrong artifact type is reported as

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -5,6 +5,24 @@ error-severity finding, and (over a directory) when the corpus is not a
 conformant OKF v0.1 bundle. Two features make that gate adoptable in CI on a
 real, pre-existing repository.
 
+## Per-type standards checks
+
+Beyond structure, `rac validate` lints each type against the standards it cites
+(ADR-056) — all deterministic, no AI:
+
+| Code | Severity | Standard |
+| --- | --- | --- |
+| `requirement-normative-keyword` | error | BCP-14: only uppercase MUST/SHALL/SHOULD/MAY are normative; lowercase is ambiguous. |
+| `requirement-not-singular` | warning | ISO 29148: one normative statement per requirement line. |
+| `requirement-non-ears` | warning | EARS: a requirement must state a normative response (SHALL/SHOULD/MAY). |
+| `requirement-ears-clause` | warning | EARS: a sentence-initial `If …` needs a `then` response clause. |
+| `invalid-roadmap-horizon` | error | A `## Horizon` value must be `now`/`next`/`later` or a quarter (e.g. `Q3 2026`); the section is optional. |
+| `roadmap-no-advancement-link` | warning | A roadmap should link a `## Related Requirements` or `## Related Decisions` it advances. |
+
+The BCP-14 error is the only gate-breaker; the rest are warnings, and all are
+overridable below. (RAC's own corpus predates these checks and disables them in
+its `.rac/config.yaml` — the warnings-first path in action.)
+
 ## Severity overrides (warnings-first onboarding)
 
 Pointing `rac validate` at a legacy corpus for the first time can surface many
@@ -12,6 +30,8 @@ pre-existing findings at once. Rather than fail the build on all of them, a
 repository can downgrade or silence specific findings in its committed
 `.rac/config.yaml`, then tighten the gate over time. The decision behind this is
 [ADR-053](https://github.com/tcballard/requirements-as-code/blob/main/rac/decisions/adr-053-validation-severity-overrides.md).
+Overrides are **repository-wide**: a downgrade applies to `rac review`,
+`rac watchkeeper`, and `rac portfolio` as well as `rac validate`.
 
 Add an optional `validation` section:
 

--- a/examples/guide/rac/req-001-user-account-lifecycle.md
+++ b/examples/guide/rac/req-001-user-account-lifecycle.md
@@ -18,11 +18,11 @@ closed account from being used for authentication.
 
 ## Requirements
 
-- [REQ-001] The service must create a user account with a unique identifier, email address, and creation timestamp.
-- [REQ-002] The service must deactivate a user account without destroying its history or audit trail.
-- [REQ-003] Deactivated accounts must not be returned by default user queries.
-- [REQ-004] The full history of a user account must be recoverable by support and compliance staff after deactivation.
-- [REQ-005] The service must support GDPR subject-access requests for deactivated accounts.
+- [REQ-001] The service MUST create a user account with a unique identifier, email address, and creation timestamp.
+- [REQ-002] The service MUST deactivate a user account without destroying its history or audit trail.
+- [REQ-003] Deactivated accounts MUST NOT be returned by default user queries.
+- [REQ-004] The full history of a user account MUST be recoverable by support and compliance staff after deactivation.
+- [REQ-005] The service MUST fulfil GDPR subject-access requests for deactivated accounts.
 
 ## Success Metrics
 

--- a/rac/decisions/adr-053-validation-severity-overrides.md
+++ b/rac/decisions/adr-053-validation-severity-overrides.md
@@ -58,11 +58,15 @@ custom-type JSON-Schema registry ADR-052 deferred.
    before status and exit code are computed, so a downgraded type or rule keeps
    the run green.
 
-4. **Scope: the `rac validate` entrypoints only.** Overrides apply to directory
-   and single-file `rac validate` (core findings and OKF conformance findings,
-   which gain a `severity`). The repository model behind `review`, `watchkeeper`,
-   and `portfolio` is unchanged (it validates with no overrides), so those
-   surfaces keep reporting the corpus as authored.
+4. **Scope: repository-wide (revised in v0.17.1).** Overrides are a repository
+   policy, so they apply wherever RAC evaluates the corpus's findings — `rac
+   validate` (directory and single-file, core + OKF findings) *and* the repository
+   model behind `review`, `watchkeeper`, and `portfolio`. The original v0.15.2
+   scoping applied overrides to `rac validate` only; v0.17.1 broadened it because a
+   rule a team downgrades in `.rac/config.yaml` should be downgraded everywhere —
+   it is incoherent for `rac validate` to report green while `rac review` flags the
+   same downgraded finding as blocking. (Repositories that declare no `validation`
+   section are unchanged, the common case.)
 
 5. **Determinism preserved (ADR-002).** The overrides live in a committed file,
    so the same repository state yields the same findings and exit code. Malformed
@@ -96,8 +100,9 @@ custom-type JSON-Schema registry ADR-052 deferred.
 
 ### Neutral
 
-- `review`/`watchkeeper`/`portfolio` deliberately ignore overrides; whether they
-  should honour them is a separate, later decision.
+- Since v0.17.1, `review`/`watchkeeper`/`portfolio` honour overrides too (the
+  repository model loads them from `.rac/config.yaml`), so a repository's severity
+  policy is consistent across every surface.
 
 ## Alternatives Considered
 

--- a/src/rac/core/validation.py
+++ b/src/rac/core/validation.py
@@ -22,6 +22,16 @@ MAX_REQUIREMENTS = 50
 AMBIGUOUS_VERBS = ("support", "handle", "allow", "enable")
 _AMBIGUOUS_RE = re.compile(r"\b(" + "|".join(AMBIGUOUS_VERBS) + r")\b", re.IGNORECASE)
 
+# Requirements quality standards (v0.17.1, ADR-056). The normative requirement
+# verbs RAC disciplines; per RFC 8174 only their ALL-CAPS form carries normative
+# weight, so a non-uppercase occurrence inside a requirement line is ambiguous.
+_NORMATIVE_RE = re.compile(r"\b(shall|must|should)\b", re.IGNORECASE)
+_EARS_IF_RE = re.compile(r"^\s*if\b", re.IGNORECASE)
+_THEN_RE = re.compile(r"\bthen\b", re.IGNORECASE)
+# Roadmap horizon (ADR-056): now/next/later or a calendar quarter (e.g. Q3 2026).
+_HORIZON_VALUES = ("now", "next", "later")
+_QUARTER_RE = re.compile(r"^Q[1-4]\s+\d{4}$")
+
 
 def has_errors(issues: list[Issue]) -> bool:
     """True if any issue is error-severity."""
@@ -50,9 +60,79 @@ def validate(product: Product) -> list[Issue]:
     if artifact_type == "requirement":
         spec = spec_for("requirement")
         assert spec is not None  # the requirement spec always exists
-        return issues + _validate_requirement(product) + _validate_status_metadata(product, spec)
-    # Unknown/legacy fallback: requirement rules only, no constrained metadata.
+        return (
+            issues
+            + _validate_requirement(product)
+            + _validate_status_metadata(product, spec)
+            + _validate_requirement_standards(product)
+        )
+    # Unknown/legacy fallback: requirement rules only, no constrained metadata or
+    # per-type standards (an Unknown document is not linted as a requirement).
     return issues + _validate_requirement(product)
+
+
+def _validate_requirement_standards(product: Product) -> list[Issue]:
+    """Per-line requirement quality checks: BCP-14, 29148 singular, EARS (ADR-056).
+
+    Deterministic and decidable by parsing — no prose judgement (ADR-002). BCP-14
+    keyword discipline is an error inside ``requirement`` artifacts; the 29148/EARS
+    checks are warnings (legacy requirements will not comply), all overridable per
+    ADR-053. Each diagnostic names the standard and the fix.
+    """
+    issues: list[Issue] = []
+    for r in product.requirements:
+        keywords = _NORMATIVE_RE.findall(r.text)
+
+        # BCP-14: only ALL-CAPS normative keywords carry weight (RFC 8174); a
+        # lowercase/mixed-case shall/must/should is ambiguous normative language.
+        ambiguous = sorted({k for k in keywords if k != k.upper()})
+        if ambiguous:
+            issues.append(
+                Issue(
+                    "error",
+                    "requirement-normative-keyword",
+                    f"{r.id} uses non-normative {', '.join(ambiguous)!r}; only "
+                    "uppercase MUST/SHALL/SHOULD/MAY carry normative weight (BCP 14).",
+                    r.line,
+                )
+            )
+
+        # 29148 well-formed: a requirement should be singular — one normative
+        # statement per line.
+        if len(keywords) > 1:
+            issues.append(
+                Issue(
+                    "warning",
+                    "requirement-not-singular",
+                    f"{r.id} has {len(keywords)} normative keywords; a requirement "
+                    "should be singular (ISO/IEC/IEEE 29148).",
+                    r.line,
+                )
+            )
+
+        # EARS: a requirement must state a normative response; a sentence-initial
+        # "If" (unwanted-behaviour pattern) needs a "then" response clause.
+        if not keywords:
+            issues.append(
+                Issue(
+                    "warning",
+                    "requirement-non-ears",
+                    f"{r.id} has no normative keyword (SHALL/SHOULD/MAY); it does not "
+                    "state a testable requirement (EARS).",
+                    r.line,
+                )
+            )
+        elif _EARS_IF_RE.search(r.text) and not _THEN_RE.search(r.text):
+            issues.append(
+                Issue(
+                    "warning",
+                    "requirement-ears-clause",
+                    f"{r.id} opens with 'If' but has no 'then' response clause "
+                    "(EARS unwanted-behaviour pattern: If <condition> then <system> SHALL …).",
+                    r.line,
+                )
+            )
+    return issues
 
 
 def _validate_status_metadata(product: Product, spec: ArtifactSpec) -> list[Issue]:
@@ -187,6 +267,33 @@ def _validate_roadmap(product: Product) -> list[Issue]:
                     f"Roadmap is missing a ## {section.title()} section.",
                 )
             )
+
+    # Horizon (v0.17.1, ADR-056): optional, validated when present — now/next/later
+    # or a calendar quarter. Absent is fine (no horizon is forced on a roadmap).
+    horizon = _first_value(product.sections.get("horizon", ""))
+    if horizon and horizon.casefold() not in _HORIZON_VALUES and not _QUARTER_RE.match(horizon):
+        issues.append(
+            Issue(
+                "error",
+                "invalid-roadmap-horizon",
+                f"## Horizon value {horizon!r} is not one of: now, next, later, "
+                "or a quarter (e.g. Q3 2026).",
+            )
+        )
+
+    # Linkage (warning): a roadmap should advance at least one requirement or
+    # decision it links to (the edge into the graph is the roadmap's value).
+    if (
+        "related requirements" not in product.sections
+        and "related decisions" not in product.sections
+    ):
+        issues.append(
+            Issue(
+                "warning",
+                "roadmap-no-advancement-link",
+                "Roadmap links no ## Related Requirements or ## Related Decisions it advances.",
+            )
+        )
 
     issues += _validate_status_metadata(product, spec)
     return issues

--- a/src/rac/services/portfolio.py
+++ b/src/rac/services/portfolio.py
@@ -30,7 +30,9 @@ from rac.core.artifacts import ARTIFACT_SPECS, spec_for
 from rac.core.classification import missing_sections
 from rac.core.corpus import CorpusEntry, walk_corpus
 from rac.core.identity import artifact_identifier
+from rac.core.overrides import apply_overrides
 from rac.core.validation import has_errors, validate
+from rac.services.init import load_overrides
 
 from .relationships import (
     ISSUE_SELF_REFERENCE,
@@ -181,6 +183,10 @@ def portfolio_from_corpus(
     the relationship summary, so a portfolio costs one walk instead of two.
     """
 
+    # Repository-wide severity overrides (ADR-053): review/portfolio/watchkeeper
+    # honour the same .rac/config.yaml policy as `rac validate`.
+    overrides = load_overrides(directory)
+
     # --- per-artifact pass ---------------------------------------------------
     by_type: dict[str, int] = {spec.name: 0 for spec in ARTIFACT_SPECS}
     by_type["unknown"] = 0
@@ -210,8 +216,8 @@ def portfolio_from_corpus(
         identifier = artifact_identifier(product, spec, str(path))
         path_to_identifier[str(path)] = identifier
 
-        # Validation
-        issues = validate(product)
+        # Validation (overrides applied, ADR-053)
+        issues = apply_overrides(validate(product), artifact_type, overrides)
         if has_errors(issues):
             invalid_count += 1
             error_codes = [i.code for i in issues if i.severity == "error"]

--- a/src/rac/services/validate.py
+++ b/src/rac/services/validate.py
@@ -17,7 +17,7 @@ from dataclasses import asdict, dataclass
 from rac.core.artifacts import spec_for
 from rac.core.corpus import CorpusEntry, walk_corpus
 from rac.core.models import Issue
-from rac.core.overrides import EMPTY, SeverityOverrides, apply_overrides
+from rac.core.overrides import SeverityOverrides, apply_overrides
 from rac.core.validation import has_errors, validate
 
 from .init import load_overrides
@@ -121,18 +121,21 @@ def validate_corpus(
     directory: str,
     entries: list[CorpusEntry],
     recursive: bool = True,
-    overrides: SeverityOverrides = EMPTY,
+    overrides: SeverityOverrides | None = None,
 ) -> DirectoryValidation:
     """Validate an already-walked corpus snapshot (v0.8.0).
 
     Same result as :func:`validate_directory`; the snapshot lets one walk
     feed several analyses (repository model, future incremental refresh).
-    Severity overrides (ADR-053) default to :data:`~rac.core.overrides.EMPTY` so
-    consumers that hold their own snapshot (the repository model behind review /
-    watchkeeper / portfolio) are unchanged; ``validate_directory`` loads the
-    repository's overrides and passes them. Overrides are applied before status
-    and exit code are computed, so a downgraded type or rule keeps the run green.
+    Severity overrides (ADR-053) are repository-wide: when not supplied they are
+    loaded from the directory's ``.rac/config.yaml``, so the repository model
+    behind review / watchkeeper / portfolio honours the same policy as
+    ``rac validate``. Pass :data:`~rac.core.overrides.EMPTY` to opt out. Overrides
+    are applied before status and exit code are computed, so a downgraded type or
+    rule keeps the run green.
     """
+    if overrides is None:
+        overrides = load_overrides(directory)
     files: list[FileValidation] = []
     for entry in entries:
         path, product = entry.path, entry.product

--- a/tests/fixtures/valid/feature.md
+++ b/tests/fixtures/valid/feature.md
@@ -6,8 +6,8 @@ Users cannot narrow large result sets, so they abandon search.
 
 ## Requirements
 
-[REQ-001] User can filter results by category
-[REQ-002] User can combine multiple filters at once
+[REQ-001] The system SHALL let users filter results by category.
+[REQ-002] The system SHALL let users combine multiple active filters.
 
 ## Success Metrics
 

--- a/tests/test_requirement_standards.py
+++ b/tests/test_requirement_standards.py
@@ -1,0 +1,115 @@
+"""Tests for per-type standards checks (v0.17.1, ADR-056).
+
+Requirements: BCP-14 keyword discipline (error), 29148 singular (warning), and
+EARS (warnings). Roadmaps: optional horizon and an advancement-linkage warning.
+Plus the repository-wide reach of severity overrides (ADR-053, revised): a rule a
+repo downgrades in .rac/config.yaml is downgraded for `rac review`/portfolio too,
+not only `rac validate`.
+"""
+
+from __future__ import annotations
+
+from rac.core.markdown import parse
+from rac.core.validation import validate
+from rac.services.portfolio import build_portfolio_summary
+
+REQ = "# R\n\n## Problem\n\np\n\n## Requirements\n\n- [REQ-001] {line}\n"
+ROADMAP = "# R\n\n## Outcomes\n\no\n\n## Initiatives\n\ni\n{extra}"
+
+
+def codes(text):
+    return {i.code for i in validate(parse(text))}
+
+
+# --- requirements: BCP-14 ----------------------------------------------------
+
+
+def test_lowercase_normative_keyword_is_error():
+    assert "requirement-normative-keyword" in codes(
+        REQ.format(line="The system shall export data.")
+    )
+    assert "requirement-normative-keyword" in codes(REQ.format(line="It must be fast."))
+
+
+def test_uppercase_normative_keyword_is_clean():
+    c = codes(REQ.format(line="The system SHALL export all account data within 24 hours."))
+    assert "requirement-normative-keyword" not in c
+    assert "requirement-non-ears" not in c
+    assert "requirement-not-singular" not in c
+
+
+def test_must_not_uppercase_is_clean():
+    assert "requirement-normative-keyword" not in codes(
+        REQ.format(line="Deactivated accounts MUST NOT be returned by default queries.")
+    )
+
+
+# --- requirements: 29148 singular --------------------------------------------
+
+
+def test_two_normative_keywords_not_singular():
+    c = codes(REQ.format(line="The system SHALL log in and SHALL also export."))
+    assert "requirement-not-singular" in c
+
+
+# --- requirements: EARS ------------------------------------------------------
+
+
+def test_no_normative_keyword_is_non_ears():
+    assert "requirement-non-ears" in codes(REQ.format(line="User can filter results by category."))
+
+
+def test_if_without_then_flags_ears_clause():
+    c = codes(REQ.format(line="If the upload fails, the system SHALL retry."))
+    assert "requirement-ears-clause" in c
+
+
+def test_if_then_is_clean():
+    c = codes(REQ.format(line="If the upload fails, then the system SHALL retry once."))
+    assert "requirement-ears-clause" not in c
+
+
+# --- roadmaps: horizon + linkage ---------------------------------------------
+
+
+def test_invalid_horizon_is_error():
+    c = codes(ROADMAP.format(extra="\n## Horizon\n\nsoonish\n"))
+    assert "invalid-roadmap-horizon" in c
+
+
+def test_valid_horizon_passes():
+    assert "invalid-roadmap-horizon" not in codes(ROADMAP.format(extra="\n## Horizon\n\nnext\n"))
+    assert "invalid-roadmap-horizon" not in codes(ROADMAP.format(extra="\n## Horizon\n\nQ3 2026\n"))
+
+
+def test_absent_horizon_is_fine():
+    assert "invalid-roadmap-horizon" not in codes(ROADMAP.format(extra=""))
+
+
+def test_roadmap_without_advancement_link_warns():
+    assert "roadmap-no-advancement-link" in codes(ROADMAP.format(extra=""))
+
+
+def test_roadmap_with_decision_link_is_clean():
+    c = codes(ROADMAP.format(extra="\n## Related Decisions\n\n- adr-049\n"))
+    assert "roadmap-no-advancement-link" not in c
+
+
+# --- overrides are repository-wide (ADR-053 revised) -------------------------
+
+BAD_REQ = "# R\n\n## Problem\n\np\n\n## Requirements\n\n- [REQ-001] The system shall export.\n"
+
+
+def test_review_honours_repository_overrides(tmp_path):
+    (tmp_path / "r.md").write_text(BAD_REQ, encoding="utf-8")
+    cfg = tmp_path / ".rac"
+    cfg.mkdir()
+    # No overrides: the BCP-14 error makes the artifact invalid in the portfolio.
+    cfg.joinpath("config.yaml").write_text("repository_key: RAC\n", encoding="utf-8")
+    assert build_portfolio_summary(str(tmp_path)).invalid_artifacts == 1
+    # Downgraded: review/portfolio see it clean too, not just `rac validate`.
+    cfg.joinpath("config.yaml").write_text(
+        "repository_key: RAC\nvalidation:\n  rules:\n    requirement-normative-keyword: off\n",
+        encoding="utf-8",
+    )
+    assert build_portfolio_summary(str(tmp_path)).invalid_artifacts == 0


### PR DESCRIPTION
# Summary

Implements **Release D** — `rac/roadmaps/v0.17.x-adoption/v0.17.1-per-type-standards-enforcement.md`
(ADR-056). `rac validate` now lints each type against the standards RAC cites,
deterministically (no AI in core, ADR-002):

- **Requirements:** BCP-14 keyword discipline (error), ISO 29148 singularity
  (warning), EARS (warnings).
- **Roadmaps:** optional, validated `## Horizon`; an advancement-linkage warning.

It also makes **severity overrides repository-wide** (ADR-053 revised) so a
warnings-first policy is consistent across `rac validate` / `review` /
`watchkeeper` / `portfolio` — and **dogfoods that** by disabling the new checks in
RAC's own `.rac/config.yaml` (per your "dogfood warnings-first" call), keeping the
corpus green without rewriting it.

# New checks

| Code | Severity | Standard |
| --- | --- | --- |
| `requirement-normative-keyword` | error | BCP-14 — only uppercase MUST/SHALL/SHOULD/MAY are normative |
| `requirement-not-singular` | warning | ISO 29148 — one normative statement per line |
| `requirement-non-ears` | warning | EARS — a requirement must state a normative response |
| `requirement-ears-clause` | warning | EARS — sentence-initial `If …` needs a `then` |
| `invalid-roadmap-horizon` | error | `## Horizon` is now/next/later or a quarter (optional section) |
| `roadmap-no-advancement-link` | warning | roadmap links no Related Requirements/Decisions |

The BCP-14 error is the only gate-breaker; the rest are warnings. All route
through the override layer.

# Key decision: overrides are now repository-wide

B (ADR-053) scoped overrides to `rac validate` only. That made the dogfood
incoherent — `rac validate rac/` could be green while `rac review rac/` flagged
the same downgraded finding as blocking. So `validate_corpus` and
`portfolio_from_corpus` now load and apply the repository's `.rac/config.yaml`
overrides, and ADR-053 point 4 is amended to "repository-wide". A test pins this
(a downgraded rule keeps `portfolio`/`review` green, not only `rac validate`).

# Dogfood (warnings-first, your chosen approach)

RAC's corpus has ~50 lowercase-"shall" requirement lines that the BCP-14 error
would fail. Rather than rewrite the corpus, `.rac/config.yaml` disables the new
requirement-quality checks — the exact warnings-first gradient an adopter uses to
go green on day one and tighten later. The feature ships at full strength for
other repos. The "valid" validate fixture and the guide **examples** were brought
up to BCP-14 (uppercase MUST/SHALL) so the exemplars model best practice.

# Verification

- `rac validate rac/` → 183 valid, 0 invalid, OKF conformant (the new error is
  downgraded in our config; warnings don't fail the gate).
- Raw impact, before the downgrade: 50 `requirement-normative-keyword` errors +
  85 `requirement-non-ears` + 36 `requirement-not-singular` + 9
  `roadmap-no-advancement-link` — confirming the checks fire as intended.
- `rac relationships rac/ --validate` → 0 issues; `rac review rac/` → health 89,
  no priority 1-2.
- `pytest` → 1169 passed (13 new); `ruff` + `ruff format` + `mypy src/rac` clean.

# Review Path

1. `src/rac/core/validation.py` — `_validate_requirement_standards` + roadmap
   horizon/linkage.
2. `src/rac/services/validate.py` + `portfolio.py` — repository-wide override
   application.
3. `rac/decisions/adr-053-*.md` — the scope amendment.
4. `.rac/config.yaml` — the dogfood downgrade; the fixture/example exemplar fixes.
5. `tests/test_requirement_standards.py`; `docs/validation.md`; CHANGELOG.

# Notes For Reviewer

- EARS is delivered as the high-precision decidable subset (a requirement must
  carry a normative response; `If` needs `then`); finer clause-cardinality/order
  analysis is a low-false-positive follow-up, noted in the design.
- Scoped to the genuine remainder: ADR status-lifecycle (C) and SARIF emission (B)
  are not re-touched. MADR-4.0 field "recognition" is a no-op (RAC never flags
  unknown body sections), so no code was needed for it.

# Implementation Process

Implemented under the maintainer's direction (dogfood warnings-first via config
over rewriting the corpus); the repository-wide override broadening and the
EARS-subset scoping were agent decisions recorded in ADR-053 and the design, for
maintainer ratification.