### PR TITLE
feat(sdk): RAC Explorer webview (v0.21.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ details, release history over commit history.
 
 ### Added
 
+- Editor navigation in the extension (v0.21.3 milestone). Hover now shows the
+  target's lifecycle status (⚠ for retired) and a snippet; **find-all-references**
+  lists every artifact that references the one under the cursor (from the export's
+  resolved edges); artifact aliases are **clickable links**; and the corpus is
+  navigable via the **Outline** (an artifact's sections) and **workspace symbols**
+  (jump to any artifact by title). All from the cached `rac export` (ADR-063).
+
 - Authoring aids in the editor extension (v0.21.2 milestone). Inside a
   relationship section, the extension now offers **artifact-alias completion**
   (human aliases like `adr-007`, from a cached `rac export`); **quick-fixes**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ details, release history over commit history.
 
 ### Added
 
+- RAC Explorer in the extension (v0.21.5 milestone). A **RAC: Open Explorer**
+  command renders the corpus relationship graph in a webview — the self-contained
+  Portal viewer produced by `rac export --html` (the `lore-web` build with the
+  corpus injected, offline). Re-run to refresh. The SDK gains `exportHtml(dir,
+  path)`. (Graph↔editor click-through is deferred — the standalone viewer doesn't
+  message a host.)
+
 - Ambient corpus awareness in the extension (v0.21.4 milestone). A **status-bar
   health score** (`rac review`, click for the Problems panel) and
   **workspace-wide diagnostics** (`rac validate <dir>`) so issues in unopened

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ details, release history over commit history.
 
 ### Added
 
+- Ambient corpus awareness in the extension (v0.21.4 milestone). A **status-bar
+  health score** (`rac review`, click for the Problems panel) and
+  **workspace-wide diagnostics** (`rac validate <dir>`) so issues in unopened
+  artifacts are visible. The live per-file diagnostics own open files; the
+  workspace scan covers the rest, so nothing is double-reported.
+
 - Editor navigation in the extension (v0.21.3 milestone). Hover now shows the
   target's lifecycle status (⚠ for retired) and a snippet; **find-all-references**
   lists every artifact that references the one under the cursor (from the export's

--- a/rac/roadmaps/v0.21.x-editor/v0.21.3-editor-navigation.md
+++ b/rac/roadmaps/v0.21.x-editor/v0.21.3-editor-navigation.md
@@ -37,19 +37,24 @@ Extend the v0.21.0 hover to include the target's lifecycle status (e.g.
 ### Initiative 2 — Find-all-references
 
 A reference provider returning incoming links — every artifact that references
-the one under the cursor — from `rac relationships` / the MCP `get_related` shape.
+the one under the cursor — computed from the export's resolved `from → to` edges
+(`rac export` carries them keyed by id), anchored at the referencing token in
+each source. No extra `rac` call beyond the cached export.
 
 ### Initiative 3 — Links, outline, and workspace symbols
 
-Document links (clickable IDs/aliases), a document-symbol provider exposing the
-artifact's `##` sections in the Outline view, and a workspace-symbol provider so
-any artifact is reachable by ID or title (from `rac find` / the index).
+Document links (clickable aliases, resolved against the export's alias index), a
+document-symbol provider exposing the artifact's `##` headings in the Outline
+view (pure Markdown), and a workspace-symbol provider listing every artifact by
+title (from the cached export).
 
 ## Constraints
 
-- Thin client only (ADR-063): incoming links from `rac relationships`/`get_related`,
-  status/snippets from `rac export`/`rac resolve`, symbols from `rac find`/index.
-- Symbol and reference lookups are served from the cache (v0.21.6) to stay responsive.
+- Thin client only (ADR-063): hover status/snippet, incoming edges, alias→file
+  links, and the symbol set all come from the cached `rac export`; the extension
+  re-derives no relationships.
+- Symbol and reference lookups are served from the per-folder export cache
+  (introduced in v0.21.2, hardened in v0.21.6) to stay responsive.
 
 ## Non-Goals
 

--- a/rac/roadmaps/v0.21.x-editor/v0.21.5-corpus-visualization.md
+++ b/rac/roadmaps/v0.21.x-editor/v0.21.5-corpus-visualization.md
@@ -31,15 +31,20 @@ building a new visualization.
 
 ### Initiative 1 — RAC Explorer webview
 
-A webview panel hosting the `lore-web` viewer, fed by `rac export --json`. It
-loads the corpus payload, renders the artifact/relationship graph, and refreshes
-on demand (and on a debounced corpus change).
+A webview panel that renders the self-contained Portal viewer produced by
+`rac export --html --out` — the `lore-web` build with the corpus already
+injected (offline, no network). The **RAC: Open Explorer** command builds and
+loads it; re-running the command refreshes. Auto-refresh on save is deliberately
+not wired, because reloading the webview would reset the viewer's scroll and
+selection; an explicit refresh is the cleaner MVP.
 
-### Initiative 2 — Editor integration
+### Initiative 2 — Editor integration (deferred)
 
-Wire panel selections to editor actions — open an artifact's file from the graph,
-and reveal the current file's artifact in the graph — so the panel and the editor
-stay in sync.
+Two-way sync — open an artifact's file from the graph, reveal the current file's
+artifact in the graph — is **deferred**. The Portal is a standalone viewer that
+does not post messages to a host, so wiring selections to editor actions would
+require changing the `lore-web` viewer build, which is out of scope for this
+thin-client release. Recorded here as the natural follow-on.
 
 ## Constraints
 
@@ -57,17 +62,17 @@ stay in sync.
 
 ## Implementation Contract
 
-- The webview renders the corpus from `rac export --json` using the `lore-web`
-  viewer assets.
-- Selecting an artifact opens its file; the panel can reveal the active file's
-  artifact.
-- The panel refreshes from a fresh export on demand and on debounced change.
+- The webview renders the corpus from the self-contained Portal HTML that
+  `rac export --html --out` produces (the `lore-web` viewer with data injected).
+- The **RAC: Open Explorer** command builds and loads it; re-running refreshes
+  from a fresh export.
+- Editor sync (graph selection ↔ open file) is deferred (Initiative 2).
 
 ## Success Measures
 
-- The panel renders the corpus relationship graph from `rac export`.
-- Clicking an artifact in the panel opens its file in the editor.
-- Editing the corpus and refreshing reflects the change in the panel.
+- The panel renders the corpus relationship graph from `rac export --html`.
+- Re-running the command after editing the corpus reflects the change.
+- With `rac` absent, the panel shows an actionable message rather than failing.
 
 ## Risks
 

--- a/typescript/rac-sdk/src/client.ts
+++ b/typescript/rac-sdk/src/client.ts
@@ -132,6 +132,19 @@ export class RacClient {
     return this.json<CreatedArtifact>(["new", artifactType, outputPath, "--json"]);
   }
 
+  /**
+   * `rac export <dir> --html --out <path>` — write the self-contained Portal
+   * HTML (the lore-web viewer with the corpus injected) to `outPath`. Resolves
+   * once written; throws {@link RacExecError} on a non-zero exit.
+   */
+  async exportHtml(directory: string, outPath: string): Promise<void> {
+    const args = ["export", directory, "--html", "--out", outPath];
+    const result = await this.run(args);
+    if (result.code !== 0) {
+      throw new RacExecError(args, result.code, result.stderr);
+    }
+  }
+
   /** `rac --version` — the installed RAC version string. */
   async version(): Promise<string> {
     const result = await this.run(["--version"]);

--- a/typescript/rac-sdk/test/client.test.ts
+++ b/typescript/rac-sdk/test/client.test.ts
@@ -193,6 +193,21 @@ describe("createArtifact", () => {
   });
 });
 
+describe("exportHtml", () => {
+  it("writes via --html --out and resolves on exit 0", async () => {
+    const { runner, calls } = fakeRunner({ stdout: "", stderr: "wrote x.html", code: 0 });
+    await new RacClient({ runner }).exportHtml("rac", "/tmp/x.html");
+    expect(calls[0]).toEqual(["export", "rac", "--html", "--out", "/tmp/x.html"]);
+  });
+
+  it("throws RacExecError on a non-zero exit", async () => {
+    const runner: RacRunner = async () => ({ stdout: "", stderr: "rac: unwritable", code: 2 });
+    await expect(
+      new RacClient({ runner }).exportHtml("rac", "/bad/x.html"),
+    ).rejects.toBeInstanceOf(RacExecError);
+  });
+});
+
 describe("error mapping", () => {
   it("raises RacNotFoundError when the binary cannot be spawned", async () => {
     const runner: RacRunner = async () => {

--- a/typescript/rac-sdk/test/integration.test.ts
+++ b/typescript/rac-sdk/test/integration.test.ts
@@ -8,8 +8,10 @@
  *     RAC_BIN=/abs/path/to/rac npm test
  */
 
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { dirname, resolve } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
@@ -61,5 +63,18 @@ describe.skipIf(!racBin)("integration (real rac)", () => {
     expect(schema.type).toBe("requirement");
     expect(schema.required).toContain("problem");
     expect(schema.required).toContain("requirements");
+  });
+
+  it("writes a self-contained Portal HTML via exportHtml", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "rac-sdk-"));
+    const out = join(dir, "portal.html");
+    try {
+      await rac.exportHtml("rac/decisions", out);
+      const html = await readFile(out, "utf8");
+      expect(html).toContain('id="lore-export"');
+      expect(html.length).toBeGreaterThan(10_000);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/typescript/rac-vscode/README.md
+++ b/typescript/rac-vscode/README.md
@@ -25,9 +25,13 @@ reimplementing it ([ADR-063](../../rac/decisions/adr-063-non-python-clients-are-
   site, drawn distinctly (from `rac relationships --validate`). Refreshes on
   save/activation, since relationship validation reads files from disk.
 - **Hover** — hovering an artifact ID or alias (e.g. `adr-007`,
-  `v0.20.0-python-sdk-foundation`) shows its title, type, and path via
-  `rac resolve`.
-- **Go-to-definition** — jump from a reference to the target artifact's file.
+  `v0.20.0-python-sdk-foundation`) shows its title, type, **lifecycle status**
+  (⚠ for retired), a snippet, and its path.
+- **Go-to-definition, find-all-references, clickable links** — jump to a target,
+  list every artifact that references the one under the cursor (from the export's
+  resolved edges), and Ctrl/Cmd-click any alias to open its file.
+- **Outline & workspace symbols** — the artifact's sections in the Outline view,
+  and jump-to-any-artifact by title (Ctrl/Cmd-T).
 - **Authoring aids** — artifact-alias completion inside relationship sections
   (`## Related Decisions`, …), quick-fixes that insert a missing `## Section`,
   and a **RAC: New Artifact** command that suggests an existing folder for the

--- a/typescript/rac-vscode/README.md
+++ b/typescript/rac-vscode/README.md
@@ -35,6 +35,9 @@ reimplementing it ([ADR-063](../../rac/decisions/adr-063-non-python-clients-are-
 - **Corpus awareness** — a status-bar health score (`rac review`, click for the
   Problems panel) and workspace-wide diagnostics (`rac validate <dir>`), so issues
   in unopened artifacts show up too.
+- **RAC Explorer** — **RAC: Open Explorer** renders the corpus relationship graph
+  in a panel (the self-contained Portal viewer from `rac export --html`); re-run
+  to refresh.
 - **Authoring aids** — artifact-alias completion inside relationship sections
   (`## Related Decisions`, …), quick-fixes that insert a missing `## Section`,
   and a **RAC: New Artifact** command that suggests an existing folder for the

--- a/typescript/rac-vscode/README.md
+++ b/typescript/rac-vscode/README.md
@@ -32,6 +32,9 @@ reimplementing it ([ADR-063](../../rac/decisions/adr-063-non-python-clients-are-
   resolved edges), and Ctrl/Cmd-click any alias to open its file.
 - **Outline & workspace symbols** — the artifact's sections in the Outline view,
   and jump-to-any-artifact by title (Ctrl/Cmd-T).
+- **Corpus awareness** — a status-bar health score (`rac review`, click for the
+  Problems panel) and workspace-wide diagnostics (`rac validate <dir>`), so issues
+  in unopened artifacts show up too.
 - **Authoring aids** — artifact-alias completion inside relationship sections
   (`## Related Decisions`, …), quick-fixes that insert a missing `## Section`,
   and a **RAC: New Artifact** command that suggests an existing folder for the

--- a/typescript/rac-vscode/package.json
+++ b/typescript/rac-vscode/package.json
@@ -25,6 +25,10 @@
       {
         "command": "rac.newArtifact",
         "title": "RAC: New Artifact"
+      },
+      {
+        "command": "rac.showExplorer",
+        "title": "RAC: Open Explorer"
       }
     ],
     "configuration": {

--- a/typescript/rac-vscode/src/extension.ts
+++ b/typescript/rac-vscode/src/extension.ts
@@ -25,6 +25,7 @@ import {
   RacNotFoundError,
   isResolved,
   type CorpusExport,
+  type ExportArtifact,
   type FileValidation,
   type Issue,
   type RelationshipIssue,
@@ -75,6 +76,10 @@ export function activate(context: vscode.ExtensionContext): void {
     vscode.commands.registerCommand("rac.newArtifact", newArtifact),
     vscode.languages.registerHoverProvider(selector, { provideHover }),
     vscode.languages.registerDefinitionProvider(selector, { provideDefinition }),
+    vscode.languages.registerReferenceProvider(selector, { provideReferences }),
+    vscode.languages.registerDocumentLinkProvider(selector, { provideDocumentLinks }),
+    vscode.languages.registerDocumentSymbolProvider(selector, { provideDocumentSymbols }),
+    vscode.languages.registerWorkspaceSymbolProvider({ provideWorkspaceSymbols }),
     vscode.languages.registerCompletionItemProvider(selector, {
       provideCompletionItems: provideCompletions,
     }),
@@ -528,9 +533,18 @@ async function provideHover(
 ): Promise<vscode.Hover | undefined> {
   const target = await resolveAt(doc, position);
   if (!target) return undefined;
+  const folder = vscode.workspace.getWorkspaceFolder(doc.uri);
+  const corpus = folder ? await corpusExport(folder) : undefined;
+  const artifact = corpus?.artifacts.find((a) => a.id === target.id);
+
   const md = new vscode.MarkdownString(undefined, true);
   md.appendMarkdown(`**${target.title}**\n\n`);
-  md.appendMarkdown(`\`${target.type}\` · \`${target.id}\`\n\n`);
+  const status = artifact ? statusLabel(artifact.status) : "";
+  md.appendMarkdown(`\`${target.type}\`${status ? ` · ${status}` : ""} · \`${target.id}\`\n\n`);
+  if (artifact) {
+    const snippet = snippetFromHtml(artifact.body_html);
+    if (snippet) md.appendMarkdown(`${snippet}\n\n`);
+  }
   md.appendMarkdown(`[${target.path}](${vscode.Uri.file(target.path)})`);
   return new vscode.Hover(md);
 }
@@ -546,6 +560,162 @@ async function provideDefinition(
   // resolve returns a path relative to the client cwd (the workspace folder).
   const uri = vscode.Uri.joinPath(folder.uri, target.path);
   return new vscode.Location(uri, new vscode.Position(0, 0));
+}
+
+// Find-all-references: incoming links from the export's resolved `from → to`
+// edges (no extra `rac` call), anchored at the referencing token in each source.
+async function provideReferences(
+  doc: vscode.TextDocument,
+  position: vscode.Position,
+): Promise<vscode.Location[] | undefined> {
+  const target = await resolveAt(doc, position);
+  if (!target) return undefined;
+  const folder = vscode.workspace.getWorkspaceFolder(doc.uri);
+  if (!folder) return undefined;
+  const corpus = await corpusExport(folder);
+  if (!corpus) return undefined;
+  const index = buildIndex(corpus);
+  const targetAliases = (index.byId.get(target.id)?.aliases ?? [target.id]).map((a) =>
+    a.toLowerCase(),
+  );
+
+  const locations: vscode.Location[] = [];
+  const sourceIds = new Set(
+    corpus.relationships.filter((r) => r.to === target.id).map((r) => r.from),
+  );
+  for (const sourceId of sourceIds) {
+    const source = index.byId.get(sourceId);
+    if (!source) continue;
+    const uri = vscode.Uri.joinPath(folder.uri, source.path);
+    try {
+      const srcDoc = await vscode.workspace.openTextDocument(uri);
+      locations.push(new vscode.Location(uri, firstAliasRange(srcDoc, targetAliases)));
+    } catch {
+      locations.push(new vscode.Location(uri, new vscode.Position(0, 0)));
+    }
+  }
+  return locations;
+}
+
+// Make known artifact aliases in the document clickable links to their files.
+async function provideDocumentLinks(
+  doc: vscode.TextDocument,
+): Promise<vscode.DocumentLink[] | undefined> {
+  if (!looksLikeRacArtifact(doc.getText())) return undefined;
+  const folder = vscode.workspace.getWorkspaceFolder(doc.uri);
+  if (!folder) return undefined;
+  const corpus = await corpusExport(folder);
+  if (!corpus) return undefined;
+  const index = buildIndex(corpus);
+
+  const links: vscode.DocumentLink[] = [];
+  const text = doc.getText();
+  const tokenRe = /[A-Za-z0-9][A-Za-z0-9._-]*[A-Za-z0-9]/g;
+  for (let m = tokenRe.exec(text); m !== null; m = tokenRe.exec(text)) {
+    const token = m[0];
+    if (!looksLikeReference(token)) continue;
+    const artifact = index.aliasToArtifact.get(token.toLowerCase());
+    if (!artifact) continue;
+    const range = new vscode.Range(doc.positionAt(m.index), doc.positionAt(m.index + token.length));
+    const link = new vscode.DocumentLink(range, vscode.Uri.joinPath(folder.uri, artifact.path));
+    link.tooltip = `${artifact.type} — ${artifact.title}`;
+    links.push(link);
+  }
+  return links;
+}
+
+// Outline: the artifact's own Markdown headings (`#` title, `##` sections).
+function provideDocumentSymbols(doc: vscode.TextDocument): vscode.DocumentSymbol[] {
+  const symbols: vscode.DocumentSymbol[] = [];
+  const lines = doc.getText().split(/\r?\n/);
+  let title: vscode.DocumentSymbol | undefined;
+  for (let i = 0; i < lines.length; i++) {
+    const heading = /^(#{1,6})\s+(.+?)\s*$/.exec(lines[i]);
+    if (!heading) continue;
+    const level = heading[1].length;
+    const range = new vscode.Range(i, 0, i, lines[i].length);
+    const symbol = new vscode.DocumentSymbol(
+      heading[2],
+      "",
+      level === 1 ? vscode.SymbolKind.File : vscode.SymbolKind.String,
+      range,
+      range,
+    );
+    if (level === 1 || !title) {
+      symbols.push(symbol);
+      title = symbol;
+    } else {
+      title.children.push(symbol);
+    }
+  }
+  return symbols;
+}
+
+// Workspace symbols: every artifact, reachable by title (VS Code filters).
+async function provideWorkspaceSymbols(): Promise<vscode.SymbolInformation[]> {
+  const symbols: vscode.SymbolInformation[] = [];
+  for (const folder of vscode.workspace.workspaceFolders ?? []) {
+    const corpus = await corpusExport(folder);
+    if (!corpus) continue;
+    for (const artifact of corpus.artifacts) {
+      const uri = vscode.Uri.joinPath(folder.uri, artifact.path);
+      symbols.push(
+        new vscode.SymbolInformation(
+          artifact.title,
+          vscode.SymbolKind.File,
+          artifact.type,
+          new vscode.Location(uri, new vscode.Position(0, 0)),
+        ),
+      );
+    }
+  }
+  return symbols;
+}
+
+interface CorpusIndex {
+  byId: Map<string, ExportArtifact>;
+  aliasToArtifact: Map<string, ExportArtifact>;
+}
+
+function buildIndex(corpus: CorpusExport): CorpusIndex {
+  const byId = new Map<string, ExportArtifact>();
+  const aliasToArtifact = new Map<string, ExportArtifact>();
+  for (const artifact of corpus.artifacts) {
+    byId.set(artifact.id, artifact);
+    for (const alias of artifact.aliases) {
+      aliasToArtifact.set(alias.toLowerCase(), artifact);
+    }
+  }
+  return { byId, aliasToArtifact };
+}
+
+function firstAliasRange(doc: vscode.TextDocument, aliasesLower: string[]): vscode.Range {
+  const lines = doc.getText().split(/\r?\n/);
+  for (let i = 0; i < lines.length; i++) {
+    const lower = lines[i].toLowerCase();
+    for (const alias of aliasesLower) {
+      const col = lower.indexOf(alias);
+      if (col >= 0) return new vscode.Range(i, col, i, col + alias.length);
+    }
+  }
+  return new vscode.Range(0, 0, 0, 0);
+}
+
+const RETIRED_STATUS = new Set(["superseded", "deprecated", "abandoned"]);
+function statusLabel(status: string): string {
+  if (!status || status.toLowerCase() === "unknown") return "";
+  return RETIRED_STATUS.has(status.toLowerCase()) ? `⚠ ${status}` : status;
+}
+
+function snippetFromHtml(html: string): string {
+  // Drop the leading <h1> title (it repeats the bold title above), strip tags.
+  const text = html
+    .replace(/^[\s\S]*?<\/h1>/i, "")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (!text) return "";
+  return text.length > 200 ? `${text.slice(0, 200)}…` : text;
 }
 
 // --- shared -----------------------------------------------------------------

--- a/typescript/rac-vscode/src/extension.ts
+++ b/typescript/rac-vscode/src/extension.ts
@@ -586,7 +586,7 @@ async function provideReferences(
   for (const sourceId of sourceIds) {
     const source = index.byId.get(sourceId);
     if (!source) continue;
-    const uri = vscode.Uri.joinPath(folder.uri, source.path);
+    const uri = artifactUri(folder, source.path);
     try {
       const srcDoc = await vscode.workspace.openTextDocument(uri);
       locations.push(new vscode.Location(uri, firstAliasRange(srcDoc, targetAliases)));
@@ -617,7 +617,7 @@ async function provideDocumentLinks(
     const artifact = index.aliasToArtifact.get(token.toLowerCase());
     if (!artifact) continue;
     const range = new vscode.Range(doc.positionAt(m.index), doc.positionAt(m.index + token.length));
-    const link = new vscode.DocumentLink(range, vscode.Uri.joinPath(folder.uri, artifact.path));
+    const link = new vscode.DocumentLink(range, artifactUri(folder, artifact.path));
     link.tooltip = `${artifact.type} — ${artifact.title}`;
     links.push(link);
   }
@@ -658,7 +658,7 @@ async function provideWorkspaceSymbols(): Promise<vscode.SymbolInformation[]> {
     const corpus = await corpusExport(folder);
     if (!corpus) continue;
     for (const artifact of corpus.artifacts) {
-      const uri = vscode.Uri.joinPath(folder.uri, artifact.path);
+      const uri = artifactUri(folder, artifact.path);
       symbols.push(
         new vscode.SymbolInformation(
           artifact.title,
@@ -670,6 +670,15 @@ async function provideWorkspaceSymbols(): Promise<vscode.SymbolInformation[]> {
     }
   }
   return symbols;
+}
+
+// `rac export` returns absolute artifact paths when given an absolute directory
+// (the extension passes one), so build the Uri from the absolute path directly;
+// fall back to joining a relative path onto the workspace folder.
+function artifactUri(folder: vscode.WorkspaceFolder, artifactPath: string): vscode.Uri {
+  return path.isAbsolute(artifactPath)
+    ? vscode.Uri.file(artifactPath)
+    : vscode.Uri.joinPath(folder.uri, artifactPath);
 }
 
 interface CorpusIndex {

--- a/typescript/rac-vscode/src/extension.ts
+++ b/typescript/rac-vscode/src/extension.ts
@@ -16,6 +16,8 @@
  * scoped for v0.21.6 (robustness/release).
  */
 
+import { readFile, rm } from "node:fs/promises";
+import * as os from "node:os";
 import * as path from "node:path";
 
 import * as vscode from "vscode";
@@ -91,6 +93,7 @@ export function activate(context: vscode.ExtensionContext): void {
     }),
     vscode.commands.registerCommand("rac.validateWorkspace", validateWorkspace),
     vscode.commands.registerCommand("rac.newArtifact", newArtifact),
+    vscode.commands.registerCommand("rac.showExplorer", showExplorer),
     vscode.languages.registerHoverProvider(selector, { provideHover }),
     vscode.languages.registerDefinitionProvider(selector, { provideDefinition }),
     vscode.languages.registerReferenceProvider(selector, { provideReferences }),
@@ -126,6 +129,7 @@ export function deactivate(): void {
   workspaceDiagnostics?.clear();
   workspaceDiagnostics?.dispose();
   statusBar?.dispose();
+  explorerPanel?.dispose();
 }
 
 // --- per-file validation ----------------------------------------------------
@@ -424,6 +428,73 @@ async function refreshWorkspaceDiagnostics(folder: vscode.WorkspaceFolder): Prom
     if (openPaths.has(uri.fsPath)) continue; // live diagnostics own open files
     workspaceDiagnostics.set(uri, file.issues.map(issueToDiagnostic));
   }
+}
+
+// --- corpus visualization (RAC Explorer webview) ----------------------------
+
+// `rac export --html` already produces a self-contained Portal viewer (the
+// lore-web build with the corpus injected, offline, no network). The command
+// renders it in a webview; re-running it refreshes. Editor sync (click an
+// artifact in the graph to open its file) is deferred — the standalone viewer
+// does not post messages to a host (see the v0.21.5 roadmap).
+
+let explorerPanel: vscode.WebviewPanel | undefined;
+
+async function showExplorer(): Promise<void> {
+  const folder = vscode.workspace.workspaceFolders?.[0];
+  if (!folder) {
+    void vscode.window.showErrorMessage("RAC: open a workspace folder first.");
+    return;
+  }
+  if (!explorerPanel) {
+    explorerPanel = vscode.window.createWebviewPanel(
+      "racExplorer",
+      "RAC Explorer",
+      vscode.ViewColumn.Beside,
+      { enableScripts: true, retainContextWhenHidden: true },
+    );
+    explorerPanel.onDidDispose(() => {
+      explorerPanel = undefined;
+    });
+  }
+  explorerPanel.reveal(vscode.ViewColumn.Beside);
+  await loadExplorer(folder);
+}
+
+async function loadExplorer(folder: vscode.WorkspaceFolder): Promise<void> {
+  const panel = explorerPanel;
+  if (!panel) return;
+  panel.webview.html = explorerMessage("Building the corpus graph…");
+  const out = path.join(os.tmpdir(), `rac-explorer-${Date.now()}.html`);
+  try {
+    await clientFor(folder).exportHtml(folder.uri.fsPath, out);
+    const html = await readFile(out, "utf8");
+    if (explorerPanel === panel) panel.webview.html = html;
+  } catch (err) {
+    if (err instanceof RacNotFoundError) warnMissingOnce();
+    if (explorerPanel === panel) {
+      const detail = err instanceof Error ? err.message : String(err);
+      panel.webview.html = explorerMessage(`RAC Explorer unavailable: ${escapeHtmlText(detail)}`);
+    }
+  } finally {
+    void rm(out, { force: true }).catch(() => undefined);
+  }
+}
+
+function explorerMessage(text: string): string {
+  return (
+    "<!DOCTYPE html><html><body " +
+    'style="font-family: var(--vscode-font-family); padding: 1rem; ' +
+    'color: var(--vscode-foreground)">' +
+    text +
+    "</body></html>"
+  );
+}
+
+function escapeHtmlText(value: string): string {
+  return value.replace(/[&<>]/g, (char) =>
+    char === "&" ? "&amp;" : char === "<" ? "&lt;" : "&gt;",
+  );
 }
 
 // --- authoring: completion, quick-fixes, new artifact -----------------------

--- a/typescript/rac-vscode/src/extension.ts
+++ b/typescript/rac-vscode/src/extension.ts
@@ -25,6 +25,7 @@ import {
   RacNotFoundError,
   isResolved,
   type CorpusExport,
+  type DirectoryValidation,
   type ExportArtifact,
   type FileValidation,
   type Issue,
@@ -35,28 +36,43 @@ import {
 
 const DEBOUNCE_MS = 300;
 const RELATIONSHIP_DEBOUNCE_MS = 600;
+const AWARENESS_DEBOUNCE_MS = 800;
 const ARTIFACT_TYPES = ["requirement", "decision", "roadmap", "prompt", "design"];
 
 let diagnostics: vscode.DiagnosticCollection;
 let relationshipDiagnostics: vscode.DiagnosticCollection;
+let workspaceDiagnostics: vscode.DiagnosticCollection;
+let statusBar: vscode.StatusBarItem;
 const clients = new Map<string, RacClient>();
 const exportCache = new Map<string, CorpusExport>();
 const debounce = new Map<string, ReturnType<typeof setTimeout>>();
 const relationshipDebounce = new Map<string, ReturnType<typeof setTimeout>>();
+const awarenessDebounce = new Map<string, ReturnType<typeof setTimeout>>();
 let warnedMissing = false;
 
 export function activate(context: vscode.ExtensionContext): void {
   diagnostics = vscode.languages.createDiagnosticCollection("rac");
   relationshipDiagnostics = vscode.languages.createDiagnosticCollection("rac-relationships");
+  workspaceDiagnostics = vscode.languages.createDiagnosticCollection("rac-workspace");
+  statusBar = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 0);
+  statusBar.command = "workbench.actions.view.problems";
   const selector: vscode.DocumentSelector = { language: "markdown", scheme: "file" };
 
   context.subscriptions.push(
     diagnostics,
     relationshipDiagnostics,
-    vscode.workspace.onDidOpenTextDocument((doc) => void validateDocument(doc)),
+    workspaceDiagnostics,
+    statusBar,
+    vscode.workspace.onDidOpenTextDocument((doc) => {
+      void validateDocument(doc);
+      // The live per-file collection owns open files; drop any workspace-scan
+      // diagnostic for it to avoid duplicates.
+      workspaceDiagnostics.delete(doc.uri);
+    }),
     vscode.workspace.onDidSaveTextDocument((doc) => {
       void validateDocument(doc);
       scheduleRelationshipsFor(doc);
+      scheduleAwarenessFor(doc);
       invalidateExportFor(doc);
     }),
     vscode.workspace.onDidChangeTextDocument((e) => scheduleValidate(e.document)),
@@ -70,6 +86,7 @@ export function activate(context: vscode.ExtensionContext): void {
         exportCache.clear();
         void validateWorkspace();
         refreshAllRelationships();
+        refreshAllAwareness();
       }
     }),
     vscode.commands.registerCommand("rac.validateWorkspace", validateWorkspace),
@@ -92,17 +109,23 @@ export function activate(context: vscode.ExtensionContext): void {
 
   for (const doc of vscode.workspace.textDocuments) void validateDocument(doc);
   refreshAllRelationships();
+  refreshAllAwareness();
 }
 
 export function deactivate(): void {
   for (const timer of debounce.values()) clearTimeout(timer);
   for (const timer of relationshipDebounce.values()) clearTimeout(timer);
+  for (const timer of awarenessDebounce.values()) clearTimeout(timer);
   debounce.clear();
   relationshipDebounce.clear();
+  awarenessDebounce.clear();
   diagnostics?.clear();
   diagnostics?.dispose();
   relationshipDiagnostics?.clear();
   relationshipDiagnostics?.dispose();
+  workspaceDiagnostics?.clear();
+  workspaceDiagnostics?.dispose();
+  statusBar?.dispose();
 }
 
 // --- per-file validation ----------------------------------------------------
@@ -323,6 +346,84 @@ function relationshipHeading(relationship: string): string {
 
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+// --- ambient awareness ------------------------------------------------------
+
+// A status-bar health score (rac review) and corpus-wide diagnostics
+// (rac validate <dir>), refreshed on save/activation. The live per-file
+// collection owns open files; the workspace scan covers the rest, so the
+// Problems panel reflects the whole corpus without double-reporting.
+
+function scheduleAwarenessFor(doc: vscode.TextDocument): void {
+  if (doc.languageId !== "markdown" || doc.uri.scheme !== "file") return;
+  if (!looksLikeRacArtifact(doc.getText())) return;
+  const folder = vscode.workspace.getWorkspaceFolder(doc.uri);
+  if (folder) scheduleAwareness(folder);
+}
+
+function scheduleAwareness(folder: vscode.WorkspaceFolder): void {
+  const key = folder.uri.fsPath;
+  const existing = awarenessDebounce.get(key);
+  if (existing) clearTimeout(existing);
+  awarenessDebounce.set(
+    key,
+    setTimeout(() => {
+      awarenessDebounce.delete(key);
+      void refreshAwareness(folder);
+    }, AWARENESS_DEBOUNCE_MS),
+  );
+}
+
+function refreshAllAwareness(): void {
+  for (const folder of vscode.workspace.workspaceFolders ?? []) {
+    void refreshAwareness(folder);
+  }
+}
+
+async function refreshAwareness(folder: vscode.WorkspaceFolder): Promise<void> {
+  if (!isEnabled()) return;
+  await Promise.allSettled([refreshStatusBar(folder), refreshWorkspaceDiagnostics(folder)]);
+}
+
+async function refreshStatusBar(folder: vscode.WorkspaceFolder): Promise<void> {
+  try {
+    const review = await clientFor(folder).review(folder.uri.fsPath);
+    statusBar.text = `$(pulse) RAC ${review.health.score}/100`;
+    statusBar.tooltip = review.ok
+      ? "RAC corpus: no blocking findings — click for Problems"
+      : "RAC corpus: blocking findings — click for Problems";
+    statusBar.show();
+  } catch (err) {
+    if (err instanceof RacNotFoundError) {
+      statusBar.hide();
+      warnMissingOnce();
+    } else {
+      console.error("RAC: review failed", err);
+    }
+  }
+}
+
+async function refreshWorkspaceDiagnostics(folder: vscode.WorkspaceFolder): Promise<void> {
+  let result: DirectoryValidation;
+  try {
+    result = await clientFor(folder).validateDirectory(folder.uri.fsPath);
+  } catch (err) {
+    if (err instanceof RacNotFoundError) warnMissingOnce();
+    else console.error("RAC: directory validation failed", err);
+    return;
+  }
+
+  workspaceDiagnostics.clear();
+  const openPaths = new Set(vscode.workspace.textDocuments.map((d) => d.uri.fsPath));
+  for (const file of result.files) {
+    if (file.issues.length === 0) continue;
+    const uri = path.isAbsolute(file.path)
+      ? vscode.Uri.file(file.path)
+      : vscode.Uri.joinPath(folder.uri, file.path);
+    if (openPaths.has(uri.fsPath)) continue; // live diagnostics own open files
+    workspaceDiagnostics.set(uri, file.issues.map(issueToDiagnostic));
+  }
 }
 
 // --- authoring: completion, quick-fixes, new artifact -----------------------


### PR DESCRIPTION
# Summary

Implements `rac/roadmaps/v0.21.x-editor/v0.21.5-corpus-visualization.md` — v0.21.5 of the `v0.21.x-editor` series. The corpus relationship graph, in an editor panel, by rendering the self-contained Portal viewer that `rac export --html` already produces (the `lore-web` build with the corpus injected, offline). Thin client (ADR-063): no viewer is bundled or re-built.

Adds:
- SDK: `exportHtml(dir, outPath)` wrapping `rac export --html --out`.
- Extension: a RAC: Open Explorer command that builds the Portal HTML and loads it in a webview; re-run to refresh. Graceful message when `rac` is absent.
- SDK unit and real-`rac` integration tests, plus README and CHANGELOG entries.

# Roadmap / ADR Trace

Roadmap:
- `rac/roadmaps/v0.21.x-editor/v0.21.5-corpus-visualization.md`

Relevant ADRs:
- `rac/decisions/adr-063-non-python-clients-are-thin.md` — the panel consumes `rac export` output; it parses and classifies nothing, and forks no second viewer.
- `rac/decisions/adr-007-additive-json-evolution.md` — reuses the stable `rac export` contract, exactly as the standalone Portal does.
- `rac/decisions/adr-002-offline-by-default.md` — the exported Portal is self-contained and offline; the webview adds no network.

# Scope

## Included
- `exportHtml` SDK method (unit test plus a real-`rac` integration that writes a Portal file).
- The webview panel rendering the corpus graph, loaded on the RAC: Open Explorer command; re-run refreshes.

## Excluded
- Graph-to-editor sync (click an artifact to open its file): the standalone Portal viewer does not post messages to a host, so wiring it would require changing the `lore-web` build — out of scope for a thin-client release. Recorded as the v0.21.5 Initiative 2 follow-on and scoped as v0.21.7.
- Auto-refresh on save: reloading the webview would reset its scroll/selection, so refresh is an explicit re-run for now.
- Robustness and packaging — deferred to v0.21.6.
- A new visualization engine distinct from `lore-web`, editing artifacts from the graph, and hosting the viewer beyond the in-editor panel (Non-Goals).

# Product / Architecture Decisions

- Reuse `rac export --html`, do not bundle a viewer. RAC already emits a self-contained Portal (inline JS/CSS/data, no network). The webview just hosts it (`enableScripts`, `retainContextWhenHidden`), so there is one viewer, kept in step with the standalone Portal via the same export contract.
- Temp-file handoff. `exportHtml` writes to an OS temp file, the extension reads it into `webview.html`, then removes it.

# User-Facing Contract

## CLI
None. No `rac` command or flag is added or changed; the SDK wraps the existing `rac export --html --out`.

## Human Output
New extension command `rac.showExplorer` (RAC: Open Explorer) opening a webview panel. No new settings. With `rac` absent, an actionable message rather than a failure.

## JSON Output
None. Consumes the existing `rac export` payload; no `rac --json` shape change.

## Exit Codes
None. No change to `rac` exit codes.

# Verification

## Ran
- SDK `npm test` — 22 passing (added `exportHtml` unit test plus a real-`rac` integration that writes a Portal HTML and asserts the `id="lore-export"` seam and size).
- Extension `npm run check-types` (strict) and `npm run compile` — clean (32.2kb bundle).
- Confirmed `rac export DIR --html --out` writes a ~560KB self-contained Portal with inlined scripts and no restrictive CSP (so it renders under `enableScripts`).
- Corpus gates: `rac validate rac/` exit 0; `rac relationships rac/ --validate` → 775 checked, 0 issues.

## Covered
- Positive: `exportHtml` argument building and real file output (integration writing a Portal file).
- Negative: `exportHtml` error path (unit).
- Not exercised: actual in-panel webview rendering is not run headlessly (no VS Code host in CI); the wiring is presentation over the tested SDK call.

# Review Path

1. `typescript/rac-sdk/src/client.ts` and its tests — `exportHtml`.
2. `typescript/rac-vscode/src/extension.ts` — the corpus-visualization section (build, webview, refresh, missing-`rac` message).
3. `typescript/rac-vscode/package.json` (command), roadmap, README, `CHANGELOG.md`.

# Notes For Reviewer

- Stacked on v0.21.4 (#114); merge after it. Targets `main`; merge in order for a clean per-release diff.
- On merge, flip the v0.21.5 roadmap `## Status` to `Achieved` (ADR-061).
- The deferred two-way sync (Initiative 2) is the first non-thin editor step (it touches the `lore-web` viewer); it is scoped separately as v0.21.7.

# Implementation Process

Implemented with AI assistance under the v0.21.5 roadmap contract; final scope, review, and acceptance decisions were made by the maintainer.