### PR TITLE
fix(decisiongrounding): make the rac arm runnable on the real PEP corpus

### DIFF
--- a/decisiongrounding/README.md
+++ b/decisiongrounding/README.md
@@ -136,8 +136,14 @@ for PEP 386's retired `verlib`/`NormalizedVersion` scheme is following a
 superseded decision; the adherent move is to cite PEP 440 instead. See
 `decisions/ADR-0002-real-corpus-pilot-peps.md`.
 
-The corpus is pinned to one immutable commit of `python/peps` and is fully
-reproducible — nothing in it is hand-written PEP prose:
+The PEPs are ingested as **RAC-native `decision` artifacts**: each carries the
+verbatim PEP under a `## Source Text` section, wrapped in a decision envelope
+(`Status`/`Context`/`Decision`/`Consequences`) plus a directional `## Supersedes`
+edge — every envelope value derived from the PEP's own headers — so the `rac` arm
+can classify them and follow the supersedes edge (see
+`decisions/ADR-0003-rac-arm-pep-integration.md`). The corpus is pinned to one
+immutable commit of `python/peps` and fully reproducible — nothing in it is
+hand-written PEP prose:
 
 ```bash
 # Regenerate the corpus from the pin, or verify it reproduces byte-for-byte.
@@ -149,15 +155,22 @@ Run the pilot for real (needs `[real]` + both keys, exactly as above):
 
 ```bash
 python -m runner.cli compare \
-  --arms context_dump,naive_rag,no_grounding \
+  --arms context_dump,naive_rag,no_grounding,rac \
   --answering claude --embedder voyage:voyage-4-large \
   --scenarios scenarios_real --seed 0
 ```
 
+The `rac` arm is the grounding layer under test: it follows the typed
+`supersedes` edge and supplies the live PEP 440, where `naive_rag` can surface
+PEP 386's appealing `verlib` section without the header that marks it superseded.
+It needs the `rac` CLI on PATH (`pip install -e .` from the repo root, or set
+`RAC_BIN`); drop `,rac` to run the baselines alone.
+
 This produces the first genuine decision-adherence result (win, tie, or loss)
 on a real corpus; like every run it is appended to `results/`. The build
 environment for this pilot had no API keys, so the scenario is offline-validated
-(loads, schema-validates, scores) and the real numbers are produced by whoever
+(loads, schema-validates, scores, and the `rac` arm's supersedes-following is
+verified against the real `rac` CLI) and the real numbers are produced by whoever
 holds the keys.
 
 Tests:
@@ -180,7 +193,7 @@ make test
 | Governing-decision recall diagnostic | ✅ real |
 | Pinned Claude answering model (`--answering claude`, Opus 4.8) | ✅ implemented; needs `[real]` + `ANTHROPIC_API_KEY` |
 | Real embeddings (`--embedder voyage:…` / `st:…`) | ✅ implemented; needs `[real]` / `[local-embeddings]` |
-| `rac` arm (typed retrieval, follows `supersedes`) | ✅ implemented; needs the `rac` CLI on PATH |
+| `rac` arm (typed retrieval, follows `supersedes`) | ✅ verified against the `rac` CLI on the real corpus; needs `rac` on PATH |
 | Real/public-derived scenario (PEP 386→440 supersession) | ✅ corpus built, pinned + verifiable; real run needs `[real]` + keys |
 | `memory_provider` arm | ⏳ typed stub + TODO |
 | LLM-judge fallback | ⏳ disclosed, not built |

--- a/decisiongrounding/decisions/ADR-0003-rac-arm-pep-integration.md
+++ b/decisiongrounding/decisions/ADR-0003-rac-arm-pep-integration.md
@@ -1,0 +1,120 @@
+---
+schema_version: 1
+id: DG-ADR-0003
+type: decision
+tags: [rac-arm, corpus, retrieval, supersession]
+---
+
+# ADR-0003: Make the `rac` Arm Runnable on the Real Corpus
+
+## Status
+
+Accepted
+
+## Category
+
+Architecture
+
+## Context
+
+ADR-0002 added the first real corpus (the PEP 386 → 440 supersession) as
+verbatim PEP text. Wiring the **`rac` arm** — the grounding layer the whole
+benchmark exists to test — to that corpus surfaced two blockers, both verified
+against the installed `rac` CLI (`rac 0.1.dev…`):
+
+1. **Content classification.** `rac` classifies artifacts by their *content*
+   (deterministic classification is RAC's core thesis), not by a front-matter
+   `type`. A file that is just a verbatim PEP classifies as `unknown`, so
+   `rac find --type decision` skips it and the arm retrieves nothing. A decision
+   is recognised only when it carries the canonical sections
+   (`Status`/`Context`/`Decision`/`Consequences`).
+2. **Relationship + query shape.** `rac relationships --json` identifies each
+   artifact by `path` (no `id` field) and exposes a directional edge only from a
+   `## Supersedes` section of bare artifact IDs — undirected `## Related
+   Decisions` prose does not resolve. Separately, `rac find` is a
+   case-insensitive **substring** search over ID/title that narrows on
+   multi-word queries, so passing the whole task sentence as the query matched
+   nothing.
+
+The arm's pre-existing `_extract_supersedes_edges` also read `art["id"]` (always
+absent), so every supersedes edge was silently dropped — it had never actually
+followed a supersession against the real CLI.
+
+## Decision
+
+Make the corpus RAC-native and fix the arm's CLI integration, changing nothing
+about the held-constant answering model or scaffold (CONTRIBUTING.md rule 4).
+
+- **Ingest emits RAC `decision` artifacts.** `ingest/peps.py` wraps each verbatim
+  PEP (preserved under a `## Source Text` section, still byte-for-byte
+  hash-verified) in a decision envelope whose every value is *derived from the
+  PEP's own headers*: `Status` from the PEP `Status`, and a directional
+  `## Supersedes: - PEP-XXXX` from the PEP `Replaces` header (only for targets
+  present in the corpus, so no reference dangles). The envelope is structural
+  scaffolding; it does not editorialise the PEP's technical content.
+- **Edge extraction reads the real JSON.** `_extract_supersedes_edges` derives
+  the source id from the artifact `path` stem (the arm writes the corpus as
+  `<id>.md`), keeping an explicit `id` path for forward compatibility.
+- **Keyword-union retrieval.** The arm queries `rac find` one salient task term
+  at a time and unions the hits, ranking by how many terms hit each decision —
+  a deterministic topic search that fits `rac find`'s substring surface — then
+  follows `supersedes` to replace a retrieved superseded decision with its live
+  successor.
+
+All arms see the identical corpus files; the `rac` arm's only advantage is that
+it *parses and follows* the typed edge that `naive_rag` embeds and `context_dump`
+merely dumps. The supersedes edge is PEP 440's own `Replaces: 386`, not ours.
+
+## Consequences
+
+### Positive
+
+- The `rac` arm runs end-to-end on the real corpus and demonstrably follows the
+  supersedes edge: on the pilot it supplies the live PEP 440 and drops the
+  superseded PEP 386 (covered by a test that runs against the real `rac` CLI).
+- The corpus passes `rac relationships --validate` (the reference resolves), so
+  the benchmark dogfoods the same relationship-integrity gate RAC ships.
+- The verbatim PEP is unchanged and still hash-verified; reproducibility holds.
+
+### Negative
+
+- Corpus artifacts are now RAC-shaped wrappers rather than raw PEP files; the
+  verbatim payload is one `## Source Text` section down.
+- The arm issues one `rac find` per salient term. Fine for a `compare` run;
+  callers running the large crossover sweep with the `rac` arm should expect more
+  subprocess calls.
+
+### Risks
+
+- **`rac` output drift.** The arm depends on `rac find` / `rac relationships`
+  JSON shape. Mitigation: extraction is defensive about both shapes, and the
+  integration is pinned by tests that skip cleanly when `rac` is absent.
+- **The synthetic `scenarios/` corpora still use undirected prose** for
+  supersession, so the `rac` arm does not follow their edges. Out of scope here
+  (they are never reported as results); flagged for a follow-up that re-encodes
+  them with `## Supersedes`.
+
+## Alternatives Considered
+
+- **Give the `rac` arm the scenario's `supersedes` edges directly.** Rejected:
+  the arm must *discover* relationships through `rac`, like the layer it models;
+  handing it the answer is the special treatment rule 4 forbids.
+- **Drop `--type decision` and retrieve unknowns.** Rejected: classification is
+  RAC's contract; representing decisions as decisions is the honest corpus.
+
+## Related Decisions
+
+- ADR-0001 — Harness Foundation (the `rac` arm gets no special treatment).
+- ADR-0002 — Real-Corpus Pilot (this makes its corpus runnable by the `rac` arm).
+
+## Success Measures
+
+- `rac relationships scenarios_real/.../corpus --validate` resolves with no
+  issues, and the `rac` arm supplies the live successor on the pilot.
+- The held-constant answering model and scaffold are unchanged; only grounding
+  assembly differs across arms.
+
+## Review Date
+
+Revisit when re-encoding the synthetic corpora for the `rac` arm, or if a `rac`
+release changes the `find` / `relationships` JSON contract.

--- a/decisiongrounding/ingest/peps.py
+++ b/decisiongrounding/ingest/peps.py
@@ -97,19 +97,82 @@ def supersedes_targets(headers: dict[str, str]) -> list[int]:
     return _header_numbers(headers, "Replaces")
 
 
-def corpus_markdown(num: int, rst: str, sha: str = PINNED_COMMIT) -> str:
-    """A corpus artifact: provenance preamble + verbatim upstream PEP text."""
-    title = parse_headers(rst).get("Title", "").strip()
+# Marker that separates the derived RAC envelope from the verbatim PEP payload.
+# Everything after it is the unedited upstream reStructuredText (hash-anchored in
+# provenance.json), so integrity checks can recover it by splitting on this line.
+SOURCE_TEXT_MARKER = "\n\n## Source Text\n\n"
+
+
+def _pep_tags(headers: dict[str, str]) -> list[str]:
+    """Deterministic tags: always `pep`, plus the PEP's own Topic if present."""
+    tags = ["pep"]
+    topic = headers.get("Topic", "").strip().lower()
+    if topic:
+        tags.append(topic)
+    return tags
+
+
+def corpus_markdown(
+    num: int,
+    rst: str,
+    sha: str = PINNED_COMMIT,
+    corpus_nums: frozenset[int] | None = None,
+) -> str:
+    """A RAC-native `decision` artifact wrapping the verbatim PEP.
+
+    The artifact carries the canonical decision sections RAC classifies on
+    (`Status`/`Context`/`Decision`/`Consequences`) plus a directional `Supersedes`
+    section, so the `rac` arm can classify it and follow the edge. Every envelope
+    value is *derived from the PEP's own header fields* — the upstream `Status`,
+    and `Replaces` for the supersedes edge — and the authoritative content is the
+    unedited PEP reproduced verbatim under `Source Text`. Nothing here editorialises
+    the PEP's technical content.
+
+    `corpus_nums` is the set of PEP numbers in the same corpus; only `Replaces`
+    targets present in it are listed under `Supersedes`, so no reference dangles.
+    """
+    headers = parse_headers(rst)
+    title = headers.get("Title", "").strip()
+    status = headers.get("Status", "").strip() or "Final"
+    in_corpus = corpus_nums if corpus_nums is not None else frozenset({num})
+    supersedes = [pep_id(t) for t in supersedes_targets(headers) if t in in_corpus]
+    tags = ", ".join(_pep_tags(headers))
+
     heading = f"# {pep_id(num)} — {title}" if title else f"# {pep_id(num)}"
-    preamble = (
-        f"{heading}\n\n"
-        f"> Source: {SOURCE_REPO} @ {sha}\n"
-        f"> Path: peps/pep-{num:04d}.rst · {source_url(num, sha)}\n"
-        f"> Verbatim public artifact, pinned and unedited. Not authored for this\n"
-        f"> benchmark; see provenance.json for the upstream sha256.\n\n"
-        f"---\n\n"
-    )
-    return preamble + rst
+    parts = [
+        "---",
+        "schema_version: 1",
+        f"id: {pep_id(num)}",
+        "type: decision",
+        f"tags: [{tags}]",
+        "---",
+        "",
+        heading,
+        "",
+        "## Status",
+        "",
+        status,
+        "",
+        "## Context",
+        "",
+        f"Public decision ingested verbatim from {SOURCE_REPO} (PEP {num}) at commit",
+        f"{sha}; source peps/pep-{num:04d}.rst ({source_url(num, sha)}). Upstream",
+        f"status: {status}. The RAC envelope sections are derived from the PEP's own",
+        "header fields; the authoritative content is the unedited PEP reproduced under",
+        "Source Text (upstream sha256 recorded in provenance.json).",
+        "",
+        "## Decision",
+        "",
+        "Defined by the verbatim PEP text under Source Text below.",
+        "",
+        "## Consequences",
+        "",
+        "As stated by the upstream PEP; see Source Text.",
+    ]
+    if supersedes:
+        parts += ["", "## Supersedes", ""] + [f"- {sid}" for sid in supersedes]
+    envelope = "\n".join(parts)
+    return envelope + SOURCE_TEXT_MARKER + rst
 
 
 def build_provenance(peps: tuple[int, ...], texts: dict[int, str], sha: str) -> dict:
@@ -149,9 +212,10 @@ def build(out_dir: Path, peps: tuple[int, ...] = PILOT_PEPS, sha: str = PINNED_C
     corpus_dir = out_dir / "corpus"
     corpus_dir.mkdir(parents=True, exist_ok=True)
     texts = {num: fetch_pep(num, sha) for num in peps}
+    corpus_nums = frozenset(peps)
     for num in peps:
         (corpus_dir / f"{pep_id(num)}.md").write_text(
-            corpus_markdown(num, texts[num], sha), encoding="utf-8"
+            corpus_markdown(num, texts[num], sha, corpus_nums), encoding="utf-8"
         )
     provenance = build_provenance(peps, texts, sha)
     (out_dir / "provenance.json").write_text(
@@ -165,6 +229,7 @@ def verify(out_dir: Path) -> list[str]:
     means the committed corpus reproduces exactly from the upstream bytes)."""
     provenance = json.loads((out_dir / "provenance.json").read_text(encoding="utf-8"))
     sha = provenance["pinned_commit"]
+    corpus_nums = frozenset(e["number"] for e in provenance["peps"])
     problems: list[str] = []
     for entry in provenance["peps"]:
         num = entry["number"]
@@ -178,7 +243,7 @@ def verify(out_dir: Path) -> list[str]:
             problems.append(
                 f"{entry['id']}: upstream sha256 changed ({got} != {entry['source_sha256']})"
             )
-        expected_md = corpus_markdown(num, rst, sha)
+        expected_md = corpus_markdown(num, rst, sha, corpus_nums)
         actual_md = (out_dir / entry["file"]).read_text(encoding="utf-8")
         if expected_md != actual_md:
             problems.append(f"{entry['id']}: committed {entry['file']} does not match upstream bytes")

--- a/decisiongrounding/providers/rac.py
+++ b/decisiongrounding/providers/rac.py
@@ -19,10 +19,29 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import shutil
 import subprocess
 import tempfile
 from pathlib import Path
+
+_TOKEN = re.compile(r"[a-z0-9]+")
+_STOP = {
+    "the", "a", "an", "to", "of", "and", "or", "for", "in", "on", "with", "is",
+    "are", "be", "as", "by", "this", "that", "it", "our", "we", "you", "so",
+    "can", "it", "use", "using", "follow", "add", "need", "needs", "standard",
+}
+
+
+def _query_tokens(text: str) -> list[str]:
+    """Salient single terms for `rac find`, which substring-matches ID/title and
+    narrows on multi-word queries. Querying one term at a time and unioning the
+    hits is the deterministic way to retrieve by topic over that surface."""
+    seen: list[str] = []
+    for tok in _TOKEN.findall(text.lower()):
+        if tok not in _STOP and len(tok) > 3 and tok not in seen:
+            seen.append(tok)
+    return seen
 
 from .base import (
     SCAFFOLD,
@@ -93,6 +112,23 @@ class RacProvider(Provider):
         ).stdout
         return json.loads(out)
 
+    def _find_candidates(self, task: Task) -> list[str]:
+        """Union `rac find` hits across salient task terms, ranked by hit count
+        then first appearance. Deterministic given the corpus and task."""
+        hits: dict[str, int] = {}
+        order: list[str] = []
+        for term in _query_tokens(f"{task.prompt} {task.proposed_action}"):
+            res = self._run("find", term, str(self._dir), "--type", "decision", "--json")
+            for m in res.get("matches", []):
+                mid = m.get("id")
+                if not mid:
+                    continue
+                if mid not in hits:
+                    hits[mid] = 0
+                    order.append(mid)
+                hits[mid] += 1
+        return sorted(order, key=lambda i: (-hits[i], order.index(i)))
+
     def prepare(self, corpus: list[CorpusArtifact]) -> None:
         # Write the corpus to a temp dir so the external `rac` CLI can index it.
         self._by_id = {a.id: a for a in corpus}
@@ -105,11 +141,11 @@ class RacProvider(Provider):
     def respond(self, task: Task):
         if self._dir is None:
             raise RuntimeError("rac arm: prepare() must run before respond()")
-        query = f"{task.prompt} {task.proposed_action}"
-
-        # 1. Typed candidate decisions, ranked by rac's deterministic search.
-        find = self._run("find", query, str(self._dir), "--type", "decision", "--json")
-        matched = [m.get("id") for m in find.get("matches", []) if m.get("id")]
+        # 1. Typed candidate decisions. `rac find` substring-matches ID/title and
+        # ANDs multi-word queries, so we query one salient task term at a time and
+        # union the hits, ranking by how many terms hit each decision (then by
+        # first appearance) — a deterministic topic search over rac's surface.
+        matched = self._find_candidates(task)
 
         # 2. Relationship graph → supersedes edges (source supersedes target).
         rels = self._run("relationships", str(self._dir), "--json")
@@ -150,7 +186,11 @@ def _extract_supersedes_edges(rels_json: dict) -> list[tuple[str, str]]:
                 edges.append((src, tgt))
 
     for art in rels_json.get("artifacts", []) or []:
-        src = art.get("id")
+        # `rac relationships --json` identifies each artifact by `path`, not `id`
+        # (this rac build emits no `id` here). The arm writes the corpus as
+        # `<id>.md`, so the file stem is the artifact id; prefer an explicit `id`
+        # if a future rac version adds one.
+        src = art.get("id") or Path(art.get("path", "")).stem or None
         targets = (art.get("relationships") or {}).get("supersedes") or []
         for tgt in targets:
             if src and tgt:

--- a/decisiongrounding/scenarios_real/peps_version_supersession/corpus/PEP-0386.md
+++ b/decisiongrounding/scenarios_real/peps_version_supersession/corpus/PEP-0386.md
@@ -1,11 +1,33 @@
+---
+schema_version: 1
+id: PEP-0386
+type: decision
+tags: [pep, packaging]
+---
+
 # PEP-0386 — Changing the version comparison module in Distutils
 
-> Source: python/peps @ f866e77409305866038471574f075cd8d83eee9e
-> Path: peps/pep-0386.rst · https://raw.githubusercontent.com/python/peps/f866e77409305866038471574f075cd8d83eee9e/peps/pep-0386.rst
-> Verbatim public artifact, pinned and unedited. Not authored for this
-> benchmark; see provenance.json for the upstream sha256.
+## Status
 
----
+Superseded
+
+## Context
+
+Public decision ingested verbatim from python/peps (PEP 386) at commit
+f866e77409305866038471574f075cd8d83eee9e; source peps/pep-0386.rst (https://raw.githubusercontent.com/python/peps/f866e77409305866038471574f075cd8d83eee9e/peps/pep-0386.rst). Upstream
+status: Superseded. The RAC envelope sections are derived from the PEP's own
+header fields; the authoritative content is the unedited PEP reproduced under
+Source Text (upstream sha256 recorded in provenance.json).
+
+## Decision
+
+Defined by the verbatim PEP text under Source Text below.
+
+## Consequences
+
+As stated by the upstream PEP; see Source Text.
+
+## Source Text
 
 PEP: 386
 Title: Changing the version comparison module in Distutils

--- a/decisiongrounding/scenarios_real/peps_version_supersession/corpus/PEP-0440.md
+++ b/decisiongrounding/scenarios_real/peps_version_supersession/corpus/PEP-0440.md
@@ -1,11 +1,37 @@
+---
+schema_version: 1
+id: PEP-0440
+type: decision
+tags: [pep, packaging]
+---
+
 # PEP-0440 — Version Identification and Dependency Specification
 
-> Source: python/peps @ f866e77409305866038471574f075cd8d83eee9e
-> Path: peps/pep-0440.rst · https://raw.githubusercontent.com/python/peps/f866e77409305866038471574f075cd8d83eee9e/peps/pep-0440.rst
-> Verbatim public artifact, pinned and unedited. Not authored for this
-> benchmark; see provenance.json for the upstream sha256.
+## Status
 
----
+Final
+
+## Context
+
+Public decision ingested verbatim from python/peps (PEP 440) at commit
+f866e77409305866038471574f075cd8d83eee9e; source peps/pep-0440.rst (https://raw.githubusercontent.com/python/peps/f866e77409305866038471574f075cd8d83eee9e/peps/pep-0440.rst). Upstream
+status: Final. The RAC envelope sections are derived from the PEP's own
+header fields; the authoritative content is the unedited PEP reproduced under
+Source Text (upstream sha256 recorded in provenance.json).
+
+## Decision
+
+Defined by the verbatim PEP text under Source Text below.
+
+## Consequences
+
+As stated by the upstream PEP; see Source Text.
+
+## Supersedes
+
+- PEP-0386
+
+## Source Text
 
 PEP: 440
 Title: Version Identification and Dependency Specification

--- a/decisiongrounding/tests/test_ingest_peps.py
+++ b/decisiongrounding/tests/test_ingest_peps.py
@@ -56,13 +56,26 @@ def test_supersedes_targets_from_replaces_header():
     assert peps.supersedes_targets({}) == []
 
 
-def test_corpus_markdown_is_provenance_plus_verbatim_body():
-    md = peps.corpus_markdown(9999, _FIXTURE, "abc123")
-    assert md.startswith("# PEP-9999 — A Superseding Example")
-    assert "Source: python/peps @ abc123" in md
-    # The upstream text is embedded verbatim after the preamble delimiter.
-    body = md.split("\n\n---\n\n", 1)[1]
+def test_corpus_markdown_is_rac_decision_wrapping_verbatim_body():
+    md = peps.corpus_markdown(9999, _FIXTURE, "abc123", frozenset({9999, 8888}))
+    # RAC-native decision artifact: front-matter + canonical decision sections so
+    # rac classifies it as a decision.
+    assert md.startswith("---\nschema_version: 1\nid: PEP-9999\ntype: decision")
+    for section in ("## Status", "## Context", "## Decision", "## Consequences"):
+        assert section in md, f"missing {section}"
+    assert "Final" in md  # status carried from the fixture's own header
+    assert "abc123" in md  # the pin is recorded in the Context provenance line
+    # Replaces: 8888 (in corpus) -> a directional, resolvable Supersedes edge.
+    assert "## Supersedes" in md and "- PEP-8888" in md
+    # The upstream text is embedded verbatim after the Source Text marker.
+    body = md.split(peps.SOURCE_TEXT_MARKER, 1)[1]
     assert body == _FIXTURE
+
+
+def test_corpus_markdown_omits_supersedes_when_target_outside_corpus():
+    # The Replaced PEP is not part of this corpus -> no dangling Supersedes ref.
+    md = peps.corpus_markdown(9999, _FIXTURE, "abc123", frozenset({9999}))
+    assert "## Supersedes" not in md
 
 
 def test_build_provenance_derives_supersedes_edge():

--- a/decisiongrounding/tests/test_real_scenarios.py
+++ b/decisiongrounding/tests/test_real_scenarios.py
@@ -13,13 +13,19 @@ from __future__ import annotations
 
 import hashlib
 import json
+import shutil
+import subprocess
 from pathlib import Path
 
 import pytest
 
+from ingest.peps import SOURCE_TEXT_MARKER
 from providers import build_provider, make_answering_model
+from providers.rac import _query_tokens
 from scenarios.loader import load_scenario, load_scenarios
 from scoring.scorer import score
+
+_HAS_RAC = shutil.which("rac") is not None
 
 _ROOT = Path(__file__).resolve().parent.parent
 _REAL_DIR = _ROOT / "scenarios_real"
@@ -54,8 +60,8 @@ def test_pilot_corpus_matches_provenance_hashes_offline():
     assert provenance["pinned_commit"]
     for entry in provenance["peps"]:
         md = (_PILOT / entry["file"]).read_text(encoding="utf-8")
-        # corpus_markdown() = provenance preamble + "\n\n---\n\n" + verbatim rst.
-        body = md.split("\n\n---\n\n", 1)[1]
+        # corpus_markdown() = RAC decision envelope + Source Text marker + rst.
+        body = md.split(SOURCE_TEXT_MARKER, 1)[1]
         got = hashlib.sha256(body.encode("utf-8")).hexdigest()
         assert got == entry["source_sha256"], f"{entry['id']} body drifted from pin"
 
@@ -80,3 +86,38 @@ def test_pilot_gold_label_is_not_a_negative_control():
     sc = load_scenario(_PILOT)
     assert sc.gold_label.governing_decision is not None
     assert sc.gold_label.verdict in ("permitted", "prohibited")
+
+
+def test_query_tokens_keeps_salient_terms_drops_noise():
+    toks = _query_tokens("Add version parsing to compare release strings, follow the scheme")
+    assert {"version", "parsing", "compare", "release", "scheme"} <= set(toks)
+    # Stopwords and short tokens are dropped (rac find substring-matches IDs/titles).
+    assert "add" not in toks and "the" not in toks and "to" not in toks
+
+
+@pytest.mark.skipif(not _HAS_RAC, reason="rac CLI not on PATH")
+def test_rac_arm_follows_supersedes_to_live_decision():
+    """The rac arm must classify the PEPs, follow the supersedes edge, and supply
+    the live successor (PEP-0440) rather than the superseded PEP-0386 — the whole
+    typed-retrieval thesis, exercised against the real rac CLI."""
+    sc = load_scenario(_PILOT)
+    arm = build_provider("rac", make_answering_model("offline-stub", 0), "local-hash")
+    arm.prepare(list(sc.corpus))
+    arm.respond(sc.task)
+    supplied = arm.grounding.artifacts_supplied
+    assert "PEP-0440" in supplied, f"governing decision not retrieved: {supplied}"
+    assert "PEP-0386" not in supplied, f"superseded decision was not dropped: {supplied}"
+
+
+@pytest.mark.skipif(not _HAS_RAC, reason="rac CLI not on PATH")
+def test_rac_corpus_relationships_resolve_cleanly():
+    """`rac relationships --validate` must resolve the Supersedes reference; a
+    dangling reference would mean the rac arm can't follow the edge."""
+    corpus_dir = _PILOT / "corpus"
+    out = subprocess.run(
+        ["rac", "relationships", str(corpus_dir), "--validate", "--json"],
+        capture_output=True,
+        text=True,
+    )
+    data = json.loads(out.stdout)
+    assert data["validation_issues"] == 0, data.get("issues")


### PR DESCRIPTION
# Summary

Makes the **`rac` arm** — the grounding layer the benchmark exists to test —
actually run on the real corpus and follow supersession. Follow-up to #110.

Wiring the rac arm to the PEP corpus surfaced that it had **never followed a
supersession against the installed `rac` CLI**: it consumed a JSON shape rac
doesn't emit, and the verbatim PEP files didn't even classify as decisions. This
fixes both, changing nothing about the held-constant answering model or scaffold
(CONTRIBUTING.md rule 4). All findings were verified against `rac 0.1.dev…`.

# What was broken (verified against the real CLI)

1. **Classification.** `rac` classifies by content, not front-matter — a verbatim
   PEP is `type: unknown`, so `rac find --type decision` skipped it and the arm
   retrieved nothing.
2. **Edge extraction.** `rac relationships --json` identifies artifacts by `path`
   (no `id`), so the arm's `art["id"]` lookup dropped every supersedes edge (its
   own TODO admitted it was unverified).
3. **Query shape.** `rac find` is a case-insensitive **substring** search that
   narrows on multi-word queries, so passing the whole task sentence matched
   nothing.

# Changes

**Ingest emits RAC-native `decision` artifacts** (`ingest/peps.py`)
- Each verbatim PEP is preserved under a `## Source Text` section (still
  byte-for-byte hash-verified) wrapped in a decision envelope
  (`Status`/`Context`/`Decision`/`Consequences`) plus a directional
  `## Supersedes: - PEP-XXXX` — every value derived from the PEP's own headers
  (`Status`, `Replaces`). Supersedes targets are corpus-scoped so no reference
  dangles. `provenance.json` and the upstream hashes are unchanged.

**rac arm fixed** (`providers/rac.py`)
- Derive the edge source id from the artifact `path` stem (the arm writes
  `<id>.md`); keep an explicit `id` path for forward-compat.
- Retrieve by unioning `rac find` hits over salient task terms, ranked by hit
  count — a deterministic topic search over rac's substring surface — then follow
  `supersedes` to swap a superseded decision for its live successor.

**Result:** on the pilot the rac arm supplies the live **PEP-0440** and drops the
superseded **PEP-0386**, and the corpus resolves under `rac relationships
--validate` (0 issues).

# Verification
- `python -m pytest -q` → **50 passed** (+4). New tests run against the real `rac`
  CLI (skip cleanly when absent): the arm follows supersedes to the live decision;
  the corpus validates. Offline 4-arm `compare` (incl. `rac`) runs end-to-end.

# Boundary (unchanged)
Still no API keys in the build env, so this is verified with the offline stub +
real `rac` CLI. The real **numbers** come from a keyed run:
```bash
python -m runner.cli compare --arms context_dump,naive_rag,no_grounding,rac \
  --answering claude --embedder voyage:voyage-4-large --scenarios scenarios_real --seed 0
```
(`rac` arm needs the `rac` CLI on PATH — `pip install -e .` from the repo root.)

The synthetic `scenarios/` corpora still use undirected prose for supersession,
so the rac arm doesn't follow their edges — out of scope here (never reported as
results), flagged in ADR-0003 as a follow-up.