### PR TITLE
feat(sdk): authoring ergonomics in the editor (v0.21.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ details, release history over commit history.
 
 ### Added
 
+- Authoring aids in the editor extension (v0.21.2 milestone). Inside a
+  relationship section, the extension now offers **artifact-alias completion**
+  (human aliases like `adr-007`, from a cached `rac export`); **quick-fixes**
+  insert a missing `## Section` to clear a `missing-<section>` finding; and a
+  **RAC: New Artifact** command scaffolds an artifact of any type via `rac new`.
+  The SDK gains `schema(type)` and `createArtifact(type, path)`.
+
 - Cross-artifact enforcement in the editor extension (v0.21.1 milestone). The
   extension now flags references that don't resolve, and references to **retired**
   (superseded/deprecated) artifacts, at the reference site — drawn distinctly

--- a/rac/roadmaps/v0.21.x-editor/v0.21.2-authoring-ergonomics.md
+++ b/rac/roadmaps/v0.21.x-editor/v0.21.2-authoring-ergonomics.md
@@ -46,8 +46,10 @@ guidance bodies from `rac schema` / `rac improve --template` are a follow-on.
 
 ### Initiative 3 — New-artifact scaffolding
 
-A "RAC: New Artifact" command that picks a type and scaffolds via `rac new`
-(opening the result), plus per-type section snippets for in-place authoring.
+A "RAC: New Artifact" command that picks a type, **suggests an existing folder**
+that already holds that type (from the cached export, so `rac new` — which does
+not create missing parents — succeeds), then scaffolds via `rac new` and opens
+the result.
 
 ## Constraints
 

--- a/rac/roadmaps/v0.21.x-editor/v0.21.2-authoring-ergonomics.md
+++ b/rac/roadmaps/v0.21.x-editor/v0.21.2-authoring-ergonomics.md
@@ -32,15 +32,17 @@ thin client (ADR-063).
 ### Initiative 1 — Artifact-ID completion
 
 A completion provider that, inside a relationship section (`Related Decisions`,
-`Related Roadmaps`, …), offers IDs/aliases from `rac find` / the repository
-index, filtered by the section's relationship type where possible. Accepting an
-item inserts the canonical reference.
+`Related Roadmaps`, …), offers artifact **aliases** (the human ones, e.g.
+`adr-007`, not the opaque id) drawn from the corpus export (`rac export`, cached
+per folder and invalidated on save); VS Code filters by what is typed. Accepting
+an item inserts a resolvable reference.
 
 ### Initiative 2 — Quick-fix code actions
 
-Code actions for structural diagnostics — e.g. "insert Success Metrics section",
-"insert Risks section" — generated from `rac improve --template` / `rac schema`,
-so the inserted skeleton matches the canonical template.
+Code actions for structural `missing-<section>` diagnostics — e.g. "Insert
+'## Success Metrics' section" — that append the canonical section heading so the
+finding clears. The section name is taken from the diagnostic code; richer
+guidance bodies from `rac schema` / `rac improve --template` are a follow-on.
 
 ### Initiative 3 — New-artifact scaffolding
 

--- a/typescript/rac-sdk/src/client.ts
+++ b/typescript/rac-sdk/src/client.ts
@@ -9,6 +9,7 @@ import { RacExecError, RacNotFoundError, RacOutputError } from "./errors.js";
 import { defaultRunner, type RacRunner, type RunResult } from "./runner.js";
 import type {
   CorpusExport,
+  CreatedArtifact,
   DirectoryValidation,
   FileValidation,
   FindResult,
@@ -16,6 +17,7 @@ import type {
   RelationshipValidation,
   ResolveResult,
   ReviewReport,
+  SchemaReference,
 } from "./types.js";
 
 export interface RacClientOptions {
@@ -118,6 +120,16 @@ export class RacClient {
     return this.json<CorpusExport>(
       this.withTopLevel(["export", directory, "--json"], options),
     );
+  }
+
+  /** `rac schema <type> --json` — the canonical section/metadata reference for a type. */
+  schema(artifactType: string): Promise<SchemaReference> {
+    return this.json<SchemaReference>(["schema", artifactType, "--json"]);
+  }
+
+  /** `rac new <type> <path> --json` — scaffold a new artifact (never overwrites). */
+  createArtifact(artifactType: string, outputPath: string): Promise<CreatedArtifact> {
+    return this.json<CreatedArtifact>(["new", artifactType, outputPath, "--json"]);
   }
 
   /** `rac --version` — the installed RAC version string. */

--- a/typescript/rac-sdk/src/index.ts
+++ b/typescript/rac-sdk/src/index.ts
@@ -60,6 +60,8 @@ export type {
   ReviewIssue,
   ReviewReport,
   PortfolioStats,
+  SchemaReference,
+  CreatedArtifact,
   CorpusMeta,
   ExportArtifact,
   ExportRelationship,

--- a/typescript/rac-sdk/src/types.ts
+++ b/typescript/rac-sdk/src/types.ts
@@ -176,6 +176,31 @@ export interface PortfolioStats {
   [key: string]: unknown;
 }
 
+// --- rac schema <type> --json ----------------------------------------------
+
+export interface SchemaReference {
+  type: string;
+  required: string[];
+  recommended: string[];
+  optional: string[];
+  /** Section name → human description. */
+  descriptions: Record<string, string>;
+  /** Section name → authoring questions. */
+  guidance: Record<string, string[]>;
+  /** Metadata vocabularies (e.g. status/category enums). */
+  metadata: Record<string, unknown>;
+}
+
+// --- rac new <type> <path> --json -------------------------------------------
+
+export interface CreatedArtifact {
+  schema_version: string;
+  created: boolean;
+  type: string;
+  path: string;
+  id: string;
+}
+
 // --- rac export <dir> --json (the lore-web viewer payload) ------------------
 
 export interface CorpusMeta {

--- a/typescript/rac-sdk/test/client.test.ts
+++ b/typescript/rac-sdk/test/client.test.ts
@@ -155,6 +155,44 @@ describe("validateRelationships", () => {
   });
 });
 
+describe("schema", () => {
+  it("returns the section reference and passes the type", async () => {
+    const { runner, calls } = fakeRunner({
+      stdout: JSON.stringify({
+        type: "requirement",
+        required: ["problem", "requirements"],
+        recommended: ["success_metrics"],
+        optional: [],
+        descriptions: { problem: "the problem" },
+        guidance: {},
+        metadata: {},
+      }),
+    });
+    const result = await new RacClient({ runner }).schema("requirement");
+    expect(result.required).toEqual(["problem", "requirements"]);
+    expect(result.descriptions.problem).toBe("the problem");
+    expect(calls[0]).toEqual(["schema", "requirement", "--json"]);
+  });
+});
+
+describe("createArtifact", () => {
+  it("scaffolds an artifact and parses the result", async () => {
+    const { runner, calls } = fakeRunner({
+      stdout: JSON.stringify({
+        schema_version: "1",
+        created: true,
+        type: "decision",
+        path: "d.md",
+        id: "RAC-NEW",
+      }),
+    });
+    const result = await new RacClient({ runner }).createArtifact("decision", "d.md");
+    expect(result.created).toBe(true);
+    expect(result.id).toBe("RAC-NEW");
+    expect(calls[0]).toEqual(["new", "decision", "d.md", "--json"]);
+  });
+});
+
 describe("error mapping", () => {
   it("raises RacNotFoundError when the binary cannot be spawned", async () => {
     const runner: RacRunner = async () => {

--- a/typescript/rac-sdk/test/integration.test.ts
+++ b/typescript/rac-sdk/test/integration.test.ts
@@ -55,4 +55,11 @@ describe.skipIf(!racBin)("integration (real rac)", () => {
     expect(bad.valid).toBe(false);
     expect(bad.errors.some((i) => i.code === "missing-title")).toBe(true);
   });
+
+  it("returns the canonical schema for a type", async () => {
+    const schema = await rac.schema("requirement");
+    expect(schema.type).toBe("requirement");
+    expect(schema.required).toContain("problem");
+    expect(schema.required).toContain("requirements");
+  });
 });

--- a/typescript/rac-vscode/README.md
+++ b/typescript/rac-vscode/README.md
@@ -30,7 +30,8 @@ reimplementing it ([ADR-063](../../rac/decisions/adr-063-non-python-clients-are-
 - **Go-to-definition** — jump from a reference to the target artifact's file.
 - **Authoring aids** — artifact-alias completion inside relationship sections
   (`## Related Decisions`, …), quick-fixes that insert a missing `## Section`,
-  and a **RAC: New Artifact** command that scaffolds via `rac new`.
+  and a **RAC: New Artifact** command that suggests an existing folder for the
+  type, then scaffolds via `rac new`.
 - **RAC: Validate Open Artifacts** command.
 - Graceful handling when `rac` is missing — a one-time prompt to install or set
   `rac.path`, never a wall of errors.

--- a/typescript/rac-vscode/README.md
+++ b/typescript/rac-vscode/README.md
@@ -28,6 +28,9 @@ reimplementing it ([ADR-063](../../rac/decisions/adr-063-non-python-clients-are-
   `v0.20.0-python-sdk-foundation`) shows its title, type, and path via
   `rac resolve`.
 - **Go-to-definition** — jump from a reference to the target artifact's file.
+- **Authoring aids** — artifact-alias completion inside relationship sections
+  (`## Related Decisions`, …), quick-fixes that insert a missing `## Section`,
+  and a **RAC: New Artifact** command that scaffolds via `rac new`.
 - **RAC: Validate Open Artifacts** command.
 - Graceful handling when `rac` is missing — a one-time prompt to install or set
   `rac.path`, never a wall of errors.

--- a/typescript/rac-vscode/package.json
+++ b/typescript/rac-vscode/package.json
@@ -21,6 +21,10 @@
       {
         "command": "rac.validateWorkspace",
         "title": "RAC: Validate Open Artifacts"
+      },
+      {
+        "command": "rac.newArtifact",
+        "title": "RAC: New Artifact"
       }
     ],
     "configuration": {

--- a/typescript/rac-vscode/src/extension.ts
+++ b/typescript/rac-vscode/src/extension.ts
@@ -433,11 +433,18 @@ async function newArtifact(): Promise<void> {
     placeHolder: "Artifact type",
   });
   if (!type) return;
-  const relPath = await vscode.window.showInputBox({
-    prompt: `Path for the new ${type}`,
-    value: `rac/${type}s/new-${type}.md`,
+
+  // Suggest an existing folder — `rac new` won't create missing parents, so
+  // steering to a folder that already holds this type avoids a needless error.
+  const dir = await pickArtifactFolder(folder, type);
+  if (dir === undefined) return;
+
+  const name = await vscode.window.showInputBox({
+    prompt: `File name for the new ${type}`,
+    value: `new-${type}.md`,
   });
-  if (!relPath) return;
+  if (!name) return;
+  const relPath = `${dir}/${name}`;
 
   try {
     const result = await clientFor(folder).createArtifact(type, relPath);
@@ -457,6 +464,31 @@ async function newArtifact(): Promise<void> {
 
 function titleCase(value: string): string {
   return value.replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+// Offer the workspace-relative folders that already hold artifacts of this type
+// (from the cached export). One match is auto-selected; none falls back to the
+// conventional `rac/<type>s`. All offered folders exist, so `rac new` succeeds.
+async function pickArtifactFolder(
+  folder: vscode.WorkspaceFolder,
+  type: string,
+): Promise<string | undefined> {
+  const corpus = await corpusExport(folder);
+  const dirs = new Set<string>();
+  for (const artifact of corpus?.artifacts ?? []) {
+    if (artifact.type !== type) continue;
+    // export paths are absolute (the extension passes an absolute dir); make
+    // them workspace-relative with forward slashes.
+    const rel = vscode.workspace.asRelativePath(vscode.Uri.file(artifact.path), false);
+    const slash = rel.lastIndexOf("/");
+    if (slash > 0) dirs.add(rel.slice(0, slash));
+  }
+  const choices = [...dirs].sort();
+  if (choices.length === 0) return `rac/${type}s`;
+  if (choices.length === 1) return choices[0];
+  return vscode.window.showQuickPick(choices, {
+    placeHolder: `Folder for the new ${type}`,
+  });
 }
 
 // --- hover & go-to-definition ----------------------------------------------

--- a/typescript/rac-vscode/src/extension.ts
+++ b/typescript/rac-vscode/src/extension.ts
@@ -345,6 +345,10 @@ async function provideCompletions(
   const corpus = await corpusExport(folder);
   if (!corpus) return undefined;
 
+  // Replace the whole hyphenated token under the cursor, so accepting "adr-007"
+  // after typing "adr-" produces "adr-007", not "adr-adr-007".
+  const replaceRange = doc.getWordRangeAtPosition(position, REFERENCE_WORD);
+
   const items: vscode.CompletionItem[] = [];
   for (const artifact of corpus.artifacts) {
     for (const alias of artifact.aliases) {
@@ -352,6 +356,7 @@ async function provideCompletions(
       const item = new vscode.CompletionItem(alias, vscode.CompletionItemKind.Reference);
       item.detail = `${artifact.type} — ${artifact.title}`;
       item.insertText = alias;
+      if (replaceRange) item.range = replaceRange;
       items.push(item);
     }
   }
@@ -366,6 +371,25 @@ function provideCodeActions(
   const actions: vscode.CodeAction[] = [];
   for (const diagnostic of context.diagnostics) {
     if (diagnostic.source !== "rac" || typeof diagnostic.code !== "string") continue;
+
+    if (diagnostic.code === "missing-title") {
+      // A title is a top-level `# ` heading, not a `## ` section — insert it
+      // after any frontmatter rather than appending a bogus "## Title" section
+      // (which would not clear the finding).
+      const action = new vscode.CodeAction(
+        "Insert title heading",
+        vscode.CodeActionKind.QuickFix,
+      );
+      action.diagnostics = [diagnostic];
+      const edit = new vscode.WorkspaceEdit();
+      edit.insert(doc.uri, titleInsertPosition(doc), "# Title\n\n");
+      action.edit = edit;
+      actions.push(action);
+      continue;
+    }
+
+    // The remaining missing-<section> codes (problem, requirements, risks,
+    // success-metrics) are genuine `## ` sections.
     const match = /^missing-(.+)$/.exec(diagnostic.code);
     if (!match) continue;
     const title = titleCase(match[1].replace(/-/g, " "));
@@ -377,15 +401,26 @@ function provideCodeActions(
     const edit = new vscode.WorkspaceEdit();
     const text = doc.getText();
     const separator = text.endsWith("\n") ? "\n" : "\n\n";
-    edit.insert(
-      doc.uri,
-      new vscode.Position(doc.lineCount, 0),
-      `${separator}## ${title}\n\n`,
-    );
+    edit.insert(doc.uri, endOfDocument(doc), `${separator}## ${title}\n\n`);
     action.edit = edit;
     actions.push(action);
   }
   return actions;
+}
+
+// A title goes immediately after the YAML frontmatter block, else at the top.
+function titleInsertPosition(doc: vscode.TextDocument): vscode.Position {
+  const lines = doc.getText().split(/\r?\n/);
+  if (lines[0] === "---") {
+    for (let i = 1; i < lines.length; i++) {
+      if (lines[i] === "---") return new vscode.Position(i + 1, 0);
+    }
+  }
+  return new vscode.Position(0, 0);
+}
+
+function endOfDocument(doc: vscode.TextDocument): vscode.Position {
+  return doc.lineAt(doc.lineCount - 1).range.end;
 }
 
 async function newArtifact(): Promise<void> {

--- a/typescript/rac-vscode/src/extension.ts
+++ b/typescript/rac-vscode/src/extension.ts
@@ -7,9 +7,13 @@
  *  - per-file validation diagnostics, live as you type (the unsaved buffer is
  *    piped through `rac validate -`), debounced, plus immediately on open/save;
  *  - cross-artifact enforcement: broken and retired-target references surfaced
- *    at the reference site, from `rac relationships --validate` (refreshed on
- *    save/activation, since relationship validation reads files from disk);
+ *    at the reference site, from `rac relationships --validate`;
+ *  - authoring aids: artifact-ID completion in relationship sections, quick-fix
+ *    insertion of missing sections, and a "New Artifact" command (`rac new`);
  *  - hover and go-to-definition on artifact IDs / aliases via `rac resolve`.
+ *
+ * The file is organized into clearly delimited sections; a module split is
+ * scoped for v0.21.6 (robustness/release).
  */
 
 import * as path from "node:path";
@@ -20,6 +24,7 @@ import {
   RacClient,
   RacNotFoundError,
   isResolved,
+  type CorpusExport,
   type FileValidation,
   type Issue,
   type RelationshipIssue,
@@ -29,10 +34,12 @@ import {
 
 const DEBOUNCE_MS = 300;
 const RELATIONSHIP_DEBOUNCE_MS = 600;
+const ARTIFACT_TYPES = ["requirement", "decision", "roadmap", "prompt", "design"];
 
 let diagnostics: vscode.DiagnosticCollection;
 let relationshipDiagnostics: vscode.DiagnosticCollection;
 const clients = new Map<string, RacClient>();
+const exportCache = new Map<string, CorpusExport>();
 const debounce = new Map<string, ReturnType<typeof setTimeout>>();
 const relationshipDebounce = new Map<string, ReturnType<typeof setTimeout>>();
 let warnedMissing = false;
@@ -49,6 +56,7 @@ export function activate(context: vscode.ExtensionContext): void {
     vscode.workspace.onDidSaveTextDocument((doc) => {
       void validateDocument(doc);
       scheduleRelationshipsFor(doc);
+      invalidateExportFor(doc);
     }),
     vscode.workspace.onDidChangeTextDocument((e) => scheduleValidate(e.document)),
     vscode.workspace.onDidCloseTextDocument((doc) => {
@@ -58,13 +66,23 @@ export function activate(context: vscode.ExtensionContext): void {
     vscode.workspace.onDidChangeConfiguration((e) => {
       if (e.affectsConfiguration("rac")) {
         clients.clear();
+        exportCache.clear();
         void validateWorkspace();
         refreshAllRelationships();
       }
     }),
     vscode.commands.registerCommand("rac.validateWorkspace", validateWorkspace),
+    vscode.commands.registerCommand("rac.newArtifact", newArtifact),
     vscode.languages.registerHoverProvider(selector, { provideHover }),
     vscode.languages.registerDefinitionProvider(selector, { provideDefinition }),
+    vscode.languages.registerCompletionItemProvider(selector, {
+      provideCompletionItems: provideCompletions,
+    }),
+    vscode.languages.registerCodeActionsProvider(
+      selector,
+      { provideCodeActions },
+      { providedCodeActionKinds: [vscode.CodeActionKind.QuickFix] },
+    ),
   );
 
   for (const doc of vscode.workspace.textDocuments) void validateDocument(doc);
@@ -302,6 +320,110 @@ function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+// --- authoring: completion, quick-fixes, new artifact -----------------------
+
+// Artifact-ID completion fires inside a relationship section, offering human
+// aliases from the corpus export (cached, invalidated on save).
+const RELATIONSHIP_HEADING = /^#{1,6}\s+(Related\s+\w+|Supersedes)\b/i;
+
+function inRelationshipSection(doc: vscode.TextDocument, line: number): boolean {
+  for (let i = line; i >= 0; i--) {
+    const text = doc.lineAt(i).text;
+    if (/^#{1,6}\s+/.test(text)) return RELATIONSHIP_HEADING.test(text);
+  }
+  return false;
+}
+
+async function provideCompletions(
+  doc: vscode.TextDocument,
+  position: vscode.Position,
+): Promise<vscode.CompletionItem[] | undefined> {
+  if (!looksLikeRacArtifact(doc.getText())) return undefined;
+  if (!inRelationshipSection(doc, position.line)) return undefined;
+  const folder = vscode.workspace.getWorkspaceFolder(doc.uri);
+  if (!folder) return undefined;
+  const corpus = await corpusExport(folder);
+  if (!corpus) return undefined;
+
+  const items: vscode.CompletionItem[] = [];
+  for (const artifact of corpus.artifacts) {
+    for (const alias of artifact.aliases) {
+      if (alias === artifact.id) continue; // offer human aliases, not the opaque id
+      const item = new vscode.CompletionItem(alias, vscode.CompletionItemKind.Reference);
+      item.detail = `${artifact.type} — ${artifact.title}`;
+      item.insertText = alias;
+      items.push(item);
+    }
+  }
+  return items;
+}
+
+function provideCodeActions(
+  doc: vscode.TextDocument,
+  _range: vscode.Range,
+  context: vscode.CodeActionContext,
+): vscode.CodeAction[] {
+  const actions: vscode.CodeAction[] = [];
+  for (const diagnostic of context.diagnostics) {
+    if (diagnostic.source !== "rac" || typeof diagnostic.code !== "string") continue;
+    const match = /^missing-(.+)$/.exec(diagnostic.code);
+    if (!match) continue;
+    const title = titleCase(match[1].replace(/-/g, " "));
+    const action = new vscode.CodeAction(
+      `Insert "## ${title}" section`,
+      vscode.CodeActionKind.QuickFix,
+    );
+    action.diagnostics = [diagnostic];
+    const edit = new vscode.WorkspaceEdit();
+    const text = doc.getText();
+    const separator = text.endsWith("\n") ? "\n" : "\n\n";
+    edit.insert(
+      doc.uri,
+      new vscode.Position(doc.lineCount, 0),
+      `${separator}## ${title}\n\n`,
+    );
+    action.edit = edit;
+    actions.push(action);
+  }
+  return actions;
+}
+
+async function newArtifact(): Promise<void> {
+  const folder = vscode.workspace.workspaceFolders?.[0];
+  if (!folder) {
+    void vscode.window.showErrorMessage("RAC: open a workspace folder first.");
+    return;
+  }
+  const type = await vscode.window.showQuickPick(ARTIFACT_TYPES, {
+    placeHolder: "Artifact type",
+  });
+  if (!type) return;
+  const relPath = await vscode.window.showInputBox({
+    prompt: `Path for the new ${type}`,
+    value: `rac/${type}s/new-${type}.md`,
+  });
+  if (!relPath) return;
+
+  try {
+    const result = await clientFor(folder).createArtifact(type, relPath);
+    const uri = vscode.Uri.joinPath(folder.uri, result.path);
+    invalidateExport(folder);
+    await vscode.window.showTextDocument(await vscode.workspace.openTextDocument(uri));
+  } catch (err) {
+    if (err instanceof RacNotFoundError) {
+      warnMissingOnce();
+      return;
+    }
+    void vscode.window.showErrorMessage(
+      `RAC: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+function titleCase(value: string): string {
+  return value.replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
 // --- hover & go-to-definition ----------------------------------------------
 
 // Reference-ish tokens: identifiers with a hyphen (adr-007, v0.20.0-foo,
@@ -376,6 +498,33 @@ function clientFor(folder: vscode.WorkspaceFolder): RacClient {
     clients.set(key, client);
   }
   return client;
+}
+
+// The corpus export, cached per folder and invalidated on save. Powers
+// alias-based completion (and, later, hover enrichment).
+async function corpusExport(
+  folder: vscode.WorkspaceFolder,
+): Promise<CorpusExport | undefined> {
+  const key = folder.uri.fsPath;
+  const cached = exportCache.get(key);
+  if (cached) return cached;
+  try {
+    const data = await clientFor(folder).exportCorpus(folder.uri.fsPath);
+    exportCache.set(key, data);
+    return data;
+  } catch (err) {
+    if (err instanceof RacNotFoundError) warnMissingOnce();
+    return undefined;
+  }
+}
+
+function invalidateExport(folder: vscode.WorkspaceFolder): void {
+  exportCache.delete(folder.uri.fsPath);
+}
+
+function invalidateExportFor(doc: vscode.TextDocument): void {
+  const folder = vscode.workspace.getWorkspaceFolder(doc.uri);
+  if (folder) invalidateExport(folder);
 }
 
 // Only treat Markdown with a leading YAML frontmatter block carrying


### PR DESCRIPTION
# Summary

Implements `rac/roadmaps/v0.21.x-editor/v0.21.2-authoring-ergonomics.md` — **v0.21.2** of the `v0.21.x-editor` series. Authoring RAC artifacts in the editor gets ergonomic: artifact-alias completion in relationship sections, quick-fixes that insert a missing section, and a command to scaffold a new artifact. Thin client (ADR-063) — completions come from `rac export`, scaffolding from `rac new`.

Adds:
- SDK: `schema(type)` (`rac schema --json`) and `createArtifact(type, path)` (`rac new --json`).
- Extension: alias completion inside relationship sections (from a per-folder `rac export` cache, invalidated on save), quick-fix code actions that append a missing `## Section` to clear a `missing-` finding, and a **RAC: New Artifact** command.

# Roadmap / ADR Trace

Roadmap:
- `rac/roadmaps/v0.21.x-editor/v0.21.2-authoring-ergonomics.md` (contract refined to match implementation)

Relevant ADRs:
- `rac/decisions/adr-063-non-python-clients-are-thin.md` — completions come from `rac export`, scaffolding from `rac new`; the extension reimplements no template logic.
- `rac/decisions/adr-007-json-output-is-additive.md` — the new `schema` / `createArtifact` SDK methods consume the additive `rac schema --json` / `rac new --json` contracts.

# Scope

## Included
- Artifact-**alias** completion (human aliases like `adr-007`, not the opaque id) inside relationship sections; VS Code filters by what's typed.
- Quick-fix: "Insert '## ' section" for `missing-` diagnostics.
- "RAC: New Artifact" command (type quick-pick → suggested folder → path → `rac new` → open).

## Excluded
- Schema-guided section *bodies* in quick-fixes (heading only for now).
- A full authoring framework or WYSIWYG editor; auto-rewriting artifact bodies; completion for free-text prose (roadmap Non-Goals).
- Navigation, awareness, visualization, robustness (v0.21.3–v0.21.6).

# Product / Architecture Decisions

- **Completion from `rac export`, not `rac find`.** Export carries human aliases; `find`/`resolve` only expose the opaque id. The export is cached per folder and invalidated on save, so completion offers readable references without a `rac` spawn per keystroke. (Proper caching is hardened in v0.21.6.)
- **Quick-fix is heading-only and code-driven.** The section name comes from the diagnostic `code` (`missing-success-metrics` → "Success Metrics"); inserting the heading clears the finding. Schema-guided bodies are a deliberate follow-on.
- **Scaffolding delegates to `rac new`.** The extension writes no templates; type validation and identity assignment stay in `rac`. The command suggests an existing folder holding that type (from the cached export) so `rac new`, which does not create missing parents, succeeds.

# User-Facing Contract

## CLI
None. No `rac` command, flag, or behavior is added or changed; Python source and packaging are untouched. The editor surface adds one command `rac.newArtifact` ("RAC: New Artifact"), alias completion inside relationship sections, and `missing-`-diagnostic quick-fixes; no new settings; existing diagnostics/hover/definition and v0.21.1 enforcement are unchanged.

## Human Output
None. No `rac` terminal output change.

## JSON Output
None. No `rac --json` shape change; the SDK's new `schema` / `createArtifact` methods consume the existing `rac schema --json` and `rac new --json` shapes.

## Exit Codes
- No change. `rac` exit codes are unchanged.

# Verification

## Ran
- SDK: `npm run build` + `npm test` — 19 passing (added `schema` unit + real-`rac` integration; `createArtifact` unit).
- Extension: `npm run check-types` (strict) + `npm run compile` clean (21.8kb).
- Grounded against real `rac`: `rac schema requirement --json` (sections + descriptions), `rac new … --json` (`{schema_version, created, type, path, id}`).
- Corpus gates: `rac validate rac/` exit 0; `rac relationships rac/ --validate` → 775 checked / 0 issues.

## Covered
- Positive: SDK `schema` / `createArtifact` arg-building + parse (unit); schema parity against actual `rac schema --json` output (real `rac`).
- Negative / boundary: completion offered only inside recognized relationship sections; quick-fix keyed off the diagnostic `code`.
- Not run: extension completion/quick-fix/command are presentation logic over the tested SDK; runtime editor behaviour is not exercised headlessly.

# Review Path

1. `typescript/rac-sdk/src/{types,client,index}.ts` — `schema` / `createArtifact`.
2. `typescript/rac-sdk/test/` — new coverage.
3. `typescript/rac-vscode/src/extension.ts` — the authoring section + the per-folder export cache in shared.
4. `typescript/rac-vscode/package.json` (command), roadmap, `CHANGELOG.md`.

# Notes For Reviewer
- **Stacked on v0.21.1 (#111); merge after it.** This PR targets `main`; until v0.21.1 merges, the diff vs `main` includes v0.21.1's commits. Merging the series in order yields a clean per-release diff.
- On merge, flip the v0.21.2 roadmap `## Status` to `Achieved` (ADR-061).

# Implementation Process
Implemented with AI assistance under the v0.21.2 roadmap contract; final scope, review, and acceptance decisions are the maintainer's.