### PR TITLE
chore(ci): bump GitHub Actions to Node 24 runtime

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,8 +22,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Install MkDocs

--- a/.github/workflows/lore-web-build.yml
+++ b/.github/workflows/lore-web-build.yml
@@ -25,9 +25,9 @@ jobs:
       run:
         working-directory: lore-web
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: npm
@@ -56,7 +56,7 @@ jobs:
 
       # Upload only — no deploy (GATE-1).
       - name: Upload site artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: lore-web-dist
           path: lore-web/dist/

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -20,11 +20,11 @@ jobs:
     name: lint (ruff + mypy)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -46,11 +46,11 @@ jobs:
     name: smoke (core + golden + dogfood, py3.11)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -76,7 +76,7 @@ jobs:
     name: watchkeeper (dogfood, source install)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -97,7 +97,7 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -26,13 +26,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           # setuptools-scm derives the version from git tags, so we need the
           # full history + tags (the default shallow checkout omits them).
           fetch-depth: 0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
 
@@ -43,7 +43,7 @@ jobs:
           python -m build
 
       - name: Upload distributions
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: release-dists
           path: dist/
@@ -69,7 +69,7 @@ jobs:
 
     steps:
       - name: Retrieve release distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: release-dists
           path: dist/

--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -41,13 +41,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           # setuptools-scm derives the version from git tags, so we need the
           # full history + tags (the default shallow checkout omits them).
           fetch-depth: 0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
 
@@ -60,7 +60,7 @@ jobs:
           python -m build
 
       - name: Upload distributions
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: testpypi-dists
           path: dist/
@@ -79,7 +79,7 @@ jobs:
 
     steps:
       - name: Retrieve release distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: testpypi-dists
           path: dist/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,11 +22,11 @@ jobs:
     name: lint (ruff + mypy)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -118,13 +118,13 @@ jobs:
           - name: golden
             paths: "tests/test_golden.py"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           # setuptools-scm derives the version from git tags; fetch them so the
           # editable install can resolve a version (mirrors python-publish.yml).
           fetch-depth: 0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -145,11 +145,11 @@ jobs:
     name: coverage (py3.11, report-only)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 

--- a/.github/workflows/watchkeeper.yml
+++ b/.github/workflows/watchkeeper.yml
@@ -51,7 +51,7 @@ jobs:
     name: watchkeeper
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           # The comparison needs the base revision's history, and a
           # source-mode install needs git metadata for setuptools-scm.


### PR DESCRIPTION
## Why

GitHub is deprecating the Node.js 20 runtime for Actions: runners force Node 24 by default from **2026-06-16** and remove Node 20 entirely on **2026-09-16**. CI currently emits the *"Node.js 20 actions are deprecated"* warning for `actions/checkout@v4` and `actions/setup-python@v5`, and the artifact / `setup-node` actions on Node 20 would be flagged next.

This moves every first-party Node action to a major version whose default runtime is `node24`, keeping the existing floating major-tag pinning style.

## Changes

| Action | From → To | Workflows |
|---|---|---|
| `actions/checkout` | v4 → **v5** | all |
| `actions/setup-python` | v5 → **v6** | tests, pr-checks, docs, python-publish, test-publish |
| `actions/setup-node` | v4 → **v5** | lore-web-build |
| `actions/upload-artifact` | v4 → **v6** | lore-web-build, python-publish, test-publish |
| `actions/download-artifact` | v4 → **v7** | python-publish, test-publish |

## Deliberately unchanged

- **GitHub Pages trio** — `configure-pages@v5`, `upload-pages-artifact@v3`, `deploy-pages@v4` are already on GitHub's recommended latest-major tags, which receive the Node 24 update in place.
- **`pypa/gh-action-pypi-publish@release/v1`** — a Docker action, unaffected by the Node runtime change.
- **Local actions** (`./`, `./validate-action`, `tcballard/requirements-as-code@main`) — the project's own composite/Docker actions.

## Verification

- `grep` confirms zero Node 20 first-party action references remain.
- All 7 workflows parse as valid YAML.
- Final check: confirm the "Node.js 20 actions are deprecated" annotation no longer appears on this PR's CI run.