### PR TITLE
docs(roadmap): scope v0.21.8 corpus graph view

### DIFF
--- a/rac/roadmaps/v0.21.x-editor/v0.21.8-corpus-graph-view.md
+++ b/rac/roadmaps/v0.21.x-editor/v0.21.8-corpus-graph-view.md
@@ -16,137 +16,169 @@ but neither drew the graph. The relationships are right there in the export
 payload (`relationships[]`, ADR-007) and already validated by
 `rac relationships`; nothing renders them as a picture.
 
-This release adds an actual node-link **graph view** to the viewer: artifacts as
-nodes, relationships as edges, laid out so the shape of the corpus — clusters,
-hubs, isolated artifacts, broken and retired links — is visible at a glance. It
-is the natural completion of "corpus visualization", and it lands on rails
-v0.21.7 already built: a node *is* a selection, so clicking one opens its file
-and the active editor reveals its node, with no new bridge. Like v0.21.7 it is a
-`lore-web` change re-vendored into the Portal shell, not an engine change — the
-export contract is untouched and `rac` computes nothing new.
+This release adds an actual node-link **graph view**, and adopts the conventions
+people already know from **Obsidian's graph** so it is familiar on sight rather
+than a bespoke widget to relearn: a **global graph** of the whole corpus and a
+**local graph** that follows the file you are editing, force-directed layout with
+the usual controls, nodes sized by how connected they are, hover-to-highlight,
+labels that fade with zoom, and an orphans toggle. It is the natural completion
+of "corpus visualization", and it lands on rails v0.21.7 already built: a node
+*is* a selection, so clicking one opens its file and the active editor reveals
+its node, with no new bridge. Like v0.21.7 it is a `lore-web` change re-vendored
+into the Portal shell, not an engine change — the export contract is untouched
+and `rac` computes nothing new.
 
 ## Outcomes
 
-- The corpus renders as a node-link graph in the viewer, with edges matching
-  `rac relationships --validate`.
-- Node type and link health read at a glance: nodes coloured by artifact type,
-  retired (superseded/deprecated, ADR-051) and unresolved targets shown
-  distinctly.
-- The graph is a first-class surface for the v0.21.7 sync — selecting a node
-  opens its file, and `reveal-artifact` centres/highlights its node — with the
-  list/detail view kept as the default and the accessible path.
+- The corpus renders as a node-link graph that an Obsidian user reads
+  immediately: a **global** view and a **local** view that follows the active
+  editor, force-directed, with familiar interactions.
+- Structure reads at a glance: hub artifacts are visibly larger (sized by link
+  count), node colour tracks artifact type, and retired (ADR-051) and unresolved
+  targets are drawn distinctly.
+- The graph is a first-class surface for the v0.21.7 sync — selecting a node opens
+  its file, and `reveal-artifact` centres/focuses its node — with the list/detail
+  view kept as the default and the accessible path.
 
 ## Initiatives
 
-### Initiative 1 — A node-link graph in the lore-web viewer
+### Initiative 1 — Global and local graph
 
-Add a graph view reachable from the viewer (a list ⇄ graph toggle and a
-`#/graph` route alongside `#/` and `#/artifact/<id>`). Nodes are the export
-`artifacts[]` coloured by `type`; edges are `relationships[]`. Layout is computed
-**client-side and deterministically** (a seeded layout, so the same corpus draws
-the same graph) — positions are never written into the export, so `rac export`
-stays deterministic and position-free. A node carries its `id`/`path`, so it
-needs no lookup the payload does not already provide.
+Two modes people expect from Obsidian. **Global** draws the whole corpus.
+**Local** draws the active editor's artifact and its neighbours out to an
+adjustable **depth** (hops), and updates as you switch files — reusing the
+v0.21.7 `reveal-artifact` signal, so the graph is the live neighbourhood of what
+you are editing. A list ⇄ graph toggle and a `#/graph` route sit alongside `#/`
+and `#/artifact/<id>`.
 
-### Initiative 2 — Health-aware rendering
+### Initiative 2 — Familiar layout, sizing, and interactions
 
-Use the distinctions the export already carries. Colour nodes by `type`; render
-**retired** artifacts (Superseded/Deprecated, ADR-051) muted and **unresolved**
-edge targets (the `to` aliases Core keeps verbatim, "not in corpus") as a
-distinct dangling edge, so the graph surfaces exactly what enforcement cares
-about (ADR-049) rather than a flat blob. Hovering a node shows its display name,
-title and status; selecting one focuses it and its neighbours.
+A force-directed layout with the conventional controls (center force, repel
+force, link force, link distance) tuned to good defaults. Nodes are **sized by
+degree** (relationship count) so hubs stand out; edges carry **direction arrows**;
+**labels fade with zoom** (a text-fade threshold) so a dense graph stays legible.
+**Hovering a node highlights it and its neighbours and dims the rest**; scroll
+zooms, drag pans, nodes can be dragged to reposition (not persisted), and a click
+opens the artifact (via the v0.21.7 bridge). Nodes are coloured by `type`;
+retired artifacts (Superseded/Deprecated, ADR-051) render muted and unresolved
+edge targets ("not in corpus") as distinct dangling edges, so the graph surfaces
+what enforcement cares about (ADR-049) rather than a flat blob.
 
-### Initiative 3 — Selection on the v0.21.7 rails
+### Initiative 3 — Filters people reach for
 
-Wire node selection to the existing host bridge: clicking a node fires
-`open-artifact` (its file opens in the editor) and an inbound `reveal-artifact`
-centres and highlights that node. No new protocol and no extension change — the
-graph becomes the surface the v0.21.7 messages were built for. Re-vendor the
-Portal shell so `rac export --html` ships the graph view; the injected data
-payload is unchanged.
+The filters an Obsidian user looks for, mapped to RAC's vocabulary: a search
+field to filter nodes, the existing **type** and **status** toggles (RAC's analog
+of Obsidian's tag toggles, shared with the list view), an **orphans** toggle to
+hide/show artifacts with no relationships, and an **unresolved-targets** toggle
+(the analog of Obsidian's "existing files only"). RAC colours by semantic type
+rather than arbitrary search-query groups, so no custom group/colour editor is
+needed.
+
+### Initiative 4 — Ride the v0.21.7 rails and re-vendor
+
+Node selection reuses the existing host bridge unchanged — `open-artifact` on
+click, `reveal-artifact` to centre/focus a node (and drive the local graph) — so
+graph↔editor sync works from the graph with no protocol or extension change.
+Re-vendor the Portal shell so `rac export --html` ships the graph view; the
+injected data payload is unchanged and the list/detail view stays default.
 
 ## Constraints
 
 - Thin client preserved (ADR-063): the graph is drawn entirely in `lore-web` from
   the export contract; `rac` gains no layout, no positions, no new fields, and the
   extension is unchanged.
-- Additive only (ADR-007): nodes/edges come from `artifacts[]`/`relationships[]`
-  as they are; the export payload for a given corpus is unchanged and only the
-  vendored viewer shell changes.
-- Deterministic and offline: layout is seeded so a corpus renders identically, the
-  Portal stays a single offline file with no network or telemetry, and the export
-  remains position-free.
+- Additive only (ADR-007): nodes/edges, degree, type, status, and unresolved
+  targets all come from `artifacts[]`/`relationships[]` as they are; the export
+  payload for a given corpus is unchanged and only the vendored shell changes.
+- Determinism stays where it belongs — in the data, not the picture. The export
+  carries **no positions**, so `rac export` is deterministic and position-free;
+  the on-screen layout is an interactive force simulation (as in Obsidian), seeded
+  so it converges to a stable shape, with coordinates held only in the browser and
+  never written back.
+- Offline and quiet: the Portal stays a single offline file with no network or
+  telemetry; the graph adds no external requests.
 - The list/detail view stays the default and the accessible path; the graph is an
   added visualization, not a replacement.
 
 ## Non-Goals
 
-- Server-side or baked-in layout, or any positions in the export (would break
+- Positions or layout in the export, or any server-side layout (breaks
   determinism and the thin boundary).
-- Editing the corpus from the graph — dragging nodes for a one-off look is fine,
-  but layout is not persisted and authoring stays in the editor / `rac new`.
-- A graph query language or new filters beyond reusing the existing type/status
-  filters.
-- New edge semantics: edges are whatever `rac` emits (`relates-to` today, the set
-  stays open); this release does not invent edge types.
-- 3D, physics toys, or a heavyweight visualization framework that compromises the
-  offline single-file Portal.
+- Persisting node positions or per-user layout state; a drag is a one-off nudge.
+- Obsidian's "animate"/time-lapse-over-history — it needs temporal data the export
+  does not carry; out of scope here.
+- Custom search-query colour **groups**: RAC colours by semantic type, which does
+  not need an arbitrary group editor.
+- New edge semantics or a graph query language: edges are whatever `rac` emits
+  (`relates-to` today, the set stays open); authoring stays in the editor /
+  `rac new`.
+- A heavyweight visualization framework that compromises the offline single-file
+  Portal.
 
 ## Implementation Contract
 
-- `lore-web` gains a node-link graph view (`#/graph`, toggle from the list) drawn
-  from `artifacts[]` (nodes, coloured by `type`) and `relationships[]` (edges),
-  with retired artifacts (ADR-051) and unresolved targets rendered distinctly.
-- Layout is computed in the viewer with a fixed seed; no positions enter the
-  export and `rac export` output for a given corpus is unchanged save for the
-  re-vendored shell.
-- Node selection reuses the v0.21.7 bridge unchanged — `open-artifact` on click,
-  `reveal-artifact` centres/highlights the node — so graph↔editor sync works from
-  the graph with no extension change.
-- The Portal shell is re-vendored (`npm run vendor:shell`); the list/detail view
-  remains default, and the drift-guard provenance is refreshed.
+- `lore-web` gains a node-link graph (`#/graph`, toggled from the list) with a
+  **global** mode and a **local** mode that follows the active editor to an
+  adjustable depth via the v0.21.7 `reveal-artifact` signal.
+- Rendering follows Obsidian conventions: force-directed with center/repel/link
+  forces and link distance, nodes **sized by degree** and coloured by `type`,
+  **direction arrows**, **zoom-based label fade**, and **hover-to-highlight with
+  the rest dimmed**; retired (ADR-051) and unresolved targets are styled
+  distinctly.
+- Filters are a node search plus type/status toggles (shared with the list view),
+  an **orphans** toggle, and an **unresolved-targets** toggle.
+- Layout is computed in the browser and seeded; no positions enter the export, and
+  `rac export` output for a given corpus is unchanged save for the re-vendored
+  shell.
+- Node selection reuses the v0.21.7 bridge unchanged (`open-artifact` /
+  `reveal-artifact`); the Portal shell is re-vendored (`npm run vendor:shell`) with
+  refreshed drift-guard provenance, and the list/detail view remains default.
 
 ## Success Measures
 
-- The corpus renders as a node-link graph whose edges match
-  `rac relationships --validate`, with type colours and distinct retired/unresolved
-  styling.
+- The corpus renders as a force-directed node-link graph whose edges match
+  `rac relationships --validate`, with degree-sized, type-coloured nodes and
+  distinct retired/unresolved styling.
+- Switching the active editor updates the **local graph** to that artifact's
+  neighbourhood; hovering a node highlights its neighbours and dims the rest.
 - From the graph, clicking a node opens its file (v0.21.7) and `reveal-artifact`
-  centres its node.
+  centres/focuses its node.
 - The graph renders responsively on the full RAC corpus and a ~500-node synthetic
   corpus; the standalone Portal stays offline and `rac export` output (the data
   payload) is unchanged.
 
 ## Risks
 
-- Layout cost and visual clutter on large corpora (hundreds of nodes, ~900
-  edges). Mitigated by a seeded, iteration-capped layout, a focus+neighbours mode,
-  and a canvas/SVG choice made for scale; the list stays the default for large
-  corpora.
+- Layout cost and visual clutter on large corpora (hundreds of nodes, ~900 edges).
+  Mitigated by the same conventions Obsidian relies on — a seeded,
+  iteration-capped simulation, hover-highlight with dimming, zoom-based label fade,
+  the local-graph mode, and a canvas/SVG choice made for scale; the list stays the
+  default for large corpora.
 - Layout non-determinism leaking into the export. Mitigated by computing positions
-  client-side from a fixed seed and keeping the payload position-free, which the
-  determinism tests already guard.
+  client-side and keeping the payload position-free, which the determinism tests
+  already guard.
 - A drawing dependency bloating or breaking the offline single-file Portal.
-  Mitigated by preferring a minimal seeded layout (hand-rolled or a small,
-  inlinable library) — the constraint is offline determinism, not any particular
-  library.
+  Mitigated by preferring a minimal, inlinable layout/render approach — the
+  constraint is offline determinism of the data, not any particular library.
 - Re-vendoring drift between `lore-web` and the embedded shell. Mitigated by the
   existing `vendor:shell` step and the drift-guard provenance, as in v0.21.7.
 
 ## Assumptions
 
-- `artifacts[]` and `relationships[]` in the export are sufficient to draw the
-  graph (nodes, edges, type, status, unresolved targets) without any new `rac`
-  output.
-- A client-side seeded layout can render the current corpus and a ~500-node
-  corpus within an interactive frame budget in a webview and from `file://`.
+- `artifacts[]` and `relationships[]` are sufficient to draw the graph and derive
+  degree, type colour, status, orphans, and unresolved targets — no new `rac`
+  output is required.
+- A client-side seeded force simulation can render the current corpus and a
+  ~500-node corpus within an interactive frame budget in a webview and from
+  `file://`.
 - The v0.21.7 host bridge (`open-artifact` / `reveal-artifact`) is the right and
-  sufficient seam for graph selection, needing no protocol change.
+  sufficient seam for graph selection and for driving the local graph, needing no
+  protocol change.
 
 ## Related Decisions
 
 - adr-007
+- adr-049
 - adr-051
 - adr-063
 

--- a/rac/roadmaps/v0.21.x-editor/v0.21.8-corpus-graph-view.md
+++ b/rac/roadmaps/v0.21.x-editor/v0.21.8-corpus-graph-view.md
@@ -45,10 +45,11 @@ and `rac` computes nothing new.
 ### Initiative 1 — Global and local graph
 
 Two modes people expect from Obsidian. **Global** draws the whole corpus.
-**Local** draws the active editor's artifact and its neighbours out to an
-adjustable **depth** (hops), and updates as you switch files — reusing the
-v0.21.7 `reveal-artifact` signal, so the graph is the live neighbourhood of what
-you are editing. A list ⇄ graph toggle and a `#/graph` route sit alongside `#/`
+**Local** draws the active editor's artifact and its neighbours out to a
+**user-set depth** (hops) — a depth control the reader changes to widen or narrow
+the neighbourhood — and updates as you switch files, reusing the v0.21.7
+`reveal-artifact` signal, so the graph is the live neighbourhood of what you are
+editing. A list ⇄ graph toggle and a `#/graph` route sit alongside `#/`
 and `#/artifact/<id>`.
 
 ### Initiative 2 — Familiar layout, sizing, and interactions
@@ -59,8 +60,10 @@ degree** (relationship count) so hubs stand out; edges carry **direction arrows*
 **labels fade with zoom** (a text-fade threshold) so a dense graph stays legible.
 **Hovering a node highlights it and its neighbours and dims the rest**; scroll
 zooms, drag pans, nodes can be dragged to reposition (not persisted), and a click
-opens the artifact (via the v0.21.7 bridge). Nodes are coloured by `type`;
-retired artifacts (Superseded/Deprecated, ADR-051) render muted and unresolved
+opens the artifact (via the v0.21.7 bridge). Nodes are coloured **by artifact
+type** — a distinct colour per family (requirement, decision, roadmap, prompt,
+design), shown in a legend; retired artifacts (Superseded/Deprecated, ADR-051)
+render muted and unresolved
 edge targets ("not in corpus") as distinct dangling edges, so the graph surfaces
 what enforcement cares about (ADR-049) rather than a flat blob.
 
@@ -118,10 +121,11 @@ injected data payload is unchanged and the list/detail view stays default.
 ## Implementation Contract
 
 - `lore-web` gains a node-link graph (`#/graph`, toggled from the list) with a
-  **global** mode and a **local** mode that follows the active editor to an
-  adjustable depth via the v0.21.7 `reveal-artifact` signal.
+  **global** mode and a **local** mode that follows the active editor to a
+  **user-set depth** via the v0.21.7 `reveal-artifact` signal.
 - Rendering follows Obsidian conventions: force-directed with center/repel/link
-  forces and link distance, nodes **sized by degree** and coloured by `type`,
+  forces and link distance, nodes **sized by degree** and coloured by `type` (a
+  distinct colour per artifact family, with a legend),
   **direction arrows**, **zoom-based label fade**, and **hover-to-highlight with
   the rest dimmed**; retired (ADR-051) and unresolved targets are styled
   distinctly.

--- a/rac/roadmaps/v0.21.x-editor/v0.21.8-corpus-graph-view.md
+++ b/rac/roadmaps/v0.21.x-editor/v0.21.8-corpus-graph-view.md
@@ -1,0 +1,156 @@
+---
+schema_version: 1
+id: RAC-KV7KAA3R9T4Q
+type: roadmap
+tags: [sdk, typescript, editor, visualization, lore-web]
+---
+# RAC v0.21.8 — Corpus Graph View
+
+## Context
+
+RAC calls the corpus a graph, but the `lore-web` viewer renders it as a
+**list/detail**: rows you search and filter, and a per-artifact page with a
+related-artifacts panel. v0.21.5 brought that viewer into the editor and named
+the release "corpus visualization", and v0.21.7 made selection sync both ways —
+but neither drew the graph. The relationships are right there in the export
+payload (`relationships[]`, ADR-007) and already validated by
+`rac relationships`; nothing renders them as a picture.
+
+This release adds an actual node-link **graph view** to the viewer: artifacts as
+nodes, relationships as edges, laid out so the shape of the corpus — clusters,
+hubs, isolated artifacts, broken and retired links — is visible at a glance. It
+is the natural completion of "corpus visualization", and it lands on rails
+v0.21.7 already built: a node *is* a selection, so clicking one opens its file
+and the active editor reveals its node, with no new bridge. Like v0.21.7 it is a
+`lore-web` change re-vendored into the Portal shell, not an engine change — the
+export contract is untouched and `rac` computes nothing new.
+
+## Outcomes
+
+- The corpus renders as a node-link graph in the viewer, with edges matching
+  `rac relationships --validate`.
+- Node type and link health read at a glance: nodes coloured by artifact type,
+  retired (superseded/deprecated, ADR-051) and unresolved targets shown
+  distinctly.
+- The graph is a first-class surface for the v0.21.7 sync — selecting a node
+  opens its file, and `reveal-artifact` centres/highlights its node — with the
+  list/detail view kept as the default and the accessible path.
+
+## Initiatives
+
+### Initiative 1 — A node-link graph in the lore-web viewer
+
+Add a graph view reachable from the viewer (a list ⇄ graph toggle and a
+`#/graph` route alongside `#/` and `#/artifact/<id>`). Nodes are the export
+`artifacts[]` coloured by `type`; edges are `relationships[]`. Layout is computed
+**client-side and deterministically** (a seeded layout, so the same corpus draws
+the same graph) — positions are never written into the export, so `rac export`
+stays deterministic and position-free. A node carries its `id`/`path`, so it
+needs no lookup the payload does not already provide.
+
+### Initiative 2 — Health-aware rendering
+
+Use the distinctions the export already carries. Colour nodes by `type`; render
+**retired** artifacts (Superseded/Deprecated, ADR-051) muted and **unresolved**
+edge targets (the `to` aliases Core keeps verbatim, "not in corpus") as a
+distinct dangling edge, so the graph surfaces exactly what enforcement cares
+about (ADR-049) rather than a flat blob. Hovering a node shows its display name,
+title and status; selecting one focuses it and its neighbours.
+
+### Initiative 3 — Selection on the v0.21.7 rails
+
+Wire node selection to the existing host bridge: clicking a node fires
+`open-artifact` (its file opens in the editor) and an inbound `reveal-artifact`
+centres and highlights that node. No new protocol and no extension change — the
+graph becomes the surface the v0.21.7 messages were built for. Re-vendor the
+Portal shell so `rac export --html` ships the graph view; the injected data
+payload is unchanged.
+
+## Constraints
+
+- Thin client preserved (ADR-063): the graph is drawn entirely in `lore-web` from
+  the export contract; `rac` gains no layout, no positions, no new fields, and the
+  extension is unchanged.
+- Additive only (ADR-007): nodes/edges come from `artifacts[]`/`relationships[]`
+  as they are; the export payload for a given corpus is unchanged and only the
+  vendored viewer shell changes.
+- Deterministic and offline: layout is seeded so a corpus renders identically, the
+  Portal stays a single offline file with no network or telemetry, and the export
+  remains position-free.
+- The list/detail view stays the default and the accessible path; the graph is an
+  added visualization, not a replacement.
+
+## Non-Goals
+
+- Server-side or baked-in layout, or any positions in the export (would break
+  determinism and the thin boundary).
+- Editing the corpus from the graph — dragging nodes for a one-off look is fine,
+  but layout is not persisted and authoring stays in the editor / `rac new`.
+- A graph query language or new filters beyond reusing the existing type/status
+  filters.
+- New edge semantics: edges are whatever `rac` emits (`relates-to` today, the set
+  stays open); this release does not invent edge types.
+- 3D, physics toys, or a heavyweight visualization framework that compromises the
+  offline single-file Portal.
+
+## Implementation Contract
+
+- `lore-web` gains a node-link graph view (`#/graph`, toggle from the list) drawn
+  from `artifacts[]` (nodes, coloured by `type`) and `relationships[]` (edges),
+  with retired artifacts (ADR-051) and unresolved targets rendered distinctly.
+- Layout is computed in the viewer with a fixed seed; no positions enter the
+  export and `rac export` output for a given corpus is unchanged save for the
+  re-vendored shell.
+- Node selection reuses the v0.21.7 bridge unchanged — `open-artifact` on click,
+  `reveal-artifact` centres/highlights the node — so graph↔editor sync works from
+  the graph with no extension change.
+- The Portal shell is re-vendored (`npm run vendor:shell`); the list/detail view
+  remains default, and the drift-guard provenance is refreshed.
+
+## Success Measures
+
+- The corpus renders as a node-link graph whose edges match
+  `rac relationships --validate`, with type colours and distinct retired/unresolved
+  styling.
+- From the graph, clicking a node opens its file (v0.21.7) and `reveal-artifact`
+  centres its node.
+- The graph renders responsively on the full RAC corpus and a ~500-node synthetic
+  corpus; the standalone Portal stays offline and `rac export` output (the data
+  payload) is unchanged.
+
+## Risks
+
+- Layout cost and visual clutter on large corpora (hundreds of nodes, ~900
+  edges). Mitigated by a seeded, iteration-capped layout, a focus+neighbours mode,
+  and a canvas/SVG choice made for scale; the list stays the default for large
+  corpora.
+- Layout non-determinism leaking into the export. Mitigated by computing positions
+  client-side from a fixed seed and keeping the payload position-free, which the
+  determinism tests already guard.
+- A drawing dependency bloating or breaking the offline single-file Portal.
+  Mitigated by preferring a minimal seeded layout (hand-rolled or a small,
+  inlinable library) — the constraint is offline determinism, not any particular
+  library.
+- Re-vendoring drift between `lore-web` and the embedded shell. Mitigated by the
+  existing `vendor:shell` step and the drift-guard provenance, as in v0.21.7.
+
+## Assumptions
+
+- `artifacts[]` and `relationships[]` in the export are sufficient to draw the
+  graph (nodes, edges, type, status, unresolved targets) without any new `rac`
+  output.
+- A client-side seeded layout can render the current corpus and a ~500-node
+  corpus within an interactive frame budget in a webview and from `file://`.
+- The v0.21.7 host bridge (`open-artifact` / `reveal-artifact`) is the right and
+  sufficient seam for graph selection, needing no protocol change.
+
+## Related Decisions
+
+- adr-007
+- adr-051
+- adr-063
+
+## Related Roadmaps
+
+- v0.21.7-graph-editor-sync
+- v0.21.5-corpus-visualization


### PR DESCRIPTION
# Summary

Implements `rac/roadmaps/v0.21.x-editor/v0.21.8-corpus-graph-view.md` — scopes the v0.21.8 Corpus Graph View: an actual node-link graph in the `lore-web` viewer, drawn to follow the conventions people already know from Obsidian's graph so it is familiar on sight.

Adds:
- A scoped roadmap artifact defining a global + local graph view, Obsidian-aligned rendering and interactions, and the filters people reach for.
- Constraints that keep the feature honest to RAC's invariants: thin client (ADR-063), additive export (ADR-007), and determinism in the data rather than the picture.
- Explicit non-goals fencing the release away from positions-in-export, persisted layout, time-lapse, custom colour groups, and heavyweight frameworks.

# Roadmap / ADR Trace

Roadmap:
- `rac/roadmaps/v0.21.x-editor/v0.21.8-corpus-graph-view.md`

Relevant ADRs:
- `rac/decisions/adr-063-non-python-clients-are-thin.md` — the graph is drawn entirely in `lore-web` from the export contract; `rac` gains no layout/positions/fields and the extension is unchanged.
- `rac/decisions/adr-007-additive-json-evolution.md` — nodes/edges, degree, type, status, and unresolved targets all come from `artifacts[]`/`relationships[]` as they are; the export payload for a given corpus is unchanged.
- `rac/decisions/adr-049-enforcement-is-the-product.md` — retired and unresolved targets are drawn distinctly so the graph surfaces what enforcement cares about rather than a flat blob.
- `rac/decisions/adr-051` — retired artifacts (Superseded/Deprecated) render muted.

# Scope

## Included
- A roadmap defining global and local graph modes, with the local graph following the active editor to a user-set depth via the v0.21.7 `reveal-artifact` signal.
- Obsidian-aligned rendering: force-directed layout with center/repel/link forces and link distance, nodes sized by degree, direction arrows, zoom-based label fade, hover-to-highlight with the rest dimmed, and colour by semantic type with a legend.
- Filters mapped to RAC's vocabulary: node search, type/status toggles (shared with the list view), an orphans toggle, and an unresolved-targets toggle.
- Riding the v0.21.7 bridge unchanged (a node is a selection) and re-vendoring the Portal shell with refreshed drift-guard provenance; list/detail stays the default and accessible path.

## Excluded
- Positions or layout in the export, or any server-side layout (breaks determinism and the thin boundary).
- Persisting node positions or per-user layout state; a drag is a one-off nudge.
- Obsidian's animate/time-lapse-over-history — it needs temporal data the export does not carry.
- Custom search-query colour groups — RAC colours by semantic type, so no arbitrary group editor.
- New edge semantics or a graph query language; a heavyweight visualization framework that compromises the offline single-file Portal.
- Any code: this PR is corpus-only (the roadmap artifact). Implementation lands in a later PR.

# Product / Architecture Decisions
- Determinism stays where it belongs — in the data, not the picture: the export carries no positions, so `rac export` stays deterministic/position-free; the on-screen layout is an interactive, seeded force simulation held only in the browser and never written back.
- Thin client (ADR-063) preserved — the graph is drawn entirely in `lore-web` from the export contract; `rac` gains no layout/positions/fields and the extension is unchanged.
- The graph rides the v0.21.7 bridge unchanged (`open-artifact` / `reveal-artifact`) — a node is a selection; no new protocol.
- Colour by semantic type (requirement, decision, roadmap, prompt, design) rather than arbitrary search-query colour groups, with retired (ADR-051) and unresolved targets (ADR-049) drawn distinctly.
- The list/detail view stays the default and accessible path; the graph is an added visualization, not a replacement.

# User-Facing Contract

## CLI
None. This is a corpus-only roadmap-scoping change; no `rac` command, flag, or behavior is added or changed.

## Human Output
None. No terminal output change.

## JSON Output
None. No `rac --json` shape change; the export payload is explicitly unchanged for a given corpus.

## Exit Codes
None. No change to `rac` exit codes.

# Verification

## Ran
- `rac validate rac/` → 0 errors (exit 0).
- `rac relationships rac/ --validate` → 901 checked, 0 issues (exit 0).
- `rac review rac/` → no priority 1–2 findings.

## Covered
- Positive: the new roadmap artifact validates as a well-formed `roadmap` and resolves its ADR/roadmap references (`rac validate`, `rac relationships --validate` both clean).
- Negative / boundary: relationship validation reports 0 issues across 901 checked references, confirming no dangling or ambiguous links were introduced by the added artifact's `Related Decisions`/`Related Roadmaps`; `rac review` surfaces no priority 1–2 findings.

# Review Path
1. `rac/roadmaps/v0.21.x-editor/v0.21.8-corpus-graph-view.md` — the scoped roadmap: Outcomes, the four Initiatives, Constraints, and Non-Goals.
2. The Constraints and Non-Goals sections specifically — they are the scope fence that keeps the feature thin, additive, and deterministic.
3. The corpus gate output (`validate` / `relationships --validate` / `review`) as the acceptance check.

# Notes For Reviewer
- Corpus only; no code. On merge the roadmap stays `Planned` until built, then flips to `Achieved` (ADR-061).
- Builds on v0.21.7 (PR #121) — that lands first; this graph view rides its bridge unchanged.
- Obsidian's docs site 403s automated fetches, so the feature set is drawn from its established, stable conventions rather than a live scrape.

# Implementation Process
Implemented with AI assistance under the v0.21.8 roadmap contract; final scope, review, and acceptance decisions are the maintainer's.