### PR TITLE
feat(schema): add Achieved terminal status to the roadmap lifecycle

### DIFF
--- a/rac/decisions/adr-061-roadmap-achieved-status.md
+++ b/rac/decisions/adr-061-roadmap-achieved-status.md
@@ -1,0 +1,86 @@
+---
+schema_version: 1
+id: RAC-KV5112MVD0AM
+type: decision
+tags: [roadmap, lifecycle, knowledge-model]
+---
+# ADR-061: Roadmaps Carry an "Achieved" Terminal Lifecycle Status
+
+## Context
+
+A roadmap's `## Status` is a *knowledge-currency* lifecycle (ADR-051): is this
+thinking the current intent, or has it moved on? The original enum —
+`Planned` (current intent), `Superseded` (replaced by newer thinking),
+`Abandoned` (dropped) — has no terminal state for "this intent was delivered."
+
+The practical consequence is wrong: a roadmap whose work has shipped is stuck
+at `Planned`, which is future-tense and false once delivered. It cannot move to
+`Superseded` (its thinking was not replaced) or `Abandoned` (it was not
+dropped). Completed series therefore read as still-planned.
+
+ADR-017 ("RAC manages knowledge, not work") deliberately keeps delivery
+tracking, scheduling, and workflow states out of RAC, so adding a "shipped"
+concept needs an explicit boundary rather than a silent reversal.
+
+## Decision
+
+Add `Achieved` to the roadmap status enum as a **live terminal** state: the
+roadmap's intent has been realized and the item is now a historical record.
+
+`Achieved` is a knowledge-lifecycle marker, not work tracking. It records *what
+the knowledge is* (a realized intent), not *how work progressed* — there is no
+assignee, no progress, no scheduling, and it is set by a human at release, not
+auto-flipped by a merge. This refines ADR-017's boundary: a terminal
+"realized" lifecycle state is knowledge currency (the same category as
+`Superseded`/`Abandoned`, which already coexist with ADR-017); work-progress
+tracking remains excluded.
+
+`Achieved` is deliberately **not** a retired status (ADR-051): a delivered
+roadmap is still valid knowledge to reference, so links to it are legal and are
+not flagged as pointing at a retired target. The live state stays `Planned`;
+no `Active`/in-progress state is introduced.
+
+## Consequences
+
+Completed roadmap items can read truthfully (`Achieved`) instead of being
+stranded at `Planned`. The status vocabulary now spans the full knowledge
+lifecycle: `Planned` → `Achieved` (delivered) or `Superseded`/`Abandoned`
+(retired). The change is additive — existing `Planned` items are unaffected,
+and the `invalid-roadmap-status` validation message picks up the new value
+automatically.
+
+Trade-off: marking an item `Achieved` is a manual editorial step at release
+time. RAC does not (and per ADR-017 will not) flip it automatically on merge;
+the delivery event itself stays in Git history.
+
+## Status
+
+Accepted
+
+## Category
+
+Architecture
+
+## Alternatives Considered
+
+- **Keep completed items at `Planned`; read delivery from Git.** The status
+  quo. Rejected: it leaves `Planned` reading as false on shipped work, which is
+  the problem being solved.
+- **Reuse `Superseded` for delivered items.** Rejected: `Superseded` means the
+  thinking was replaced by newer thinking, which is not what delivery means;
+  it would also (incorrectly) mark the item retired, breaking inbound links.
+- **Add a full work-state machine (in-progress, in-review, done).** Rejected:
+  that is exactly the work tracking ADR-017 excludes. A single terminal
+  knowledge state is the minimal, in-scope change.
+- **Auto-set `Achieved` from a merge hook.** Rejected: merge-triggered status
+  automation is workflow tooling; the status is authored knowledge, set at
+  release by a human.
+
+## Related Decisions
+
+- adr-017
+- adr-051
+
+## Related Roadmaps
+
+- v0.19.0-roadmap-achieved-status

--- a/rac/roadmaps/v0.19.x-lifecycle/v0.19.0-roadmap-achieved-status.md
+++ b/rac/roadmaps/v0.19.x-lifecycle/v0.19.0-roadmap-achieved-status.md
@@ -1,0 +1,62 @@
+---
+schema_version: 1
+id: RAC-KV5113Q1YCVK
+type: roadmap
+---
+# RAC v0.19.0 — Roadmap "Achieved" Lifecycle Status
+
+## Status
+
+Planned
+
+## Outcomes
+
+Roadmap status reads truthfully across the whole knowledge lifecycle. A
+delivered roadmap can be marked as realized rather than being stranded at
+`Planned`, so a reader can tell current intent from delivered intent from
+retired intent at a glance — without consulting Git or release notes to
+discover that a "Planned" item actually shipped long ago.
+
+The change stays inside RAC's remit (ADR-017): status remains a knowledge
+lifecycle, not a work tracker. The new terminal state records that an intent
+was realized; it does not introduce progress, assignment, or scheduling, and it
+is authored by a human at release rather than driven by a merge.
+
+## Initiatives
+
+- **Add an `Achieved` terminal status to the roadmap `ArtifactSpec`** as a live
+  (non-retired) state, so links to a delivered roadmap remain valid. The
+  validation message and `rac schema roadmap` pick it up automatically.
+- **Record the boundary as a decision** (ADR-061) that refines ADR-017: a
+  terminal "realized" knowledge-lifecycle marker is in scope; work-progress
+  tracking remains out.
+- **Cover the behavior**: `Achieved` validates, and a live artifact referencing
+  an achieved roadmap is not flagged as pointing at a retired target.
+
+## Success Measures
+
+- `rac schema roadmap` lists `Achieved` among the allowed status values.
+- A roadmap with `## Status: Achieved` validates cleanly, and references to it
+  pass `rac relationships --validate` with no retired-target finding.
+- Existing `Planned` items are unaffected; the corpus gates stay green.
+
+## Assumptions
+
+- Marking an item `Achieved` is a manual editorial step at release time;
+  RAC does not flip it automatically (ADR-017).
+- The existing lifecycle/retired-status mechanism (ADR-051) is the right seam:
+  `Achieved` is simply a permitted status that is absent from `retired_status`.
+
+## Risks
+
+- Treating `Achieved` as retired would silently break inbound links to
+  delivered roadmaps; mitigated by keeping it out of `retired_status` and
+  testing the reference path explicitly.
+- Scope creep toward work tracking; mitigated by ADR-061's explicit boundary
+  and by adding exactly one terminal knowledge state, nothing more.
+
+## Related Decisions
+
+- ADR-061
+- ADR-017
+- ADR-051

--- a/src/rac/core/artifacts.py
+++ b/src/rac/core/artifacts.py
@@ -234,10 +234,14 @@ ARTIFACT_SPECS: tuple[ArtifactSpec, ...] = (
             "related designs",
             "related roadmaps",
         ),
-        # Lifecycle status (ADR-051): Planned is the live state; Superseded /
-        # Abandoned mark replaced or dropped *intent* — knowledge states, not
-        # delivery tracking (ADR-017). Per-milestone progress stays out.
-        metadata={"status": ("Planned", "Superseded", "Abandoned")},
+        # Lifecycle status (ADR-051, ADR-061): Planned is the live state and
+        # Achieved is the live terminal state (the intent was delivered, so the
+        # item is now a realized record — still valid to reference, not retired).
+        # Superseded / Abandoned mark replaced or dropped *intent*. All four are
+        # knowledge states, not delivery tracking (ADR-017): a terminal "the
+        # intent was realized" marker set at release is knowledge currency, while
+        # per-milestone work progress stays out.
+        metadata={"status": ("Planned", "Achieved", "Superseded", "Abandoned")},
         retired_status=("Superseded", "Abandoned"),
         descriptions={
             "outcomes": "The user, business, or operational outcomes this roadmap pursues",

--- a/tests/test_lifecycle_status.py
+++ b/tests/test_lifecycle_status.py
@@ -34,6 +34,11 @@ def test_valid_status_passes_per_type():
     assert "invalid-design-status" not in codes(DESIGN.format(s="Superseded"))
 
 
+def test_roadmap_achieved_is_a_valid_terminal_status():
+    # ADR-061: Achieved is the live terminal state for a delivered roadmap.
+    assert "invalid-roadmap-status" not in codes(ROADMAP.format(s="Achieved"))
+
+
 def test_out_of_enum_status_fails_per_type():
     # roadmap has no Accepted; prompt has no Proposed — each is out of enum.
     assert "invalid-requirement-status" in codes(REQUIREMENT.format(s="Done"))

--- a/tests/test_relationship_validation.py
+++ b/tests/test_relationship_validation.py
@@ -376,6 +376,20 @@ def test_deprecated_target_is_reported(tmp_path):
     assert [i.code for i in report.issues] == [ISSUE_TARGET_SUPERSEDED]
 
 
+def test_reference_to_achieved_roadmap_is_not_retired(tmp_path):
+    # ADR-061: Achieved is a live terminal state (a delivered roadmap), so a
+    # live artifact may reference it without a retired-target finding.
+    (tmp_path / "v1.md").write_text(
+        _ROADMAP.format(t="One") + "\n## Status\n\nAchieved\n", encoding="utf-8"
+    )
+    (tmp_path / "adr-001.md").write_text(
+        _decision("Live", "Accepted", "\n## Related Roadmaps\n\n- v1\n"), encoding="utf-8"
+    )
+    report = validate_relationships(str(tmp_path))
+    assert report.ok
+    assert ISSUE_TARGET_SUPERSEDED not in [i.code for i in report.issues]
+
+
 def test_retired_source_reference_is_exempt(tmp_path):
     # A retired decision referencing another retired decision is a historical
     # chain, not live knowledge pointing at dead knowledge — not flagged.

--- a/tests/test_roadmap.py
+++ b/tests/test_roadmap.py
@@ -51,11 +51,13 @@ def test_requirement_does_not_classify_as_roadmap():
 
 
 def test_roadmap_carries_lifecycle_status():
-    # ADR-051: status is a knowledge lifecycle (Planned/Superseded/Abandoned),
-    # never work/delivery state; no category or supersedes metadata.
+    # ADR-051/ADR-061: status is a knowledge lifecycle (Planned, Achieved,
+    # Superseded, Abandoned), never work/delivery state; no category or
+    # supersedes metadata. Achieved is a live terminal state (delivered intent),
+    # so it is deliberately NOT in retired_status.
     spec = spec_for("roadmap")
     assert spec is not None
-    assert spec.metadata == {"status": ("Planned", "Superseded", "Abandoned")}
+    assert spec.metadata == {"status": ("Planned", "Achieved", "Superseded", "Abandoned")}
     assert spec.retired_status == ("Superseded", "Abandoned")
 
 


### PR DESCRIPTION
# Summary

Implements `rac/roadmaps/v0.19.x-lifecycle/v0.19.0-roadmap-achieved-status.md`.

Roadmap status is a knowledge-currency lifecycle (ADR-051), but it had no terminal state for "this intent was delivered" — so a shipped roadmap was stranded at `Planned`, which reads as false. This adds a fourth status, **`Achieved`**: the live terminal state for a delivered roadmap.

Adds:
- `Achieved` to the roadmap `ArtifactSpec` status enum, as a **live (non-retired)** state.
- ADR-061 recording the decision and refining ADR-017's knowledge-vs-work boundary.
- A versioned roadmap item (`v0.19.0`, new `v0.19.x-lifecycle` series).
- Validation + relationship coverage for the new state.

# Roadmap / ADR Trace

Roadmap:
- `rac/roadmaps/v0.19.x-lifecycle/v0.19.0-roadmap-achieved-status.md`

Relevant ADRs:
- `rac/decisions/adr-061-roadmap-achieved-status.md` (new) — the decision
- ADR-017 (RAC manages knowledge, not work) — refined, not reversed
- ADR-051 (generalized lifecycle status / retired-target mechanism) — the seam used

# Scope

## Included
- **`Achieved` status** (`src/rac/core/artifacts.py`): roadmap `metadata["status"]` becomes `("Planned", "Achieved", "Superseded", "Abandoned")`. `retired_status` stays `("Superseded", "Abandoned")` — `Achieved` is a *live* terminal state, so links to a delivered roadmap remain legal. The `invalid-roadmap-status` message and `rac schema roadmap` pick up the value automatically.
- **Tests**: enum-contract update in `tests/test_roadmap.py`; `Achieved` validates in `tests/test_lifecycle_status.py`; a boundary test in `tests/test_relationship_validation.py` that a live artifact referencing an `Achieved` roadmap is not flagged as a retired target.
- **Corpus**: ADR-061 + the v0.19.0 roadmap item, cross-linked.

## Excluded
- **No back-filling** of existing completed roadmap items to `Achieved` (separate editorial pass).
- **No `Active`/in-progress state** — `Planned` stays the live state; only the terminal `Achieved` is added.
- **No merge-triggered automation.** Per ADR-017, status is authored by a human at release; RAC does not flip it on merge. The delivery event stays in Git history.
- **No full work-state machine** (in-progress/in-review/done) — that is the work tracking ADR-017 excludes.

# Product / Architecture Decisions

- **`Achieved` is knowledge currency, not work tracking** (ADR-061). It records *what the knowledge is* (a realized intent), not *how work progressed*. This refines ADR-017's boundary rather than reversing it: a terminal "realized" lifecycle state is the same category as the existing `Superseded`/`Abandoned`, which already coexist with ADR-017.
- **`Achieved` is deliberately not retired** (ADR-051): a delivered roadmap is still valid knowledge to reference, so it is absent from `retired_status` and inbound links stay legal.
- **ADR numbering**: this branch is cut from `main` (latest ADR `adr-058`); `adr-059`/`adr-060` are reserved for the open engine-simplification PR (#100), so this decision is `adr-061` to avoid a collision when both merge.

# User-Facing Contract

## CLI
`rac schema roadmap` now lists `Status: Planned | Achieved | Superseded | Abandoned`. No command, flag, or exit code changes.

## Human / JSON Output
A roadmap with `## Status: Achieved` is now valid where it previously raised `invalid-roadmap-status`. This is the one intended behavior change. No output shape changes.

## Exit Codes
Unchanged (`0` success, `1` validation/relationship errors, `2` usage/IO).

# Verification

## Ran
- `python -m pytest -q` → **1300 passed** (1298 + 2 new tests)
- `python -m ruff check src/ tests/`, `python -m ruff format --check src/ tests/`, `python -m mypy src/` → all clean
- `rac schema roadmap` → shows `Achieved`
- `rac validate rac/` (185 valid, 0 invalid), `rac relationships rac/ --validate` (714 checked, 0 issues), `rac review rac/` (0 invalid, 0 broken)

## Covered
- Positive: a roadmap with `## Status: Achieved` validates (no `invalid-roadmap-status`).
- Boundary: a live artifact referencing an `Achieved` roadmap is **not** flagged as pointing at a retired target (Achieved is live).
- Contract: the roadmap spec enum and `retired_status` assertions updated to encode the new lifecycle.
- Negative (unchanged): an out-of-enum value like `Accepted` still fails for roadmaps.

# Review Path

1. `src/rac/core/artifacts.py` — the roadmap status enum + the comment explaining `Achieved` as a live terminal state (and why it stays out of `retired_status`).
2. `rac/decisions/adr-061-roadmap-achieved-status.md` — the boundary against ADR-017.
3. `tests/test_roadmap.py`, `tests/test_lifecycle_status.py`, `tests/test_relationship_validation.py` — contract + behavior coverage.
4. `rac/roadmaps/v0.19.x-lifecycle/v0.19.0-roadmap-achieved-status.md` — the roadmap trace.

# Notes For Reviewer

- The single behavior change is that `Achieved` is now an accepted roadmap status; everything else is additive (docs/tests).
- This is intentionally separate from PR #100 (engine simplification), which is behavior-preserving — a validation-behavior change does not belong there.
- Adopting `Achieved` for already-shipped items is a follow-up editorial pass, deliberately not done here.

# Implementation Process

Implemented with AI assistance under the roadmap contract; final scope, review, and acceptance decisions are the maintainer's.