### PR TITLE
docs(decision): record multi-repo extraction strategy [roadmap:repo-extraction-programme]

### DIFF
--- a/rac/decisions/adr-063-multi-repo-extraction-strategy.md
+++ b/rac/decisions/adr-063-multi-repo-extraction-strategy.md
@@ -29,9 +29,11 @@ because a personal account is, in practice, a single repository:
 - `validate-action/action.yml` and the root `action.yml` (Watchkeeper) —
   thin GitHub composite actions that wrap the `rac` CLI (ADR-058 governs the
   validation action).
-- `examples/` and the planned liftable SDK examples sub-project — pedagogical
-  material. The v0.20.1 roadmap already designs the SDK examples to "graduate
-  to their own repo," mirroring the `decisiongrounding/` liftable pattern.
+- `examples/` — the flagship grounding demo (`examples/guide/`, referenced by
+  `guide-grounding-demo` and the v0.10.2 roadmap) and dashboard fixtures the
+  test suite depends on. This is product-defining, dogfooded material, distinct
+  from the *separately planned* liftable SDK examples sub-project that the
+  v0.20.1 roadmap designs to "graduate to their own repo."
 
 An organisation can host sibling repositories, so colocation is no longer
 forced. There is no recorded decision about the org move or about which
@@ -60,8 +62,13 @@ engine and everything that ships or governs it in
 | Component | Current path | New repo | Why it leaves |
 | --- | --- | --- | --- |
 | Decision-grounding benchmark | `decisiongrounding/` | `itsthelore/decisiongrounding` | Zero code coupling; own packaging, tests, LICENSE, and ADRs, which travel with it. |
-| GitHub Actions | `validate-action/action.yml`, root `action.yml` | `itsthelore/rac-actions` (or per-action repos) | Thin CLI wrappers reusable by any repo, with a release cadence independent of the engine. |
-| Examples | `examples/`, the planned SDK examples sub-project | `itsthelore/rac-examples` | Pedagogical; the SDK examples are already designed liftable (v0.20.1). |
+| GitHub Actions | `validate-action/action.yml`, root `action.yml` | `itsthelore/rac-actions` | Thin CLI wrappers reusable by any repo, with a release cadence independent of the engine. |
+
+The GitHub Actions land in a **single** `itsthelore/rac-actions` repository,
+each action in its own subdirectory (`gatekeeper/`, `watchkeeper/`), referenced
+as `itsthelore/rac-actions/<name>@<ref>`. The `validate` action is **renamed
+Gatekeeper** — it holds the gate on corpus validity, a sibling to Watchkeeper
+(ADR-049, "enforcement is the product").
 
 **Keep in `itsthelore/requirements-as-code`:**
 
@@ -71,6 +78,10 @@ engine and everything that ships or governs it in
   are shipped resources, discovered and installed by the CLI.
 - The dogfood corpus (`rac/`) — it governs the project and stays with the code
   it governs.
+- `examples/` — the grounding demo (`examples/guide/`) is the product's
+  headline proof, woven into the corpus (a design and the v0.10.2 roadmap
+  reference it) and into the test fixtures (`example_dashboard_v*.md`).
+  Extracting it would fragment the demo and strand the fixtures; it stays.
 - `lore-web/` — no Python coupling, but its Portal shell is *vendored* into
   `src/rac/` through a build script and a drift-guard test. Extraction is
   **deferred** until a publish/vendor contract exists; it is a future review
@@ -78,7 +89,9 @@ engine and everything that ships or governs it in
 
 Distribution names stay frozen (ADR-036, ADR-039). Extracted repos follow the
 `rac-<name>` convention where they relate to the engine; `decisiongrounding`
-keeps its established name.
+keeps its established name. Each repo carries its own `examples/` subdirectory
+where useful — the same convention the engine keeps for `examples/guide` —
+rather than a central examples repository.
 
 ## Consequences
 
@@ -122,8 +135,26 @@ Leave all components colocated and rely on directory boundaries.
 #### Disadvantages
 
 - Couples unrelated release cadences to the engine's, and keeps the engine
-  repository carrying a benchmark, actions, and examples that no longer need
-  to be there now that an org can host siblings.
+  repository carrying a benchmark and actions that no longer need to be there
+  now that an org can host siblings.
+
+### Extract `examples/` to its own repo
+
+Lift `examples/` into a dedicated `itsthelore/rac-examples` alongside the
+benchmark.
+
+#### Advantages
+
+- A single home for pedagogical material across the org.
+
+#### Disadvantages
+
+- `examples/guide` is the grounding demo — the product's headline proof — and
+  is referenced by a design, the v0.10.2 roadmap, and the test fixtures.
+  Extracting it fragments the demo and strands fixtures the suite depends on.
+  Rejected; examples stays, and each repo keeps its own `examples/` subdir
+  instead. (The separately planned liftable SDK examples sub-project, v0.20.1,
+  is unaffected.)
 
 ### Extract `lore-web` now as well
 

--- a/rac/decisions/adr-063-multi-repo-extraction-strategy.md
+++ b/rac/decisions/adr-063-multi-repo-extraction-strategy.md
@@ -1,0 +1,174 @@
+---
+schema_version: 1
+id: RAC-KV68XJGEXBNB
+type: decision
+tags: [structure, org, packaging, distribution]
+---
+# ADR-063: Multi-Repo Extraction Strategy for the itsthelore Organisation
+
+## Status
+
+Accepted
+
+## Category
+
+Architecture
+
+## Context
+
+`requirements-as-code` has moved from a personal GitHub account
+(`tcballard`) into the `itsthelore` organisation. The repository is a
+monorepo for **Lore** (the product) whose engine is **RAC** — the
+`requirements-as-code` package under `src/rac/`. Alongside the engine it
+carries several components that are self-contained and were only colocated
+because a personal account is, in practice, a single repository:
+
+- `decisiongrounding/` — a reproducible benchmark with its own
+  `pyproject.toml`, tests, LICENSE, and independent version. It treats `rac`
+  as an external CLI on `PATH` and imports no engine code (DG-ADR-0001).
+- `validate-action/action.yml` and the root `action.yml` (Watchkeeper) —
+  thin GitHub composite actions that wrap the `rac` CLI (ADR-058 governs the
+  validation action).
+- `examples/` and the planned liftable SDK examples sub-project — pedagogical
+  material. The v0.20.1 roadmap already designs the SDK examples to "graduate
+  to their own repo," mirroring the `decisiongrounding/` liftable pattern.
+
+An organisation can host sibling repositories, so colocation is no longer
+forced. There is no recorded decision about the org move or about which
+components should live in their own repos, and RAC's own rules require
+durable, cross-cutting structural thinking to be recorded in the corpus
+(`rac-agent-session-start`). This ADR settles the repository topology; the
+`repo-extraction-programme` roadmap sequences the moves.
+
+Two existing decisions fence this one:
+
+- ADR-029 freezes the engine and its MCP server (`rac mcp`) into a *single*
+  package and release pipeline. This decision must not fragment that.
+- ADR-036 and ADR-039 freeze the distribution names (PyPI
+  `requirements-as-code`, CLI `rac`, server identity `lore`). This decision is
+  about repository topology, not renaming any shipped surface.
+
+## Decision
+
+Adopt a small **multi-repo** topology under `itsthelore`: extract the
+genuinely standalone components into their own repositories, and keep the
+engine and everything that ships or governs it in
+`itsthelore/requirements-as-code`.
+
+**Extract into their own `itsthelore` repositories:**
+
+| Component | Current path | New repo | Why it leaves |
+| --- | --- | --- | --- |
+| Decision-grounding benchmark | `decisiongrounding/` | `itsthelore/decisiongrounding` | Zero code coupling; own packaging, tests, LICENSE, and ADRs, which travel with it. |
+| GitHub Actions | `validate-action/action.yml`, root `action.yml` | `itsthelore/rac-actions` (or per-action repos) | Thin CLI wrappers reusable by any repo, with a release cadence independent of the engine. |
+| Examples | `examples/`, the planned SDK examples sub-project | `itsthelore/rac-examples` | Pedagogical; the SDK examples are already designed liftable (v0.20.1). |
+
+**Keep in `itsthelore/requirements-as-code`:**
+
+- The engine — `src/rac/` (CLI, core, services, output, explorer) and the MCP
+  server (`rac mcp`). ADR-029 keeps these one package; do not split them.
+- Bundled agent skills (`src/rac/skills/`), templates, and git hooks — these
+  are shipped resources, discovered and installed by the CLI.
+- The dogfood corpus (`rac/`) — it governs the project and stays with the code
+  it governs.
+- `lore-web/` — no Python coupling, but its Portal shell is *vendored* into
+  `src/rac/` through a build script and a drift-guard test. Extraction is
+  **deferred** until a publish/vendor contract exists; it is a future review
+  trigger, not decided here.
+
+Distribution names stay frozen (ADR-036, ADR-039). Extracted repos follow the
+`rac-<name>` convention where they relate to the engine; `decisiongrounding`
+keeps its established name.
+
+## Consequences
+
+### Positive
+
+- Ownership and release cadence become per-component: a benchmark run, an
+  action bump, or an examples refresh no longer rides the engine's release.
+- The engine repository shrinks to the engine, its shipped resources, and its
+  governing corpus — a smaller surface to validate, review, and reason about.
+- The standalone components prove themselves as outside consumers of the
+  published package exactly as a third party would, strengthening the public
+  contract (ADR-062).
+
+### Negative
+
+- More repositories to create, permission, and maintain under the org.
+- Extracting the GitHub Actions **changes the `uses:` path** consumers
+  reference (`itsthelore/requirements-as-code/validate-action@ref` and the
+  root action) — a breaking change that requires a versioned cutover and a
+  documentation update, not a silent move.
+
+### Risks
+
+- **Cross-repo drift.** Components that no longer live beside the engine can
+  lag its contract. Mitigation: each extracted repo depends on the *published*
+  package or the public CLI, never on engine internals, and pins a version.
+- **Stranded action references.** Consumers pinned to the old `uses:` path
+  break on extraction. Mitigation: the roadmap extracts the actions last,
+  behind a versioned cutover with a deprecation note.
+
+## Alternatives Considered
+
+### Keep everything in the monorepo
+
+Leave all components colocated and rely on directory boundaries.
+
+#### Advantages
+
+- No migration work; no `uses:`-path churn.
+
+#### Disadvantages
+
+- Couples unrelated release cadences to the engine's, and keeps the engine
+  repository carrying a benchmark, actions, and examples that no longer need
+  to be there now that an org can host siblings.
+
+### Extract `lore-web` now as well
+
+Lift the web viewer in the same pass.
+
+#### Advantages
+
+- Fully separates the TypeScript stack from the Python engine.
+
+#### Disadvantages
+
+- The Portal shell is vendored into `src/rac/` via a build script and a
+  drift-guard. Extracting before a publish/vendor contract exists would break
+  the vendoring path. Rejected for now; tracked as a future review trigger.
+
+## Related Decisions
+
+- adr-012
+- adr-029
+- adr-036
+- adr-039
+- adr-058
+- adr-062
+
+## Related Requirements
+
+- rac-growth-extensibility
+
+## Related Roadmaps
+
+- repo-extraction-programme
+
+## Success Measures
+
+- Each extracted component lives in its own `itsthelore` repository, depends
+  only on the published package or public CLI, and shows no engine-coupling
+  regression.
+- Consumer-facing references (action `uses:` paths, docs, CI) are updated and
+  no issue traces to a stranded reference.
+- The engine repository's `rac validate`, `rac relationships --validate`, and
+  `rac review` gates stay green after each extraction.
+
+## Review Date
+
+Revisit when the `lore-web` Portal-shell vendoring gains a publish/vendor
+contract (then decide its extraction), or when a third-party schema-bundle
+ecosystem (`rac-growth-extensibility`) begins and the `rac-<name>` repo
+convention needs hardening.

--- a/rac/decisions/adr-064-multi-repo-extraction-strategy.md
+++ b/rac/decisions/adr-064-multi-repo-extraction-strategy.md
@@ -4,7 +4,7 @@ id: RAC-KV68XJGEXBNB
 type: decision
 tags: [structure, org, packaging, distribution]
 ---
-# ADR-063: Multi-Repo Extraction Strategy for the itsthelore Organisation
+# ADR-064: Multi-Repo Extraction Strategy for the itsthelore Organisation
 
 ## Status
 

--- a/rac/roadmaps/future/repo-extraction-programme.md
+++ b/rac/roadmaps/future/repo-extraction-programme.md
@@ -12,14 +12,14 @@ Planned
 
 ## Context
 
-ADR-063 records the decision to adopt a small multi-repo topology under the
+ADR-064 records the decision to adopt a small multi-repo topology under the
 `itsthelore` organisation: extract the standalone components and keep the
 engine, its shipped resources, and its governing corpus in
 `itsthelore/requirements-as-code`. This programme sequences those extractions.
 It is a non-versioned `future/` item because the work is structural and
 cross-cutting, not a feature release on the current series.
 
-Two components extract; `examples/` is explicitly kept (ADR-063), since
+Two components extract; `examples/` is explicitly kept (ADR-064), since
 `examples/guide` is the grounding demo and the dashboards are test fixtures.
 The two extraction targets differ in risk. `decisiongrounding` imports no
 engine code and can move with no consumer impact. The GitHub Actions are the
@@ -65,7 +65,7 @@ validation action and moves with it.
 ### Initiative 3 — Keep `examples/`; adopt the per-repo examples convention
 
 `examples/` is **not** extracted. `examples/guide` is the grounding demo and
-the dashboards are test fixtures, so they stay in the engine repo (ADR-063).
+the dashboards are test fixtures, so they stay in the engine repo (ADR-064).
 The convention going forward: each repo carries its own `examples/`
 subdirectory where useful, rather than a central examples repository. The
 separately planned liftable SDK examples sub-project (v0.20.1) is unaffected by
@@ -85,8 +85,8 @@ this programme.
 ## Non-Goals
 
 - Extracting `examples/` or creating a `rac-examples` repo — examples stays in
-  the engine repo (ADR-063).
-- Extracting `lore-web` — deferred by ADR-063 until its Portal-shell vendoring
+  the engine repo (ADR-064).
+- Extracting `lore-web` — deferred by ADR-064 until its Portal-shell vendoring
   has a publish/vendor contract.
 - Renaming the package, CLI, or server.
 - Creating the org repositories as part of this corpus task; the repos are
@@ -164,7 +164,7 @@ and `pytest` passes.
 
 ## Related Decisions
 
-- adr-063
+- adr-064
 - adr-058
 
 ## Related Roadmaps

--- a/rac/roadmaps/future/repo-extraction-programme.md
+++ b/rac/roadmaps/future/repo-extraction-programme.md
@@ -1,0 +1,138 @@
+---
+schema_version: 1
+id: RAC-KV68XS3J7P6C
+type: roadmap
+tags: [structure, org, distribution]
+---
+# Repo Extraction Programme
+
+## Status
+
+Planned
+
+## Context
+
+ADR-063 records the decision to adopt a small multi-repo topology under the
+`itsthelore` organisation: extract the standalone components and keep the
+engine, its shipped resources, and its governing corpus in
+`itsthelore/requirements-as-code`. This programme sequences those extractions.
+It is a non-versioned `future/` item because the work is structural and
+cross-cutting, not a feature release on the current series.
+
+The three targets differ sharply in risk. `decisiongrounding` imports no
+engine code and can move with no consumer impact. The examples are
+pedagogical and partly still being built liftable (v0.20.1). The GitHub
+Actions are the only target whose move is consumer-breaking: extraction
+changes the `uses:` path that downstream workflows reference, so it must come
+last and behind a versioned cutover.
+
+## Outcomes
+
+- Each target component lives in its own `itsthelore` repository, depending
+  only on the published `requirements-as-code` package or the public `rac`
+  CLI — never on engine internals — with no coupling regression.
+- The engine repository carries only the engine, its shipped resources
+  (skills, templates, hooks), and the dogfood corpus.
+- Every consumer-facing reference (action `uses:` paths, docs, CI workflows)
+  is updated, and no stranded reference is left behind.
+
+## Initiatives
+
+### Initiative 1 — Extract `decisiongrounding` (reference migration)
+
+The cleanest target and the pattern for the rest. Move `decisiongrounding/`
+to `itsthelore/decisiongrounding` with history preserved, carrying its own
+`pyproject.toml`, tests, LICENSE, Makefile, and its `decisions/` ADRs
+(DG-ADR-0001 onward). It already treats `rac` as an external CLI on `PATH`, so
+no code changes are needed; remove the directory from the monorepo and update
+any references to it (including the v0.20.1 roadmap's "mirrors
+`decisiongrounding/`" note, which becomes a cross-repo reference).
+
+### Initiative 2 — Extract examples to `itsthelore/rac-examples`
+
+Build the SDK examples sub-project liftable per v0.20.1 (own `pyproject.toml`
+depending on the published package), then graduate it together with
+`examples/` into `itsthelore/rac-examples`. The examples depend on the
+published package or the public CLI, proving the surface from outside the
+source tree.
+
+### Initiative 3 — Extract the GitHub Actions (versioned cutover)
+
+Move `validate-action/action.yml` and the root `action.yml` (Watchkeeper) to
+`itsthelore/rac-actions` (or per-action repos). This changes the `uses:` path
+consumers reference, so it ships behind a versioned cutover: publish the new
+location, document the new `uses:` reference, leave a deprecation note for the
+old path, and update this repository's own `.github/workflows/` to the new
+location. ADR-058 governs the validation action and moves with it.
+
+## Constraints
+
+- No engine behaviour change and no change to the public surface: this is a
+  topology move, not a feature.
+- Distribution names stay frozen (ADR-036, ADR-039): PyPI
+  `requirements-as-code`, CLI `rac`, server identity `lore`.
+- The engine and MCP server stay one package (ADR-029); they are not part of
+  any extraction.
+- Each extraction preserves history (`git filter-repo` or `git subtree`,
+  decided per repo) rather than copying files flat.
+
+## Non-Goals
+
+- Extracting `lore-web` — deferred by ADR-063 until its Portal-shell vendoring
+  has a publish/vendor contract.
+- Renaming the package, CLI, or server.
+- Creating the org repositories as part of this corpus task; the repos are
+  created when each initiative is executed.
+
+## Implementation Contract
+
+- Each extraction produces a new `itsthelore/<repo>` populated by a
+  history-preserving move, the source directory removed from the monorepo, and
+  all in-repo and documentation references updated.
+- The actions extraction additionally ships a versioned cutover: new `uses:`
+  reference documented, old path deprecated, this repo's workflows updated.
+- After each extraction the engine repository's `rac validate rac/`,
+  `rac relationships rac/ --validate`, and `rac review rac/` gates stay green.
+
+## Success Measures
+
+- All three targets are extracted and consume only the published package or
+  public CLI; no extracted repo imports engine internals.
+- No issue traces to a stranded `uses:` path or a missing relocated component.
+- The engine repository's corpus gates remain green throughout.
+
+## Assumptions
+
+- The `itsthelore` organisation can host the sibling repositories and the
+  maintainer can create and permission them when each initiative runs.
+- `decisiongrounding` continues to consume `rac` only as an external CLI on
+  `PATH`, so its move needs no code change (DG-ADR-0001 holds).
+- The published `requirements-as-code` package remains the dependency surface
+  for the examples, and the public `rac` CLI for the actions — neither needs
+  engine internals.
+- `lore-web` stays in this repository until its vendoring contract exists, so
+  no Portal-shell drift-guard breaks during this programme.
+
+## Risks
+
+- **Stranded action references.** Consumers pinned to the old `uses:` path
+  break. Mitigation: actions move last, behind a versioned cutover with a
+  deprecation note.
+- **Cross-repo drift.** Extracted components lag the engine contract.
+  Mitigation: each pins a published-package or CLI version and depends on no
+  internals.
+- **History loss.** A flat copy discards provenance. Mitigation: the contract
+  mandates a history-preserving move.
+
+## Related Decisions
+
+- adr-063
+- adr-058
+
+## Related Roadmaps
+
+- v0.20.1-python-sdk-docs
+
+## Related Requirements
+
+- rac-growth-extensibility

--- a/rac/roadmaps/future/repo-extraction-programme.md
+++ b/rac/roadmaps/future/repo-extraction-programme.md
@@ -19,12 +19,12 @@ engine, its shipped resources, and its governing corpus in
 It is a non-versioned `future/` item because the work is structural and
 cross-cutting, not a feature release on the current series.
 
-The three targets differ sharply in risk. `decisiongrounding` imports no
-engine code and can move with no consumer impact. The examples are
-pedagogical and partly still being built liftable (v0.20.1). The GitHub
-Actions are the only target whose move is consumer-breaking: extraction
-changes the `uses:` path that downstream workflows reference, so it must come
-last and behind a versioned cutover.
+Two components extract; `examples/` is explicitly kept (ADR-063), since
+`examples/guide` is the grounding demo and the dashboards are test fixtures.
+The two extraction targets differ in risk. `decisiongrounding` imports no
+engine code and can move with no consumer impact. The GitHub Actions are the
+consumer-breaking target: extraction changes the `uses:` path that downstream
+workflows reference, so they come last and behind a versioned cutover.
 
 ## Outcomes
 
@@ -48,22 +48,28 @@ no code changes are needed; remove the directory from the monorepo and update
 any references to it (including the v0.20.1 roadmap's "mirrors
 `decisiongrounding/`" note, which becomes a cross-repo reference).
 
-### Initiative 2 — Extract examples to `itsthelore/rac-examples`
+### Initiative 2 — Extract the GitHub Actions to `itsthelore/rac-actions`
 
-Build the SDK examples sub-project liftable per v0.20.1 (own `pyproject.toml`
-depending on the published package), then graduate it together with
-`examples/` into `itsthelore/rac-examples`. The examples depend on the
-published package or the public CLI, proving the surface from outside the
-source tree.
+Move `validate-action/action.yml` and the root `action.yml` (Watchkeeper) into
+a single `itsthelore/rac-actions` repository, each action in its own
+subdirectory: `gatekeeper/` (the `validate` action, **renamed Gatekeeper** — it
+holds the gate on corpus validity, a sibling to Watchkeeper) and
+`watchkeeper/`. This changes the `uses:` path consumers reference, so it ships
+behind a versioned cutover: publish the new location, document the new `uses:`
+references (`itsthelore/rac-actions/gatekeeper@v1`,
+`itsthelore/rac-actions/watchkeeper@v1`), leave a deprecation note for the old
+`itsthelore/requirements-as-code/validate-action@ref` path, and update this
+repository's own `.github/workflows/` to the new location. ADR-058 governs the
+validation action and moves with it.
 
-### Initiative 3 — Extract the GitHub Actions (versioned cutover)
+### Initiative 3 — Keep `examples/`; adopt the per-repo examples convention
 
-Move `validate-action/action.yml` and the root `action.yml` (Watchkeeper) to
-`itsthelore/rac-actions` (or per-action repos). This changes the `uses:` path
-consumers reference, so it ships behind a versioned cutover: publish the new
-location, document the new `uses:` reference, leave a deprecation note for the
-old path, and update this repository's own `.github/workflows/` to the new
-location. ADR-058 governs the validation action and moves with it.
+`examples/` is **not** extracted. `examples/guide` is the grounding demo and
+the dashboards are test fixtures, so they stay in the engine repo (ADR-063).
+The convention going forward: each repo carries its own `examples/`
+subdirectory where useful, rather than a central examples repository. The
+separately planned liftable SDK examples sub-project (v0.20.1) is unaffected by
+this programme.
 
 ## Constraints
 
@@ -78,6 +84,8 @@ location. ADR-058 governs the validation action and moves with it.
 
 ## Non-Goals
 
+- Extracting `examples/` or creating a `rac-examples` repo — examples stays in
+  the engine repo (ADR-063).
 - Extracting `lore-web` — deferred by ADR-063 until its Portal-shell vendoring
   has a publish/vendor contract.
 - Renaming the package, CLI, or server.
@@ -86,18 +94,49 @@ location. ADR-058 governs the validation action and moves with it.
 
 ## Implementation Contract
 
-- Each extraction produces a new `itsthelore/<repo>` populated by a
-  history-preserving move, the source directory removed from the monorepo, and
-  all in-repo and documentation references updated.
-- The actions extraction additionally ships a versioned cutover: new `uses:`
-  reference documented, old path deprecated, this repo's workflows updated.
-- After each extraction the engine repository's `rac validate rac/`,
-  `rac relationships rac/ --validate`, and `rac review rac/` gates stay green.
+**Safety sequencing.** Populate each destination repo with preserved history
+and confirm it *before* removing anything from the engine repo. Never delete
+from `requirements-as-code` until the content lives elsewhere.
+
+**Seed `itsthelore/decisiongrounding`** (history-preserving):
+
+```bash
+git clone <engine-url> dg && cd dg
+git filter-repo --path decisiongrounding/ --path-rename decisiongrounding/:
+git remote add origin <decisiongrounding-url> && git push -u origin main
+```
+
+**Seed `itsthelore/rac-actions`** (history-preserving, two subdirs):
+
+```bash
+git clone <engine-url> acts && cd acts
+git filter-repo --path validate-action/ --path action.yml \
+  --path-rename validate-action/:gatekeeper/ \
+  --path-rename action.yml:watchkeeper/action.yml
+```
+
+Then rename the validate action to **Gatekeeper** inside
+`gatekeeper/action.yml` (the `name:` field and header comment), add a README
+documenting the new `uses:` references, tag `v1`, and push.
+
+**Removal + rewire PR on `requirements-as-code`** (one PR for the whole
+carve-out): remove `decisiongrounding/`, `validate-action/`, and the root
+`action.yml`; repoint the engine's own self-tests in
+`.github/workflows/pr-checks.yml` (`uses: ./` → `…/rac-actions/watchkeeper@v1`;
+`uses: ./validate-action` → `…/rac-actions/gatekeeper@v1`); update or remove
+`tests/test_validate_action.py` and `tests/test_watchkeeper.py`; update
+`docs/watchkeeper.md`, `docs/validation.md` (grep for others) to the new repo
+and add a deprecation note for the old path; keep `examples/` untouched.
+
+After the removals the engine repository's `rac validate rac/`,
+`rac relationships rac/ --validate`, and `rac review rac/` gates stay green,
+and `pytest` passes.
 
 ## Success Measures
 
-- All three targets are extracted and consume only the published package or
-  public CLI; no extracted repo imports engine internals.
+- Both extraction targets (`decisiongrounding`, `rac-actions`) live in their
+  own repos and consume only the published package or public CLI; neither
+  imports engine internals.
 - No issue traces to a stranded `uses:` path or a missing relocated component.
 - The engine repository's corpus gates remain green throughout.
 
@@ -107,9 +146,8 @@ location. ADR-058 governs the validation action and moves with it.
   maintainer can create and permission them when each initiative runs.
 - `decisiongrounding` continues to consume `rac` only as an external CLI on
   `PATH`, so its move needs no code change (DG-ADR-0001 holds).
-- The published `requirements-as-code` package remains the dependency surface
-  for the examples, and the public `rac` CLI for the actions — neither needs
-  engine internals.
+- The extracted actions consume only the public `rac` CLI, not engine
+  internals, so they run from any repo once published.
 - `lore-web` stays in this repository until its vendoring contract exists, so
   no Portal-shell drift-guard breaks during this programme.
 


### PR DESCRIPTION
# Summary

Records the repository-topology decision now that `requirements-as-code` lives
under the `itsthelore` organisation, and the carve-out programme that will
execute it. Corpus artifacts only — no code, no extractions are performed in
this PR.

Adds:
- `rac/decisions/adr-064-multi-repo-extraction-strategy.md` — the decision (split matrix + rationale)
- `rac/roadmaps/future/repo-extraction-programme.md` — the non-versioned programme that sequences the moves and carries the carve-out mechanics

# Roadmap / ADR Trace

Roadmap:
- `rac/roadmaps/future/repo-extraction-programme.md`

Relevant ADRs:
- `rac/decisions/adr-064-multi-repo-extraction-strategy.md` (new)
- `adr-029` (single-package MCP — engine stays one package)
- `adr-036`, `adr-039` (distribution names frozen — this is topology, not renaming)
- `adr-049` (enforcement is the product — informs the Gatekeeper naming)
- `adr-058` (validation action moves with the actions)
- `adr-062` (SDK public surface)

# Scope

## Included
- An ADR fixing which components leave and which stay, with rationale and risks.
- A `future/` roadmap sequencing the extractions and carrying the concrete
  carve-out mechanics (history-preserving `git filter-repo` commands, the
  populate-first safety rule, and the engine-side references a removal PR rewires).
- Front-matter relationships wiring the ADR ↔ roadmap and to the fencing ADRs/requirement.

## Excluded
- Any actual extraction: no directories removed, no references rewired, no org
  repos created. Those are deliberately deferred — the destination repos must be
  created and populated (history-preserving) before anything is removed, and
  this session cannot create/populate sibling repos.
- `lore-web` extraction: deferred by ADR-064 until its Portal-shell vendoring has
  a publish/vendor contract.
- Renaming the package, CLI, or server (frozen by ADR-036/ADR-039).

# Product / Architecture Decisions

- **Extract** `decisiongrounding/` (zero coupling — treats `rac` as an external
  CLI, DG-ADR-0001) into `itsthelore/decisiongrounding`.
- **Extract** the GitHub Actions into a **single** `itsthelore/rac-actions`,
  each in its own subdir: `gatekeeper/` (the `validate` action, **renamed
  Gatekeeper** — it holds the gate on corpus validity, a sibling to Watchkeeper
  per ADR-049) and `watchkeeper/`.
- **Keep** `examples/` in the engine repo — `examples/guide` is the flagship
  grounding demo (referenced by a design + the v0.10.2 roadmap) and the
  dashboards are test fixtures; extracting it would fragment the demo and strand
  the fixtures. Each repo instead carries its own `examples/` subdir.
- **Keep** the engine (`src/rac/`) and MCP server as one package (ADR-029), the
  bundled skills/templates/hooks, the dogfood corpus, and — for now — `lore-web`.
- The GitHub Actions extraction is the only consumer-breaking move (it changes
  the `uses:` path), so the roadmap orders it last behind a versioned cutover.

# User-Facing Contract

No CLI, human-output, JSON, or exit-code changes. Documentation/corpus only.

# Verification

## Ran
- `rac validate rac/` → exit 0 (202 valid, 0 invalid)
- `rac relationships rac/ --validate` → exit 0 (787 relationships checked, 0 broken)
- `rac review rac/` → exit 0, no Priority 1–2 findings
- `pytest tests/test_dogfood.py` → the corpus relationship + review gates pass

## Covered
- Both new artifacts pass type validation and the recommended-section checks.
- ADR ↔ roadmap relationships resolve in both directions; no dangling or
  ambiguous targets across the corpus (the ADR is numbered 064 to avoid the
  `adr-063` that landed on `main` after this branch was cut).

# Review Path

1. `rac/decisions/adr-064-multi-repo-extraction-strategy.md` — the decision and its split matrix.
2. `rac/roadmaps/future/repo-extraction-programme.md` — the sequencing, the carve-out mechanics, constraints, and non-goals.

# Notes For Reviewer

- This is the decision record only; the carve-out is a follow-up that must run
  from a session scoped to all destination repos, populate them first, then
  remove from the monorepo via a single PR.
- Destination repos: `itsthelore/decisiongrounding` (created) and
  `itsthelore/rac-actions` (to create). No `rac-examples` — examples stays here.
