### PR TITLE
fix(release): make the extension vsix-packageable

### DIFF
--- a/typescript/rac-vscode/package.json
+++ b/typescript/rac-vscode/package.json
@@ -70,10 +70,8 @@
     "watch": "node esbuild.mjs --watch",
     "vscode:prepublish": "npm run check-types && npm run compile"
   },
-  "dependencies": {
-    "@rac/sdk": "file:../rac-sdk"
-  },
   "devDependencies": {
+    "@rac/sdk": "file:../rac-sdk",
     "@types/node": "^22.0.0",
     "@types/vscode": "^1.85.0",
     "esbuild": "^0.25.0",


### PR DESCRIPTION
# Summary

Implements `rac/roadmaps/v0.21.x-editor/v0.21.6-extension-robustness.md` follow-up — makes the VS Code extension actually produce a `.vsix`, the prerequisite for the Marketplace / OpenVSX publish step.

Adds:
- Moves `@rac/sdk` from production `dependencies` to `devDependencies` in `typescript/rac-vscode/package.json` so `vsce package` stops trying to vendor the SDK's out-of-root `node_modules`.
- No runtime behavior change: esbuild already inlines `@rac/sdk` into `dist/extension.js` at build time, so it is a build-time dependency and `devDependencies` is its correct home.

# Roadmap / ADR Trace

Roadmap:
- `rac/roadmaps/v0.21.x-editor/v0.21.6-extension-robustness.md`

Relevant ADRs:
- `rac/decisions/adr-063-non-python-clients-are-thin.md` — the SDK is a build-time bundling input to the thin client, not a runtime-vendored dependency; this change makes the packaging match that boundary.

# Scope

## Included
- One-line manifest change: `@rac/sdk` declared under `devDependencies` rather than `dependencies` in `typescript/rac-vscode/package.json`.
- `vsce package` now succeeds and produces a clean 7-file `.vsix` with no stray `node_modules`.

## Excluded
- The actual `vsce publish` / `ovsx publish` step — this only unblocks it; publishing is a separate action.
- Any change to the extension's runtime behavior, bundle contents, or `rac` CLI.
- Any change to how esbuild resolves or bundles `@rac/sdk` during `compile`.

# Product / Architecture Decisions
- `vsce` packages an extension's production dependencies. `@rac/sdk` was declared as a production `file:../rac-sdk` dependency, so `vsce` followed the link and tried to vendor the SDK's `node_modules` from outside the extension root — an invalid relative path (`extension/../rac-sdk/node_modules/@types/node/zlib.d.ts`) and ~57 MB of files it should never ship.
- The SDK is bundled at build time: esbuild inlines it into `dist/extension.js` (the bundle contains `RacClient`); at runtime nothing imports `@rac/sdk` from `node_modules`. It is therefore a build-time dependency and belongs in `devDependencies`. esbuild still resolves it from `node_modules` during `compile`; `vsce` no longer traverses it.
- This surfaced that v0.21.6's "packaged for the Marketplace / OpenVSX" claim was never exercised end-to-end — `vsce package` did not succeed until this change.

# User-Facing Contract

## CLI
None. No `rac` command, flag, or behavior is added or changed.

## Human Output
None. No terminal output change.

## JSON Output
None. No `rac --json` shape change.

## Exit Codes
None. No change to `rac` exit codes. `vsce package` now exits `0` (it previously errored before producing a `.vsix`).

# Verification

## Ran
- `npx @vscode/vsce package` → `DONE  Packaged: rac-vscode-0.1.0.vsix (7 files, 25.07 KB)`. Contents: `extension.js` (bundle), `icon.png`, `LICENSE.txt`, `readme.md`, `package.json`, manifest — no stray `node_modules`.
- `npm run check-types` → clean.
- `npm run compile` (esbuild) → `dist/extension.js` 35.3 kb, unchanged from before the manifest edit.

## Covered
- Positive: `vsce package` produces a clean 7-file ~25 KB `.vsix`; the esbuild bundle is byte-comparable (35.3 kb) confirming the SDK is still inlined and runtime behavior is unchanged.
- Negative / regression: the prior failure mode — `vsce` vendoring `../rac-sdk/node_modules` and erroring on an invalid relative path — no longer occurs; the packaged contents contain no `node_modules`.
- Boundary: the package manifest is the only changed surface; `check-types` confirms no type resolution regression from the dependency-section move.

# Review Path
1. `typescript/rac-vscode/package.json` — the one-line move of `@rac/sdk` to `devDependencies`.
2. Confirm esbuild still bundles `@rac/sdk` (the bundle contains `RacClient`) so the move is runtime-safe.
3. The `vsce package` output (7-file `.vsix`, no `node_modules`) as the acceptance check.

# Notes For Reviewer
- This is a packaging fix, not a feature: the diff is +1/-3 in a single manifest file.
- Live `vsce publish` / `ovsx publish` is the remaining human step this unblocks; it is intentionally not performed here.
- Watch that future SDK API additions stay reachable through the esbuild bundle, since `@rac/sdk` is now only a dev/build-time dependency rather than a vendored runtime one.

# Implementation Process
Implemented with AI assistance under the v0.21.x editor roadmap series; final scope, review, and acceptance decisions are the maintainer's.