### PR TITLE
feat(decisiongrounding): real-corpus pilot — PEP 386→440 supersession

### DIFF
--- a/decisiongrounding/CONTRIBUTING.md
+++ b/decisiongrounding/CONTRIBUTING.md
@@ -63,6 +63,20 @@ temperature + seed so it reproduces.
    `rationale`.
 4. `make test`.
 
+### Real vs synthetic scenarios
+
+`scenarios/` is for **synthetic** worked scenarios that exercise the harness;
+they are never reported as results (rule 2). **Real / public-derived** corpora —
+the only ones eligible to be reported — live under `scenarios_real/`, kept
+physically separate so the default offline demo never blurs the line.
+
+Real corpus material must be **reproducible**, not transcribed: derive it from a
+public source pinned to an immutable revision, and commit the verbatim artifact
+plus a `provenance.json` recording the source URL and a content hash. The PEP
+pilot does this via `ingest/peps.py` (`build` / `verify`) against a pinned
+`python/peps` commit. Excerpting or paraphrasing the source is the cherry-picking
+rule 2 forbids — pin, fetch verbatim, and hash instead.
+
 ## Adding an arm
 
 See "Add an arm" in the README. Then confirm it is scored by the same

--- a/decisiongrounding/README.md
+++ b/decisiongrounding/README.md
@@ -125,6 +125,41 @@ scenarios**. That is the plumbing for evidence, not the evidence. The real
 result requires real/public-derived corpora (see CONTRIBUTING.md); until then
 the crossover is plumbing, not evidence.
 
+### Real-corpus pilot (PEP supersession)
+
+`scenarios_real/` holds the first **real, public-derived** corpus: the
+**PEP 386 → PEP 440** version-scheme supersession. PEP 386 carries
+`Status: Superseded` / `Superseded-By: 440`; PEP 440 (`Replaces: 386`) states
+"this PEP MUST be used … and supersedes PEP 386 … Tools SHOULD ignore any
+versions which cannot be parsed by the rules in this PEP." An agent that reaches
+for PEP 386's retired `verlib`/`NormalizedVersion` scheme is following a
+superseded decision; the adherent move is to cite PEP 440 instead. See
+`decisions/ADR-0002-real-corpus-pilot-peps.md`.
+
+The corpus is pinned to one immutable commit of `python/peps` and is fully
+reproducible — nothing in it is hand-written PEP prose:
+
+```bash
+# Regenerate the corpus from the pin, or verify it reproduces byte-for-byte.
+python -m ingest.peps build  --out scenarios_real/peps_version_supersession
+python -m ingest.peps verify --out scenarios_real/peps_version_supersession
+```
+
+Run the pilot for real (needs `[real]` + both keys, exactly as above):
+
+```bash
+python -m runner.cli compare \
+  --arms context_dump,naive_rag,no_grounding \
+  --answering claude --embedder voyage:voyage-4-large \
+  --scenarios scenarios_real --seed 0
+```
+
+This produces the first genuine decision-adherence result (win, tie, or loss)
+on a real corpus; like every run it is appended to `results/`. The build
+environment for this pilot had no API keys, so the scenario is offline-validated
+(loads, schema-validates, scores) and the real numbers are produced by whoever
+holds the keys.
+
 Tests:
 
 ```bash
@@ -146,9 +181,10 @@ make test
 | Pinned Claude answering model (`--answering claude`, Opus 4.8) | ✅ implemented; needs `[real]` + `ANTHROPIC_API_KEY` |
 | Real embeddings (`--embedder voyage:…` / `st:…`) | ✅ implemented; needs `[real]` / `[local-embeddings]` |
 | `rac` arm (typed retrieval, follows `supersedes`) | ✅ implemented; needs the `rac` CLI on PATH |
+| Real/public-derived scenario (PEP 386→440 supersession) | ✅ corpus built, pinned + verifiable; real run needs `[real]` + keys |
 | `memory_provider` arm | ⏳ typed stub + TODO |
 | LLM-judge fallback | ⏳ disclosed, not built |
-| Full N=300 corpus (real/public-derived) | ⏳ next increment |
+| Full N=300 corpus (real/public-derived) | ⏳ next increment (more real pairs) |
 
 > **Pinned model caveat:** the answering model is `claude-opus-4-8`, which
 > rejects `temperature`/`top_p`/`seed` (the API 400s on them). There is no
@@ -165,11 +201,13 @@ decisiongrounding/
   spec/        FROZEN scenario taxonomy + scoring rubric (pre-registration)
   schema/      JSON Schema (Draft 2020-12) for Scenario and RunResult
   providers/   uniform adapter (prepare/respond) + the arms + answering/embedding
-  scenarios/   loader + four worked scenarios with tiny synthetic corpora
+  scenarios/   loader + worked scenarios with tiny synthetic corpora
+  scenarios_real/  real/public-derived corpora (PEP supersession pilot)
+  ingest/      deterministic ingest of public artifacts (PEPs) into corpora
   scoring/     deterministic scorer, metrics, crossover dataset + chart
   runner/      CLI; pins model + seed; append-only report writer
   results/     append-only run outputs (generated; not committed)
-  tests/       schema, scorer, and offline arm-smoke coverage
+  tests/       schema, scorer, ingest, real-corpus, and offline arm-smoke coverage
 ```
 
 ## Add an arm

--- a/decisiongrounding/decisions/ADR-0002-real-corpus-pilot-peps.md
+++ b/decisiongrounding/decisions/ADR-0002-real-corpus-pilot-peps.md
@@ -1,0 +1,133 @@
+---
+schema_version: 1
+id: DG-ADR-0002
+type: decision
+tags: [corpus, methodology, supersession, pilot]
+---
+
+# ADR-0002: Real-Corpus Pilot — PEP Supersession
+
+## Status
+
+Accepted
+
+## Category
+
+Methodology
+
+## Context
+
+ADR-0001 built the harness and recorded an explicit limitation: the headline
+crossover "remains an unvalidated hypothesis until the pinned Claude answering
+model runs on **real/public-derived corpora**." Every scenario shipped so far
+lives under `scenarios/` and is synthetic — useful for exercising the harness,
+but disqualified from being reported as a result by CONTRIBUTING.md rule 2 (no
+win-only / hand-authored corpora).
+
+To move the thesis from "plumbing" to "evidence" we need a first corpus that:
+
+1. is derived from a **real, public** decision set, not invented here;
+2. contains a genuine, *machine-stated* `supersedes` relationship (the
+   discriminating signal the benchmark is built around); and
+3. is **byte-for-byte reproducible** by a skeptic, so the corpus itself cannot
+   be dismissed as cherry-picked or quietly edited.
+
+Python Enhancement Proposals (PEPs) fit. They are public, carry RFC-2822
+headers that state supersession in the artifact itself (`Status: Superseded`,
+`Superseded-By:`, `Replaces:`), and the `python/peps` repository can be pinned
+to an immutable commit.
+
+## Decision
+
+Add a **real-corpus pilot**: one `superseded_decision` scenario built from the
+**PEP 386 → PEP 440** version-scheme supersession, plus a deterministic ingest
+tool that produces the corpus from a pinned upstream commit.
+
+- **Pair.** PEP 386 (*Changing the version comparison module in Distutils*,
+  `Status: Superseded`, `Superseded-By: 440`) is superseded by PEP 440
+  (*Version Identification and Dependency Specification*, `Status: Final`,
+  `Replaces: 386`). PEP 440 states verbatim: "this PEP MUST be used for all
+  versions of metadata and supersedes PEP 386 … Tools SHOULD ignore any versions
+  which cannot be parsed by the rules in this PEP." The supersession is stated
+  by the artifacts, not asserted by us.
+- **Pin.** Sources are fetched from `python/peps` at commit
+  `f866e77409305866038471574f075cd8d83eee9e`. The pin is a constant in
+  `ingest/peps.py`; bumping it is a deliberate, reviewable change because it
+  changes the corpus.
+- **Layout.** Real scenarios live under a new top-level `scenarios_real/`,
+  separate from the synthetic `scenarios/`, so the default offline demo never
+  silently mixes real and synthetic corpora. Each PEP becomes a `decision`
+  artifact (provenance preamble + verbatim reStructuredText); `provenance.json`
+  records the upstream URL, sha256, parsed headers, and the header-derived
+  `supersedes` edges.
+- **Verb mapping.** The scenario uses `verdict: prohibited`: the proposed action
+  implements the retired PEP 386 `verlib`/`NormalizedVersion` scheme, which the
+  governing decision (PEP 440) forbids. Adherence = recognise PEP 386 is
+  superseded and cite PEP 440; citing only PEP 386 and proceeding is the
+  `stale_decision_followed` failure. This matches the deterministic scorer's
+  superseded-decision branch without a bespoke scorer.
+- **Blind gold label.** The gold label was authored from the pinned PEP texts
+  with no arm having been run (this environment has no API keys, so no arm
+  output could exist), satisfying CONTRIBUTING.md rule 1 by construction.
+
+## Consequences
+
+### Positive
+
+- The benchmark now has a real, public, reproducible corpus exercising the
+  discriminating `supersedes` mechanism — the headline is testable on it.
+- The ingest tool (`build`/`verify`) lets any reviewer regenerate the corpus and
+  prove it matches the upstream pin, turning "trust us" into "re-run it."
+- Synthetic and real corpora are physically separated, so the credibility rule
+  "synthetic scenarios are never reported as results" is enforced by layout.
+
+### Negative
+
+- The corpus carries large verbatim documents (PEP 440 is ~67 KB). This is
+  intentional — trimming would invite "you cherry-picked" — but it is heavier
+  than a synthetic scenario.
+
+### Risks
+
+- **Single pair is not a benchmark.** One scenario is a pilot, not a result.
+  Mitigation: this ADR scopes it as the first increment; more public pairs
+  (e.g. the PEP 345 → 566 metadata supersession) follow before any headline
+  claim.
+- **Real numbers not yet produced.** Running the pilot needs the `[real]` extra,
+  `ANTHROPIC_API_KEY`, and `VOYAGE_API_KEY`, which are absent in the build
+  environment. Mitigation: the scenario is offline-validated (loads,
+  schema-validates, scores) and the exact real-run command is documented; the
+  run appends to `results/` like any other.
+
+## Alternatives Considered
+
+- **PEP 345 → 566 (package metadata).** Also a real, machine-stated
+  supersession, but the conflict (metadata field formats) is dryer and maps less
+  cleanly onto an action an agent is "on the verge of taking." Kept as the next
+  pair, not the first.
+- **Mix real scenarios into `scenarios/`.** Rejected: the crossover would graft
+  synthetic filler onto a real scenario and the default demo would blur the
+  synthetic/real line that CONTRIBUTING.md draws.
+- **Hand-transcribe the relevant PEP sections.** Rejected: excerpting is exactly
+  the cherry-picking the credibility rules exist to prevent. Verbatim + pinned +
+  hashed is the defensible form.
+
+## Related Decisions
+
+- ADR-0001 — Harness Foundation (this pilot realises its "real/public-derived
+  corpora" success condition).
+
+## Success Measures
+
+- A reviewer can run `python -m ingest.peps verify --out
+  scenarios_real/peps_version_supersession` and reproduce the corpus from the
+  pin.
+- The scenario loads, schema-validates, and is scored by the same deterministic
+  scorer as every other scenario — no bespoke scoring.
+- When run with the pinned Claude model on real embeddings, the result (win,
+  tie, or loss) is appended to `results/` and reported.
+
+## Review Date
+
+Revisit once a second real pair lands, or if the deterministic scorer's
+superseded-decision branch proves too coarse for real, prose-heavy artifacts.

--- a/decisiongrounding/ingest/__init__.py
+++ b/decisiongrounding/ingest/__init__.py
@@ -1,0 +1,8 @@
+"""Deterministic ingest of real, public artifacts into benchmark corpora.
+
+This package turns public decision documents (currently Python PEPs) into
+`decisiongrounding` corpus artifacts WITHOUT hand-writing their prose, so a
+skeptic can reproduce the corpus byte-for-byte from an immutable upstream pin.
+The gold label and task are always authored by hand and blind (CONTRIBUTING.md
+rule 1); ingest only produces the mechanical, verifiable corpus material.
+"""

--- a/decisiongrounding/ingest/peps.py
+++ b/decisiongrounding/ingest/peps.py
@@ -1,0 +1,222 @@
+"""Deterministic ingest of real Python PEPs into corpus artifacts.
+
+Real/public-derived corpus material (CONTRIBUTING.md rule 2). PEP sources are
+pinned to one immutable commit of `python/peps`, so the corpus is byte-for-byte
+reproducible and auditable — nothing here is hand-written PEP prose.
+
+    python -m ingest.peps build  --out scenarios_real/peps_version_supersession
+    python -m ingest.peps verify --out scenarios_real/peps_version_supersession
+
+`build` fetches each pinned PEP and writes:
+
+* `corpus/PEP-XXXX.md` — a short provenance preamble plus the verbatim upstream
+  reStructuredText, and
+* `provenance.json` — per-PEP source URL, sha256 of the upstream `.rst`, the
+  parsed RFC-2822 headers, and the supersedes edges *derived from those headers*
+  (`Superseded-By` / `Replaces`).
+
+`verify` re-fetches at the same pin and fails if any committed corpus file no
+longer reproduces from the recorded upstream bytes — catching both upstream
+drift and local tampering.
+
+The task and gold label in `scenario.json` are authored by hand, blind to arm
+outputs (rule 1). This tool never writes them.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+import urllib.request
+from pathlib import Path
+
+# One immutable commit of python/peps. Bumping this is a deliberate, reviewable
+# act (it changes the corpus); never float it to a branch name.
+PINNED_COMMIT = "f866e77409305866038471574f075cd8d83eee9e"
+SOURCE_REPO = "python/peps"
+_RAW = "https://raw.githubusercontent.com/{repo}/{sha}/peps/pep-{num:04d}.rst"
+
+# The pilot corpus: the real PEP supersession pair. PEP 440 (Final) Replaces
+# PEP 386 (Superseded); both edges are stated in the artifacts' own headers.
+PILOT_PEPS = (386, 440)
+
+
+def pep_id(num: int) -> str:
+    """Stable corpus artifact id for a PEP number (e.g. 386 -> 'PEP-0386')."""
+    return f"PEP-{num:04d}"
+
+
+def source_url(num: int, sha: str = PINNED_COMMIT) -> str:
+    return _RAW.format(repo=SOURCE_REPO, sha=sha, num=num)
+
+
+def fetch_pep(num: int, sha: str = PINNED_COMMIT, timeout: float = 20.0) -> str:
+    """Fetch one PEP's reStructuredText at the pinned commit."""
+    url = source_url(num, sha)
+    req = urllib.request.Request(url, headers={"User-Agent": "decisiongrounding-ingest"})
+    with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 - pinned host
+        return resp.read().decode("utf-8")
+
+
+def parse_headers(rst: str) -> dict[str, str]:
+    """Parse the RFC-2822-style PEP header block (everything before the first
+    blank line). Continuation lines (leading whitespace) fold into the prior
+    field, matching how PEP tooling reads multi-line Author/Post-History values.
+    """
+    headers: dict[str, str] = {}
+    last_key: str | None = None
+    for line in rst.splitlines():
+        if line.strip() == "":
+            break
+        if line[:1].isspace() and last_key is not None:
+            headers[last_key] = f"{headers[last_key]} {line.strip()}".strip()
+            continue
+        key, sep, value = line.partition(":")
+        if not sep:
+            continue
+        last_key = key.strip()
+        headers[last_key] = value.strip()
+    return headers
+
+
+def _header_numbers(headers: dict[str, str], key: str) -> list[int]:
+    """PEP numbers from a comma-separated header value (e.g. 'Replaces: 386')."""
+    raw = headers.get(key, "")
+    return [int(tok) for tok in raw.replace(",", " ").split() if tok.isdigit()]
+
+
+def supersedes_targets(headers: dict[str, str]) -> list[int]:
+    """PEP numbers this PEP supersedes, per its own headers.
+
+    A `Replaces:` header on the newer PEP and a `Superseded-By:` header on the
+    older PEP both encode the same edge; we read `Replaces` as the authoritative
+    forward edge (newer -> older).
+    """
+    return _header_numbers(headers, "Replaces")
+
+
+def corpus_markdown(num: int, rst: str, sha: str = PINNED_COMMIT) -> str:
+    """A corpus artifact: provenance preamble + verbatim upstream PEP text."""
+    title = parse_headers(rst).get("Title", "").strip()
+    heading = f"# {pep_id(num)} — {title}" if title else f"# {pep_id(num)}"
+    preamble = (
+        f"{heading}\n\n"
+        f"> Source: {SOURCE_REPO} @ {sha}\n"
+        f"> Path: peps/pep-{num:04d}.rst · {source_url(num, sha)}\n"
+        f"> Verbatim public artifact, pinned and unedited. Not authored for this\n"
+        f"> benchmark; see provenance.json for the upstream sha256.\n\n"
+        f"---\n\n"
+    )
+    return preamble + rst
+
+
+def build_provenance(peps: tuple[int, ...], texts: dict[int, str], sha: str) -> dict:
+    """The auditable record: per-PEP hashes, headers, and derived edges."""
+    entries = []
+    edges = []
+    for num in peps:
+        rst = texts[num]
+        headers = parse_headers(rst)
+        replaces = supersedes_targets(headers)
+        entries.append(
+            {
+                "id": pep_id(num),
+                "number": num,
+                "file": f"corpus/{pep_id(num)}.md",
+                "url": source_url(num, sha),
+                "source_sha256": hashlib.sha256(rst.encode("utf-8")).hexdigest(),
+                "status": headers.get("Status", ""),
+                "title": headers.get("Title", ""),
+                "replaces": [pep_id(n) for n in replaces],
+                "superseded_by": [pep_id(n) for n in _header_numbers(headers, "Superseded-By")],
+            }
+        )
+        for target in replaces:
+            if target in peps:
+                edges.append({"source": pep_id(num), "type": "supersedes", "target": pep_id(target)})
+    return {
+        "source_repo": SOURCE_REPO,
+        "pinned_commit": sha,
+        "peps": entries,
+        "supersedes_edges": edges,
+    }
+
+
+def build(out_dir: Path, peps: tuple[int, ...] = PILOT_PEPS, sha: str = PINNED_COMMIT) -> dict:
+    """Fetch the pinned PEPs and write corpus files + provenance.json."""
+    corpus_dir = out_dir / "corpus"
+    corpus_dir.mkdir(parents=True, exist_ok=True)
+    texts = {num: fetch_pep(num, sha) for num in peps}
+    for num in peps:
+        (corpus_dir / f"{pep_id(num)}.md").write_text(
+            corpus_markdown(num, texts[num], sha), encoding="utf-8"
+        )
+    provenance = build_provenance(peps, texts, sha)
+    (out_dir / "provenance.json").write_text(
+        json.dumps(provenance, indent=2) + "\n", encoding="utf-8"
+    )
+    return provenance
+
+
+def verify(out_dir: Path) -> list[str]:
+    """Re-fetch at the recorded pin; return a list of integrity problems (empty
+    means the committed corpus reproduces exactly from the upstream bytes)."""
+    provenance = json.loads((out_dir / "provenance.json").read_text(encoding="utf-8"))
+    sha = provenance["pinned_commit"]
+    problems: list[str] = []
+    for entry in provenance["peps"]:
+        num = entry["number"]
+        try:
+            rst = fetch_pep(num, sha)
+        except Exception as exc:  # noqa: BLE001 - report, don't crash
+            problems.append(f"{entry['id']}: fetch failed: {exc}")
+            continue
+        got = hashlib.sha256(rst.encode("utf-8")).hexdigest()
+        if got != entry["source_sha256"]:
+            problems.append(
+                f"{entry['id']}: upstream sha256 changed ({got} != {entry['source_sha256']})"
+            )
+        expected_md = corpus_markdown(num, rst, sha)
+        actual_md = (out_dir / entry["file"]).read_text(encoding="utf-8")
+        if expected_md != actual_md:
+            problems.append(f"{entry['id']}: committed {entry['file']} does not match upstream bytes")
+    return problems
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="ingest.peps", description=__doc__)
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    for name in ("build", "verify"):
+        sp = sub.add_parser(name)
+        sp.add_argument("--out", required=True, help="scenario directory to write/verify")
+        if name == "build":
+            sp.add_argument(
+                "--peps",
+                default=",".join(str(n) for n in PILOT_PEPS),
+                help="comma-separated PEP numbers (default: the pilot pair 386,440)",
+            )
+    args = parser.parse_args(argv)
+    out_dir = Path(args.out)
+
+    if args.cmd == "build":
+        peps = tuple(int(x) for x in args.peps.split(",") if x.strip())
+        provenance = build(out_dir, peps)
+        print(f"wrote {len(peps)} PEP corpus file(s) + provenance.json to {out_dir}")
+        for edge in provenance["supersedes_edges"]:
+            print(f"  edge: {edge['source']} supersedes {edge['target']}")
+        return 0
+
+    problems = verify(out_dir)
+    if problems:
+        print("verify FAILED:", file=sys.stderr)
+        for p in problems:
+            print(f"  - {p}", file=sys.stderr)
+        return 1
+    print(f"verify OK: corpus in {out_dir} reproduces from {SOURCE_REPO}@{PINNED_COMMIT}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/decisiongrounding/pyproject.toml
+++ b/decisiongrounding/pyproject.toml
@@ -35,4 +35,4 @@ dev = ["pytest>=7"]
 decisiongrounding = "runner.cli:main"
 
 [tool.setuptools]
-packages = ["providers", "scenarios", "scoring", "runner"]
+packages = ["providers", "scenarios", "scoring", "runner", "ingest"]

--- a/decisiongrounding/scenarios_real/peps_version_supersession/corpus/PEP-0386.md
+++ b/decisiongrounding/scenarios_real/peps_version_supersession/corpus/PEP-0386.md
@@ -1,0 +1,519 @@
+# PEP-0386 — Changing the version comparison module in Distutils
+
+> Source: python/peps @ f866e77409305866038471574f075cd8d83eee9e
+> Path: peps/pep-0386.rst · https://raw.githubusercontent.com/python/peps/f866e77409305866038471574f075cd8d83eee9e/peps/pep-0386.rst
+> Verbatim public artifact, pinned and unedited. Not authored for this
+> benchmark; see provenance.json for the upstream sha256.
+
+---
+
+PEP: 386
+Title: Changing the version comparison module in Distutils
+Author: Tarek Ziadé <tarek@ziade.org>
+Status: Superseded
+Type: Standards Track
+Topic: Packaging
+Created: 04-Jun-2009
+Superseded-By: 440
+
+
+Abstract
+========
+
+Note: This PEP has been superseded by the version identification and
+dependency specification scheme defined in :pep:`440`.
+
+This PEP proposed a new version comparison schema system in Distutils.
+
+Motivation
+==========
+
+In Python there are no real restrictions yet on how a project should manage its
+versions, and how they should be incremented.
+
+Distutils provides a ``version`` distribution meta-data field but it is freeform and
+current users, such as PyPI usually consider the latest version pushed as the
+``latest`` one, regardless of the expected semantics.
+
+Distutils will soon extend its capabilities to allow distributions to express a
+dependency on other distributions through the ``Requires-Dist`` metadata field
+(see :pep:`345`) and it will optionally allow use of that field to
+restrict the dependency to a set of compatible versions. Notice that this field
+is replacing ``Requires`` that was expressing dependencies on modules and packages.
+
+The ``Requires-Dist`` field will allow a distribution to define a dependency on
+another package and optionally restrict this dependency to a set of
+compatible versions, so one may write::
+
+    Requires-Dist: zope.interface (>3.5.0)
+
+This means that the distribution requires ``zope.interface`` with a version
+greater than ``3.5.0``.
+
+This also means that Python projects will need to follow the same convention
+as the tool that will be used to install them, so they are able to compare
+versions.
+
+That is why this PEP proposes, for the sake of interoperability, a standard
+schema to express version information and its comparison semantics.
+
+Furthermore, this will make OS packagers' work easier when repackaging standards
+compliant distributions, because as of now it can be difficult to decide how two
+distribution versions compare.
+
+
+Requisites and current status
+=============================
+
+It is not in the scope of this PEP to provide a universal versioning schema
+intended to support all or even most of existing versioning schemas. There
+will always be competing grammars, either mandated by distro or project
+policies or by historical reasons that we cannot expect to change.
+
+The proposed schema should be able to express the usual versioning semantics,
+so it's possible to parse any alternative versioning schema and transform it
+into a compliant one. This is how OS packagers usually deal with the existing
+version schemas and is a preferable alternative than supporting an arbitrary
+set of versioning schemas.
+
+Conformance to usual practice and conventions, as well as a simplicity are a
+plus, to ease frictionless adoption and painless transition. Practicality beats
+purity, sometimes.
+
+Projects have very different versioning needs, but the following are widely
+considered important semantics:
+
+1. it should be possible to express more than one versioning level
+   (usually this is expressed as major and minor revision and, sometimes,
+   also a micro revision).
+2. a significant number of projects need special meaning versions for
+   "pre-releases" (such as "alpha", "beta", "rc"), and these have widely
+   used aliases ("a" stands for "alpha", "b" for "beta" and "c" for "rc").
+   And these pre-release versions make it impossible to use a simple
+   alphanumerical ordering of the version string components.
+   (Example: 3.1a1 < 3.1)
+3. some projects also need "post-releases" of regular versions,
+   mainly for installer work which can't be clearly expressed otherwise.
+4. development versions allow packagers of unreleased work to avoid version
+   clash with later regular releases.
+
+For people that want to go further and use a tool to manage their version
+numbers, the two major ones are:
+
+- The current Distutils system [#distutils]_
+- Setuptools [#setuptools]_
+
+Distutils
+---------
+
+Distutils currently provides a ``StrictVersion`` and a ``LooseVersion`` class
+that can be used to manage versions.
+
+The ``LooseVersion`` class is quite lax. From Distutils doc::
+
+    Version numbering for anarchists and software realists.
+    Implements the standard interface for version number classes as
+    described above.  A version number consists of a series of numbers,
+    separated by either periods or strings of letters.  When comparing
+    version numbers, the numeric components will be compared
+    numerically, and the alphabetic components lexically.  The following
+    are all valid version numbers, in no particular order:
+
+        1.5.1
+        1.5.2b2
+        161
+        3.10a
+        8.02
+        3.4j
+        1996.07.12
+        3.2.pl0
+        3.1.1.6
+        2g6
+        11g
+        0.960923
+        2.2beta29
+        1.13++
+        5.5.kw
+        2.0b1pl0
+
+    In fact, there is no such thing as an invalid version number under
+    this scheme; the rules for comparison are simple and predictable,
+    but may not always give the results you want (for some definition
+    of "want").
+
+This class makes any version string valid, and provides an algorithm to sort
+them numerically then lexically. It means that anything can be used to version
+your project::
+
+    >>> from distutils.version import LooseVersion as V
+    >>> v1 = V('FunkyVersion')
+    >>> v2 = V('GroovieVersion')
+    >>> v1 > v2
+    False
+
+The problem with this is that while it allows expressing any
+nesting level it doesn't allow giving special meaning to versions
+(pre and post-releases as well as development versions), as expressed in
+requisites 2, 3 and 4.
+
+The ``StrictVersion`` class is more strict. From the doc::
+
+    Version numbering for meticulous retentive and software idealists.
+    Implements the standard interface for version number classes as
+    described above.  A version number consists of two or three
+    dot-separated numeric components, with an optional "pre-release" tag
+    on the end.  The pre-release tag consists of the letter 'a' or 'b'
+    followed by a number.  If the numeric components of two version
+    numbers are equal, then one with a pre-release tag will always
+    be deemed earlier (lesser) than one without.
+
+    The following are valid version numbers (shown in the order that
+    would be obtained by sorting according to the supplied cmp function):
+
+        0.4       0.4.0  (these two are equivalent)
+        0.4.1
+        0.5a1
+        0.5b3
+        0.5
+        0.9.6
+        1.0
+        1.0.4a3
+        1.0.4b1
+        1.0.4
+
+    The following are examples of invalid version numbers:
+
+        1
+        2.7.2.2
+        1.3.a4
+        1.3pl1
+        1.3c4
+
+This class enforces a few rules, and makes a decent tool to work with version
+numbers::
+
+    >>> from distutils.version import StrictVersion as V
+    >>> v2 = V('GroovieVersion')
+    Traceback (most recent call last):
+    ...
+    ValueError: invalid version number 'GroovieVersion'
+    >>> v2 = V('1.1')
+    >>> v3 = V('1.3')
+    >>> v2 < v3
+    True
+
+It adds pre-release versions, and some structure, but lacks a few semantic
+elements to make it usable, such as development releases or post-release tags,
+as expressed in requisites 3 and 4.
+
+Also, note that Distutils version classes have been present for years
+but are not really used in the community.
+
+
+Setuptools
+----------
+
+Setuptools provides another version comparison tool [#setuptools-version]_
+which does not enforce any rules for the version, but tries to provide a better
+algorithm to convert the strings to sortable keys, with a ``parse_version``
+function.
+
+From the doc::
+
+    Convert a version string to a chronologically-sortable key
+
+    This is a rough cross between Distutils' StrictVersion and LooseVersion;
+    if you give it versions that would work with StrictVersion, then it behaves
+    the same; otherwise it acts like a slightly-smarter LooseVersion. It is
+    *possible* to create pathological version coding schemes that will fool
+    this parser, but they should be very rare in practice.
+
+    The returned value will be a tuple of strings.  Numeric portions of the
+    version are padded to 8 digits so they will compare numerically, but
+    without relying on how numbers compare relative to strings.  Dots are
+    dropped, but dashes are retained.  Trailing zeros between alpha segments
+    or dashes are suppressed, so that e.g. "2.4.0" is considered the same as
+    "2.4". Alphanumeric parts are lower-cased.
+
+    The algorithm assumes that strings like "-" and any alpha string that
+    alphabetically follows "final"  represents a "patch level".  So, "2.4-1"
+    is assumed to be a branch or patch of "2.4", and therefore "2.4.1" is
+    considered newer than "2.4-1", which in turn is newer than "2.4".
+
+    Strings like "a", "b", "c", "alpha", "beta", "candidate" and so on (that
+    come before "final" alphabetically) are assumed to be pre-release versions,
+    so that the version "2.4" is considered newer than "2.4a1".
+
+    Finally, to handle miscellaneous cases, the strings "pre", "preview", and
+    "rc" are treated as if they were "c", i.e. as though they were release
+    candidates, and therefore are not as new as a version string that does not
+    contain them, and "dev" is replaced with an '@' so that it sorts lower
+    than any other pre-release tag.
+
+In other words, ``parse_version`` will return a tuple for each version string,
+that is compatible with ``StrictVersion`` but also accept arbitrary version and
+deal with them so they can be compared::
+
+    >>> from pkg_resources import parse_version as V
+    >>> V('1.2')
+    ('00000001', '00000002', '*final')
+    >>> V('1.2b2')
+    ('00000001', '00000002', '*b', '00000002', '*final')
+    >>> V('FunkyVersion')
+    ('*funkyversion', '*final')
+
+In this schema practicality takes priority over purity, but as a result it
+doesn't enforce any policy and leads to very complex semantics due to the lack
+of a clear standard. It just tries to adapt to widely used conventions.
+
+Caveats of existing systems
+---------------------------
+
+The major problem with the described version comparison tools is that they are
+too permissive and, at the same time, aren't capable of expressing some of the
+required semantics. Many of the versions on PyPI [#pypi]_ are obviously not
+useful versions, which makes it difficult for users to grok the versioning that
+a particular package was using and to provide tools on top of PyPI.
+
+Distutils classes are not really used in Python projects, but the
+Setuptools function is quite widespread because it's used by tools like
+``easy_install`` [#ezinstall]_, ``pip`` [#pip]_ or ``zc.buildout``
+[#zc.buildout]_ to install dependencies of a given project.
+
+While Setuptools *does* provide a mechanism for comparing/sorting versions,
+it is much preferable if the versioning spec is such that a human can make a
+reasonable attempt at that sorting without having to run it against some code.
+
+Also there's a problem with the use of dates at the "major" version number
+(e.g. a version string "20090421") with RPMs: it means that any attempt to
+switch to a more typical "major.minor..." version scheme is problematic because
+it will always sort less than "20090421".
+
+Last, the meaning of ``-`` is specific to Setuptools, while it is avoided in
+some packaging systems like the one used by Debian or Ubuntu.
+
+The new versioning algorithm
+============================
+
+During Pycon, members of the Python, Ubuntu and Fedora community worked on
+a version standard that would be acceptable for everyone.
+
+It's currently called ``verlib`` and a prototype lives at [#prototype]_.
+
+The pseudo-format supported is::
+
+    N.N[.N]+[{a|b|c|rc}N[.N]+][.postN][.devN]
+
+The real regular expression is::
+
+    expr = r"""^
+    (?P<version>\d+\.\d+)         # minimum 'N.N'
+    (?P<extraversion>(?:\.\d+)*)  # any number of extra '.N' segments
+    (?:
+        (?P<prerel>[abc]|rc)         # 'a' = alpha, 'b' = beta
+                                     # 'c' or 'rc' = release candidate
+        (?P<prerelversion>\d+(?:\.\d+)*)
+    )?
+    (?P<postdev>(\.post(?P<post>\d+))?(\.dev(?P<dev>\d+))?)?
+    $"""
+
+Some examples probably make it clearer::
+
+    >>> from verlib import NormalizedVersion as V
+    >>> (V('1.0a1')
+    ...  < V('1.0a2.dev456')
+    ...  < V('1.0a2')
+    ...  < V('1.0a2.1.dev456')
+    ...  < V('1.0a2.1')
+    ...  < V('1.0b1.dev456')
+    ...  < V('1.0b2')
+    ...  < V('1.0b2.post345')
+    ...  < V('1.0c1.dev456')
+    ...  < V('1.0c1')
+    ...  < V('1.0.dev456')
+    ...  < V('1.0')
+    ...  < V('1.0.post456.dev34')
+    ...  < V('1.0.post456'))
+    True
+
+The trailing ``.dev123`` is for pre-releases. The ``.post123`` is for
+post-releases -- which apparently are used by a number of projects out there
+(e.g. Twisted [#twisted]_). For example, *after* a ``1.2.0`` release there might
+be a ``1.2.0-r678`` release. We used ``post`` instead of ``r`` because the
+``r`` is ambiguous as to whether it indicates a pre- or post-release.
+
+``.post456.dev34`` indicates a dev marker for a post release, that sorts
+before a ``.post456`` marker. This can be used to do development versions
+of post releases.
+
+Pre-releases can use ``a`` for "alpha", ``b`` for "beta" and ``c`` for
+"release candidate". ``rc`` is an alternative notation for "release candidate"
+that is added to make the version scheme compatible with Python's own version
+scheme. ``rc`` sorts after ``c``::
+
+    >>> from verlib import NormalizedVersion as V
+    >>> (V('1.0a1')
+    ...  < V('1.0a2')
+    ...  < V('1.0b3')
+    ...  < V('1.0c1')
+    ...  < V('1.0rc2')
+    ...  < V('1.0'))
+    True
+
+Note that ``c`` is the preferred marker for third party projects.
+
+``verlib`` provides a ``NormalizedVersion`` class and a
+``suggest_normalized_version`` function.
+
+NormalizedVersion
+-----------------
+
+The ``NormalizedVersion`` class is used to hold a version and to compare it
+with others. It takes a string as an argument, that contains the representation
+of the version::
+
+    >>> from verlib import NormalizedVersion
+    >>> version = NormalizedVersion('1.0')
+
+The version can be represented as a string::
+
+    >>> str(version)
+    '1.0'
+
+Or compared with others::
+
+    >>> NormalizedVersion('1.0') > NormalizedVersion('0.9')
+    True
+    >>> NormalizedVersion('1.0') < NormalizedVersion('1.1')
+    True
+
+A class method called ``from_parts`` is available if you want to create an
+instance by providing the parts that composes the version.
+
+Examples ::
+
+    >>> version = NormalizedVersion.from_parts((1, 0))
+    >>> str(version)
+    '1.0'
+
+    >>> version = NormalizedVersion.from_parts((1, 0), ('c', 4))
+    >>> str(version)
+    '1.0c4'
+
+    >>> version = NormalizedVersion.from_parts((1, 0), ('c', 4), ('dev', 34))
+    >>> str(version)
+    '1.0c4.dev34'
+
+
+suggest_normalized_version
+--------------------------
+
+``suggest_normalized_version`` is a function that suggests a normalized version
+close to the given version string. If you have a version string that isn't
+normalized (i.e. ``NormalizedVersion`` doesn't like it) then you might be able
+to get an equivalent (or close) normalized version from this function.
+
+This does a number of simple normalizations to the given string, based
+on an observation of versions currently in use on PyPI.
+
+Given a dump of those versions on January 6th 2010, the function has given those
+results out of the 8821 distributions PyPI had:
+
+- 7822 (88.67%) already match ``NormalizedVersion`` without any change
+- 717 (8.13%) match when using this suggestion method
+- 282 (3.20%) don't match at all.
+
+The 3.20% of projects that are incompatible with ``NormalizedVersion``
+and cannot be transformed into a compatible form, are for most of them date-based
+version schemes, versions with custom markers, or dummy versions. Examples:
+
+- working proof of concept
+- 1 (first draft)
+- unreleased.unofficialdev
+- 0.1.alphadev
+- 2008-03-29_r219
+- etc.
+
+When a tool needs to work with versions, a strategy is to use
+``suggest_normalized_version`` on the versions string. If this function returns
+``None``, it means that the provided version is not close enough to the
+standard scheme. If it returns a version that slightly differs from
+the original version, it's a suggested normalized version. Last, if it
+returns the same string, it means that the version matches the scheme.
+
+Here's an example of usage::
+
+    >>> from verlib import suggest_normalized_version, NormalizedVersion
+    >>> import warnings
+    >>> def validate_version(version):
+    ...     rversion = suggest_normalized_version(version)
+    ...     if rversion is None:
+    ...         raise ValueError('Cannot work with "%s"' % version)
+    ...     if rversion != version:
+    ...         warnings.warn('"%s" is not a normalized version.\n'
+    ...                       'It has been transformed into "%s" '
+    ...                       'for interoperability.' % (version, rversion))
+    ...     return NormalizedVersion(rversion)
+    ...
+
+    >>> validate_version('2.4-rc1')
+    __main__:8: UserWarning: "2.4-rc1" is not a normalized version.
+    It has been transformed into "2.4c1" for interoperability.
+    NormalizedVersion('2.4c1')
+
+    >>> validate_version('2.4c1')
+    NormalizedVersion('2.4c1')
+
+    >>> validate_version('foo')
+    Traceback (most recent call last):
+    File "<stdin>", line 1, in <module>
+    File "<stdin>", line 4, in validate_version
+    ValueError: Cannot work with "foo"
+
+Roadmap
+=======
+
+Distutils will deprecate its existing versions class in favor of
+``NormalizedVersion``. The ``verlib`` module presented in this PEP will be
+renamed to ``version`` and placed into the ``distutils`` package.
+
+References
+==========
+
+.. [#distutils]
+   https://docs.python.org/3.11/distutils/
+
+.. [#setuptools]
+   https://peak.telecommunity.com/DevCenter/setuptools
+
+.. [#setuptools-version]
+   https://peak.telecommunity.com/DevCenter/setuptools#specifying-your-project-s-version
+
+.. [#pypi]
+   https://pypi.org/
+
+.. [#pip]
+   https://pypi.org/project/pip/
+
+.. [#ezinstall]
+   https://peak.telecommunity.com/DevCenter/EasyInstall
+
+.. [#zc.buildout]
+   https://pypi.org/project/zc.buildout/
+
+.. [#twisted]
+   https://twisted.org/
+
+.. [#prototype]
+   https://web.archive.org/web/20090726093825/http://bitbucket.org/tarek/distutilsversion/
+
+Acknowledgments
+===============
+
+Trent Mick, Matthias Klose, Phillip Eby, David Lyon, and many people at Pycon
+and Distutils-SIG.
+
+Copyright
+=========
+
+This document has been placed in the public domain.

--- a/decisiongrounding/scenarios_real/peps_version_supersession/corpus/PEP-0440.md
+++ b/decisiongrounding/scenarios_real/peps_version_supersession/corpus/PEP-0440.md
@@ -1,0 +1,1669 @@
+# PEP-0440 — Version Identification and Dependency Specification
+
+> Source: python/peps @ f866e77409305866038471574f075cd8d83eee9e
+> Path: peps/pep-0440.rst · https://raw.githubusercontent.com/python/peps/f866e77409305866038471574f075cd8d83eee9e/peps/pep-0440.rst
+> Verbatim public artifact, pinned and unedited. Not authored for this
+> benchmark; see provenance.json for the upstream sha256.
+
+---
+
+PEP: 440
+Title: Version Identification and Dependency Specification
+Author: Alyssa Coghlan <ncoghlan@gmail.com>,
+        Donald Stufft <donald@stufft.io>
+BDFL-Delegate: Alyssa Coghlan <ncoghlan@gmail.com>
+Discussions-To: distutils-sig@python.org
+Status: Final
+Type: Standards Track
+Topic: Packaging
+Created: 18-Mar-2013
+Post-History: 30-Mar-2013, 27-May-2013, 20-Jun-2013,
+              21-Dec-2013, 28-Jan-2014, 08-Aug-2014,
+              22-Aug-2014
+Replaces: 386
+Resolution: https://mail.python.org/pipermail/distutils-sig/2014-August/024673.html
+
+.. canonical-pypa-spec:: :ref:`version-specifiers`
+
+
+Abstract
+========
+
+This PEP describes a scheme for identifying versions of Python software
+distributions, and declaring dependencies on particular versions.
+
+This document addresses several limitations of the previous attempt at a
+standardized approach to versioning, as described in :pep:`345` and :pep:`386`.
+
+
+Definitions
+===========
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+"SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and "OPTIONAL" in this
+document are to be interpreted as described in :rfc:`2119`.
+
+"Projects" are software components that are made available for integration.
+Projects include Python libraries, frameworks, scripts, plugins,
+applications, collections of data or other resources, and various
+combinations thereof. Public Python projects are typically registered on
+the `Python Package Index <https://pypi.org/>`__.
+
+"Releases" are uniquely identified snapshots of a project.
+
+"Distributions" are the packaged files which are used to publish
+and distribute a release.
+
+"Build tools" are automated tools intended to run on development systems,
+producing source and binary distribution archives. Build tools may also be
+invoked by integration tools in order to build software distributed as
+sdists rather than prebuilt binary archives.
+
+"Index servers" are active distribution registries which publish version and
+dependency metadata and place constraints on the permitted metadata.
+
+"Publication tools" are automated tools intended to run on development
+systems and upload source and binary distribution archives to index servers.
+
+"Installation tools" are integration tools specifically intended to run on
+deployment targets, consuming source and binary distribution archives from
+an index server or other designated location and deploying them to the target
+system.
+
+"Automated tools" is a collective term covering build tools, index servers,
+publication tools, integration tools and any other software that produces
+or consumes distribution version and dependency metadata.
+
+Version scheme
+==============
+
+Distributions are identified by a public version identifier which
+supports all defined version comparison operations
+
+The version scheme is used both to describe the distribution version
+provided by a particular distribution archive, as well as to place
+constraints on the version of dependencies needed in order to build or
+run the software.
+
+
+Public version identifiers
+--------------------------
+
+The canonical public version identifiers MUST comply with the following
+scheme::
+
+    [N!]N(.N)*[{a|b|rc}N][.postN][.devN]
+
+Public version identifiers MUST NOT include leading or trailing whitespace.
+
+Public version identifiers MUST be unique within a given distribution.
+
+Installation tools SHOULD ignore any public versions which do not comply with
+this scheme but MUST also include the normalizations specified below.
+Installation tools MAY warn the user when non-compliant or ambiguous versions
+are detected.
+
+See also ``Appendix B : Parsing version strings with regular expressions``
+which provides a regular expression to check strict conformance with the
+canonical format, as well as a more permissive regular expression accepting
+inputs that may require subsequent normalization.
+
+Public version identifiers are separated into up to five segments:
+
+* Epoch segment: ``N!``
+* Release segment: ``N(.N)*``
+* Pre-release segment: ``{a|b|rc}N``
+* Post-release segment: ``.postN``
+* Development release segment: ``.devN``
+
+Any given release will be a "final release", "pre-release", "post-release" or
+"developmental release" as defined in the following sections.
+
+All numeric components MUST be non-negative integers represented as sequences
+of ASCII digits.
+
+All numeric components MUST be interpreted and ordered according to their
+numeric value, not as text strings.
+
+All numeric components MAY be zero. Except as described below for the
+release segment, a numeric component of zero has no special significance
+aside from always being the lowest possible value in the version ordering.
+
+.. note::
+
+   Some hard to read version identifiers are permitted by this scheme in
+   order to better accommodate the wide range of versioning practices
+   across existing public and private Python projects.
+
+   Accordingly, some of the versioning practices which are technically
+   permitted by the PEP are strongly discouraged for new projects. Where
+   this is the case, the relevant details are noted in the following
+   sections.
+
+
+Local version identifiers
+-------------------------
+
+Local version identifiers MUST comply with the following scheme::
+
+    <public version identifier>[+<local version label>]
+
+They consist of a normal public version identifier (as defined in the
+previous section), along with an arbitrary "local version label", separated
+from the public version identifier by a plus. Local version labels have
+no specific semantics assigned, but some syntactic restrictions are imposed.
+
+Local version identifiers are used to denote fully API (and, if applicable,
+ABI) compatible patched versions of upstream projects. For example, these
+may be created by application developers and system integrators by applying
+specific backported bug fixes when upgrading to a new upstream release would
+be too disruptive to the application or other integrated system (such as a
+Linux distribution).
+
+The inclusion of the local version label makes it possible to differentiate
+upstream releases from potentially altered rebuilds by downstream
+integrators. The use of a local version identifier does not affect the kind
+of a release but, when applied to a source distribution, does indicate that
+it may not contain the exact same code as the corresponding upstream release.
+
+To ensure local version identifiers can be readily incorporated as part of
+filenames and URLs, and to avoid formatting inconsistencies in hexadecimal
+hash representations, local version labels MUST be limited to the following
+set of permitted characters:
+
+* ASCII letters (``[a-zA-Z]``)
+* ASCII digits (``[0-9]``)
+* periods (``.``)
+
+Local version labels MUST start and end with an ASCII letter or digit.
+
+Comparison and ordering of local versions considers each segment of the local
+version (divided by a ``.``) separately. If a segment consists entirely of
+ASCII digits then that section should be considered an integer for comparison
+purposes and if a segment contains any ASCII letters then that segment is
+compared lexicographically with case insensitivity. When comparing a numeric
+and lexicographic segment, the numeric section always compares as greater than
+the lexicographic segment. Additionally a local version with a great number of
+segments will always compare as greater than a local version with fewer
+segments, as long as the shorter local version's segments match the beginning
+of the longer local version's segments exactly.
+
+An "upstream project" is a project that defines its own public versions. A
+"downstream project" is one which tracks and redistributes an upstream project,
+potentially backporting security and bug fixes from later versions of the
+upstream project.
+
+Local version identifiers SHOULD NOT be used when publishing upstream
+projects to a public index server, but MAY be used to identify private
+builds created directly from the project source. Local
+version identifiers SHOULD be used by downstream projects when releasing a
+version that is API compatible with the version of the upstream project
+identified by the public version identifier, but contains additional changes
+(such as bug fixes). As the Python Package Index is intended solely for
+indexing and hosting upstream projects, it MUST NOT allow the use of local
+version identifiers.
+
+Source distributions using a local version identifier SHOULD provide the
+``python.integrator`` extension metadata (as defined in :pep:`459`).
+
+
+Final releases
+--------------
+
+A version identifier that consists solely of a release segment and optionally
+an epoch identifier is termed a "final release".
+
+The release segment consists of one or more non-negative integer
+values, separated by dots::
+
+    N(.N)*
+
+Final releases within a project MUST be numbered in a consistently
+increasing fashion, otherwise automated tools will not be able to upgrade
+them correctly.
+
+Comparison and ordering of release segments considers the numeric value
+of each component of the release segment in turn. When comparing release
+segments with different numbers of components, the shorter segment is
+padded out with additional zeros as necessary.
+
+While any number of additional components after the first are permitted
+under this scheme, the most common variants are to use two components
+("major.minor") or three components ("major.minor.micro").
+
+For example::
+
+    0.9
+    0.9.1
+    0.9.2
+    ...
+    0.9.10
+    0.9.11
+    1.0
+    1.0.1
+    1.1
+    2.0
+    2.0.1
+    ...
+
+A release series is any set of final release numbers that start with a
+common prefix. For example, ``3.3.1``, ``3.3.5`` and ``3.3.9.45`` are all
+part of the ``3.3`` release series.
+
+.. note::
+
+   ``X.Y`` and ``X.Y.0`` are not considered distinct release numbers, as
+   the release segment comparison rules implicit expand the two component
+   form to ``X.Y.0`` when comparing it to any release segment that includes
+   three components.
+
+Date based release segments are also permitted. An example of a date based
+release scheme using the year and month of the release::
+
+    2012.4
+    2012.7
+    2012.10
+    2013.1
+    2013.6
+    ...
+
+
+Pre-releases
+------------
+
+Some projects use an "alpha, beta, release candidate" pre-release cycle to
+support testing by their users prior to a final release.
+
+If used as part of a project's development cycle, these pre-releases are
+indicated by including a pre-release segment in the version identifier::
+
+    X.YaN   # Alpha release
+    X.YbN   # Beta release
+    X.YrcN  # Release Candidate
+    X.Y     # Final release
+
+A version identifier that consists solely of a release segment and a
+pre-release segment is termed a "pre-release".
+
+The pre-release segment consists of an alphabetical identifier for the
+pre-release phase, along with a non-negative integer value. Pre-releases for
+a given release are ordered first by phase (alpha, beta, release candidate)
+and then by the numerical component within that phase.
+
+Installation tools MAY accept both ``c`` and ``rc`` releases for a common
+release segment in order to handle some existing legacy distributions.
+
+Installation tools SHOULD interpret ``c`` versions as being equivalent to
+``rc`` versions (that is, ``c1`` indicates the same version as ``rc1``).
+
+Build tools, publication tools and index servers SHOULD disallow the creation
+of both ``rc`` and ``c`` releases for a common release segment.
+
+
+Post-releases
+-------------
+
+Some projects use post-releases to address minor errors in a final release
+that do not affect the distributed software (for example, correcting an error
+in the release notes).
+
+If used as part of a project's development cycle, these post-releases are
+indicated by including a post-release segment in the version identifier::
+
+    X.Y.postN    # Post-release
+
+A version identifier that includes a post-release segment without a
+developmental release segment is termed a "post-release".
+
+The post-release segment consists of the string ``.post``, followed by a
+non-negative integer value. Post-releases are ordered by their
+numerical component, immediately following the corresponding release,
+and ahead of any subsequent release.
+
+.. note::
+
+   The use of post-releases to publish maintenance releases containing
+   actual bug fixes is strongly discouraged. In general, it is better
+   to use a longer release number and increment the final component
+   for each maintenance release.
+
+Post-releases are also permitted for pre-releases::
+
+    X.YaN.postM   # Post-release of an alpha release
+    X.YbN.postM   # Post-release of a beta release
+    X.YrcN.postM  # Post-release of a release candidate
+
+.. note::
+
+   Creating post-releases of pre-releases is strongly discouraged, as
+   it makes the version identifier difficult to parse for human readers.
+   In general, it is substantially clearer to simply create a new
+   pre-release by incrementing the numeric component.
+
+
+Developmental releases
+----------------------
+
+Some projects make regular developmental releases, and system packagers
+(especially for Linux distributions) may wish to create early releases
+directly from source control which do not conflict with later project
+releases.
+
+If used as part of a project's development cycle, these developmental
+releases are indicated by including a developmental release segment in the
+version identifier::
+
+    X.Y.devN    # Developmental release
+
+A version identifier that includes a developmental release segment is
+termed a "developmental release".
+
+The developmental release segment consists of the string ``.dev``,
+followed by a non-negative integer value. Developmental releases are ordered
+by their numerical component, immediately before the corresponding release
+(and before any pre-releases with the same release segment), and following
+any previous release (including any post-releases).
+
+Developmental releases are also permitted for pre-releases and
+post-releases::
+
+    X.YaN.devM       # Developmental release of an alpha release
+    X.YbN.devM       # Developmental release of a beta release
+    X.YrcN.devM      # Developmental release of a release candidate
+    X.Y.postN.devM   # Developmental release of a post-release
+
+.. note::
+
+   While they may be useful for continuous integration purposes, publishing
+   developmental releases of pre-releases to general purpose public index
+   servers is strongly discouraged, as it makes the version identifier
+   difficult to parse for human readers. If such a release needs to be
+   published, it is substantially clearer to instead create a new
+   pre-release by incrementing the numeric component.
+
+   Developmental releases of post-releases are also strongly discouraged,
+   but they may be appropriate for projects which use the post-release
+   notation for full maintenance releases which may include code changes.
+
+
+Version epochs
+--------------
+
+If included in a version identifier, the epoch appears before all other
+components, separated from the release segment by an exclamation mark::
+
+    E!X.Y  # Version identifier with epoch
+
+If no explicit epoch is given, the implicit epoch is ``0``.
+
+Most version identifiers will not include an epoch, as an explicit epoch is
+only needed if a project *changes* the way it handles version numbering in
+a way that means the normal version ordering rules will give the wrong
+answer. For example, if a project is using date based versions like
+``2014.04`` and would like to switch to semantic versions like ``1.0``, then
+the new releases would be identified as *older* than the date based releases
+when using the normal sorting scheme::
+
+    1.0
+    1.1
+    2.0
+    2013.10
+    2014.04
+
+However, by specifying an explicit epoch, the sort order can be changed
+appropriately, as all versions from a later epoch are sorted after versions
+from an earlier epoch::
+
+    2013.10
+    2014.04
+    1!1.0
+    1!1.1
+    1!2.0
+
+Normalization
+-------------
+
+In order to maintain better compatibility with existing versions there are a
+number of "alternative" syntaxes that MUST be taken into account when parsing
+versions. These syntaxes MUST be considered when parsing a version, however
+they should be "normalized" to the standard syntax defined above.
+
+
+Case sensitivity
+~~~~~~~~~~~~~~~~
+
+All ascii letters should be interpreted case insensitively within a version and
+the normal form is lowercase. This allows versions such as ``1.1RC1`` which
+would be normalized to ``1.1rc1``.
+
+
+Integer Normalization
+~~~~~~~~~~~~~~~~~~~~~
+
+All integers are interpreted via the ``int()`` built in and normalize to the
+string form of the output. This means that an integer version of ``00`` would
+normalize to ``0`` while ``09000`` would normalize to ``9000``. This does not
+hold true for integers inside of an alphanumeric segment of a local version
+such as ``1.0+foo0100`` which is already in its normalized form.
+
+
+Pre-release separators
+~~~~~~~~~~~~~~~~~~~~~~
+
+Pre-releases should allow a ``.``, ``-``, or ``_`` separator between the
+release segment and the pre-release segment. The normal form for this is
+without a separator. This allows versions such as ``1.1.a1`` or ``1.1-a1``
+which would be normalized to ``1.1a1``. It should also allow a separator to
+be used between the pre-release signifier and the numeral. This allows versions
+such as ``1.0a.1`` which would be normalized to ``1.0a1``.
+
+
+Pre-release spelling
+~~~~~~~~~~~~~~~~~~~~
+
+Pre-releases allow the additional spellings of ``alpha``, ``beta``, ``c``,
+``pre``, and ``preview`` for ``a``, ``b``, ``rc``, ``rc``, and ``rc``
+respectively. This allows versions such as ``1.1alpha1``, ``1.1beta2``, or
+``1.1c3`` which normalize to ``1.1a1``, ``1.1b2``, and ``1.1rc3``. In every
+case the additional spelling should be considered equivalent to their normal
+forms.
+
+
+Implicit pre-release number
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Pre releases allow omitting the numeral in which case it is implicitly assumed
+to be ``0``. The normal form for this is to include the ``0`` explicitly. This
+allows versions such as ``1.2a`` which is normalized to ``1.2a0``.
+
+
+Post release separators
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Post releases allow a ``.``, ``-``, or ``_`` separator as well as omitting the
+separator all together. The normal form of this is with the ``.`` separator.
+This allows versions such as ``1.2-post2`` or ``1.2post2`` which normalize to
+``1.2.post2``. Like the pre-release separator this also allows an optional
+separator between the post release signifier and the numeral. This allows
+versions like ``1.2.post-2`` which would normalize to ``1.2.post2``.
+
+
+Post release spelling
+~~~~~~~~~~~~~~~~~~~~~
+
+Post-releases allow the additional spellings of ``rev`` and ``r``. This allows
+versions such as ``1.0-r4`` which normalizes to ``1.0.post4``. As with the
+pre-releases the additional spellings should be considered equivalent to their
+normal forms.
+
+
+Implicit post release number
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Post releases allow omitting the numeral in which case it is implicitly assumed
+to be ``0``. The normal form for this is to include the ``0`` explicitly. This
+allows versions such as ``1.2.post`` which is normalized to ``1.2.post0``.
+
+
+Implicit post releases
+~~~~~~~~~~~~~~~~~~~~~~
+
+Post releases allow omitting the ``post`` signifier all together. When using
+this form the separator MUST be ``-`` and no other form is allowed. This allows
+versions such as ``1.0-1`` to be normalized to ``1.0.post1``. This particular
+normalization MUST NOT be used in conjunction with the implicit post release
+number rule. In other words, ``1.0-`` is *not* a valid version and it does *not*
+normalize to ``1.0.post0``.
+
+
+Development release separators
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Development releases allow a ``.``, ``-``, or a ``_`` separator as well as
+omitting the separator all together. The normal form of this is with the ``.``
+separator. This allows versions such as ``1.2-dev2`` or ``1.2dev2`` which
+normalize to ``1.2.dev2``.
+
+
+Implicit development release number
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Development releases allow omitting the numeral in which case it is implicitly
+assumed to be ``0``. The normal form for this is to include the ``0``
+explicitly. This allows versions such as ``1.2.dev`` which is normalized to
+``1.2.dev0``.
+
+
+Local version segments
+~~~~~~~~~~~~~~~~~~~~~~
+
+With a local version, in addition to the use of ``.`` as a separator of
+segments, the use of ``-`` and ``_`` is also acceptable. The normal form is
+using the ``.`` character. This allows versions such as ``1.0+ubuntu-1`` to be
+normalized to ``1.0+ubuntu.1``.
+
+
+Preceding v character
+~~~~~~~~~~~~~~~~~~~~~
+
+In order to support the common version notation of ``v1.0`` versions may be
+preceded by a single literal ``v`` character. This character MUST be ignored
+for all purposes and should be omitted from all normalized forms of the
+version. The same version with and without the ``v`` is considered equivalent.
+
+
+Leading and Trailing Whitespace
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Leading and trailing whitespace must be silently ignored and removed from all
+normalized forms of a version. This includes ``" "``, ``\t``, ``\n``, ``\r``,
+``\f``, and ``\v``. This allows accidental whitespace to be handled sensibly,
+such as a version like ``1.0\n`` which normalizes to ``1.0``.
+
+
+Examples of compliant version schemes
+-------------------------------------
+
+The standard version scheme is designed to encompass a wide range of
+identification practices across public and private Python projects. In
+practice, a single project attempting to use the full flexibility offered
+by the scheme would create a situation where human users had difficulty
+figuring out the relative order of versions, even though the rules above
+ensure all compliant tools will order them consistently.
+
+The following examples illustrate a small selection of the different
+approaches projects may choose to identify their releases, while still
+ensuring that the "latest release" and the "latest stable release" can
+be easily determined, both by human users and automated tools.
+
+Simple "major.minor" versioning::
+
+    0.1
+    0.2
+    0.3
+    1.0
+    1.1
+    ...
+
+Simple "major.minor.micro" versioning::
+
+    1.1.0
+    1.1.1
+    1.1.2
+    1.2.0
+    ...
+
+"major.minor" versioning with alpha, beta and candidate
+pre-releases::
+
+    0.9
+    1.0a1
+    1.0a2
+    1.0b1
+    1.0rc1
+    1.0
+    1.1a1
+    ...
+
+"major.minor" versioning with developmental releases, release candidates
+and post-releases for minor corrections::
+
+    0.9
+    1.0.dev1
+    1.0.dev2
+    1.0.dev3
+    1.0.dev4
+    1.0c1
+    1.0c2
+    1.0
+    1.0.post1
+    1.1.dev1
+    ...
+
+Date based releases, using an incrementing serial within each year, skipping
+zero::
+
+    2012.1
+    2012.2
+    2012.3
+    ...
+    2012.15
+    2013.1
+    2013.2
+    ...
+
+
+Summary of permitted suffixes and relative ordering
+---------------------------------------------------
+
+.. note::
+
+   This section is intended primarily for authors of tools that
+   automatically process distribution metadata, rather than developers
+   of Python distributions deciding on a versioning scheme.
+
+The epoch segment of version identifiers MUST be sorted according to the
+numeric value of the given epoch. If no epoch segment is present, the
+implicit numeric value is ``0``.
+
+The release segment of version identifiers MUST be sorted in
+the same order as Python's tuple sorting when the normalized release segment is
+parsed as follows::
+
+    tuple(map(int, release_segment.split(".")))
+
+All release segments involved in the comparison MUST be converted to a
+consistent length by padding shorter segments with zeros as needed.
+
+Within a numeric release (``1.0``, ``2.7.3``), the following suffixes
+are permitted and MUST be ordered as shown::
+
+   .devN, aN, bN, rcN, <no suffix>, .postN
+
+Note that ``c`` is considered to be semantically equivalent to ``rc`` and must
+be sorted as if it were ``rc``. Tools MAY reject the case of having the same
+``N`` for both a ``c`` and a ``rc`` in the same release segment as ambiguous
+and remain in compliance with the PEP.
+
+Within an alpha (``1.0a1``), beta (``1.0b1``), or release candidate
+(``1.0rc1``, ``1.0c1``), the following suffixes are permitted and MUST be
+ordered as shown::
+
+   .devN, <no suffix>, .postN
+
+Within a post-release (``1.0.post1``), the following suffixes are permitted
+and MUST be ordered as shown::
+
+    .devN, <no suffix>
+
+Note that ``devN`` and ``postN`` MUST always be preceded by a dot, even
+when used immediately following a numeric version (e.g. ``1.0.dev456``,
+``1.0.post1``).
+
+Within a pre-release, post-release or development release segment with a
+shared prefix, ordering MUST be by the value of the numeric component.
+
+The following example covers many of the possible combinations::
+
+    1.dev0
+    1.0.dev456
+    1.0a1
+    1.0a2.dev456
+    1.0a12.dev456
+    1.0a12
+    1.0b1.dev456
+    1.0b2
+    1.0b2.post345.dev456
+    1.0b2.post345
+    1.0rc1.dev456
+    1.0rc1
+    1.0
+    1.0+abc.5
+    1.0+abc.7
+    1.0+5
+    1.0.post456.dev34
+    1.0.post456
+    1.0.15
+    1.1.dev1
+
+
+Version ordering across different metadata versions
+---------------------------------------------------
+
+Metadata v1.0 (:pep:`241`) and metadata v1.1 (:pep:`314`) do not specify a standard
+version identification or ordering scheme. However metadata v1.2 (:pep:`345`)
+does specify a scheme which is defined in :pep:`386`.
+
+Due to the nature of the simple installer API it is not possible for an
+installer to be aware of which metadata version a particular distribution was
+using. Additionally installers required the ability to create a reasonably
+prioritized list that includes all, or as many as possible, versions of
+a project to determine which versions it should install. These requirements
+necessitate a standardization across one parsing mechanism to be used for all
+versions of a project.
+
+Due to the above, this PEP MUST be used for all versions of metadata and
+supersedes :pep:`386` even for metadata v1.2. Tools SHOULD ignore any versions
+which cannot be parsed by the rules in this PEP, but MAY fall back to
+implementation defined version parsing and ordering schemes if no versions
+complying with this PEP are available.
+
+Distribution users may wish to explicitly remove non-compliant versions from
+any private package indexes they control.
+
+
+Compatibility with other version schemes
+----------------------------------------
+
+Some projects may choose to use a version scheme which requires
+translation in order to comply with the public version scheme defined in
+this PEP. In such cases, the project specific version can be stored in the
+metadata while the translated public version is published in the version field.
+
+This allows automated distribution tools to provide consistently correct
+ordering of published releases, while still allowing developers to use
+the internal versioning scheme they prefer for their projects.
+
+
+Semantic versioning
+~~~~~~~~~~~~~~~~~~~
+
+`Semantic versioning`_ is a popular version identification scheme that is
+more prescriptive than this PEP regarding the significance of different
+elements of a release number. Even if a project chooses not to abide by
+the details of semantic versioning, the scheme is worth understanding as
+it covers many of the issues that can arise when depending on other
+distributions, and when publishing a distribution that others rely on.
+
+The "Major.Minor.Patch" (described in this PEP as "major.minor.micro")
+aspects of semantic versioning (clauses 1-8 in the 2.0.0 specification)
+are fully compatible with the version scheme defined in this PEP, and abiding
+by these aspects is encouraged.
+
+Semantic versions containing a hyphen (pre-releases - clause 10) or a
+plus sign (builds - clause 11) are *not* compatible with this PEP
+and are not permitted in the public version field.
+
+One possible mechanism to translate such semantic versioning based source
+labels to compatible public versions is to use the ``.devN`` suffix to
+specify the appropriate version order.
+
+Specific build information may also be included in local version labels.
+
+.. _Semantic versioning: https://semver.org/
+
+
+DVCS based version labels
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Many build tools integrate with distributed version control systems like
+Git and Mercurial in order to add an identifying hash to the version
+identifier. As hashes cannot be ordered reliably such versions are not
+permitted in the public version field.
+
+As with semantic versioning, the public ``.devN`` suffix may be used to
+uniquely identify such releases for publication, while the original DVCS based
+label can be stored in the project metadata.
+
+Identifying hash information may also be included in local version labels.
+
+
+Olson database versioning
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``pytz`` project inherits its versioning scheme from the corresponding
+Olson timezone database versioning scheme: the year followed by a lowercase
+character indicating the version of the database within that year.
+
+This can be translated to a compliant public version identifier as
+``<year>.<serial>``, where the serial starts at zero or one (for the
+'<year>a' release) and is incremented with each subsequent database
+update within the year.
+
+As with other translated version identifiers, the corresponding Olson
+database version could be recorded in the project metadata.
+
+
+Version specifiers
+==================
+
+A version specifier consists of a series of version clauses, separated by
+commas. For example::
+
+   ~= 0.9, >= 1.0, != 1.3.4.*, < 2.0
+
+The comparison operator determines the kind of version clause:
+
+* ``~=``: `Compatible release`_ clause
+* ``==``: `Version matching`_ clause
+* ``!=``: `Version exclusion`_ clause
+* ``<=``, ``>=``: `Inclusive ordered comparison`_ clause
+* ``<``, ``>``: `Exclusive ordered comparison`_ clause
+* ``===``: `Arbitrary equality`_ clause.
+
+The comma (",") is equivalent to a logical **and** operator: a candidate
+version must match all given version clauses in order to match the
+specifier as a whole.
+
+Whitespace between a conditional operator and the following version
+identifier is optional, as is the whitespace around the commas.
+
+When multiple candidate versions match a version specifier, the preferred
+version SHOULD be the latest version as determined by the consistent
+ordering defined by the standard `Version scheme`_. Whether or not
+pre-releases are considered as candidate versions SHOULD be handled as
+described in `Handling of pre-releases`_.
+
+Except where specifically noted below, local version identifiers MUST NOT be
+permitted in version specifiers, and local version labels MUST be ignored
+entirely when checking if candidate versions match a given version
+specifier.
+
+
+Compatible release
+------------------
+
+A compatible release clause consists of the compatible release operator ``~=``
+and a version identifier. It matches any candidate version that is expected
+to be compatible with the specified version.
+
+The specified version identifier must be in the standard format described in
+`Version scheme`_. Local version identifiers are NOT permitted in this
+version specifier.
+
+For a given release identifier ``V.N``, the compatible release clause is
+approximately equivalent to the pair of comparison clauses::
+
+    >= V.N, == V.*
+
+This operator MUST NOT be used with a single segment version number such as
+``~=1``.
+
+For example, the following groups of version clauses are equivalent::
+
+    ~= 2.2
+    >= 2.2, == 2.*
+
+    ~= 1.4.5
+    >= 1.4.5, == 1.4.*
+
+If a pre-release, post-release or developmental release is named in a
+compatible release clause as ``V.N.suffix``, then the suffix is ignored
+when determining the required prefix match::
+
+    ~= 2.2.post3
+    >= 2.2.post3, == 2.*
+
+    ~= 1.4.5a4
+    >= 1.4.5a4, == 1.4.*
+
+The padding rules for release segment comparisons means that the assumed
+degree of forward compatibility in a compatible release clause can be
+controlled by appending additional zeros to the version specifier::
+
+    ~= 2.2.0
+    >= 2.2.0, == 2.2.*
+
+    ~= 1.4.5.0
+    >= 1.4.5.0, == 1.4.5.*
+
+
+Version matching
+----------------
+
+A version matching clause includes the version matching operator ``==``
+and a version identifier.
+
+The specified version identifier must be in the standard format described in
+`Version scheme`_, but a trailing ``.*`` is permitted on public version
+identifiers as described below.
+
+By default, the version matching operator is based on a strict equality
+comparison: the specified version must be exactly the same as the requested
+version. The *only* substitution performed is the zero padding of the
+release segment to ensure the release segments are compared with the same
+length.
+
+Whether or not strict version matching is appropriate depends on the specific
+use case for the version specifier. Automated tools SHOULD at least issue
+warnings and MAY reject them entirely when strict version matches are used
+inappropriately.
+
+Prefix matching may be requested instead of strict comparison, by appending
+a trailing ``.*`` to the version identifier in the version matching clause.
+This means that additional trailing segments will be ignored when
+determining whether or not a version identifier matches the clause. If the
+specified version includes only a release segment, than trailing components
+(or the lack thereof) in the release segment are also ignored.
+
+For example, given the version ``1.1.post1``, the following clauses would
+match or not as shown::
+
+    == 1.1        # Not equal, so 1.1.post1 does not match clause
+    == 1.1.post1  # Equal, so 1.1.post1 matches clause
+    == 1.1.*      # Same prefix, so 1.1.post1 matches clause
+
+For purposes of prefix matching, the pre-release segment is considered to
+have an implied preceding ``.``, so given the version ``1.1a1``, the
+following clauses would match or not as shown::
+
+    == 1.1        # Not equal, so 1.1a1 does not match clause
+    == 1.1a1      # Equal, so 1.1a1 matches clause
+    == 1.1.*      # Same prefix, so 1.1a1 matches clause if pre-releases are requested
+
+An exact match is also considered a prefix match (this interpretation is
+implied by the usual zero padding rules for the release segment of version
+identifiers). Given the version ``1.1``, the following clauses would
+match or not as shown::
+
+    == 1.1        # Equal, so 1.1 matches clause
+    == 1.1.0      # Zero padding expands 1.1 to 1.1.0, so it matches clause
+    == 1.1.dev1   # Not equal (dev-release), so 1.1 does not match clause
+    == 1.1a1      # Not equal (pre-release), so 1.1 does not match clause
+    == 1.1.post1  # Not equal (post-release), so 1.1 does not match clause
+    == 1.1.*      # Same prefix, so 1.1 matches clause
+
+It is invalid to have a prefix match containing a development or local release
+such as ``1.0.dev1.*`` or ``1.0+foo1.*``. If present, the development release
+segment is always the final segment in the public version, and the local version
+is ignored for comparison purposes, so using either in a prefix match wouldn't
+make any sense.
+
+The use of ``==`` (without at least the wildcard suffix) when defining
+dependencies for published distributions is strongly discouraged as it
+greatly complicates the deployment of security fixes. The strict version
+comparison operator is intended primarily for use when defining
+dependencies for repeatable *deployments of applications* while using
+a shared distribution index.
+
+If the specified version identifier is a public version identifier (no
+local version label), then the local version label of any candidate versions
+MUST be ignored when matching versions.
+
+If the specified version identifier is a local version identifier, then the
+local version labels of candidate versions MUST be considered when matching
+versions, with the public version identifier being matched as described
+above, and the local version label being checked for equivalence using a
+strict string equality comparison.
+
+
+Version exclusion
+-----------------
+
+A version exclusion clause includes the version exclusion operator ``!=``
+and a version identifier.
+
+The allowed version identifiers and comparison semantics are the same as
+those of the `Version matching`_ operator, except that the sense of any
+match is inverted.
+
+For example, given the version ``1.1.post1``, the following clauses would
+match or not as shown::
+
+    != 1.1        # Not equal, so 1.1.post1 matches clause
+    != 1.1.post1  # Equal, so 1.1.post1 does not match clause
+    != 1.1.*      # Same prefix, so 1.1.post1 does not match clause
+
+
+Inclusive ordered comparison
+----------------------------
+
+An inclusive ordered comparison clause includes a comparison operator and a
+version identifier, and will match any version where the comparison is correct
+based on the relative position of the candidate version and the specified
+version given the consistent ordering defined by the standard
+`Version scheme`_.
+
+The inclusive ordered comparison operators are ``<=`` and ``>=``.
+
+As with version matching, the release segment is zero padded as necessary to
+ensure the release segments are compared with the same length.
+
+Local version identifiers are NOT permitted in this version specifier.
+
+
+Exclusive ordered comparison
+----------------------------
+
+The exclusive ordered comparisons ``>`` and ``<`` are similar to the inclusive
+ordered comparisons in that they rely on the relative position of the candidate
+version and the specified version given the consistent ordering defined by the
+standard `Version scheme`_. However, they specifically exclude pre-releases,
+post-releases, and local versions of the specified version.
+
+The exclusive ordered comparison ``>V`` **MUST NOT** allow a post-release
+of the given version unless ``V`` itself is a post release. You may mandate
+that releases are later than a particular post release, including additional
+post releases, by using ``>V.postN``. For example, ``>1.7`` will allow
+``1.7.1`` but not ``1.7.0.post1`` and ``>1.7.post2`` will allow ``1.7.1``
+and ``1.7.0.post3`` but not ``1.7.0``.
+
+The exclusive ordered comparison ``>V`` **MUST NOT** match a local version of
+the specified version.
+
+The exclusive ordered comparison ``<V`` **MUST NOT** allow a pre-release of
+the specified version unless the specified version is itself a pre-release.
+Allowing pre-releases that are earlier than, but not equal to a specific
+pre-release may be accomplished by using ``<V.rc1`` or similar.
+
+As with version matching, the release segment is zero padded as necessary to
+ensure the release segments are compared with the same length.
+
+Local version identifiers are NOT permitted in this version specifier.
+
+
+Arbitrary equality
+------------------
+
+Arbitrary equality comparisons are simple string equality operations which do
+not take into account any of the semantic information such as zero padding or
+local versions. This operator also does not support prefix matching as the
+``==`` operator does.
+
+The primary use case for arbitrary equality is to allow for specifying a
+version which cannot otherwise be represented by this PEP. This operator is
+special and acts as an escape hatch to allow someone using a tool which
+implements this PEP to still install a legacy version which is otherwise
+incompatible with this PEP.
+
+An example would be ``===foobar`` which would match a version of ``foobar``.
+
+This operator may also be used to explicitly require an unpatched version
+of a project such as ``===1.0`` which would not match for a version
+``1.0+downstream1``.
+
+Use of this operator is heavily discouraged and tooling MAY display a warning
+when it is used.
+
+
+Handling of pre-releases
+------------------------
+
+Pre-releases of any kind, including developmental releases, are implicitly
+excluded from all version specifiers, *unless* they are already present
+on the system, explicitly requested by the user, or if the only available
+version that satisfies the version specifier is a pre-release.
+
+By default, dependency resolution tools SHOULD:
+
+* accept already installed pre-releases for all version specifiers
+* accept remotely available pre-releases for version specifiers where
+  there is no final or post release that satisfies the version specifier
+* exclude all other pre-releases from consideration
+
+Dependency resolution tools MAY issue a warning if a pre-release is needed
+to satisfy a version specifier.
+
+Dependency resolution tools SHOULD also allow users to request the
+following alternative behaviours:
+
+* accepting pre-releases for all version specifiers
+* excluding pre-releases for all version specifiers (reporting an error or
+  warning if a pre-release is already installed locally, or if a
+  pre-release is the only way to satisfy a particular specifier)
+
+Dependency resolution tools MAY also allow the above behaviour to be
+controlled on a per-distribution basis.
+
+Post-releases and final releases receive no special treatment in version
+specifiers - they are always included unless explicitly excluded.
+
+
+Examples
+--------
+
+* ``~=3.1``: version 3.1 or later, but not version 4.0 or later.
+* ``~=3.1.2``: version 3.1.2 or later, but not version 3.2.0 or later.
+* ``~=3.1a1``: version 3.1a1 or later, but not version 4.0 or later.
+* ``== 3.1``: specifically version 3.1 (or 3.1.0), excludes all pre-releases,
+  post releases, developmental releases and any 3.1.x maintenance releases.
+* ``== 3.1.*``: any version that starts with 3.1. Equivalent to the
+  ``~=3.1.0`` compatible release clause.
+* ``~=3.1.0, != 3.1.3``: version 3.1.0 or later, but not version 3.1.3 and
+  not version 3.2.0 or later.
+
+
+Direct references
+=================
+
+Some automated tools may permit the use of a direct reference as an
+alternative to a normal version specifier. A direct reference consists of
+the specifier ``@`` and an explicit URL.
+
+Whether or not direct references are appropriate depends on the specific
+use case for the version specifier. Automated tools SHOULD at least issue
+warnings and MAY reject them entirely when direct references are used
+inappropriately.
+
+Public index servers SHOULD NOT allow the use of direct references in
+uploaded distributions. Direct references are intended as a tool for
+software integrators rather than publishers.
+
+Depending on the use case, some appropriate targets for a direct URL
+reference may be an sdist or a wheel binary archive. The exact URLs and
+targets supported will be tool dependent.
+
+For example, a local source archive may be referenced directly::
+
+    pip @ file:///localbuilds/pip-1.3.1.zip
+
+Alternatively, a prebuilt archive may also be referenced::
+
+    pip @ file:///localbuilds/pip-1.3.1-py33-none-any.whl
+
+All direct references that do not refer to a local file URL SHOULD specify
+a secure transport mechanism (such as ``https``) AND include an expected
+hash value in the URL for verification purposes. If a direct reference is
+specified without any hash information, with hash information that the
+tool doesn't understand, or with a selected hash algorithm that the tool
+considers too weak to trust, automated tools SHOULD at least emit a warning
+and MAY refuse to rely on the URL. If such a direct reference also uses an
+insecure transport, automated tools SHOULD NOT rely on the URL.
+
+It is RECOMMENDED that only hashes which are unconditionally provided by
+the latest version of the standard library's ``hashlib`` module be used
+for source archive hashes. At time of writing, that list consists of
+``'md5'``, ``'sha1'``, ``'sha224'``, ``'sha256'``, ``'sha384'``, and
+``'sha512'``.
+
+For source archive and wheel references, an expected hash value may be
+specified by including a ``<hash-algorithm>=<expected-hash>`` entry as
+part of the URL fragment.
+
+For version control references, the ``VCS+protocol`` scheme SHOULD be
+used to identify both the version control system and the secure transport,
+and a version control system with hash based commit identifiers SHOULD be
+used. Automated tools MAY omit warnings about missing hashes for version
+control systems that do not provide hash based commit identifiers.
+
+To handle version control systems that do not support including commit or
+tag references directly in the URL, that information may be appended to the
+end of the URL using the ``@<commit-hash>`` or the ``@<tag>#<commit-hash>``
+notation.
+
+.. note::
+
+   This isn't *quite* the same as the existing VCS reference notation
+   supported by pip. Firstly, the distribution name is moved in front rather
+   than embedded as part of the URL. Secondly, the commit hash is included
+   even when retrieving based on a tag, in order to meet the requirement
+   above that *every* link should include a hash to make things harder to
+   forge (creating a malicious repo with a particular tag is easy, creating
+   one with a specific *hash*, less so).
+
+Remote URL examples::
+
+    pip @ https://github.com/pypa/pip/archive/1.3.1.zip#sha1=da9234ee9982d4bbb3c72346a6de940a148ea686
+    pip @ git+https://github.com/pypa/pip.git@7921be1537eac1e97bc40179a57f0349c2aee67d
+    pip @ git+https://github.com/pypa/pip.git@1.3.1#7921be1537eac1e97bc40179a57f0349c2aee67d
+
+
+File URLs
+---------
+
+File URLs take the form of ``file://<host>/<path>``. If the ``<host>`` is
+omitted it is assumed to be ``localhost`` and even if the ``<host>`` is omitted
+the third slash MUST still exist. The ``<path>`` defines what the file path on
+the filesystem that is to be accessed.
+
+On the various \*nix operating systems the only allowed values for ``<host>``
+is for it to be omitted, ``localhost``, or another FQDN that the current
+machine believes matches its own host. In other words, on \*nix the ``file://``
+scheme can only be used to access paths on the local machine.
+
+On Windows the file format should include the drive letter if applicable as
+part of the ``<path>`` (e.g. ``file:///c:/path/to/a/file``). Unlike \*nix on
+Windows the ``<host>`` parameter may be used to specify a file residing on a
+network share. In other words, in order to translate ``\\machine\volume\file``
+to a ``file://`` url, it would end up as ``file://machine/volume/file``. For
+more information on ``file://`` URLs on Windows see MSDN [4]_.
+
+
+Updating the versioning specification
+=====================================
+
+The versioning specification may be updated with clarifications without
+requiring a new PEP or a change to the metadata version.
+
+Any technical changes that impact the version identification and comparison
+syntax and semantics would require an updated versioning scheme to be
+defined in a new PEP.
+
+
+Summary of differences from pkg_resources.parse_version
+=======================================================
+
+* Note: this comparison is to ``pkg_resourses.parse_version`` as it existed at
+  the time the PEP was written. After the PEP was accepted, setuptools 6.0 and
+  later versions adopted the behaviour described in this PEP.
+
+* Local versions sort differently, this PEP requires that they sort as greater
+  than the same version without a local version, whereas
+  ``pkg_resources.parse_version`` considers it a pre-release marker.
+
+* This PEP purposely restricts the syntax which constitutes a valid version
+  while ``pkg_resources.parse_version`` attempts to provide some meaning from
+  *any* arbitrary string.
+
+* ``pkg_resources.parse_version`` allows arbitrarily deeply nested version
+  signifiers like ``1.0.dev1.post1.dev5``. This PEP however allows only a
+  single use of each type and they must exist in a certain order.
+
+
+Summary of differences from PEP 386
+===================================
+
+* Moved the description of version specifiers into the versioning PEP
+
+* Added the "direct reference" concept as a standard notation for direct
+  references to resources (rather than each tool needing to invent its own)
+
+* Added the "local version identifier" and "local version label" concepts to
+  allow system integrators to indicate patched builds in a way that is
+  supported by the upstream tools, as well as to allow the incorporation of
+  build tags into the versioning of binary distributions.
+
+* Added the "compatible release" clause
+
+* Added the trailing wildcard syntax for prefix based version matching
+  and exclusion
+
+* Changed the top level sort position of the ``.devN`` suffix
+
+* Allowed single value version numbers
+
+* Explicit exclusion of leading or trailing whitespace
+
+* Explicit support for date based versions
+
+* Explicit normalisation rules to improve compatibility with
+  existing version metadata on PyPI where it doesn't introduce
+  ambiguity
+
+* Implicitly exclude pre-releases unless they're already present or
+  needed to satisfy a dependency
+
+* Treat post releases the same way as unqualified releases
+
+* Discuss ordering and dependencies across metadata versions
+
+* Switch from preferring ``c`` to ``rc``.
+
+The rationale for major changes is given in the following sections.
+
+
+Changing the version scheme
+---------------------------
+
+One key change in the version scheme in this PEP relative to that in
+:pep:`386` is to sort top level developmental releases like ``X.Y.devN`` ahead
+of alpha releases like ``X.Ya1``. This is a far more logical sort order, as
+projects already using both development releases and alphas/betas/release
+candidates do not want their developmental releases sorted in
+between their release candidates and their final releases. There is no
+rationale for using ``dev`` releases in that position rather than
+merely creating additional release candidates.
+
+The updated sort order also means the sorting of ``dev`` versions is now
+consistent between the metadata standard and the pre-existing behaviour
+of ``pkg_resources`` (and hence the behaviour of current installation
+tools).
+
+Making this change should make it easier for affected existing projects to
+migrate to the latest version of the metadata standard.
+
+Another change to the version scheme is to allow single number
+versions, similar to those used by non-Python projects like Mozilla
+Firefox, Google Chrome and the Fedora Linux distribution. This is actually
+expected to be more useful for version specifiers, but it is easier to
+allow it for both version specifiers and release numbers, rather than
+splitting the two definitions.
+
+The exclusion of leading and trailing whitespace was made explicit after
+a couple of projects with version identifiers differing only in a
+trailing ``\n`` character were found on PyPI.
+
+Various other normalisation rules were also added as described in the
+separate section on version normalisation below.
+
+``Appendix A`` shows detailed results of an analysis of PyPI distribution
+version information, as collected on 8th August, 2014. This analysis
+compares the behavior of the explicitly ordered version scheme defined in
+this PEP with the de facto standard defined by the behavior of setuptools.
+These metrics are useful, as the intent of this PEP is to follow existing
+setuptools behavior as closely as is feasible, while still throwing
+exceptions for unorderable versions (rather than trying to guess an
+appropriate order as setuptools does).
+
+
+A more opinionated description of the versioning scheme
+-------------------------------------------------------
+
+As in :pep:`386`, the primary focus is on codifying existing practices to make
+them more amenable to automation, rather than demanding that existing
+projects make non-trivial changes to their workflow. However, the
+standard scheme allows significantly more flexibility than is needed
+for the vast majority of simple Python packages (which often don't even
+need maintenance releases - many users are happy with needing to upgrade to a
+new feature release to get bug fixes).
+
+For the benefit of novice developers, and for experienced developers
+wishing to better understand the various use cases, the specification
+now goes into much greater detail on the components of the defined
+version scheme, including examples of how each component may be used
+in practice.
+
+The PEP also explicitly guides developers in the direction of
+semantic versioning (without requiring it), and discourages the use of
+several aspects of the full versioning scheme that have largely been
+included in order to cover esoteric corner cases in the practices of
+existing projects and in repackaging software for Linux distributions.
+
+
+Describing version specifiers alongside the versioning scheme
+-------------------------------------------------------------
+
+The main reason to even have a standardised version scheme in the first place
+is to make it easier to do reliable automated dependency analysis. It makes
+more sense to describe the primary use case for version identifiers alongside
+their definition.
+
+
+Changing the interpretation of version specifiers
+-------------------------------------------------
+
+The previous interpretation of version specifiers made it very easy to
+accidentally download a pre-release version of a dependency. This in
+turn made it difficult for developers to publish pre-release versions
+of software to the Python Package Index, as even marking the package as
+hidden wasn't enough to keep automated tools from downloading it, and also
+made it harder for users to obtain the test release manually through the
+main PyPI web interface.
+
+The previous interpretation also excluded post-releases from some version
+specifiers for no adequately justified reason.
+
+The updated interpretation is intended to make it difficult to accidentally
+accept a pre-release version as satisfying a dependency, while still
+allowing pre-release versions to be retrieved automatically when that's the
+only way to satisfy a dependency.
+
+The "some forward compatibility assumed" version constraint is derived from the
+Ruby community's "pessimistic version constraint" operator [2]_ to allow
+projects to take a cautious approach to forward compatibility promises, while
+still easily setting a minimum required version for their dependencies. The
+spelling of the compatible release clause (``~=``) is inspired by the Ruby
+(``~>``) and PHP (``~``) equivalents.
+
+Further improvements are also planned to the handling of parallel
+installation of multiple versions of the same library, but these will
+depend on updates to the installation database definition along with
+improved tools for dynamic path manipulation.
+
+The trailing wildcard syntax to request prefix based version matching was
+added to make it possible to sensibly define compatible release clauses.
+
+
+Support for date based version identifiers
+------------------------------------------
+
+Excluding date based versions caused significant problems in migrating
+``pytz`` to the new metadata standards. It also caused concerns for the
+OpenStack developers, as they use a date based versioning scheme and would
+like to be able to migrate to the new metadata standards without changing
+it.
+
+
+Adding version epochs
+---------------------
+
+Version epochs are added for the same reason they are part of other
+versioning schemes, such as those of the Fedora and Debian Linux
+distributions: to allow projects to gracefully change their approach to
+numbering releases, without having a new release appear to have a lower
+version number than previous releases and without having to change the name
+of the project.
+
+In particular, supporting version epochs allows a project that was previously
+using date based versioning to switch to semantic versioning by specifying
+a new version epoch.
+
+The ``!`` character was chosen to delimit an epoch version rather than the
+``:`` character, which is commonly used in other systems, due to the fact that
+``:`` is not a valid character in a Windows directory name.
+
+
+Adding direct references
+------------------------
+
+Direct references are added as an "escape clause" to handle messy real
+world situations that don't map neatly to the standard distribution model.
+This includes dependencies on unpublished software for internal use, as well
+as handling the more complex compatibility issues that may arise when
+wrapping third party libraries as C extensions (this is of especial concern
+to the scientific community).
+
+Index servers are deliberately given a lot of freedom to disallow direct
+references, since they're intended primarily as a tool for integrators
+rather than publishers. PyPI in particular is currently going through the
+process of *eliminating* dependencies on external references, as unreliable
+external services have the effect of slowing down installation operations,
+as well as reducing PyPI's own apparent reliability.
+
+
+Adding arbitrary equality
+-------------------------
+
+Arbitrary equality is added as an "escape clause" to handle the case where
+someone needs to install a project which uses a non compliant version. Although
+this PEP is able to attain ~97% compatibility with the versions that are
+already on PyPI there are still ~3% of versions which cannot be parsed. This
+operator gives a simple and effective way to still depend on them without
+having to "guess" at the semantics of what they mean (which would be required
+if anything other than strict string based equality was supported).
+
+
+Adding local version identifiers
+--------------------------------
+
+It's a fact of life that downstream integrators often need to backport
+upstream bug fixes to older versions. It's one of the services that gets
+Linux distro vendors paid, and application developers may also apply patches
+they need to bundled dependencies.
+
+Historically, this practice has been invisible to cross-platform language
+specific distribution tools - the reported "version" in the upstream
+metadata is the same as for the unmodified code. This inaccuracy can then
+cause problems when attempting to work with a mixture of integrator
+provided code and unmodified upstream code, or even just attempting to
+identify exactly which version of the software is installed.
+
+The introduction of local version identifiers and "local version labels"
+into the versioning scheme, with the corresponding ``python.integrator``
+metadata extension allows this kind of activity to be represented
+accurately, which should improve interoperability between the upstream
+tools and various integrated platforms.
+
+The exact scheme chosen is largely modeled on the existing behavior of
+``pkg_resources.parse_version`` and ``pkg_resources.parse_requirements``,
+with the main distinction being that where ``pkg_resources`` currently always
+takes the suffix into account when comparing versions for exact matches,
+the PEP requires that the local version label of the candidate version be
+ignored when no local version label is present in the version specifier
+clause. Furthermore, the PEP does not attempt to impose any structure on
+the local version labels (aside from limiting the set of permitted
+characters and defining their ordering).
+
+This change is designed to ensure that an integrator provided version like
+``pip 1.5+1`` or ``pip 1.5+1.git.abc123de`` will still satisfy a version
+specifier like ``pip>=1.5``.
+
+The plus is chosen primarily for readability of local version identifiers.
+It was chosen instead of the hyphen to prevent
+``pkg_resources.parse_version`` from parsing it as a prerelease, which is
+important for enabling a successful migration to the new, more structured,
+versioning scheme. The plus was chosen instead of a tilde because of the
+significance of the tilde in Debian's version ordering algorithm.
+
+
+Providing explicit version normalization rules
+----------------------------------------------
+
+Historically, the de facto standard for parsing versions in Python has been the
+``pkg_resources.parse_version`` command from the setuptools project. This does
+not attempt to reject *any* version and instead tries to make something
+meaningful, with varying levels of success, out of whatever it is given. It has
+a few simple rules but otherwise it more or less relies largely on string
+comparison.
+
+The normalization rules provided in this PEP exist primarily to either increase
+the compatibility with ``pkg_resources.parse_version``, particularly in
+documented use cases such as ``rev``, ``r``, ``pre``, etc or to do something
+more reasonable with versions that already exist on PyPI.
+
+All possible normalization rules were weighed against whether or not they were
+*likely* to cause any ambiguity (e.g. while someone might devise a scheme where
+``v1.0`` and ``1.0`` are considered distinct releases, the likelihood of anyone
+actually doing that, much less on any scale that is noticeable, is fairly low).
+They were also weighed against how ``pkg_resources.parse_version`` treated a
+particular version string, especially with regards to how it was sorted. Finally
+each rule was weighed against the kinds of additional versions it allowed, how
+"ugly" those versions looked, how hard there were to parse (both mentally and
+mechanically) and how much additional compatibility it would bring.
+
+The breadth of possible normalizations were kept to things that could easily
+be implemented as part of the parsing of the version and not pre-parsing
+transformations applied to the versions. This was done to limit the side
+effects of each transformation as simple search and replace style transforms
+increase the likelihood of ambiguous or "junk" versions.
+
+For an extended discussion on the various types of normalizations that were
+considered, please see the proof of concept for :pep:`440` within pip [5]_.
+
+
+Allowing Underscore in Normalization
+------------------------------------
+
+There are not a lot of projects on PyPI which utilize a ``_`` in the version
+string. However this PEP allows its use anywhere that ``-`` is acceptable. The
+reason for this is that the Wheel normalization scheme specifies that ``-``
+gets normalized to a ``_`` to enable easier parsing of the filename.
+
+
+Summary of changes to PEP 440
+=============================
+
+The following changes were made to this PEP based on feedback received after
+the initial reference implementation was released in setuptools 8.0 and pip
+6.0:
+
+* The exclusive ordered comparisons were updated to no longer imply a ``!=V.*``
+  which was deemed to be surprising behavior which was too hard to accurately
+  describe. Instead the exclusive ordered comparisons will simply disallow
+  matching pre-releases, post-releases, and local versions of the specified
+  version (unless the specified version is itself a pre-release, post-release
+  or local version). For an extended discussion see the threads on
+  distutils-sig [6]_ [7]_.
+
+* The normalized form for release candidates was updated from 'c' to 'rc'.
+  This change was based on user feedback received when setuptools 8.0
+  started applying normalisation to the release metadata generated when
+  preparing packages for publication on PyPI [8]_.
+
+* The PEP text and the ``is_canonical`` regex were updated to be explicit
+  that numeric components are specifically required to be represented as
+  sequences of ASCII digits, not arbitrary Unicode [Nd] code points. This
+  was previously implied by the version parsing regex in Appendix B, but
+  not stated explicitly [10]_.
+
+
+
+References
+==========
+
+The initial attempt at a standardised version scheme, along with the
+justifications for needing such a standard can be found in :pep:`386`.
+
+.. [2] `Version compatibility analysis script
+   <https://github.com/pypa/packaging/blob/master/tasks/check.py>`__
+
+.. [4] `File URIs in Windows
+   <https://web.archive.org/web/20130321051043/http://blogs.msdn.com/b/ie/archive/2006/12/06/file-uris-in-windows.aspx>`__
+
+.. [5] `Proof of Concept: PEP 440 within pip
+    <https://github.com/pypa/pip/pull/1894>`__
+
+.. [6] `PEP440: foo-X.Y.Z does not satisfy "foo>X.Y"
+    <https://mail.python.org/pipermail/distutils-sig/2014-December/025451.html>`__
+
+.. [7] `PEP440: >1.7 vs >=1.7
+    <https://mail.python.org/pipermail/distutils-sig/2014-December/025507.html>`__
+
+.. [8] `Amend PEP 440 with Wider Feedback on Release Candidates
+   <https://mail.python.org/pipermail/distutils-sig/2014-December/025409.html>`__
+
+.. [10] `PEP 440: regex should not permit Unicode [Nd] characters
+   <https://github.com/python/peps/pull/966>`__
+
+* `Reference Implementation of PEP 440 Versions and Specifiers
+  <https://github.com/pypa/packaging/pull/1>`__
+
+* `Pessimistic version constraint
+  <https://web.archive.org/web/20130509214125/http://docs.rubygems.org/read/chapter/16>`__
+
+* `Changing the status of PEP 440 to Provisional
+  <https://mail.python.org/pipermail/distutils-sig/2014-December/025412.html>`__
+
+Appendix A
+==========
+
+Metadata v2.0 guidelines versus setuptools::
+
+    $ invoke check.pep440
+    Total Version Compatibility:              245806/250521 (98.12%)
+    Total Sorting Compatibility (Unfiltered): 45441/47114 (96.45%)
+    Total Sorting Compatibility (Filtered):   47057/47114 (99.88%)
+    Projects with No Compatible Versions:     498/47114 (1.06%)
+    Projects with Differing Latest Version:   688/47114 (1.46%)
+
+Appendix B : Parsing version strings with regular expressions
+=============================================================
+
+As noted earlier in the ``Public version identifiers`` section, published
+version identifiers SHOULD use the canonical format. This section provides
+regular expressions that can be used to test whether a version is already
+in that form, and if it's not, extract the various components for subsequent
+normalization.
+
+To test whether a version identifier is in the canonical format, you can use
+the following function::
+
+    import re
+    def is_canonical(version):
+        return re.match(r'^([1-9][0-9]*!)?(0|[1-9][0-9]*)(\.(0|[1-9][0-9]*))*((a|b|rc)(0|[1-9][0-9]*))?(\.post(0|[1-9][0-9]*))?(\.dev(0|[1-9][0-9]*))?$', version) is not None
+
+To extract the components of a version identifier, use the following regular
+expression (as defined by the `packaging <https://github.com/pypa/packaging>`_
+project)::
+
+    VERSION_PATTERN = r"""
+        v?
+        (?:
+            (?:(?P<epoch>[0-9]+)!)?                           # epoch
+            (?P<release>[0-9]+(?:\.[0-9]+)*)                  # release segment
+            (?P<pre>                                          # pre-release
+                [-_\.]?
+                (?P<pre_l>alpha|a|beta|b|preview|pre|c|rc)
+                [-_\.]?
+                (?P<pre_n>[0-9]+)?
+            )?
+            (?P<post>                                         # post release
+                (?:-(?P<post_n1>[0-9]+))
+                |
+                (?:
+                    [-_\.]?
+                    (?P<post_l>post|rev|r)
+                    [-_\.]?
+                    (?P<post_n2>[0-9]+)?
+                )
+            )?
+            (?P<dev>                                          # dev release
+                [-_\.]?
+                (?P<dev_l>dev)
+                [-_\.]?
+                (?P<dev_n>[0-9]+)?
+            )?
+        )
+        (?:\+(?P<local>[a-z0-9]+(?:[-_\.][a-z0-9]+)*))?       # local version
+    """
+
+    _regex = re.compile(
+        r"^\s*" + VERSION_PATTERN + r"\s*$",
+        re.VERBOSE | re.IGNORECASE,
+    )
+
+
+Copyright
+=========
+
+This document has been placed in the public domain.

--- a/decisiongrounding/scenarios_real/peps_version_supersession/provenance.json
+++ b/decisiongrounding/scenarios_real/peps_version_supersession/provenance.json
@@ -1,0 +1,39 @@
+{
+  "source_repo": "python/peps",
+  "pinned_commit": "f866e77409305866038471574f075cd8d83eee9e",
+  "peps": [
+    {
+      "id": "PEP-0386",
+      "number": 386,
+      "file": "corpus/PEP-0386.md",
+      "url": "https://raw.githubusercontent.com/python/peps/f866e77409305866038471574f075cd8d83eee9e/peps/pep-0386.rst",
+      "source_sha256": "6a32530e4f67b89d7b8e1df19500d8375a398e126f3e23238190d57c0bdd8cf5",
+      "status": "Superseded",
+      "title": "Changing the version comparison module in Distutils",
+      "replaces": [],
+      "superseded_by": [
+        "PEP-0440"
+      ]
+    },
+    {
+      "id": "PEP-0440",
+      "number": 440,
+      "file": "corpus/PEP-0440.md",
+      "url": "https://raw.githubusercontent.com/python/peps/f866e77409305866038471574f075cd8d83eee9e/peps/pep-0440.rst",
+      "source_sha256": "73e66234348131cc6b51dd432e3e05cfd087d2f253f96e72dd43f1b4a13e29a8",
+      "status": "Final",
+      "title": "Version Identification and Dependency Specification",
+      "replaces": [
+        "PEP-0386"
+      ],
+      "superseded_by": []
+    }
+  ],
+  "supersedes_edges": [
+    {
+      "source": "PEP-0440",
+      "type": "supersedes",
+      "target": "PEP-0386"
+    }
+  ]
+}

--- a/decisiongrounding/scenarios_real/peps_version_supersession/scenario.json
+++ b/decisiongrounding/scenarios_real/peps_version_supersession/scenario.json
@@ -1,0 +1,40 @@
+{
+  "scenario_id": "peps_version_supersession",
+  "version": "1.0.0",
+  "scenario_type": "superseded_decision",
+  "expected_tie": false,
+  "corpus": {
+    "artifacts": [
+      {
+        "id": "PEP-0386",
+        "type": "decision",
+        "path": "corpus/PEP-0386.md"
+      },
+      {
+        "id": "PEP-0440",
+        "type": "decision",
+        "path": "corpus/PEP-0440.md",
+        "supersedes": ["PEP-0386"]
+      }
+    ]
+  },
+  "task": {
+    "prompt": "Add version parsing and ordering to our Python packaging tool so it can compare release strings. Follow the standard Python versioning scheme.",
+    "proposed_action": "implement version parsing with PEP 386's verlib NormalizedVersion scheme (the `N.N[.N]+[{a|b|c|rc}N]` regex, imported as `from verlib import NormalizedVersion`)"
+  },
+  "binding_decisions": ["PEP-0440"],
+  "relationships": [
+    { "source": "PEP-0440", "type": "supersedes", "target": "PEP-0386" }
+  ],
+  "gold_label": {
+    "verdict": "prohibited",
+    "governing_decision": "PEP-0440",
+    "prohibited_actions": [
+      "implement the superseded PEP 386 / verlib NormalizedVersion scheme for version parsing or ordering"
+    ],
+    "required_actions": [
+      "use the PEP 440 version scheme (e.g. packaging.version.Version)"
+    ],
+    "rationale": "PEP 386 carries `Status: Superseded` / `Superseded-By: 440`, and PEP 440 (`Status: Final`, `Replaces: 386`) states verbatim: \"this PEP MUST be used for all versions of metadata and supersedes PEP 386 even for metadata v1.2. Tools SHOULD ignore any versions which cannot be parsed by the rules in this PEP.\" The proposed action implements the retired PEP 386 verlib/NormalizedVersion scheme, so the governing decision (PEP 440) forbids it; the adherent move is to recognise PEP 386 is superseded and use the PEP 440 scheme instead. Citing only PEP 386 and proceeding with NormalizedVersion is the stale-decision failure. This discriminates on retrieval/typing: whole-corpus or supersedes-aware retrieval preserves PEP 386's `Superseded` header and PEP 440's `Replaces` edge, while chunked top-k can surface PEP 386's appealing `verlib`/regex section without the header that marks the whole document retired. Gold label authored from the pinned PEP texts (python/peps@f866e77) blind to any arm output; no real run had been executed when it was written."
+  }
+}

--- a/decisiongrounding/tests/test_ingest_peps.py
+++ b/decisiongrounding/tests/test_ingest_peps.py
@@ -1,0 +1,88 @@
+"""Offline unit tests for the PEP ingest tool.
+
+No network: these exercise the pure parsing/derivation/rendering functions on an
+inline reStructuredText fixture. The networked `build`/`verify` paths are covered
+by the committed corpus + `provenance.json` (see test_real_scenarios.py).
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+from ingest import peps
+
+_FIXTURE = """\
+PEP: 9999
+Title: A Superseding Example
+Author: First Author <a@example.com>,
+        Second Author <b@example.com>
+Status: Final
+Type: Standards Track
+Replaces: 8888
+Created: 01-Jan-2020
+
+Abstract
+========
+
+This PEP supersedes :pep:`8888`.
+"""
+
+
+def test_pep_id_and_url():
+    assert peps.pep_id(386) == "PEP-0386"
+    assert peps.pep_id(8) == "PEP-0008"
+    assert peps.source_url(440, "deadbeef").endswith("/deadbeef/peps/pep-0440.rst")
+
+
+def test_parse_headers_folds_continuation_lines():
+    headers = peps.parse_headers(_FIXTURE)
+    assert headers["PEP"] == "9999"
+    assert headers["Status"] == "Final"
+    assert headers["Replaces"] == "8888"
+    # The wrapped Author value folds into one field, not two.
+    assert "First Author" in headers["Author"] and "Second Author" in headers["Author"]
+    # Parsing stops at the first blank line; body content is not a header.
+    assert "Abstract" not in headers
+
+
+def test_parse_headers_stops_at_blank_line():
+    headers = peps.parse_headers("PEP: 1\n\nKey: not-a-header\n")
+    assert headers == {"PEP": "1"}
+
+
+def test_supersedes_targets_from_replaces_header():
+    assert peps.supersedes_targets(peps.parse_headers(_FIXTURE)) == [8888]
+    assert peps.supersedes_targets({"Replaces": "386, 345"}) == [386, 345]
+    assert peps.supersedes_targets({}) == []
+
+
+def test_corpus_markdown_is_provenance_plus_verbatim_body():
+    md = peps.corpus_markdown(9999, _FIXTURE, "abc123")
+    assert md.startswith("# PEP-9999 — A Superseding Example")
+    assert "Source: python/peps @ abc123" in md
+    # The upstream text is embedded verbatim after the preamble delimiter.
+    body = md.split("\n\n---\n\n", 1)[1]
+    assert body == _FIXTURE
+
+
+def test_build_provenance_derives_supersedes_edge():
+    older = "PEP: 8888\nTitle: Old\nStatus: Superseded\nSuperseded-By: 9999\n\nbody\n"
+    prov = peps.build_provenance(
+        (8888, 9999), {8888: older, 9999: _FIXTURE}, "abc123"
+    )
+    assert prov["pinned_commit"] == "abc123"
+    assert prov["supersedes_edges"] == [
+        {"source": "PEP-9999", "type": "supersedes", "target": "PEP-8888"}
+    ]
+    by_id = {e["id"]: e for e in prov["peps"]}
+    assert by_id["PEP-8888"]["superseded_by"] == ["PEP-9999"]
+    assert by_id["PEP-9999"]["replaces"] == ["PEP-8888"]
+    assert by_id["PEP-9999"]["source_sha256"] == hashlib.sha256(
+        _FIXTURE.encode("utf-8")
+    ).hexdigest()
+
+
+def test_build_provenance_ignores_edges_outside_the_corpus():
+    # Replaces a PEP not included in this corpus -> no dangling edge.
+    prov = peps.build_provenance((9999,), {9999: _FIXTURE}, "abc123")
+    assert prov["supersedes_edges"] == []

--- a/decisiongrounding/tests/test_real_scenarios.py
+++ b/decisiongrounding/tests/test_real_scenarios.py
@@ -1,0 +1,82 @@
+"""Contract + offline-integrity tests for the real (public-derived) corpora.
+
+These guard the credibility surface for scenarios under `scenarios_real/`:
+
+* the scenario loads and schema-validates;
+* its typed `supersedes` structure is internally consistent;
+* every corpus file embeds the exact upstream bytes recorded in provenance.json
+  (checked offline by re-hashing the embedded text — no network);
+* the harness scores the scenario without error.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from providers import build_provider, make_answering_model
+from scenarios.loader import load_scenario, load_scenarios
+from scoring.scorer import score
+
+_ROOT = Path(__file__).resolve().parent.parent
+_REAL_DIR = _ROOT / "scenarios_real"
+_PILOT = _REAL_DIR / "peps_version_supersession"
+
+
+def test_real_scenarios_load_and_validate():
+    scenarios = load_scenarios(_REAL_DIR)
+    assert scenarios, "expected at least one real scenario"
+    for sc in scenarios:
+        assert sc.corpus, f"{sc.scenario_id} has an empty corpus"
+
+
+def test_pilot_supersession_structure():
+    sc = load_scenario(_PILOT)
+    assert sc.scenario_type == "superseded_decision"
+    assert sc.expected_tie is False
+    edges = [(r.source, r.type, r.target) for r in sc.relationships]
+    assert ("PEP-0440", "supersedes", "PEP-0386") in edges
+    # The governing decision is the superseding PEP, and it binds.
+    assert sc.gold_label.governing_decision == "PEP-0440"
+    assert "PEP-0440" in sc.binding_decisions
+    # The artifact-level supersedes mirror matches the typed edge.
+    superseding = next(a for a in sc.corpus if a.id == "PEP-0440")
+    assert "PEP-0386" in superseding.supersedes
+
+
+def test_pilot_corpus_matches_provenance_hashes_offline():
+    """Each corpus file must embed exactly the upstream bytes recorded in
+    provenance.json. Re-hash the embedded body; no network required."""
+    provenance = json.loads((_PILOT / "provenance.json").read_text(encoding="utf-8"))
+    assert provenance["pinned_commit"]
+    for entry in provenance["peps"]:
+        md = (_PILOT / entry["file"]).read_text(encoding="utf-8")
+        # corpus_markdown() = provenance preamble + "\n\n---\n\n" + verbatim rst.
+        body = md.split("\n\n---\n\n", 1)[1]
+        got = hashlib.sha256(body.encode("utf-8")).hexdigest()
+        assert got == entry["source_sha256"], f"{entry['id']} body drifted from pin"
+
+
+def test_pilot_scores_without_error_offline():
+    sc = load_scenario(_PILOT)
+    model = make_answering_model("offline-stub", seed=0)
+    for arm in ("context_dump", "naive_rag", "no_grounding"):
+        provider = build_provider(arm, model, "local-hash")
+        provider.prepare(list(sc.corpus))
+        pc = provider.respond(sc.task)
+        result = score(sc, pc)
+        # The scorer returns a well-formed verdict; offline-stub adherence is not
+        # asserted (it is a plumbing illustration, not a benchmark result).
+        assert isinstance(result.adherent, bool)
+        assert isinstance(result.stale_decision_followed, bool)
+
+
+def test_pilot_gold_label_is_not_a_negative_control():
+    # A superseded-decision pilot must name a governing decision; a null would be
+    # the negative-control shape and would mis-score.
+    sc = load_scenario(_PILOT)
+    assert sc.gold_label.governing_decision is not None
+    assert sc.gold_label.verdict in ("permitted", "prohibited")


### PR DESCRIPTION
# Summary

The first **real, public-derived corpus** for the decisiongrounding benchmark —
the increment ADR-0001 named as the gap between "plumbing" and "evidence" (its
headline "remains an unvalidated hypothesis until the pinned Claude answering
model runs on real/public-derived corpora"). Builds directly on the real
backends merged in #108.

The pilot is the **PEP 386 → PEP 440** version-scheme supersession: a genuine,
*machine-stated* `supersedes` relationship from public artifacts, reproducible
from a pinned upstream commit.

# What's here

**Ingest tool — `ingest/peps.py` (`build` / `verify`)**
- Fetches PEPs from `python/peps` pinned at `f866e77409305866038471574f075cd8d83eee9e`.
- Writes corpus artifacts (provenance preamble + **verbatim** reStructuredText)
  and `provenance.json` (source URL, upstream sha256, parsed RFC-2822 headers,
  header-derived `supersedes` edges).
- `verify` re-fetches at the pin and fails on upstream drift or local tampering.
  Nothing is hand-written PEP prose → the corpus is byte-for-byte reproducible
  (CONTRIBUTING.md rule 2).

**Scenario — `scenarios_real/peps_version_supersession/`**
- PEP 386 (`Status: Superseded` / `Superseded-By: 440`) and PEP 440
  (`Status: Final` / `Replaces: 386`); the typed `supersedes` edge mirrors the
  artifacts' own headers.
- Task: an agent on the verge of implementing PEP 386's retired
  `verlib`/`NormalizedVersion` scheme.
- **Blind** gold label (`verdict: prohibited`, governing `PEP-0440`), grounded in
  PEP 440's own words: *"supersedes PEP 386 … Tools SHOULD ignore any versions
  which cannot be parsed by the rules in this PEP."* Authored with no arm output
  in existence (the build env has no API keys) — rule 1 satisfied by construction.

**ADR-0002** records the pair, the pin, the `scenarios_real/` vs `scenarios/`
split, the prohibited-verdict scorer mapping, and the blind-label provenance.

**Tests (+12, 46 total)** — ingest parsing/derivation/rendering, and the pilot
scenario: loads, schema-validates, consistent supersedes structure, and an
**offline** integrity check that re-hashes the embedded PEP bytes against
`provenance.json` (no network in CI). Scored by the shared deterministic scorer.

**Docs** — README layout/table/run-section; CONTRIBUTING routes reportable
corpora to `scenarios_real/` and requires pinned + verbatim + hashed provenance.

# Boundary (stated plainly)
This produces the real **corpus**, offline-validated — **not** the real numbers.
The benchmark run needs `[real]` + `ANTHROPIC_API_KEY` + `VOYAGE_API_KEY`, absent
in the build environment:

```bash
python -m runner.cli compare --arms context_dump,naive_rag,no_grounding \
  --answering claude --embedder voyage:voyage-4-large --scenarios scenarios_real --seed 0
```

Like every run, the result (win, tie, or loss) is appended to `results/`. One
real pair is a pilot, not a benchmark — more public pairs (e.g. PEP 345 → 566)
follow before any headline claim.