### PR TITLE
docs(roadmap): close the v0.21.x editor series and scope v0.21.7 graph↔editor sync

### DIFF
--- a/rac/roadmaps/v0.21.x-editor/v0.21.0-typescript-sdk-and-extension.md
+++ b/rac/roadmaps/v0.21.x-editor/v0.21.0-typescript-sdk-and-extension.md
@@ -8,7 +8,7 @@ tags: [sdk, typescript, editor]
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/rac/roadmaps/v0.21.x-editor/v0.21.1-cross-artifact-enforcement.md
+++ b/rac/roadmaps/v0.21.x-editor/v0.21.1-cross-artifact-enforcement.md
@@ -8,7 +8,7 @@ tags: [sdk, typescript, editor, enforcement]
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/rac/roadmaps/v0.21.x-editor/v0.21.2-authoring-ergonomics.md
+++ b/rac/roadmaps/v0.21.x-editor/v0.21.2-authoring-ergonomics.md
@@ -8,7 +8,7 @@ tags: [sdk, typescript, editor, authoring]
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/rac/roadmaps/v0.21.x-editor/v0.21.3-editor-navigation.md
+++ b/rac/roadmaps/v0.21.x-editor/v0.21.3-editor-navigation.md
@@ -8,7 +8,7 @@ tags: [sdk, typescript, editor, navigation]
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/rac/roadmaps/v0.21.x-editor/v0.21.4-ambient-awareness.md
+++ b/rac/roadmaps/v0.21.x-editor/v0.21.4-ambient-awareness.md
@@ -8,7 +8,7 @@ tags: [sdk, typescript, editor, awareness]
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/rac/roadmaps/v0.21.x-editor/v0.21.5-corpus-visualization.md
+++ b/rac/roadmaps/v0.21.x-editor/v0.21.5-corpus-visualization.md
@@ -8,7 +8,7 @@ tags: [sdk, typescript, editor, visualization]
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/rac/roadmaps/v0.21.x-editor/v0.21.6-extension-robustness.md
+++ b/rac/roadmaps/v0.21.x-editor/v0.21.6-extension-robustness.md
@@ -8,7 +8,7 @@ tags: [sdk, typescript, editor, release]
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/rac/roadmaps/v0.21.x-editor/v0.21.7-graph-editor-sync.md
+++ b/rac/roadmaps/v0.21.x-editor/v0.21.7-graph-editor-sync.md
@@ -1,0 +1,148 @@
+---
+schema_version: 1
+id: RAC-KV7GBY6A3H7T
+type: roadmap
+tags: [sdk, typescript, editor, visualization, lore-web]
+---
+# RAC v0.21.7 — Graph ↔ Editor Sync
+
+## Status
+
+Planned
+
+## Context
+
+v0.21.5 brought the corpus graph into the editor as the RAC Explorer webview,
+but deliberately one-way: the panel renders the self-contained Portal that
+`rac export --html` produces, and a selection in that Portal goes nowhere —
+v0.21.5 named the two-way sync as Initiative 2 and deferred it. The reason was
+structural, not cosmetic: every release from v0.21.0 to v0.21.6 was a *thin*
+client (ADR-063) that only consumes `rac` output, whereas making the graph talk
+back to the editor requires changing the `lore-web` viewer itself — the one
+piece the extension reuses rather than owns.
+
+This release closes that loop. Clicking an artifact in the graph opens its file;
+the artifact for the file you are editing is revealed in the graph. The export
+payload already carries everything needed — each artifact serializes its `path`
+and `id` (ADR-007) — so no engine change is required; the work is a small,
+inert-by-default host-integration seam in the viewer plus a message handler in
+the extension. It is the first editor release that touches three surfaces (the
+viewer, the vendored Portal shell, and the extension) rather than the extension
+alone, which is exactly why it was held back from the thin-client series and
+recorded as a follow-on.
+
+## Outcomes
+
+- Selecting an artifact in the Explorer graph opens that artifact's file in the
+  editor.
+- The artifact for the active editor file is revealed (selected/scrolled-to) in
+  the Explorer graph.
+- The viewer remains a valid standalone Portal: the host seam is inert when no
+  editor host is present, and `rac export --html` output stays byte-identical for
+  the same corpus (the injected data and its hash are unchanged).
+
+## Initiatives
+
+### Initiative 1 — A host-integration seam in the lore-web viewer
+
+Add an optional host bridge to the `lore-web` viewer: when it detects an editor
+host (`acquireVsCodeApi` is present), selecting an artifact posts a message
+(`{ type: "open-artifact", path, id }`) to the host, and the viewer listens for
+an inbound `{ type: "reveal-artifact", id }` to select and scroll to that
+artifact. When no host is present — the standalone Portal — the bridge is inert
+and the viewer behaves exactly as today. The seam carries the artifact `path`
+(already in the export payload, ADR-007), so the extension needs no separate
+lookup. After the change, re-vendor the Portal shell
+(`lore-web` `npm run vendor:shell`) so the new viewer is embedded in
+`src/rac/templates/portal/lore-portal-shell.html`; `rac export --html` then
+serves it unchanged in its pipeline.
+
+### Initiative 2 — Editor wiring in the extension
+
+Wire the Explorer webview panel both ways. On `panel.webview.onDidReceiveMessage`,
+handle `open-artifact` by resolving the artifact `path` against the workspace
+(reusing the `artifactUri` resolution and `openTextDocument` / `showTextDocument`
+flow already built for navigation in v0.21.3) and opening the file beside the
+panel. On active-editor change, post `reveal-artifact` with the current file's
+artifact `id` (from the cached corpus export) so the graph follows the editor.
+The extension still computes no graph and classifies nothing — it forwards a
+`path` to open and an `id` to reveal — so its side of the boundary stays thin.
+
+## Constraints
+
+- The extension stays thin (ADR-063): it opens a file by `path` and reveals by
+  `id`; it derives no relationships and reimplements no viewer. The viewer change
+  lives in `lore-web`, which is a consumer of the export contract, not the engine.
+- Additive only (ADR-007): the host seam uses the `path`/`id` already in the
+  export payload; no new export fields and no change to `rac export` output for a
+  given corpus (determinism and the shell hash are preserved when no host is
+  attached).
+- The standalone Portal must keep working unchanged: the bridge is feature-detected
+  and inert without a host, and adds no telemetry or network calls.
+- Inbound messages are untrusted input: the extension acts only on known message
+  types and opens only paths that resolve inside the workspace, never an arbitrary
+  or absolute path outside it.
+
+## Non-Goals
+
+- A new graph/visualization engine — this reuses `lore-web` (ADR-063), as v0.21.5
+  established.
+- Editing artifacts from the graph; authoring stays in the editor / `rac new`
+  (v0.21.2).
+- A bidirectional live model or a language server; refresh semantics remain those
+  of v0.21.5 (explicit / on-change); this only adds selection sync.
+- Changing how `rac` computes or exports the corpus.
+
+## Implementation Contract
+
+- The `lore-web` viewer gains a feature-detected host bridge: it posts
+  `{ type: "open-artifact", path, id }` on selection and handles inbound
+  `{ type: "reveal-artifact", id }`; with no host detected it is inert and the
+  standalone Portal is unchanged.
+- The Portal shell is re-vendored from `lore-web` into
+  `src/rac/templates/portal/lore-portal-shell.html`, and `rac export --html`
+  emits the same payload and hash as before for a given corpus.
+- The extension's Explorer panel handles `open-artifact` by opening the resolved
+  workspace file (reusing the v0.21.3 navigation resolution) and posts
+  `reveal-artifact` on active-editor change; it validates message type and
+  confines opened paths to the workspace.
+
+## Success Measures
+
+- Clicking an artifact in the Explorer graph opens that artifact's file in the
+  editor.
+- Switching the active editor to an artifact file reveals/selects it in the graph.
+- Running the standalone Portal (no editor host) behaves exactly as in v0.21.5,
+  and `rac export --html` output for an unchanged corpus is byte-identical to
+  before this release.
+
+## Risks
+
+- Coupling the extension to the viewer's message shape. Mitigated by keeping the
+  protocol tiny (`open-artifact` / `reveal-artifact`) and carrying only the
+  `path`/`id` already in the export contract (ADR-007); if it grows, the message
+  protocol is a candidate for its own ADR.
+- Re-vendoring drift between `lore-web` and the embedded shell. Mitigated by the
+  existing `vendor:shell` step and its provenance manifest, run as part of this
+  release rather than by hand.
+- A malformed or hostile inbound message opening an unintended file. Mitigated by
+  acting only on known message types and resolving paths strictly inside the
+  workspace.
+
+## Assumptions
+
+- A VS Code / Cursor webview exposes `acquireVsCodeApi`, `postMessage`, and
+  `onDidReceiveMessage`, which the viewer can feature-detect for the host bridge.
+- The export payload's `path` and `id` are sufficient to open the file and to
+  reveal the matching artifact, as they already are for the standalone viewer.
+
+## Related Decisions
+
+- adr-007
+- adr-063
+
+## Related Roadmaps
+
+- v0.21.5-corpus-visualization
+- v0.21.3-editor-navigation
+- v0.21.6-extension-robustness


### PR DESCRIPTION
# Summary

Implements `rac/roadmaps/v0.21.x-editor/v0.21.7-graph-editor-sync.md` and ratifies the achieved status of the shipped v0.21.0–v0.21.6 editor series. Corpus-only; no code changes.

Adds:
- Seven roadmap status flips from `Planned` to the `Achieved` terminal lifecycle state (ADR-061) now that the whole TypeScript SDK and extension series (v0.21.0–v0.21.6) has merged to `main`. Status only — no scope changes.
- A new v0.21.7 roadmap — Graph ↔ Editor Sync — recording the deferred v0.21.5 Initiative 2 as a real deliverable: two-way selection sync between the RAC Explorer graph and the editor.

# Roadmap / ADR Trace

Roadmap:
- `rac/roadmaps/v0.21.x-editor/v0.21.7-graph-editor-sync.md` (newly scoped)
- `rac/roadmaps/v0.21.x-editor/v0.21.0-typescript-sdk-and-extension.md` through `v0.21.6-extension-robustness.md` (flipped to `Achieved`)

Relevant ADRs:
- `rac/decisions/adr-061-...` — gives roadmaps an `Achieved` terminal state so a delivered series reads truthfully; the flip is a manual editorial step at release time, set by a human, and merging this PR is that ratification.
- `rac/decisions/adr-063-non-python-clients-are-thin.md` — frames why v0.21.7 is held separate: it is the first editor step that is not purely thin (it touches the `lore-web` viewer, not just the extension).
- `rac/decisions/adr-007-additive-json-evolution.md` — the v0.21.7 host seam reuses the `path`/`id` already in the export payload; no new export fields.

# Scope

## Included
- Status-only flips of the seven v0.21.0–v0.21.6 roadmaps to `Achieved`.
- The full v0.21.7 roadmap artifact: context, outcomes, two initiatives (a feature-detected host bridge in the `lore-web` viewer re-vendored into `src/rac/templates/portal/`; an `onDidReceiveMessage` handler in the extension reusing the v0.21.3 navigation flow), constraints, non-goals, implementation contract, and success measures.

## Excluded
- Any implementation of v0.21.7 — this PR scopes the roadmap only; the viewer/extension code lands in its own release.
- Any scope change to the v0.21.0–v0.21.6 roadmaps — the flips are status-only, no content edits.
- Code changes of any kind — corpus only.

# Product / Architecture Decisions

- `Achieved` is a human ratification, not an automated flip. ADR-061 makes the terminal state a deliberate editorial act at release time; this PR is that act for the merged series.
- v0.21.7 is recorded as the first non-thin editor release. v0.21.5 named the click-through as the natural follow-on but deferred it because it requires changing the `lore-web` viewer and re-vendoring the Portal shell, not just the extension. v0.21.7 captures that scope honestly while keeping the extension side thin (ADR-063): it forwards a `path` to open and an `id` to reveal, deriving nothing.

# User-Facing Contract

## CLI
None. No `rac` command, flag, or behavior is added or changed.

## Human Output
None. No terminal output change.

## JSON Output
None. No `rac --json` shape change.

## Exit Codes
None. No change to `rac` exit codes.

# Verification

## Ran
- `rac validate rac/` → 218 valid, 0 invalid (exit 0).
- `rac relationships rac/ --validate` → 895 checked, 0 issues (exit 0).
- `rac review rac/` → no priority 1–2 findings.

## Covered
- Positive: the new v0.21.7 roadmap validates as a well-formed roadmap artifact and resolves cleanly against its related roadmaps and ADRs.
- Boundary: the seven status flips leave relationship integrity intact (895 checked, 0 issues), confirming no dangling or duplicated references were introduced by the edits.
- Negative: not applicable — corpus-only status/scope edits; the gates above are the regression surface (no code path to exercise).

# Review Path

1. `rac/roadmaps/v0.21.x-editor/v0.21.7-graph-editor-sync.md` — the new scope (the substantive change).
2. The v0.21.0–v0.21.6 roadmap files — confirm each `## Status` flip is `Achieved` and nothing else changed.
3. The gate output above — confirm validate/relationships/review are clean.

# Notes For Reviewer

- The flips are deliberately status-only; diff each roadmap to confirm no scope drift crept in alongside the lifecycle change.
- v0.21.7 is scoped but not implemented here; it stays `Planned` until its own release lands, then flips to `Achieved` (ADR-061).
- v0.21.7 will touch three surfaces (the `lore-web` viewer, the vendored Portal shell, and the extension), so it is the first editor release that is not extension-only.

# Implementation Process

Implemented with AI assistance under the v0.21.7 roadmap contract; final scope, review, and acceptance decisions were made by the maintainer.