### PR TITLE
feat(sdk): Python SDK foundation and close the validate gate leak [roadmap:v0.20.0]

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,7 +56,7 @@ jobs:
         # enforced by tests/test_ci_batteries.py in the core battery.
         battery:
           - name: core
-            paths: "tests/test_validate.py tests/test_okf_conformance.py tests/test_overrides.py tests/test_requirement_standards.py tests/test_sarif.py tests/test_parser.py tests/test_schema.py tests/test_identity.py tests/test_frontmatter.py tests/test_metadata_identity.py tests/test_idgen.py tests/test_ci_batteries.py tests/test_corpus.py tests/test_operations.py"
+            paths: "tests/test_validate.py tests/test_okf_conformance.py tests/test_overrides.py tests/test_requirement_standards.py tests/test_sarif.py tests/test_parser.py tests/test_schema.py tests/test_identity.py tests/test_frontmatter.py tests/test_metadata_identity.py tests/test_idgen.py tests/test_ci_batteries.py tests/test_corpus.py tests/test_operations.py tests/test_sdk_surface.py"
           - name: cli
             paths: "tests/test_cli.py"
           - name: compare

--- a/rac/decisions/adr-062-python-sdk-public-surface.md
+++ b/rac/decisions/adr-062-python-sdk-public-surface.md
@@ -1,0 +1,107 @@
+---
+schema_version: 1
+id: RAC-KV5DJYE5FGH0
+type: decision
+tags: [sdk, api, architecture, packaging]
+---
+# ADR-062: The Python SDK's Public Surface Is `rac.__all__`
+
+## Context
+
+RAC has always been "agent-ready architecture" (ADR-008): pure analysis lives
+in `rac.core`, reusable capabilities behind the service gate in `rac.services`,
+and thin interfaces (CLI, MCP, Explorer) on top, with "easy SDK support" named
+as an explicit goal. ADR-015 reinforces this — build the consumer-facing service
+first, then point the interface at it.
+
+The capability to consume RAC as a library already exists: services return typed
+dataclasses with a stable `to_dict()` JSON contract (ADR-007), and the package
+ships src-layout with optional `explorer` / `ingest*` extras. What was missing is
+a *sealed, discoverable* surface. Before this decision, `import rac` exposed only
+`__version__`; a programmatic consumer had to deep-import private module paths
+(`from rac.services.review import build_review`), every service exception
+inherited `Exception` directly with no common root, and nothing said which names
+were public and stable versus internal and free to change.
+
+Two distinct questions had to be answered: *what is the public API* (so consumers
+and maintainers share one boundary), and *how stable is it* (what a consumer may
+rely on). The first is decidable now; the second depends on what a future `1.0`
+will mean, which is not yet settled.
+
+## Decision
+
+The RAC Python SDK's public surface is exactly the set of names exported in
+`rac.__all__`. Three rules pin it:
+
+1. **One flat namespace.** Everything a consumer is expected to use is importable
+   directly from the top-level package — `from rac import build_review,
+   validate_directory, RACError`. `rac.services.__all__` mirrors the
+   service-layer subset. Anything not listed in `rac.__all__` (modules under
+   `rac.core`, `rac.cli`, the output renderers, helper functions) is internal and
+   may change without notice.
+
+2. **One exception root.** Every error a public SDK function raises derives from
+   `rac.errors.RACError`, so a consumer can catch the whole family with a single
+   `except RACError`. Concrete subclasses keep their names and messages and live
+   beside the service that raises them; new service errors inherit from `RACError`
+   rather than `Exception`.
+
+3. **Additive results.** SDK result objects keep the `to_dict()` JSON contract and
+   evolve additively under ADR-007 — fields are added, never removed or
+   repurposed, and `schema_version` gates any breaking shape change.
+
+The meaning of `1.0` — whether it freezes the surface, and whether semantic
+versioning then governs breaking changes — is **explicitly deferred** and is not
+decided here. Until then RAC is pre-1.0: breaking changes to `rac.__all__` are
+permitted but must be called out in the release that makes them. This ADR
+establishes *what the public surface is*, not a stability pledge over it.
+
+## Consequences
+
+Consumers get a single, documented import boundary and one exception to catch;
+maintainers get a clear line between public and internal, so refactors inside
+`rac.core` or a service's private helpers are free as long as `rac.__all__` and
+the result contracts hold. The exception re-rooting is mechanical and backward
+compatible — `RACError` is an `Exception` subclass, so existing `except` clauses
+that name a concrete error keep working.
+
+Trade-offs: re-exporting the service surface at the top level makes `import rac`
+import the service tree eagerly (a small import-time cost, acceptable for a
+library), and the public list is now a maintained artifact — adding a capability
+means deciding, deliberately, whether it belongs in `rac.__all__`. Leaving `1.0`
+semantics open is itself a trade-off: consumers cannot yet assume a frozen API,
+which is the honest position for a pre-1.0 project and avoids a premature pledge.
+
+## Status
+
+Accepted
+
+## Category
+
+Architecture
+
+## Alternatives Considered
+
+- **Leave consumers to deep-import private module paths.** The status quo.
+  Rejected: it couples consumers to internal layout, so no refactor is safe and
+  there is no public/internal boundary at all.
+- **Export every service function and result class.** Rejected: a maximal surface
+  is as hard to keep stable as no boundary — the public list should be the
+  curated capabilities a consumer needs, not the entire service tree.
+- **Pledge semver and freeze the API now (declare 1.0).** Rejected: RAC is pre-1.0
+  and still evolving its artifact families; committing to a frozen surface before
+  the SDK has real consumers would force either churn or stagnation. The pledge is
+  deferred to whenever `1.0` is defined.
+- **Keep exceptions rooted at `Exception`.** Rejected: without a common root a
+  consumer must import and enumerate every service's exception types to handle
+  RAC failures generically, which defeats a usable SDK.
+
+## Related Decisions
+
+- adr-007
+- adr-008
+- adr-015
+
+## Related Roadmaps
+
+- v0.20.0-python-sdk-foundation

--- a/rac/designs/python-sdk-surface.md
+++ b/rac/designs/python-sdk-surface.md
@@ -1,0 +1,169 @@
+---
+schema_version: 1
+id: RAC-KV5DJX7Q5BTQ
+type: design
+tags: [sdk, api, packaging, architecture]
+---
+# Design: Python SDK Public Surface
+
+## Context
+
+RAC's layered architecture (ADR-008, ADR-015) already separates pure analysis
+(`rac.core`) from reusable capabilities behind the service gate (`rac.services`)
+from thin interfaces (CLI, MCP, Explorer). Everything an SDK needs exists —
+typed dataclass results with `to_dict()` JSON contracts (ADR-007), src-layout
+packaging, optional `explorer` / `ingest*` extras — but there is no public
+*surface*: `import rac` exposes only `__version__`, service exceptions have no
+common root, and nothing marks public versus internal.
+
+ADR-062 fixes the boundary (the public surface is `rac.__all__`; one exception
+root; additive results; `1.0` semantics deferred). This design is the *how*: the
+concrete symbol list, the exception hierarchy, and the extras mapping the
+foundation release (v0.20.0) implements.
+
+## User Need
+
+A Python author embedding RAC — a CI script, an internal tool, an editor
+integration, an agent runtime — needs to:
+
+- import RAC capabilities from one obvious place, not deep private module paths;
+- catch RAC failures with a single `except`, without enumerating every service's
+  exception types;
+- read results programmatically with a contract that will not silently break;
+- know which names are stable to depend on and which are internal.
+
+The need is *library ergonomics*, not new analysis behaviour: the SDK re-exposes
+existing services, it does not compute anything the CLI does not already.
+
+## Design
+
+### 1. Flat public namespace (`rac.__all__`)
+
+The top-level package re-exports a curated set, grouped by purpose. `import rac`
+imports the service tree eagerly (accepted in ADR-062). The set:
+
+- **Core authoring primitives:** `Product`, `Issue`, `parse`, `parse_file`,
+  `classify`, `validate`, `has_errors` — Markdown ↔ Product AST.
+- **Validation services:** `validate_product` (single parsed artifact, with
+  repository severity overrides), `validate_directory` (a corpus),
+  `validate_relationships`.
+- **Portfolio / repository intelligence:** `collect_stats`, `build_review`,
+  `build_portfolio_summary`, `build_repository_index`, `summarize_relationships`,
+  `build_relationship_report`, `relationships_from_corpus`, `artifact_recency`,
+  `build_watchkeeper_report`.
+- **Lookup:** `resolve_artifact`, `find_artifacts`.
+- **Authoring / lifecycle:** `create_artifact` (+ `CreatedArtifact`),
+  `quickstart`, `init_repository`, `improve_product`, `build_inspection`,
+  `inspect_directory`, `ingest`, `diff_artifacts`, `migrate_metadata`,
+  `build_corpus_export`.
+- **Errors:** `RACError`.
+
+`rac.services.__all__` mirrors the service-layer subset, so
+`from rac.services import build_review` is equally valid; `from rac import
+build_review` is the canonical form. The `diff` service is re-exported as
+`diff_artifacts` to avoid a too-generic top-level name.
+
+Curation principle: export the capabilities a consumer drives, not every public
+function in the service tree. Internal helpers (`report_from_corpus`,
+`index_from_corpus`, the `*_from_corpus` snapshot variants) stay reachable by
+explicit module import but are out of `__all__` — internal, free to change.
+
+### 2. Exception hierarchy rooted at `RACError`
+
+`rac/errors.py` owns a single base, `class RACError(Exception)`. Every
+service/core exception that can propagate out of a public function re-roots under
+it, keeping its own name, message, and module home:
+
+| Module | Exceptions |
+| --- | --- |
+| `services.create` | `OutputPathExists`, `OutputDirectoryMissing`, `MissingRepositoryConfig`, `IdGenerationExhausted` |
+| `services.ingest` | `ConversionError`, `UnsupportedDocument` (already chains `ConversionError`) |
+| `services.init` | `InvalidRepositoryKey`, `RepositoryKeyConflict`, `MalformedRepositoryConfig` |
+| `services.quickstart` | `CorpusNotEmpty` |
+| `services.hook` | `NotAGitWorkTree`, `HookFileExists` |
+| `services.skill` | `SkillFileExists` |
+| `services.revisions` | `NotAGitRepository`, `RevisionNotFound` |
+| `core.templates` | `TemplateNotFound`, `TemplateResourceMissing` |
+| `core.skills` | `SkillNotFound`, `SkillResourceMissing` |
+| `core.hooks` | `HookNotFound`, `HookResourceMissing` |
+| `core.operations` | `OperationCancelled` |
+| `explorer.launch` | `ExplorerUnavailable` |
+| `output.portal` | `PortalShellMissing`, `PortalSeamMissing` |
+
+`rac.errors` imports nothing from `rac`, so re-rooting introduces no import
+cycle. The change is backward compatible: `RACError` is an `Exception`, so
+existing `except ConcreteError` clauses are unaffected and `except RACError`
+becomes the generic catch.
+
+### 3. Extras mapping
+
+The SDK keeps the core install light and gates heavy dependencies behind extras,
+matching the lazy-import discipline already in the codebase:
+
+| Install | Pulls | Powers |
+| --- | --- | --- |
+| `requirements-as-code` (core) | `markdown-it-py`, `pyyaml`, `mcp` | parse/validate/stats/review/relationships/resolve/index/portfolio, MCP |
+| `[explorer]` | `textual>=1.0` | `rac.explorer` TUI; `ExplorerUnavailable` if absent |
+| `[ingest]` / `[ingest-pdf]` / `[ingest-office]` / `[ingest-all]` | `markitdown[...]` | `ingest` converters; `UnsupportedDocument` if the needed extra is absent |
+
+`ingest` and the explorer launcher import their heavy dependency lazily inside
+the call path, so `import rac` succeeds on a core-only install and a missing
+extra surfaces as a typed `RACError` subclass with an install hint, never an
+`ImportError` traceback.
+
+## Constraints
+
+- Additive only (ADR-007): result `to_dict()` contracts gain fields, never lose
+  or repurpose them; `schema_version` gates breaking shape changes.
+- No import cycles: `rac.errors` depends on nothing in `rac`; the top-level
+  re-exports pull only from `rac.core`, `rac.services`, and `rac.errors`.
+- Pre-1.0 (ADR-062): the surface may change between minor versions, called out in
+  release notes; no frozen-API pledge until `1.0` is defined.
+- The SDK adds no new analysis — it re-exposes existing services; behaviour
+  parity with the CLI is a requirement, not a goal.
+
+## Rationale
+
+A single flat namespace plus one exception root is the smallest change that turns
+an internally-layered codebase into a usable library, and it costs almost
+nothing because the services already exist and already return typed results. The
+curated (not maximal) export list keeps the stable surface small enough to
+maintain, while explicit module imports remain available for the internal
+helpers power users occasionally need. Re-rooting exceptions is mechanical and
+backward compatible, so it buys generic error handling at no migration cost.
+
+## Alternatives
+
+- **Generated `__all__` from a registry.** Rejected: the public surface is an
+  editorial decision, not a mechanical one; an explicit hand-maintained list is
+  the artifact that records intent.
+- **A separate `rac-sdk` distribution.** Rejected: the SDK is the same code as
+  the CLI behind the same gate; a second package would duplicate packaging and
+  diverge. One distribution, one surface.
+- **Export result classes for every service.** Rejected: consumers can use
+  results via duck typing and `to_dict()`; exporting only the most-annotated
+  types keeps the surface lean. More can be added additively if demand appears.
+
+## Accessibility
+
+Not applicable — this is a code-level API surface with no user-facing UI. Docs
+(v0.20.1) follow the repository's existing readable-prose conventions.
+
+## Style Guidance
+
+- Public functions keep verb-first names (`build_*`, `validate_*`, `collect_*`)
+  consistent with the existing service vocabulary.
+- Exception names stay noun phrases describing the condition
+  (`OutputPathExists`, `CorpusNotEmpty`).
+- Docstrings on `rac/__init__.py`, `rac/errors.py`, and `rac/services/__init__.py`
+  state the public-surface contract so the boundary is discoverable from the code.
+
+## Open Questions
+
+- What `1.0` freezes, and whether semver then governs the surface (deferred by
+  ADR-062) — decided when the `1.x` line is defined.
+- Whether more result dataclasses (e.g. `DirectoryValidation`, `PortfolioStats`)
+  should join `__all__` for type-annotation convenience; added additively if
+  consumers ask.
+- Whether a typed `py.typed` marker and published stubs are needed for downstream
+  type-checking (likely yes; scoped with the v0.20.1 docs work).

--- a/rac/roadmaps/future/v1.4-python-sdk.md
+++ b/rac/roadmaps/future/v1.4-python-sdk.md
@@ -1,5 +1,0 @@
-Goal:
-from rac import validate
-from rac import stats
-from rac import inspect
-for programmatic use.

--- a/rac/roadmaps/v0.20.x-sdk/v0.20.0-python-sdk-foundation.md
+++ b/rac/roadmaps/v0.20.x-sdk/v0.20.0-python-sdk-foundation.md
@@ -1,0 +1,179 @@
+---
+schema_version: 1
+id: RAC-KV5DJTVFT6CD
+type: roadmap
+tags: [sdk, api, packaging]
+---
+# RAC v0.20.0 — Python SDK Foundation
+
+## Status
+
+Planned
+
+## Context
+
+RAC is built as "agent-ready architecture" (ADR-008): pure analysis in
+`rac.core`, reusable capabilities behind the service gate in `rac.services`,
+thin interfaces on top, with "easy SDK support" a stated goal. ADR-015 reinforces
+the order — build the consumer-facing service, then point the interface at it.
+
+The capability to use RAC as a library is already present: services return typed
+dataclasses with stable `to_dict()` JSON contracts (ADR-007), and the package
+ships src-layout with optional extras. What is missing is a *public surface*.
+`import rac` exposes only `__version__`; a programmatic consumer must deep-import
+private paths (`from rac.services.review import build_review`); every service
+exception inherits `Exception` directly with no common root; and nothing marks
+which names are public and stable.
+
+An audit also found the service gate leaking in one place: single-file
+`rac validate` reimplements, inline in the CLI, the exact
+validate + classify + override composition that directory validation already
+performs behind the gate (ADR-015). The fix produces `validate_product()` — which
+is precisely the SDK's `from rac import validate_product` — so the gate
+correction and the SDK foundation are the same work and land together here.
+
+ADR-062 records the surface boundary; the `python-sdk-surface` design records the
+concrete symbol list, exception hierarchy, and extras mapping. This milestone
+implements them.
+
+## Outcomes
+
+- A Python author can `from rac import validate_directory, build_review,
+  collect_stats, RACError` and drive RAC's analysis without touching private
+  module paths.
+- Every error a public function raises can be caught with one
+  `except rac.RACError`; concrete exception types keep their names and messages.
+- The single-file `rac validate` path computes nothing the gate does not — its
+  validate/override composition lives in one service function shared by the CLI
+  and the SDK, so interface and library never drift (ADR-015).
+- `rac stats`'s success logic moves behind the gate onto the stats result model;
+  the CLI only reads it.
+- The public surface is documented in code (`rac.__all__`,
+  `rac.services.__all__`, `rac.errors.RACError`) so the public/internal boundary
+  is discoverable.
+
+## Initiatives
+
+### Initiative 1 — Close the single-file validate gate leak
+
+Add `validate_product(product, start=".")` to `rac.services.validate`, wrapping
+the `validate()` + `classify()` + `apply_overrides()` + `load_overrides()`
+composition that single-file `rac validate` performed inline. It mirrors the
+existing `validate_directory()` / `validate_corpus()` pair. The CLI's
+`cmd_validate` calls the one service function; single-file and directory
+validation now share one composition.
+
+### Initiative 2 — Move stats success logic behind the gate
+
+Add a `has_meaningful_content` property to the portfolio stats result model
+(sibling to `is_empty`), capturing "at least one valid analysable artifact." The
+CLI's `cmd_stats` reads `stats.has_meaningful_content or stats.is_empty` instead
+of recomputing the rule inline.
+
+### Initiative 3 — Exception hierarchy rooted at `RACError`
+
+A new `rac/errors.py` owns `class RACError(Exception)`. Every service/core
+exception that can propagate out of a public function re-roots under it (keeping
+name, message, and module home), per the table in the `python-sdk-surface`
+design. `rac.errors` imports nothing from `rac`, so there is no import cycle, and
+the change is backward compatible.
+
+### Initiative 4 — Flat public namespace
+
+`rac/__init__.py` gains `__all__` and re-exports the curated public set (core
+authoring primitives, validation, portfolio intelligence, lookup, authoring, and
+`RACError`). `rac/services/__init__.py` mirrors the service-layer subset. The
+`diff` service is exported as `diff_artifacts`. Each `__init__` and `errors.py`
+carries a docstring stating the public-surface contract.
+
+## Constraints
+
+- Additive and backward compatible (ADR-007): no result field is removed or
+  repurposed; re-rooting exceptions under `RACError` (an `Exception` subclass)
+  does not break existing `except` clauses.
+- No behaviour change at the interfaces: CLI exit codes, JSON contracts, and
+  output for validate and stats are identical for every non-trivial input;
+  single-file and directory validation produce the same issues for the same
+  artifact as before.
+- No new import cycles: `rac.errors` depends on nothing in `rac`; top-level
+  re-exports pull only from `rac.core`, `rac.services`, and `rac.errors`.
+- Pre-1.0 (ADR-062): the surface may evolve in later minors; no frozen-API pledge.
+
+## Non-Goals
+
+- SDK documentation, quickstart, examples, and a published API reference — those
+  are v0.20.1.
+- A `py.typed` marker / published type stubs — scoped with the docs work.
+- New analysis behaviour: the SDK re-exposes existing services only.
+- Moving the display-only `score_artifacts(product)` call in `rac inspect` behind
+  a service. It has no state or exit-code impact and is verbose-output
+  presentation; it stays in the CLI deliberately.
+- A `--strict` flag for `rac stats` (the non-empty all-invalid failure remains
+  where v0.13.1 left it).
+- Defining what `1.0` freezes or pledging semver (deferred by ADR-062).
+
+## Implementation Contract
+
+The following are pinned for v0.20.0.
+
+### Services
+
+- `rac.services.validate.validate_product(product, start=".") -> list[Issue]`
+  applies repository severity overrides loaded from `start`.
+- The portfolio stats model gains `has_meaningful_content -> bool`.
+
+### Public surface
+
+- `rac.__all__` lists the curated public names; every listed name is importable
+  from `rac`.
+- `rac.services.__all__` lists the service-layer subset.
+- `rac.errors.RACError` is the base of every exception a public function raises.
+
+### Interfaces
+
+- `rac validate <file>` and `rac validate -` produce byte-identical human and
+  JSON output and exit codes to the prior release for the same input.
+- `rac stats` exit codes are unchanged (empty corpus exits 0 per v0.13.1;
+  non-empty all-invalid still fails).
+
+## Success Measures
+
+- `from rac import validate_directory, validate_product, RACError` works, and
+  every name in `rac.__all__` is importable from `rac` — asserted by tests.
+- A concrete service error (e.g. `OutputPathExists`, `TemplateNotFound`) is
+  catchable as `RACError` — asserted by tests.
+- Single-file and directory validation return identical issues for the same
+  artifact — asserted by tests.
+- `has_meaningful_content` is true/false as specified across empty, valid, and
+  all-invalid corpora — asserted by tests.
+- `rac validate rac/` and `rac relationships rac/ --validate` exit 0; the full
+  suite passes.
+
+## Risks
+
+- Re-exporting the service tree makes `import rac` import more eagerly, a small
+  import-time cost. Mitigated: heavy extras (`ingest`, `explorer`) import lazily,
+  so core-only installs still `import rac` cleanly.
+- Broad exception re-rooting touches many modules. Mitigated: each change is a
+  one-line base swap plus an import; `RACError` subclasses `Exception`, so
+  existing handlers are unaffected, and tests assert catchability.
+- A maintained public list can drift from what is actually exported. Mitigated: a
+  test asserts every `__all__` name resolves on the package.
+
+## Assumptions
+
+- The service result `to_dict()` contracts are already stable enough (ADR-007) to
+  be the SDK's machine-readable surface without rework.
+- Curating the export set (rather than exporting everything) is acceptable; more
+  names can be added additively if consumers need them.
+
+## Related Decisions
+
+- adr-007
+- adr-008
+- adr-015
+- adr-062
+
+## Related Roadmaps
+
+- v0.20.1-python-sdk-docs

--- a/rac/roadmaps/v0.20.x-sdk/v0.20.1-python-sdk-docs.md
+++ b/rac/roadmaps/v0.20.x-sdk/v0.20.1-python-sdk-docs.md
@@ -1,0 +1,120 @@
+---
+schema_version: 1
+id: RAC-KV5DJW21AVHB
+type: roadmap
+tags: [sdk, docs]
+---
+# RAC v0.20.1 — Python SDK Documentation & Examples
+
+## Status
+
+Planned
+
+## Context
+
+v0.20.0 ships the Python SDK's public surface — a flat `rac.__all__` namespace,
+the `rac.errors.RACError` hierarchy, and behaviour parity with the CLI (ADR-062,
+`python-sdk-surface` design). A surface without documentation is undiscoverable:
+a consumer cannot tell which names to import, what each returns, or how to handle
+errors without reading source. This milestone makes the SDK *usable from the
+README and docs*, not just importable.
+
+It also closes the typing gap: a published `py.typed` marker lets downstream
+type-checkers see RAC's annotations, which the foundation release deferred.
+
+## Outcomes
+
+- A new author can go from `pip install requirements-as-code` to a working script
+  using the README's "Python SDK" section alone — import, call, read the result,
+  handle a `RACError`.
+- The public surface has an API reference enumerating each exported name, its
+  purpose, and its result type, kept honest against `rac.__all__`.
+- Worked examples cover the common consumer tasks: validate a corpus, search and
+  resolve artifacts, produce a portfolio/review summary, create an artifact.
+- Downstream type-checkers see RAC's types via a `py.typed` marker.
+- The extras story (`explorer`, `ingest*`) is documented so consumers install the
+  right dependency for the capability they need.
+
+## Initiatives
+
+### Initiative 1 — README "Python SDK" section
+
+A top-level README section showing the canonical import form
+(`from rac import ...`), a minimal end-to-end example, and the
+`except RACError` pattern, linking to the fuller reference.
+
+### Initiative 2 — API reference for `rac.__all__`
+
+A reference page listing every exported name grouped as in the design (core
+primitives, validation, portfolio intelligence, lookup, authoring, errors), each
+with its signature, one-line purpose, and result type. Kept honest against
+`rac.__all__` so it cannot silently drift.
+
+### Initiative 3 — Worked examples
+
+Three to five runnable snippets for the common tasks (validate a repo, search +
+resolve, build a review/portfolio summary, create an artifact, catch an error),
+usable as copy-paste starting points.
+
+### Initiative 4 — `py.typed` and extras guide
+
+Ship the `py.typed` marker so RAC's annotations are visible to consumers'
+type-checkers, and document the extras-to-capability mapping from the design.
+
+## Constraints
+
+- Documentation and packaging metadata only — no change to the public surface or
+  any service behaviour. If a doc need exposes a surface gap, that is a separate,
+  explicitly-scoped change, not folded in here.
+- Examples must run against the shipped SDK exactly as written (no private
+  imports, no undocumented names).
+- The API reference reflects `rac.__all__` as the single source of truth.
+
+## Non-Goals
+
+- Changing or expanding `rac.__all__` (foundation's surface stands; additions are
+  their own scoped change).
+- A hosted documentation site or generated doc tooling beyond what the repo
+  already uses (docs-site scoping is tracked separately).
+- Defining `1.0` / a stability pledge (deferred by ADR-062).
+
+## Implementation Contract
+
+- README gains a "Python SDK" section with a runnable end-to-end example and the
+  `except RACError` pattern.
+- An API reference enumerates every name in `rac.__all__` with purpose and result
+  type.
+- A `py.typed` marker is included in the distribution.
+- The extras-to-capability mapping is documented.
+
+## Success Measures
+
+- Every example in the docs runs as written against the installed package —
+  asserted by a doctest-style or example-execution test.
+- The API reference covers exactly the names in `rac.__all__` (no missing, no
+  extra) — asserted by a test comparing the reference to `rac.__all__`.
+- A type-checker run over a small consumer script sees RAC's types (no
+  "missing stubs" error) once `py.typed` ships.
+
+## Risks
+
+- Examples rot as the surface evolves. Mitigated: examples are executed in CI and
+  the reference is checked against `rac.__all__`, so drift fails the build.
+- Shipping `py.typed` advertises type completeness RAC may not fully have.
+  Mitigated: the marker is honest about existing annotations; gaps are fixed
+  incrementally and are not a regression for untyped consumers.
+
+## Assumptions
+
+- v0.20.0 has shipped the public surface, so the docs describe a stable-for-the-
+  minor API rather than a moving target.
+- The repository's existing docs conventions are sufficient; no new docs platform
+  is required for this milestone.
+
+## Related Decisions
+
+- adr-062
+
+## Related Roadmaps
+
+- v0.20.0-python-sdk-foundation

--- a/rac/roadmaps/v0.20.x-sdk/v0.20.1-python-sdk-docs.md
+++ b/rac/roadmaps/v0.20.x-sdk/v0.20.1-python-sdk-docs.md
@@ -17,7 +17,9 @@ the `rac.errors.RACError` hierarchy, and behaviour parity with the CLI (ADR-062,
 `python-sdk-surface` design). A surface without documentation is undiscoverable:
 a consumer cannot tell which names to import, what each returns, or how to handle
 errors without reading source. This milestone makes the SDK *usable from the
-README and docs*, not just importable.
+README and docs*, not just importable, and proves external consumability with a
+standalone example sub-project (mirroring the `decisiongrounding/` benchmark)
+that depends on `requirements-as-code` as a real package.
 
 It also closes the typing gap: a published `py.typed` marker lets downstream
 type-checkers see RAC's annotations, which the foundation release deferred.
@@ -29,8 +31,10 @@ type-checkers see RAC's annotations, which the foundation release deferred.
   handle a `RACError`.
 - The public surface has an API reference enumerating each exported name, its
   purpose, and its result type, kept honest against `rac.__all__`.
-- Worked examples cover the common consumer tasks: validate a corpus, search and
-  resolve artifacts, produce a portfolio/review summary, create an artifact.
+- Worked examples cover the common consumer tasks (validate a corpus, search and
+  resolve artifacts, produce a portfolio/review summary, create an artifact) and
+  live in a standalone sub-project that depends on the published package, so they
+  exercise the SDK as an outside consumer and can graduate to their own repo.
 - Downstream type-checkers see RAC's types via a `py.typed` marker.
 - The extras story (`explorer`, `ingest*`) is documented so consumers install the
   right dependency for the capability they need.
@@ -50,11 +54,22 @@ primitives, validation, portfolio intelligence, lookup, authoring, errors), each
 with its signature, one-line purpose, and result type. Kept honest against
 `rac.__all__` so it cannot silently drift.
 
-### Initiative 3 — Worked examples
+### Initiative 3 — Worked examples as a standalone consumer sub-project
 
-Three to five runnable snippets for the common tasks (validate a repo, search +
-resolve, build a review/portfolio summary, create an artifact, catch an error),
-usable as copy-paste starting points.
+The worked examples live as a self-contained sub-project in the monorepo,
+mirroring the `decisiongrounding/` benchmark: its own `pyproject.toml`, README,
+LICENSE, Makefile, and `tests/`, structured so it can graduate into its own
+repository later without rework. Unlike `decisiongrounding` (which treats `rac`
+as an external CLI on PATH), this sub-project declares `requirements-as-code` as
+a real Python dependency and consumes the SDK exactly as an external user would
+— the strongest proof the public surface is usable from outside the source tree.
+
+It holds three to five runnable examples covering the common consumer tasks
+(validate a corpus, search + resolve, build a review/portfolio summary, create
+an artifact, catch a `RACError`), led by a custom CI-gate example (fail a build
+on invalid artifacts, broken relationships, or a sub-threshold health score).
+The directory name is provisional (e.g. `sdk-examples/`); the README's "Python
+SDK" section links into it.
 
 ### Initiative 4 — `py.typed` and extras guide
 
@@ -63,11 +78,14 @@ type-checkers, and document the extras-to-capability mapping from the design.
 
 ## Constraints
 
-- Documentation and packaging metadata only — no change to the public surface or
-  any service behaviour. If a doc need exposes a surface gap, that is a separate,
-  explicitly-scoped change, not folded in here.
+- Documentation, the example sub-project, and packaging metadata only — no change
+  to the public surface or any service behaviour. If a doc or example exposes a
+  surface gap, that is a separate, explicitly-scoped change, not folded in here.
 - Examples must run against the shipped SDK exactly as written (no private
-  imports, no undocumented names).
+  imports, no undocumented names) and depend on `requirements-as-code` as an
+  external package, never on the source tree's internal layout.
+- The example sub-project is self-contained (own `pyproject.toml`, README,
+  LICENSE, tests) so it can be lifted into its own repository without edits.
 - The API reference reflects `rac.__all__` as the single source of truth.
 
 ## Non-Goals
@@ -76,12 +94,17 @@ type-checkers, and document the extras-to-capability mapping from the design.
   their own scoped change).
 - A hosted documentation site or generated doc tooling beyond what the repo
   already uses (docs-site scoping is tracked separately).
+- Actually extracting the example sub-project into its own published repository.
+  It is built liftable here; the split itself is a later, separate step.
 - Defining `1.0` / a stability pledge (deferred by ADR-062).
 
 ## Implementation Contract
 
+- A standalone example sub-project (decisiongrounding-style: own `pyproject.toml`
+  depending on `requirements-as-code`, README, LICENSE, Makefile, `tests/`) ships
+  the worked examples, led by the custom CI-gate example.
 - README gains a "Python SDK" section with a runnable end-to-end example and the
-  `except RACError` pattern.
+  `except RACError` pattern, linking into the example sub-project.
 - An API reference enumerates every name in `rac.__all__` with purpose and result
   type.
 - A `py.typed` marker is included in the distribution.
@@ -89,8 +112,8 @@ type-checkers, and document the extras-to-capability mapping from the design.
 
 ## Success Measures
 
-- Every example in the docs runs as written against the installed package —
-  asserted by a doctest-style or example-execution test.
+- The example sub-project installs against the published package and its own
+  `tests/` pass in CI, proving the examples run as written for an outside consumer.
 - The API reference covers exactly the names in `rac.__all__` (no missing, no
   extra) — asserted by a test comparing the reference to `rac.__all__`.
 - A type-checker run over a small consumer script sees RAC's types (no
@@ -98,8 +121,12 @@ type-checkers, and document the extras-to-capability mapping from the design.
 
 ## Risks
 
-- Examples rot as the surface evolves. Mitigated: examples are executed in CI and
-  the reference is checked against `rac.__all__`, so drift fails the build.
+- Examples rot as the surface evolves. Mitigated: the example sub-project's own
+  `tests/` run in CI and the reference is checked against `rac.__all__`, so drift
+  fails the build.
+- A self-contained sub-project duplicates packaging scaffolding inside the
+  monorepo. Accepted: this is the established `decisiongrounding/` pattern and is
+  the cost of keeping the examples liftable into their own repo.
 - Shipping `py.typed` advertises type completeness RAC may not fully have.
   Mitigated: the marker is honest about existing annotations; gaps are fixed
   incrementally and are not a regression for untyped consumers.

--- a/src/rac/__init__.py
+++ b/src/rac/__init__.py
@@ -1,11 +1,60 @@
 """RAC — Requirements As Code.
 
-A small CLI for linting and diffing product requirements written in Markdown.
-Markdown is the source format; the Product AST (see :mod:`rac.core.models`) is the
-internal model that validation and diffing operate on.
+A small CLI *and* Python SDK for linting, diffing, and reasoning about
+product-management artifacts written in Markdown. Markdown is the source format;
+the Product AST (see :mod:`rac.core.models`) is the internal model that
+validation and diffing operate on.
+
+The names exported here are the SDK's public surface (ADR-062): everything in
+:data:`__all__` is importable directly from ``rac`` —
+
+    from rac import validate_directory, collect_stats, RACError
+
+    result = validate_directory("rac/")
+    if not result.ok:
+        ...
+
+Every error a public function raises derives from :class:`rac.errors.RACError`,
+so one ``except RACError`` catches the whole family. Result objects expose a
+stable ``to_dict()`` JSON contract (ADR-007). Anything not listed in
+:data:`__all__` (modules under :mod:`rac.core`, ``rac.cli``, output renderers)
+is internal and may change without notice.
 """
 
 from importlib.metadata import PackageNotFoundError, version
+
+from rac.core.classification import classify
+from rac.core.markdown import parse, parse_file
+from rac.core.models import Issue, Product
+from rac.core.validation import has_errors, validate
+from rac.errors import RACError
+from rac.services import (
+    CreatedArtifact,
+    artifact_recency,
+    build_corpus_export,
+    build_inspection,
+    build_portfolio_summary,
+    build_relationship_report,
+    build_repository_index,
+    build_review,
+    build_watchkeeper_report,
+    collect_stats,
+    create_artifact,
+    diff_artifacts,
+    find_artifacts,
+    improve_product,
+    ingest,
+    init_repository,
+    inspect_directory,
+    migrate_metadata,
+    quickstart,
+    relationships_from_corpus,
+    resolve_artifact,
+    summarize_relationships,
+    validate_directory,
+    validate_product,
+    validate_relationships,
+)
 
 try:
     # Single source of truth: the version declared in pyproject.toml and
@@ -13,3 +62,46 @@ try:
     __version__ = version("requirements-as-code")
 except PackageNotFoundError:  # running from a source tree that isn't installed
     __version__ = "0.0.0+unknown"
+
+__all__ = [
+    "__version__",
+    # Errors — the root every RAC exception derives from (ADR-062).
+    "RACError",
+    # Core authoring primitives (Markdown ↔ Product AST).
+    "Product",
+    "Issue",
+    "parse",
+    "parse_file",
+    "classify",
+    "validate",
+    "has_errors",
+    # Validation services.
+    "validate_product",
+    "validate_directory",
+    "validate_relationships",
+    # Portfolio / repository intelligence.
+    "collect_stats",
+    "build_review",
+    "build_portfolio_summary",
+    "build_repository_index",
+    "summarize_relationships",
+    "build_relationship_report",
+    "relationships_from_corpus",
+    "artifact_recency",
+    "build_watchkeeper_report",
+    # Lookup.
+    "resolve_artifact",
+    "find_artifacts",
+    # Authoring / lifecycle.
+    "create_artifact",
+    "CreatedArtifact",
+    "quickstart",
+    "init_repository",
+    "improve_product",
+    "build_inspection",
+    "inspect_directory",
+    "ingest",
+    "diff_artifacts",
+    "migrate_metadata",
+    "build_corpus_export",
+]

--- a/src/rac/cli.py
+++ b/src/rac/cli.py
@@ -75,7 +75,7 @@ from pathlib import Path
 
 from rac import consent
 from rac import output as outputs
-from rac.core.classification import classify, score_artifacts
+from rac.core.classification import score_artifacts
 from rac.core.hooks import (
     DEFAULT_STYLE,
     HookNotFound,
@@ -85,7 +85,6 @@ from rac.core.hooks import (
 )
 from rac.core.markdown import parse, parse_file
 from rac.core.models import Product
-from rac.core.overrides import apply_overrides
 from rac.core.schema import available_schemas, schema_reference
 from rac.core.skills import SkillNotFound, SkillResourceMissing, skill_specs
 from rac.core.templates import (
@@ -93,7 +92,7 @@ from rac.core.templates import (
     TemplateResourceMissing,
     available_templates,
 )
-from rac.core.validation import has_errors, validate
+from rac.core.validation import has_errors
 from rac.output.portal import PortalSeamMissing, PortalShellMissing
 from rac.services.create import (
     IdGenerationExhausted,
@@ -114,7 +113,6 @@ from rac.services.init import (
     MalformedRepositoryConfig,
     RepositoryKeyConflict,
     init_repository,
-    load_overrides,
 )
 from rac.services.inspect import build_inspection, inspect_directory
 from rac.services.migrate import migrate_metadata
@@ -137,7 +135,7 @@ from rac.services.review import DEFAULT_STALE_AFTER_DAYS, build_review
 from rac.services.revisions import NotAGitRepository, RevisionNotFound
 from rac.services.skill import SkillFileExists, install_skills
 from rac.services.stats import collect_stats
-from rac.services.validate import validate_directory
+from rac.services.validate import validate_directory, validate_product
 from rac.services.watchkeeper import build_watchkeeper_report
 
 from . import __version__
@@ -188,7 +186,7 @@ def cmd_validate(args: argparse.Namespace) -> int:
 
     product = _read_validate_input(args.file)
     start = "." if args.file == "-" else str(Path(args.file).parent)
-    issues = apply_overrides(validate(product), classify(product).type, load_overrides(start))
+    issues = validate_product(product, start)
     if args.json:
         print(outputs.render_validation_json(product, issues))
     else:
@@ -216,22 +214,14 @@ def cmd_stats(args: argparse.Namespace) -> int:
         print(outputs.render_stats_json(stats))
     else:
         print(outputs.render_stats_human(stats))
-    # Success as long as the portfolio has analysable content: at least one valid
-    # feature, one decision, one valid roadmap, one valid prompt, or one valid
-    # design. Invalid files are reported but don't fail the run on their own. (A
-    # future --strict flag will fail the run if *any* file is invalid, for CI use.)
-    has_content = (
-        stats.valid_features > 0
-        or stats.decision_count > 0
-        or stats.valid_roadmaps > 0
-        or stats.valid_prompts > 0
-        or stats.valid_designs > 0
-    )
-    # An empty corpus is a valid day-one state, not a failure (v0.13.1): it
-    # exits 0, matching validate/review/portfolio. The "files exist but none are
-    # valid known artifacts" failure is preserved for a non-empty corpus, and
-    # will move behind a future --strict flag.
-    return EXIT_OK if (has_content or stats.is_empty) else EXIT_VALIDATION_FAILED
+    # Success as long as the portfolio has analysable content (at least one valid
+    # feature/decision/roadmap/prompt/design) or is an empty day-one corpus.
+    # `has_meaningful_content` and `is_empty` are computed behind the gate
+    # (ADR-015); the CLI only reads them. An empty corpus is a valid state, not a
+    # failure (v0.13.1): it exits 0, matching validate/review/portfolio. The
+    # "files exist but none are valid known artifacts" failure is preserved for a
+    # non-empty corpus, and will move behind a future --strict flag for CI use.
+    return EXIT_OK if (stats.has_meaningful_content or stats.is_empty) else EXIT_VALIDATION_FAILED
 
 
 def cmd_ingest(args: argparse.Namespace) -> int:

--- a/src/rac/core/hooks.py
+++ b/src/rac/core/hooks.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from importlib import resources
 
+from rac.errors import RACError
+
 
 @dataclass(frozen=True)
 class HookSpec:
@@ -43,7 +45,7 @@ BUNDLED_HOOKS = (
 DEFAULT_STYLE = BUNDLED_HOOKS[0].style
 
 
-class HookNotFound(Exception):
+class HookNotFound(RACError):
     """The requested hook style is not in the bundled registry (usage error)."""
 
     def __init__(self, style: str):
@@ -51,7 +53,7 @@ class HookNotFound(Exception):
         super().__init__(f"unknown hook style: {style} (available: {', '.join(available_hooks())})")
 
 
-class HookResourceMissing(Exception):
+class HookResourceMissing(RACError):
     """A registered hook's packaged resource is absent (operational error)."""
 
     def __init__(self, style: str):

--- a/src/rac/core/operations.py
+++ b/src/rac/core/operations.py
@@ -16,6 +16,8 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Protocol
 
+from rac.errors import RACError
+
 
 @dataclass(frozen=True)
 class Progress:
@@ -32,7 +34,7 @@ class Progress:
 ProgressCallback = Callable[[Progress], None]
 
 
-class OperationCancelled(Exception):
+class OperationCancelled(RACError):
     """Raised when an operation observes a cancelled token at a checkpoint."""
 
 

--- a/src/rac/core/skills.py
+++ b/src/rac/core/skills.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from importlib import resources
 
+from rac.errors import RACError
+
 
 @dataclass(frozen=True)
 class SkillSpec:
@@ -50,7 +52,7 @@ BUNDLED_SKILLS = (
 )
 
 
-class SkillNotFound(Exception):
+class SkillNotFound(RACError):
     """The requested skill is not in the bundled registry (usage error)."""
 
     def __init__(self, skill_name: str):
@@ -60,7 +62,7 @@ class SkillNotFound(Exception):
         )
 
 
-class SkillResourceMissing(Exception):
+class SkillResourceMissing(RACError):
     """A registered skill's packaged resource is absent (operational error)."""
 
     def __init__(self, skill_name: str):

--- a/src/rac/core/templates.py
+++ b/src/rac/core/templates.py
@@ -18,9 +18,10 @@ from __future__ import annotations
 from importlib import resources
 
 from rac.core.artifacts import ARTIFACT_SPECS
+from rac.errors import RACError
 
 
-class TemplateNotFound(Exception):
+class TemplateNotFound(RACError):
     """The requested artifact type has no canonical template (usage error)."""
 
     def __init__(self, artifact_type: str):
@@ -31,7 +32,7 @@ class TemplateNotFound(Exception):
         )
 
 
-class TemplateResourceMissing(Exception):
+class TemplateResourceMissing(RACError):
     """A registered type's packaged template is absent (operational error)."""
 
     def __init__(self, artifact_type: str):

--- a/src/rac/errors.py
+++ b/src/rac/errors.py
@@ -1,0 +1,21 @@
+"""Exception hierarchy for the RAC Python SDK.
+
+Every error raised by a public RAC service derives from :class:`RACError`, so an
+SDK consumer can catch the whole family with a single ``except rac.RACError``
+without importing each service's exception module (ADR-062). The concrete
+subclasses keep their own names and messages and live next to the service that
+raises them; this module only owns the shared root.
+"""
+
+from __future__ import annotations
+
+
+class RACError(Exception):
+    """Base class for every error a RAC service raises.
+
+    Catch this to handle any RAC failure generically; catch a concrete subclass
+    (for example :class:`rac.services.create.OutputPathExists`) to handle a
+    specific condition. The hierarchy is part of the SDK's public surface, so new
+    service errors are expected to inherit from it rather than from
+    :class:`Exception` directly.
+    """

--- a/src/rac/explorer/launch.py
+++ b/src/rac/explorer/launch.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from rac.errors import RACError
+
 if TYPE_CHECKING:  # pragma: no cover — typing only, never at runtime
     from rac.explorer.app import ExplorerApp
 
@@ -18,7 +20,7 @@ MISSING_EXTRA_HINT = (
 )
 
 
-class ExplorerUnavailable(Exception):
+class ExplorerUnavailable(RACError):
     """The Explorer cannot start because the ``explorer`` extra is missing."""
 
 

--- a/src/rac/output/portal.py
+++ b/src/rac/output/portal.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 from importlib import resources
 
+from rac.errors import RACError
 from rac.services.export import CorpusExport
 
 from .json import render_export_json
@@ -36,7 +37,7 @@ from .json import render_export_json
 _SEAM = '<script type="application/json" id="lore-export"></script>'
 
 
-class PortalShellMissing(Exception):
+class PortalShellMissing(RACError):
     """The packaged Portal shell is absent (broken installation)."""
 
     def __init__(self) -> None:
@@ -46,7 +47,7 @@ class PortalShellMissing(Exception):
         )
 
 
-class PortalSeamMissing(Exception):
+class PortalSeamMissing(RACError):
     """The packaged shell lacks its single empty data seam (corrupt vendoring)."""
 
     def __init__(self) -> None:

--- a/src/rac/services/__init__.py
+++ b/src/rac/services/__init__.py
@@ -5,4 +5,61 @@ operations, portfolio/repository intelligence, ingestion, and diffing. Services
 provide stable APIs consumed by the CLI, Explorer, tests, and future
 integrations (ADR-008, ADR-015). They depend on :mod:`rac.core`, never on the
 CLI or output layers.
+
+The names re-exported here are the SDK's service surface (ADR-062): a consumer
+imports them flat — ``from rac.services import build_review`` — instead of
+reaching into individual modules. The top-level :mod:`rac` package re-exports
+the same set, so ``from rac import build_review`` is the canonical form.
 """
+
+from rac.services.create import CreatedArtifact, create_artifact
+from rac.services.diff import diff as diff_artifacts
+from rac.services.export import build_corpus_export
+from rac.services.improve import improve_product
+from rac.services.index import build_repository_index
+from rac.services.ingest import ingest
+from rac.services.init import init_repository
+from rac.services.inspect import build_inspection, inspect_directory
+from rac.services.migrate import migrate_metadata
+from rac.services.portfolio import build_portfolio_summary
+from rac.services.quickstart import quickstart
+from rac.services.recency import artifact_recency
+from rac.services.relationships import (
+    build_relationship_report,
+    relationships_from_corpus,
+    summarize_relationships,
+    validate_relationships,
+)
+from rac.services.resolve import find_artifacts, resolve_artifact
+from rac.services.review import build_review
+from rac.services.stats import collect_stats
+from rac.services.validate import validate_directory, validate_product
+from rac.services.watchkeeper import build_watchkeeper_report
+
+__all__ = [
+    "CreatedArtifact",
+    "create_artifact",
+    "diff_artifacts",
+    "build_corpus_export",
+    "improve_product",
+    "build_repository_index",
+    "ingest",
+    "init_repository",
+    "build_inspection",
+    "inspect_directory",
+    "migrate_metadata",
+    "build_portfolio_summary",
+    "quickstart",
+    "artifact_recency",
+    "build_relationship_report",
+    "relationships_from_corpus",
+    "summarize_relationships",
+    "validate_relationships",
+    "find_artifacts",
+    "resolve_artifact",
+    "build_review",
+    "collect_stats",
+    "validate_directory",
+    "validate_product",
+    "build_watchkeeper_report",
+]

--- a/src/rac/services/create.py
+++ b/src/rac/services/create.py
@@ -32,6 +32,7 @@ from pathlib import Path
 
 from rac.core.idgen import generate_id
 from rac.core.templates import load_template
+from rac.errors import RACError
 from rac.services.index import build_repository_index
 from rac.services.init import load_repository_config
 
@@ -41,7 +42,7 @@ from rac.services.init import load_repository_config
 _MAX_ID_ATTEMPTS = 5
 
 
-class OutputPathExists(Exception):
+class OutputPathExists(RACError):
     """The requested output path already exists; RAC never overwrites it."""
 
     def __init__(self, path: str):
@@ -49,7 +50,7 @@ class OutputPathExists(Exception):
         super().__init__(f"{path} already exists; rac new never overwrites")
 
 
-class OutputDirectoryMissing(Exception):
+class OutputDirectoryMissing(RACError):
     """The output path's parent directory does not exist (no auto-create)."""
 
     def __init__(self, path: str):
@@ -57,7 +58,7 @@ class OutputDirectoryMissing(Exception):
         super().__init__(f"directory does not exist: {path}")
 
 
-class MissingRepositoryConfig(Exception):
+class MissingRepositoryConfig(RACError):
     """No repository identity namespace is established (run `rac init`)."""
 
     def __init__(self, start_dir: str):
@@ -68,7 +69,7 @@ class MissingRepositoryConfig(Exception):
         )
 
 
-class IdGenerationExhausted(Exception):
+class IdGenerationExhausted(RACError):
     """Repeated ID collisions — the entropy source is not behaving."""
 
     def __init__(self, attempts: int):

--- a/src/rac/services/hook.py
+++ b/src/rac/services/hook.py
@@ -22,9 +22,10 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from rac.core.hooks import DEFAULT_STYLE, HookNotFound, available_hooks, load_hook
+from rac.errors import RACError
 
 
-class NotAGitWorkTree(Exception):
+class NotAGitWorkTree(RACError):
     """The target directory has no ``.git`` directory (usage error)."""
 
     def __init__(self, directory: str):
@@ -34,7 +35,7 @@ class NotAGitWorkTree(Exception):
         )
 
 
-class HookFileExists(Exception):
+class HookFileExists(RACError):
     """A target hook file already exists; RAC never overwrites it."""
 
     def __init__(self, path: str):

--- a/src/rac/services/ingest.py
+++ b/src/rac/services/ingest.py
@@ -17,8 +17,10 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Protocol, runtime_checkable
 
+from rac.errors import RACError
 
-class ConversionError(Exception):
+
+class ConversionError(RACError):
     """A document was recognized but could not be converted."""
 
 

--- a/src/rac/services/init.py
+++ b/src/rac/services/init.py
@@ -21,6 +21,7 @@ from pathlib import Path
 import yaml
 
 from rac.core.overrides import EMPTY, RULE_VALUES, TYPE_VALUES, SeverityOverrides
+from rac.errors import RACError
 
 # Repository key contract (v0.7.11): uppercase alphanumeric, leading letter,
 # 2-10 characters. The key is the human-recognizable ID prefix, e.g. RAC.
@@ -31,7 +32,7 @@ CONFIG_DIR = ".rac"
 CONFIG_FILE = "config.yaml"
 
 
-class InvalidRepositoryKey(Exception):
+class InvalidRepositoryKey(RACError):
     """The requested repository key fails the syntax contract (usage error)."""
 
     def __init__(self, key: str):
@@ -42,7 +43,7 @@ class InvalidRepositoryKey(Exception):
         )
 
 
-class RepositoryKeyConflict(Exception):
+class RepositoryKeyConflict(RACError):
     """An established repository key differs from the requested one."""
 
     def __init__(self, existing: str, requested: str, config_path: str):
@@ -56,7 +57,7 @@ class RepositoryKeyConflict(Exception):
         )
 
 
-class MalformedRepositoryConfig(Exception):
+class MalformedRepositoryConfig(RACError):
     """An existing configuration file cannot be read (operational error)."""
 
     def __init__(self, config_path: str, reason: str):

--- a/src/rac/services/quickstart.py
+++ b/src/rac/services/quickstart.py
@@ -33,6 +33,7 @@ from pathlib import Path
 
 from rac.core.idgen import generate_id
 from rac.core.templates import load_template
+from rac.errors import RACError
 from rac.services.create import CreatedArtifact, create_artifact
 from rac.services.index import build_repository_index
 from rac.services.init import DEFAULT_KEY, init_repository
@@ -40,7 +41,7 @@ from rac.services.init import DEFAULT_KEY, init_repository
 DEFAULT_TYPE = "requirement"
 
 
-class CorpusNotEmpty(Exception):
+class CorpusNotEmpty(RACError):
     """The corpus already holds a recognised artifact; quickstart refuses.
 
     Onboarding writes a starter artifact only into an empty corpus (ADR-044);

--- a/src/rac/services/revisions.py
+++ b/src/rac/services/revisions.py
@@ -21,12 +21,14 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
 
+from rac.errors import RACError
 
-class NotAGitRepository(Exception):
+
+class NotAGitRepository(RACError):
     """The directory is not inside a git work tree (or git is unavailable)."""
 
 
-class RevisionNotFound(Exception):
+class RevisionNotFound(RACError):
     """The named revision does not resolve to a commit."""
 
 

--- a/src/rac/services/skill.py
+++ b/src/rac/services/skill.py
@@ -26,9 +26,10 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from rac.core.skills import SkillNotFound, available_skills, load_skill
+from rac.errors import RACError
 
 
-class SkillFileExists(Exception):
+class SkillFileExists(RACError):
     """A target skill file already exists; RAC never overwrites it.
 
     For a no-name install every existing target is collected and reported

--- a/src/rac/services/stats.py
+++ b/src/rac/services/stats.py
@@ -276,6 +276,24 @@ class PortfolioStats:
         """True on a day-one corpus: no recognized or unrecognized artifacts."""
         return self.total_artifacts == 0 and self.unrecognized_count == 0
 
+    @property
+    def has_meaningful_content(self) -> bool:
+        """True when the portfolio holds at least one *valid* analysable artifact.
+
+        Distinct from :attr:`is_empty`: a corpus of only invalid files is neither
+        empty nor meaningful. ``rac stats`` exits OK when this is true *or* the
+        corpus is empty — a day-one corpus is a valid state, not a failure
+        (v0.13.1). The "files exist but none are valid known artifacts" failure is
+        preserved for a non-empty corpus.
+        """
+        return (
+            self.valid_features > 0
+            or self.decision_count > 0
+            or self.valid_roadmaps > 0
+            or self.valid_prompts > 0
+            or self.valid_designs > 0
+        )
+
 
 def _bucket(decisions: list[DecisionStat], attr: str, metadata_key: str) -> dict[str, int]:
     """Count ``decisions`` by ``attr`` in the artifact spec's declared order."""

--- a/src/rac/services/validate.py
+++ b/src/rac/services/validate.py
@@ -15,8 +15,9 @@ from __future__ import annotations
 from dataclasses import asdict, dataclass
 
 from rac.core.artifacts import spec_for
+from rac.core.classification import classify
 from rac.core.corpus import CorpusEntry, walk_corpus
-from rac.core.models import Issue
+from rac.core.models import Issue, Product
 from rac.core.overrides import SeverityOverrides, apply_overrides
 from rac.core.validation import has_errors, validate
 
@@ -104,6 +105,19 @@ class DirectoryValidation:
         if self.okf is not None:
             payload["okf"] = self.okf.to_dict()
         return payload
+
+
+def validate_product(product: Product, start: str = ".") -> list[Issue]:
+    """Validate one parsed artifact with repository severity overrides applied.
+
+    The single-file analogue of :func:`validate_directory`: run the
+    classification-dispatched rules (:func:`validate`) and apply the repository's
+    severity overrides (ADR-053) loaded from ``start`` (the directory whose
+    ``.rac/config.yaml`` governs policy). The CLI's single-file ``rac validate``
+    and SDK callers share this one composition, so behind-the-gate analysis never
+    drifts from what the interface reports (ADR-015).
+    """
+    return apply_overrides(validate(product), classify(product).type, load_overrides(start))
 
 
 def validate_directory(directory: str, recursive: bool = True) -> DirectoryValidation:

--- a/tests/test_sdk_surface.py
+++ b/tests/test_sdk_surface.py
@@ -1,0 +1,86 @@
+"""Tests for the Python SDK public surface (v0.20.0, ADR-062).
+
+The SDK contract is: every name in ``rac.__all__`` imports from ``rac``; the
+service-layer subset imports from ``rac.services``; and every error a public
+function raises derives from ``rac.errors.RACError``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import rac
+import rac.services
+from rac import RACError
+
+
+def test_top_level_all_names_are_importable():
+    # The maintained public list cannot drift from what the package exports.
+    missing = [name for name in rac.__all__ if not hasattr(rac, name)]
+    assert missing == []
+
+
+def test_service_subset_names_are_importable():
+    missing = [name for name in rac.services.__all__ if not hasattr(rac.services, name)]
+    assert missing == []
+
+
+def test_canonical_imports_resolve():
+    from rac import (  # noqa: F401 — importability is the assertion
+        Product,
+        RACError,
+        build_review,
+        collect_stats,
+        create_artifact,
+        find_artifacts,
+        parse,
+        resolve_artifact,
+        validate_directory,
+        validate_product,
+    )
+
+
+def test_racerror_is_an_exception():
+    assert issubclass(RACError, Exception)
+
+
+@pytest.mark.parametrize(
+    "module_path, name",
+    [
+        ("rac.services.create", "OutputPathExists"),
+        ("rac.services.create", "MissingRepositoryConfig"),
+        ("rac.services.ingest", "ConversionError"),
+        ("rac.services.ingest", "UnsupportedDocument"),
+        ("rac.services.init", "RepositoryKeyConflict"),
+        ("rac.services.quickstart", "CorpusNotEmpty"),
+        ("rac.services.hook", "HookFileExists"),
+        ("rac.services.skill", "SkillFileExists"),
+        ("rac.services.revisions", "NotAGitRepository"),
+        ("rac.core.templates", "TemplateNotFound"),
+        ("rac.core.skills", "SkillNotFound"),
+        ("rac.core.hooks", "HookNotFound"),
+        ("rac.core.operations", "OperationCancelled"),
+        ("rac.output.portal", "PortalShellMissing"),
+        ("rac.explorer.launch", "ExplorerUnavailable"),
+    ],
+)
+def test_service_exceptions_derive_from_racerror(module_path, name):
+    import importlib
+
+    exc = getattr(importlib.import_module(module_path), name)
+    assert issubclass(exc, RACError)
+
+
+def test_raised_service_error_is_caught_as_racerror(tmp_path):
+    # A real public call that fails surfaces as RACError without the consumer
+    # importing the concrete exception type.
+    from rac import create_artifact
+
+    with pytest.raises(RACError):
+        create_artifact("not-a-real-type", str(tmp_path / "x.md"))
+
+
+def test_diff_is_exported_as_diff_artifacts():
+    # The generic ``diff`` service name is re-exported under a clearer SDK name.
+    assert hasattr(rac, "diff_artifacts")
+    assert "diff_artifacts" in rac.__all__

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -184,3 +184,38 @@ def test_unrecognized_key_absent_from_json_when_none(capsys):
     main(["stats", fixture_path("portfolio"), "--json"])
     payload = json.loads(capsys.readouterr().out)
     assert "unrecognized" not in payload
+
+
+# --- meaningful content (v0.20.0: stats success logic behind the gate) --------
+
+
+def test_has_meaningful_content_empty_corpus(tmp_path):
+    # A day-one corpus is empty and not meaningful: distinct states.
+    s = collect_stats(str(tmp_path))
+    assert s.is_empty is True
+    assert s.has_meaningful_content is False
+
+
+def test_has_meaningful_content_with_one_valid_feature(tmp_path):
+    (tmp_path / "ok.md").write_text(_OK_FEATURE)
+    s = collect_stats(str(tmp_path))
+    assert s.has_meaningful_content is True
+    assert s.is_empty is False
+
+
+def test_has_meaningful_content_all_invalid_is_neither_empty_nor_meaningful(tmp_path):
+    # Files exist but none validate: not empty, not meaningful -> stats fails.
+    (tmp_path / "broken.md").write_text("## Problem\n\nno title\n")
+    s = collect_stats(str(tmp_path))
+    assert s.is_empty is False
+    assert s.has_meaningful_content is False
+
+
+def test_cli_stats_exit_codes_track_meaningful_content(tmp_path):
+    # The CLI exit code follows the gate-computed property: empty -> 0,
+    # all-invalid -> 1, one valid artifact -> 0.
+    assert main(["stats", str(tmp_path)]) == 0  # empty
+    (tmp_path / "broken.md").write_text("## Problem\n\nno title\n")
+    assert main(["stats", str(tmp_path)]) == 1  # all-invalid
+    (tmp_path / "ok.md").write_text(_OK_FEATURE)
+    assert main(["stats", str(tmp_path)]) == 0  # one valid feature

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -14,6 +14,7 @@ from rac.services.validate import (
     STATUS_SKIPPED,
     STATUS_VALID,
     validate_directory,
+    validate_product,
 )
 
 
@@ -193,3 +194,49 @@ def test_cli_single_file_behavior_unchanged(capsys):
     # Unknown single files still fall back to the legacy requirement rules.
     rc = main(["validate", fixture_path("portfolio_summary", "all_types", "unknown.md")])
     assert rc == 1
+
+
+# --- validate_product (v0.20.0: single-file composition behind the gate) ------
+
+
+def test_validate_product_matches_raw_validate_without_overrides(tmp_path):
+    # With no repository overrides, validate_product is exactly validate().
+    product = parse_file(fixture_path("valid", "minimal.md"))
+    assert codes(validate_product(product, str(tmp_path))) == codes(validate(product))
+
+
+def test_validate_product_agrees_with_directory_validation():
+    # The same artifact yields the same issues whether validated as a single
+    # file (validate_product) or inside a directory walk (validate_directory):
+    # one composition, one home (ADR-015).
+    path = fixture_path("portfolio", "broken.md")
+    single = codes(validate_product(parse_file(path)))
+
+    result = validate_directory(fixture_path("portfolio"))
+    in_dir = next(f for f in result.files if f.path.endswith("broken.md"))
+    assert {i.code for i in in_dir.issues} == single
+
+
+def test_validate_product_applies_repository_overrides(tmp_path):
+    # A severity override at `start` (ADR-053) is honoured by validate_product,
+    # proving the CLI no longer needs to compose validate + classify + overrides
+    # itself. `missing-success-metrics` is a warning by default; override it to
+    # error and validate_product must report it as an error.
+    (tmp_path / "feature.md").write_text(
+        "# Ok\n\n## Problem\n\np\n\n## Requirements\n\n[REQ-001] x\n"
+    )
+    product = parse_file(str(tmp_path / "feature.md"))
+
+    def metric_issues(start):
+        return [i for i in validate_product(product, start) if i.code == "missing-success-metrics"]
+
+    default = metric_issues(str(tmp_path))
+    assert default and default[0].severity == "warning"  # no config yet
+
+    config_dir = tmp_path / ".rac"
+    config_dir.mkdir()
+    (config_dir / "config.yaml").write_text(
+        "repository_key: RAC\nvalidation:\n  rules:\n    missing-success-metrics: error\n"
+    )
+    overridden = metric_issues(str(tmp_path))
+    assert overridden and overridden[0].severity == "error"


### PR DESCRIPTION
# Summary

Implements `rac/roadmaps/v0.20.x-sdk/v0.20.0-python-sdk-foundation.md` and opens
the `v0.20.x` SDK series. Turns RAC's internally-layered codebase into a usable
Python library and, in the same work, closes a gate-architecture leak in the CLI.

Adds:
- `from rac import validate_directory, build_review, collect_stats, RACError, ...`
  — a curated flat public surface (`rac.__all__`, 34 names) plus a service-layer
  mirror (`rac.services.__all__`).
- `rac.errors.RACError` — one root that every public-facing exception now derives
  from, so a consumer catches the whole family with a single `except`.
- `rac.services.validate.validate_product(product, start)` — the single-file
  analogue of `validate_directory`, applying repository severity overrides
  (ADR-053). Single-file `rac validate` now delegates to it instead of composing
  the logic inline.
- `PortfolioStats.has_meaningful_content` — the `rac stats` success rule lifted
  onto the result model behind the gate.
- Corpus records: ADR-062 (public surface), the `python-sdk-surface` design, and
  the `v0.20.0` / `v0.20.1` roadmaps (promoted from the invalid `future/v1.4`
  stub).
- Tests for the public surface, the exception hierarchy, `validate_product`
  parity, and `has_meaningful_content`.

# Roadmap / ADR Trace

Roadmap:
- `rac/roadmaps/v0.20.x-sdk/v0.20.0-python-sdk-foundation.md`
- `rac/roadmaps/v0.20.x-sdk/v0.20.1-python-sdk-docs.md` (Planned; not implemented here)

Relevant ADRs:
- `rac/decisions/adr-062-python-sdk-public-surface.md` (new)
- `adr-008` (agent-ready architecture — "easy SDK support")
- `adr-015` (consumers before interfaces)
- `adr-007` (additive JSON contracts)

Design:
- `rac/designs/python-sdk-surface.md` (new)

# Scope

## Included
- Flat public namespace at `rac` and `rac.services`, curated (not maximal):
  core primitives, validation, portfolio intelligence, lookup, authoring, errors.
- `RACError` base; ~24 service/core exceptions re-rooted under it across 13
  modules (mechanical, backward compatible — `RACError` subclasses `Exception`).
- `validate_product()` service; `cmd_validate` rewired to it (single-file and
  directory validation now share one composition).
- `has_meaningful_content` on the stats model; `cmd_stats` rewired to read it.
- The `decisiongrounding`-style placement for v0.20.1's worked examples recorded
  in the roadmap (a standalone sub-project depending on the published package).

## Excluded
- SDK documentation, the API reference, the worked-example sub-project, and the
  `py.typed` marker — all scoped to **v0.20.1**, not built here.
- Moving `score_artifacts(product)` in `rac inspect` behind a service: it is
  display-only with no state/exit-code impact, so it stays in the CLI by design
  (recorded in the v0.20.0 Non-Goals).
- A `--strict` flag for `rac stats` (the non-empty all-invalid failure stays
  where v0.13.1 left it).
- Defining what `1.0` freezes or any semver pledge — explicitly deferred by
  ADR-062.

# Product / Architecture Decisions

- The public surface **is** `rac.__all__` (ADR-062). Anything not listed —
  `rac.core` internals, `rac.cli`, output renderers, `*_from_corpus` snapshot
  helpers — is internal and free to change.
- One exception root (`RACError`) rather than per-module bases, so generic error
  handling needs no enumeration of concrete types. Concrete names/messages and
  module homes are unchanged.
- `diff` is re-exported as `diff_artifacts` to avoid a too-generic top-level name.
- `validate_product` lives in the service layer (ADR-015): the consumer-facing
  capability is built first, then the CLI points at it — which is why the gate
  fix and the SDK's first public function are the same change.
- `has_meaningful_content` is a sibling to `is_empty`, keeping "empty day-one
  corpus" and "files exist but none valid" as distinct, gate-computed states.
- `import rac` now imports the service tree eagerly (small cost, accepted);
  heavy extras (`ingest`, `explorer`) still import lazily, so core-only installs
  import cleanly.

# User-Facing Contract

## Python API
- `from rac import validate_directory, validate_product, collect_stats,
  build_review, resolve_artifact, find_artifacts, create_artifact, RACError, ...`
- Every error raised by a public function is catchable as `rac.RACError`.
- Result objects keep their `to_dict()` JSON contract (additive, ADR-007).

## CLI
- No behavioural change. Single-file `rac validate` (and `rac validate -`) and
  `rac stats` produce identical human output, JSON, and exit codes for the same
  input; the composition simply moved behind the gate.

## Exit Codes
- Unchanged. `0` success; `1` validation failure / no valid artifacts; `2` usage.
  `rac stats` on an empty corpus still exits `0` (v0.13.1); non-empty all-invalid
  still exits `1`.

# Verification

## Ran
- `pytest` — full suite green (1328 passed; the one environmental hook test that
  needs `rac` on `PATH` passes with it present, as it will in CI).
- `ruff check`, `ruff format --check`, `mypy src/rac` — all clean.
- `rac validate rac/` → exit 0 (192 artifacts valid; also fixes the previously
  invalid `future/v1.4-python-sdk` stub by promoting it).
- `rac relationships rac/ --validate` → exit 0 (734 checked, 0 issues).
- `rac review rac/` → no priority 1–2 findings.
- Smoke: `from rac import validate_directory, validate_product, RACError;
  validate_directory('rac/').ok` → `True`.

## Covered
- Every name in `rac.__all__` and `rac.services.__all__` resolves on its package.
- Each re-rooted exception (15 representative types across services and core) is
  `issubclass(..., RACError)`; a real failing call (`create_artifact` with a bad
  type) is caught as `RACError`.
- `validate_product` returns the same issues as the directory walk for the same
  artifact, and honours a `validation.rules` severity override.
- `has_meaningful_content` is False/True across empty, valid, and all-invalid
  corpora; CLI exit codes track it.
- `test_sdk_surface.py` registered in the core CI battery (ADR-027 guard).

# Review Path

1. `src/rac/services/validate.py`, `src/rac/services/stats.py`, `src/rac/cli.py`
   — the gate fix (the behavioural core).
2. `src/rac/errors.py` and the exception re-roots across `src/rac/services/*` and
   `src/rac/core/*` (plus `output/portal.py`, `explorer/launch.py`).
3. `src/rac/__init__.py`, `src/rac/services/__init__.py` — the public surface.
4. `tests/test_sdk_surface.py`, `tests/test_validate.py`, `tests/test_stats.py`,
   `.github/workflows/tests.yml`.
5. Corpus: ADR-062, the design, and the two roadmaps.

# Notes For Reviewer
- The exception re-root touches many files but each change is a one-line base
  swap plus an import; no message or name changed, so existing `except` clauses
  are unaffected.
- v0.20.1 is recorded but deliberately unbuilt; its worked-example sub-project is
  planned to live in the monorepo like `decisiongrounding/` (own packaging,
  depending on `requirements-as-code`) and to graduate to its own repo later.
- A planned GitHub org move and file restructure will shift some paths after this
  merges (CI battery entries, `src/rac` layout, roadmap path references); these
  are mechanical to re-point and out of scope here.

# Implementation Process

Implemented with AI assistance under the roadmap contract; final scope, review,
and acceptance decisions were made by the maintainer.