### PR TITLE
feat(sdk): cross-artifact enforcement in the editor (v0.21.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ details, release history over commit history.
 
 ### Added
 
+- Cross-artifact enforcement in the editor extension (v0.21.1 milestone). The
+  extension now flags references that don't resolve, and references to **retired**
+  (superseded/deprecated) artifacts, at the reference site — drawn distinctly
+  (an unresolved reference is an error, a retired one a warning). Findings come
+  from `rac relationships --validate`; the engine's `relationship-target-*` codes
+  map to editor diagnostics, anchored to the target token inside the source
+  artifact's relationship section. This is what makes the extension RAC rather
+  than a generic Markdown linter (ADR-049, ADR-051). Relationship diagnostics
+  refresh on save/activation (relationship validation reads files from disk).
+
 - TypeScript SDK and editor extension (v0.21.0 milestone — TypeScript-only; the
   Python package is unchanged and versions independently). `@rac/sdk` is a thin
   Node client that shells out to the installed `rac` CLI and returns typed results

--- a/rac/roadmaps/v0.21.x-editor/v0.21.1-cross-artifact-enforcement.md
+++ b/rac/roadmaps/v0.21.x-editor/v0.21.1-cross-artifact-enforcement.md
@@ -40,14 +40,21 @@ Run `rac relationships --validate` over the workspace and map each issue
 (`source_path`, `relationship`, `target`, `code`) to a diagnostic. Relationship
 issues carry no line, so the extension locates the `target` token within the
 declared relationship section of the source artifact and anchors the diagnostic
-there. Refreshed on save and on debounced change.
+there (falling back to the section heading, then the file head). Because
+relationship validation reads files from disk, it reflects the *saved* corpus —
+so it refreshes on save and on activation, not on unsaved buffer edits (which
+`rac relationships` cannot see). Diagnostics live in their own collection,
+separate from the live per-file validation diagnostics.
 
 ### Initiative 2 — Retired-target awareness
 
-Distinguish a reference to a retired artifact (status from `rac resolve` /
-`rac export`, retired per ADR-051) from an unresolved one, with its own
-diagnostic message and severity, so "you are pointing at superseded thinking"
-reads differently from "this target does not exist".
+The engine already distinguishes a reference to a retired
+(superseded/deprecated, ADR-051) artifact: `rac relationships --validate` emits
+`relationship-target-superseded` as its own `code`, separate from
+`relationship-target-not-found`. The extension maps the two to distinct messages
+and severities — a retired reference is an advisory warning ("you are pointing at
+superseded thinking"), an unresolved one an error ("this target does not exist")
+— so no separate status lookup is needed.
 
 ## Constraints
 
@@ -66,12 +73,17 @@ reads differently from "this target does not exist".
 
 ## Implementation Contract
 
-- Broken-reference and retired-reference diagnostics are anchored to the target
-  token inside the relationship section of the source artifact.
-- Retired-target diagnostics are visually and textually distinct from
-  unresolved-target ones.
-- If `rac relationships`/`review` cannot localize a finding precisely, the
-  extension anchors at the relationship section heading rather than guessing.
+- Diagnostics come from `rac relationships --validate` and are anchored to the
+  target token inside the source artifact's relationship section, with the
+  section heading and then the file head as fallbacks.
+- `relationship-target-not-found` maps to an error and
+  `relationship-target-superseded` to a warning, so retired references read
+  distinctly from unresolved ones; the other relationship codes (ambiguous,
+  type-mismatch, self-reference, cycle, edge-unsupported) map to sensible
+  severities.
+- Relationship diagnostics live in a separate collection from per-file
+  validation, and refresh on save/activation (debounced), since relationship
+  validation reads disk and cannot see unsaved edits.
 
 ## Success Measures
 

--- a/typescript/rac-vscode/README.md
+++ b/typescript/rac-vscode/README.md
@@ -20,6 +20,10 @@ reimplementing it ([ADR-063](../../rac/decisions/adr-063-non-python-clients-are-
 - **Live validation** — diagnostics update as you type (the unsaved buffer is
   piped through `rac validate -`, debounced), and immediately on open/save.
   Errors + warnings are mapped to the right lines.
+- **Cross-artifact enforcement** — references that don't resolve, and references
+  to **retired** (superseded/deprecated) artifacts, are flagged at the reference
+  site, drawn distinctly (from `rac relationships --validate`). Refreshes on
+  save/activation, since relationship validation reads files from disk.
 - **Hover** — hovering an artifact ID or alias (e.g. `adr-007`,
   `v0.20.0-python-sdk-foundation`) shows its title, type, and path via
   `rac resolve`.

--- a/typescript/rac-vscode/src/extension.ts
+++ b/typescript/rac-vscode/src/extension.ts
@@ -4,10 +4,15 @@
  * Wires the `@rac/sdk` thin client to the editor. All analysis stays in `rac`
  * (ADR-063); this extension maps its output into the editor:
  *
- *  - validation diagnostics, live as you type (the unsaved buffer is piped
- *    through `rac validate -`), debounced, plus immediately on open/save;
+ *  - per-file validation diagnostics, live as you type (the unsaved buffer is
+ *    piped through `rac validate -`), debounced, plus immediately on open/save;
+ *  - cross-artifact enforcement: broken and retired-target references surfaced
+ *    at the reference site, from `rac relationships --validate` (refreshed on
+ *    save/activation, since relationship validation reads files from disk);
  *  - hover and go-to-definition on artifact IDs / aliases via `rac resolve`.
  */
+
+import * as path from "node:path";
 
 import * as vscode from "vscode";
 
@@ -17,24 +22,34 @@ import {
   isResolved,
   type FileValidation,
   type Issue,
+  type RelationshipIssue,
+  type RelationshipValidation,
   type ResolvedArtifact,
 } from "@rac/sdk";
 
 const DEBOUNCE_MS = 300;
+const RELATIONSHIP_DEBOUNCE_MS = 600;
 
 let diagnostics: vscode.DiagnosticCollection;
+let relationshipDiagnostics: vscode.DiagnosticCollection;
 const clients = new Map<string, RacClient>();
 const debounce = new Map<string, ReturnType<typeof setTimeout>>();
+const relationshipDebounce = new Map<string, ReturnType<typeof setTimeout>>();
 let warnedMissing = false;
 
 export function activate(context: vscode.ExtensionContext): void {
   diagnostics = vscode.languages.createDiagnosticCollection("rac");
+  relationshipDiagnostics = vscode.languages.createDiagnosticCollection("rac-relationships");
   const selector: vscode.DocumentSelector = { language: "markdown", scheme: "file" };
 
   context.subscriptions.push(
     diagnostics,
+    relationshipDiagnostics,
     vscode.workspace.onDidOpenTextDocument((doc) => void validateDocument(doc)),
-    vscode.workspace.onDidSaveTextDocument((doc) => void validateDocument(doc)),
+    vscode.workspace.onDidSaveTextDocument((doc) => {
+      void validateDocument(doc);
+      scheduleRelationshipsFor(doc);
+    }),
     vscode.workspace.onDidChangeTextDocument((e) => scheduleValidate(e.document)),
     vscode.workspace.onDidCloseTextDocument((doc) => {
       cancelScheduled(doc);
@@ -44,6 +59,7 @@ export function activate(context: vscode.ExtensionContext): void {
       if (e.affectsConfiguration("rac")) {
         clients.clear();
         void validateWorkspace();
+        refreshAllRelationships();
       }
     }),
     vscode.commands.registerCommand("rac.validateWorkspace", validateWorkspace),
@@ -52,16 +68,21 @@ export function activate(context: vscode.ExtensionContext): void {
   );
 
   for (const doc of vscode.workspace.textDocuments) void validateDocument(doc);
+  refreshAllRelationships();
 }
 
 export function deactivate(): void {
   for (const timer of debounce.values()) clearTimeout(timer);
+  for (const timer of relationshipDebounce.values()) clearTimeout(timer);
   debounce.clear();
+  relationshipDebounce.clear();
   diagnostics?.clear();
   diagnostics?.dispose();
+  relationshipDiagnostics?.clear();
+  relationshipDiagnostics?.dispose();
 }
 
-// --- diagnostics ------------------------------------------------------------
+// --- per-file validation ----------------------------------------------------
 
 function isEnabled(): boolean {
   return vscode.workspace
@@ -138,6 +159,147 @@ async function validateWorkspace(): Promise<void> {
   for (const doc of vscode.workspace.textDocuments) {
     await validateDocument(doc);
   }
+  refreshAllRelationships();
+}
+
+// --- cross-artifact enforcement ---------------------------------------------
+
+// Severity and message per relationship-validation code. The headline split:
+// a reference that does not resolve (error) vs. a reference to a retired
+// (superseded/deprecated) artifact (warning) — the latter is what makes the
+// extension RAC, not a generic linter (ADR-049, ADR-051).
+const RELATIONSHIP_SEVERITY: Record<string, vscode.DiagnosticSeverity> = {
+  "relationship-target-not-found": vscode.DiagnosticSeverity.Error,
+  "relationship-target-ambiguous": vscode.DiagnosticSeverity.Error,
+  "relationship-cycle": vscode.DiagnosticSeverity.Error,
+  "relationship-target-type-mismatch": vscode.DiagnosticSeverity.Warning,
+  "relationship-target-superseded": vscode.DiagnosticSeverity.Warning,
+  "relationship-self-reference": vscode.DiagnosticSeverity.Warning,
+  "relationship-edge-unsupported": vscode.DiagnosticSeverity.Warning,
+};
+
+const RELATIONSHIP_MESSAGE: Record<string, string> = {
+  "relationship-target-not-found": "Reference does not resolve",
+  "relationship-target-ambiguous": "Ambiguous reference (matches multiple artifacts)",
+  "relationship-cycle": "Relationship cycle through",
+  "relationship-target-type-mismatch": "Reference resolves to the wrong artifact type",
+  "relationship-target-superseded": "References a retired (superseded/deprecated) artifact",
+  "relationship-self-reference": "Artifact references itself",
+  "relationship-edge-unsupported": "Unsupported relationship for this artifact type",
+};
+
+function scheduleRelationshipsFor(doc: vscode.TextDocument): void {
+  if (doc.languageId !== "markdown" || doc.uri.scheme !== "file") return;
+  if (!looksLikeRacArtifact(doc.getText())) return;
+  const folder = vscode.workspace.getWorkspaceFolder(doc.uri);
+  if (folder) scheduleRelationships(folder);
+}
+
+function scheduleRelationships(folder: vscode.WorkspaceFolder): void {
+  const key = folder.uri.fsPath;
+  const existing = relationshipDebounce.get(key);
+  if (existing) clearTimeout(existing);
+  relationshipDebounce.set(
+    key,
+    setTimeout(() => {
+      relationshipDebounce.delete(key);
+      void refreshRelationships(folder);
+    }, RELATIONSHIP_DEBOUNCE_MS),
+  );
+}
+
+function refreshAllRelationships(): void {
+  for (const folder of vscode.workspace.workspaceFolders ?? []) {
+    void refreshRelationships(folder);
+  }
+}
+
+async function refreshRelationships(folder: vscode.WorkspaceFolder): Promise<void> {
+  if (!isEnabled()) return;
+  let result: RelationshipValidation;
+  try {
+    // Relationship validation reads files from disk, so it reflects the saved
+    // corpus (not unsaved buffers) — hence save/activation-triggered.
+    result = await clientFor(folder).validateRelationships(folder.uri.fsPath);
+  } catch (err) {
+    if (err instanceof RacNotFoundError) warnMissingOnce();
+    else console.error("RAC: relationship validation failed", err);
+    return;
+  }
+
+  const byFile = new Map<string, RelationshipIssue[]>();
+  for (const issue of result.issues) {
+    const list = byFile.get(issue.source_path) ?? [];
+    list.push(issue);
+    byFile.set(issue.source_path, list);
+  }
+
+  relationshipDiagnostics.clear();
+  for (const [source, issues] of byFile) {
+    const uri = path.isAbsolute(source)
+      ? vscode.Uri.file(source)
+      : vscode.Uri.joinPath(folder.uri, source);
+    let doc: vscode.TextDocument;
+    try {
+      doc = await vscode.workspace.openTextDocument(uri);
+    } catch {
+      continue; // a referenced source we cannot open — skip rather than guess.
+    }
+    relationshipDiagnostics.set(
+      uri,
+      issues.map((issue) => relationshipDiagnostic(doc, issue)),
+    );
+  }
+}
+
+function relationshipDiagnostic(
+  doc: vscode.TextDocument,
+  issue: RelationshipIssue,
+): vscode.Diagnostic {
+  const range = findReferenceRange(doc, issue.relationship, issue.target);
+  const label = RELATIONSHIP_MESSAGE[issue.code] ?? "Relationship issue";
+  const severity = RELATIONSHIP_SEVERITY[issue.code] ?? vscode.DiagnosticSeverity.Warning;
+  const diagnostic = new vscode.Diagnostic(range, `${label}: ${issue.target}`, severity);
+  diagnostic.source = "rac";
+  diagnostic.code = issue.code;
+  return diagnostic;
+}
+
+// Relationship issues carry no line, so anchor the diagnostic on the target
+// token inside the declared relationship section (e.g. "## Related Decisions"),
+// falling back to the section heading, then the file head.
+function findReferenceRange(
+  doc: vscode.TextDocument,
+  relationship: string,
+  target: string,
+): vscode.Range {
+  const lines = doc.getText().split(/\r?\n/);
+  const heading = relationshipHeading(relationship);
+  const headingRe = new RegExp(`^#{1,6}\\s+${escapeRegExp(heading)}\\s*$`, "i");
+  const headingIdx = lines.findIndex((line) => headingRe.test(line));
+
+  const from = headingIdx >= 0 ? headingIdx + 1 : 0;
+  for (let i = from; i < lines.length; i++) {
+    if (headingIdx >= 0 && /^#{1,6}\s+/.test(lines[i])) break; // next heading ends the section
+    const col = lines[i].indexOf(target);
+    if (col >= 0) return new vscode.Range(i, col, i, col + target.length);
+  }
+  if (headingIdx >= 0) {
+    return new vscode.Range(headingIdx, 0, headingIdx, lines[headingIdx].length);
+  }
+  return new vscode.Range(0, 0, 0, Number.MAX_SAFE_INTEGER);
+}
+
+function relationshipHeading(relationship: string): string {
+  // "related_requirements" -> "Related Requirements"
+  return relationship
+    .split("_")
+    .map((word) => (word ? word[0].toUpperCase() + word.slice(1) : word))
+    .join(" ");
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 // --- hover & go-to-definition ----------------------------------------------


### PR DESCRIPTION
# Summary

Implements `rac/roadmaps/v0.21.x-editor/v0.21.1-cross-artifact-enforcement.md` — **v0.21.1** of the `v0.21.x-editor` series. The VS Code / Cursor extension now enforces RAC's *cross-artifact* rules in the editor — the feature that makes it RAC rather than a generic Markdown linter (ADR-049). References that don't resolve, and references to **retired** (superseded/deprecated, ADR-051) artifacts, are flagged at the reference site, drawn distinctly. TypeScript-only; thin client (ADR-063) — findings come from `rac relationships --validate`, the extension re-derives nothing.

Adds:
- Relationship diagnostics in the extension: each `rac relationships --validate` issue (`source_path`, `relationship`, `target`, `code`) becomes a diagnostic anchored to the target token inside the source artifact's relationship section.
- The retired-vs-broken split: `relationship-target-not-found` → error, `relationship-target-superseded` → warning, plus sensible severities for the other relationship codes (ambiguous, type-mismatch, self-reference, cycle, edge-unsupported).

# Roadmap / ADR Trace

Roadmap:
- `rac/roadmaps/v0.21.x-editor/v0.21.1-cross-artifact-enforcement.md` (contract refined in this PR to match the implementation)

Relevant ADRs:
- `rac/decisions/adr-049-enforcement-is-the-product.md` — cross-artifact enforcement is the differentiated behavior this release surfaces in the editor.
- `rac/decisions/adr-051-lifecycle-status.md` — the retired (superseded/deprecated) status that the warning-vs-error split distinguishes.
- `rac/decisions/adr-063-non-python-clients-are-thin.md` — findings come from `rac relationships --validate`; the extension computes no graph.
- `rac/decisions/adr-007-json-output-is-additive.md` — consumes the existing relationship-issue JSON shape.

Requirement:
- `rac/requirements/rac-cross-artifact-enforcement.md` — the requirement this realizes in the editor.

# Scope

## Included
- Cross-artifact relationship diagnostics, refreshed on save/activation, in a diagnostic collection separate from the live per-file validation.
- Distinct retired-target (warning) vs unresolved (error) diagnostics, plus sensible severities for the remaining relationship codes.

## Excluded
- Auto-fixing references; a quick-fix to search for the intended target (v0.21.2).
- Find-all-references / navigation (v0.21.3); a relationship graph view (v0.21.5).
- Any change to how `rac` computes relationships or statuses (roadmap Non-Goal).

# Product / Architecture Decisions

- **Retired-target awareness needs no extra lookups.** The engine already emits `relationship-target-superseded` as its own code, so the extension maps codes to severities rather than calling `rac resolve` per reference.
- **Save/activation-triggered, not live.** `rac relationships` reads files from disk, so it reflects the saved corpus; refreshing on unsaved edits would show stale results. Per-file validation stays live (it pipes the buffer via stdin).
- **Anchoring without a line.** Relationship issues carry no line, so each diagnostic is anchored to the target token within the declared relationship section, with the section heading then the file head as fallbacks.

# User-Facing Contract

## CLI
None. No `rac` command, flag, or behavior is added or changed; Python source and packaging are untouched. The editor surface adds diagnostics with `source: "rac"` and the engine's `relationship-target-*` code on artifacts whose declared references are broken or retired; no new editor settings or commands; it honours `rac.validate.enable`.

## Human Output
None. No `rac` terminal output change.

## JSON Output
None. No `rac --json` shape change; the extension consumes the existing relationship-issue fields (`source_path`, `relationship`, `target`, `code`).

## Exit Codes
- No change. `rac` exit codes are unchanged; the extension reads relationship issues as data.

# Verification

## Ran
- Extension `npm run check-types` (strict) and `npm run compile` (esbuild) clean.
- Confirmed `relationship-target-superseded` fires with the expected `{source_path, relationship, target, code}` shape via a real `rac` scenario (a live requirement referencing a Superseded decision).
- Corpus gates: `rac validate rac/` exit 0; `rac relationships rac/ --validate` → 775 checked / 0 issues.

## Covered
- Positive: the SDK's `validateRelationships` is unit- and integration-tested (v0.21.0); the superseded-target scenario produces the expected issue shape against real `rac`.
- Negative / boundary: the retired (warning) vs unresolved (error) code→severity split is the distinguishing path; the extension mapping (code → severity/message) and section-anchored range are presentation logic over that tested data.
- Not run: runtime editor behaviour is not exercised headlessly (no VS Code host in CI).

# Review Path

1. `typescript/rac-vscode/src/extension.ts` — the cross-artifact enforcement section (severity/message maps, `refreshRelationships`, `findReferenceRange`).
2. `rac/roadmaps/v0.21.x-editor/v0.21.1-cross-artifact-enforcement.md` — refined contract.
3. `CHANGELOG.md`, `typescript/rac-vscode/README.md`.

# Notes For Reviewer
- Stacked release: this PR targets `main`; later v0.21.x PRs build on it and also target `main`, so merging the series in order yields a clean per-release diff.
- On merge, flip the v0.21.1 roadmap `## Status` to `Achieved` (ADR-061).

# Implementation Process
Implemented with AI assistance under the v0.21.1 roadmap contract; final scope, review, and acceptance decisions are the maintainer's.