### PR TITLE
feat(decisiongrounding): run the crossover on real backends + reproducibility metadata

### DIFF
--- a/decisiongrounding/README.md
+++ b/decisiongrounding/README.md
@@ -107,10 +107,23 @@ python -m runner.cli compare \
 with its `query` role, so the RAG baseline uses asymmetric query/document
 embeddings the way Voyage intends — a fair, strong baseline, not a strawman.
 The default Voyage model is `voyage-4-large` (Voyage's current flagship);
-override with `--embedder voyage:<model>`.
+override with `--embedder voyage:<model>`. Each report records the embedder id +
+dimension and the installed `anthropic`/`voyageai` versions (`backend_versions`)
+so a run says exactly what produced it.
 
-This is where the thesis is actually tested. Until it runs on real/public-derived
-corpora, the offline crossover is plumbing, not evidence.
+The **crossover** can also run on the real backends:
+
+```bash
+# Real-model crossover. --ns keeps the API spend small (arms x scenarios x |ns|).
+python -m runner.cli demo \
+  --answering claude --embedder voyage:voyage-4-large --ns 10,50
+```
+
+This is where the thesis is actually tested — but note the boundary: with
+`--answering claude` you get a real-*model* crossover **on the tiny synthetic
+scenarios**. That is the plumbing for evidence, not the evidence. The real
+result requires real/public-derived corpora (see CONTRIBUTING.md); until then
+the crossover is plumbing, not evidence.
 
 Tests:
 

--- a/decisiongrounding/providers/__init__.py
+++ b/decisiongrounding/providers/__init__.py
@@ -45,6 +45,29 @@ ARMS: dict[str, type[Provider]] = {
 
 REAL_ARMS = ("context_dump", "naive_rag", "no_grounding")
 
+
+def make_answering_model(name: str, seed: int) -> AnsweringModel:
+    """Build the held-constant answering model from a name.
+
+    `offline-stub` -> ScriptedAnsweringModel (deterministic, no network);
+    `claude` -> ClaudeAnsweringModel (pinned Opus 4.8, needs the [real] extra +
+    ANTHROPIC_API_KEY). Lives here so both the CLI and the crossover can build
+    backends without importing each other.
+    """
+    if name == "offline-stub":
+        return ScriptedAnsweringModel(seed=seed)
+    if name == "claude":
+        return ClaudeAnsweringModel(seed=seed)
+    raise ValueError(f"unknown answering model {name!r}; use 'offline-stub' or 'claude'.")
+
+
+def build_provider(arm: str, answering_model, embedder_spec: str = "local-hash") -> Provider:
+    """Instantiate an arm, wiring a real embedder into naive_rag when asked."""
+    if arm == "naive_rag":
+        return NaiveRagProvider(answering_model, embedder=make_embedder(embedder_spec))
+    return ARMS[arm](answering_model)
+
+
 __all__ = [
     "ARMS",
     "REAL_ARMS",
@@ -57,6 +80,8 @@ __all__ = [
     "AnsweringModel",
     "ScriptedAnsweringModel",
     "ClaudeAnsweringModel",
+    "make_answering_model",
+    "build_provider",
     "Embedder",
     "LocalDeterministicEmbedder",
     "VoyageEmbedder",

--- a/decisiongrounding/pyproject.toml
+++ b/decisiongrounding/pyproject.toml
@@ -20,9 +20,10 @@ schema = ["jsonschema>=4.20"]
 chart = ["matplotlib>=3.7"]
 # Real benchmark backends: the pinned Claude answering model (anthropic) and
 # Voyage embeddings (Anthropic's recommended embedding provider — Anthropic has
-# no embeddings endpoint). Replaces the offline stubs.
-# TODO: pin exact package versions before publishing runs.
-real = ["anthropic>=0.40", "voyageai>=0.3"]
+# no embeddings endpoint). Replaces the offline stubs. Floors are set to
+# verified-working versions; the exact runtime versions are recorded in every
+# report's `backend_versions`, which is the reproducibility pin.
+real = ["anthropic>=0.109", "voyageai>=0.4"]
 # Local, offline-capable embeddings alternative to Voyage.
 local-embeddings = ["sentence-transformers>=2.2"]
 # The rac arm additionally needs the `rac` CLI on PATH (or RAC_BIN) — it is an

--- a/decisiongrounding/runner/cli.py
+++ b/decisiongrounding/runner/cli.py
@@ -27,10 +27,8 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from providers import (  # noqa: E402
     ARMS,
     REAL_ARMS,
-    ClaudeAnsweringModel,
-    NaiveRagProvider,
-    ScriptedAnsweringModel,
-    make_embedder,
+    build_provider,
+    make_answering_model,
 )
 from providers.base import ProposedChange  # noqa: E402
 from scenarios.loader import Scenario, load_scenarios  # noqa: E402
@@ -43,22 +41,16 @@ _DEFAULT_RESULTS = _ROOT / "results"
 
 
 def _answering_model(name: str, seed: int):
-    if name == "offline-stub":
-        return ScriptedAnsweringModel(seed=seed)
-    if name == "claude":
-        # Real, pinned answering model (Claude Opus 4.8). Requires the [real]
-        # extra + ANTHROPIC_API_KEY; not runnable in the offline demo.
-        return ClaudeAnsweringModel(seed=seed)
-    raise SystemExit(
-        f"unknown answering model {name!r}; use 'offline-stub' or 'claude'."
-    )
+    # Thin CLI wrapper: surface the factory's error as a usage exit.
+    try:
+        return make_answering_model(name, seed)
+    except ValueError as e:
+        raise SystemExit(str(e))
 
 
 def _provider(arm: str, model, embedder_spec: str):
     """Instantiate an arm, wiring a real embedder into naive_rag when asked."""
-    if arm == "naive_rag":
-        return NaiveRagProvider(model, embedder=make_embedder(embedder_spec))
-    return ARMS[arm](model)
+    return build_provider(arm, model, embedder_spec)
 
 
 def _pc_to_dict(pc: ProposedChange) -> dict:
@@ -79,6 +71,10 @@ def run_one(arm: str, scenario: Scenario, model, seed: int, embedder: str = "loc
     g = provider.grounding
     gov = scenario.gold_label.governing_decision
     governing_retrieved = None if gov is None else (gov in g.artifacts_supplied)
+    # Reproducibility: record the embedder identity for retrieval arms (the dim
+    # is probed during prepare()); null for arms that don't embed.
+    emb = getattr(provider, "embedder", None)
+    embedder_meta = {"name": emb.name, "dim": emb.dim} if emb is not None else None
     return {
         "run_id": str(uuid.uuid4()),
         "timestamp": datetime.now(timezone.utc).isoformat(),
@@ -96,11 +92,26 @@ def run_one(arm: str, scenario: Scenario, model, seed: int, embedder: str = "loc
             "token_estimate": g.token_estimate,
             "artifacts_supplied": list(g.artifacts_supplied),
         },
+        "embedder": embedder_meta,
         "proposed_change": _pc_to_dict(pc),
         "score": sc.as_dict(),
         "retrieval": {"governing_decision_retrieved": governing_retrieved},
         "harness_version": HARNESS_VERSION,
     }
+
+
+def _backend_versions() -> dict:
+    """Best-effort: the installed versions of the real backends, so each report
+    records exactly what produced it. Empty when the [real] extra isn't present."""
+    import importlib.metadata as md
+
+    out: dict[str, str] = {}
+    for pkg in ("anthropic", "voyageai"):
+        try:
+            out[pkg] = md.version(pkg)
+        except Exception:  # noqa: BLE001 - absence is expected offline
+            pass
+    return out
 
 
 def _write_report(results: list[dict], out_dir: Path, label: str) -> Path:
@@ -126,6 +137,7 @@ def _write_report(results: list[dict], out_dir: Path, label: str) -> Path:
         "harness_version": HARNESS_VERSION,
         "generated": datetime.now(timezone.utc).isoformat(),
         "label": label,
+        "backend_versions": _backend_versions(),
         "metrics_by_arm": metrics,
         "runs": results,
     }
@@ -180,7 +192,14 @@ def cmd_compare(args) -> int:
 def cmd_demo(args) -> int:
     arms = REAL_ARMS
     scenarios = load_scenarios(args.scenarios)
-    model = _answering_model("offline-stub", args.seed)
+    ns = tuple(int(x) for x in args.ns.split(",") if x.strip())
+    if args.answering == "claude":
+        print(
+            f"NOTE: --answering claude makes real API calls "
+            f"(~ {len(arms)} arms x scenarios x {len(ns)} corpus sizes). "
+            f"Use --ns to keep a real run cheap (e.g. --ns 10,50).\n"
+        )
+    model = _answering_model(args.answering, args.seed)
     print("== per-scenario, per-arm (tiny corpus) ==")
     results: list[dict] = []
     for arm in arms:
@@ -190,7 +209,14 @@ def cmd_demo(args) -> int:
     report = _write_report(results, Path(args.out), "demo")
 
     print("\n== adherence vs corpus size (discriminating scenarios, averaged) ==")
-    dataset = build_dataset(scenarios, arms=arms, seed=args.seed)
+    dataset = build_dataset(
+        scenarios,
+        arms=arms,
+        ns=ns,
+        seed=args.seed,
+        answering_model_name=args.answering,
+        embedder_spec=args.embedder,
+    )
     for arm in arms:
         row = " ".join(f"N={p['N']}:{p['adherence_rate']:.2f}" for p in dataset["arms"][arm])
         print(f"{arm:<16}{row}")
@@ -209,10 +235,16 @@ def cmd_demo(args) -> int:
             print(f"{arm:<13}{sid:<32}{row}")
     data_path, chart_path = emit(dataset, Path(args.out))
     print(f"\nwrote {report}\nwrote {data_path}\nwrote {chart_path}")
-    print(
-        "\nNOTE: offline-stub output is a harness illustration, NOT a benchmark "
-        "result. See README and ADR-0001."
-    )
+    if args.answering == "offline-stub":
+        print(
+            "\nNOTE: offline-stub output is a harness illustration, NOT a benchmark "
+            "result. See README and ADR-0001."
+        )
+    else:
+        print(
+            "\nNOTE: real-model run on the tiny SYNTHETIC scenarios — a real-model "
+            "crossover, not yet the real-CORPUS evidence run. See README and ADR-0001."
+        )
     return 0
 
 
@@ -238,6 +270,13 @@ def main(argv: list[str] | None = None) -> int:
             sp.add_argument("--arm", required=True, choices=sorted(ARMS))
         if name == "compare":
             sp.add_argument("--arms", default=",".join(REAL_ARMS))
+        if name == "demo":
+            sp.add_argument(
+                "--ns",
+                default="10,50,150,300",
+                help="comma-separated corpus sizes for the crossover sweep "
+                "(smaller keeps a real run cheap, e.g. 10,50)",
+            )
 
     args = p.parse_args(argv)
     return {"run": cmd_run, "compare": cmd_compare, "demo": cmd_demo}[args.cmd](args)

--- a/decisiongrounding/schema/run_result.schema.json
+++ b/decisiongrounding/schema/run_result.schema.json
@@ -72,6 +72,16 @@
       },
       "description": "What this arm placed in the answering model's context. The single symmetric grounding opportunity."
     },
+    "embedder": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "required": ["name", "dim"],
+      "properties": {
+        "name": { "type": "string" },
+        "dim": { "type": "integer", "minimum": 1 }
+      },
+      "description": "Embedder identity for retrieval arms (model id + vector dimension), recorded for reproducibility. null for arms that do not embed."
+    },
     "proposed_change": {
       "type": "object",
       "additionalProperties": false,

--- a/decisiongrounding/scoring/crossover.py
+++ b/decisiongrounding/scoring/crossover.py
@@ -20,7 +20,7 @@ import random
 import re
 from pathlib import Path
 
-from providers import ARMS, ScriptedAnsweringModel
+from providers import build_provider, make_answering_model
 from providers.base import CorpusArtifact
 from scenarios.loader import Scenario
 from scoring.scorer import score
@@ -81,8 +81,8 @@ def make_filler_notes(
     return notes
 
 
-def _run_arm_on_corpus(arm_name: str, corpus, scenario, seed: int):
-    provider = ARMS[arm_name](ScriptedAnsweringModel(seed=seed))
+def _run_arm_on_corpus(arm_name: str, corpus, scenario, answering_model, embedder_spec: str):
+    provider = build_provider(arm_name, answering_model, embedder_spec)
     provider.prepare(list(corpus))
     pc = provider.respond(scenario.task)
     gov = scenario.gold_label.governing_decision
@@ -95,9 +95,18 @@ def build_dataset(
     arms: tuple[str, ...] = ("context_dump", "naive_rag"),
     ns: tuple[int, ...] = DEFAULT_NS,
     seed: int = 0,
+    answering_model_name: str = "offline-stub",
+    embedder_spec: str = "local-hash",
 ) -> dict:
-    """Compute per-arm adherence at each N, averaged over discriminating scenarios."""
+    """Compute per-arm adherence at each N, averaged over discriminating scenarios.
+
+    Defaults keep the offline spine (scripted model + local-hash embedder). Pass
+    `answering_model_name="claude"` and an `embedder_spec` like
+    `voyage:voyage-4-large` to produce a real-model crossover.
+    """
     discriminating = [s for s in scenarios if s.scenario_type in DISCRIMINATING]
+    # One answering model instance reused across the sweep (lazy client for real).
+    answering_model = make_answering_model(answering_model_name, seed)
     points: dict[str, list[dict]] = {arm: [] for arm in arms}
     # per_scenario[arm][scenario_id] -> [{N, adherent, stale}]
     per_scenario: dict[str, dict[str, list[dict]]] = {
@@ -112,7 +121,9 @@ def build_dataset(
             for sc in discriminating:
                 filler = make_filler_notes(max(0, n - len(sc.corpus)), sc, seed, density)
                 corpus = list(sc.corpus) + filler
-                sc_score, gov_retrieved = _run_arm_on_corpus(arm, corpus, sc, seed)
+                sc_score, gov_retrieved = _run_arm_on_corpus(
+                    arm, corpus, sc, answering_model, embedder_spec
+                )
                 adhered += 1 if sc_score.adherent else 0
                 retrieved_flags.append(gov_retrieved)
                 per_scenario[arm][sc.scenario_id].append(
@@ -135,6 +146,8 @@ def build_dataset(
         "note": "Filler is synthetic untyped `note` padding. Illustrative, not a real corpus.",
         "seed": seed,
         "ns": list(ns),
+        "answering_model": answering_model.version,
+        "embedder": embedder_spec,
         "arms": {arm: points[arm] for arm in arms},
         "per_scenario": per_scenario,
     }

--- a/decisiongrounding/tests/test_arms_smoke.py
+++ b/decisiongrounding/tests/test_arms_smoke.py
@@ -37,6 +37,33 @@ def test_both_real_arms_run_and_emit_valid_runresults():
             assert rr["arm"] == arm
 
 
+def test_run_one_records_embedder_metadata():
+    # Retrieval arms record the embedder id + dim; non-embedding arms record null.
+    model = ScriptedAnsweringModel(seed=0)
+    sc = load_scenarios(_SCENARIOS)[0]
+    rr_rag = run_one("naive_rag", sc, model, seed=0, embedder="local-hash")
+    assert rr_rag["embedder"] == {"name": "local-hash-bow-256", "dim": 256}
+    _validate_run(rr_rag)
+    rr_cd = run_one("context_dump", sc, model, seed=0)
+    assert rr_cd["embedder"] is None
+    _validate_run(rr_cd)
+
+
+def test_build_dataset_honors_ns_and_defaults_to_offline_backends():
+    # Backward compatible: explicit offline backends + a custom ns sweep.
+    scenarios = load_scenarios(_SCENARIOS)
+    ds = build_dataset(
+        scenarios,
+        arms=("context_dump", "naive_rag"),
+        ns=(10, 50),
+        answering_model_name="offline-stub",
+        embedder_spec="local-hash",
+    )
+    assert ds["ns"] == [10, 50]
+    assert ds["embedder"] == "local-hash"
+    assert [p["N"] for p in ds["arms"]["naive_rag"]] == [10, 50]
+
+
 def test_tiny_corpus_is_an_expected_tie():
     # On the tiny corpus both real arms should adhere on every worked scenario.
     model = ScriptedAnsweringModel(seed=0)

--- a/decisiongrounding/tests/test_real_backends.py
+++ b/decisiongrounding/tests/test_real_backends.py
@@ -11,9 +11,13 @@ import pytest
 
 from providers import (
     ClaudeAnsweringModel,
+    ContextDumpProvider,
     LocalDeterministicEmbedder,
+    NaiveRagProvider,
     ScriptedAnsweringModel,
     VoyageEmbedder,
+    build_provider,
+    make_answering_model,
     make_embedder,
     resolve_supersedes,
 )
@@ -100,3 +104,24 @@ def test_claude_answering_model_is_pinned():
     m = ClaudeAnsweringModel(seed=0)
     assert m.version == "claude-opus-4-8"  # pinned model id
     assert m.temperature is None  # Opus 4.8 exposes no temperature/seed knob
+
+
+# --- shared backend factories (reused by CLI and crossover) -----------------
+
+def test_make_answering_model_routes_by_name():
+    assert isinstance(make_answering_model("offline-stub", 0), ScriptedAnsweringModel)
+    # Constructing the real model is lazy (no client/key needed until respond()).
+    assert isinstance(make_answering_model("claude", 0), ClaudeAnsweringModel)
+
+
+def test_make_answering_model_rejects_unknown():
+    with pytest.raises(ValueError):
+        make_answering_model("gpt", 0)
+
+
+def test_build_provider_wires_embedder_into_naive_rag_only():
+    model = ScriptedAnsweringModel(seed=0)
+    p = build_provider("naive_rag", model, "local-hash")
+    assert isinstance(p, NaiveRagProvider)
+    assert isinstance(p.embedder, LocalDeterministicEmbedder)
+    assert isinstance(build_provider("context_dump", model), ContextDumpProvider)


### PR DESCRIPTION
# Summary

Makes the headline **crossover curve producible on a real model** and records the
reproducibility metadata a credible real run needs. Prerequisite for the
real-corpus pilot work.

Previously `build_dataset` / `_run_arm_on_corpus` (`scoring/crossover.py`)
hardcoded the scripted answering model + local-hash embedder, so the crossover
could only ever run offline. This threads real backends through it (defaults stay
offline) and adds per-run/per-report provenance.

# Changes

**Real backends in the crossover**
- New shared factories in `providers/`: `make_answering_model(name, seed)` and
  `build_provider(arm, model, embedder_spec)`, so the CLI and the crossover build
  identical backends without importing each other (removes the circular-import
  risk).
- `build_dataset(...)` gains `answering_model_name` + `embedder_spec` (defaults
  keep the offline spine); `_run_arm_on_corpus` builds providers via the shared
  factory instead of hardcoding `ScriptedAnsweringModel`.
- `demo` gains `--ns` (comma-separated corpus sizes) to keep a real sweep cheap,
  plus a cost warning when `--answering claude`.
- `demo --answering claude --embedder voyage:voyage-4-large --ns 10,50` now
  produces a real-model crossover.

**Reproducibility**
- Nullable `embedder { name, dim }` per RunResult (schema + `run_one`); null for
  arms that don't embed.
- `backend_versions { anthropic, voyageai }` recorded in each report header
  (the honest pin — each report says exactly what produced it).
- `[real]` floors tightened to verified-working versions (`anthropic>=0.109`,
  `voyageai>=0.4`); crossover dataset header records the model + embedder.

# Verification
- `cd decisiongrounding && python -m pytest -q` — **34 passed** (+5 new).
- Default `demo`/`compare` unchanged; `demo --ns 10,50` and the new metadata
  verified; all generated RunResults validate against the schema.

# Boundary (unchanged, stated plainly)
With `--answering claude` you get a real-*model* crossover **on the tiny synthetic
scenarios** — plumbing for evidence, not the evidence. The real-*corpus* run is a
separate increment (the PEP-supersession pilot, which builds on this).