### PR TITLE
docs(release): cut v0.19.0 release notes — the "kitchen sink" release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,26 @@ details, release history over commit history.
 
 ## Unreleased
 
+## v0.19.0 — 2026-06-15
+
+The kitchen-sink release. Everything since v0.7.3 lands at once. Over this
+stretch RAC grew from a requirements validator into a product-knowledge
+system: the Explorer TUI, canonical frontmatter identity and opaque IDs, the
+relationship graph and its integrity checks, repository intelligence
+(`rac portfolio`, `rac watchkeeper`), the Portal and OKF interop exports,
+per-type standards enforcement, and a GitHub Action that brings all of it to
+pull requests. This entry collects the whole arc into one formal release — the
+individual `(vX.Y.Z)` markers below trace where each capability landed.
+
 ### Added
+
+- Roadmap "Achieved" lifecycle status (v0.19.0): a roadmap whose scope has
+  shipped can declare `## Status: Achieved`, a validated *live terminal* state
+  (ADR-061) — the intent was delivered, so the roadmap reads as done without
+  being treated as retired, and inbound references to it are not flagged as
+  pointing at a superseded target. `rac schema roadmap` lists it among the
+  allowed statuses; the roadmap enum is now Planned / Achieved / Superseded /
+  Abandoned.
 
 - Validate GitHub Action (v0.17.2): a composite action
   (`tcballard/requirements-as-code/validate-action@<ref>`) runs
@@ -447,8 +466,6 @@ details, release history over commit history.
 - `rac portfolio --json` now lists `artifacts.unknown_paths` (additive).
 - `rac index` — flat artifact inventory (id, type, title, path) for tools and
   agents (v0.7.5).
-
-### Changed
 
 - Documentation restructured around task-focused guides under `docs/`
   (quickstart, CLI reference, artifacts, relationships, repository workflow,


### PR DESCRIPTION
## Summary

Dates the long-accumulated `Unreleased` changelog into one formal release,
**v0.19.0 — 2026-06-15**, the "kitchen sink" release that collects everything
since the last dated entry (v0.7.3). Over this stretch RAC grew from a
requirements validator into a product-knowledge system.

This PR is **release notes only** — no code changes. The `v0.19.0` git tag (cut
on merge) is what bumps the package version; the latest tag was `v0.10.6` while
`main` is 209 commits ahead.

## What changed in `CHANGELOG.md`

- Renamed the `Unreleased` block to `## v0.19.0 — 2026-06-15` with a one-paragraph
  kitchen-sink intro, in the tone of the existing dated entries; left a fresh
  empty `Unreleased` on top.
- Added the missing **roadmap "Achieved" live-terminal status** entry
  (ADR-061) — it had landed on `main` but was absent from the changelog.
- Merged two duplicate `### Changed` blocks into one.

The v0.18 engine-simplification refactor is deliberately omitted — internal, no
user-visible change, per the changelog's "user impact over implementation" rule.

## Highlights bundled into this release

Explorer TUI · canonical frontmatter identity + opaque IDs · relationship graph
& integrity checks · repository intelligence (`rac portfolio`, `rac watchkeeper`)
· Portal (HTML) and OKF interop exports · per-type standards enforcement
(ISO 29148 / EARS / BCP-14) · validation severity overrides + SARIF · the
`rac validate` GitHub Action.

## Gates

- `rac validate rac/` → exit 0 (188/188 valid, OKF v0.1 conformant)
- `rac relationships rac/ --validate` → exit 0 (723 checked, 0 issues)
- `rac review rac/` → exit 0 (no priority 1–2; health 89/100)