### PR TITLE
Community-alignment programme: MADR decision alignment + roadmap/design authority survey

### DIFF
--- a/rac/designs/community-alignment/madr-decision-alignment.md
+++ b/rac/designs/community-alignment/madr-decision-alignment.md
@@ -1,0 +1,203 @@
+---
+schema_version: 1
+id: RAC-KV7K13484Z0P
+type: design
+tags: [decisions, madr, adr, interop, export]
+---
+# Design: MADR / ADR Decision Alignment
+
+## Context
+
+The decision artifact's community neighbour is the **ADR** (Architecture
+Decision Record) ecosystem. Three authorities matter:
+
+- **MADR (Markdown Any Decision Records), v4.0.0** — `github.com/adr/madr`,
+  the most-adopted Markdown ADR template. Its full template (verified against
+  `raw.githubusercontent.com/adr/madr/main/template/adr-template.md`,
+  fetched 2026-06-16) carries optional YAML front matter `status`, `date`,
+  `decision-makers`, `consulted`, `informed`, and the headings, in order:
+  `# {short title}`, `## Context and Problem Statement`, `## Decision Drivers`,
+  `## Considered Options`, `## Decision Outcome` (with `### Consequences` and
+  `### Confirmation`), `## Pros and Cons of the Options`, `## More Information`.
+  The **minimal** template keeps only `# {title}`, `## Context and Problem
+  Statement`, `## Considered Options`, `## Decision Outcome`, `### Consequences`.
+  Files are `NNNN-title-with-dashes.md` under `docs/decisions/`. MADR follows
+  the community **immutability + supersede** convention: an accepted record is
+  not edited; a changed decision is a new record that supersedes the old.
+- **Nygard / adr-tools** — the original 2011 floor (Title, Status, Context,
+  Decision, Consequences), plain Markdown, no front matter; tooled by
+  `npryce/adr-tools` (`adr new`, `adr new -s` to supersede).
+- **SMADR (Structured MADR)** — `smadr.dev`, a machine-readable superset that
+  adds a JSON Schema and richer front matter (`title`, `type`, `category`,
+  `tags`, `status`, `created`, `updated`, `author`, risk/audit sections).
+
+RAC already records most of how it relates to this ecosystem, but
+asymmetrically. ADR-049 positions MADR as *table-stakes interop*, not a
+differentiator; ADR-048 maps RAC `decision → ADR` in the OKF bundle; v0.17.1
+plans to *recognise* optional MADR fields on the way in. What is missing is the
+mirror of what prompts already have: ADR-057 gives the prompt artifact a
+derived `--dotprompt` export, but the decision artifact has no derived MADR
+export — so RAC can read MADR-shaped decisions but cannot emit canonical MADR.
+This design closes that gap and states the full bidirectional picture in one
+place, under the community-alignment programme.
+
+## User Need
+
+Two audiences, matching the programme's two goals:
+
+- **Onboarding (inbound).** A team with an existing `docs/decisions/` tree of
+  MADR or Nygard ADRs wants those files to classify as RAC `decision`
+  artifacts and pass `rac validate`, so it can adopt RAC's graph enforcement
+  without rewriting its history.
+- **Dogfooding (outbound).** A team standardised on the adr ecosystem (MADR
+  templates, adr-manager, adr-log) wants RAC to emit canonical MADR files, so
+  RAC-authored decisions drop into a MADR repository and are read by existing
+  ADR tooling unchanged.
+
+Neither audience should have to abandon its format, and neither path may
+weaken RAC's strict validation.
+
+## Design
+
+### 1. MADR ↔ RAC field map
+
+The two formats are close; the map is mostly one-to-one onto RAC's existing
+Decision schema (`src/rac/core/artifacts.py`), with a few deliberate
+non-mappings called out.
+
+| MADR (full template) | RAC Decision section | Notes |
+| --- | --- | --- |
+| `# {short title}` | `# Title` | one H1, required both sides |
+| `## Context and Problem Statement` | `## Context` | required ↔ required |
+| `## Decision Outcome` | `## Decision` | required ↔ required (the "chosen option") |
+| `### Consequences` | `## Consequences` | required ↔ required |
+| `## Considered Options` + `## Pros and Cons of the Options` | `## Alternatives Considered` | recommended; the two MADR sections fold into one |
+| `## Decision Drivers` | recognised optional | already named in v0.17.1 field recognition |
+| `### Confirmation`, `## More Information` | recognised optional / `## Related <Type>` | recognised inbound; on export, links degrade to body prose (as in OKF) |
+| front matter `status` | `## Status` | enum maps; **MADR `rejected` has no RAC value** (gap, see Open Questions) |
+| front matter `date` | git-derived | RAC never stores dates in source (ADR-045); derived on export |
+| front matter `decision-makers` / `consulted` / `informed` | no source home | ADR-025 uniform envelope holds; recognised inbound, derived or omitted outbound |
+| — | `## Category` (Architecture/Product/Process/Technical/Other) | RAC-only; no MADR equivalent — dropped or emitted as a tag on export |
+
+The **Nygard floor** (Title, Status, Context, Decision, Consequences) is a
+strict subset of the RAC required sections plus Status, so RAC already
+classifies and validates a Nygard ADR with no new work. **SMADR** is a
+machine-readable superset; its extra front matter is out of scope here and
+recorded as an Open Question rather than mapped.
+
+### 2. Inbound — recognise MADR / Nygard on the way in
+
+Recognition reuses the existing classifier rather than adding a branch. The
+classifier scores `##` headings against `ArtifactSpec` (`classification.py`),
+and the spec already carries a `synonyms` table. MADR's heading vocabulary is
+added there as decision-section synonyms — `context and problem statement →
+context`, `decision outcome → decision`, `considered options → alternatives
+considered` — so a MADR or Nygard file classifies as a `decision` and routes
+through the normal validator. This *extends* the v0.17.1 MADR-field-recognition
+initiative and the `rac-import` skill's single-document flow; it does not
+re-decide them, and it adds no new command. A recognised MADR file then
+benefits from RAC's graph checks the moment it joins a corpus.
+
+### 3. Outbound — a derived MADR export
+
+RAC gains a derived MADR view, exactly parallel to ADR-057's `--dotprompt`
+projection and ADR-048's OKF bundle: a `rac export … --madr` surface (the
+exact flag fenced to implementation) projects each `decision` artifact into a
+canonical MADR file — MADR front matter (`status` from `## Status`, `date`
+git-derived) and the MADR heading layout, written as `NNNN-title.md`. The RAC
+source stays the uniform ADR-025 envelope; the MADR file is a *derived,
+deterministic* contract regenerable from the artifact, never a second source of
+truth (ADR-002, ADR-007). Validation aligns the *contract*, not the prose: RAC
+checks that a decision can produce a valid MADR projection (the required
+sections exist), exactly as ADR-057 checks the dotprompt projection — no model
+judges the decision text.
+
+### 4. Dogfooding hooks
+
+Two demonstrations make the alignment concrete rather than asserted: (a) round-
+trip fixtures built from real MADR and adr-tools example repositories — import,
+validate, export, diff — proving RAC reads and re-emits artifacts it did not
+author; (b) RAC's own `rac/decisions/` corpus exported to MADR as a reference
+bundle. Both reinforce the ADR-049 line: MADR validates a single file in
+isolation; RAC additionally enforces the corpus as a graph.
+
+## Constraints
+
+- **No AI in core (ADR-002).** Recognition and export are pure parsing and
+  projection; nothing judges decision prose. Deterministic: same artifact, same
+  MADR output and ordering.
+- **Uniform envelope (ADR-025).** No MADR-specific fields enter decision
+  *source* front matter; `decision-makers`/`consulted`/`informed`/`date` stay
+  out of source and are derived or omitted on export.
+- **Derived-contract pattern (ADR-048, ADR-057).** The MADR view is an export,
+  parallel to OKF and dotprompt — one mental model for interchange views.
+- **Additive, contract-stable (ADR-007).** New synonyms and a new export only;
+  no existing decision code, enum, or JSON contract changes.
+- **Identity (ADR-026).** RAC keeps its opaque `id`; MADR's `NNNN` sequential
+  number is an export-time concern, not a second identity in source.
+- **Table-stakes positioning (ADR-049).** MADR compatibility is interop, not
+  the pitch; the graph-enforcement differentiator is untouched.
+
+## Rationale
+
+Reusing the derived-contract pattern (OKF, SARIF, dotprompt) means the MADR
+view inherits determinism, regenerability, and the existing export plumbing,
+and gives users one model for "speak another tool's format". Folding MADR
+headings into the classifier's synonym table — rather than a MADR-specific
+parser — keeps recognition spec-driven and consistent with how RAC already
+handles section aliases. Together they close the prompt/decision asymmetry
+(prompts could already be emitted to dotprompt; decisions could not be emitted
+to MADR) at low cost, serving both onboarding and dogfooding without conceding
+the differentiator.
+
+## Alternatives
+
+- **Add MADR fields to decision source front matter.** Rejected for the same
+  reasons ADR-057 rejected the dotprompt analogue: it forks the uniform ADR-025
+  envelope and pulls per-type schema machinery (and SMADR's JSON Schema) into
+  source. Reconsider only on real demand.
+- **Inbound recognition only (the v0.17.1 floor).** Insufficient: it serves
+  onboarding but not dogfooding — RAC could read MADR but never emit it, leaving
+  the prompt/decision asymmetry in place.
+- **A hand-authored MADR sidecar per decision.** Rejected: a second source that
+  drifts; the derived export gives the same output without the drift.
+- **Do nothing.** Rejected: MADR is the decision-interop frontrunner and the
+  derived view is cheap given the OKF/dotprompt precedent.
+
+## Open Questions
+
+- Pin to MADR 4.0.0, and revisit on a new MADR release (as ADR-048 does for
+  OKF)?
+- Is SMADR (the machine-readable superset) worth a separate export profile, or
+  out of scope until a user asks?
+- How should MADR's `rejected` status map, given RAC's lifecycle is
+  Proposed/Accepted/Superseded/Deprecated (ADR-051)? And does MADR's
+  immutability + supersede convention reconcile cleanly with RAC's `supersedes`
+  relationship and status-consistency check?
+- What is the export filename / numbering source — derive `NNNN` from a stable
+  ordering, reuse the legacy `adr-NNN` prefix, or keep the opaque id?
+- Which release series schedules the `--madr` export (v0.15.x interop or
+  v0.17.x adoption)? Recorded here as intent; scheduling is a separate decision.
+
+## Related Decisions
+
+- adr-049
+- adr-048
+- adr-057
+- adr-025
+- adr-051
+- adr-026
+- adr-006
+- adr-002
+- adr-007
+
+## Related Requirements
+
+- rac-cross-artifact-enforcement
+- rac-okf-carrier-profile
+
+## Related Roadmaps
+
+- community-alignment-programme
+- v0.17.0-single-document-import-skill
+- v0.17.1-per-type-standards-enforcement

--- a/rac/designs/community-alignment/roadmap-design-authority-survey.md
+++ b/rac/designs/community-alignment/roadmap-design-authority-survey.md
@@ -1,0 +1,160 @@
+---
+schema_version: 1
+id: RAC-KV7KKEY005V9
+type: design
+tags: [roadmap, design, interop, standards, survey]
+---
+# Design: Roadmap and Design Authority Survey
+
+## Context
+
+The community-alignment programme's Initiative 3 asks whether RAC's **roadmap**
+and **design** artifact families have an external community authority worth
+aligning to — a MADR-equivalent — and to record the finding so the question is
+not reopened without cause.
+
+Four of RAC's five families already have such an authority: decision ↔ MADR,
+prompt ↔ dotprompt, requirement ↔ ISO/IEC/IEEE 29148 + EARS, carrier ↔ OKF.
+Each clears a recognisable bar that makes bidirectional interop (inbound
+recognition + an outbound derived export) meaningful. This survey applies the
+same bar to the two remaining families and records the result.
+
+Findings derive from web research conducted 2026-06-16; primary URLs are cited
+inline. Adoption is characterised qualitatively (and conservatively) — the
+durable basis for each verdict is structural, not a snapshot of star counts.
+
+The bar — a candidate qualifies only if it meets most of these:
+
+1. **Named and community-maintained** — an open, named spec/repo, not a single
+   vendor's product and not merely a blog-post concept.
+2. **A concrete per-artifact file format** — a defined Markdown/YAML template or
+   schema RAC could recognise and emit, not a methodology or a process.
+3. **Tooling** — a CLI, editor extension, linter, or generator exists.
+4. **Real adoption** — meaningful ecosystem presence, not a niche solo project.
+5. **Per-artifact fit** — represents one roadmap / one design as a discrete
+   document (as MADR represents one decision), so RAC could map its sections.
+
+## User Need
+
+A maintainer deciding where to spend alignment effort needs a defensible,
+recorded answer for the two unaligned families, so effort flows to the families
+where a real standard exists and is not repeatedly re-litigated for families
+where none does. A negative finding, recorded with its reopen conditions, is the
+deliverable.
+
+## Design
+
+### Roadmap family — finding: NO qualifying authority
+
+| Candidate | Kind | Verdict |
+| --- | --- | --- |
+| Now/Next/Later (ProdPad) | methodology / time-horizon framework | NOT-A-FORMAT |
+| OKRs (Objectives & Key Results) | goal-setting methodology | NOT-A-FORMAT |
+| RICE | prioritisation technique | NOT-A-FORMAT |
+| GitHub public roadmap | issues + project board, platform-bound | NOT-A-FORMAT |
+| SierraSoftworks/roadmap | YAML + JSON-schema file format with a CLI | ADJACENT — fails adoption (tens of stars; no ecosystem) |
+
+The product/release roadmap space is dominated by *methodologies* (Now/Next/
+Later, OKRs, RICE) and *proprietary tools* (ProdPad, Jira, ProductPlan), none of
+which is a portable, interoperable file format. The only genuine open file
+format found, `SierraSoftworks/roadmap` (a YAML schema with a graphviz CLI), has
+negligible adoption and no community presence. **No external roadmap authority
+clears the bar.** Sources:
+[ProdPad](https://www.prodpad.com/blog/invented-now-next-later-roadmap/),
+[SierraSoftworks/roadmap](https://github.com/SierraSoftworks/roadmap),
+[github/roadmap](https://github.com/github/roadmap).
+
+### Design family — finding: NO qualifying authority
+
+| Candidate | Kind | Verdict |
+| --- | --- | --- |
+| arc42 | whole-system architecture documentation (12 sections) | ADJACENT — not per-artifact |
+| IEEE 1016 (SDD) | formal whole-system design standard, paywalled | ADJACENT — not per-artifact, not community-maintained |
+| RFC / RFD tradition (Rust, React, PEP, Oxide) | per-proposal pattern, project-specific templates | ADJACENT — no shared cross-community standard |
+| C4 model | architecture diagramming notation | NOT-A-FORMAT |
+| DESIGN.md (Google Labs) | design-system token format (UI), different domain | NOT-A-FORMAT |
+| Diátaxis / DACI / TOGAF | doc-structure / decision-roles / enterprise framework | NOT-A-FORMAT |
+
+The strongest signals — the RFC/RFD tradition (Rust RFCs, React RFCs, Python
+PEPs, Oxide RFDs) — prove that per-artifact design-as-code is popular, but each
+project maintains its own template in its own repo; there is no shared,
+cross-community design-doc standard to interoperate with. arc42 and IEEE 1016
+are mature and named, but document a *whole system* rather than one design, so
+they are containers for many designs, not a per-artifact peer to MADR. **No
+single cross-community per-design-document authority comparable to MADR or
+dotprompt exists.** Sources:
+[arc42](https://arc42.org/),
+[rust-lang/rfcs](https://github.com/rust-lang/rfcs),
+[Oxide RFD 1](https://oxide.computer/blog/rfd-1-requests-for-discussion),
+[Pragmatic Engineer: RFCs and design docs](https://blog.pragmaticengineer.com/rfcs-and-design-docs/).
+
+### Cross-family conclusion
+
+Of RAC's five families, **four** have a real external authority and a clear
+interop mechanism; **two — roadmap and design — have none**. The bidirectional
+recognition-plus-derived-export mechanism the programme defines therefore
+applies to four families. For roadmap and design there is, at the survey date,
+nothing to align to: no recognition target on import, no canonical format to
+emit on export. These families stay RAC-native until a qualifying standard
+emerges.
+
+## Constraints
+
+- **Do not invent alignment where no authority exists.** Building a derived
+  export to a niche or single-vendor format would contradict the ADR-049 frame
+  (alignment is table-stakes interop with a *community*, not the differentiator)
+  and pin RAC to a moving, low-adoption target (cf. ADR-048's informative,
+  pinned-dependency posture).
+- **The finding is dated.** It reflects the 2026-06-16 landscape; standards
+  move, so the verdict is revisited under the reopen conditions below, not
+  treated as permanent.
+- **Analysis only.** This artifact records a survey result; it changes no code
+  and schedules no work.
+
+## Rationale
+
+Recording the negative finding is itself the value Initiative 3 asked for: it
+stops the question being reopened without cause and concentrates alignment
+effort on the four families that have a real peer. The verdict rests on durable
+structural distinctions — methodology vs. file format, whole-system framework
+vs. per-artifact document, project-specific pattern vs. cross-community standard
+— rather than on adoption counts that will drift, so it remains sound even as
+the specific projects evolve.
+
+## Alternatives
+
+- **Adopt SierraSoftworks/roadmap as RAC's roadmap interop target.** Rejected:
+  it fails the adoption bar; aligning to a tens-of-stars solo project is not
+  interop with a community and pins RAC to a moving niche format.
+- **Treat arc42 or the RFC pattern as the design authority.** Rejected: arc42
+  is whole-system, not per-design; the RFC tradition has no shared template or
+  tooling to interoperate with — only per-project variants.
+- **Publish RAC's own roadmap/design format and seek to make it the standard.**
+  Out of scope for an alignment survey — that is a leadership move, recorded if
+  pursued as a separate decision (an ADR), not concluded here.
+- **Do nothing and leave the question implicit.** Rejected: the programme
+  explicitly wants the finding recorded so it is not silently reopened.
+
+## Open Questions
+
+These are the conditions under which the question should be reopened:
+
+- **Roadmap.** A roadmap file format reaches MADR-class adoption and tooling —
+  for example `SierraSoftworks/roadmap` crosses a real adoption threshold, or a
+  new community standard emerges with an open spec and ecosystem.
+- **Design.** A cross-community per-artifact design-doc Markdown standard
+  emerges — for example the RFC traditions converge on a shared template, or
+  arc42 ships a per-design sub-template usable as a discrete artifact.
+- **Leadership.** Whether RAC should publish its own roadmap/design format
+  (rather than align to one) is a separate, future decision, not part of this
+  survey.
+
+## Related Decisions
+
+- adr-049
+- adr-048
+- adr-057
+
+## Related Roadmaps
+
+- community-alignment-programme

--- a/rac/roadmaps/community-alignment/community-alignment-programme.md
+++ b/rac/roadmaps/community-alignment/community-alignment-programme.md
@@ -72,7 +72,13 @@ nothing to them beyond the cross-cutting frame above.
 For roadmap and design, investigate whether a community authority worth
 aligning to exists at all. If one does, record it as a new per-authority
 design under `rac/designs/community-alignment/`; if none does, record that
-finding so the question is not reopened without cause.
+finding so the question is not reopened without cause. **Done:** the
+`roadmap-design-authority-survey` design records the result — neither family
+has a qualifying authority (roadmap is dominated by methodologies and one
+low-adoption schema; design has only whole-system frameworks and
+project-specific RFC patterns, no cross-community per-artifact standard) — with
+explicit reopen conditions. Both families stay RAC-native until a qualifying
+standard emerges.
 
 ### Initiative 4 — Ecosystem presence and dogfooding
 
@@ -141,6 +147,7 @@ stays behind the growth-programme's GATE-1.
 ## Related Designs
 
 - madr-decision-alignment
+- roadmap-design-authority-survey
 - per-type-standards-checks
 
 ## Related Roadmaps

--- a/rac/roadmaps/community-alignment/community-alignment-programme.md
+++ b/rac/roadmaps/community-alignment/community-alignment-programme.md
@@ -1,0 +1,151 @@
+---
+schema_version: 1
+id: RAC-KV7K127TT87W
+type: roadmap
+tags: [adoption, interop, standards, community]
+---
+# Community-Alignment Programme
+
+## Outcomes
+
+RAC neighbours a set of living community standards — one per artifact family.
+This programme makes RAC's relationship to each of them explicit, coherent, and
+recorded in one place, so that two things become true: a team can bring its
+existing artifacts *into* RAC (onboarding), and RAC can emit each community's
+canonical format and sit *inside* that community's tooling (dogfooding).
+
+The framing is inherited from ADR-049: the markdown carrier and the per-type
+schemas are *table stakes*; RAC's differentiator is deterministic, CI-enforced
+validation of the corpus as a graph. Alignment therefore means *compatibility*
+(recognise the format on the way in, emit it on the way out), never adopting a
+community schema as RAC's source of truth.
+
+For each family the programme records the same three things — the external
+**authority**, the alignment **mechanism** (inbound recognition and/or an
+outbound derived export), and the **corpus artifact** that holds the detail —
+and then names where a gap remains:
+
+- **decision ↔ MADR / Nygard / SMADR.** Mechanism: inbound field recognition
+  (begun in v0.17.1) plus a new outbound derived MADR export. Record:
+  `madr-decision-alignment` design (this programme's first concrete output).
+  Gap closed here — decisions previously had no symmetric export, unlike
+  prompts.
+- **requirement ↔ ISO/IEC/IEEE 29148, EARS, BCP-14.** Mechanism: deterministic
+  per-type checks (the decidable subset). Record: ADR-056 and the
+  `per-type-standards-checks` design, scheduled in v0.17.1. No new work — the
+  programme references it.
+- **prompt ↔ dotprompt.** Mechanism: a derived `.prompt` export, source
+  unchanged. Record: ADR-057. No new work — referenced.
+- **carrier ↔ OKF.** Mechanism: an OKF-conformant bundle view and a
+  conformance check, with `decision → ADR` already in the type map. Record:
+  ADR-048, ADR-052, the `rac-okf-carrier-profile` requirement, and the
+  v0.15.1 conformance gate. No new work — referenced.
+- **roadmap ↔ ? and design ↔ ?.** No established external community authority
+  is yet identified. Open: survey whether one exists (Now/Next/Later horizons
+  and OKRs for roadmaps; RFC / design-doc conventions for designs) before
+  proposing any alignment.
+
+The outcome is a single map a reader can scan to see, per family, what RAC
+already speaks, what it does not, and which artifact to read for the detail.
+
+## Initiatives
+
+### Initiative 1 — Decision ↔ MADR (the net-new gap)
+
+Produce the `madr-decision-alignment` design: an exact MADR↔RAC field map, an
+inbound recognition path that extends the v0.17.1 MADR-field work and the
+`rac-import` skill, and an outbound derived MADR export that mirrors ADR-057's
+dotprompt projection and ADR-048's OKF bundle. Bidirectional, deterministic,
+source unchanged. This is the only family that lacked a symmetric design, and
+it is delivered alongside this programme.
+
+### Initiative 2 — Consolidate the already-recorded families
+
+Reference, do not duplicate. Requirement (29148/EARS/BCP-14), prompt
+(dotprompt), and carrier (OKF) alignment are already decided and designed; the
+programme links to ADR-056 / `per-type-standards-checks`, ADR-057, and
+ADR-048 / ADR-052 / `rac-okf-carrier-profile` / v0.15.1 respectively, and adds
+nothing to them beyond the cross-cutting frame above.
+
+### Initiative 3 — Survey the unaligned families
+
+For roadmap and design, investigate whether a community authority worth
+aligning to exists at all. If one does, record it as a new per-authority
+design under `rac/designs/community-alignment/`; if none does, record that
+finding so the question is not reopened without cause.
+
+### Initiative 4 — Ecosystem presence and dogfooding
+
+Establish RAC as a recognised tool in the adr ecosystem (the adr org index,
+adr-manager / adr-log neighbours) and validate real community corpora —
+MADR and adr-tools example repositories — as round-trip fixtures, so the
+import/export claims are demonstrated against artifacts RAC did not author.
+This is where the ADR-049 positioning line ("MADR validates one file; RAC
+enforces the graph") is shown rather than asserted. Public-facing posting
+stays behind the growth-programme's GATE-1.
+
+## Success Measures
+
+- A reader can name, for every RAC artifact family, its community authority,
+  the alignment mechanism, and the artifact that records the detail — from this
+  one document.
+- Each per-authority design produced by the programme passes `rac validate`,
+  and every relationship in this programme and its designs resolves under
+  `rac relationships --validate`.
+- Importing a real MADR or adr-tools decision yields a RAC artifact that
+  validates; exporting a RAC decision yields a file a MADR consumer accepts.
+- No community schema is adopted as a RAC source format; the ADR-049
+  enforcement differentiator is preserved on every aligned family.
+
+## Assumptions
+
+- The programme is unscheduled: it lives in a named theme folder
+  (`rac/roadmaps/community-alignment/`), not a version series, and feeds the
+  adoption/interop releases rather than constituting one. Scheduling any
+  outbound export is a later, separately recorded decision.
+- This programme introduces the first `rac/designs/` subfolder
+  (`community-alignment/`). Folder layout is ungoverned by any ADR and
+  validation walks recursively, so the grouping is organizational only and
+  changes no behaviour.
+- The external standards remain as cited; the programme tracks the decidable,
+  compatibility-level surface of each, not their evolving prose.
+
+## Risks
+
+- Scope sprawl across five families. Mitigated: only the decision/MADR gap is
+  worked here; the rest are references, and the unaligned families are a survey
+  before any commitment.
+- Drift as upstream standards move (MADR, dotprompt, OKF are pre- or
+  early-stable). Mitigated: each alignment is pinned and revisited in its own
+  artifact, consistent with ADR-048's informative-dependency posture.
+- Positioning confusion — alignment read as RAC conceding the differentiator.
+  Mitigated: the ADR-049 frame is restated here and in each design; alignment
+  is interop, not foundation.
+
+## Related Decisions
+
+- adr-049
+- adr-048
+- adr-052
+- adr-057
+- adr-056
+- adr-036
+
+## Related Requirements
+
+- rac-cross-artifact-enforcement
+- rac-okf-carrier-profile
+- rac-growth-adoption
+- rac-growth-positioning
+
+## Related Designs
+
+- madr-decision-alignment
+- per-type-standards-checks
+
+## Related Roadmaps
+
+- growth-programme
+- v0.17.0-single-document-import-skill
+- v0.17.1-per-type-standards-enforcement
+- v0.15.1-okf-conformance-check


### PR DESCRIPTION
# Summary

Implements the community-alignment programme
(`rac/roadmaps/community-alignment/community-alignment-programme.md`): an
unscheduled theme that records, in one place, how each RAC artifact family
relates to its external community standard — so a team can bring existing
artifacts *into* RAC (onboarding) and RAC can emit each community's canonical
format and sit *inside* its tooling (dogfooding). The frame is inherited from
ADR-049: carriers and per-type schemas are table stakes; RAC's differentiator
is deterministic, CI-enforced graph validation. Alignment means compatibility,
never adopting a community schema as RAC's source of truth.

Adds (corpus artifacts only — no code):

- A **programme roadmap** mapping all five families to authority + mechanism +
  the corpus artifact that records the detail, consolidating the
  already-recorded families by reference rather than duplicating them.
- A **MADR/decision alignment design** — the net-new gap: decisions had no
  symmetric export the way prompts gained one in ADR-057.
- A **roadmap/design authority survey** recording a negative finding with
  explicit reopen conditions.
- Two new theme folders: `rac/roadmaps/community-alignment/` and
  `rac/designs/community-alignment/` (the first `rac/designs/` subfolder).

# Roadmap / ADR Trace

Roadmap (programme, unscheduled — a theme folder, not a version series):
- `rac/roadmaps/community-alignment/community-alignment-programme.md`

Designs:
- `rac/designs/community-alignment/madr-decision-alignment.md`
- `rac/designs/community-alignment/roadmap-design-authority-survey.md`

Relevant ADRs (referenced, not modified):
- `rac/decisions/adr-049-enforcement-is-the-product.md` — the table-stakes frame
- `rac/decisions/adr-048-okf-carrier-profile.md` — derived-contract + pinned-dependency posture
- `rac/decisions/adr-057-prompt-dotprompt-alignment.md` — the derived-export precedent this design mirrors
- `rac/decisions/adr-025-hybrid-artifact-metadata.md` — uniform front-matter envelope
- `rac/decisions/adr-051-lifecycle-status-generalized.md`, `adr-026-opaque-artifact-identities.md`, `adr-002`, `adr-007`, `adr-006`

# Scope

## Included
- Programme roadmap that frames alignment across all five families and points
  at the existing records for requirement↔29148/EARS (ADR-056,
  `per-type-standards-checks`), prompt↔dotprompt (ADR-057), and carrier↔OKF
  (ADR-048/052, `rac-okf-carrier-profile`, v0.15.1).
- MADR/decision design: an exact MADR↔RAC field map; an inbound recognition
  path via the classifier synonym table (extends v0.17.1 and the `rac-import`
  skill); and an outbound derived `rac export --madr` view mirroring ADR-057's
  `--dotprompt` and ADR-048's OKF bundle.
- Authority survey for the two unaligned families, with a stated bar, candidate
  tables, and reopen conditions.

## Excluded
- **No source code.** No new CLI command, flag, schema field, classifier
  synonym, or export is implemented here — these designs record intent; the
  `--madr` export and MADR recognition are scoped to a later, separately
  recorded release decision.
- **No re-decision of the aligned families.** Requirement, prompt, and carrier
  alignment are referenced, not re-documented.
- **No alignment invented for roadmap/design.** The survey deliberately declines
  to adopt a low-adoption or single-vendor format; whether RAC should *publish*
  its own roadmap/design format is left as a separate future decision.
- **No release scheduled.** The programme is unscheduled.

# Product / Architecture Decisions

- **Derived export, not a source change.** The MADR view is projected from the
  artifact (parallel to OKF and dotprompt), keeping the ADR-025 uniform
  front-matter envelope; MADR-specific fields (`decision-makers`, `consulted`,
  `informed`, `date`) never enter decision source.
- **Recognition via the classifier synonym table**, not a MADR-specific parser,
  keeping inbound mapping spec-driven.
- **Negative findings are recorded, not omitted.** The survey rests on durable
  structural distinctions (methodology vs. file format; whole-system framework
  vs. per-artifact document; project-specific pattern vs. cross-community
  standard), so it stays sound as specific projects evolve, and it names the
  conditions that would reopen the question.
- **Theme-folder layout** for the programme and its designs. Folder layout is
  ungoverned by any ADR and validation walks recursively, so the grouping is
  organizational only and changes no behavior (recorded in the programme's
  Assumptions).

# User-Facing Contract

Not applicable — this is a corpus-only change. No CLI command, human/JSON
output, schema, or exit-code behavior is added or changed. The artifacts
*describe* a future `rac export --madr` surface but do not implement it.

# Verification

## Ran
- `rac validate rac/` → exit 0
- `rac relationships rac/ --validate` → exit 0
- `rac review rac/` → 0 priority-1/2 findings; health 91/100 (unchanged from baseline)
- `rac inspect` on each new file → Roadmap (100%), Design (85%), Design (85%)
- `python3 -m pytest tests/test_corpus.py tests/test_dogfood.py tests/test_relationship_validation.py tests/test_relationship_graph.py` → 58 passed
- MADR v4.0.0 template verified against the primary source
  (`raw.githubusercontent.com/adr/madr/main/template/adr-template.md`, fetched 2026-06-16)

## Covered
- Every relationship target in the three artifacts resolves (verified per-id
  with `rac resolve`); nothing references a Superseded/Deprecated decision.
- Edge-legality: the survey initially carried a `## Related Designs` section;
  `rac relationships --validate` correctly flagged it (a design declares no
  design→design edge, per `rac-cross-artifact-enforcement` REQ-004), and it was
  removed — the survey↔programme↔designs linkage runs through the programme's
  Related Designs instead. This is the negative-boundary evidence that the
  edge-legality rule works on the new content.

# Review Path

1. `community-alignment-programme.md` — the framing and the all-families map.
2. `madr-decision-alignment.md` — the net-new field map and bidirectional mechanism.
3. `roadmap-design-authority-survey.md` — the survey, verdicts, and reopen conditions.

# Notes For Reviewer

- The MADR design leaves scheduling of the `--madr` export (v0.15.x interop vs.
  v0.17.x adoption) as an open question — intentionally not decided here.
- Survey adoption claims are kept qualitative and conservative and cite primary
  sources; the load-bearing conclusion is structural, not a star-count snapshot.
- The programme's Initiative 3 is marked done and references the survey.

# Implementation Process

Drafted with AI assistance under the community-alignment programme; the survey's
external research was fact-checked against primary sources. Final scope, review,
and acceptance decisions are the maintainer's.