### PR TITLE
feat(decisiongrounding): default Voyage to voyage-4-large with input_type roles

### DIFF
--- a/decisiongrounding/README.md
+++ b/decisiongrounding/README.md
@@ -99,9 +99,15 @@ export VOYAGE_API_KEY=...           # real embeddings for naive_rag
 python -m runner.cli compare \
   --arms context_dump,naive_rag,rac \
   --answering claude \
-  --embedder voyage:voyage-3 \
+  --embedder voyage:voyage-4-large \
   --scenarios scenarios/ --seed 0
 ```
+
+`naive_rag` embeds corpus sections with Voyage's `document` role and the task
+with its `query` role, so the RAG baseline uses asymmetric query/document
+embeddings the way Voyage intends — a fair, strong baseline, not a strawman.
+The default Voyage model is `voyage-4-large` (Voyage's current flagship);
+override with `--embedder voyage:<model>`.
 
 This is where the thesis is actually tested. Until it runs on real/public-derived
 corpora, the offline crossover is plumbing, not evidence.

--- a/decisiongrounding/providers/embedding.py
+++ b/decisiongrounding/providers/embedding.py
@@ -26,13 +26,18 @@ def _tokenize(text: str) -> list[str]:
 
 
 class Embedder(ABC):
-    """Maps text to a fixed-width vector. Implementations must be deterministic."""
+    """Maps text to a fixed-width vector. Implementations must be deterministic.
+
+    `input_type` is an optional retrieval role (`"query"` or `"document"`).
+    Backends that distinguish the two (e.g. Voyage) embed them asymmetrically
+    for better retrieval; backends that do not simply ignore it.
+    """
 
     name: str = "base"
     dim: int = 0
 
     @abstractmethod
-    def embed(self, text: str) -> list[float]:
+    def embed(self, text: str, input_type: str | None = None) -> list[float]:
         ...
 
 
@@ -43,7 +48,8 @@ class LocalDeterministicEmbedder(Embedder):
         self.dim = dim
         self.name = f"local-hash-bow-{dim}"
 
-    def embed(self, text: str) -> list[float]:
+    def embed(self, text: str, input_type: str | None = None) -> list[float]:
+        # Offline bag-of-words has no notion of query vs document; ignore the role.
         vec = [0.0] * self.dim
         for tok in _tokenize(text):
             h = hashlib.blake2b(tok.encode("utf-8"), digest_size=8).digest()
@@ -76,7 +82,7 @@ class VoyageEmbedder(Embedder):
     keeps importing without the dependency.
     """
 
-    def __init__(self, model: str = "voyage-3") -> None:
+    def __init__(self, model: str = "voyage-4-large") -> None:
         self.model = model
         self.name = f"voyage:{model}"
         self._client = None
@@ -87,13 +93,18 @@ class VoyageEmbedder(Embedder):
 
             self._client = voyageai.Client()
             # Probe dimensionality once so cosine() comparisons are well-defined.
-            probe = self._client.embed(["."], model=self.model).embeddings[0]
+            probe = self._client.embed(
+                ["."], model=self.model, input_type="document"
+            ).embeddings[0]
             self.dim = len(probe)
         return self._client
 
-    def embed(self, text: str) -> list[float]:
+    def embed(self, text: str, input_type: str | None = None) -> list[float]:
         client = self._ensure_client()
-        vec = client.embed([text], model=self.model).embeddings[0]
+        # Voyage embeds queries and documents asymmetrically when told the role.
+        vec = client.embed(
+            [text], model=self.model, input_type=input_type
+        ).embeddings[0]
         return _l2_normalize(list(vec))
 
 
@@ -117,7 +128,8 @@ class SentenceTransformerEmbedder(Embedder):
             self.dim = self._model.get_sentence_embedding_dimension()
         return self._model
 
-    def embed(self, text: str) -> list[float]:
+    def embed(self, text: str, input_type: str | None = None) -> list[float]:
+        # This model does not take a query/document role; ignore input_type.
         model = self._ensure_model()
         vec = model.encode(text, normalize_embeddings=True)
         return [float(x) for x in vec]
@@ -133,7 +145,7 @@ def make_embedder(spec: str) -> Embedder:
         return LocalDeterministicEmbedder()
     if spec.startswith("voyage"):
         _, _, model = spec.partition(":")
-        return VoyageEmbedder(model or "voyage-3")
+        return VoyageEmbedder(model or "voyage-4-large")
     if spec.startswith("st"):
         _, _, model = spec.partition(":")
         return SentenceTransformerEmbedder(model or "all-MiniLM-L6-v2")

--- a/decisiongrounding/providers/naive_rag.py
+++ b/decisiongrounding/providers/naive_rag.py
@@ -9,7 +9,11 @@ section that marks a decision superseded — can fall out of the retrieved set,
 severing a relationship that whole-corpus or typed retrieval would preserve.
 
 For real runs, swap the embedder for a pinned hosted/local model via the
-`[real]` extra; the retrieval logic is unchanged.
+`[real]` extra; the retrieval logic is unchanged. Corpus sections are embedded
+with the `document` role and the task with the `query` role, so a backend that
+supports asymmetric query/document embeddings (e.g. Voyage `input_type`) is used
+the way it is meant to be — this keeps `naive_rag` a fair, strong baseline
+rather than a strawman.
 """
 
 from __future__ import annotations
@@ -65,13 +69,20 @@ class NaiveRagProvider(Provider):
         for a in corpus:
             for section in _split_sections(a.text):
                 self._chunks.append(
-                    _Chunk(a.id, a.type, section, self.embedder.embed(section))
+                    _Chunk(
+                        a.id,
+                        a.type,
+                        section,
+                        self.embedder.embed(section, input_type="document"),
+                    )
                 )
         # Grounding is task-dependent for RAG; assembled lazily in respond().
         self._grounding = GroundingContext(text="", artifacts_supplied=(), token_estimate=0)
 
     def respond(self, task: Task):
-        query = self.embedder.embed(f"{task.prompt}\n{task.proposed_action}")
+        query = self.embedder.embed(
+            f"{task.prompt}\n{task.proposed_action}", input_type="query"
+        )
         ranked = sorted(
             self._chunks, key=lambda c: cosine(query, c.vector), reverse=True
         )

--- a/decisiongrounding/pyproject.toml
+++ b/decisiongrounding/pyproject.toml
@@ -22,7 +22,7 @@ chart = ["matplotlib>=3.7"]
 # Voyage embeddings (Anthropic's recommended embedding provider — Anthropic has
 # no embeddings endpoint). Replaces the offline stubs.
 # TODO: pin exact package versions before publishing runs.
-real = ["anthropic>=0.40", "voyageai>=0.2"]
+real = ["anthropic>=0.40", "voyageai>=0.3"]
 # Local, offline-capable embeddings alternative to Voyage.
 local-embeddings = ["sentence-transformers>=2.2"]
 # The rac arm additionally needs the `rac` CLI on PATH (or RAC_BIN) — it is an

--- a/decisiongrounding/tests/test_real_backends.py
+++ b/decisiongrounding/tests/test_real_backends.py
@@ -76,9 +76,24 @@ def test_make_embedder_offline_default():
 
 def test_make_embedder_constructs_real_backends_lazily():
     # Constructing must not require the optional dependency (import is lazy).
-    e = make_embedder("voyage:voyage-3")
+    e = make_embedder("voyage:voyage-4-large")
     assert isinstance(e, VoyageEmbedder)
-    assert e.name == "voyage:voyage-3"
+    assert e.name == "voyage:voyage-4-large"
+
+
+def test_make_embedder_voyage_defaults_to_flagship():
+    # `voyage` with no model pins the current flagship.
+    e = make_embedder("voyage")
+    assert isinstance(e, VoyageEmbedder)
+    assert e.name == "voyage:voyage-4-large"
+
+
+def test_input_type_is_backward_compatible_offline():
+    # The retrieval-role argument must be accepted and ignored by backends that
+    # have no query/document distinction, so offline runs are unchanged.
+    e = LocalDeterministicEmbedder()
+    assert e.embed("hello world", input_type="query") == e.embed("hello world")
+    assert e.embed("hello world", input_type="document") == e.embed("hello world")
 
 
 def test_claude_answering_model_is_pinned():


### PR DESCRIPTION
# Summary

Upgrades the `decisiongrounding` benchmark's Voyage embedding backend to the
current flagship `voyage-4-large` and makes `naive_rag` use Voyage's asymmetric
query/document embeddings, so the RAG baseline is run the way it is meant to be
— a fair, strong baseline rather than a strawman. Offline behaviour is unchanged.

The real-backend benchmark run is intentionally **not** part of this PR; it is
held until API keys are configured in the environment. This change is verified
offline only.

# Changes

- `providers/embedding.py`: `Embedder.embed` gains an optional `input_type`
  (`"query"`/`"document"`, default `None`, backward compatible). `VoyageEmbedder`
  defaults to `voyage-4-large` and forwards `input_type` to `client.embed(...)`;
  the dim probe uses the `document` role. `LocalDeterministicEmbedder` and
  `SentenceTransformerEmbedder` accept and ignore the role.
- `providers/naive_rag.py`: embeds corpus sections with `input_type="document"`
  and the task with `input_type="query"`.
- `pyproject.toml`: `[real]` extra floor bumped `voyageai>=0.2` → `>=0.3`.
- `README.md`: real-run command points at `voyage-4-large`; documents the
  document/query roles.
- `tests/test_real_backends.py`: factory assertions updated to `voyage-4-large`,
  a default-model case added, and a test that `input_type` is accepted and
  ignored offline (retrieval stays backward compatible).

# Why input_type matters

Voyage embeds queries and documents asymmetrically when given the role, which
materially improves retrieval. Without it, `naive_rag` would be an artificially
weak baseline and a reviewer could fairly object that the RAG arm was crippled.
Threading the role removes that objection while leaving the offline spine
(which has no such distinction) untouched.

# Verification

- `cd decisiongrounding && python -m pytest -q` — 29 passed (was 27; +2 net new
  tests).
- Real clients install cleanly: `voyageai 0.4.0`, `anthropic 0.109.1`.
- `git grep voyage-3` under `decisiongrounding/` — no matches.

# Not in this PR (deliberately)

- The real-backend run (`--answering claude --embedder voyage:voyage-4-large`)
  is held pending `VOYAGE_API_KEY` / `ANTHROPIC_API_KEY` in the environment. It
  would run on the tiny synthetic scenarios — a real end-to-end check and a real
  "tie" point, **not** the N=300 real/public-corpus evidence run, which remains a
  separate increment.
- No changes to scoring, scenarios, or other arms.