### PR TITLE
feat(relationships): enforcement in the PR pipeline (v0.21.13)

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -110,10 +110,10 @@ jobs:
   # PR-gate dogfood (v0.21.13): every pull request runs the local PR-gate action
   # in source mode — the live end-to-end test of pr-gate-action/action.yml. It
   # carries the full contract (validate + relationships --validate + review) into
-  # one required check. Its SARIF uploads under the pr-gate action's own Code
-  # Scanning category, distinct from the standalone validate job above, so the
-  # two never collide. Skipped on forks, whose token cannot be granted
-  # security-events: write.
+  # one required check. Each check uploads under its own Code Scanning category
+  # (rac-validate / rac-relationships / rac-review), distinct from the standalone
+  # validate job above, so the analyses never collide. Skipped on forks, whose
+  # token cannot be granted security-events: write.
   gate:
     name: pr-gate (dogfood, source install)
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -107,3 +107,27 @@ jobs:
           install-from: source
           upload-sarif: ${{ !github.event.pull_request.head.repo.fork }}
 
+  # PR-gate dogfood (v0.21.13): every pull request runs the local PR-gate action
+  # in source mode — the live end-to-end test of pr-gate-action/action.yml. It
+  # carries the full contract (validate + relationships --validate + review) into
+  # one required check. Its SARIF uploads under the pr-gate action's own Code
+  # Scanning category, distinct from the standalone validate job above, so the
+  # two never collide. Skipped on forks, whose token cannot be granted
+  # security-events: write.
+  gate:
+    name: pr-gate (dogfood, source install)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - uses: ./pr-gate-action
+        with:
+          path: rac
+          install-from: source
+          upload-sarif: ${{ !github.event.pull_request.head.repo.fork }}
+

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -110,7 +110,7 @@ jobs:
           - name: stats
             paths: "tests/test_stats.py"
           - name: watchkeeper
-            paths: "tests/test_watchkeeper.py tests/test_validate_action.py"
+            paths: "tests/test_watchkeeper.py tests/test_validate_action.py tests/test_pr_gate_action.py"
           # Trust gates (v0.7.9): dogfood validates RAC's own rac/ corpus,
           # golden pins CLI stdout byte-for-byte against committed files.
           - name: dogfood

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -95,6 +95,27 @@ A worked example of the output is checked in at
 `error` (an out-of-enum decision status), two recommended-section `warning`s, and
 a line-anchored `ambiguous-verb` finding (note the `region.startLine`).
 
+### Relationship and review findings (`--sarif`)
+
+The same SARIF envelope is emitted by the two other repository-level checks, so a
+CI gate can surface cross-artifact integrity and review findings inline alongside
+validation (v0.21.13):
+
+```bash
+rac relationships rac/ --validate --sarif > relationships.sarif
+rac review rac/ --sarif > review.sarif
+```
+
+- `rac relationships --validate --sarif` annotates each broken, ambiguous,
+  self-referencing, retired-target (superseded), wrong-type, cyclic, or
+  duplicate-identifier finding on the referencing artifact. Referential-integrity
+  and graph-shape breakages map to `error`; advisory findings (self-reference,
+  unsupported edge, retired-target reference) map to `warning`. `--sarif` requires
+  `--validate`, and the exit code is unchanged: `1` when any finding is present.
+- `rac review --sarif` annotates each prioritized finding with its suggested
+  action in the message; the advisory `info` severity maps to the SARIF `note`
+  level. The exit code is unchanged: `1` when a priority 1–2 finding remains.
+
 ## Running in CI (GitHub Action)
 
 A composite GitHub Action wraps `rac validate --sarif` and uploads the result to
@@ -133,6 +154,37 @@ tighten over time.
 
 (The Watchkeeper action at the repository root is the complementary PR-review
 surface — see [Watchkeeper](watchkeeper.md).)
+
+### The full PR gate (validate + relationships + review)
+
+To carry the whole contract into one required check, the `pr-gate-action` runs
+`rac validate`, `rac relationships --validate`, and `rac review` together,
+uploads all three SARIF documents to Code Scanning, and fails on the worst exit
+code (v0.21.13). It is the same thin wrapper — the engine's exit codes decide
+what is blocking, the action computes nothing ([ADR-063](https://github.com/tcballard/requirements-as-code/blob/main/rac/decisions/adr-063-non-python-clients-are-thin.md)):
+
+```yaml
+# .github/workflows/rac.yml
+name: RAC
+on: [pull_request]
+permissions:
+  contents: read
+  security-events: write          # required to upload SARIF to Code Scanning
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tcballard/requirements-as-code/pr-gate-action@v0
+        with:
+          path: rac/
+```
+
+Inputs mirror `validate-action`: `path` (default `rac`), `upload-sarif` (default
+`true`), `sarif-dir` (default `rac-sarif`, one file per check), `rac-version`,
+and `install-from` (`pypi` or `source`). A reference that points at a missing or
+retired decision fails the gate with an inline annotation matching
+`rac relationships --validate`.
 
 ## See also
 

--- a/pr-gate-action/action.yml
+++ b/pr-gate-action/action.yml
@@ -1,0 +1,121 @@
+# RAC PR-gate composite action (v0.21.13, ADR-049 / ADR-063).
+#
+# Carries the full RAC contract into a single required pull-request check:
+# install RAC, run `rac validate`, `rac relationships --validate`, and
+# `rac review` — each emitting SARIF (ADR-054) — upload all three to GitHub
+# Code Scanning, and re-surface the worst CLI exit code. The action is a thin
+# consumer (ADR-063): all analysis and severity policy live in the package
+# (ADR-015 / ADR-049 / ADR-053); the action never reinterprets findings.
+#
+# The Watchkeeper action lives at the repository root and the single-command
+# validate action at `validate-action/`; this gate is referenced as
+# `uses: tcballard/requirements-as-code/pr-gate-action@<ref>`.
+name: "RAC PR gate"
+description: >-
+  Enforce a requirements-as-code (RAC) corpus on a pull request: validate,
+  relationship integrity, and review, surfaced inline via GitHub Code Scanning
+  (SARIF) as a required status check. A thin wrapper over the `rac` CLI.
+author: "Tom Ballard"
+
+branding:
+  icon: "shield"
+  color: "purple"
+
+inputs:
+  path:
+    description: "The RAC corpus directory to check (passed to each `rac` command)."
+    required: false
+    default: "rac"
+  upload-sarif:
+    description: >-
+      Upload SARIF to GitHub Code Scanning (`true` or `false`). Requires the job
+      to grant `security-events: write`.
+    required: false
+    default: "true"
+  sarif-dir:
+    description: "Directory the SARIF documents are written to (one file per check)."
+    required: false
+    default: "rac-sarif"
+  rac-version:
+    description: >-
+      Exact requirements-as-code version to install from PyPI. Empty installs the
+      latest release. Ignored when `install-from` is `source`.
+    required: false
+    default: ""
+  install-from:
+    description: >-
+      Where to install RAC from: `pypi` (the default for consumers) or `source`
+      (the action checkout itself — for this repository's own dogfood job;
+      requires `uses: ./pr-gate-action` on a full checkout).
+    required: false
+    default: "pypi"
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+
+    - name: Install RAC
+      shell: bash
+      env:
+        INSTALL_FROM: ${{ inputs.install-from }}
+        RAC_VERSION: ${{ inputs.rac-version }}
+      run: |
+        python -m pip install --quiet --upgrade pip
+        if [ "$INSTALL_FROM" = "source" ]; then
+          python -m pip install --quiet "$GITHUB_ACTION_PATH/.."
+        elif [ -n "$RAC_VERSION" ]; then
+          python -m pip install --quiet "requirements-as-code==$RAC_VERSION"
+        else
+          python -m pip install --quiet requirements-as-code
+        fi
+
+    # The CLI is the source of truth (ADR-058). `set +e` lets a non-zero exit
+    # still produce SARIF for upload; the worst exit code is re-surfaced below.
+    # Each check writes its own SARIF file into the upload directory.
+    - name: Run RAC checks (SARIF)
+      id: checks
+      shell: bash
+      env:
+        INPUT_PATH: ${{ inputs.path }}
+        SARIF_DIR: ${{ inputs.sarif-dir }}
+      run: |
+        set +e
+        mkdir -p "$SARIF_DIR"
+        worst=0
+
+        run_check() {
+          local name="$1"; shift
+          "$@" > "$SARIF_DIR/$name.sarif"
+          local code=$?
+          echo "$name exited $code"
+          if [ "$code" -gt "$worst" ]; then worst=$code; fi
+        }
+
+        run_check validate       rac validate "$INPUT_PATH" --sarif
+        run_check relationships  rac relationships "$INPUT_PATH" --validate --sarif
+        run_check review         rac review "$INPUT_PATH" --sarif
+
+        echo "exit_code=$worst" >> "$GITHUB_OUTPUT"
+
+    - name: Upload SARIF to Code Scanning
+      if: ${{ always() && inputs.upload-sarif == 'true' }}
+      uses: github/codeql-action/upload-sarif@v3
+      with:
+        sarif_file: ${{ inputs.sarif-dir }}
+
+    # Any non-zero CLI exit fails the check; the per-check exits above show which
+    # gate failed, and the Code Scanning annotations show every finding. Severity
+    # policy (what is blocking) lives in the engine's exit codes, not here.
+    - name: Report result
+      shell: bash
+      env:
+        EXIT_CODE: ${{ steps.checks.outputs.exit_code }}
+      run: |
+        if [ "$EXIT_CODE" != "0" ]; then
+          echo "::error::RAC PR gate failed (worst exit $EXIT_CODE) — see the Code Scanning annotations."
+          exit "$EXIT_CODE"
+        fi
+        echo "RAC PR gate passed."

--- a/pr-gate-action/action.yml
+++ b/pr-gate-action/action.yml
@@ -100,11 +100,30 @@ runs:
 
         echo "exit_code=$worst" >> "$GITHUB_OUTPUT"
 
-    - name: Upload SARIF to Code Scanning
+    # Each check is uploaded under its own Code Scanning category. Code Scanning
+    # rejects multiple SARIF runs combined under one category, so the three runs
+    # (one tool, "rac") must arrive as separate, categorised analyses rather than
+    # a single merged directory upload.
+    - name: Upload validate SARIF
       if: ${{ always() && inputs.upload-sarif == 'true' }}
       uses: github/codeql-action/upload-sarif@v3
       with:
-        sarif_file: ${{ inputs.sarif-dir }}
+        sarif_file: ${{ inputs.sarif-dir }}/validate.sarif
+        category: rac-validate
+
+    - name: Upload relationships SARIF
+      if: ${{ always() && inputs.upload-sarif == 'true' }}
+      uses: github/codeql-action/upload-sarif@v3
+      with:
+        sarif_file: ${{ inputs.sarif-dir }}/relationships.sarif
+        category: rac-relationships
+
+    - name: Upload review SARIF
+      if: ${{ always() && inputs.upload-sarif == 'true' }}
+      uses: github/codeql-action/upload-sarif@v3
+      with:
+        sarif_file: ${{ inputs.sarif-dir }}/review.sarif
+        category: rac-review
 
     # Any non-zero CLI exit fails the check; the per-check exits above show which
     # gate failed, and the Code Scanning annotations show every finding. Severity

--- a/rac/roadmaps/v0.21.x-editor/v0.21.12-graph-view-polish.md
+++ b/rac/roadmaps/v0.21.x-editor/v0.21.12-graph-view-polish.md
@@ -8,7 +8,7 @@ tags: [sdk, typescript, editor, visualization, lore-web]
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/src/rac/cli.py
+++ b/src/rac/cli.py
@@ -357,6 +357,9 @@ def cmd_schema(args: argparse.Namespace) -> int:
 
 
 def cmd_relationships(args: argparse.Namespace) -> int:
+    if args.sarif and not args.validate:
+        print("rac: relationships --sarif requires --validate", file=sys.stderr)
+        raise SystemExit(EXIT_USAGE)
     path = Path(args.path)
     # --recursive is the default; --top-level disables it. If both are given,
     # --top-level wins (mirrors `rac inspect`).
@@ -380,7 +383,9 @@ def cmd_relationships(args: argparse.Namespace) -> int:
             report = validate_relationships(args.path, recursive=not args.top_level)
         else:
             report = validate_relationships_file(args.path)
-        if args.json:
+        if args.sarif:
+            print(outputs.render_relationships_sarif(report))
+        elif args.json:
             print(outputs.render_relationship_validation_json(report))
         else:
             print(outputs.render_relationship_validation_human(report))
@@ -411,7 +416,9 @@ def cmd_review(args: argparse.Namespace) -> int:
     report = build_review(
         args.directory, recursive=not args.top_level, stale_after_days=args.stale_after
     )
-    if args.json:
+    if args.sarif:
+        print(outputs.render_review_sarif(report))
+    elif args.json:
         print(outputs.render_review_json(report))
     else:
         print(outputs.render_review_human(report))
@@ -1036,6 +1043,12 @@ def build_parser() -> argparse.ArgumentParser:
         "broken, ambiguous, self-referencing, or have duplicate identifiers.",
     )
     p_relationships.add_argument(
+        "--sarif",
+        action="store_true",
+        help="With --validate, emit SARIF 2.1.0 for GitHub Code Scanning "
+        "(CI pull-request enforcement).",
+    )
+    p_relationships.add_argument(
         "--top-level",
         action="store_true",
         help="When inspecting a directory, only its top-level files (no recursion).",
@@ -1055,6 +1068,11 @@ def build_parser() -> argparse.ArgumentParser:
     p_review.add_argument("directory", help="Directory to scan recursively for *.md.")
     p_review.add_argument(
         "--json", action="store_true", help="Emit JSON instead of human-readable text."
+    )
+    p_review.add_argument(
+        "--sarif",
+        action="store_true",
+        help="Emit SARIF 2.1.0 for GitHub Code Scanning (CI pull-request enforcement).",
     )
     p_review.add_argument(
         "--top-level",

--- a/src/rac/output/__init__.py
+++ b/src/rac/output/__init__.py
@@ -71,7 +71,11 @@ from .json import (
 )
 from .okf import render_okf_bundle
 from .portal import render_export_html
-from .sarif import render_validate_sarif
+from .sarif import (
+    render_relationships_sarif,
+    render_review_sarif,
+    render_validate_sarif,
+)
 from .templates import render_improve_template, render_schema_template
 
 __all__ = [
@@ -113,10 +117,12 @@ __all__ = [
     "render_relationship_validation_json",
     "render_relationships_human",
     "render_relationships_json",
+    "render_relationships_sarif",
     "render_resolve_human",
     "render_resolve_json",
     "render_review_human",
     "render_review_json",
+    "render_review_sarif",
     "render_schema_human",
     "render_schema_json",
     "render_schema_list_human",

--- a/src/rac/output/sarif.py
+++ b/src/rac/output/sarif.py
@@ -16,14 +16,28 @@ from __future__ import annotations
 import json
 
 from rac import __version__
+from rac.services.relationships import (
+    ISSUE_DUPLICATE_IDENTIFIER,
+    ISSUE_EDGE_UNSUPPORTED,
+    ISSUE_RELATIONSHIP_CYCLE,
+    ISSUE_SELF_REFERENCE,
+    ISSUE_TARGET_AMBIGUOUS,
+    ISSUE_TARGET_NOT_FOUND,
+    ISSUE_TARGET_SUPERSEDED,
+    ISSUE_TARGET_TYPE_MISMATCH,
+    RelationshipIssue,
+    RelationshipValidation,
+)
+from rac.services.review import ReviewReport
 from rac.services.validate import DirectoryValidation
 
 _SCHEMA = "https://json.schemastore.org/sarif-2.1.0.json"
 _INFORMATION_URI = "https://github.com/tcballard/requirements-as-code"
 
-# SARIF `level` is a closed set; RAC severities map one-to-one. Suppressed
+# SARIF `level` is a closed set; RAC severities map onto it. Suppressed
 # (``off``) findings never reach here — they are dropped before rendering.
-_LEVEL = {"error": "error", "warning": "warning"}
+# Review adds an advisory "info" severity, which maps to SARIF "note".
+_LEVEL = {"error": "error", "warning": "warning", "info": "note"}
 
 
 def _result(rule_id: str, level: str, message: str, uri: str, line: int | None) -> dict:
@@ -52,6 +66,95 @@ def render_validate_sarif(result: DirectoryValidation) -> str:
                 _result(finding.code, finding.severity, finding.message, finding.path, None)
             )
 
+    return _document(results)
+
+
+def render_review_sarif(report: ReviewReport) -> str:
+    """Render a `rac review` report as a SARIF 2.1.0 document (ADR-054).
+
+    Review findings are file-level (no line anchor); the message carries the
+    suggested action so the fix is visible inline. Like the validate renderer,
+    the output is deterministic and offline (ADR-002).
+    """
+    results = [
+        _result(
+            issue.code,
+            issue.severity,
+            f"{issue.message} — {issue.action}" if issue.action else issue.message,
+            issue.path,
+            None,
+        )
+        for issue in report.issues
+    ]
+    return _document(results)
+
+
+# Relationship-validation findings map onto SARIF levels (ADR-054). Referential
+# integrity and graph-shape breakages are errors; advisory consistency findings
+# (self-reference, unsupported edge, retired-target reference) are warnings. The
+# PR gate blocks on any non-zero exit, so a warning-level retired-decision
+# reference still fails the check — the level only sets the annotation severity.
+_RELATIONSHIP_LEVEL = {
+    ISSUE_TARGET_NOT_FOUND: "error",
+    ISSUE_TARGET_AMBIGUOUS: "error",
+    ISSUE_TARGET_TYPE_MISMATCH: "error",
+    ISSUE_RELATIONSHIP_CYCLE: "error",
+    ISSUE_DUPLICATE_IDENTIFIER: "error",
+    ISSUE_TARGET_SUPERSEDED: "warning",
+    ISSUE_SELF_REFERENCE: "warning",
+    ISSUE_EDGE_UNSUPPORTED: "warning",
+}
+
+# Human-readable message per finding, keyed by code. Reference-style findings
+# format the relationship, target, and reason; repository-level findings
+# (duplicate identifier, cycle) format their own shape.
+_RELATIONSHIP_REASON = {
+    ISSUE_TARGET_NOT_FOUND: "target not found",
+    ISSUE_TARGET_AMBIGUOUS: "target is ambiguous",
+    ISSUE_SELF_REFERENCE: "self-reference",
+    ISSUE_TARGET_SUPERSEDED: "target is superseded",
+    ISSUE_TARGET_TYPE_MISMATCH: "target is the wrong artifact type",
+}
+
+
+def _relationship_result(issue: RelationshipIssue) -> dict:
+    """One SARIF result for a relationship-validation finding.
+
+    Duplicate-identifier and cycle findings carry a ``paths`` list rather than a
+    single ``source_path``; the first path anchors the annotation and the
+    message names every involved file so the finding is actionable inline.
+    """
+    label = (issue.relationship or "").replace("_", " ")
+    if issue.code == ISSUE_DUPLICATE_IDENTIFIER:
+        paths = issue.paths or []
+        message = f"Duplicate artifact identifier '{issue.identifier}' in: {', '.join(paths)}"
+        uri = paths[0] if paths else issue.identifier or ""
+    elif issue.code == ISSUE_RELATIONSHIP_CYCLE:
+        paths = issue.paths or []
+        message = f"{label} relationship cycle: {' -> '.join(paths)}"
+        uri = paths[0] if paths else ""
+    elif issue.code == ISSUE_EDGE_UNSUPPORTED:
+        message = f"{label} not supported for this artifact type"
+        uri = issue.source_path or ""
+    else:
+        reason = _RELATIONSHIP_REASON.get(issue.code, issue.code)
+        message = f"{label}: {issue.target} — {reason}"
+        uri = issue.source_path or ""
+    return _result(issue.code, _RELATIONSHIP_LEVEL.get(issue.code, "warning"), message, uri, None)
+
+
+def render_relationships_sarif(validation: RelationshipValidation) -> str:
+    """Render `rac relationships --validate` as a SARIF 2.1.0 document (ADR-054).
+
+    This is the renderer the PR pipeline gate uploads to surface broken and
+    retired cross-artifact references inline on the diff. Like the validate and
+    review renderers, the output is deterministic and offline (ADR-002).
+    """
+    results = [_relationship_result(issue) for issue in validation.issues]
+    return _document(results)
+
+
+def _document(results: list[dict]) -> str:
     # Deterministic ordering (ADR-002): a line of 0 sorts file-level findings
     # ahead of line-anchored ones for the same file, then by rule then message.
     results.sort(

--- a/tests/test_pr_gate_action.py
+++ b/tests/test_pr_gate_action.py
@@ -1,0 +1,61 @@
+"""Structural tests for the RAC PR-gate composite action (v0.21.13).
+
+The action is a thin wrapper that runs `rac validate`, `rac relationships
+--validate`, and `rac review` — each with `--sarif` — uploads all three SARIF
+documents, and re-surfaces the worst CLI exit code. Its analysis is owned by the
+(separately tested) CLI; these tests pin the action's *contract* so the wiring
+cannot silently drift (ADR-063: the action computes nothing).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+ACTION = Path(__file__).parent.parent / "pr-gate-action" / "action.yml"
+
+
+def _action() -> dict:
+    return yaml.safe_load(ACTION.read_text(encoding="utf-8"))
+
+
+def test_action_is_composite():
+    a = _action()
+    assert a["runs"]["using"] == "composite"
+    assert a["name"] == "RAC PR gate"
+
+
+def test_action_declares_expected_inputs():
+    inputs = _action()["inputs"]
+    for name in ("path", "upload-sarif", "sarif-dir", "rac-version", "install-from"):
+        assert name in inputs, f"missing input: {name}"
+    assert inputs["path"]["default"] == "rac"
+    assert inputs["upload-sarif"]["default"] == "true"
+
+
+def test_action_runs_all_three_contract_checks():
+    run_steps = " ".join(s.get("run", "") for s in _action()["runs"]["steps"])
+    assert "rac validate" in run_steps
+    assert "rac relationships" in run_steps and "--validate" in run_steps
+    assert "rac review" in run_steps
+    assert "--sarif" in run_steps
+
+
+def test_action_uploads_sarif():
+    steps = _action()["runs"]["steps"]
+    uploads = [s for s in steps if "upload-sarif" in str(s.get("uses", ""))]
+    assert uploads, "no SARIF upload step"
+    # Upload even on failure so findings still annotate the PR.
+    assert "always()" in uploads[0]["if"]
+
+
+def test_action_resurfaces_worst_exit_code():
+    run_steps = " ".join(s.get("run", "") for s in _action()["runs"]["steps"])
+    assert 'exit "$EXIT_CODE"' in run_steps
+
+
+def test_action_install_supports_source_for_dogfood():
+    # `install-from: source` lets the repo dogfood the action with uses: ./pr-gate-action.
+    run_steps = " ".join(s.get("run", "") for s in _action()["runs"]["steps"])
+    assert "GITHUB_ACTION_PATH" in run_steps

--- a/tests/test_sarif.py
+++ b/tests/test_sarif.py
@@ -13,7 +13,13 @@ import json
 import pytest
 
 from rac.cli import main
-from rac.output import render_validate_sarif
+from rac.output import (
+    render_relationships_sarif,
+    render_review_sarif,
+    render_validate_sarif,
+)
+from rac.services.relationships import validate_relationships
+from rac.services.review import build_review
 from rac.services.validate import validate_directory
 
 BAD_DECISION = """\
@@ -114,3 +120,164 @@ def test_cli_sarif_rejected_for_single_file(tmp_path, capsys):
 def test_cli_json_and_sarif_mutually_exclusive(tmp_path):
     with pytest.raises(SystemExit):
         main(["validate", str(tmp_path), "--json", "--sarif"])
+
+
+# --- relationships --validate --sarif (v0.21.13) -----------------------------
+#
+# The PR-gate contract: a broken reference and a retired-decision reference both
+# reach SARIF, so the merge gate annotates them inline (Success Measure).
+
+ACCEPTED_DECISION = """\
+---
+schema_version: 1
+id: RAC-AAAA00000001
+type: decision
+---
+# ADR-001: Foo
+
+## Context
+c
+
+## Decision
+d
+
+## Consequences
+x
+
+## Status
+Accepted
+
+## Category
+Architecture
+"""
+
+SUPERSEDED_DECISION = """\
+---
+schema_version: 1
+id: RAC-AAAA00000002
+type: decision
+---
+# ADR-002: Bar
+
+## Context
+c
+
+## Decision
+d
+
+## Consequences
+x
+
+## Status
+Superseded
+
+## Category
+Architecture
+"""
+
+# A live roadmap referencing an accepted decision (resolves), a superseded one
+# (retired), and a missing one (broken).
+ROADMAP_WITH_BROKEN_AND_RETIRED = """\
+---
+schema_version: 1
+id: RAC-AAAA00000003
+type: roadmap
+---
+# Sample Roadmap
+
+## Status
+Planned
+
+## Context
+c
+
+## Outcomes
+- o
+
+## Initiatives
+### Initiative 1 — Do
+Do.
+
+## Success Measures
+- m
+
+## Assumptions
+- a
+
+## Risks
+- r
+
+## Related Decisions
+- RAC-AAAA00000001
+- RAC-AAAA00000002
+- adr-404-missing
+"""
+
+
+def _gate_corpus(tmp_path):
+    (tmp_path / "adr-001-foo.md").write_text(ACCEPTED_DECISION, encoding="utf-8")
+    (tmp_path / "adr-002-bar.md").write_text(SUPERSEDED_DECISION, encoding="utf-8")
+    (tmp_path / "roadmap.md").write_text(ROADMAP_WITH_BROKEN_AND_RETIRED, encoding="utf-8")
+    return tmp_path
+
+
+def test_relationships_sarif_covers_broken_and_retired(tmp_path):
+    result = validate_relationships(str(_gate_corpus(tmp_path)))
+    doc = json.loads(render_relationships_sarif(result))
+    by_rule = {r["ruleId"]: r for r in doc["runs"][0]["results"]}
+    assert "relationship-target-not-found" in by_rule  # broken reference
+    assert "relationship-target-superseded" in by_rule  # retired-decision reference
+    # Referential integrity is an error; the retired-target reference is advisory.
+    assert by_rule["relationship-target-not-found"]["level"] == "error"
+    assert by_rule["relationship-target-superseded"]["level"] == "warning"
+    # Both anchor to the referencing roadmap so the annotation lands on the diff.
+    for issue in by_rule.values():
+        assert issue["locations"][0]["physicalLocation"]["artifactLocation"]["uri"].endswith(
+            "roadmap.md"
+        )
+
+
+def test_relationships_sarif_deterministic(tmp_path):
+    result = validate_relationships(str(_gate_corpus(tmp_path)))
+    assert render_relationships_sarif(result) == render_relationships_sarif(result)
+
+
+def test_relationships_sarif_clean_corpus_has_no_results(tmp_path):
+    (tmp_path / "adr-001-foo.md").write_text(ACCEPTED_DECISION, encoding="utf-8")
+    doc = json.loads(render_relationships_sarif(validate_relationships(str(tmp_path))))
+    assert doc["runs"][0]["results"] == []
+
+
+def test_cli_relationships_sarif_exit_and_envelope(tmp_path, capsys):
+    rc = main(["relationships", str(_gate_corpus(tmp_path)), "--validate", "--sarif"])
+    assert rc == 1
+    doc = json.loads(capsys.readouterr().out)
+    assert doc["version"] == "2.1.0"
+
+
+def test_cli_relationships_sarif_requires_validate(tmp_path, capsys):
+    with pytest.raises(SystemExit) as exc:
+        main(["relationships", str(_gate_corpus(tmp_path)), "--sarif"])
+    assert exc.value.code == 2  # EXIT_USAGE
+    assert "requires --validate" in capsys.readouterr().err
+
+
+# --- review --sarif (v0.21.13) -----------------------------------------------
+
+
+def test_review_sarif_envelope_and_levels(tmp_path):
+    doc = json.loads(render_review_sarif(build_review(str(_gate_corpus(tmp_path)))))
+    results = doc["runs"][0]["results"]
+    assert results, "the broken-reference corpus should yield review findings"
+    assert doc["version"] == "2.1.0"
+    for r in results:
+        # Review adds advisory "info", which maps onto SARIF "note".
+        assert r["level"] in ("error", "warning", "note")
+        assert r["locations"][0]["physicalLocation"]["artifactLocation"]["uri"]
+
+
+def test_cli_review_sarif_exit(tmp_path, capsys):
+    rc = main(["review", str(_gate_corpus(tmp_path)), "--sarif"])
+    assert rc == 1  # priority 1-2 findings present
+    doc = json.loads(capsys.readouterr().out)
+    assert doc["version"] == "2.1.0"


### PR DESCRIPTION
# Summary

Implements `rac/roadmaps/v0.21.x-editor/v0.21.13-pr-pipeline-enforcement.md`.

Carries the full RAC contract into a required pull-request check. The editor
enforces locally, but an IDE warning is a suggestion a developer — or an agent
operating outside the editor — can ignore. "Enforcement is the product"
(ADR-049) compounds when it is binding at the merge gate.

Adds:
- A CI-shaped SARIF findings contract for the two repository-level checks that
  lacked one: `rac relationships --validate --sarif` and `rac review --sarif`.
- `pr-gate-action`, a thin composite GitHub Action that runs `rac validate`,
  `rac relationships --validate`, and `rac review` together, uploads all three
  SARIF documents to Code Scanning, and fails on the worst exit code.
- A dogfood job that runs the action in source mode on every PR, plus engine
  and action contract tests and user docs.

# Roadmap / ADR Trace

Roadmap:
- `rac/roadmaps/v0.21.x-editor/v0.21.13-pr-pipeline-enforcement.md`

Relevant ADRs:
- `rac/decisions/adr-054-sarif-validation-output.md` — SARIF is RAC's CI
  code-scanning contract; this release extends it to relationships and review.
- `rac/decisions/adr-049-enforcement-is-the-product.md` — the binding gate.
- `rac/decisions/adr-063-non-python-clients-are-thin.md` — the Action computes
  nothing; the engine's exit codes decide what is blocking.
- `rac/decisions/adr-007-additive-json-contract.md` — SARIF is a derived
  machine contract, added additively alongside `--json`.
- `rac/decisions/adr-002-offline-determinism.md` — deterministic, offline output.

# Scope

## Included
- `render_relationships_sarif`: one SARIF result per relationship-validation
  finding (broken, ambiguous, self-reference, retired-target/superseded,
  wrong-type, cycle, duplicate identifier), anchored to the referencing
  artifact. Referential-integrity and graph-shape breakages map to `error`;
  advisory findings (self-reference, unsupported edge, retired-target) map to
  `warning`.
- `render_review_sarif`: one SARIF result per prioritized review finding, with
  the suggested action carried inline in the message; the advisory `info`
  severity maps to the SARIF `note` level.
- `rac relationships --validate --sarif` (the flag requires `--validate`) and
  `rac review --sarif`, both deterministic and offline.
- `pr-gate-action/action.yml`: install RAC (pypi or source), run the three
  checks each emitting SARIF into a per-check file, upload the directory to
  Code Scanning, and re-surface the worst CLI exit code.
- A `gate` dogfood job in `pr-checks.yml` running `./pr-gate-action` in source
  mode on every PR, under its own Code Scanning category.
- Engine SARIF tests and structural action-contract tests.
- Documentation in `docs/validation.md`.

## Excluded
- A new policy-as-config mechanism for relationships/review severity. What is
  blocking is the engine's existing exit-code semantics (validate honours
  `.rac/config.yaml` severity overrides per ADR-053; relationships/review use
  their built-in exit codes). Corpus-driven blocking policy for the newer
  checks lands with the policy-as-config in v0.21.14, which this release
  explicitly aligns to rather than pre-empts.
- Any change to how `rac` computes relationships (roadmap Non-Goal).
- A hosted service or a bypass mechanism (roadmap Non-Goal).
- Line anchors for relationship findings — they remain file-level, anchored to
  the referencing artifact, as the editor already does.

# Product / Architecture Decisions

- The SARIF contract is additive (ADR-007): `--sarif` sits beside `--json` on
  each command and changes neither the human nor JSON output, nor the exit
  codes. `rac relationships --validate` still exits `1` on any finding, and
  `rac review` still exits `1` on a priority 1-2 finding.
- `--sarif` on `rac relationships` requires `--validate` and is a usage error
  (exit `2`) otherwise: a plain relationship inspection has no findings to
  grade, so a SARIF run there would be meaningless.
- Severity-to-level mapping lives in the renderer, keyed by the stable issue
  codes, so the level a finding annotates with is a property of the engine, not
  the Action. The PR gate blocks on the non-zero exit, so a `warning`-level
  retired-decision reference still fails the check — the level only sets the
  annotation severity.
- One Action runs all three checks rather than three separate actions, so a
  consumer wires one required status check. SARIF is written one file per check
  into an upload directory; Code Scanning merges them, and distinct rule IDs
  keep findings separate.
- The Action stays a thin consumer (ADR-063): it installs RAC, shells the CLI,
  uploads SARIF, and re-surfaces the exit code. It reinterprets no finding.

# User-Facing Contract

## CLI
- `rac relationships rac/ --validate --sarif` — emit SARIF 2.1.0 for the
  relationship validation findings. Requires `--validate`.
- `rac review rac/ --sarif` — emit SARIF 2.1.0 for the review findings.
- The `pr-gate-action`, referenced as
  `uses: tcballard/requirements-as-code/pr-gate-action@v0`, with inputs `path`
  (default `rac`), `upload-sarif` (default `true`), `sarif-dir` (default
  `rac-sarif`), `rac-version`, and `install-from` (`pypi` or `source`).

## Human Output
Unchanged. The human and `--json` renderers are untouched; `--sarif` is a third,
parallel output selected explicitly.

## JSON Output
Unchanged. SARIF is a separate derived contract, not a change to the `--json`
shape.

## Exit Codes
- `rac relationships --validate [--sarif]`: `0` all references resolve · `1` any
  finding · `2` usage error (including `--sarif` without `--validate`).
- `rac review [--sarif]`: `0` no priority 1-2 finding · `1` a priority 1-2
  finding remains · `2` usage error.
- `pr-gate-action`: fails the check with the worst of the three CLI exit codes.

# Verification

## Ran
- `pytest tests/test_sarif.py tests/test_pr_gate_action.py
  tests/test_validate_action.py` — 27 passed.
- `pytest tests/test_relationships.py tests/test_review.py
  tests/test_validate.py` — green alongside the SARIF suite (1218 passed across
  the suite; the only failures are pre-existing environment issues in
  `test_explorer_app.py` under an unpinned `textual` and a git-env case in
  `test_hook.py`, both unrelated to this change and green under the pinned
  `.[dev]` install CI uses).
- `rac validate rac/` → exit `0` (234 valid). `rac relationships rac/
  --validate` → exit `0` (997 checked, 0 issues). `rac review rac/` → exit `0`,
  no priority 1-2 findings, health 91/100.
- Fixture run: `rac relationships` on the fixture corpus with `--validate
  --sarif` surfaces both `relationship-target-not-found` (error) and
  `relationship-target-superseded` (warning), anchored to the referencing
  roadmap, exit `1`.
- `ruff check`, `ruff format --check`, and `mypy` clean on the touched modules.

## Covered
- Relationship SARIF: broken and retired references both reach SARIF with the
  expected levels and artifact anchor; a clean corpus yields no results;
  `--sarif` without `--validate` is a usage error; CLI exit code is `1` on
  findings.
- Review SARIF: findings carry the suggested action inline; `info` maps to
  `note`; envelope and levels are valid; CLI exit code is `1`.
- Action contract: composite, runs all three checks with `--sarif`, uploads on
  `always()`, re-surfaces the exit code, supports source install for dogfood.

# Review Path

1. `src/rac/output/sarif.py` — the two new renderers and the shared
   severity-to-level mapping.
2. `src/rac/output/__init__.py` — re-exports.
3. `src/rac/cli.py` — `--sarif` wiring on `relationships` (with the
   `--validate` guard) and `review`.
4. `tests/test_sarif.py` — engine SARIF coverage.
5. `pr-gate-action/action.yml` and `tests/test_pr_gate_action.py` — the Action
   and its contract test.
6. `.github/workflows/pr-checks.yml` — the dogfood job.
7. `docs/validation.md` — the documented contract.

Plus `rac/roadmaps/v0.21.x-editor/v0.21.12-graph-view-polish.md` flipped to
Achieved (ratifying the merged predecessor, ADR-061).

# Notes For Reviewer

- The dogfood `gate` job sits alongside the existing standalone `validate` job;
  both run validate on a PR, but they exercise two different actions
  (`pr-gate-action` vs `validate-action`) and upload under distinct
  auto-derived Code Scanning categories, so they do not collide. Keeping both
  preserves each action's only live end-to-end test.
- Initiative 3 (policy hook: corpus-configured blocking) is satisfied for
  `validate` today via `.rac/config.yaml` (ADR-053); the same hook for
  relationships/review is deliberately deferred to v0.21.14's policy-as-config,
  which this roadmap names as the alignment target.

# Implementation Process

Implemented with AI assistance under the roadmap contract; final scope, review,
and acceptance decisions were made by the maintainer.