### PR TITLE
docs(roadmap): define v0.23.0 hardening scope, requirements, and ADRs [roadmap:v0.23.0]

### DIFF
--- a/rac/decisions/adr-065-artifact-content-untrusted.md
+++ b/rac/decisions/adr-065-artifact-content-untrusted.md
@@ -1,0 +1,142 @@
+---
+schema_version: 1
+id: RAC-KV6KFBDZ4D23
+type: decision
+tags: [security, trust, mcp, grounding, agents]
+---
+# ADR-065: Artifact Content Is Untrusted Input; the Trust Boundary Is Human PR Review
+
+## Status
+
+Accepted
+
+## Category
+
+Architecture
+
+## Context
+
+A coding agent connected to Lore ingests artifact content as **authoritative
+grounding** — it reads a decision and treats it as the team's settled position.
+That is the whole point (ADR-034: Lore serves facts, the agent reasons over
+them). It also makes artifact content an attack surface that earlier decisions
+did not address.
+
+The four MCP tools are read-only (ADR-030, ADR-032). The read-only guarantee
+protects the *store*: nothing the agent or server does can mutate the corpus.
+It says nothing about protecting the *agent*. A poisoned artifact — or a hostile
+pull request that adds one — can carry text engineered to steer the consuming
+agent: imperative overrides ("ignore previous instructions…"), impersonation of
+system/agent/tool messages, or content that argues the agent away from a
+recorded decision. The server will serve that text faithfully and deterministically,
+because serving recorded content faithfully is exactly its job.
+
+The red-team of the v0.23.0 plan flagged this as the highest-priority gap: we
+assert artifacts are trustworthy without recording *why* they are trustworthy or
+where that trust comes from. Determinism (ADR-002) guarantees the server returns
+the same bytes every time; it does not guarantee those bytes are benign.
+
+## Decision
+
+Artifact content is **untrusted input**. It becomes authoritative for an agent
+only because a human reviewed and merged it.
+
+- The **trust boundary is human pull-request review.** An artifact is trusted
+  to the extent that a human accepted it into the corpus through the project's
+  PR process. Content that has not passed human review — unreviewed branches,
+  machine-ingested documents not yet merged, anything outside the reviewed
+  corpus — is **out of scope and MUST NOT be treated as trusted.**
+- The **read-only MCP server protects the store, not the agent** (ADR-030,
+  ADR-032). It is not, and will not become, a content sanitizer or a verdict
+  engine; that would require the semantic judgment ADR-034 keeps out of core.
+- The mitigation against poisoned content is twofold and deterministic:
+  (1) the human PR gate, and (2) a `lore doctor` check that **flags
+  injection-style content** — imperative overrides, system/agent/tool
+  impersonation, and decision-steering language — as a reviewable warning,
+  never an auto-edit.
+- This trust model is **documented** (`SECURITY.md`) so users understand what
+  the read-only guarantee does and does not cover.
+
+This decision does not weaken determinism or the read-only surface; it names the
+threat those properties do not address and places the mitigation at the human
+review boundary, where it belongs.
+
+## Consequences
+
+### Positive
+
+- The product's central claim — "the agent grounds on trustworthy decisions" —
+  is now backed by a stated reason (human review) rather than an unexamined
+  assumption.
+- A poisoned-artifact attempt is catchable before merge: the `doctor` flag
+  surfaces it to the reviewer who is already the trust boundary.
+- The read-only server keeps a single, honest job; we do not bolt a fragile
+  content-sanitizer onto the serving path.
+
+### Negative
+
+- The guarantee is procedural, not technical: a project that does not actually
+  review PRs inherits no protection. We document this limit rather than pretend
+  to solve it in the server.
+- The injection-content heuristic is lexical and will both miss novel phrasings
+  and occasionally false-positive; it assists a human reviewer, it does not
+  replace one.
+
+### Risks
+
+- A reader mistakes the `doctor` flag for a guarantee and stops reviewing.
+  Mitigation: `SECURITY.md` states plainly that PR review is the boundary and
+  the flag is an aid, not a gate.
+- Pressure to make the server "just sanitize the content." Mitigation: this ADR
+  names the boundary; crossing it (a semantic verdict in core) requires
+  superseding both this decision and ADR-034.
+
+## Alternatives Considered
+
+### Sanitize or rewrite artifact content in the server
+
+Strip or neutralize suspicious content before serving it.
+
+#### Disadvantages
+
+- Rewriting served content silently changes recorded knowledge — it breaks the
+  byte-stable, read-only contract (ADR-032) and the no-auto-edit principle.
+- Deciding what is "suspicious" is semantic judgment core must not contain
+  (ADR-034).
+
+### A trust/verdict score on each artifact
+
+Return a computed "trustworthiness" number per artifact.
+
+#### Disadvantages
+
+- A deterministic lexical score dressed as a verdict is wrong in both directions
+  and consumed as authority anyway — the exact failure ADR-034 rejects.
+
+### Do nothing — rely on determinism alone
+
+Treat the read-only guarantee as sufficient.
+
+#### Disadvantages
+
+- Conflates protecting the store with protecting the agent; leaves the
+  highest-priority red-team gap unaddressed.
+
+Naming artifact content as untrusted, with PR review as the boundary and a
+`doctor` flag as the aid, is selected.
+
+## Related Decisions
+
+- adr-030
+- adr-032
+- adr-034
+- adr-049
+
+## Related Requirements
+
+- rac-artifact-trust-model
+- rac-doctor-diagnostic-validator
+
+## Related Roadmaps
+
+- v0.23.0-hardening

--- a/rac/decisions/adr-066-deterministic-grounding-eval.md
+++ b/rac/decisions/adr-066-deterministic-grounding-eval.md
@@ -1,0 +1,138 @@
+---
+schema_version: 1
+id: RAC-KV6KFCC8MHTM
+type: decision
+tags: [eval, determinism, retrieval, ci, benchmark]
+---
+# ADR-066: Grounding Eval Scoring Is Deterministic — No Embeddings, No LLM Judge
+
+## Status
+
+Accepted
+
+## Category
+
+Technical
+
+## Context
+
+v0.23.0 adds a grounding benchmark (`rac eval`, WS1): it runs a fixed query set
+against the real retrieval tools and scores whether the right artifacts come
+back. A benchmark gives us a number, and a number invites the usual ways of
+producing it — embedding similarity, a vector index, an LLM-as-judge scoring
+relevance. Each would make the benchmark *look* more sophisticated.
+
+Each would also poison the property the benchmark exists to defend. RAC core is
+deterministic by principle (ADR-002: AI is optional; ADR-034: no semantic
+verdicts in core; ADR-037/ADR-038: token-boundary, tiered search). A benchmark
+whose *score* depends on an embedding model, a vector store, or a model call is
+non-deterministic, network- and key-dependent, and unreproducible across
+machines and over time — so it could neither gate CI honestly nor be trusted to
+detect a real regression versus model drift. We would be measuring the judge,
+not the retrieval.
+
+The benchmark's job is narrow and adversarial-by-design: prove that the
+retrieval tools return the relevant artifacts and **never** surface a
+must-not-return artifact (a superseded decision presented as current is the
+exact failure Lore exists to prevent). That is a structural, countable property,
+not a semantic one.
+
+## Decision
+
+Eval scoring is a **pure, deterministic function of `(corpus, query set,
+retrieval code)`**.
+
+- **No embeddings, no vector search, no LLM judge** anywhere in the scored path
+  — consistent with ADR-002 and ADR-034. The eval runs offline with no API keys.
+- Scoring uses set-membership metrics over ranked tool output: Precision@k and
+  Recall@k against a declared relevant set, plus a hard-negative violation count
+  against a declared must-not-return set. The hard-negative check is a gate, not
+  a soft metric.
+- Rankings are made byte-stable by a defined tie-break: equal-scored artifacts
+  order by **ascending artifact id**, layered on the existing deterministic
+  retrieval sort (ADR-037).
+- The gated statistic is the `metrics` object only; diagnostic `metadata`
+  (timestamps, hashes) and `per_query` detail are excluded from gate comparison
+  so a clock never breaks the build. The `metrics` object MUST be byte-identical
+  across repeated runs on an unchanged corpus.
+- Re-baselining is **human-gated** (`rac eval --update-baseline`); CI never
+  updates the baseline.
+
+The eval measures real retrieval (it calls the same code the MCP tools call), so
+it guards the product surface rather than a parallel scoring model.
+
+## Consequences
+
+### Positive
+
+- The benchmark is reproducible, offline, and contract-testable byte-for-byte;
+  a failing gate means retrieval changed, not that a judge drifted.
+- Regression-injection tests can prove the gate is real (a forced recall drop or
+  hard-negative violation must fail it deterministically).
+- The benchmark reinforces, rather than erodes, the determinism guarantee the
+  rest of core depends on.
+
+### Negative
+
+- Set-membership metrics over a curated corpus do not capture graded relevance
+  or "good but not labelled" results; the benchmark guards labelled retrieval,
+  not subjective quality.
+- The corpus and query set must be authored and maintained by hand; their value
+  depends on sourcing realistic cases, not tuning numbers.
+
+### Risks
+
+- The fixture corpus drifts from real-world retrieval. Mitigation: grow the
+  query set from design-partner usage and treat the in-repo corpus as a
+  regression guard, not a vanity score.
+- A future contributor adds a "smarter" embedding-based scorer. Mitigation: this
+  ADR makes that a superseding decision, not a quiet change; the determinism
+  rule is pinned by the byte-stability test.
+
+## Alternatives Considered
+
+### Embedding / vector-similarity scoring
+
+Score relevance by cosine similarity in an embedding space.
+
+#### Disadvantages
+
+- Non-deterministic across model and library versions; requires a model and
+  often network; violates ADR-002 and the byte-stable contract.
+
+### LLM-as-judge
+
+Ask a model whether each result is relevant.
+
+#### Disadvantages
+
+- Non-deterministic, costly, key- and network-dependent; measures the judge, not
+  the retrieval; embeds the semantic verdict ADR-034 keeps out of core.
+
+### No benchmark — rely on unit tests
+
+Trust existing tests to catch retrieval regressions.
+
+#### Disadvantages
+
+- Unit tests assert individual behaviors; they do not measure aggregate
+  retrieval quality or guard against silent ranking regressions and
+  superseded-decision leakage across a realistic corpus.
+
+Deterministic set-membership scoring over real tool output is selected.
+
+## Related Decisions
+
+- adr-002
+- adr-034
+- adr-037
+- adr-038
+- adr-007
+
+## Related Requirements
+
+- rac-grounding-eval-benchmark
+
+## Related Roadmaps
+
+- v0.23.0-hardening

--- a/rac/designs/grounding-eval-scorecard.md
+++ b/rac/designs/grounding-eval-scorecard.md
@@ -1,0 +1,132 @@
+---
+schema_version: 1
+id: RAC-KV6KFDACQYYH
+type: design
+tags: [eval, scorecard, ci, gate, determinism]
+---
+# Grounding Eval Scorecard and CI Gate
+
+## Context
+
+WS1 of the v0.23.0 hardening release adds a deterministic grounding benchmark
+(`rac eval`). The non-trivial structure worth recording here is the *scorecard*
+— the machine-readable artifact every run writes — and the *gate* semantics that
+compare it against a committed baseline. The scoring rules are fixed by ADR-066
+(deterministic, no embeddings, no LLM judge); this design pins the data shapes
+and the gate's pass/fail logic so they can be implemented and tested without
+re-litigation.
+
+## User Need
+
+The maintainer and CI need to answer two questions deterministically and
+offline: "is retrieval still returning the right decisions?" and "did this
+change make retrieval worse?" They need a human-readable summary to read at a
+glance and a machine-readable scorecard CI can diff against a baseline — with
+timestamps and hashes excluded from the comparison so a clock never fails a
+build.
+
+## Design
+
+### Metrics (computed per case, then macro-aggregated)
+
+For each query case, obtain a deterministic ranked result list `R_q` from the
+target tool (`search_artifacts` or `get_related`). Tie-break: equal scores order
+by ascending artifact id (ADR-066). Let `Rel` be the declared `relevant` set and
+`top_k` the first `k` of `R_q`:
+
+- `P@k = |Rel ∩ top_k| / k` — empty/missing slots count against precision.
+- `R@k = |Rel ∩ top_k| / |Rel|` — `|Rel| ≥ 1` by construction.
+- Hard-negative violation: the case violates iff `must_not_return ∩ top_k ≠ ∅`.
+
+Aggregate as macro-averages (equal weight per case) at `k ∈ {1, 3, 5}` for both
+P and R, reported `overall`, `by_category`, and `by_tool`. Macro is the gated
+statistic. `negative_violations` is the summed violation count.
+
+### Scorecard shape (written every run; baseline at `tests/eval/baseline.json`)
+
+Three top-level objects. Only `metrics` is compared by the gate; `metadata` and
+`per_query` are diagnostic and excluded from comparison.
+
+```json
+{
+  "metrics": {
+    "overall": {"p_at_1": 0.0, "p_at_3": 0.0, "p_at_5": 0.0,
+                "r_at_1": 0.0, "r_at_3": 0.0, "r_at_5": 0.0,
+                "negative_violations": 0},
+    "by_category": {"constraint_check": {"p_at_1": 0.0, "r_at_5": 0.0}},
+    "by_tool": {"search_artifacts": {"p_at_1": 0.0, "r_at_5": 0.0},
+                "get_related": {"p_at_1": 0.0, "r_at_5": 0.0}}
+  },
+  "metadata": {"lore_version": "", "corpus_hash": "sha256:…",
+               "query_set_hash": "sha256:…", "n_queries": 0, "generated_at": ""},
+  "per_query": [{"id": "Q001", "returned": ["…"], "p_at_5": 0.0,
+                 "r_at_5": 0.0, "violations": []}]
+}
+```
+
+### Gate semantics (`rac eval --check`)
+
+Floors live in committed config (initial: `negative_violations == 0` always,
+`overall.p_at_1 ≥ 0.90`, `overall.r_at_5 ≥ 0.95`; tolerance `T = 0.02`). The
+gate FAILS if any of: (a) `negative_violations > 0`; (b) any gated metric
+`< floor`; (c) any gated metric `< baseline_value − T`. On failure it prints
+which rule fired plus the metric name, baseline value, and current value.
+Baselines are updated only by `rac eval --update-baseline`; CI never rebaselines.
+
+## Constraints
+
+- Deterministic and offline (ADR-066): no randomness, clock, or network in the
+  scored path; the `metrics` object is byte-identical across runs on an
+  unchanged corpus.
+- Scoring calls the same retrieval code the MCP tools call, so the benchmark
+  guards the real surface.
+- The scorecard JSON is an additive, stable contract (ADR-007).
+- Reuse the WS8 content-hash short-circuit so re-runs skip unchanged artifacts.
+
+## Rationale
+
+Separating `metrics` (gated) from `metadata`/`per_query` (diagnostic) is what
+lets the scorecard be both byte-stable for the gate and richly informative for a
+human, without a timestamp ever breaking CI. Macro-averaging weights every case
+equally, so a single category cannot be drowned out by case count.
+
+## Alternatives
+
+- Micro-averaging (weight by case count): rejected — lets large categories mask
+  regressions in small but important ones (e.g. supersession).
+- A single overall score with no per-category/per-tool breakdown: rejected —
+  hides *where* retrieval regressed, which is the actionable signal.
+- Token-based or similarity-based scoring: rejected by ADR-066.
+
+## Accessibility
+
+The human-readable summary prints plain-text tables (overall, by-category,
+by-tool) and lists every violating case with its returned ids, so the result is
+legible in a terminal and in CI logs without color or graphics.
+
+## Style Guidance
+
+Human summary: one overall table, then by-category and by-tool tables, then an
+explicit "Violations" section. Failure output names the rule, metric, baseline,
+and current value on one line each. JSON output follows the shape above exactly.
+
+## Open Questions
+
+- Initial floors are a starting point; calibrate from the first green run and
+  record any change with the baseline commit.
+- Whether `get_related` cases should weight relationship-type categories
+  differently is deferred until the query set grows from real usage.
+
+## Related Decisions
+
+- adr-066
+- adr-007
+- adr-037
+
+## Related Requirements
+
+- rac-grounding-eval-benchmark
+
+## Related Roadmaps
+
+- v0.23.0-hardening

--- a/rac/prompts/rac-v0.23-hardening-brief.md
+++ b/rac/prompts/rac-v0.23-hardening-brief.md
@@ -1,0 +1,101 @@
+---
+schema_version: 1
+id: RAC-KV6KFEA3F53R
+type: prompt
+tags: [release, hardening, brief, agent]
+---
+# v0.23.0 Hardening Release Brief
+
+## Objective
+
+Direct a coding agent to ship the v0.23.0 hardening release: harden Lore into a
+provably correct, transparent, robust deterministic grounding layer for coding
+agents. This prompt is the source brief for the release; it lives in the graph
+so the plan and its origin are both recorded (dogfooding). The authoritative
+expansion is the roadmap `v0.23.0-hardening` and its per-workstream requirements.
+
+The release succeeds only if a real or partner-representative agent
+demonstrably stops relitigating at least one real decision (the obey-demo,
+T3-A). Green CI and the eval gate are necessary but not sufficient.
+
+## Input
+
+- The RAC repository and its corpus under `rac/`: requirements, decisions
+  (ADRs), roadmaps, prompts, designs.
+- The four read-only MCP tools (`get_artifact`, `search_artifacts`,
+  `get_related`, `get_summary`) and the code-defined schema envelope.
+- The recorded decisions this release rests on: ADR-030, ADR-032, ADR-033,
+  ADR-002, ADR-034, ADR-052, ADR-049, plus the two it adds (ADR-065, ADR-066).
+
+## Instructions
+
+Build strictly in tier order; finish Tier 1 before Tier 2; touch Tier 3 only for
+its two carve-outs. Prefer the smallest change that satisfies each acceptance
+criterion. If a guardrail appears to block a requirement, pause and ask — do not
+work around it.
+
+- Tier 1 (this is the release): WS1 grounding eval + CI gate; WS2 explainable
+  retrieval; WS3 `rac doctor`; WS4 parser + bounded-traversal robustness;
+  WS11 trust model + injection flag + review signal.
+- Tier 2 (scope down, cut from the bottom if short): WS6 single-schema agreement
+  test (no Pydantic); WS5 minimal provenance; WS8 content-hash short-circuit
+  (core only); WS10 honest changelog + tiered tests.
+- Tier 3 (carve-outs only): T3-A manual obey-demo; T3-B `schema_version` already
+  present (no work); T3-C resumability not built.
+
+Each workstream is one requirement artifact carrying its normative statements and
+acceptance criteria; load-bearing decisions are recorded as ADRs (citing existing
+ones rather than duplicating them). Run `lore doctor` over the emitted artifacts;
+they must be schema-valid and pass the same checks the product enforces.
+
+## Output
+
+A correctly scoped, approved set of changes: the artifact graph (this brief, the
+roadmap, one requirement per workstream, ADR-065 and ADR-066, the eval-scorecard
+design); the `rac eval` and `rac doctor` subcommands with CI gates; additive
+`evidence`, provenance, and review-status fields on the four tools;
+`SECURITY.md`; an honest CHANGELOG entry; and a recorded obey-demo. The MCP
+surface stays exactly four read-only tools, with additive output only.
+
+## Constraints
+
+- Determinism is load-bearing: no AI/LLM, RAG, embeddings, or vector search in
+  any serving, validation, eval-scoring, doctor, or indexing path; runs offline.
+- The MCP tool surface is locked at four tools and stays read-only.
+- Humans author and review; nothing auto-edits artifact content. Artifact
+  content is untrusted; the trust boundary is human PR review.
+- The schema is defined once in code; all MCP output changes are additive and
+  backward-compatible.
+- Markdown + git + the existing stack only; no database, queue, daemon, HTTP+
+  OAuth server, or plugin system; no heavyweight dependencies.
+
+## Examples
+
+A search result enriched per WS2 carries deterministic evidence, for example:
+"matched field: title; term: 'eval'; via search_artifacts tier 1" — accurate,
+non-empty, reproducible.
+
+A `rac doctor` finding names the file, the problem, and a paste-ready fix, for
+example: "rac/decisions/adr-099.md: references missing adr-100 — run
+`rac find adr-100` or correct the reference in `## Related Decisions`."
+
+## Evaluation
+
+- The obey-demo shows the agent declining a forbidden change after consulting
+  Lore (the definition of done).
+- Tier 1 complete with all acceptance criteria; the full suite plus the eval
+  gate and `doctor` pass in CI.
+- Tier 2 complete or consciously descoped per each item's defer rules.
+- Tier 3 not built beyond the `schema_version` field and the manual obey-demo.
+- The MCP tools still number exactly four and remain read-only; no AI in core.
+
+## Related Decisions
+
+- adr-065
+- adr-066
+- adr-030
+- adr-034
+
+## Related Roadmaps
+
+- v0.23.0-hardening

--- a/rac/requirements/rac-artifact-trust-model.md
+++ b/rac/requirements/rac-artifact-trust-model.md
@@ -1,0 +1,71 @@
+---
+schema_version: 1
+id: RAC-KV6KFK645AMN
+type: requirement
+tags: [user-facing, security, trust, mcp, grounding]
+---
+# Requirement: Trust Model and Artifact-as-Attack-Surface
+
+## Status
+
+Proposed
+
+Classification: `[user-facing]` — assurance the grounding layer is not an
+injection vector. Scoped to the v0.23.0 hardening release (WS11).
+
+## Problem
+
+A coding agent ingests artifact content as authoritative grounding. The
+read-only MCP server protects the store, not the agent: a poisoned artifact or a
+hostile pull request can carry text engineered to steer the consuming agent away
+from recorded decisions. This was the red-team's highest-priority gap — we
+assert artifacts are trustworthy without recording why, or giving a consumer any
+signal to distinguish a reviewed decision from an unreviewed draft.
+
+## Requirements
+
+- [REQ-001] The release MUST document the trust model in `SECURITY.md`: artifact content is authoritative because it passed human PR review; the read-only MCP server protects the store, not the agent; unreviewed or machine-ingested content is out of scope and MUST NOT be treated as trusted (ADR-065).
+- [REQ-002] `SECURITY.md` MUST state the threat (a poisoned artifact or hostile PR can attempt to steer the consuming agent) and the mitigation (PR review plus the `rac doctor` injection flag).
+- [REQ-003] `rac doctor` MUST flag instruction-like / injection-style content in artifacts (shared with WS3).
+- [REQ-004] `get_artifact` MUST surface a review/trust signal — at minimum the artifact's status — additively, so a consumer can distinguish a reviewed-`Accepted` decision from a `Proposed`/draft artifact.
+- [REQ-005] Nothing in this release may auto-edit artifact content; the trust boundary remains human PR review.
+
+## Acceptance Criteria
+
+- The trust model is documented in `SECURITY.md`.
+- `rac doctor` flags a planted injection-style fixture, and a test asserts the
+  flag fires.
+- `get_artifact` exposes review status, verified by a test, as an additive
+  backward-compatible field.
+
+## Success Metrics
+
+- A user can articulate, from the docs, exactly what the read-only guarantee
+  does and does not protect.
+- A consumer can tell reviewed decisions apart from drafts via tool output.
+
+## Risks
+
+- A reader mistakes the doctor flag for a guarantee. Mitigation: `SECURITY.md`
+  states plainly that PR review is the boundary and the flag is an aid.
+
+## Assumptions
+
+- Front-matter status plus the provenance fields (WS5) carry enough signal to
+  power the review/trust distinction without PR-API plumbing this release.
+
+## Related Decisions
+
+- adr-065
+- adr-030
+- adr-032
+- adr-034
+
+## Related Requirements
+
+- rac-provenance-surfacing
+- rac-doctor-diagnostic-validator
+
+## Related Roadmaps
+
+- v0.23.0-hardening

--- a/rac/requirements/rac-doctor-diagnostic-validator.md
+++ b/rac/requirements/rac-doctor-diagnostic-validator.md
@@ -1,0 +1,72 @@
+---
+schema_version: 1
+id: RAC-KV6KFH925GH8
+type: requirement
+tags: [user-facing, doctor, validation, diagnostics]
+---
+# Requirement: Repository Health Diagnostic (doctor)
+
+## Status
+
+Proposed
+
+Classification: `[user-facing]` — the user runs it on their repo. Scoped to the
+v0.23.0 hardening release (WS3).
+
+## Problem
+
+`rac validate` answers pass/fail per file. When a repository is unhealthy — a
+broken reference, a dangling relationship, a duplicate id, a decision left
+`Accepted` that a later `Accepted` decision supersedes — a user is told *that*
+something is wrong but not *where* or *how to fix it*. A new adopter pointing
+Lore at a real, years-old corpus needs a single command that diagnoses health
+and hands back actionable, paste-ready fixes.
+
+## Requirements
+
+- [REQ-001] RAC MUST provide a `rac doctor` CLI subcommand that diagnoses repository health across malformed/invalid front matter, dangling or broken typed relationships, orphaned artifacts, duplicate ids, schema drift, and deterministically detectable contradictions.
+- [REQ-002] For every finding, `rac doctor` MUST print the exact file, the problem, and a paste-ready fix command or edit.
+- [REQ-003] `rac doctor` MUST flag relationship cycles and high-fan-out hubs, so authors fix the data that WS4 bounds at runtime.
+- [REQ-004] `rac doctor` MUST flag instruction-like / injection-style content — imperative overrides, impersonation of system/agent/tool instructions, or content steering the agent away from recorded decisions (supports WS11).
+- [REQ-005] `rac doctor` MUST exit non-zero on errors and zero when only warnings are present, and MUST be deterministic.
+- [REQ-006] `rac doctor` MUST be wired into CI alongside existing validation, and SHOULD reuse existing validation and relationship-integrity logic rather than re-deriving it (ADR-055, ADR-049).
+
+## Acceptance Criteria
+
+- `rac doctor` detects each defect class, covered by fixtures, and prints
+  actionable fixes.
+- Output is deterministic across runs on an unchanged repo.
+- A malformed artifact yields a clear `doctor` error rather than crashing
+  `get_artifact` / `search_artifacts` (with WS4).
+
+## Success Metrics
+
+- A user can take a real repository from "unknown health" to "clean" by
+  following `rac doctor` output without reading RAC's source.
+
+## Risks
+
+- The injection-content heuristic can false-positive. Mitigation: it is a
+  reviewable warning for a human, never an auto-edit or a standalone hard
+  failure (ADR-065).
+
+## Assumptions
+
+- The validator and relationship engine already detect most defect classes;
+  doctor aggregates and explains them with fixes rather than re-implementing.
+
+## Related Decisions
+
+- adr-055
+- adr-051
+- adr-049
+- adr-065
+
+## Related Requirements
+
+- rac-parser-traversal-robustness
+- rac-artifact-trust-model
+
+## Related Roadmaps
+
+- v0.23.0-hardening

--- a/rac/requirements/rac-explainable-retrieval.md
+++ b/rac/requirements/rac-explainable-retrieval.md
@@ -1,0 +1,69 @@
+---
+schema_version: 1
+id: RAC-KV6KFGA4PY4C
+type: requirement
+tags: [user-facing, retrieval, explainability, mcp]
+---
+# Requirement: Explainable Retrieval
+
+## Status
+
+Proposed
+
+Classification: `[user-facing]` — the user sees *why* the agent grounded. Scoped
+to the v0.23.0 hardening release (WS2).
+
+## Problem
+
+When Lore returns a search result, the consuming agent — and the human watching
+— sees *that* an artifact was retrieved but not *why*. "No guessing" is a claim
+we cannot currently show. Without a deterministic explanation of the match, a
+result is opaque: a user cannot tell whether a title, a tag, the body, or a
+relationship edge surfaced it, which undermines trust in the grounding.
+
+## Requirements
+
+- [REQ-001] Each `search_artifacts` result MUST carry a deterministic, non-empty `evidence` structure stating which field matched (id / title / path / heading / body), the matched term(s), and the retrieval tier.
+- [REQ-002] `get_related` results SHOULD carry evidence identifying the relationship edge (section and target) that surfaced the artifact.
+- [REQ-003] The `evidence` structure MUST be an additive, backward-compatible field on the existing tool output; the response schema and tool count MUST NOT otherwise change (ADR-007, ADR-030).
+- [REQ-004] RAC MUST provide a `rac find --explain` mode that prints per-stage match attribution for a query.
+- [REQ-005] The explanation MUST be a faithful description of the real match reason, derived from the existing token-tier match data (ADR-037, ADR-038), not a separate heuristic.
+
+## Acceptance Criteria
+
+- Every search result includes a non-empty, accurate, deterministic explanation,
+  and a test asserts the explanation matches the real match reason.
+- `rac find --explain` works from the CLI and prints per-stage attribution.
+- Existing MCP contract and golden tests still pass with the additive field
+  present (backward compatibility verified).
+
+## Success Metrics
+
+- A user inspecting a result can name the field and term that caused it without
+  reading the matcher's source.
+
+## Risks
+
+- Evidence text could be mistaken for a relevance verdict. Mitigation: it
+  describes the structural match (field, term, tier), never a semantic judgment
+  (ADR-034).
+
+## Assumptions
+
+- The existing matcher already computes the tier and matched terms, so evidence
+  is surfacing existing data rather than recomputing it.
+
+## Related Decisions
+
+- adr-037
+- adr-038
+- adr-007
+- adr-030
+
+## Related Requirements
+
+- rac-grounding-eval-benchmark
+
+## Related Roadmaps
+
+- v0.23.0-hardening

--- a/rac/requirements/rac-grounding-eval-benchmark.md
+++ b/rac/requirements/rac-grounding-eval-benchmark.md
@@ -1,0 +1,82 @@
+---
+schema_version: 1
+id: RAC-KV6KFF98VDBX
+type: requirement
+tags: [user-facing, eval, retrieval, benchmark, ci]
+---
+# Requirement: Grounding Retrieval Benchmark
+
+## Status
+
+Proposed
+
+Classification: `[user-facing]` — it is the proof the tool works. Scoped to the
+v0.23.0 hardening release (WS1).
+
+## Problem
+
+Lore's core claim is that an agent retrieves the right recorded decision at the
+right moment. Today that claim rests on unit tests of individual behaviors and
+on demo anecdote; nothing measures aggregate retrieval quality or guards against
+silent regressions. The failure that matters most — surfacing a superseded
+decision as if it were current — is exactly what Lore exists to prevent, yet
+there is no gate that fails the build when it happens.
+
+## Requirements
+
+- [REQ-001] RAC MUST provide a `rac eval` CLI subcommand that scores the retrieval tools against a versioned fixture corpus and query set.
+- [REQ-002] Eval scoring MUST be deterministic and offline: a pure function of `(corpus, query set, retrieval code)`, with no network, no API keys, no randomness, no clock in the scored path, and no embeddings or LLM judge (ADR-066).
+- [REQ-003] `rac eval` MUST compute Precision@k and Recall@k at `k ∈ {1, 3, 5}` as macro-averages reported `overall`, `by_category`, and `by_tool`, and MUST count hard-negative violations (a `must_not_return` id appearing in top-k).
+- [REQ-004] Ranking MUST be byte-stable: equal-scored artifacts order by ascending artifact id, layered on the existing deterministic retrieval sort.
+- [REQ-005] `rac eval` MUST write a scorecard with `metrics`, `metadata`, and `per_query` objects, and MUST record a `corpus_hash` and `query_set_hash`; only `metrics` is compared by the gate.
+- [REQ-006] RAC MUST provide a `rac eval --check` CI gate that FAILS on any hard-negative violation, any gated metric below an absolute floor, or any gated metric below `baseline − tolerance`, printing which rule fired with the metric, baseline, and current values.
+- [REQ-007] Re-baselining MUST be human-gated via `rac eval --update-baseline`; CI MUST NOT ever update the baseline.
+- [REQ-008] The fixture corpus MUST be schema-valid, pass `rac doctor`, span all five artifact types, and include a supersession chain, distractors, and an ambiguous pair.
+- [REQ-009] The eval SHOULD reuse the WS8 content-hash short-circuit so re-runs skip unchanged artifacts.
+
+## Acceptance Criteria
+
+- `rac eval` runs offline with no network or keys; the `metrics` object is
+  byte-identical across repeated runs on an unchanged corpus.
+- Three regression-injection tests prove the gate is real: a clean corpus
+  passes; a deterministically removed relevant artifact drops `r_at_5` and fails
+  the gate; a forced `must_not_return` id in top-k fails the gate on violations.
+- The human-readable summary prints overall, by-category, and by-tool tables and
+  lists every violating case with its returned ids.
+- The gate is wired into CI and fails the build on regression.
+
+## Success Metrics
+
+- The committed baseline meets the initial floors (`negative_violations == 0`,
+  `overall.p_at_1 ≥ 0.90`, `overall.r_at_5 ≥ 0.95`).
+- A deliberately introduced retrieval regression is caught by CI rather than by
+  a human noticing later.
+
+## Risks
+
+- Floors mis-calibrated before the first green run. Mitigation: calibrate from
+  the first run, commit the baseline, gate on `baseline − tolerance` thereafter.
+- A fixture corpus that drifts from real retrieval. Mitigation: source cases
+  from real or partner-representative repos and grow from design-partner usage.
+
+## Assumptions
+
+- The existing deterministic retrieval surfaces (`search_artifacts`,
+  `get_related`) are the right thing to benchmark and guard.
+
+## Related Decisions
+
+- adr-066
+- adr-002
+- adr-037
+- adr-038
+- adr-007
+
+## Related Requirements
+
+- rac-idempotent-content-hash-processing
+- rac-single-schema-agreement
+
+## Related Roadmaps
+
+- v0.23.0-hardening

--- a/rac/requirements/rac-honest-changelog-tiered-tests.md
+++ b/rac/requirements/rac-honest-changelog-tiered-tests.md
@@ -1,0 +1,64 @@
+---
+schema_version: 1
+id: RAC-KV6KFQ0J1TEM
+type: requirement
+tags: [internal, changelog, testing, release]
+---
+# Requirement: Honest Changelog and Tiered Tests
+
+## Status
+
+Proposed
+
+Classification: `[internal]`. Scoped to the v0.23.0 hardening release (WS10).
+
+## Problem
+
+A hardening release needs trust signals and fast feedback loops. The test suite
+runs as 24 CI batteries but is not organized into documented tiers a developer
+can run locally, and a release with significant deferred scope needs a changelog
+that is honest about what shipped, what was deferred, and what the known limits
+are — without overclaiming.
+
+## Requirements
+
+- [REQ-001] The release MUST structure the test suite into three documented tiers — a unit-test inner loop, a pre-push verify gate, and a full local CI command — and document each tier's command.
+- [REQ-002] The release MUST add a CHANGELOG entry with honest scope notes: what shipped, what is deferred, and known limits — explicitly that the MCP server is pull-based and that code-vs-decision CI enforcement is a future release.
+- [REQ-003] The CHANGELOG user-facing headline MUST lead only with the user-facing items (explainable retrieval, `rac doctor`, provenance, the trust model) plus "provably works"; internal plumbing MUST NOT be headlined.
+- [REQ-004] The release version MUST be set to `v0.23.0` via the git tag (setuptools-scm); there is no VERSION file to edit.
+
+## Acceptance Criteria
+
+- The three test tiers exist and are documented with their commands.
+- The CHANGELOG entry is specific and honest about scope, tradeoffs, and limits.
+- The version is bumped to `v0.23.0` at release via tag.
+
+## Success Metrics
+
+- A developer can run the right test tier for the change at hand without reading
+  CI internals.
+- A reader of the CHANGELOG understands exactly what this release does and does
+  not deliver.
+
+## Risks
+
+- Headlining internal items would misrepresent the release as feature-heavy.
+  Mitigation: the narrative discipline is encoded in REQ-003.
+
+## Assumptions
+
+- The existing 24-battery structure can be grouped into three documented tiers
+  without restructuring the tests themselves.
+
+## Related Decisions
+
+- adr-027
+- adr-007
+
+## Related Requirements
+
+- rac-grounding-eval-benchmark
+
+## Related Roadmaps
+
+- v0.23.0-hardening

--- a/rac/requirements/rac-idempotent-content-hash-processing.md
+++ b/rac/requirements/rac-idempotent-content-hash-processing.md
@@ -1,0 +1,64 @@
+---
+schema_version: 1
+id: RAC-KV6KFP1QDRB0
+type: requirement
+tags: [internal, performance, determinism, hashing]
+---
+# Requirement: Idempotent Content-Hash Processing
+
+## Status
+
+Proposed
+
+Classification: `[internal]`. Scoped to the v0.23.0 hardening release (WS8,
+core only).
+
+## Problem
+
+Lore's buyers are teams with years of accumulated decisions, not a tiny repo on
+day one. The inner loop and CI must stay fast on an ICP-sized corpus, and the
+determinism guarantee that underpins the eval benchmark (WS1) needs reinforcing:
+the same input must always produce identical derived output. Today, validation,
+eval, and doctor reprocess everything every run.
+
+## Requirements
+
+- [REQ-001] RAC MUST content-hash every artifact and short-circuit unchanged artifacts in validation, eval, and doctor processing.
+- [REQ-002] Derived output MUST be idempotent and byte-stable: the same input produces identical output, underpinning WS1's byte-stability.
+- [REQ-003] The short-circuit MUST apply to CLI processing only and MUST NOT introduce a persistent cache into the MCP serving path, which re-reads per call (ADR-032).
+- [REQ-004] Resumability and crash-safe incremental job machinery (partial-run resumption, two-phase persistence) are explicitly out of scope; there is no long-running interruptible operation yet.
+
+## Acceptance Criteria
+
+- Re-running on an unchanged repo does near-zero work and is provably idempotent
+  (test).
+- Changing one artifact reprocesses only that artifact.
+- Outputs are byte-stable across runs.
+
+## Success Metrics
+
+- CI and the inner loop stay fast on a large, realistic corpus.
+
+## Risks
+
+- A hash short-circuit could mask a real change. Mitigation: hash over full
+  artifact content; cover with tests that change one artifact and assert only it
+  reprocesses.
+
+## Assumptions
+
+- The source of truth stays in markdown/git; derived data is always rebuildable.
+
+## Related Decisions
+
+- adr-032
+- adr-011
+- adr-013
+
+## Related Requirements
+
+- rac-grounding-eval-benchmark
+
+## Related Roadmaps
+
+- v0.23.0-hardening

--- a/rac/requirements/rac-obey-demo-grounding-proof.md
+++ b/rac/requirements/rac-obey-demo-grounding-proof.md
@@ -1,0 +1,67 @@
+---
+schema_version: 1
+id: RAC-KV6KFQZHDFR5
+type: requirement
+tags: [user-facing, demo, grounding, proof]
+---
+# Requirement: Obey-Demo Grounding Proof
+
+## Status
+
+Proposed
+
+Classification: the release's success proof. Scoped to the v0.23.0 hardening
+release (T3-A).
+
+## Problem
+
+The release's definition of done is an outcome, not green CI: a real coding
+agent must demonstrably stop relitigating a recorded decision. An automated
+multi-agent CI harness to prove this would be non-deterministic, slow, costly,
+and only half-automatable in a week. What is needed instead is one reproducible,
+honest manual demonstration.
+
+## Requirements
+
+- [REQ-001] The release MUST produce one reproducible manual demonstration: a fixture or partner-representative repo with an `Accepted` ADR forbidding a change, a real coding agent wired to the four tools, and a prompt that would violate the decision.
+- [REQ-002] The demonstration MUST capture a recording or log showing the agent consulted Lore and did NOT perform the forbidden change.
+- [REQ-003] The demonstration MUST ship with written, repeatable steps and MUST NOT be a CI gate.
+- [REQ-004] The release MUST NOT build an automated multi-agent CI harness; this manual obey-demo supersedes that intent.
+- [REQ-005] Results MUST be genuine; faked or staged outcomes are unacceptable.
+
+## Acceptance Criteria
+
+- A recorded, repeatable demo plus written steps exists.
+- It is explicitly a manual smoke, not a CI gate, with no faked results.
+- Setup notes for additional agents (Cursor, Codex) MAY be documented but are
+  not required.
+
+## Success Metrics
+
+- The release success criterion is met: a real or partner-representative agent
+  does not relitigate the forbidden decision after consulting Lore.
+
+## Risks
+
+- A single demo may not generalize. Mitigation: source the scenario from a real
+  or partner-representative decision and document the steps so it can be re-run
+  and extended.
+
+## Assumptions
+
+- A real coding agent wired to the four read-only tools is sufficient to
+  demonstrate grounding without bespoke harness infrastructure.
+
+## Related Decisions
+
+- adr-034
+- adr-065
+
+## Related Requirements
+
+- rac-artifact-trust-model
+- rac-grounding-eval-benchmark
+
+## Related Roadmaps
+
+- v0.23.0-hardening

--- a/rac/requirements/rac-parser-traversal-robustness.md
+++ b/rac/requirements/rac-parser-traversal-robustness.md
@@ -1,0 +1,71 @@
+---
+schema_version: 1
+id: RAC-KV6KFJ7BERWG
+type: requirement
+tags: [internal, robustness, parser, traversal, mcp]
+---
+# Requirement: Parser and Bounded-Traversal Robustness
+
+## Status
+
+Proposed
+
+Classification: `[internal]` — invisible, but the server must never crash in
+front of a partner. Scoped to the v0.23.0 hardening release (WS4).
+
+## Problem
+
+The MCP server sits in an agent's critical path. A malformed artifact, an
+oversized field, or a pathological relationship graph must never crash, hang, or
+exhaust memory. The front-matter/markdown parser currently has no input-size
+caps and no fuzz coverage, and while `get_related` is one-hop and the ADR-033
+response budget bounds its output, those guarantees are not yet asserted against
+adversarial input.
+
+## Requirements
+
+- [REQ-001] The parser MUST cap input sizes per-file and per-field, and MUST guard any user-defined regex/pattern features against catastrophic backtracking (ReDoS).
+- [REQ-002] A single malformed artifact MUST degrade gracefully — reported and skipped — and MUST NOT crash `get_artifact` / `search_artifacts` or fail CI uninformatively.
+- [REQ-003] The release MUST add fuzz/property tests over the parser covering malformed YAML, oversized fields, unicode, deep nesting, and binary junk.
+- [REQ-004] `get_related` output MUST remain bounded by the ADR-033 response budget, with a deterministic result cap and ordering (relationship type, then ascending artifact id) and a backward-compatible truncation signal.
+- [REQ-005] When any cap truncates output, the kept items MUST be selected and ordered deterministically so output stays byte-stable.
+- [REQ-006] Any future multi-hop traversal MUST add explicit depth, frontier, visited-set, and work-budget caps before shipping; this release does not add multi-hop traversal.
+
+## Acceptance Criteria
+
+- Parser fuzz tests pass; a malformed artifact yields a clear `doctor` error and
+  does not crash `get_artifact` / `search_artifacts`.
+- Graph fuzz fixtures — cycles, self-references, deep chains, and a high-fan-out
+  hub — all terminate within budget with well-formed, deterministically
+  truncated output and the truncation signal set.
+- A test asserts traversal/serving over an adversarial graph completes within
+  the budget with no unbounded time or memory.
+
+## Success Metrics
+
+- No input — malformed file or pathological graph — can hang, crash, or OOM the
+  serving path.
+
+## Risks
+
+- Over-tight caps could reject legitimately large artifacts. Mitigation: caps
+  are configurable with safe defaults proven against adversarial input.
+
+## Assumptions
+
+- The ADR-033 budget already bounds response size; this release proves and
+  extends that guarantee rather than re-architecting serving.
+
+## Related Decisions
+
+- adr-033
+- adr-055
+- adr-032
+
+## Related Requirements
+
+- rac-doctor-diagnostic-validator
+
+## Related Roadmaps
+
+- v0.23.0-hardening

--- a/rac/requirements/rac-provenance-surfacing.md
+++ b/rac/requirements/rac-provenance-surfacing.md
@@ -1,0 +1,64 @@
+---
+schema_version: 1
+id: RAC-KV6KFN3HPGS1
+type: requirement
+tags: [user-facing, provenance, git, mcp]
+---
+# Requirement: Provenance Surfacing
+
+## Status
+
+Proposed
+
+Classification: `[user-facing]` — the agent can cite who decided and when.
+Scoped to the v0.23.0 hardening release (WS5).
+
+## Problem
+
+Lore claims every decision has an accountable human author, but `get_artifact`
+does not surface that accountability. An agent grounding on a decision cannot
+cite who made it, when, or whether it has moved from proposed to accepted to
+superseded. The information already exists in front matter and git history; it
+is simply not exposed on the tool surface.
+
+## Requirements
+
+- [REQ-001] `get_artifact` MUST expose, additively and backward-compatibly, at minimum: author(s) plus last-commit author, relevant dates, and status history (Proposed → Accepted → Superseded), sourced from front matter plus git.
+- [REQ-002] Provenance MUST be derived from git rather than stored dates in front matter (ADR-045); a `reviewers` front-matter field MAY be used to power the WS11 review signal.
+- [REQ-003] Provenance fields SHOULD be surfaced in search/explain output where useful.
+- [REQ-004] Full PR-reviewer extraction (squash-merge handling, review threads) is out of scope for this release.
+
+## Acceptance Criteria
+
+- Provenance populates for this release's dogfooded ADRs (ADR-065, ADR-066).
+- Tests assert the fields populate from front matter plus git.
+- The new fields are additive; existing `get_artifact` consumers are unaffected.
+
+## Success Metrics
+
+- An agent can cite an accountable author and the status of a decision directly
+  from tool output.
+
+## Risks
+
+- Git plumbing can balloon. Mitigation: limit to author/last-commit-author,
+  dates, and status history; defer PR-reviewer extraction.
+
+## Assumptions
+
+- Git history and front matter carry enough provenance for this release without
+  a PR-API integration.
+
+## Related Decisions
+
+- adr-045
+- adr-050
+- adr-025
+
+## Related Requirements
+
+- rac-artifact-trust-model
+
+## Related Roadmaps
+
+- v0.23.0-hardening

--- a/rac/requirements/rac-single-schema-agreement.md
+++ b/rac/requirements/rac-single-schema-agreement.md
@@ -1,0 +1,63 @@
+---
+schema_version: 1
+id: RAC-KV6KFM5484B9
+type: requirement
+tags: [internal, schema, contract, mcp, tui]
+---
+# Requirement: Single-Schema Cross-Consumer Agreement
+
+## Status
+
+Proposed
+
+Classification: `[internal]`. Scoped to the v0.23.0 hardening release (WS6).
+
+## Problem
+
+The artifact schema — front-matter fields, types, relationship kinds, status
+enums, required sections — is consumed by the validator, the four MCP tool
+serializers, and the TUI. If those consumers could drift apart, a field valid in
+one surface might be mis-served in another. RAC already defines the schema once,
+in code, as the front-matter envelope (ADR-052, ADR-049); the gap is that no
+test *asserts* the consumers still agree, so drift would be silent.
+
+## Requirements
+
+- [REQ-001] The schema MUST remain defined once as the code-defined envelope; this release MUST NOT introduce a parallel schema framework such as a new Pydantic model layer or a JSON-Schema source of truth (ADR-052, ADR-049).
+- [REQ-002] The release MUST add a test asserting the validator, the four MCP serializers, and the TUI adapter all agree with the single schema definition for types, statuses, relationship kinds, and required sections.
+- [REQ-003] Any residual ad-hoc schema logic found on those consumer paths SHOULD be removed in favor of the single definition.
+- [REQ-004] Changing a field in the single definition MUST propagate to every consumer that reads it, demonstrated by the agreement test.
+
+## Acceptance Criteria
+
+- Exactly one schema source exists.
+- A test asserts the validator, MCP output, and TUI agree with it.
+- Changing a field in one place propagates everywhere it is consumed.
+
+## Success Metrics
+
+- A schema change cannot ship without the agreement test reflecting it across
+  all consumers.
+
+## Risks
+
+- The TUI could lag the schema. Mitigation: the TUI already consumes Core via
+  `load_repository`, so the agreement test covers it without a migration.
+
+## Assumptions
+
+- The code-defined envelope is, and remains, the authoritative schema (ADR-052).
+
+## Related Decisions
+
+- adr-052
+- adr-049
+- adr-025
+
+## Related Requirements
+
+- rac-grounding-eval-benchmark
+
+## Related Roadmaps
+
+- v0.23.0-hardening

--- a/rac/roadmaps/v0.23.x-hardening/v0.23.0-hardening.md
+++ b/rac/roadmaps/v0.23.x-hardening/v0.23.0-hardening.md
@@ -1,0 +1,224 @@
+---
+schema_version: 1
+id: RAC-KV6KFAFC4HYK
+type: roadmap
+tags: [hardening, eval, doctor, trust, robustness, provenance]
+---
+# RAC v0.23.0 — Hardening
+
+## Status
+
+Planned
+
+## Context
+
+Lore (the product) grounds coding agents in a team's recorded decisions, served
+deterministically over four read-only MCP tools (ADR-030, ADR-032, ADR-034). The
+core claim — "the agent stops relitigating settled decisions" — rests on three
+properties we assert but have never *proven* in the repository: that retrieval
+returns the right artifact, that the serving path cannot be crashed or flooded
+by hostile input, and that the artifact content an agent ingests as authoritative
+is trustworthy because a human reviewed it.
+
+This release hardens those properties and makes them legible to a user. It is
+ruthlessly scoped to one week. It adds **no AI to the core**, **no fifth tool**,
+**no write capability**, and **no new infrastructure** — every capability ships
+as a CLI subcommand or CI check, or as additive fields on the existing four
+tools' output (ADR-007). A prior ten-item plan was red-teamed; this is the
+surviving, re-tiered scope, reconciled against the decisions RAC has already
+recorded rather than re-deciding them.
+
+## Outcomes
+
+User-felt outcomes (the release narrative leads only with these):
+
+- **Explainable grounding** — a search result shows *why* it was retrieved
+  (which field matched, which term, which relationship edge), not just *that*
+  it was (WS2).
+- **`rac doctor`** — a user runs one command on their repo and gets actionable,
+  paste-ready fixes for malformed front matter, broken/cyclic relationships,
+  orphans, duplicate IDs, contradictions, and injection-style content (WS3).
+- **Provenance** — `get_artifact` exposes who decided, when, and the status
+  history, so an agent can cite an accountable human author (WS5).
+- **A documented trust model** — artifact content is untrusted input made
+  authoritative by human PR review; the read-only server protects the store,
+  the PR gate protects the agent (WS11, ADR-065).
+- **Proof it works and does not break** — a gated retrieval benchmark (WS1) and
+  parser/traversal robustness (WS4) turn "trust us" into a regression guard.
+
+Internal plumbing (WS6 schema agreement, WS8 content-hash short-circuit, WS10
+tiered tests) ships quietly; there is no user-facing "hardening release."
+
+## Initiatives
+
+### Tier 1 — this is the release (built first, complete before Tier 2)
+
+- **WS1 — Grounding benchmark, gated in CI** `[user-facing]`. `rac eval` over a
+  versioned fixture corpus + query set; deterministic Precision@k / Recall@k
+  plus a hard-negative violation check; committed baseline; `rac eval --check`
+  CI gate. Proves retrieval is right and stays right.
+- **WS2 — Explainable retrieval** `[user-facing]`. Additive `evidence` on
+  `search_artifacts` / `get_related` results; `rac find --explain`.
+- **WS3 — `rac doctor` diagnostic validator** `[user-facing]`. Health diagnosis
+  with actionable fixes; flags cycles, high-fan-out hubs, contradictions, and
+  injection-style content.
+- **WS4 — Robustness: parser + bounded traversal** `[internal]`. Input-size
+  caps, ReDoS guards, graceful degradation, fuzz tests; confirm the ADR-033
+  response budget bounds `get_related` output deterministically.
+- **WS11 — Trust model & artifact-as-attack-surface** `[user-facing]`.
+  `SECURITY.md`; the doctor injection flag; a review/trust signal on
+  `get_artifact`. Records ADR-065.
+
+### Tier 2 — keep, scope down (cut from the bottom if the week runs short)
+
+- **WS6 — Contract-first single schema** `[internal]`. The schema is already
+  single-sourced as the code-defined envelope (ADR-052, ADR-049); add a
+  cross-consumer agreement test across the validator, the four MCP serializers,
+  and the TUI. No Pydantic, no rewrite.
+- **WS5 — Provenance (minimal)** `[user-facing]`. Additive author/date/status-
+  history fields on `get_artifact`, from front matter + git (ADR-045).
+- **WS8 — Idempotent, content-hash short-circuit (core only)** `[internal]`.
+  Content-hash artifacts; skip unchanged ones in validation/eval/doctor;
+  byte-stable derived output. CLI processing only — never a server cache
+  (ADR-032).
+- **WS10 — Honest changelog + tiered tests** `[internal]`. Three documented test
+  tiers; an honest CHANGELOG entry; the `v0.23.0` tag.
+
+### Tier 3 — deferred / cut (only the two carve-outs)
+
+- **T3-A — Obey-demo** (the success proof). One reproducible *manual* demo of a
+  real agent declining a forbidden change after consulting Lore. Not a CI gate.
+- **T3-B — `schema_version`**. Already present (`schema_version: 1`); no work.
+- **T3-C — Resumability / crash-safe jobs**. Not built.
+
+## Workstream Checklist
+
+Cross-session progress tracker. Status: `planned` → `in-progress` → `done` /
+`descoped`. This roadmap is the canonical tracker; there is no separate
+`RELEASE_PLAN.md`.
+
+Tier 1:
+
+- [ ] WS1 grounding-eval-benchmark — `rac eval` + CI gate — `planned`
+- [ ] WS2 explainable-retrieval — `evidence` + `--explain` — `planned`
+- [ ] WS3 doctor-diagnostic-validator — `rac doctor` — `planned`
+- [ ] WS4 parser-traversal-robustness — caps + fuzz + bounded output — `planned`
+- [ ] WS11 artifact-trust-model — `SECURITY.md` + injection flag + review signal — `planned`
+
+Tier 2:
+
+- [ ] WS6 single-schema-agreement — cross-consumer agreement test — `planned`
+- [ ] WS5 provenance-surfacing — author/date/status-history on `get_artifact` — `planned`
+- [ ] WS8 idempotent-content-hash-processing — short-circuit + byte-stability — `planned`
+- [ ] WS10 honest-changelog-tiered-tests — tiers + CHANGELOG + tag — `planned`
+
+Tier 3 (carve-outs only):
+
+- [ ] T3-A obey-demo-grounding-proof — recorded manual demo — `planned`
+
+## Success Measures
+
+The release succeeds only if the **obey-demo (T3-A)** shows a real or
+partner-representative coding agent *demonstrably declining to relitigate at
+least one real decision* after consulting Lore. Green CI and the new eval gate
+are necessary but not sufficient — if every workstream is complete but that one
+outcome cannot be shown, the release is not done.
+
+Supporting measures:
+
+- `rac eval --check` passes on the committed baseline; its `metrics` object is
+  byte-identical across repeated runs on an unchanged corpus; the three
+  regression-injection tests prove the gate fires.
+- `rac doctor` detects every defect class on fixtures, deterministically, with
+  paste-ready fixes.
+- The full test suite plus the new eval gate and `doctor` pass in CI; the MCP
+  surface is still exactly four read-only tools, with only additive output
+  changes.
+
+## Constraints
+
+Non-negotiable guardrails, each a recorded decision:
+
+- Determinism is load-bearing: no AI/LLM, RAG, embeddings, or vector search in
+  any serving, validation, eval-scoring, doctor, or indexing path (ADR-002,
+  ADR-034, ADR-066). Everything runs offline with no keys.
+- The MCP tool surface is locked at exactly four tools — `get_artifact`,
+  `search_artifacts`, `get_related`, `get_summary` — and stays read-only
+  (ADR-030, ADR-032).
+- Humans author and review; nothing auto-edits artifact content. Artifact
+  content is untrusted input; the trust boundary is human PR review (ADR-065).
+- The schema is defined once, in code, as the front-matter envelope
+  (ADR-052, ADR-049); all MCP output changes are additive and
+  backward-compatible (ADR-007).
+- Markdown + git + the existing stack only; no database, queue, daemon, HTTP+
+  OAuth server, or plugin system.
+
+## Non-Goals
+
+- No Pydantic schema rewrite — the code-defined envelope already is the single
+  source (ADR-052); WS6 adds an agreement test only.
+- No automated multi-agent CI harness — replaced by the manual obey-demo (T3-A),
+  which is deterministic to reproduce and honest about being a manual smoke.
+- No schema-migration framework — reduced to the existing `schema_version`
+  field (T3-B); revisit when a real v1→v2 migration exists.
+- No resumability / crash-safe job machinery — there is no long-running
+  interruptible operation yet (T3-C).
+- No multi-hop relationship-traversal engine — `get_related` is 1-hop; the
+  ADR-033 response budget already bounds its output.
+- No full CI enforcement of code-vs-decision conflicts — noted in the CHANGELOG
+  as a future release.
+
+## Risks
+
+- The eval floors (`p_at_1 ≥ 0.90`, `r_at_5 ≥ 0.95`) may be mis-calibrated
+  before the first green run. Mitigation: calibrate from the first run, commit
+  the baseline, and gate on `baseline − tolerance` thereafter; CI never
+  rebaselines.
+- A fixture-only corpus can drift from real retrieval. Mitigation: source query
+  cases from real or partner-representative repos where possible and grow the
+  set from design-partner usage; treat the in-repo corpus as a regression guard.
+- The injection-content check is heuristic and can false-positive. Mitigation:
+  it is a `doctor` warning surfaced for human review, never an auto-edit or a
+  hard CI failure on its own.
+
+## Assumptions
+
+- The existing deterministic retrieval (ADR-037, ADR-038) and 1-hop
+  relationship resolution are the right surfaces to benchmark and explain; the
+  release guards them rather than replacing them.
+- Front matter plus git history carry enough provenance (author, dates, status)
+  to power WS5 and WS11 without PR-API plumbing this release (ADR-045).
+
+## Related Decisions
+
+- adr-065
+- adr-066
+- adr-030
+- adr-032
+- adr-033
+- adr-034
+- adr-052
+- adr-049
+- adr-055
+- adr-007
+
+## Related Requirements
+
+- rac-grounding-eval-benchmark
+- rac-explainable-retrieval
+- rac-doctor-diagnostic-validator
+- rac-parser-traversal-robustness
+- rac-artifact-trust-model
+- rac-single-schema-agreement
+- rac-provenance-surfacing
+- rac-idempotent-content-hash-processing
+- rac-honest-changelog-tiered-tests
+- rac-obey-demo-grounding-proof
+
+## Related Prompts
+
+- rac-v0.23-hardening-brief
+
+## Related Roadmaps
+
+- v0.21.0-typescript-sdk-and-extension


### PR DESCRIPTION
# Summary

Defines the scope (Step 0) of the v0.23.0 "Hardening" release by emitting its
artifact graph in RAC's own format. **This PR is planning/scope only** — it adds
no product code. Implementation follows in per-workstream PRs once other work
lands on main.

Adds:
- the `v0.23.0-hardening` roadmap: release success criterion, tier plan, and the
  workstream checklist that doubles as the cross-session progress tracker
- one requirement per workstream (10), each carrying normative MUST/SHOULD
  statements, acceptance criteria, and a user-facing/internal classification
- `ADR-064` (artifact content is untrusted input; the trust boundary is human PR
  review) and `ADR-065` (grounding eval scoring is deterministic — no embeddings,
  no LLM judge)
- the `grounding-eval-scorecard` design and the release brief stored as a prompt
  artifact

# Roadmap / ADR Trace

Roadmap:
- `rac/roadmaps/v0.23.x-hardening/v0.23.0-hardening.md`

ADRs introduced:
- `rac/decisions/adr-064-artifact-content-untrusted.md`
- `rac/decisions/adr-065-deterministic-grounding-eval.md`

ADRs cited (already accepted; not duplicated):
- `adr-030` (four-tool surface), `adr-032` (read-only/stateless), `adr-033`
  (response budget + truncation), `adr-002`/`adr-034` (no AI in core),
  `adr-052`/`adr-049` (single code-defined schema), `adr-055`, `adr-037`,
  `adr-038`, `adr-045`, `adr-007`

# Scope

## Included (this PR)
- the release artifact graph only: 1 roadmap, 10 requirements, 2 ADRs, 1 design,
  1 prompt — 15 schema-valid, relationship-clean artifacts

## Excluded (deliberately)
- all implementation code (WS1 `rac eval`, WS2 explainable retrieval, WS3
  `rac doctor`, WS4 robustness, WS11 trust model, WS5/WS6/WS8/WS10) — lands in
  follow-up PRs, built strictly in tier order
- a Pydantic schema rewrite — honor `adr-052`/`adr-049`; WS6 is an agreement test
- a fifth MCP tool, any write capability, an automated multi-agent harness, a
  schema-migration framework, resumable/crash-safe jobs — recorded Non-Goals
- minting ADRs for decisions already accepted — those are cited instead

# Product / Architecture Decisions

Reconciliations baked into the artifacts (the brief was written against an older
repo snapshot and a different naming era):
- the fourth tool is `get_summary`, not `get_repository_summary`; the surface
  stays exactly four read-only tools (`adr-030`)
- statuses are Title-Case (`Proposed`/`Accepted`/`Superseded`…)
- relationships are type-bucketed structural references (`## Related X` +
  `supersedes`, `adr-016`/`adr-055`), not a semantic edge vocabulary
- WS6 adds a cross-consumer agreement test rather than introducing Pydantic,
  because the schema is already single-sourced as the code-defined envelope
  (`adr-052`/`adr-049`)
- WS4's truncation signal already exists (`rac/mcp/budget.py`, `adr-033`) and
  `get_related` is 1-hop, so WS4 scopes to parser hardening + bounded-output
  proof + doctor flags, not a traversal engine
- `schema_version` already exists, so T3-B needs no work
- structured as a single `v0.23.0` release roadmap

`ADR-064` records the highest-priority red-team gap: the read-only server
protects the store, not the agent, so artifact content is untrusted and the
trust boundary is human PR review, with a `doctor` injection flag as the aid.
`ADR-065` pins eval scoring as a deterministic, offline, set-membership function
over real tool output.

# Verification

## Ran
- `rac validate rac/` → PASS, 215 artifacts, 215 valid, 0 invalid, OKF v0.1
  conformant
- `rac relationships rac/ --validate` → 878 relationships checked, 0 issues
- `rac review rac/` → health 91/100, 0 priority-1/2 findings
- baseline before changes: `pytest -q` → 1311 passed, 1 skipped;
  `ruff check`/`ruff format --check` on `src/ tests/` clean

## Covered
- the emitted graph is schema-valid and relationship-clean, and it dogfoods the
  product: it seeds the corpus WS1 will evaluate, the provenance WS5 will
  surface, and the review status WS11 will expose
- `[REQ-NNN]` statements verified single-line so the requirement linter accepts
  them; ADR sections complete (incl. recommended `Category`)

# Review Path

Suggested order: the `v0.23.0-hardening` roadmap (success criterion, tiers,
checklist) → `ADR-064` → `ADR-065` → the 10 workstream requirements → the
`grounding-eval-scorecard` design → the release-brief prompt.

# Notes For Reviewer

- This is Step 0 of an approved plan; implementation is intentionally paused
  pending review. The next change is WS1 (`rac eval` + CI gate).
- The roadmap's workstream checklist is the canonical cross-session tracker;
  there is no separate `RELEASE_PLAN.md`.
- No source files changed, so no behavioral contract changes in this PR.

# Implementation Process

Planned and emitted with AI assistance under the roadmap contract; final scope,
review, and acceptance decisions are the maintainer's.