### PR TITLE
feat(sdk): editor navigation over the corpus (v0.21.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ details, release history over commit history.
 
 ### Added
 
+- Editor navigation in the extension (v0.21.3 milestone). Hover now shows the
+  target's lifecycle status (⚠ for retired) and a snippet; **find-all-references**
+  lists every artifact that references the one under the cursor (from the export's
+  resolved edges); artifact aliases are **clickable links**; and the corpus is
+  navigable via the **Outline** (an artifact's sections) and **workspace symbols**
+  (jump to any artifact by title). All from the cached `rac export` (ADR-063).
+
 - Authoring aids in the editor extension (v0.21.2 milestone). Inside a
   relationship section, the extension now offers **artifact-alias completion**
   (human aliases like `adr-007`, from a cached `rac export`); **quick-fixes**

--- a/rac/roadmaps/v0.21.x-editor/v0.21.3-editor-navigation.md
+++ b/rac/roadmaps/v0.21.x-editor/v0.21.3-editor-navigation.md
@@ -37,19 +37,24 @@ Extend the v0.21.0 hover to include the target's lifecycle status (e.g.
 ### Initiative 2 — Find-all-references
 
 A reference provider returning incoming links — every artifact that references
-the one under the cursor — from `rac relationships` / the MCP `get_related` shape.
+the one under the cursor — computed from the export's resolved `from → to` edges
+(`rac export` carries them keyed by id), anchored at the referencing token in
+each source. No extra `rac` call beyond the cached export.
 
 ### Initiative 3 — Links, outline, and workspace symbols
 
-Document links (clickable IDs/aliases), a document-symbol provider exposing the
-artifact's `##` sections in the Outline view, and a workspace-symbol provider so
-any artifact is reachable by ID or title (from `rac find` / the index).
+Document links (clickable aliases, resolved against the export's alias index), a
+document-symbol provider exposing the artifact's `##` headings in the Outline
+view (pure Markdown), and a workspace-symbol provider listing every artifact by
+title (from the cached export).
 
 ## Constraints
 
-- Thin client only (ADR-063): incoming links from `rac relationships`/`get_related`,
-  status/snippets from `rac export`/`rac resolve`, symbols from `rac find`/index.
-- Symbol and reference lookups are served from the cache (v0.21.6) to stay responsive.
+- Thin client only (ADR-063): hover status/snippet, incoming edges, alias→file
+  links, and the symbol set all come from the cached `rac export`; the extension
+  re-derives no relationships.
+- Symbol and reference lookups are served from the per-folder export cache
+  (introduced in v0.21.2, hardened in v0.21.6) to stay responsive.
 
 ## Non-Goals
 

--- a/typescript/rac-vscode/README.md
+++ b/typescript/rac-vscode/README.md
@@ -25,9 +25,13 @@ reimplementing it ([ADR-063](../../rac/decisions/adr-063-non-python-clients-are-
   site, drawn distinctly (from `rac relationships --validate`). Refreshes on
   save/activation, since relationship validation reads files from disk.
 - **Hover** — hovering an artifact ID or alias (e.g. `adr-007`,
-  `v0.20.0-python-sdk-foundation`) shows its title, type, and path via
-  `rac resolve`.
-- **Go-to-definition** — jump from a reference to the target artifact's file.
+  `v0.20.0-python-sdk-foundation`) shows its title, type, **lifecycle status**
+  (⚠ for retired), a snippet, and its path.
+- **Go-to-definition, find-all-references, clickable links** — jump to a target,
+  list every artifact that references the one under the cursor (from the export's
+  resolved edges), and Ctrl/Cmd-click any alias to open its file.
+- **Outline & workspace symbols** — the artifact's sections in the Outline view,
+  and jump-to-any-artifact by title (Ctrl/Cmd-T).
 - **Authoring aids** — artifact-alias completion inside relationship sections
   (`## Related Decisions`, …), quick-fixes that insert a missing `## Section`,
   and a **RAC: New Artifact** command that suggests an existing folder for the

--- a/typescript/rac-vscode/src/extension.ts
+++ b/typescript/rac-vscode/src/extension.ts
@@ -25,6 +25,7 @@ import {
   RacNotFoundError,
   isResolved,
   type CorpusExport,
+  type ExportArtifact,
   type FileValidation,
   type Issue,
   type RelationshipIssue,
@@ -75,6 +76,10 @@ export function activate(context: vscode.ExtensionContext): void {
     vscode.commands.registerCommand("rac.newArtifact", newArtifact),
     vscode.languages.registerHoverProvider(selector, { provideHover }),
     vscode.languages.registerDefinitionProvider(selector, { provideDefinition }),
+    vscode.languages.registerReferenceProvider(selector, { provideReferences }),
+    vscode.languages.registerDocumentLinkProvider(selector, { provideDocumentLinks }),
+    vscode.languages.registerDocumentSymbolProvider(selector, { provideDocumentSymbols }),
+    vscode.languages.registerWorkspaceSymbolProvider({ provideWorkspaceSymbols }),
     vscode.languages.registerCompletionItemProvider(selector, {
       provideCompletionItems: provideCompletions,
     }),
@@ -528,9 +533,18 @@ async function provideHover(
 ): Promise<vscode.Hover | undefined> {
   const target = await resolveAt(doc, position);
   if (!target) return undefined;
+  const folder = vscode.workspace.getWorkspaceFolder(doc.uri);
+  const corpus = folder ? await corpusExport(folder) : undefined;
+  const artifact = corpus?.artifacts.find((a) => a.id === target.id);
+
   const md = new vscode.MarkdownString(undefined, true);
   md.appendMarkdown(`**${target.title}**\n\n`);
-  md.appendMarkdown(`\`${target.type}\` · \`${target.id}\`\n\n`);
+  const status = artifact ? statusLabel(artifact.status) : "";
+  md.appendMarkdown(`\`${target.type}\`${status ? ` · ${status}` : ""} · \`${target.id}\`\n\n`);
+  if (artifact) {
+    const snippet = snippetFromHtml(artifact.body_html);
+    if (snippet) md.appendMarkdown(`${snippet}\n\n`);
+  }
   md.appendMarkdown(`[${target.path}](${vscode.Uri.file(target.path)})`);
   return new vscode.Hover(md);
 }
@@ -546,6 +560,162 @@ async function provideDefinition(
   // resolve returns a path relative to the client cwd (the workspace folder).
   const uri = vscode.Uri.joinPath(folder.uri, target.path);
   return new vscode.Location(uri, new vscode.Position(0, 0));
+}
+
+// Find-all-references: incoming links from the export's resolved `from → to`
+// edges (no extra `rac` call), anchored at the referencing token in each source.
+async function provideReferences(
+  doc: vscode.TextDocument,
+  position: vscode.Position,
+): Promise<vscode.Location[] | undefined> {
+  const target = await resolveAt(doc, position);
+  if (!target) return undefined;
+  const folder = vscode.workspace.getWorkspaceFolder(doc.uri);
+  if (!folder) return undefined;
+  const corpus = await corpusExport(folder);
+  if (!corpus) return undefined;
+  const index = buildIndex(corpus);
+  const targetAliases = (index.byId.get(target.id)?.aliases ?? [target.id]).map((a) =>
+    a.toLowerCase(),
+  );
+
+  const locations: vscode.Location[] = [];
+  const sourceIds = new Set(
+    corpus.relationships.filter((r) => r.to === target.id).map((r) => r.from),
+  );
+  for (const sourceId of sourceIds) {
+    const source = index.byId.get(sourceId);
+    if (!source) continue;
+    const uri = vscode.Uri.joinPath(folder.uri, source.path);
+    try {
+      const srcDoc = await vscode.workspace.openTextDocument(uri);
+      locations.push(new vscode.Location(uri, firstAliasRange(srcDoc, targetAliases)));
+    } catch {
+      locations.push(new vscode.Location(uri, new vscode.Position(0, 0)));
+    }
+  }
+  return locations;
+}
+
+// Make known artifact aliases in the document clickable links to their files.
+async function provideDocumentLinks(
+  doc: vscode.TextDocument,
+): Promise<vscode.DocumentLink[] | undefined> {
+  if (!looksLikeRacArtifact(doc.getText())) return undefined;
+  const folder = vscode.workspace.getWorkspaceFolder(doc.uri);
+  if (!folder) return undefined;
+  const corpus = await corpusExport(folder);
+  if (!corpus) return undefined;
+  const index = buildIndex(corpus);
+
+  const links: vscode.DocumentLink[] = [];
+  const text = doc.getText();
+  const tokenRe = /[A-Za-z0-9][A-Za-z0-9._-]*[A-Za-z0-9]/g;
+  for (let m = tokenRe.exec(text); m !== null; m = tokenRe.exec(text)) {
+    const token = m[0];
+    if (!looksLikeReference(token)) continue;
+    const artifact = index.aliasToArtifact.get(token.toLowerCase());
+    if (!artifact) continue;
+    const range = new vscode.Range(doc.positionAt(m.index), doc.positionAt(m.index + token.length));
+    const link = new vscode.DocumentLink(range, vscode.Uri.joinPath(folder.uri, artifact.path));
+    link.tooltip = `${artifact.type} — ${artifact.title}`;
+    links.push(link);
+  }
+  return links;
+}
+
+// Outline: the artifact's own Markdown headings (`#` title, `##` sections).
+function provideDocumentSymbols(doc: vscode.TextDocument): vscode.DocumentSymbol[] {
+  const symbols: vscode.DocumentSymbol[] = [];
+  const lines = doc.getText().split(/\r?\n/);
+  let title: vscode.DocumentSymbol | undefined;
+  for (let i = 0; i < lines.length; i++) {
+    const heading = /^(#{1,6})\s+(.+?)\s*$/.exec(lines[i]);
+    if (!heading) continue;
+    const level = heading[1].length;
+    const range = new vscode.Range(i, 0, i, lines[i].length);
+    const symbol = new vscode.DocumentSymbol(
+      heading[2],
+      "",
+      level === 1 ? vscode.SymbolKind.File : vscode.SymbolKind.String,
+      range,
+      range,
+    );
+    if (level === 1 || !title) {
+      symbols.push(symbol);
+      title = symbol;
+    } else {
+      title.children.push(symbol);
+    }
+  }
+  return symbols;
+}
+
+// Workspace symbols: every artifact, reachable by title (VS Code filters).
+async function provideWorkspaceSymbols(): Promise<vscode.SymbolInformation[]> {
+  const symbols: vscode.SymbolInformation[] = [];
+  for (const folder of vscode.workspace.workspaceFolders ?? []) {
+    const corpus = await corpusExport(folder);
+    if (!corpus) continue;
+    for (const artifact of corpus.artifacts) {
+      const uri = vscode.Uri.joinPath(folder.uri, artifact.path);
+      symbols.push(
+        new vscode.SymbolInformation(
+          artifact.title,
+          vscode.SymbolKind.File,
+          artifact.type,
+          new vscode.Location(uri, new vscode.Position(0, 0)),
+        ),
+      );
+    }
+  }
+  return symbols;
+}
+
+interface CorpusIndex {
+  byId: Map<string, ExportArtifact>;
+  aliasToArtifact: Map<string, ExportArtifact>;
+}
+
+function buildIndex(corpus: CorpusExport): CorpusIndex {
+  const byId = new Map<string, ExportArtifact>();
+  const aliasToArtifact = new Map<string, ExportArtifact>();
+  for (const artifact of corpus.artifacts) {
+    byId.set(artifact.id, artifact);
+    for (const alias of artifact.aliases) {
+      aliasToArtifact.set(alias.toLowerCase(), artifact);
+    }
+  }
+  return { byId, aliasToArtifact };
+}
+
+function firstAliasRange(doc: vscode.TextDocument, aliasesLower: string[]): vscode.Range {
+  const lines = doc.getText().split(/\r?\n/);
+  for (let i = 0; i < lines.length; i++) {
+    const lower = lines[i].toLowerCase();
+    for (const alias of aliasesLower) {
+      const col = lower.indexOf(alias);
+      if (col >= 0) return new vscode.Range(i, col, i, col + alias.length);
+    }
+  }
+  return new vscode.Range(0, 0, 0, 0);
+}
+
+const RETIRED_STATUS = new Set(["superseded", "deprecated", "abandoned"]);
+function statusLabel(status: string): string {
+  if (!status || status.toLowerCase() === "unknown") return "";
+  return RETIRED_STATUS.has(status.toLowerCase()) ? `⚠ ${status}` : status;
+}
+
+function snippetFromHtml(html: string): string {
+  // Drop the leading <h1> title (it repeats the bold title above), strip tags.
+  const text = html
+    .replace(/^[\s\S]*?<\/h1>/i, "")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (!text) return "";
+  return text.length > 200 ? `${text.slice(0, 200)}…` : text;
 }
 
 // --- shared -----------------------------------------------------------------

--- a/typescript/rac-vscode/src/extension.ts
+++ b/typescript/rac-vscode/src/extension.ts
@@ -586,7 +586,7 @@ async function provideReferences(
   for (const sourceId of sourceIds) {
     const source = index.byId.get(sourceId);
     if (!source) continue;
-    const uri = vscode.Uri.joinPath(folder.uri, source.path);
+    const uri = artifactUri(folder, source.path);
     try {
       const srcDoc = await vscode.workspace.openTextDocument(uri);
       locations.push(new vscode.Location(uri, firstAliasRange(srcDoc, targetAliases)));
@@ -617,7 +617,7 @@ async function provideDocumentLinks(
     const artifact = index.aliasToArtifact.get(token.toLowerCase());
     if (!artifact) continue;
     const range = new vscode.Range(doc.positionAt(m.index), doc.positionAt(m.index + token.length));
-    const link = new vscode.DocumentLink(range, vscode.Uri.joinPath(folder.uri, artifact.path));
+    const link = new vscode.DocumentLink(range, artifactUri(folder, artifact.path));
     link.tooltip = `${artifact.type} — ${artifact.title}`;
     links.push(link);
   }
@@ -658,7 +658,7 @@ async function provideWorkspaceSymbols(): Promise<vscode.SymbolInformation[]> {
     const corpus = await corpusExport(folder);
     if (!corpus) continue;
     for (const artifact of corpus.artifacts) {
-      const uri = vscode.Uri.joinPath(folder.uri, artifact.path);
+      const uri = artifactUri(folder, artifact.path);
       symbols.push(
         new vscode.SymbolInformation(
           artifact.title,
@@ -670,6 +670,15 @@ async function provideWorkspaceSymbols(): Promise<vscode.SymbolInformation[]> {
     }
   }
   return symbols;
+}
+
+// `rac export` returns absolute artifact paths when given an absolute directory
+// (the extension passes one), so build the Uri from the absolute path directly;
+// fall back to joining a relative path onto the workspace folder.
+function artifactUri(folder: vscode.WorkspaceFolder, artifactPath: string): vscode.Uri {
+  return path.isAbsolute(artifactPath)
+    ? vscode.Uri.file(artifactPath)
+    : vscode.Uri.joinPath(folder.uri, artifactPath);
 }
 
 interface CorpusIndex {


### PR DESCRIPTION
# Summary

Implements `rac/roadmaps/v0.21.x-editor/v0.21.3-editor-navigation.md` — **v0.21.3** of the `v0.21.x-editor` series. Completes editor navigation over the corpus — all from the cached `rac export` (resolved `from → to` edges + an alias index), so the extension re-derives nothing (ADR-063). Extension-only; no SDK change.

Adds:
- **Hover enrichment** — the target's lifecycle status (⚠ for retired, ADR-051) and a body snippet, so hover answers "is this still current?".
- **Find-all-references** — every artifact that references the one under the cursor, from the export's resolved edges, anchored at the referencing token.
- **Clickable links** — artifact aliases become document links to their files.
- **Outline** (the artifact's `##` headings) and **workspace symbols** (jump to any artifact by title).

# Roadmap / ADR Trace

Roadmap:
- `rac/roadmaps/v0.21.x-editor/v0.21.3-editor-navigation.md` (contract refined to match implementation)

Relevant ADRs:
- `rac/decisions/adr-051-lifecycle-status.md` — hover surfaces the target's retired (superseded/deprecated) status.
- `rac/decisions/adr-063-non-python-clients-are-thin.md` — every feature reads the cached `rac export`; the extension computes no relationships.
- `rac/decisions/adr-007-json-output-is-additive.md` — consumes the existing `rac export` shape (resolved edges, aliases, status, body).

# Scope

## Included
- Status/snippet hover, find-all-references, alias links, document symbols (Outline), workspace symbols — all over the per-folder export cache.

## Excluded
- Status-bar health + workspace-wide diagnostics (v0.21.4).
- Corpus-graph webview (v0.21.5); caching/robustness hardening (v0.21.6).
- A graphical relationship view; rename/refactor of artifact IDs across the corpus; Outline entries beyond the artifact's own sections (roadmap Non-Goals).

# Product / Architecture Decisions

- **Everything from the export.** `rac export` already carries resolved `from→to` edges (by id) and per-artifact aliases/status/body, so find-references, links, hover-status, and symbols need no new `rac` calls — just the cache from v0.21.2.
- **Outline is pure Markdown.** Document symbols are the file's own headings, not a RAC-specific parse — generic and cheap.
- **Reference anchoring.** Each incoming reference is anchored at the first line in the source containing an alias of the target, falling back to the file head.

# User-Facing Contract

## CLI
None. No `rac` command, flag, or behavior is added or changed; there is no SDK or Python change. The editor surface adds hover enrichment, find-all-references (Shift+F12), clickable alias links (Ctrl/Cmd-click), Outline (document symbols), and workspace symbols (Ctrl/Cmd-T) on RAC artifacts; no new settings or commands.

## Human Output
None. No `rac` terminal output change.

## JSON Output
None. No `rac --json` shape change; the features read the existing `rac export` fields (resolved `from→to` edges, `aliases`, `status`, `body_html`).

## Exit Codes
- No change. `rac` exit codes are unchanged.

# Verification

## Ran
- Extension `npm run check-types` (strict) + `npm run compile` clean (26.9kb).
- Confirmed export edges are resolved by id (`{from, to, type}`, ids) and artifacts carry `aliases` / `status` / `body_html` — the data all five features use.
- Corpus gates: `rac validate rac/` exit 0; `rac relationships rac/ --validate` → 775 checked / 0 issues.

## Covered
- Positive: the SDK's `exportCorpus` is integration-tested (v0.21.0); the export carries the resolved edges, aliases, status, and body snippets these five providers consume.
- Boundary: reference anchoring falls back to the file head when no alias line is found; Outline reflects only the artifact's own `##` headings.
- Not run: these providers are presentation logic over that tested data; runtime editor behaviour is not exercised headlessly.

# Review Path

1. `typescript/rac-vscode/src/extension.ts` — enriched `provideHover`, the new navigation providers, and `buildIndex` / helpers in shared.
2. Roadmap, README, `CHANGELOG.md`.

# Notes For Reviewer
- **Stacked on v0.21.2 (#112); merge after it.** Targets `main`; the diff vs `main` includes earlier v0.21.x commits until they merge. Merge in order for a clean per-release diff.
- On merge, flip the v0.21.3 roadmap `## Status` to `Achieved` (ADR-061).

# Implementation Process
Implemented with AI assistance under the v0.21.3 roadmap contract; final scope, review, and acceptance decisions are the maintainer's.