### PR TITLE
feat(sdk): first-run onboarding and rac provisioning (v0.21.11)

### DIFF
--- a/typescript/rac-sdk/src/client.ts
+++ b/typescript/rac-sdk/src/client.ts
@@ -13,7 +13,9 @@ import type {
   DirectoryValidation,
   FileValidation,
   FindResult,
+  InitResult,
   PortfolioStats,
+  QuickstartResult,
   RelationshipValidation,
   ResolveResult,
   ReviewReport,
@@ -130,6 +132,27 @@ export class RacClient {
   /** `rac new <type> <path> --json` — scaffold a new artifact (never overwrites). */
   createArtifact(artifactType: string, outputPath: string): Promise<CreatedArtifact> {
     return this.json<CreatedArtifact>(["new", artifactType, outputPath, "--json"]);
+  }
+
+  /** `rac init <dir> [--key K] --json` — establish the repository identity (`.rac/config.yaml`). */
+  init(directory: string, key?: string): Promise<InitResult> {
+    const args = ["init", directory, "--json"];
+    if (key !== undefined) args.push("--key", key);
+    return this.json<InitResult>(args);
+  }
+
+  /**
+   * `rac quickstart <dir> [--key K] [--type T] --json` — guided first run:
+   * establish the identity and scaffold a starter artifact.
+   */
+  quickstart(
+    directory: string,
+    options: { key?: string; type?: string } = {},
+  ): Promise<QuickstartResult> {
+    const args = ["quickstart", directory, "--json"];
+    if (options.key !== undefined) args.push("--key", options.key);
+    if (options.type !== undefined) args.push("--type", options.type);
+    return this.json<QuickstartResult>(args);
   }
 
   /**

--- a/typescript/rac-sdk/src/index.ts
+++ b/typescript/rac-sdk/src/index.ts
@@ -62,6 +62,8 @@ export type {
   PortfolioStats,
   SchemaReference,
   CreatedArtifact,
+  InitResult,
+  QuickstartResult,
   CorpusMeta,
   ExportArtifact,
   ExportRelationship,

--- a/typescript/rac-sdk/src/types.ts
+++ b/typescript/rac-sdk/src/types.ts
@@ -201,6 +201,19 @@ export interface CreatedArtifact {
   id: string;
 }
 
+// --- rac init / rac quickstart --json ---------------------------------------
+
+export interface InitResult {
+  schema_version: string;
+  repository_key: string;
+  config_path: string;
+  created: boolean;
+}
+
+export interface QuickstartResult extends InitResult {
+  artifact: { type: string; path: string; id: string };
+}
+
 // --- rac export <dir> --json (the lore-web viewer payload) ------------------
 
 export interface CorpusMeta {

--- a/typescript/rac-sdk/test/client.test.ts
+++ b/typescript/rac-sdk/test/client.test.ts
@@ -238,3 +238,67 @@ describe("error mapping", () => {
     );
   });
 });
+
+describe("init", () => {
+  it("runs `rac init <dir> --json` with the key and parses the result", async () => {
+    const { runner, calls } = fakeRunner({
+      stdout: JSON.stringify({
+        schema_version: "1",
+        repository_key: "DEMO",
+        config_path: "/w/.rac/config.yaml",
+        created: true,
+      }),
+    });
+    const result = await new RacClient({ runner }).init("/w", "DEMO");
+    expect(result.repository_key).toBe("DEMO");
+    expect(result.created).toBe(true);
+    expect(calls[0]).toEqual(["init", "/w", "--json", "--key", "DEMO"]);
+  });
+
+  it("omits --key when not given", async () => {
+    const { runner, calls } = fakeRunner({
+      stdout: JSON.stringify({
+        schema_version: "1",
+        repository_key: "W",
+        config_path: "p",
+        created: true,
+      }),
+    });
+    await new RacClient({ runner }).init("/w");
+    expect(calls[0]).toEqual(["init", "/w", "--json"]);
+  });
+});
+
+describe("quickstart", () => {
+  it("runs `rac quickstart <dir> --json` with key/type and parses the scaffolded artifact", async () => {
+    const { runner, calls } = fakeRunner({
+      stdout: JSON.stringify({
+        schema_version: "1",
+        repository_key: "DEMO",
+        config_path: "/w/.rac/config.yaml",
+        created: true,
+        artifact: {
+          type: "requirement",
+          path: "/w/rac/requirements/first-requirement.md",
+          id: "DEMO-KV8QR2AVYDFN",
+        },
+      }),
+    });
+    const result = await new RacClient({ runner }).quickstart("/w", {
+      key: "DEMO",
+      type: "requirement",
+    });
+    expect(result.repository_key).toBe("DEMO");
+    expect(result.artifact.id).toBe("DEMO-KV8QR2AVYDFN");
+    expect(result.artifact.path).toContain("first-requirement.md");
+    expect(calls[0]).toEqual([
+      "quickstart",
+      "/w",
+      "--json",
+      "--key",
+      "DEMO",
+      "--type",
+      "requirement",
+    ]);
+  });
+});

--- a/typescript/rac-sdk/test/integration.test.ts
+++ b/typescript/rac-sdk/test/integration.test.ts
@@ -77,4 +77,19 @@ describe.skipIf(!racBin)("integration (real rac)", () => {
       await rm(dir, { recursive: true, force: true });
     }
   });
+
+  it("scaffolds a corpus with quickstart", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "rac-sdk-qs-"));
+    try {
+      const result = await rac.quickstart(dir, { key: "QSTEST" });
+      expect(result.repository_key).toBe("QSTEST");
+      expect(result.created).toBe(true);
+      expect(result.config_path).toContain(".rac");
+      expect(result.artifact.id.startsWith("QSTEST-")).toBe(true);
+      const body = await readFile(result.artifact.path, "utf8");
+      expect(body).toContain("schema_version");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
 });

--- a/typescript/rac-vscode/package.json
+++ b/typescript/rac-vscode/package.json
@@ -31,7 +31,9 @@
   ],
   "main": "./dist/extension.js",
   "activationEvents": [
-    "workspaceContains:**/.rac/config.yaml"
+    "workspaceContains:**/.rac/config.yaml",
+    "onCommand:rac.setupWorkspace",
+    "onCommand:rac.installRac"
   ],
   "contributes": {
     "commands": [
@@ -46,6 +48,38 @@
       {
         "command": "rac.showExplorer",
         "title": "RAC: Open Explorer"
+      },
+      {
+        "command": "rac.setupWorkspace",
+        "title": "RAC: Set Up Workspace"
+      }
+    ],
+    "walkthroughs": [
+      {
+        "id": "rac.gettingStarted",
+        "title": "Get Started with RAC",
+        "description": "Set up a requirements-as-code corpus and watch the editor enforce your recorded decisions.",
+        "steps": [
+          {
+            "id": "install",
+            "title": "Install the rac CLI",
+            "description": "The extension runs your local `rac` CLI and reimplements nothing. Install it with pipx, or point the extension at an existing install.\n[Install with pipx](command:rac.installRac)\n[Set rac.path](command:workbench.action.openSettings?%5B%22rac.path%22%5D)",
+            "media": { "markdown": "walkthroughs/install.md" }
+          },
+          {
+            "id": "scaffold",
+            "title": "Set up your corpus",
+            "description": "Create a `.rac/config.yaml` identity and a starter artifact via `rac quickstart`.\n[Set Up Workspace](command:rac.setupWorkspace)",
+            "media": { "markdown": "walkthroughs/scaffold.md" },
+            "completionEvents": ["onCommand:rac.setupWorkspace"]
+          },
+          {
+            "id": "enforce",
+            "title": "See enforcement in your editor",
+            "description": "In a relationship section (e.g. `## Related Decisions`), reference a decision that does not exist — RAC flags it at the reference site, exactly as `rac relationships --validate` does on the CLI. That is the whole idea: the decisions your team already made, enforced where you type.",
+            "media": { "markdown": "walkthroughs/enforce.md" }
+          }
+        ]
       }
     ],
     "configuration": {

--- a/typescript/rac-vscode/src/extension.ts
+++ b/typescript/rac-vscode/src/extension.ts
@@ -109,6 +109,8 @@ export function activate(context: vscode.ExtensionContext): void {
     vscode.commands.registerCommand("rac.validateWorkspace", validateWorkspace),
     vscode.commands.registerCommand("rac.newArtifact", newArtifact),
     vscode.commands.registerCommand("rac.showExplorer", showExplorer),
+    vscode.commands.registerCommand("rac.setupWorkspace", setupWorkspace),
+    vscode.commands.registerCommand("rac.installRac", installRac),
     vscode.languages.registerHoverProvider(selector, { provideHover }),
     vscode.languages.registerDefinitionProvider(selector, { provideDefinition }),
     vscode.languages.registerReferenceProvider(selector, { provideReferences }),
@@ -1130,18 +1132,71 @@ function log(message: string, err?: unknown): void {
 function warnMissingOnce(): void {
   if (warnedMissing) return;
   warnedMissing = true;
+  const INSTALL = "Install with pipx";
+  const PATH = "Set rac.path";
   void vscode.window
     .showWarningMessage(
-      "RAC: the `rac` CLI was not found. Install it (pip install requirements-as-code) " +
-        "or set `rac.path` in settings.",
-      "Open Settings",
+      "RAC: the `rac` CLI was not found. Install it, or point the extension at an existing install.",
+      INSTALL,
+      PATH,
     )
     .then((choice) => {
-      if (choice === "Open Settings") {
-        void vscode.commands.executeCommand(
-          "workbench.action.openSettings",
-          "rac.path",
-        );
+      if (choice === INSTALL) installRac();
+      else if (choice === PATH) {
+        void vscode.commands.executeCommand("workbench.action.openSettings", "rac.path");
       }
     });
+}
+
+// Open a terminal pre-loaded with the recommended install, for the user to run.
+// Wired to the missing-rac prompt and the Get-Started walkthrough.
+function installRac(): void {
+  const term = vscode.window.createTerminal("Install rac");
+  term.show();
+  term.sendText("pipx install requirements-as-code");
+}
+
+// Scaffold an empty workspace into a RAC corpus via `rac quickstart` (identity +
+// a starter artifact), then open it. The thin client computes nothing — `rac`
+// establishes the `.rac/config.yaml` identity and the template. Available in any
+// workspace (the command activates the extension), not just RAC ones.
+async function setupWorkspace(): Promise<void> {
+  const folder = vscode.workspace.workspaceFolders?.[0];
+  if (!folder) {
+    void vscode.window.showErrorMessage("RAC: open a folder first, then set up a corpus.");
+    return;
+  }
+  const config = vscode.Uri.joinPath(folder.uri, ".rac", "config.yaml");
+  try {
+    await vscode.workspace.fs.stat(config);
+    void vscode.window.showInformationMessage(
+      "RAC: this workspace already has a corpus (.rac/config.yaml).",
+    );
+    return;
+  } catch {
+    // not set up yet — proceed
+  }
+  // A default repository key from the folder name; `rac` validates/normalizes it.
+  const key =
+    path.basename(folder.uri.fsPath).replace(/[^A-Za-z0-9]/g, "").toUpperCase().slice(0, 12) ||
+    "RAC";
+  try {
+    const result = await clientFor(folder).quickstart(folder.uri.fsPath, { key });
+    const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(result.artifact.path));
+    await vscode.window.showTextDocument(doc);
+    void vscode.window.showInformationMessage(
+      `RAC: corpus ready (key ${result.repository_key}). Edit the starter artifact and save to see it validate.`,
+    );
+    void validateWorkspace();
+    refreshAllRelationships();
+  } catch (err) {
+    if (err instanceof RacNotFoundError) {
+      warnMissingOnce();
+      return;
+    }
+    log("setupWorkspace failed", err);
+    void vscode.window.showErrorMessage(
+      `RAC: setup failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
 }

--- a/typescript/rac-vscode/src/test/suite/extension.test.ts
+++ b/typescript/rac-vscode/src/test/suite/extension.test.ts
@@ -35,6 +35,10 @@ suite("RAC extension", () => {
       cmds.includes("rac.validateWorkspace"),
       "rac.validateWorkspace is registered",
     );
+    assert.ok(
+      cmds.includes("rac.setupWorkspace"),
+      "rac.setupWorkspace is registered",
+    );
   });
 
   test("surfaces a relationship violation as a diagnostic", async () => {

--- a/typescript/rac-vscode/walkthroughs/enforce.md
+++ b/typescript/rac-vscode/walkthroughs/enforce.md
@@ -1,0 +1,23 @@
+# See enforcement in your editor
+
+This is the point of RAC: your recorded decisions are enforced where you work.
+
+Open any artifact and, in a relationship section, reference a decision that does
+not exist:
+
+```markdown
+## Related Decisions
+
+- adr-does-not-exist
+```
+
+Save the file. The extension flags the broken reference **at the reference
+site** — the same finding `rac relationships --validate` reports on the command
+line, because the extension runs `rac` rather than guessing.
+
+References to **retired** (superseded/deprecated) decisions are flagged
+distinctly, so your agent — and your teammates — stop re-litigating settled
+calls.
+
+Other things to try: hover an artifact id for its status, go-to-definition on a
+reference, or **RAC: Open Explorer** for the corpus graph.

--- a/typescript/rac-vscode/walkthroughs/install.md
+++ b/typescript/rac-vscode/walkthroughs/install.md
@@ -1,0 +1,21 @@
+# Install the `rac` CLI
+
+The RAC extension is a thin client — it runs your local `rac` CLI and never
+reimplements its analysis. So the first step is to make `rac` available.
+
+**Recommended (isolated):**
+
+```sh
+pipx install requirements-as-code
+```
+
+or with pip:
+
+```sh
+pip install requirements-as-code
+```
+
+Already have `rac` somewhere specific? Set its path in **`rac.path`** instead.
+
+Once `rac` is on your `PATH` (or `rac.path` is set), the extension validates RAC
+artifacts as you open and save them.

--- a/typescript/rac-vscode/walkthroughs/scaffold.md
+++ b/typescript/rac-vscode/walkthroughs/scaffold.md
@@ -1,0 +1,14 @@
+# Set up your corpus
+
+A RAC corpus is just Markdown under `rac/`, identified by a `.rac/config.yaml`.
+
+**Set Up Workspace** runs `rac quickstart` in this folder, which:
+
+- establishes the repository identity (`.rac/config.yaml`), and
+- scaffolds a first artifact you can edit.
+
+The extension computes none of this itself — `rac` owns the identity and the
+templates. Once the corpus exists, the extension activates automatically and
+starts validating.
+
+> Already set up? The command will tell you, and leave your corpus untouched.


### PR DESCRIPTION
# Summary

Implements `rac/roadmaps/v0.21.x-editor/v0.21.11-first-run-onboarding.md` — turn the missing-`rac` cliff into guided setup, scaffold a corpus from inside the editor, and add a Get-Started walkthrough that lands on the enforcement "aha".

Adds:
- SDK `init` and `quickstart` methods (typed, over `rac init` / `rac quickstart --json`).
- A guided pipx install offered when `rac` is missing, alongside Set `rac.path`.
- A "RAC: Set Up Workspace" command that runs `rac quickstart` and opens the starter artifact.
- A three-step Get-Started walkthrough (install, set up, see enforcement).

# Roadmap / ADR Trace

Roadmap:
- `rac/roadmaps/v0.21.x-editor/v0.21.11-first-run-onboarding.md`

Relevant ADRs:
- `rac/decisions/adr-063-non-python-clients-are-thin.md` — the editor scaffolds via `rac quickstart` and the SDK; identity and template logic stay in `rac`.
- `rac/decisions/adr-007-additive-json-evolution.md` — the SDK consumes the existing additive `init`/`quickstart --json` contracts.
- `rac/decisions/adr-049-enforcement-is-the-product.md` — the walkthrough ends by staging an enforcement diagnostic.

# Scope

## Included
- SDK: `init(dir, key?)` and `quickstart(dir, {key?, type?})` returning `InitResult`/`QuickstartResult`; fake-runner unit tests (argv + parsing) and a real-`rac` integration test that quickstarts a temp directory.
- Extension: a guided install (a terminal pre-loaded with `pipx install requirements-as-code`) on the missing-`rac` prompt; a `rac.setupWorkspace` command that runs `rac quickstart`, opens the artifact, and re-validates; a `rac.installRac` command; and the provider test now asserts `rac.setupWorkspace` is registered.
- The setup command activates via `onCommand` so it works in a not-yet-RAC workspace, and no-ops with a notice if a corpus already exists.
- A `contributes.walkthroughs` entry with three steps and their media markdown.

## Excluded
- Auto-installing `rac` without consent — the guided install opens a terminal with the command for the user to run; it is never executed silently.
- Bundling or vendoring the `rac` binary (Non-Goal); install stays the user's, just guided.
- Agent-rules / MCP setup — that is v0.21.15, not onboarding.
- A custom `rac.path` picker/validator UI — out of scope.

# Product / Architecture Decisions
- Scaffolding delegates to `rac quickstart` (identity + template) and is never reimplemented in TypeScript (ADR-063); the SDK adds only thin typed wrappers.
- The setup command activates via `onCommand:rac.setupWorkspace` to resolve the chicken-and-egg: the extension otherwise activates only when a `.rac/config.yaml` is present, but onboarding must run before one exists.
- The default repository key is derived from the folder name and normalized by `rac` (the engine validates it), so the extension encodes no identity rules.
- Guided install opens a terminal rather than spawning a child process, so the user sees and consents to the command.

# User-Facing Contract

## CLI
None. No `rac` command or flag is added; the SDK calls the existing `rac init` / `rac quickstart --json`.

## Human Output
A richer missing-`rac` prompt (Install with pipx / Set `rac.path`); a "RAC: Set Up Workspace" command; a "Get Started with RAC" walkthrough; on setup, the starter artifact opens with a success notice.

## JSON Output
None. The SDK consumes the existing `init`/`quickstart` JSON shapes.

## Exit Codes
None. No change to `rac` exit codes.

# Verification

## Ran
- SDK: `npm run build` clean; `RAC_BIN=rac npx vitest run` → 26 passed (18 unit, incl. new `init`/`quickstart` argv + parsing tests; 8 integration, incl. a real-`rac` quickstart of a temp directory).
- Confirmed the real shapes directly: `rac init --json` returns `{schema_version, repository_key, config_path, created}`; `rac quickstart --json` adds `artifact: {type, path, id}`.
- Extension: `npm run check-types` and `npm run compile` clean; `npm run compile-tests` clean (`out/test` emitted); `package.json` parses.

## Covered
- Positive: the SDK builds the right argv and parses `init`/`quickstart`; a real `rac quickstart` scaffolds a temp directory (a config plus a `QSTEST-` artifact); the provider test asserts `rac.setupWorkspace` is registered.
- Boundary: `setupWorkspace` no-ops with a notice when `.rac/config.yaml` already exists; a missing `rac` routes to the guided prompt.
- Not run: the live VS Code flows (the terminal install, the walkthrough UI, the scaffold-from-empty command) — there is no VS Code host in the dev sandbox; the provider suite runs in CI under xvfb.

# Review Path
1. `rac/roadmaps/v0.21.x-editor/v0.21.11-first-run-onboarding.md` — the contract.
2. `typescript/rac-sdk/src/client.ts` and `types.ts` — `init` / `quickstart`.
3. `typescript/rac-vscode/src/extension.ts` — `setupWorkspace`, `installRac`, the enhanced `warnMissingOnce`.
4. `typescript/rac-vscode/package.json` — the `onCommand` activation, the command, the walkthrough.
5. `typescript/rac-vscode/walkthroughs/` — the step media.
6. The SDK and extension tests.

# Notes For Reviewer
- The walkthrough's install button opens a terminal; the user runs the install — by design, no silent install.
- The scaffold-from-empty path and the walkthrough UI are not exercisable headlessly; the provider suite (CI, xvfb) asserts command registration and the SDK integration test covers the real quickstart.
- Based on post-#128 `main`, so it carries the v0.21.10 webview hardening with no overlap.
- On merge, flip the v0.21.11 roadmap to `Achieved` (ADR-061).

# Implementation Process
Implemented with AI assistance under the v0.21.11 roadmap contract; final scope, review, and acceptance decisions were made by the maintainer.