### PR TITLE
chore(release): dogfood the validate action in CI [roadmap:v0.17.2]

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -84,3 +84,26 @@ jobs:
         with:
           path: rac
           install-from: source
+
+  # Validate dogfood (v0.17.2): every pull request runs the local validate
+  # action in source mode — the live end-to-end test of validate-action/action.yml
+  # (install, `rac validate --sarif`, exit-code propagation). SARIF uploads to
+  # Code Scanning for same-repo PRs; it is skipped on forks, whose token cannot be
+  # granted security-events: write, so the check never fails on a missing scope.
+  validate:
+    name: validate (dogfood, source install)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: ./validate-action
+        with:
+          path: rac
+          install-from: source
+          upload-sarif: ${{ !github.event.pull_request.head.repo.fork }}
+


### PR DESCRIPTION
# Summary

Dogfoods the validate GitHub Action (shipped in #97) in RAC's own CI: a new
`validate` job in `pr-checks.yml` runs the local action in source mode against
RAC's corpus on every pull request — the live end-to-end test of
`validate-action/action.yml`, mirroring the existing Watchkeeper dogfood.

```yaml
  validate:
    name: validate (dogfood, source install)
    runs-on: ubuntu-latest
    permissions:
      contents: read
      security-events: write
    steps:
      - uses: actions/checkout@v4
        with: { fetch-depth: 0 }
      - uses: ./validate-action
        with:
          path: rac
          install-from: source
          upload-sarif: ${{ !github.event.pull_request.head.repo.fork }}
```

# Why this shape

- **`uses: ./validate-action` + `install-from: source`** — runs the action from the
  PR's own checkout (installing `rac` from source via setuptools-scm, hence
  `fetch-depth: 0`), so the action wiring is exercised exactly as a consumer would,
  on RAC's real corpus. Same pattern the Watchkeeper job already uses.
- **Job-level `security-events: write`** — the workflow default is `contents: read`;
  only this job is granted the scope needed to upload SARIF to Code Scanning.
- **Fork-safe upload** — `upload-sarif` is set to `false` on fork PRs (whose
  `GITHUB_TOKEN` cannot be granted `security-events: write`), so the check never
  fails on a permission it cannot have; same-repo PRs upload and annotate inline.

# Verification

- The exact command the job runs — `rac validate rac --sarif` — exits `0` locally
  on the current corpus and emits valid SARIF (the `.rac/config.yaml` warnings-first
  downgrades keep it green), so the job passes.
- `pr-checks.yml` parses as valid YAML; the new job is independent and additive
  (lint/smoke/watchkeeper unchanged).
- `tests/test_validate_action.py` (the action contract) and `tests/test_ci_batteries.py`
  pass.

# Notes For Reviewer

- This requires GitHub **Code Scanning** to be enabled on the repo for the SARIF
  upload to surface as alerts; if it is not enabled yet, the upload step is a no-op
  warning rather than a failure.
- No package or corpus changes — workflow only.

# Implementation Process

Implemented at the maintainer's request to dogfood the validate action in RAC's
own CI; the fork-safe `upload-sarif` gating was an agent decision to avoid red
checks on fork PRs.