### PR TITLE
feat(release): rac validate GitHub Action + CI docs [roadmap:v0.17.2]

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,7 +56,7 @@ jobs:
         # enforced by tests/test_ci_batteries.py in the core battery.
         battery:
           - name: core
-            paths: "tests/test_validate.py tests/test_okf_conformance.py tests/test_overrides.py tests/test_sarif.py tests/test_parser.py tests/test_schema.py tests/test_identity.py tests/test_frontmatter.py tests/test_metadata_identity.py tests/test_idgen.py tests/test_ci_batteries.py tests/test_corpus.py tests/test_operations.py"
+            paths: "tests/test_validate.py tests/test_okf_conformance.py tests/test_overrides.py tests/test_requirement_standards.py tests/test_sarif.py tests/test_parser.py tests/test_schema.py tests/test_identity.py tests/test_frontmatter.py tests/test_metadata_identity.py tests/test_idgen.py tests/test_ci_batteries.py tests/test_corpus.py tests/test_operations.py"
           - name: cli
             paths: "tests/test_cli.py"
           - name: compare

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -110,7 +110,7 @@ jobs:
           - name: stats
             paths: "tests/test_stats.py"
           - name: watchkeeper
-            paths: "tests/test_watchkeeper.py"
+            paths: "tests/test_watchkeeper.py tests/test_validate_action.py"
           # Trust gates (v0.7.9): dogfood validates RAC's own rac/ corpus,
           # golden pins CLI stdout byte-for-byte against committed files.
           - name: dogfood

--- a/.rac/config.yaml
+++ b/.rac/config.yaml
@@ -1,1 +1,14 @@
 repository_key: RAC
+
+# Warnings-first onboarding (ADR-053), dogfooded: RAC's own corpus predates the
+# v0.17.1 requirement-quality checks (29148 / EARS / BCP-14, ADR-056), so they are
+# disabled here pending incremental cleanup. The checks ship at full strength for
+# adopting repositories; this is the same gradient a new adopter would use to take
+# RAC's gate green on day one and tighten over time.
+validation:
+  rules:
+    requirement-normative-keyword: off   # BCP-14: lowercase shall/should (error)
+    requirement-not-singular: off        # 29148: one normative statement per line
+    requirement-non-ears: off            # EARS: a line with no SHALL/SHOULD/MAY
+    requirement-ears-clause: off         # EARS: "If …" without a "then" response
+    roadmap-no-advancement-link: off     # roadmap links no requirement/decision

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ details, release history over commit history.
 
 ### Added
 
+- Validate GitHub Action (v0.17.2): a composite action
+  (`tcballard/requirements-as-code/validate-action@<ref>`) runs
+  `rac validate --sarif` and uploads the result to GitHub Code Scanning, so RAC
+  findings annotate a pull request inline. A thin wrapper over the CLI (ADR-058):
+  errors fail the check, warnings (including findings downgraded in
+  `.rac/config.yaml`) annotate without failing — warnings-first onboarding. Docs
+  cover the workflow, the `security-events: write` permission, and the
+  custom-types/edges extensibility boundary (deferred, ADR-052/ADR-055).
+
 - Per-type standards enforcement (v0.17.1): `rac validate` now lints requirement
   *quality* against the standards RAC cites — BCP-14 keyword discipline
   (`requirement-normative-keyword`, error: only uppercase MUST/SHALL/SHOULD/MAY are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ details, release history over commit history.
 
 ### Added
 
+- Per-type standards enforcement (v0.17.1): `rac validate` now lints requirement
+  *quality* against the standards RAC cites — BCP-14 keyword discipline
+  (`requirement-normative-keyword`, error: only uppercase MUST/SHALL/SHOULD/MAY are
+  normative), ISO 29148 singularity (`requirement-not-singular`, warning), and EARS
+  (`requirement-non-ears` / `requirement-ears-clause`, warnings). Roadmaps gain an
+  optional, validated `## Horizon` (now/next/later or a quarter) and an
+  advancement-linkage warning. All checks are deterministic (no AI in core) and
+  overridable per the v0.15.2 model. Severity overrides are now **repository-wide**
+  (ADR-053 revised): a rule downgraded in `.rac/config.yaml` is downgraded for
+  `rac review`/`watchkeeper`/`portfolio` too, not only `rac validate` — so a
+  warnings-first policy is consistent across every surface.
+
 - Relationship-graph integrity (v0.16.0): `rac relationships --validate` now
   validates the corpus as a graph (ADR-055). A `## Related <Type>` reference that
   resolves to the wrong artifact type is reported as

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -5,6 +5,24 @@ error-severity finding, and (over a directory) when the corpus is not a
 conformant OKF v0.1 bundle. Two features make that gate adoptable in CI on a
 real, pre-existing repository.
 
+## Per-type standards checks
+
+Beyond structure, `rac validate` lints each type against the standards it cites
+(ADR-056) — all deterministic, no AI:
+
+| Code | Severity | Standard |
+| --- | --- | --- |
+| `requirement-normative-keyword` | error | BCP-14: only uppercase MUST/SHALL/SHOULD/MAY are normative; lowercase is ambiguous. |
+| `requirement-not-singular` | warning | ISO 29148: one normative statement per requirement line. |
+| `requirement-non-ears` | warning | EARS: a requirement must state a normative response (SHALL/SHOULD/MAY). |
+| `requirement-ears-clause` | warning | EARS: a sentence-initial `If …` needs a `then` response clause. |
+| `invalid-roadmap-horizon` | error | A `## Horizon` value must be `now`/`next`/`later` or a quarter (e.g. `Q3 2026`); the section is optional. |
+| `roadmap-no-advancement-link` | warning | A roadmap should link a `## Related Requirements` or `## Related Decisions` it advances. |
+
+The BCP-14 error is the only gate-breaker; the rest are warnings, and all are
+overridable below. (RAC's own corpus predates these checks and disables them in
+its `.rac/config.yaml` — the warnings-first path in action.)
+
 ## Severity overrides (warnings-first onboarding)
 
 Pointing `rac validate` at a legacy corpus for the first time can surface many
@@ -12,6 +30,8 @@ pre-existing findings at once. Rather than fail the build on all of them, a
 repository can downgrade or silence specific findings in its committed
 `.rac/config.yaml`, then tighten the gate over time. The decision behind this is
 [ADR-053](https://github.com/tcballard/requirements-as-code/blob/main/rac/decisions/adr-053-validation-severity-overrides.md).
+Overrides are **repository-wide**: a downgrade applies to `rac review`,
+`rac watchkeeper`, and `rac portfolio` as well as `rac validate`.
 
 Add an optional `validation` section:
 

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -60,8 +60,9 @@ policy (a per-developer file would not keep CI green). Determinism holds: the
 same corpus *and config* yield the same findings and exit code. An absent
 `validation` section is a pure no-op — the default gate is strict.
 
-Overrides apply to `rac validate` only; `rac review`, `rac watchkeeper`, and
-`rac portfolio` report the corpus as authored.
+Overrides are repository-wide (ADR-053): a downgrade applies to `rac review`,
+`rac watchkeeper`, and `rac portfolio` as well as `rac validate`, so a
+warnings-first policy is consistent across every surface.
 
 A typical onboarding path: start by capping noisy types to `warning`, get CI
 green, then remove entries (or restore `error`) rule-by-rule as the corpus is
@@ -93,6 +94,45 @@ A worked example of the output is checked in at
 [`docs/examples/rac-validate.sarif.json`](examples/rac-validate.sarif.json): one
 `error` (an out-of-enum decision status), two recommended-section `warning`s, and
 a line-anchored `ambiguous-verb` finding (note the `region.startLine`).
+
+## Running in CI (GitHub Action)
+
+A composite GitHub Action wraps `rac validate --sarif` and uploads the result to
+GitHub Code Scanning, so findings annotate the pull request inline. The decision
+behind it is
+[ADR-058](https://github.com/tcballard/requirements-as-code/blob/main/rac/decisions/adr-058-validation-github-action.md);
+it is a thin wrapper — the `rac` CLI stays the source of truth.
+
+```yaml
+# .github/workflows/rac.yml
+name: RAC
+on: [pull_request]
+permissions:
+  contents: read
+  security-events: write          # required to upload SARIF to Code Scanning
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tcballard/requirements-as-code/validate-action@v0
+        with:
+          path: rac/
+```
+
+Inputs: `path` (default `rac`), `upload-sarif` (default `true`), `sarif-file`,
+`rac-version` (pin a release), and `install-from` (`pypi` or `source`). Errors
+fail the check; warnings — including findings downgraded in `.rac/config.yaml` —
+annotate without failing, so a legacy repo can adopt the gate green on day one and
+tighten over time.
+
+> **Extensibility boundary.** RAC's built-in artifact types and relationship
+> edges are the supported surface, defined in code. Custom artifact types and
+> custom relationship edges are deferred (ADR-052, ADR-055); a repo-local schema
+> registry is a future, separately recorded decision.
+
+(The Watchkeeper action at the repository root is the complementary PR-review
+surface — see [Watchkeeper](watchkeeper.md).)
 
 ## See also
 

--- a/examples/guide/rac/req-001-user-account-lifecycle.md
+++ b/examples/guide/rac/req-001-user-account-lifecycle.md
@@ -18,11 +18,11 @@ closed account from being used for authentication.
 
 ## Requirements
 
-- [REQ-001] The service must create a user account with a unique identifier, email address, and creation timestamp.
-- [REQ-002] The service must deactivate a user account without destroying its history or audit trail.
-- [REQ-003] Deactivated accounts must not be returned by default user queries.
-- [REQ-004] The full history of a user account must be recoverable by support and compliance staff after deactivation.
-- [REQ-005] The service must support GDPR subject-access requests for deactivated accounts.
+- [REQ-001] The service MUST create a user account with a unique identifier, email address, and creation timestamp.
+- [REQ-002] The service MUST deactivate a user account without destroying its history or audit trail.
+- [REQ-003] Deactivated accounts MUST NOT be returned by default user queries.
+- [REQ-004] The full history of a user account MUST be recoverable by support and compliance staff after deactivation.
+- [REQ-005] The service MUST fulfil GDPR subject-access requests for deactivated accounts.
 
 ## Success Metrics
 

--- a/rac/decisions/adr-053-validation-severity-overrides.md
+++ b/rac/decisions/adr-053-validation-severity-overrides.md
@@ -58,11 +58,15 @@ custom-type JSON-Schema registry ADR-052 deferred.
    before status and exit code are computed, so a downgraded type or rule keeps
    the run green.
 
-4. **Scope: the `rac validate` entrypoints only.** Overrides apply to directory
-   and single-file `rac validate` (core findings and OKF conformance findings,
-   which gain a `severity`). The repository model behind `review`, `watchkeeper`,
-   and `portfolio` is unchanged (it validates with no overrides), so those
-   surfaces keep reporting the corpus as authored.
+4. **Scope: repository-wide (revised in v0.17.1).** Overrides are a repository
+   policy, so they apply wherever RAC evaluates the corpus's findings — `rac
+   validate` (directory and single-file, core + OKF findings) *and* the repository
+   model behind `review`, `watchkeeper`, and `portfolio`. The original v0.15.2
+   scoping applied overrides to `rac validate` only; v0.17.1 broadened it because a
+   rule a team downgrades in `.rac/config.yaml` should be downgraded everywhere —
+   it is incoherent for `rac validate` to report green while `rac review` flags the
+   same downgraded finding as blocking. (Repositories that declare no `validation`
+   section are unchanged, the common case.)
 
 5. **Determinism preserved (ADR-002).** The overrides live in a committed file,
    so the same repository state yields the same findings and exit code. Malformed
@@ -96,8 +100,9 @@ custom-type JSON-Schema registry ADR-052 deferred.
 
 ### Neutral
 
-- `review`/`watchkeeper`/`portfolio` deliberately ignore overrides; whether they
-  should honour them is a separate, later decision.
+- Since v0.17.1, `review`/`watchkeeper`/`portfolio` honour overrides too (the
+  repository model loads them from `.rac/config.yaml`), so a repository's severity
+  policy is consistent across every surface.
 
 ## Alternatives Considered
 

--- a/src/rac/core/validation.py
+++ b/src/rac/core/validation.py
@@ -22,6 +22,16 @@ MAX_REQUIREMENTS = 50
 AMBIGUOUS_VERBS = ("support", "handle", "allow", "enable")
 _AMBIGUOUS_RE = re.compile(r"\b(" + "|".join(AMBIGUOUS_VERBS) + r")\b", re.IGNORECASE)
 
+# Requirements quality standards (v0.17.1, ADR-056). The normative requirement
+# verbs RAC disciplines; per RFC 8174 only their ALL-CAPS form carries normative
+# weight, so a non-uppercase occurrence inside a requirement line is ambiguous.
+_NORMATIVE_RE = re.compile(r"\b(shall|must|should)\b", re.IGNORECASE)
+_EARS_IF_RE = re.compile(r"^\s*if\b", re.IGNORECASE)
+_THEN_RE = re.compile(r"\bthen\b", re.IGNORECASE)
+# Roadmap horizon (ADR-056): now/next/later or a calendar quarter (e.g. Q3 2026).
+_HORIZON_VALUES = ("now", "next", "later")
+_QUARTER_RE = re.compile(r"^Q[1-4]\s+\d{4}$")
+
 
 def has_errors(issues: list[Issue]) -> bool:
     """True if any issue is error-severity."""
@@ -50,9 +60,79 @@ def validate(product: Product) -> list[Issue]:
     if artifact_type == "requirement":
         spec = spec_for("requirement")
         assert spec is not None  # the requirement spec always exists
-        return issues + _validate_requirement(product) + _validate_status_metadata(product, spec)
-    # Unknown/legacy fallback: requirement rules only, no constrained metadata.
+        return (
+            issues
+            + _validate_requirement(product)
+            + _validate_status_metadata(product, spec)
+            + _validate_requirement_standards(product)
+        )
+    # Unknown/legacy fallback: requirement rules only, no constrained metadata or
+    # per-type standards (an Unknown document is not linted as a requirement).
     return issues + _validate_requirement(product)
+
+
+def _validate_requirement_standards(product: Product) -> list[Issue]:
+    """Per-line requirement quality checks: BCP-14, 29148 singular, EARS (ADR-056).
+
+    Deterministic and decidable by parsing — no prose judgement (ADR-002). BCP-14
+    keyword discipline is an error inside ``requirement`` artifacts; the 29148/EARS
+    checks are warnings (legacy requirements will not comply), all overridable per
+    ADR-053. Each diagnostic names the standard and the fix.
+    """
+    issues: list[Issue] = []
+    for r in product.requirements:
+        keywords = _NORMATIVE_RE.findall(r.text)
+
+        # BCP-14: only ALL-CAPS normative keywords carry weight (RFC 8174); a
+        # lowercase/mixed-case shall/must/should is ambiguous normative language.
+        ambiguous = sorted({k for k in keywords if k != k.upper()})
+        if ambiguous:
+            issues.append(
+                Issue(
+                    "error",
+                    "requirement-normative-keyword",
+                    f"{r.id} uses non-normative {', '.join(ambiguous)!r}; only "
+                    "uppercase MUST/SHALL/SHOULD/MAY carry normative weight (BCP 14).",
+                    r.line,
+                )
+            )
+
+        # 29148 well-formed: a requirement should be singular — one normative
+        # statement per line.
+        if len(keywords) > 1:
+            issues.append(
+                Issue(
+                    "warning",
+                    "requirement-not-singular",
+                    f"{r.id} has {len(keywords)} normative keywords; a requirement "
+                    "should be singular (ISO/IEC/IEEE 29148).",
+                    r.line,
+                )
+            )
+
+        # EARS: a requirement must state a normative response; a sentence-initial
+        # "If" (unwanted-behaviour pattern) needs a "then" response clause.
+        if not keywords:
+            issues.append(
+                Issue(
+                    "warning",
+                    "requirement-non-ears",
+                    f"{r.id} has no normative keyword (SHALL/SHOULD/MAY); it does not "
+                    "state a testable requirement (EARS).",
+                    r.line,
+                )
+            )
+        elif _EARS_IF_RE.search(r.text) and not _THEN_RE.search(r.text):
+            issues.append(
+                Issue(
+                    "warning",
+                    "requirement-ears-clause",
+                    f"{r.id} opens with 'If' but has no 'then' response clause "
+                    "(EARS unwanted-behaviour pattern: If <condition> then <system> SHALL …).",
+                    r.line,
+                )
+            )
+    return issues
 
 
 def _validate_status_metadata(product: Product, spec: ArtifactSpec) -> list[Issue]:
@@ -187,6 +267,33 @@ def _validate_roadmap(product: Product) -> list[Issue]:
                     f"Roadmap is missing a ## {section.title()} section.",
                 )
             )
+
+    # Horizon (v0.17.1, ADR-056): optional, validated when present — now/next/later
+    # or a calendar quarter. Absent is fine (no horizon is forced on a roadmap).
+    horizon = _first_value(product.sections.get("horizon", ""))
+    if horizon and horizon.casefold() not in _HORIZON_VALUES and not _QUARTER_RE.match(horizon):
+        issues.append(
+            Issue(
+                "error",
+                "invalid-roadmap-horizon",
+                f"## Horizon value {horizon!r} is not one of: now, next, later, "
+                "or a quarter (e.g. Q3 2026).",
+            )
+        )
+
+    # Linkage (warning): a roadmap should advance at least one requirement or
+    # decision it links to (the edge into the graph is the roadmap's value).
+    if (
+        "related requirements" not in product.sections
+        and "related decisions" not in product.sections
+    ):
+        issues.append(
+            Issue(
+                "warning",
+                "roadmap-no-advancement-link",
+                "Roadmap links no ## Related Requirements or ## Related Decisions it advances.",
+            )
+        )
 
     issues += _validate_status_metadata(product, spec)
     return issues

--- a/src/rac/services/portfolio.py
+++ b/src/rac/services/portfolio.py
@@ -30,7 +30,9 @@ from rac.core.artifacts import ARTIFACT_SPECS, spec_for
 from rac.core.classification import missing_sections
 from rac.core.corpus import CorpusEntry, walk_corpus
 from rac.core.identity import artifact_identifier
+from rac.core.overrides import apply_overrides
 from rac.core.validation import has_errors, validate
+from rac.services.init import load_overrides
 
 from .relationships import (
     ISSUE_SELF_REFERENCE,
@@ -181,6 +183,10 @@ def portfolio_from_corpus(
     the relationship summary, so a portfolio costs one walk instead of two.
     """
 
+    # Repository-wide severity overrides (ADR-053): review/portfolio/watchkeeper
+    # honour the same .rac/config.yaml policy as `rac validate`.
+    overrides = load_overrides(directory)
+
     # --- per-artifact pass ---------------------------------------------------
     by_type: dict[str, int] = {spec.name: 0 for spec in ARTIFACT_SPECS}
     by_type["unknown"] = 0
@@ -210,8 +216,8 @@ def portfolio_from_corpus(
         identifier = artifact_identifier(product, spec, str(path))
         path_to_identifier[str(path)] = identifier
 
-        # Validation
-        issues = validate(product)
+        # Validation (overrides applied, ADR-053)
+        issues = apply_overrides(validate(product), artifact_type, overrides)
         if has_errors(issues):
             invalid_count += 1
             error_codes = [i.code for i in issues if i.severity == "error"]

--- a/src/rac/services/validate.py
+++ b/src/rac/services/validate.py
@@ -17,7 +17,7 @@ from dataclasses import asdict, dataclass
 from rac.core.artifacts import spec_for
 from rac.core.corpus import CorpusEntry, walk_corpus
 from rac.core.models import Issue
-from rac.core.overrides import EMPTY, SeverityOverrides, apply_overrides
+from rac.core.overrides import SeverityOverrides, apply_overrides
 from rac.core.validation import has_errors, validate
 
 from .init import load_overrides
@@ -121,18 +121,21 @@ def validate_corpus(
     directory: str,
     entries: list[CorpusEntry],
     recursive: bool = True,
-    overrides: SeverityOverrides = EMPTY,
+    overrides: SeverityOverrides | None = None,
 ) -> DirectoryValidation:
     """Validate an already-walked corpus snapshot (v0.8.0).
 
     Same result as :func:`validate_directory`; the snapshot lets one walk
     feed several analyses (repository model, future incremental refresh).
-    Severity overrides (ADR-053) default to :data:`~rac.core.overrides.EMPTY` so
-    consumers that hold their own snapshot (the repository model behind review /
-    watchkeeper / portfolio) are unchanged; ``validate_directory`` loads the
-    repository's overrides and passes them. Overrides are applied before status
-    and exit code are computed, so a downgraded type or rule keeps the run green.
+    Severity overrides (ADR-053) are repository-wide: when not supplied they are
+    loaded from the directory's ``.rac/config.yaml``, so the repository model
+    behind review / watchkeeper / portfolio honours the same policy as
+    ``rac validate``. Pass :data:`~rac.core.overrides.EMPTY` to opt out. Overrides
+    are applied before status and exit code are computed, so a downgraded type or
+    rule keeps the run green.
     """
+    if overrides is None:
+        overrides = load_overrides(directory)
     files: list[FileValidation] = []
     for entry in entries:
         path, product = entry.path, entry.product

--- a/tests/fixtures/valid/feature.md
+++ b/tests/fixtures/valid/feature.md
@@ -6,8 +6,8 @@ Users cannot narrow large result sets, so they abandon search.
 
 ## Requirements
 
-[REQ-001] User can filter results by category
-[REQ-002] User can combine multiple filters at once
+[REQ-001] The system SHALL let users filter results by category.
+[REQ-002] The system SHALL let users combine multiple active filters.
 
 ## Success Metrics
 

--- a/tests/test_requirement_standards.py
+++ b/tests/test_requirement_standards.py
@@ -1,0 +1,115 @@
+"""Tests for per-type standards checks (v0.17.1, ADR-056).
+
+Requirements: BCP-14 keyword discipline (error), 29148 singular (warning), and
+EARS (warnings). Roadmaps: optional horizon and an advancement-linkage warning.
+Plus the repository-wide reach of severity overrides (ADR-053, revised): a rule a
+repo downgrades in .rac/config.yaml is downgraded for `rac review`/portfolio too,
+not only `rac validate`.
+"""
+
+from __future__ import annotations
+
+from rac.core.markdown import parse
+from rac.core.validation import validate
+from rac.services.portfolio import build_portfolio_summary
+
+REQ = "# R\n\n## Problem\n\np\n\n## Requirements\n\n- [REQ-001] {line}\n"
+ROADMAP = "# R\n\n## Outcomes\n\no\n\n## Initiatives\n\ni\n{extra}"
+
+
+def codes(text):
+    return {i.code for i in validate(parse(text))}
+
+
+# --- requirements: BCP-14 ----------------------------------------------------
+
+
+def test_lowercase_normative_keyword_is_error():
+    assert "requirement-normative-keyword" in codes(
+        REQ.format(line="The system shall export data.")
+    )
+    assert "requirement-normative-keyword" in codes(REQ.format(line="It must be fast."))
+
+
+def test_uppercase_normative_keyword_is_clean():
+    c = codes(REQ.format(line="The system SHALL export all account data within 24 hours."))
+    assert "requirement-normative-keyword" not in c
+    assert "requirement-non-ears" not in c
+    assert "requirement-not-singular" not in c
+
+
+def test_must_not_uppercase_is_clean():
+    assert "requirement-normative-keyword" not in codes(
+        REQ.format(line="Deactivated accounts MUST NOT be returned by default queries.")
+    )
+
+
+# --- requirements: 29148 singular --------------------------------------------
+
+
+def test_two_normative_keywords_not_singular():
+    c = codes(REQ.format(line="The system SHALL log in and SHALL also export."))
+    assert "requirement-not-singular" in c
+
+
+# --- requirements: EARS ------------------------------------------------------
+
+
+def test_no_normative_keyword_is_non_ears():
+    assert "requirement-non-ears" in codes(REQ.format(line="User can filter results by category."))
+
+
+def test_if_without_then_flags_ears_clause():
+    c = codes(REQ.format(line="If the upload fails, the system SHALL retry."))
+    assert "requirement-ears-clause" in c
+
+
+def test_if_then_is_clean():
+    c = codes(REQ.format(line="If the upload fails, then the system SHALL retry once."))
+    assert "requirement-ears-clause" not in c
+
+
+# --- roadmaps: horizon + linkage ---------------------------------------------
+
+
+def test_invalid_horizon_is_error():
+    c = codes(ROADMAP.format(extra="\n## Horizon\n\nsoonish\n"))
+    assert "invalid-roadmap-horizon" in c
+
+
+def test_valid_horizon_passes():
+    assert "invalid-roadmap-horizon" not in codes(ROADMAP.format(extra="\n## Horizon\n\nnext\n"))
+    assert "invalid-roadmap-horizon" not in codes(ROADMAP.format(extra="\n## Horizon\n\nQ3 2026\n"))
+
+
+def test_absent_horizon_is_fine():
+    assert "invalid-roadmap-horizon" not in codes(ROADMAP.format(extra=""))
+
+
+def test_roadmap_without_advancement_link_warns():
+    assert "roadmap-no-advancement-link" in codes(ROADMAP.format(extra=""))
+
+
+def test_roadmap_with_decision_link_is_clean():
+    c = codes(ROADMAP.format(extra="\n## Related Decisions\n\n- adr-049\n"))
+    assert "roadmap-no-advancement-link" not in c
+
+
+# --- overrides are repository-wide (ADR-053 revised) -------------------------
+
+BAD_REQ = "# R\n\n## Problem\n\np\n\n## Requirements\n\n- [REQ-001] The system shall export.\n"
+
+
+def test_review_honours_repository_overrides(tmp_path):
+    (tmp_path / "r.md").write_text(BAD_REQ, encoding="utf-8")
+    cfg = tmp_path / ".rac"
+    cfg.mkdir()
+    # No overrides: the BCP-14 error makes the artifact invalid in the portfolio.
+    cfg.joinpath("config.yaml").write_text("repository_key: RAC\n", encoding="utf-8")
+    assert build_portfolio_summary(str(tmp_path)).invalid_artifacts == 1
+    # Downgraded: review/portfolio see it clean too, not just `rac validate`.
+    cfg.joinpath("config.yaml").write_text(
+        "repository_key: RAC\nvalidation:\n  rules:\n    requirement-normative-keyword: off\n",
+        encoding="utf-8",
+    )
+    assert build_portfolio_summary(str(tmp_path)).invalid_artifacts == 0

--- a/tests/test_validate_action.py
+++ b/tests/test_validate_action.py
@@ -1,0 +1,60 @@
+"""Structural tests for the RAC validate composite action (v0.17.2, ADR-058).
+
+The action is a thin wrapper over `rac validate --sarif`; its behaviour is owned
+by the (separately tested) CLI. These tests pin the action's *contract* — that it
+stays a composite action that runs `rac validate --sarif`, uploads SARIF, and
+re-surfaces the CLI exit code — so the wiring cannot silently drift.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+ACTION = Path(__file__).parent.parent / "validate-action" / "action.yml"
+
+
+def _action() -> dict:
+    return yaml.safe_load(ACTION.read_text(encoding="utf-8"))
+
+
+def test_action_is_composite():
+    a = _action()
+    assert a["runs"]["using"] == "composite"
+    assert a["name"] == "RAC validate"
+
+
+def test_action_declares_expected_inputs():
+    inputs = _action()["inputs"]
+    for name in ("path", "upload-sarif", "sarif-file", "rac-version", "install-from"):
+        assert name in inputs, f"missing input: {name}"
+    assert inputs["path"]["default"] == "rac"
+    assert inputs["upload-sarif"]["default"] == "true"
+
+
+def test_action_runs_rac_validate_sarif():
+    steps = _action()["runs"]["steps"]
+    run_steps = " ".join(s.get("run", "") for s in steps)
+    assert "rac validate" in run_steps
+    assert "--sarif" in run_steps
+
+
+def test_action_uploads_sarif():
+    steps = _action()["runs"]["steps"]
+    uploads = [s for s in steps if "upload-sarif" in str(s.get("uses", ""))]
+    assert uploads, "no SARIF upload step"
+    # Upload even on failure so findings still annotate the PR.
+    assert "always()" in uploads[0]["if"]
+
+
+def test_action_resurfaces_exit_code():
+    steps = _action()["runs"]["steps"]
+    run_steps = " ".join(s.get("run", "") for s in steps)
+    assert 'exit "$EXIT_CODE"' in run_steps
+
+
+def test_action_install_supports_source_for_dogfood():
+    # `install-from: source` lets the repo dogfood the action with uses: ./validate-action.
+    run_steps = " ".join(s.get("run", "") for s in _action()["runs"]["steps"])
+    assert "GITHUB_ACTION_PATH" in run_steps

--- a/validate-action/action.yml
+++ b/validate-action/action.yml
@@ -1,0 +1,100 @@
+# RAC validate composite action (v0.17.2, ADR-058).
+#
+# A thin wrapper: install RAC, run one `rac validate --sarif`, upload the SARIF
+# to GitHub Code Scanning, and re-surface the CLI exit code. All analysis and
+# severity policy live in the package (ADR-015 / ADR-053); the action never
+# reinterprets findings. The Watchkeeper action lives at the repository root;
+# this validate action is referenced as
+# `uses: tcballard/requirements-as-code/validate-action@<ref>`.
+name: "RAC validate"
+description: >-
+  Validate a requirements-as-code (RAC) corpus and surface findings on the pull
+  request via GitHub Code Scanning (SARIF). A thin wrapper over the `rac` CLI.
+author: "Tom Ballard"
+
+branding:
+  icon: "check-circle"
+  color: "purple"
+
+inputs:
+  path:
+    description: "The RAC corpus directory to validate (passed to `rac validate`)."
+    required: false
+    default: "rac"
+  upload-sarif:
+    description: >-
+      Upload SARIF to GitHub Code Scanning (`true` or `false`). Requires the job
+      to grant `security-events: write`.
+    required: false
+    default: "true"
+  sarif-file:
+    description: "Where the SARIF document is written."
+    required: false
+    default: "rac.sarif"
+  rac-version:
+    description: >-
+      Exact requirements-as-code version to install from PyPI. Empty installs the
+      latest release. Ignored when `install-from` is `source`.
+    required: false
+    default: ""
+  install-from:
+    description: >-
+      Where to install RAC from: `pypi` (the default for consumers) or `source`
+      (the action checkout itself — for this repository's own dogfood job;
+      requires `uses: ./validate-action` on a full checkout).
+    required: false
+    default: "pypi"
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+
+    - name: Install RAC
+      shell: bash
+      env:
+        INSTALL_FROM: ${{ inputs.install-from }}
+        RAC_VERSION: ${{ inputs.rac-version }}
+      run: |
+        python -m pip install --quiet --upgrade pip
+        if [ "$INSTALL_FROM" = "source" ]; then
+          python -m pip install --quiet "$GITHUB_ACTION_PATH/.."
+        elif [ -n "$RAC_VERSION" ]; then
+          python -m pip install --quiet "requirements-as-code==$RAC_VERSION"
+        else
+          python -m pip install --quiet requirements-as-code
+        fi
+
+    # The CLI is the source of truth (ADR-058). `set +e` lets a non-zero exit
+    # still produce SARIF for upload; the exit code is re-surfaced below.
+    - name: Run rac validate (SARIF)
+      id: validate
+      shell: bash
+      env:
+        INPUT_PATH: ${{ inputs.path }}
+        SARIF_FILE: ${{ inputs.sarif-file }}
+      run: |
+        set +e
+        rac validate "$INPUT_PATH" --sarif > "$SARIF_FILE"
+        echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+
+    - name: Upload SARIF to Code Scanning
+      if: ${{ always() && inputs.upload-sarif == 'true' }}
+      uses: github/codeql-action/upload-sarif@v3
+      with:
+        sarif_file: ${{ inputs.sarif-file }}
+
+    # Errors fail the check; warnings (including findings downgraded in
+    # .rac/config.yaml, ADR-053) annotate without failing — warnings-first.
+    - name: Report result
+      shell: bash
+      env:
+        EXIT_CODE: ${{ steps.validate.outputs.exit_code }}
+      run: |
+        if [ "$EXIT_CODE" != "0" ]; then
+          echo "::error::rac validate exited $EXIT_CODE — see the Code Scanning annotations."
+          exit "$EXIT_CODE"
+        fi
+        echo "rac validate passed."


### PR DESCRIPTION
> **Stacked on #96 (Release D).** This branch is based on the D branch, so until
> #96 merges this PR's diff also shows D's commits. **Merge #96 first**, then this
> PR's diff is just the E changes below. (You asked to implement D then E
> sequentially.)

# Summary

Implements **Release E** — `rac/roadmaps/v0.17.x-adoption/v0.17.2-ci-action-and-dx.md`
(ADR-058): the CI distribution surface for RAC's write-time gate.

Adds:
- A **composite GitHub Action** at `validate-action/` that runs
  `rac validate --sarif` and uploads to GitHub Code Scanning (inline PR
  annotations).
- A **"Running in CI" doc** (workflow snippet, permission, warnings-first, and the
  custom-types/edges "deferred" boundary note).
- A structural **test** pinning the action's contract.

# Why a subdirectory action

The repository root `action.yml` is already the **Watchkeeper** action. Moving it
would break existing `uses: tcballard/requirements-as-code@REF` references, so the
validate action lives at `validate-action/` and is referenced as
`uses: tcballard/requirements-as-code/validate-action@REF`. It mirrors the
Watchkeeper action's conventions (branding, `rac-version`, `install-from:
pypi|source` for dogfooding). (The plan/ADR assumed a root `action.yml`; reality
has Watchkeeper there — noted.)

# How it works (thin wrapper, ADR-058)

```yaml
# .github/workflows/rac.yml
on: [pull_request]
permissions:
  contents: read
  security-events: write
jobs:
  validate:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - uses: tcballard/requirements-as-code/validate-action@v0
        with: { path: rac/ }
```

- install rac → `rac validate <path> --sarif` (`set +e`) → upload SARIF on
  `always()` (so findings annotate even when the check fails) → re-surface the CLI
  exit code.
- Errors fail the check; warnings — including findings downgraded in
  `.rac/config.yaml` (D / ADR-053) — annotate without failing. Warnings-first by
  construction.
- The CLI is the source of truth; the action owns no validation logic. OKF-grain
  invariant holds — the only network step is the SARIF upload.

# Verification

- `pytest` → 1175 passed (6 new structural action tests); `ruff` + `ruff format`
  clean; the action.yml parses as a valid composite action.
- `rac validate rac/` → 183 valid, 0 invalid, OKF conformant (unchanged).
- SARIF emission itself is covered by the existing `tests/test_sarif.py` (B); this
  PR adds the distribution wrapper around it.

# Review Path

1. `validate-action/action.yml` — the composite action.
2. `tests/test_validate_action.py` — the contract test; CI battery entry.
3. `docs/validation.md` — the "Running in CI" section (+ a stale-line fix: overrides
   are repository-wide as of D).
4. `CHANGELOG.md`.

# Notes For Reviewer

- I did **not** modify RAC's own live CI workflows to self-use the action (to
  avoid disturbing required checks overnight). Dogfooding it via
  `uses: ./validate-action` with `install-from: source` is a clean follow-up.
- With D + E merged, the brief's A–E arc is complete (A–C shipped; D = per-type
  standards; E = CI distribution), and the v0.17.x adoption series is delivered.

# Implementation Process

Implemented under the maintainer's "implement D and E sequentially, a PR each"
direction; the subdirectory-action placement (root is Watchkeeper) was an agent
decision, noted here for ratification.