### PR TITLE
feat(sdk): ambient corpus awareness in the editor (v0.21.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ details, release history over commit history.
 
 ### Added
 
+- Editor navigation in the extension (v0.21.3 milestone). Hover now shows the
+  target's lifecycle status (⚠ for retired) and a snippet; **find-all-references**
+  lists every artifact that references the one under the cursor (from the export's
+  resolved edges); artifact aliases are **clickable links**; and the corpus is
+  navigable via the **Outline** (an artifact's sections) and **workspace symbols**
+  (jump to any artifact by title). All from the cached `rac export` (ADR-063).
+
 - Authoring aids in the editor extension (v0.21.2 milestone). Inside a
   relationship section, the extension now offers **artifact-alias completion**
   (human aliases like `adr-007`, from a cached `rac export`); **quick-fixes**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ details, release history over commit history.
 
 ### Added
 
+- Ambient corpus awareness in the extension (v0.21.4 milestone). A **status-bar
+  health score** (`rac review`, click for the Problems panel) and
+  **workspace-wide diagnostics** (`rac validate <dir>`) so issues in unopened
+  artifacts are visible. The live per-file diagnostics own open files; the
+  workspace scan covers the rest, so nothing is double-reported.
+
 - Editor navigation in the extension (v0.21.3 milestone). Hover now shows the
   target's lifecycle status (⚠ for retired) and a snippet; **find-all-references**
   lists every artifact that references the one under the cursor (from the export's

--- a/rac/roadmaps/v0.21.x-editor/v0.21.3-editor-navigation.md
+++ b/rac/roadmaps/v0.21.x-editor/v0.21.3-editor-navigation.md
@@ -37,19 +37,24 @@ Extend the v0.21.0 hover to include the target's lifecycle status (e.g.
 ### Initiative 2 — Find-all-references
 
 A reference provider returning incoming links — every artifact that references
-the one under the cursor — from `rac relationships` / the MCP `get_related` shape.
+the one under the cursor — computed from the export's resolved `from → to` edges
+(`rac export` carries them keyed by id), anchored at the referencing token in
+each source. No extra `rac` call beyond the cached export.
 
 ### Initiative 3 — Links, outline, and workspace symbols
 
-Document links (clickable IDs/aliases), a document-symbol provider exposing the
-artifact's `##` sections in the Outline view, and a workspace-symbol provider so
-any artifact is reachable by ID or title (from `rac find` / the index).
+Document links (clickable aliases, resolved against the export's alias index), a
+document-symbol provider exposing the artifact's `##` headings in the Outline
+view (pure Markdown), and a workspace-symbol provider listing every artifact by
+title (from the cached export).
 
 ## Constraints
 
-- Thin client only (ADR-063): incoming links from `rac relationships`/`get_related`,
-  status/snippets from `rac export`/`rac resolve`, symbols from `rac find`/index.
-- Symbol and reference lookups are served from the cache (v0.21.6) to stay responsive.
+- Thin client only (ADR-063): hover status/snippet, incoming edges, alias→file
+  links, and the symbol set all come from the cached `rac export`; the extension
+  re-derives no relationships.
+- Symbol and reference lookups are served from the per-folder export cache
+  (introduced in v0.21.2, hardened in v0.21.6) to stay responsive.
 
 ## Non-Goals
 

--- a/typescript/rac-vscode/README.md
+++ b/typescript/rac-vscode/README.md
@@ -25,9 +25,13 @@ reimplementing it ([ADR-063](../../rac/decisions/adr-063-non-python-clients-are-
   site, drawn distinctly (from `rac relationships --validate`). Refreshes on
   save/activation, since relationship validation reads files from disk.
 - **Hover** — hovering an artifact ID or alias (e.g. `adr-007`,
-  `v0.20.0-python-sdk-foundation`) shows its title, type, and path via
-  `rac resolve`.
-- **Go-to-definition** — jump from a reference to the target artifact's file.
+  `v0.20.0-python-sdk-foundation`) shows its title, type, **lifecycle status**
+  (⚠ for retired), a snippet, and its path.
+- **Go-to-definition, find-all-references, clickable links** — jump to a target,
+  list every artifact that references the one under the cursor (from the export's
+  resolved edges), and Ctrl/Cmd-click any alias to open its file.
+- **Outline & workspace symbols** — the artifact's sections in the Outline view,
+  and jump-to-any-artifact by title (Ctrl/Cmd-T).
 - **Authoring aids** — artifact-alias completion inside relationship sections
   (`## Related Decisions`, …), quick-fixes that insert a missing `## Section`,
   and a **RAC: New Artifact** command that suggests an existing folder for the

--- a/typescript/rac-vscode/README.md
+++ b/typescript/rac-vscode/README.md
@@ -32,6 +32,9 @@ reimplementing it ([ADR-063](../../rac/decisions/adr-063-non-python-clients-are-
   resolved edges), and Ctrl/Cmd-click any alias to open its file.
 - **Outline & workspace symbols** — the artifact's sections in the Outline view,
   and jump-to-any-artifact by title (Ctrl/Cmd-T).
+- **Corpus awareness** — a status-bar health score (`rac review`, click for the
+  Problems panel) and workspace-wide diagnostics (`rac validate <dir>`), so issues
+  in unopened artifacts show up too.
 - **Authoring aids** — artifact-alias completion inside relationship sections
   (`## Related Decisions`, …), quick-fixes that insert a missing `## Section`,
   and a **RAC: New Artifact** command that suggests an existing folder for the

--- a/typescript/rac-vscode/src/extension.ts
+++ b/typescript/rac-vscode/src/extension.ts
@@ -25,6 +25,7 @@ import {
   RacNotFoundError,
   isResolved,
   type CorpusExport,
+  type ExportArtifact,
   type FileValidation,
   type Issue,
   type RelationshipIssue,
@@ -75,6 +76,10 @@ export function activate(context: vscode.ExtensionContext): void {
     vscode.commands.registerCommand("rac.newArtifact", newArtifact),
     vscode.languages.registerHoverProvider(selector, { provideHover }),
     vscode.languages.registerDefinitionProvider(selector, { provideDefinition }),
+    vscode.languages.registerReferenceProvider(selector, { provideReferences }),
+    vscode.languages.registerDocumentLinkProvider(selector, { provideDocumentLinks }),
+    vscode.languages.registerDocumentSymbolProvider(selector, { provideDocumentSymbols }),
+    vscode.languages.registerWorkspaceSymbolProvider({ provideWorkspaceSymbols }),
     vscode.languages.registerCompletionItemProvider(selector, {
       provideCompletionItems: provideCompletions,
     }),
@@ -528,9 +533,18 @@ async function provideHover(
 ): Promise<vscode.Hover | undefined> {
   const target = await resolveAt(doc, position);
   if (!target) return undefined;
+  const folder = vscode.workspace.getWorkspaceFolder(doc.uri);
+  const corpus = folder ? await corpusExport(folder) : undefined;
+  const artifact = corpus?.artifacts.find((a) => a.id === target.id);
+
   const md = new vscode.MarkdownString(undefined, true);
   md.appendMarkdown(`**${target.title}**\n\n`);
-  md.appendMarkdown(`\`${target.type}\` · \`${target.id}\`\n\n`);
+  const status = artifact ? statusLabel(artifact.status) : "";
+  md.appendMarkdown(`\`${target.type}\`${status ? ` · ${status}` : ""} · \`${target.id}\`\n\n`);
+  if (artifact) {
+    const snippet = snippetFromHtml(artifact.body_html);
+    if (snippet) md.appendMarkdown(`${snippet}\n\n`);
+  }
   md.appendMarkdown(`[${target.path}](${vscode.Uri.file(target.path)})`);
   return new vscode.Hover(md);
 }
@@ -546,6 +560,162 @@ async function provideDefinition(
   // resolve returns a path relative to the client cwd (the workspace folder).
   const uri = vscode.Uri.joinPath(folder.uri, target.path);
   return new vscode.Location(uri, new vscode.Position(0, 0));
+}
+
+// Find-all-references: incoming links from the export's resolved `from → to`
+// edges (no extra `rac` call), anchored at the referencing token in each source.
+async function provideReferences(
+  doc: vscode.TextDocument,
+  position: vscode.Position,
+): Promise<vscode.Location[] | undefined> {
+  const target = await resolveAt(doc, position);
+  if (!target) return undefined;
+  const folder = vscode.workspace.getWorkspaceFolder(doc.uri);
+  if (!folder) return undefined;
+  const corpus = await corpusExport(folder);
+  if (!corpus) return undefined;
+  const index = buildIndex(corpus);
+  const targetAliases = (index.byId.get(target.id)?.aliases ?? [target.id]).map((a) =>
+    a.toLowerCase(),
+  );
+
+  const locations: vscode.Location[] = [];
+  const sourceIds = new Set(
+    corpus.relationships.filter((r) => r.to === target.id).map((r) => r.from),
+  );
+  for (const sourceId of sourceIds) {
+    const source = index.byId.get(sourceId);
+    if (!source) continue;
+    const uri = vscode.Uri.joinPath(folder.uri, source.path);
+    try {
+      const srcDoc = await vscode.workspace.openTextDocument(uri);
+      locations.push(new vscode.Location(uri, firstAliasRange(srcDoc, targetAliases)));
+    } catch {
+      locations.push(new vscode.Location(uri, new vscode.Position(0, 0)));
+    }
+  }
+  return locations;
+}
+
+// Make known artifact aliases in the document clickable links to their files.
+async function provideDocumentLinks(
+  doc: vscode.TextDocument,
+): Promise<vscode.DocumentLink[] | undefined> {
+  if (!looksLikeRacArtifact(doc.getText())) return undefined;
+  const folder = vscode.workspace.getWorkspaceFolder(doc.uri);
+  if (!folder) return undefined;
+  const corpus = await corpusExport(folder);
+  if (!corpus) return undefined;
+  const index = buildIndex(corpus);
+
+  const links: vscode.DocumentLink[] = [];
+  const text = doc.getText();
+  const tokenRe = /[A-Za-z0-9][A-Za-z0-9._-]*[A-Za-z0-9]/g;
+  for (let m = tokenRe.exec(text); m !== null; m = tokenRe.exec(text)) {
+    const token = m[0];
+    if (!looksLikeReference(token)) continue;
+    const artifact = index.aliasToArtifact.get(token.toLowerCase());
+    if (!artifact) continue;
+    const range = new vscode.Range(doc.positionAt(m.index), doc.positionAt(m.index + token.length));
+    const link = new vscode.DocumentLink(range, vscode.Uri.joinPath(folder.uri, artifact.path));
+    link.tooltip = `${artifact.type} — ${artifact.title}`;
+    links.push(link);
+  }
+  return links;
+}
+
+// Outline: the artifact's own Markdown headings (`#` title, `##` sections).
+function provideDocumentSymbols(doc: vscode.TextDocument): vscode.DocumentSymbol[] {
+  const symbols: vscode.DocumentSymbol[] = [];
+  const lines = doc.getText().split(/\r?\n/);
+  let title: vscode.DocumentSymbol | undefined;
+  for (let i = 0; i < lines.length; i++) {
+    const heading = /^(#{1,6})\s+(.+?)\s*$/.exec(lines[i]);
+    if (!heading) continue;
+    const level = heading[1].length;
+    const range = new vscode.Range(i, 0, i, lines[i].length);
+    const symbol = new vscode.DocumentSymbol(
+      heading[2],
+      "",
+      level === 1 ? vscode.SymbolKind.File : vscode.SymbolKind.String,
+      range,
+      range,
+    );
+    if (level === 1 || !title) {
+      symbols.push(symbol);
+      title = symbol;
+    } else {
+      title.children.push(symbol);
+    }
+  }
+  return symbols;
+}
+
+// Workspace symbols: every artifact, reachable by title (VS Code filters).
+async function provideWorkspaceSymbols(): Promise<vscode.SymbolInformation[]> {
+  const symbols: vscode.SymbolInformation[] = [];
+  for (const folder of vscode.workspace.workspaceFolders ?? []) {
+    const corpus = await corpusExport(folder);
+    if (!corpus) continue;
+    for (const artifact of corpus.artifacts) {
+      const uri = vscode.Uri.joinPath(folder.uri, artifact.path);
+      symbols.push(
+        new vscode.SymbolInformation(
+          artifact.title,
+          vscode.SymbolKind.File,
+          artifact.type,
+          new vscode.Location(uri, new vscode.Position(0, 0)),
+        ),
+      );
+    }
+  }
+  return symbols;
+}
+
+interface CorpusIndex {
+  byId: Map<string, ExportArtifact>;
+  aliasToArtifact: Map<string, ExportArtifact>;
+}
+
+function buildIndex(corpus: CorpusExport): CorpusIndex {
+  const byId = new Map<string, ExportArtifact>();
+  const aliasToArtifact = new Map<string, ExportArtifact>();
+  for (const artifact of corpus.artifacts) {
+    byId.set(artifact.id, artifact);
+    for (const alias of artifact.aliases) {
+      aliasToArtifact.set(alias.toLowerCase(), artifact);
+    }
+  }
+  return { byId, aliasToArtifact };
+}
+
+function firstAliasRange(doc: vscode.TextDocument, aliasesLower: string[]): vscode.Range {
+  const lines = doc.getText().split(/\r?\n/);
+  for (let i = 0; i < lines.length; i++) {
+    const lower = lines[i].toLowerCase();
+    for (const alias of aliasesLower) {
+      const col = lower.indexOf(alias);
+      if (col >= 0) return new vscode.Range(i, col, i, col + alias.length);
+    }
+  }
+  return new vscode.Range(0, 0, 0, 0);
+}
+
+const RETIRED_STATUS = new Set(["superseded", "deprecated", "abandoned"]);
+function statusLabel(status: string): string {
+  if (!status || status.toLowerCase() === "unknown") return "";
+  return RETIRED_STATUS.has(status.toLowerCase()) ? `⚠ ${status}` : status;
+}
+
+function snippetFromHtml(html: string): string {
+  // Drop the leading <h1> title (it repeats the bold title above), strip tags.
+  const text = html
+    .replace(/^[\s\S]*?<\/h1>/i, "")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (!text) return "";
+  return text.length > 200 ? `${text.slice(0, 200)}…` : text;
 }
 
 // --- shared -----------------------------------------------------------------

--- a/typescript/rac-vscode/src/extension.ts
+++ b/typescript/rac-vscode/src/extension.ts
@@ -586,7 +586,7 @@ async function provideReferences(
   for (const sourceId of sourceIds) {
     const source = index.byId.get(sourceId);
     if (!source) continue;
-    const uri = vscode.Uri.joinPath(folder.uri, source.path);
+    const uri = artifactUri(folder, source.path);
     try {
       const srcDoc = await vscode.workspace.openTextDocument(uri);
       locations.push(new vscode.Location(uri, firstAliasRange(srcDoc, targetAliases)));
@@ -617,7 +617,7 @@ async function provideDocumentLinks(
     const artifact = index.aliasToArtifact.get(token.toLowerCase());
     if (!artifact) continue;
     const range = new vscode.Range(doc.positionAt(m.index), doc.positionAt(m.index + token.length));
-    const link = new vscode.DocumentLink(range, vscode.Uri.joinPath(folder.uri, artifact.path));
+    const link = new vscode.DocumentLink(range, artifactUri(folder, artifact.path));
     link.tooltip = `${artifact.type} — ${artifact.title}`;
     links.push(link);
   }
@@ -658,7 +658,7 @@ async function provideWorkspaceSymbols(): Promise<vscode.SymbolInformation[]> {
     const corpus = await corpusExport(folder);
     if (!corpus) continue;
     for (const artifact of corpus.artifacts) {
-      const uri = vscode.Uri.joinPath(folder.uri, artifact.path);
+      const uri = artifactUri(folder, artifact.path);
       symbols.push(
         new vscode.SymbolInformation(
           artifact.title,
@@ -670,6 +670,15 @@ async function provideWorkspaceSymbols(): Promise<vscode.SymbolInformation[]> {
     }
   }
   return symbols;
+}
+
+// `rac export` returns absolute artifact paths when given an absolute directory
+// (the extension passes one), so build the Uri from the absolute path directly;
+// fall back to joining a relative path onto the workspace folder.
+function artifactUri(folder: vscode.WorkspaceFolder, artifactPath: string): vscode.Uri {
+  return path.isAbsolute(artifactPath)
+    ? vscode.Uri.file(artifactPath)
+    : vscode.Uri.joinPath(folder.uri, artifactPath);
 }
 
 interface CorpusIndex {

--- a/typescript/rac-vscode/src/extension.ts
+++ b/typescript/rac-vscode/src/extension.ts
@@ -25,6 +25,7 @@ import {
   RacNotFoundError,
   isResolved,
   type CorpusExport,
+  type DirectoryValidation,
   type ExportArtifact,
   type FileValidation,
   type Issue,
@@ -35,28 +36,43 @@ import {
 
 const DEBOUNCE_MS = 300;
 const RELATIONSHIP_DEBOUNCE_MS = 600;
+const AWARENESS_DEBOUNCE_MS = 800;
 const ARTIFACT_TYPES = ["requirement", "decision", "roadmap", "prompt", "design"];
 
 let diagnostics: vscode.DiagnosticCollection;
 let relationshipDiagnostics: vscode.DiagnosticCollection;
+let workspaceDiagnostics: vscode.DiagnosticCollection;
+let statusBar: vscode.StatusBarItem;
 const clients = new Map<string, RacClient>();
 const exportCache = new Map<string, CorpusExport>();
 const debounce = new Map<string, ReturnType<typeof setTimeout>>();
 const relationshipDebounce = new Map<string, ReturnType<typeof setTimeout>>();
+const awarenessDebounce = new Map<string, ReturnType<typeof setTimeout>>();
 let warnedMissing = false;
 
 export function activate(context: vscode.ExtensionContext): void {
   diagnostics = vscode.languages.createDiagnosticCollection("rac");
   relationshipDiagnostics = vscode.languages.createDiagnosticCollection("rac-relationships");
+  workspaceDiagnostics = vscode.languages.createDiagnosticCollection("rac-workspace");
+  statusBar = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 0);
+  statusBar.command = "workbench.actions.view.problems";
   const selector: vscode.DocumentSelector = { language: "markdown", scheme: "file" };
 
   context.subscriptions.push(
     diagnostics,
     relationshipDiagnostics,
-    vscode.workspace.onDidOpenTextDocument((doc) => void validateDocument(doc)),
+    workspaceDiagnostics,
+    statusBar,
+    vscode.workspace.onDidOpenTextDocument((doc) => {
+      void validateDocument(doc);
+      // The live per-file collection owns open files; drop any workspace-scan
+      // diagnostic for it to avoid duplicates.
+      workspaceDiagnostics.delete(doc.uri);
+    }),
     vscode.workspace.onDidSaveTextDocument((doc) => {
       void validateDocument(doc);
       scheduleRelationshipsFor(doc);
+      scheduleAwarenessFor(doc);
       invalidateExportFor(doc);
     }),
     vscode.workspace.onDidChangeTextDocument((e) => scheduleValidate(e.document)),
@@ -70,6 +86,7 @@ export function activate(context: vscode.ExtensionContext): void {
         exportCache.clear();
         void validateWorkspace();
         refreshAllRelationships();
+        refreshAllAwareness();
       }
     }),
     vscode.commands.registerCommand("rac.validateWorkspace", validateWorkspace),
@@ -92,17 +109,23 @@ export function activate(context: vscode.ExtensionContext): void {
 
   for (const doc of vscode.workspace.textDocuments) void validateDocument(doc);
   refreshAllRelationships();
+  refreshAllAwareness();
 }
 
 export function deactivate(): void {
   for (const timer of debounce.values()) clearTimeout(timer);
   for (const timer of relationshipDebounce.values()) clearTimeout(timer);
+  for (const timer of awarenessDebounce.values()) clearTimeout(timer);
   debounce.clear();
   relationshipDebounce.clear();
+  awarenessDebounce.clear();
   diagnostics?.clear();
   diagnostics?.dispose();
   relationshipDiagnostics?.clear();
   relationshipDiagnostics?.dispose();
+  workspaceDiagnostics?.clear();
+  workspaceDiagnostics?.dispose();
+  statusBar?.dispose();
 }
 
 // --- per-file validation ----------------------------------------------------
@@ -323,6 +346,84 @@ function relationshipHeading(relationship: string): string {
 
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+// --- ambient awareness ------------------------------------------------------
+
+// A status-bar health score (rac review) and corpus-wide diagnostics
+// (rac validate <dir>), refreshed on save/activation. The live per-file
+// collection owns open files; the workspace scan covers the rest, so the
+// Problems panel reflects the whole corpus without double-reporting.
+
+function scheduleAwarenessFor(doc: vscode.TextDocument): void {
+  if (doc.languageId !== "markdown" || doc.uri.scheme !== "file") return;
+  if (!looksLikeRacArtifact(doc.getText())) return;
+  const folder = vscode.workspace.getWorkspaceFolder(doc.uri);
+  if (folder) scheduleAwareness(folder);
+}
+
+function scheduleAwareness(folder: vscode.WorkspaceFolder): void {
+  const key = folder.uri.fsPath;
+  const existing = awarenessDebounce.get(key);
+  if (existing) clearTimeout(existing);
+  awarenessDebounce.set(
+    key,
+    setTimeout(() => {
+      awarenessDebounce.delete(key);
+      void refreshAwareness(folder);
+    }, AWARENESS_DEBOUNCE_MS),
+  );
+}
+
+function refreshAllAwareness(): void {
+  for (const folder of vscode.workspace.workspaceFolders ?? []) {
+    void refreshAwareness(folder);
+  }
+}
+
+async function refreshAwareness(folder: vscode.WorkspaceFolder): Promise<void> {
+  if (!isEnabled()) return;
+  await Promise.allSettled([refreshStatusBar(folder), refreshWorkspaceDiagnostics(folder)]);
+}
+
+async function refreshStatusBar(folder: vscode.WorkspaceFolder): Promise<void> {
+  try {
+    const review = await clientFor(folder).review(folder.uri.fsPath);
+    statusBar.text = `$(pulse) RAC ${review.health.score}/100`;
+    statusBar.tooltip = review.ok
+      ? "RAC corpus: no blocking findings — click for Problems"
+      : "RAC corpus: blocking findings — click for Problems";
+    statusBar.show();
+  } catch (err) {
+    if (err instanceof RacNotFoundError) {
+      statusBar.hide();
+      warnMissingOnce();
+    } else {
+      console.error("RAC: review failed", err);
+    }
+  }
+}
+
+async function refreshWorkspaceDiagnostics(folder: vscode.WorkspaceFolder): Promise<void> {
+  let result: DirectoryValidation;
+  try {
+    result = await clientFor(folder).validateDirectory(folder.uri.fsPath);
+  } catch (err) {
+    if (err instanceof RacNotFoundError) warnMissingOnce();
+    else console.error("RAC: directory validation failed", err);
+    return;
+  }
+
+  workspaceDiagnostics.clear();
+  const openPaths = new Set(vscode.workspace.textDocuments.map((d) => d.uri.fsPath));
+  for (const file of result.files) {
+    if (file.issues.length === 0) continue;
+    const uri = path.isAbsolute(file.path)
+      ? vscode.Uri.file(file.path)
+      : vscode.Uri.joinPath(folder.uri, file.path);
+    if (openPaths.has(uri.fsPath)) continue; // live diagnostics own open files
+    workspaceDiagnostics.set(uri, file.issues.map(issueToDiagnostic));
+  }
 }
 
 // --- authoring: completion, quick-fixes, new artifact -----------------------


### PR DESCRIPTION
# Summary

Implements `rac/roadmaps/v0.21.x-editor/v0.21.4-ambient-awareness.md` — v0.21.4 of the `v0.21.x-editor` series. Always-on awareness of the whole corpus, not just the open file: a status-bar health score and workspace-wide diagnostics. Extension-only; a thin client over `rac review` and `rac validate DIR` (ADR-063).

Adds:
- Status-bar item — `$(pulse) RAC SCORE/100` sourced from `rac review`, click to open the Problems panel; tooltip reflects whether there are blocking findings.
- Workspace-wide diagnostics — `rac validate DIR` populates the Problems panel for every artifact, including unopened ones, with line-anchored issues.
- README and CHANGELOG entries for the ambient-awareness surface.

# Roadmap / ADR Trace

Roadmap:
- `rac/roadmaps/v0.21.x-editor/v0.21.4-ambient-awareness.md`

Relevant ADRs:
- `rac/decisions/adr-049-enforcement-is-the-product.md` — enforcement is the product; ambient awareness surfaces real findings, it does not invent its own scoring.
- `rac/decisions/adr-063-non-python-clients-are-thin.md` — the extension consumes `rac review` / `rac validate DIR` output and derives nothing itself.
- `rac/decisions/adr-007-additive-json-evolution.md` — relies on the existing `--json` shape (`files[].issues`, `health.score`, `ok`); no new fields required.

# Scope

## Included
- Status-bar health, refreshed on save and activation, debounced (800ms).
- Workspace-wide diagnostics in their own collection (`rac-workspace`), reconciled with the live per-file diagnostics (open files are owned by the live `rac` collection).

## Excluded
- Corpus-graph webview — deferred to v0.21.5.
- Caching, scoped activation, version-skew handling, and packaging — deferred to v0.21.6 (this release still re-scans on each debounced change).
- A separate dashboard or report view beyond the status bar and Problems panel (Non-Goal).
- Blocking the editor on corpus scans; everything is async and advisory (Non-Goal).

# Product / Architecture Decisions

- Health from `rac review`. The status bar shows RAC's real portfolio health score (matching `rac review`), not a derived valid/total ratio.
- No double-reporting. Workspace diagnostics live in a separate collection (`rac-workspace`) and skip files currently open in an editor — those are covered by the live per-file collection (`rac`). Opening a file clears its workspace diagnostic; the next save re-scans.
- Save/activation-triggered, debounced. Both read disk, so they reflect the saved corpus; an 800ms debounce keeps them off the keystroke path. Caching to cut the repeat scans lands in v0.21.6.

# User-Facing Contract

## CLI
None. No `rac` command, flag, or behavior is added or changed; the extension calls existing `rac review` and `rac validate DIR`.

## Human Output
A status-bar item (`$(pulse) RAC SCORE/100`) and additional Problems-panel entries on RAC workspaces. No new settings or commands; honours `rac.validate.enable`.

## JSON Output
None. Consumes the existing `rac --json` shape (`files[].issues` with `{severity, code, message, line}`; `review.health.score` and `ok`); no shape change.

## Exit Codes
None. No change to `rac` exit codes.

# Verification

## Ran
- Extension `npm run check-types` (strict) and `npm run compile` — clean (29.8kb bundle).
- Confirmed `rac validate DIR --json` `files[].issues` carry `{severity, code, message, line}` (line-anchored), and `rac review --json` carries `health.score` and `ok`.
- Corpus gates: `rac validate rac/` exit 0; `rac relationships rac/ --validate` → 775 checked, 0 issues.

## Covered
- Positive: the SDK's `review` and `validateDirectory` are integration-tested (v0.21.0); the status bar and workspace-diagnostics wiring is presentation over that verified surface.
- Boundary: workspace diagnostics reconcile with the live per-file collection — an open file's workspace entry clears and re-scans on save (no duplicate or stale entries).
- Not exercised: runtime editor behaviour is not run headlessly (no VS Code host in CI).

# Review Path

1. `typescript/rac-vscode/src/extension.ts` — the ambient-awareness section and its activate/deactivate wiring (status bar, `rac-workspace` collection).
2. README and `CHANGELOG.md` — the user-facing surface.

# Notes For Reviewer

- Stacked on v0.21.3 (#113); merge after it. Targets `main`; merge the series in order for a clean per-release diff.
- On merge, flip the v0.21.4 roadmap `## Status` to `Achieved` (ADR-061).
- Repeat-scan cost on large corpora is a known limitation here; caching lands in v0.21.6.

# Implementation Process

Implemented with AI assistance under the v0.21.4 roadmap contract; final scope, review, and acceptance decisions were made by the maintainer.