### PR TITLE
feat(gate): security & governance posture (v0.21.14)

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -107,13 +107,14 @@ jobs:
           install-from: source
           upload-sarif: ${{ !github.event.pull_request.head.repo.fork }}
 
-  # PR-gate dogfood (v0.21.13): every pull request runs the local PR-gate action
+  # PR-gate dogfood (v0.21.14): every pull request runs the local PR-gate action
   # in source mode — the live end-to-end test of pr-gate-action/action.yml. It
-  # carries the full contract (validate + relationships --validate + review) into
-  # one required check. Each check uploads under its own Code Scanning category
-  # (rac-validate / rac-relationships / rac-review), distinct from the standalone
-  # validate job above, so the analyses never collide. Skipped on forks, whose
-  # token cannot be granted security-events: write.
+  # carries the full contract via a single `rac gate` command — validation,
+  # relationships, and review under the corpus enforcement policy — into one
+  # required check, uploading one SARIF document under the Code Scanning category
+  # `rac-gate` (distinct from the standalone validate job above, so the analyses
+  # never collide). Skipped on forks, whose token cannot be granted
+  # security-events: write.
   gate:
     name: pr-gate (dogfood, source install)
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,7 +56,7 @@ jobs:
         # enforced by tests/test_ci_batteries.py in the core battery.
         battery:
           - name: core
-            paths: "tests/test_validate.py tests/test_okf_conformance.py tests/test_overrides.py tests/test_requirement_standards.py tests/test_sarif.py tests/test_parser.py tests/test_schema.py tests/test_identity.py tests/test_frontmatter.py tests/test_metadata_identity.py tests/test_idgen.py tests/test_ci_batteries.py tests/test_corpus.py tests/test_operations.py tests/test_sdk_surface.py"
+            paths: "tests/test_validate.py tests/test_okf_conformance.py tests/test_overrides.py tests/test_requirement_standards.py tests/test_sarif.py tests/test_parser.py tests/test_schema.py tests/test_identity.py tests/test_frontmatter.py tests/test_metadata_identity.py tests/test_idgen.py tests/test_ci_batteries.py tests/test_corpus.py tests/test_operations.py tests/test_sdk_surface.py tests/test_sbom.py"
           - name: cli
             paths: "tests/test_cli.py"
           - name: compare
@@ -110,7 +110,7 @@ jobs:
           - name: stats
             paths: "tests/test_stats.py"
           - name: watchkeeper
-            paths: "tests/test_watchkeeper.py tests/test_validate_action.py tests/test_pr_gate_action.py"
+            paths: "tests/test_watchkeeper.py tests/test_validate_action.py tests/test_pr_gate_action.py tests/test_gate.py tests/test_no_egress.py"
           # Trust gates (v0.7.9): dogfood validates RAC's own rac/ corpus,
           # golden pins CLI stdout byte-for-byte against committed files.
           - name: dogfood

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -305,6 +305,35 @@ one-screen summary and `review` when you want the prioritized worklist.
 
 ---
 
+## gate
+
+Enforce a corpus in one command: run validation, relationships, and review, then
+classify every finding as **blocking** or **advisory** under the corpus
+enforcement policy. The single enforcement entry point — one exit code, one SARIF
+document — used by the PR-gate Action.
+
+- **Input:** `rac gate <directory>` — scanned recursively for `*.md`.
+- **Options:** `--json` · `--sarif` (mutually exclusive) · `--top-level`
+- **Exit codes:** `0` nothing blocking · `1` a blocking finding (or malformed
+  `.rac/config.yaml`) · `2` not a directory
+
+```bash
+rac gate rac/                # human summary
+rac gate rac/ --json         # stable JSON contract (schema_version "1")
+rac gate rac/ --sarif        # one SARIF 2.1.0 document over all findings
+```
+
+Which findings block versus merely annotate is governed by an optional
+`enforcement:` section in `.rac/config.yaml` (`blocking` / `advisory` / `off`
+lists of finding codes). With no policy, the gate's verdict is exactly
+`validate ∧ relationships ∧ review`. The `--json` envelope carries `ok`,
+`blocking_count`, `advisory_count`, and `findings[]` (each with `source`, `code`,
+`severity`, `enforcement`, `path`, `line`, `message`); `--sarif` emits one
+combined document for GitHub Code Scanning. See
+[Governance](governance.md) for the policy shape and fleet-readiness guidance.
+
+---
+
 ## watchkeeper
 
 Review product knowledge *changes* between two repository states: what was

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -1,0 +1,148 @@
+# Governance: the enforcement policy & `rac gate`
+
+`rac gate` is RAC's single enforcement entry point. It runs validation,
+relationship integrity, and review over a corpus, then classifies every finding
+as **blocking** or **advisory** under the corpus *enforcement policy*. One
+command, one exit code, one SARIF document — so a pull-request gate carries the
+whole RAC contract as a single required check.
+
+The policy is governed, not hardcoded. A repository declares which finding
+classes block the gate in its committed `.rac/config.yaml`, so the same policy
+travels with the corpus and applies identically in the editor and in CI. The
+decisions behind this are
+[ADR-049](https://github.com/tcballard/requirements-as-code/blob/main/rac/decisions/adr-049-enforcement-is-the-product.md)
+(enforcement is the product) and
+[ADR-063](https://github.com/tcballard/requirements-as-code/blob/main/rac/decisions/adr-063-non-python-clients-are-thin.md)
+(policy lives in the corpus, not in any consumer).
+
+## Running the gate
+
+```bash
+rac gate rac/              # human summary; exit 0 if nothing blocking, else 1
+rac gate rac/ --json       # stable JSON contract (ADR-007)
+rac gate rac/ --sarif      # one SARIF 2.1.0 document over all findings
+rac gate rac/ --top-level  # do not recurse into subdirectories
+```
+
+The exit code is the only enforcement signal: `0` when nothing is blocking, `1`
+when at least one finding is blocking. Advisory findings are reported (and
+annotated in SARIF) but never fail the gate.
+
+## The `enforcement:` policy
+
+Add an optional top-level `enforcement:` section to `.rac/config.yaml`. It maps
+**finding codes** (the stable `[code]` shown in `rac validate`, `rac review`, and
+`rac relationships --validate` output) to an enforcement class:
+
+```yaml
+repository_key: RAC
+
+enforcement:
+  blocking:                          # force these codes to fail the gate
+    - missing-recommended-sections
+  advisory:                          # downgrade these to annotate-only
+    - relationship-target-superseded
+  off:                               # drop these findings entirely
+    - stale-corpus
+```
+
+- **`blocking`** promotes a code so any matching finding fails the gate.
+- **`advisory`** downgrades a code so matching findings annotate but do not fail.
+- **`off`** suppresses matching findings entirely — they do not appear at all.
+
+**Precedence** (so a code listed in more than one set is deterministic): `off`
+wins, then `blocking`, then `advisory`, otherwise the finding keeps its default
+class. The section is additive and offline; an absent `enforcement:` section is a
+pure no-op, and the gate's default verdict is then exactly
+`validate.ok AND relationships.ok AND review.ok` — the strict v0.21.13 behaviour.
+
+> YAML note: the bare word `off` is a boolean in YAML 1.1, but `rac` accepts it
+> as the suppression key without quotes — write `off:` directly.
+
+### Default classifications
+
+With no policy, each finding carries a default class chosen so the gate is
+`ok` exactly when validate, relationships, and review all pass:
+
+| Source | Default classification |
+| --- | --- |
+| `validate` — `error` severity | **blocking** |
+| `validate` — `warning` / `info` (incl. OKF) | advisory |
+| `relationships` — every finding | **blocking** |
+| `review` — priority 1–2 (invalid artifact, broken relationship) | **blocking** |
+| `review` — priority 3+ (unknown artifact, missing recommended, stale) | advisory |
+
+A policy entry only *changes* a default; it never invents findings.
+
+## Worked example: downgrade a superseded reference
+
+Suppose a live roadmap references a decision the team has retired. By default that
+is a blocking `relationship-target-superseded` finding, so the gate fails:
+
+```text
+$ rac gate rac/
+...
+Blocking:   1
+  ✗ rac/roadmaps/v1.md
+      [relationships] relationship-target-superseded: related_decisions: adr-002 — target is superseded
+✗ Gate failed — 1 blocking finding(s).
+$ echo $?
+1
+```
+
+Downgrade just that code in `.rac/config.yaml`:
+
+```yaml
+enforcement:
+  advisory:
+    - relationship-target-superseded
+```
+
+The finding still surfaces — now as advisory, and it still annotates the pull
+request in SARIF — but the gate passes:
+
+```text
+$ rac gate rac/
+...
+Blocking:   0
+Advisory:   1
+  ! rac/roadmaps/v1.md
+      [relationships] relationship-target-superseded: related_decisions: adr-002 — target is superseded
+✓ Gate passed — nothing blocking.
+$ echo $?
+0
+```
+
+The reference is still visible to reviewers; what changed is whether it *blocks*
+the merge — exactly the governed knob a maintainer wants.
+
+## Fleet readiness — one policy across many repositories
+
+Enforcement only standardises an organisation when *which findings are blocking*
+is set centrally, not re-litigated per repository. Because the policy is plain
+data in `.rac/config.yaml`, a team can standardise it across a fleet:
+
+- **Commit a shared `enforcement:` block.** Keep the canonical policy in one
+  place (a platform repo, a template repo, or a copier/cookiecutter template) and
+  have every RAC repository carry the same `.rac/config.yaml` enforcement section.
+  Each repository's `rac gate` then makes the same blocking-versus-advisory
+  decisions without per-repository edits.
+- **Tighten centrally, roll out by sync.** Promoting a code from `advisory` to
+  `blocking` in the shared block, then syncing the file, tightens the gate across
+  every repository at once — the change is visible in version control and applies
+  identically in the editor and in CI.
+- **Adopt warnings-first, then ratchet.** A new team can start with broad
+  `advisory`/`off` entries to get the gate green on a legacy corpus, then move
+  codes back to `blocking` one at a time as the corpus is cleaned up — the same
+  ratchet the severity overrides ([ADR-053](https://github.com/tcballard/requirements-as-code/blob/main/rac/decisions/adr-053-validation-severity-overrides.md))
+  offer for `rac validate`, now spanning the whole gate.
+
+Because the same file governs both the editor and the PR action, a fleet-wide
+policy change lands in one edit and is enforced everywhere the corpus is checked.
+
+## See also
+
+- [Validation](validation.md) — severity overrides (ADR-053) and SARIF.
+- [Security posture](security.md) — the offline guarantee behind the gate.
+- [Repository Workflow](repo-workflow.md) — `rac init` and `.rac/config.yaml`.
+- [CLI Reference](cli.md) — `rac gate` flags and exit codes.

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,103 @@
+# Security posture
+
+RAC is **offline by design**. The `rac` CLI and the editor extension model
+product knowledge from local Markdown files and emit local files and exit codes;
+they make no network calls and send no telemetry. This document records that
+posture as a control a security office can verify and sign — not a marketing
+claim — and points at the artifacts that prove it.
+
+The posture is self-attestable: it is backed by the package's own deterministic
+behaviour, a committed SBOM, and a runnable network-isolation test. It is **not**
+a hosted service or a third-party certification (see [Scope](#scope-and-non-goals)).
+
+## The no-egress guarantee
+
+- **No network access.** `rac` reads and writes the local filesystem only. None
+  of its analysis paths — validation, relationships, review, the unified gate,
+  search, and export — open a socket. This is enforced as an architectural
+  invariant ([ADR-002](https://github.com/tcballard/requirements-as-code/blob/main/rac/decisions/adr-002-ai-optional.md)):
+  RAC is deterministic and AI-optional, so the core never depends on a remote
+  call.
+- **No telemetry.** RAC collects no usage analytics in its default operation. The
+  optional MCP server and any AI-assisted authoring are explicitly opt-in and
+  bring-your-own-credentials ([ADR-035](https://github.com/tcballard/requirements-as-code/blob/main/rac/decisions/adr-035-byo-ai-credentials.md));
+  nothing phones home on your behalf.
+- **Deterministic, local-only data flow.** The same corpus state yields
+  byte-identical JSON and SARIF output, with no timestamps and stable ordering
+  (ADR-002). Nothing leaves the machine: input is local Markdown, output is local
+  text and an exit code.
+
+## Data flow
+
+```
+local Markdown (rac/)  ->  rac (pure, in-process analysis)  ->  local output
+                                                                 (stdout: human / JSON / SARIF,
+                                                                  files, exit code)
+```
+
+There is no intermediate service, no upload, and no callback. A CI gate uploads
+SARIF to *your* GitHub Code Scanning from *your* runner — that egress is your
+CI's, configured by you, not RAC's.
+
+## Dependency surface
+
+RAC declares three runtime dependencies (`pyproject.toml`, `[project].dependencies`):
+
+| Dependency | Purpose |
+| --- | --- |
+| `markdown-it-py` | Markdown parsing (the artifact source format). |
+| `pyyaml` | Frontmatter and `.rac/config.yaml` parsing. |
+| `mcp` | The optional Model Context Protocol server surface. |
+
+The full, machine-readable dependency list — including resolved versions — is the
+committed [`sbom.json`](https://github.com/tcballard/requirements-as-code/blob/main/sbom.json)
+at the repository root.
+
+## How to verify
+
+You can re-derive every part of this posture yourself, offline:
+
+- **SBOM.** Regenerate and diff the Bill of Materials:
+
+  ```bash
+  python scripts/generate_sbom.py --stdout
+  ```
+
+  It emits a deterministic [CycloneDX 1.5](https://cyclonedx.org/) JSON document
+  for the package and its runtime dependencies (no timestamps, stable ordering).
+  `tests/test_sbom.py` guards the committed `sbom.json` against drift from the
+  declared dependencies, so the SBOM can never silently fall behind.
+
+- **No-egress test.** Run the network-isolation test, which patches
+  `socket.socket` / `socket.create_connection` to raise on use, then exercises
+  validation, relationships, review, the gate, search, and export over a fixture
+  corpus — failing if any path attempts a socket:
+
+  ```bash
+  python -m pytest tests/test_no_egress.py -q
+  ```
+
+  This is the runnable control backing the no-egress claim.
+
+- **Audit the dependency tree.** The three runtime dependencies above are the
+  entire surface; there is no transitive network client in RAC's own code.
+
+## Scope and non-goals
+
+This posture is **self-attestable and offline-first**. It deliberately does not
+include:
+
+- a hosted control plane or any server-side component;
+- per-user analytics or usage tracking;
+- a third-party security certification.
+
+The guarantee is that RAC runs locally with no egress and no telemetry, and that
+this is verifiable from the repository. Anything beyond a self-attestable,
+offline posture is out of scope for the project (v0.21.14 Non-Goals).
+
+## See also
+
+- [Governance](governance.md) — the `enforcement:` policy and `rac gate`.
+- [Validation](validation.md) — the write-time gate and SARIF output.
+- [ADR-002](https://github.com/tcballard/requirements-as-code/blob/main/rac/decisions/adr-002-ai-optional.md) — deterministic, AI-optional core.
+- [ADR-035](https://github.com/tcballard/requirements-as-code/blob/main/rac/decisions/adr-035-byo-ai-credentials.md) — bring-your-own AI credentials.

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -155,13 +155,15 @@ tighten over time.
 (The Watchkeeper action at the repository root is the complementary PR-review
 surface — see [Watchkeeper](watchkeeper.md).)
 
-### The full PR gate (validate + relationships + review)
+### The full PR gate (`rac gate`)
 
-To carry the whole contract into one required check, the `pr-gate-action` runs
-`rac validate`, `rac relationships --validate`, and `rac review` together,
-uploads all three SARIF documents to Code Scanning, and fails on the worst exit
-code (v0.21.13). It is the same thin wrapper — the engine's exit codes decide
-what is blocking, the action computes nothing ([ADR-063](https://github.com/tcballard/requirements-as-code/blob/main/rac/decisions/adr-063-non-python-clients-are-thin.md)):
+To carry the whole contract into one required check, `rac gate` composes
+validation, relationship integrity, and review into a single enforced verdict
+under the corpus **enforcement policy**, and emits one combined SARIF document
+(v0.21.14). The `pr-gate-action` runs it and uploads that single SARIF to Code
+Scanning under one category (`rac-gate`), failing when any finding is *blocking*.
+It is the same thin wrapper — the engine decides what is blocking, the action
+computes nothing ([ADR-063](https://github.com/tcballard/requirements-as-code/blob/main/rac/decisions/adr-063-non-python-clients-are-thin.md)):
 
 ```yaml
 # .github/workflows/rac.yml
@@ -181,13 +183,20 @@ jobs:
 ```
 
 Inputs mirror `validate-action`: `path` (default `rac`), `upload-sarif` (default
-`true`), `sarif-dir` (default `rac-sarif`, one file per check), `rac-version`,
-and `install-from` (`pypi` or `source`). A reference that points at a missing or
-retired decision fails the gate with an inline annotation matching
-`rac relationships --validate`.
+`true`), `sarif-dir` (default `rac-sarif`, now one `gate.sarif`), `rac-version`,
+and `install-from` (`pypi` or `source`).
+
+`rac gate <dir>` is also runnable locally — `--json` and `--sarif` produce the
+machine contracts, the exit code is `0` when nothing is blocking and `1`
+otherwise. **Which findings are blocking versus advisory is governed centrally**
+by an `enforcement:` section in the committed `.rac/config.yaml`. See
+[Governance](governance.md) for the policy shape, the default classifications,
+and how to standardise one policy across a fleet of repositories.
 
 ## See also
 
+- [Governance](governance.md) — the `enforcement:` policy and `rac gate`.
+- [Security posture](security.md) — the no-egress guarantee, SBOM, and how to verify it.
 - [CLI Reference](cli.md) — all `rac validate` flags and exit codes.
 - [OKF Profile](okf-profile.md) — the conformance findings SARIF also reports.
 - [Repository Workflow](repo-workflow.md) — `rac init` and `.rac/config.yaml`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,6 +35,8 @@ nav:
   - Artifacts: artifacts.md
   - Relationships: relationships.md
   - Validation: validation.md
+  - Governance: governance.md
+  - Security: security.md
   - OKF Profile: okf-profile.md
   - Repository Workflow: repo-workflow.md
   - Examples: examples.md

--- a/pr-gate-action/action.yml
+++ b/pr-gate-action/action.yml
@@ -1,20 +1,23 @@
-# RAC PR-gate composite action (v0.21.13, ADR-049 / ADR-063).
+# RAC PR-gate composite action (v0.21.14, ADR-049 / ADR-063).
 #
 # Carries the full RAC contract into a single required pull-request check:
-# install RAC, run `rac validate`, `rac relationships --validate`, and
-# `rac review` — each emitting SARIF (ADR-054) — upload all three to GitHub
-# Code Scanning, and re-surface the worst CLI exit code. The action is a thin
-# consumer (ADR-063): all analysis and severity policy live in the package
-# (ADR-015 / ADR-049 / ADR-053); the action never reinterprets findings.
+# install RAC and run `rac gate` — one command that enforces validation,
+# relationship integrity, and review under the corpus enforcement policy
+# (`.rac/config.yaml`), emitting one SARIF document (ADR-054). The single SARIF
+# is uploaded to GitHub Code Scanning under one category (`rac-gate`), and the
+# CLI exit code is re-surfaced. The action is a thin consumer (ADR-063): all
+# analysis and enforcement policy live in the package (ADR-015 / ADR-049); the
+# action never reinterprets findings or decides what is blocking.
 #
 # The Watchkeeper action lives at the repository root and the single-command
 # validate action at `validate-action/`; this gate is referenced as
 # `uses: tcballard/requirements-as-code/pr-gate-action@<ref>`.
 name: "RAC PR gate"
 description: >-
-  Enforce a requirements-as-code (RAC) corpus on a pull request: validate,
-  relationship integrity, and review, surfaced inline via GitHub Code Scanning
-  (SARIF) as a required status check. A thin wrapper over the `rac` CLI.
+  Enforce a requirements-as-code (RAC) corpus on a pull request with a single
+  `rac gate` command — validation, relationship integrity, and review under the
+  corpus enforcement policy — surfaced inline via GitHub Code Scanning (SARIF) as
+  a required status check. A thin wrapper over the `rac` CLI.
 author: "Tom Ballard"
 
 branding:
@@ -23,7 +26,7 @@ branding:
 
 inputs:
   path:
-    description: "The RAC corpus directory to check (passed to each `rac` command)."
+    description: "The RAC corpus directory to enforce (passed to `rac gate`)."
     required: false
     default: "rac"
   upload-sarif:
@@ -33,7 +36,7 @@ inputs:
     required: false
     default: "true"
   sarif-dir:
-    description: "Directory the SARIF documents are written to (one file per check)."
+    description: "Directory the single `gate.sarif` document is written to."
     required: false
     default: "rac-sarif"
   rac-version:
@@ -73,10 +76,11 @@ runs:
         fi
 
     # The CLI is the source of truth (ADR-058). `set +e` lets a non-zero exit
-    # still produce SARIF for upload; the worst exit code is re-surfaced below.
-    # Each check writes its own SARIF file into the upload directory.
-    - name: Run RAC checks (SARIF)
-      id: checks
+    # still produce SARIF for upload; the exit code is re-surfaced below. One
+    # command, one SARIF document — `rac gate` already composes validation,
+    # relationships, and review under the corpus enforcement policy.
+    - name: Run RAC gate (SARIF)
+      id: gate
       shell: bash
       env:
         INPUT_PATH: ${{ inputs.path }}
@@ -84,57 +88,30 @@ runs:
       run: |
         set +e
         mkdir -p "$SARIF_DIR"
-        worst=0
+        rac gate "$INPUT_PATH" --sarif > "$SARIF_DIR/gate.sarif"
+        code=$?
+        echo "gate exited $code"
+        echo "exit_code=$code" >> "$GITHUB_OUTPUT"
 
-        run_check() {
-          local name="$1"; shift
-          "$@" > "$SARIF_DIR/$name.sarif"
-          local code=$?
-          echo "$name exited $code"
-          if [ "$code" -gt "$worst" ]; then worst=$code; fi
-        }
-
-        run_check validate       rac validate "$INPUT_PATH" --sarif
-        run_check relationships  rac relationships "$INPUT_PATH" --validate --sarif
-        run_check review         rac review "$INPUT_PATH" --sarif
-
-        echo "exit_code=$worst" >> "$GITHUB_OUTPUT"
-
-    # Each check is uploaded under its own Code Scanning category. Code Scanning
-    # rejects multiple SARIF runs combined under one category, so the three runs
-    # (one tool, "rac") must arrive as separate, categorised analyses rather than
-    # a single merged directory upload.
-    - name: Upload validate SARIF
+    # A single SARIF document uploaded under one Code Scanning category. The gate
+    # is one tool ("rac") producing one run, so one categorised analysis suffices.
+    - name: Upload gate SARIF
       if: ${{ always() && inputs.upload-sarif == 'true' }}
       uses: github/codeql-action/upload-sarif@v3
       with:
-        sarif_file: ${{ inputs.sarif-dir }}/validate.sarif
-        category: rac-validate
+        sarif_file: ${{ inputs.sarif-dir }}/gate.sarif
+        category: rac-gate
 
-    - name: Upload relationships SARIF
-      if: ${{ always() && inputs.upload-sarif == 'true' }}
-      uses: github/codeql-action/upload-sarif@v3
-      with:
-        sarif_file: ${{ inputs.sarif-dir }}/relationships.sarif
-        category: rac-relationships
-
-    - name: Upload review SARIF
-      if: ${{ always() && inputs.upload-sarif == 'true' }}
-      uses: github/codeql-action/upload-sarif@v3
-      with:
-        sarif_file: ${{ inputs.sarif-dir }}/review.sarif
-        category: rac-review
-
-    # Any non-zero CLI exit fails the check; the per-check exits above show which
-    # gate failed, and the Code Scanning annotations show every finding. Severity
-    # policy (what is blocking) lives in the engine's exit codes, not here.
+    # Any non-zero CLI exit fails the check; the Code Scanning annotations show
+    # every finding, blocking and advisory. What is blocking is decided by the
+    # engine under the corpus enforcement policy (ADR-049), not here.
     - name: Report result
       shell: bash
       env:
-        EXIT_CODE: ${{ steps.checks.outputs.exit_code }}
+        EXIT_CODE: ${{ steps.gate.outputs.exit_code }}
       run: |
         if [ "$EXIT_CODE" != "0" ]; then
-          echo "::error::RAC PR gate failed (worst exit $EXIT_CODE) — see the Code Scanning annotations."
+          echo "::error::RAC PR gate failed (exit $EXIT_CODE) — see the Code Scanning annotations."
           exit "$EXIT_CODE"
         fi
         echo "RAC PR gate passed."

--- a/rac/roadmaps/v0.21.x-editor/v0.21.13-pr-pipeline-enforcement.md
+++ b/rac/roadmaps/v0.21.x-editor/v0.21.13-pr-pipeline-enforcement.md
@@ -8,7 +8,7 @@ tags: [sdk, typescript, editor, enforcement, ci]
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/sbom.json
+++ b/sbom.json
@@ -1,0 +1,37 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "version": 1,
+  "metadata": {
+    "component": {
+      "type": "library",
+      "name": "requirements-as-code",
+      "version": "0.19.1.dev105+g1942d0d88.d20260616",
+      "bom-ref": "requirements-as-code@0.19.1.dev105+g1942d0d88.d20260616",
+      "purl": "pkg:pypi/requirements-as-code@0.19.1.dev105+g1942d0d88.d20260616"
+    }
+  },
+  "components": [
+    {
+      "type": "library",
+      "name": "markdown-it-py",
+      "version": "4.2.0",
+      "bom-ref": "markdown-it-py@4.2.0",
+      "purl": "pkg:pypi/markdown-it-py@4.2.0"
+    },
+    {
+      "type": "library",
+      "name": "mcp",
+      "version": "1.27.2",
+      "bom-ref": "mcp@1.27.2",
+      "purl": "pkg:pypi/mcp@1.27.2"
+    },
+    {
+      "type": "library",
+      "name": "pyyaml",
+      "version": "6.0.1",
+      "bom-ref": "pyyaml@6.0.1",
+      "purl": "pkg:pypi/pyyaml@6.0.1"
+    }
+  ]
+}

--- a/scripts/generate_sbom.py
+++ b/scripts/generate_sbom.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Generate a CycloneDX 1.5 SBOM for requirements-as-code (v0.21.14).
+
+A Software Bill of Materials is the verifiable artifact behind RAC's security
+posture (``docs/security.md``): it enumerates the package and its declared
+runtime dependencies so a security office can review the dependency surface
+without trusting a prose claim. The dependency *names* are read from
+``pyproject.toml`` (``[project].dependencies`` — the single source of truth);
+each version is resolved from the installed environment via
+``importlib.metadata``.
+
+Determinism and offline (ADR-002): no network access, no timestamps, and a
+stable component ordering, so re-running on the same environment yields a
+byte-identical ``sbom.json``. The committed ``sbom.json`` at the repository root
+is produced by this script; ``tests/test_sbom.py`` guards it against drift from
+the declared dependencies.
+
+Usage::
+
+    python scripts/generate_sbom.py            # write sbom.json at the repo root
+    python scripts/generate_sbom.py --stdout   # print to stdout instead
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import tomllib
+from importlib import metadata
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+SBOM_PATH = REPO_ROOT / "sbom.json"
+
+PACKAGE_NAME = "requirements-as-code"
+
+# A PEP 508 requirement string starts with the distribution name; strip any
+# version specifier, extras, or environment marker to recover the bare name.
+_NAME_RE = re.compile(r"^[A-Za-z0-9._-]+")
+
+
+def _dependency_names() -> list[str]:
+    """The runtime dependency names declared in ``[project].dependencies``."""
+    data = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
+    requirements = data["project"]["dependencies"]
+    names: list[str] = []
+    for requirement in requirements:
+        match = _NAME_RE.match(requirement.strip())
+        if match:
+            names.append(match.group(0))
+    return names
+
+
+def _installed_version(name: str) -> str:
+    """The installed version of ``name``, or ``"unknown"`` when not installed.
+
+    Offline: reads only local distribution metadata. A missing dependency yields
+    ``"unknown"`` rather than failing, so the SBOM can still be generated in a
+    partial environment; the test suite asserts the declared names are present.
+    """
+    try:
+        return metadata.version(name)
+    except metadata.PackageNotFoundError:
+        return "unknown"
+
+
+def _component(name: str, version: str) -> dict:
+    """One CycloneDX ``library`` component for ``name`` at ``version``."""
+    return {
+        "type": "library",
+        "name": name,
+        "version": version,
+        "bom-ref": f"{name}@{version}",
+        "purl": f"pkg:pypi/{name}@{version}",
+    }
+
+
+def build_sbom() -> dict:
+    """The CycloneDX 1.5 SBOM document for RAC and its runtime dependencies.
+
+    The package itself is the root metadata component; the runtime dependencies
+    are the ``components`` list, sorted by name for determinism. No timestamp is
+    emitted so the document is byte-stable across runs (ADR-002).
+    """
+    root = _component(PACKAGE_NAME, _installed_version(PACKAGE_NAME))
+
+    dependencies = sorted(_dependency_names(), key=str.casefold)
+    components = [_component(name, _installed_version(name)) for name in dependencies]
+
+    return {
+        "bomFormat": "CycloneDX",
+        "specVersion": "1.5",
+        "version": 1,
+        # No serialNumber and no metadata.timestamp: both would make the document
+        # non-deterministic. The component list is the verifiable content.
+        "metadata": {"component": root},
+        "components": components,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Generate the RAC CycloneDX SBOM.")
+    parser.add_argument(
+        "--stdout",
+        action="store_true",
+        help="Print the SBOM to stdout instead of writing sbom.json.",
+    )
+    args = parser.parse_args(argv)
+
+    document = build_sbom()
+    text = json.dumps(document, indent=2) + "\n"
+    if args.stdout:
+        sys.stdout.write(text)
+    else:
+        SBOM_PATH.write_text(text, encoding="utf-8")
+        print(f"wrote {SBOM_PATH.relative_to(REPO_ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/rac/cli.py
+++ b/src/rac/cli.py
@@ -10,6 +10,7 @@ Commands:
     rac schema [--list] [type] [--json | --template]
     rac relationships <dir | file.md> [--validate] [--json] [--top-level]
     rac review <directory> [--json] [--top-level]
+    rac gate <directory> [--json | --sarif] [--top-level]
     rac watchkeeper [directory] [--base REF] [--head REF]
                     [--format human|json|github] [--json] [--fail-on POLICY]
                     [--no-annotate]
@@ -103,6 +104,7 @@ from rac.services.create import (
 )
 from rac.services.diff import diff as diff_asts
 from rac.services.export import build_corpus_export
+from rac.services.gate import build_gate
 from rac.services.hook import HookFileExists, NotAGitWorkTree, install_hook
 from rac.services.improve import improve_product
 from rac.services.index import build_repository_index
@@ -424,6 +426,26 @@ def cmd_review(args: argparse.Namespace) -> int:
         print(outputs.render_review_human(report))
     # Priority 1-2 findings (invalid artifacts, broken relationships) fail the
     # review; priority 3-4 findings are advisory (REQ-Repository-Review-Mode).
+    return EXIT_OK if report.ok else EXIT_VALIDATION_FAILED
+
+
+def cmd_gate(args: argparse.Namespace) -> int:
+    if not Path(args.directory).is_dir():
+        print(f"rac: not a directory: {args.directory}", file=sys.stderr)
+        raise SystemExit(EXIT_USAGE)
+    try:
+        report = build_gate(args.directory, recursive=not args.top_level)
+    except MalformedRepositoryConfig as exc:  # unreadable/invalid .rac/config.yaml
+        print(f"rac: {exc}", file=sys.stderr)
+        return EXIT_VALIDATION_FAILED
+    if args.sarif:
+        print(outputs.render_gate_sarif(report))
+    elif args.json:
+        print(outputs.render_gate_json(report))
+    else:
+        print(outputs.render_gate_human(report))
+    # The gate fails when any finding is blocking under the corpus enforcement
+    # policy; advisory findings annotate but never fail (ADR-049 / v0.21.14).
     return EXIT_OK if report.ok else EXIT_VALIDATION_FAILED
 
 
@@ -1100,6 +1122,30 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     p_review.set_defaults(func=cmd_review)
+
+    p_gate = sub.add_parser(
+        "gate",
+        help="Enforce the corpus: validation, relationships, and review under "
+        "the corpus enforcement policy.",
+        parents=[version_parent],
+    )
+    p_gate.add_argument("directory", help="The RAC corpus directory to enforce.")
+    gate_format = p_gate.add_mutually_exclusive_group()
+    gate_format.add_argument(
+        "--json", action="store_true", help="Emit JSON instead of human-readable text."
+    )
+    gate_format.add_argument(
+        "--sarif",
+        action="store_true",
+        help="Emit one SARIF 2.1.0 document over all findings for GitHub Code "
+        "Scanning (CI pull-request enforcement).",
+    )
+    p_gate.add_argument(
+        "--top-level",
+        action="store_true",
+        help="Only the top-level files in the directory (no recursion).",
+    )
+    p_gate.set_defaults(func=cmd_gate)
 
     p_watchkeeper = sub.add_parser(
         "watchkeeper",

--- a/src/rac/output/__init__.py
+++ b/src/rac/output/__init__.py
@@ -11,6 +11,7 @@ from .human import (
     render_diff_human,
     render_dir_inspect_human,
     render_find_human,
+    render_gate_human,
     render_hook_install_human,
     render_hook_list_human,
     render_improve_human,
@@ -43,6 +44,7 @@ from .json import (
     render_dir_inspect_json,
     render_export_json,
     render_find_json,
+    render_gate_json,
     render_hook_install_json,
     render_hook_list_json,
     render_improve_json,
@@ -72,6 +74,7 @@ from .json import (
 from .okf import render_okf_bundle
 from .portal import render_export_html
 from .sarif import (
+    render_gate_sarif,
     render_relationships_sarif,
     render_review_sarif,
     render_validate_sarif,
@@ -83,6 +86,9 @@ __all__ = [
     "render_diff_json",
     "render_find_human",
     "render_find_json",
+    "render_gate_human",
+    "render_gate_json",
+    "render_gate_sarif",
     "render_dir_inspect_human",
     "render_dir_inspect_json",
     "render_export_html",

--- a/src/rac/output/human.py
+++ b/src/rac/output/human.py
@@ -23,6 +23,7 @@ from rac.services.compare import (
     RelationshipIssueRef,
 )
 from rac.services.create import CreatedArtifact
+from rac.services.gate import GateReport
 from rac.services.hook import InstalledHook
 from rac.services.improve import ImprovementResult
 from rac.services.index import RepositoryIndex
@@ -810,6 +811,47 @@ def render_review_human(r: ReviewReport) -> str:
     ]
     if p.total_artifacts == 0:
         lines += ["", EMPTY_CORPUS_HINT]
+    return "\n".join(lines)
+
+
+# --- gate --------------------------------------------------------------------
+
+
+def render_gate_human(report: GateReport) -> str:
+    """Human-readable `rac gate` output (v0.21.14).
+
+    The unified enforcement verdict: blocking versus advisory counts, then the
+    findings grouped by enforcement class, each with its source, code, and
+    location. Blocking findings fail the gate; advisory findings annotate but do
+    not. The style mirrors `rac review` — coloured icons, a green clear line.
+    """
+    blocking = report.blocking
+    advisory = report.advisory
+    lines = [
+        _bold("Corpus Gate"),
+        "===========",
+        "",
+        f"Directory:  {report.directory}",
+        f"Blocking:   {len(blocking)}",
+        f"Advisory:   {len(advisory)}",
+    ]
+
+    def _emit(group: list, title: str, icon: str) -> None:
+        if not group:
+            return
+        lines.extend(["", _bold(f"{title} ({len(group)})"), "-" * len(f"{title} ({len(group)})")])
+        for f in group:
+            lines.append(f"  {icon} {_loc(f.path, f.line)}")
+            lines.append(f"      [{f.source}] {f.code}: {f.message}")
+
+    _emit(blocking, "Blocking", _red("✗"))
+    _emit(advisory, "Advisory", _yellow("!"))
+
+    lines.append("")
+    if report.ok:
+        lines.append(_green("✓ Gate passed — nothing blocking."))
+    else:
+        lines.append(_red(f"✗ Gate failed — {len(blocking)} blocking finding(s)."))
     return "\n".join(lines)
 
 

--- a/src/rac/output/json.py
+++ b/src/rac/output/json.py
@@ -17,6 +17,7 @@ from rac.core.schema import SchemaReference
 from rac.core.skills import SkillSpec
 from rac.services.create import CreatedArtifact
 from rac.services.export import CorpusExport
+from rac.services.gate import GateReport
 from rac.services.hook import InstalledHook
 from rac.services.improve import ImprovementResult
 from rac.services.index import RepositoryIndex
@@ -62,6 +63,14 @@ def render_validate_dir_json(result: DirectoryValidation) -> str:
 
 def render_review_json(report: ReviewReport) -> str:
     """JSON `rac review` output (stable contract, ADR-007)."""
+    return json.dumps(report.to_dict(), indent=2)
+
+
+# --- gate --------------------------------------------------------------------
+
+
+def render_gate_json(report: GateReport) -> str:
+    """JSON `rac gate` output (stable contract, ADR-007)."""
     return json.dumps(report.to_dict(), indent=2)
 
 

--- a/src/rac/output/sarif.py
+++ b/src/rac/output/sarif.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import json
 
 from rac import __version__
+from rac.services.gate import GateReport
 from rac.services.relationships import (
     ISSUE_DUPLICATE_IDENTIFIER,
     ISSUE_EDGE_UNSUPPORTED,
@@ -25,6 +26,7 @@ from rac.services.relationships import (
     ISSUE_TARGET_NOT_FOUND,
     ISSUE_TARGET_SUPERSEDED,
     ISSUE_TARGET_TYPE_MISMATCH,
+    RELATIONSHIP_SEVERITY,
     RelationshipIssue,
     RelationshipValidation,
 )
@@ -89,21 +91,13 @@ def render_review_sarif(report: ReviewReport) -> str:
     return _document(results)
 
 
-# Relationship-validation findings map onto SARIF levels (ADR-054). Referential
-# integrity and graph-shape breakages are errors; advisory consistency findings
-# (self-reference, unsupported edge, retired-target reference) are warnings. The
-# PR gate blocks on any non-zero exit, so a warning-level retired-decision
-# reference still fails the check — the level only sets the annotation severity.
-_RELATIONSHIP_LEVEL = {
-    ISSUE_TARGET_NOT_FOUND: "error",
-    ISSUE_TARGET_AMBIGUOUS: "error",
-    ISSUE_TARGET_TYPE_MISMATCH: "error",
-    ISSUE_RELATIONSHIP_CYCLE: "error",
-    ISSUE_DUPLICATE_IDENTIFIER: "error",
-    ISSUE_TARGET_SUPERSEDED: "warning",
-    ISSUE_SELF_REFERENCE: "warning",
-    ISSUE_EDGE_UNSUPPORTED: "warning",
-}
+# Relationship-validation findings map onto SARIF levels (ADR-054) via the
+# canonical intrinsic severity owned by the relationships service
+# (``RELATIONSHIP_SEVERITY``), so the SARIF annotation level and the `rac gate`
+# enforcement layer read one source and can never disagree. The PR gate blocks on
+# any non-zero exit, so a warning-level retired-decision reference still fails the
+# check — the level only sets the annotation severity, not the enforcement class.
+_RELATIONSHIP_LEVEL = RELATIONSHIP_SEVERITY
 
 # Human-readable message per finding, keyed by code. Reference-style findings
 # format the relationship, target, and reason; repository-level findings
@@ -151,6 +145,20 @@ def render_relationships_sarif(validation: RelationshipValidation) -> str:
     review renderers, the output is deterministic and offline (ADR-002).
     """
     results = [_relationship_result(issue) for issue in validation.issues]
+    return _document(results)
+
+
+def render_gate_sarif(report: GateReport) -> str:
+    """Render a `rac gate` report as a single SARIF 2.1.0 document (v0.21.14).
+
+    One combined run over *all* gate findings — blocking and advisory alike — so
+    the PR gate uploads a single SARIF under one Code Scanning category instead of
+    three. The finding's intrinsic ``severity`` drives the annotation level (an
+    advisory finding still annotates at its own severity); the enforcement class is
+    carried in the gate's exit code, not the SARIF level. Deterministic and offline
+    (ADR-002): results are sorted by ``_document`` and no timestamps are emitted.
+    """
+    results = [_result(f.code, f.severity, f.message, f.path, f.line) for f in report.findings]
     return _document(results)
 
 

--- a/src/rac/services/gate.py
+++ b/src/rac/services/gate.py
@@ -1,0 +1,287 @@
+"""Policy-aware unified enforcement — `rac gate` (v0.21.14, ADR-049 / ADR-063).
+
+``rac gate`` is the single enforcement entry point: it runs validation,
+relationship integrity, and review over a corpus, then classifies every finding
+as *blocking* or *advisory* under the corpus enforcement policy (ADR-049 —
+enforcement is the product). One command, one exit code, one SARIF document, so
+the PR gate carries the whole RAC contract as a single required check instead of
+three separate uploads.
+
+The classification is governed, not hardcoded (ADR-063: the thin client renders;
+the engine decides). A corpus declares an optional ``enforcement:`` section in
+its committed ``.rac/config.yaml`` (loaded by :mod:`rac.services.init`, which
+owns the file) mapping finding codes to ``blocking``/``advisory``/``off``. The
+*default* enforcement classes are chosen so that, with no policy, a gate run is
+``ok`` exactly when validate, relationships, and review all pass — preserving the
+v0.21.13 behaviour the policy refines.
+
+Determinism and offline (ADR-002): the gate composes the same deterministic
+services, applies a pure policy pass, and sorts findings by a stable key, so the
+same corpus state yields a byte-identical report, JSON, and SARIF.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from rac.services.init import load_enforcement_policy
+from rac.services.relationships import (
+    RELATIONSHIP_SEVERITY,
+    RelationshipIssue,
+    validate_relationships,
+)
+from rac.services.review import (
+    PRIORITY_BROKEN_RELATIONSHIP,
+    ReviewIssue,
+    build_review,
+)
+from rac.services.validate import DirectoryValidation, validate_directory
+
+# The two enforcement classes a finding can carry, plus the suppressed marker
+# (``off`` drops the finding entirely). Sources name where a finding originated.
+ENFORCEMENT_BLOCKING = "blocking"
+ENFORCEMENT_ADVISORY = "advisory"
+ENFORCEMENT_OFF = "off"
+
+SOURCE_VALIDATE = "validate"
+SOURCE_RELATIONSHIPS = "relationships"
+SOURCE_REVIEW = "review"
+
+
+@dataclass(frozen=True)
+class EnforcementPolicy:
+    """A corpus enforcement policy: finding codes mapped to a class (ADR-049).
+
+    Three disjoint *intent* sets of finding codes. ``classify`` resolves a
+    finding's effective class with a fixed precedence — ``off`` (suppress) wins,
+    then ``blocking``, then ``advisory``, else the caller's default. A code in
+    more than one set is therefore harmless: precedence makes the result
+    deterministic regardless of declaration order.
+    """
+
+    blocking: frozenset[str] = frozenset()
+    advisory: frozenset[str] = frozenset()
+    off: frozenset[str] = frozenset()
+
+    def classify(self, code: str, default: str) -> str | None:
+        """The effective enforcement class for ``code``, or ``None`` if suppressed.
+
+        Precedence: ``off`` -> ``blocking`` -> ``advisory`` -> ``default``. A
+        ``None`` result means the finding is dropped (the policy turned it off).
+        """
+        if code in self.off:
+            return None
+        if code in self.blocking:
+            return ENFORCEMENT_BLOCKING
+        if code in self.advisory:
+            return ENFORCEMENT_ADVISORY
+        return default
+
+
+# The neutral policy: every finding keeps its default class (ADR-049). Used when
+# a corpus declares no ``enforcement:`` section, so the no-policy path is a no-op.
+EMPTY_POLICY = EnforcementPolicy()
+
+
+@dataclass(frozen=True)
+class GateFinding:
+    """One enforced finding, normalised across the three underlying services.
+
+    ``source`` records which service produced it; ``severity`` is the intrinsic
+    severity (drives the SARIF level); ``enforcement`` is the policy-resolved
+    class that drives the exit code. ``to_dict`` is the stable JSON contract
+    (ADR-007); fields are additive and ordered for deterministic output.
+    """
+
+    source: str  # SOURCE_VALIDATE | SOURCE_RELATIONSHIPS | SOURCE_REVIEW
+    code: str
+    severity: str  # "error" | "warning" | "info"
+    enforcement: str  # ENFORCEMENT_BLOCKING | ENFORCEMENT_ADVISORY
+    path: str
+    line: int | None
+    message: str
+
+    def to_dict(self) -> dict:
+        return {
+            "source": self.source,
+            "code": self.code,
+            "severity": self.severity,
+            "enforcement": self.enforcement,
+            "path": self.path,
+            "line": self.line,
+            "message": self.message,
+        }
+
+
+@dataclass
+class GateReport:
+    """The unified enforcement result over a corpus (v0.21.14).
+
+    ``ok`` is False when any finding is blocking — the single exit-code signal
+    the PR gate consumes. ``to_dict`` is the stable JSON contract (ADR-007).
+    """
+
+    directory: str
+    recursive: bool
+    findings: list[GateFinding] = field(default_factory=list)
+
+    @property
+    def blocking(self) -> list[GateFinding]:
+        return [f for f in self.findings if f.enforcement == ENFORCEMENT_BLOCKING]
+
+    @property
+    def advisory(self) -> list[GateFinding]:
+        return [f for f in self.findings if f.enforcement == ENFORCEMENT_ADVISORY]
+
+    @property
+    def ok(self) -> bool:
+        """True when nothing is blocking — advisory findings never fail the gate."""
+        return not self.blocking
+
+    def to_dict(self) -> dict:
+        return {
+            "schema_version": "1",
+            "directory": self.directory,
+            "recursive": self.recursive,
+            "ok": self.ok,
+            "blocking_count": len(self.blocking),
+            "advisory_count": len(self.advisory),
+            "findings": [f.to_dict() for f in self.findings],
+        }
+
+
+# Default enforcement classes per source. These are chosen so that, under the
+# EMPTY_POLICY, a gate run is ``ok`` exactly when validate.ok AND
+# relationships.ok AND review.ok — the v0.21.13 behaviour the policy refines.
+
+# Validate: an "error" fails validation (it sets the invalid status), so it is
+# blocking by default; warnings and OKF info findings are advisory.
+_VALIDATE_DEFAULT = {"error": ENFORCEMENT_BLOCKING}
+
+# Relationships: today *any* relationship issue fails `--validate` (exit 1), so
+# every relationship finding is blocking by default. The intrinsic severity used
+# for the SARIF level is the canonical mapping owned by the relationships
+# service (RELATIONSHIP_SEVERITY), so SARIF and the gate never disagree.
+
+
+def _validate_findings(result: DirectoryValidation) -> list[tuple[str, str, str, int | None, str]]:
+    """``(code, severity, path, line, message)`` for every validate finding.
+
+    Core validation findings carry a line anchor when present; OKF conformance
+    findings are file-level (no line). Mirrors ``render_validate_sarif``.
+    """
+    out: list[tuple[str, str, str, int | None, str]] = []
+    for file in result.files:
+        for issue in file.issues:
+            out.append((issue.code, issue.severity, file.path, issue.line, issue.message))
+    if result.okf is not None:
+        for finding in result.okf.findings:
+            out.append((finding.code, finding.severity, finding.path, None, finding.message))
+    return out
+
+
+def _relationship_finding(issue: RelationshipIssue) -> tuple[str, str, str, int | None, str]:
+    """``(code, severity, path, line, message)`` for one relationship finding.
+
+    The message and anchor mirror ``render_relationships_sarif``: repository-level
+    findings (duplicate identifier, cycle) anchor on the first involved path and
+    name every file; reference findings anchor on the source. Line is always None
+    (relationship findings are file-level).
+    """
+    from rac.output.sarif import _relationship_result
+
+    # Reuse the SARIF result builder so the message and URI never drift from the
+    # standalone `rac relationships --sarif` output (one formatting source).
+    result = _relationship_result(issue)
+    uri = result["locations"][0]["physicalLocation"]["artifactLocation"]["uri"]
+    severity = RELATIONSHIP_SEVERITY.get(issue.code, "warning")
+    return (issue.code, severity, uri, None, result["message"]["text"])
+
+
+def _review_finding(issue: ReviewIssue) -> tuple[str, str, str, int | None, str]:
+    """``(code, severity, path, line, message)`` for one review finding.
+
+    The message carries the suggested action so the fix is visible inline, exactly
+    as ``render_review_sarif`` formats it.
+    """
+    message = f"{issue.message} — {issue.action}" if issue.action else issue.message
+    return (issue.code, issue.severity, issue.path, None, message)
+
+
+def build_gate(
+    directory: str,
+    recursive: bool = True,
+    policy: EnforcementPolicy | None = None,
+) -> GateReport:
+    """Run validation, relationships, and review and enforce the corpus policy.
+
+    When ``policy`` is None it is loaded from the directory's ``.rac/config.yaml``
+    (:func:`load_enforcement_policy`). Each underlying finding is mapped to a
+    :class:`GateFinding` with a default enforcement class, then the policy is
+    applied — findings the policy turns ``off`` are dropped. Findings are sorted
+    deterministically by ``(path, line, source, code, message)`` so the report,
+    JSON, and SARIF are byte-stable (ADR-002).
+    """
+    if policy is None:
+        policy = load_enforcement_policy(directory)
+
+    validation = validate_directory(directory, recursive=recursive)
+    relationships = validate_relationships(directory, recursive=recursive)
+    review = build_review(directory, recursive=recursive)
+
+    findings: list[GateFinding] = []
+
+    def add(
+        source: str,
+        code: str,
+        severity: str,
+        path: str,
+        line: int | None,
+        message: str,
+        default: str,
+    ) -> None:
+        enforcement = policy.classify(code, default)
+        if enforcement is None:
+            return  # suppressed by an ``off`` policy entry
+        findings.append(
+            GateFinding(
+                source=source,
+                code=code,
+                severity=severity,
+                enforcement=enforcement,
+                path=path,
+                line=line,
+                message=message,
+            )
+        )
+
+    for code, severity, path, line, message in _validate_findings(validation):
+        add(
+            SOURCE_VALIDATE,
+            code,
+            severity,
+            path,
+            line,
+            message,
+            _VALIDATE_DEFAULT.get(severity, ENFORCEMENT_ADVISORY),
+        )
+
+    for rel_issue in relationships.issues:
+        code, severity, path, line, message = _relationship_finding(rel_issue)
+        # Every relationship issue fails `--validate` today, so the default is
+        # blocking; a policy may downgrade a specific code (e.g. superseded).
+        add(SOURCE_RELATIONSHIPS, code, severity, path, line, message, ENFORCEMENT_BLOCKING)
+
+    for review_issue in review.issues:
+        code, severity, path, line, message = _review_finding(review_issue)
+        # Priority 1-2 findings fail review today (ReviewReport.ok), so they are
+        # blocking by default; advisory priorities (3+) are advisory.
+        default = (
+            ENFORCEMENT_BLOCKING
+            if review_issue.priority <= PRIORITY_BROKEN_RELATIONSHIP
+            else ENFORCEMENT_ADVISORY
+        )
+        add(SOURCE_REVIEW, code, severity, path, line, message, default)
+
+    findings.sort(key=lambda f: (f.path, f.line or 0, f.source, f.code, f.message))
+    return GateReport(directory=directory, recursive=recursive, findings=findings)

--- a/src/rac/services/init.py
+++ b/src/rac/services/init.py
@@ -17,8 +17,12 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import yaml
+
+if TYPE_CHECKING:
+    from rac.services.gate import EnforcementPolicy
 
 from rac.core.overrides import EMPTY, RULE_VALUES, TYPE_VALUES, SeverityOverrides
 from rac.errors import RACError
@@ -155,6 +159,69 @@ def load_overrides(start_dir: str) -> SeverityOverrides:
     rules = _parse_severity_map(config_path, section.get("rules"), "validation.rules", RULE_VALUES)
     types = _parse_severity_map(config_path, section.get("types"), "validation.types", TYPE_VALUES)
     return SeverityOverrides(rules=rules, types=types)
+
+
+def load_enforcement_policy(start_dir: str) -> EnforcementPolicy:
+    """Read the ``enforcement`` policy from the nearest config (ADR-049 / v0.21.14).
+
+    The enforcement section maps finding *codes* to an enforcement class for
+    ``rac gate``: three optional list-of-strings keys ``blocking``, ``advisory``,
+    and ``off``. It is the central, governed knob that decides which finding
+    classes fail the gate versus merely annotate (ADR-063: the policy lives in the
+    committed corpus, not hardcoded in a consumer)::
+
+        enforcement:
+          advisory:
+            - relationship-target-superseded
+          off:
+            - stale-corpus
+
+    Returns :data:`~rac.services.gate.EMPTY_POLICY` when there is no config file or
+    no ``enforcement`` section. Malformed shapes (a non-mapping section, a
+    non-list key, or a non-string entry) raise :class:`MalformedRepositoryConfig`,
+    mirroring :func:`load_overrides` — policy is never silently ignored.
+    """
+    # Imported lazily to avoid a cycle: gate.py imports this loader, and the
+    # policy model lives alongside the gate service.
+    from rac.services.gate import EMPTY_POLICY, EnforcementPolicy
+
+    config_path = find_config_file(start_dir)
+    if config_path is None:
+        return EMPTY_POLICY
+    try:
+        data = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise MalformedRepositoryConfig(str(config_path), f"invalid YAML: {exc}") from exc
+    section = data.get("enforcement") if isinstance(data, dict) else None
+    if section is None:
+        return EMPTY_POLICY
+    if not isinstance(section, dict):
+        raise MalformedRepositoryConfig(str(config_path), "'enforcement' must be a mapping")
+    blocking = _parse_code_list(config_path, section.get("blocking"), "enforcement.blocking")
+    advisory = _parse_code_list(config_path, section.get("advisory"), "enforcement.advisory")
+    # YAML 1.1 resolves the bare key ``off`` to ``False`` (the same gotcha the
+    # severity loader handles for values). ``off`` is the natural suppression
+    # keyword, so accept the coerced ``False`` key rather than forcing quotes.
+    off_value = section["off"] if "off" in section else section.get(False)
+    off = _parse_code_list(config_path, off_value, "enforcement.off")
+    return EnforcementPolicy(
+        blocking=frozenset(blocking), advisory=frozenset(advisory), off=frozenset(off)
+    )
+
+
+def _parse_code_list(config_path: Path, value: object, where: str) -> list[str]:
+    """Validate one ``enforcement`` key as a list of finding-code strings.
+
+    ``None`` (absent) is an empty list. Any non-list shape, or a non-string entry,
+    is a malformed config — finding codes are plain strings (ADR-007 stable codes).
+    """
+    if value is None:
+        return []
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise MalformedRepositoryConfig(
+            str(config_path), f"'{where}' must be a list of finding-code strings"
+        )
+    return value
 
 
 def _parse_severity_map(

--- a/src/rac/services/relationships.py
+++ b/src/rac/services/relationships.py
@@ -323,6 +323,25 @@ ISSUE_TARGET_TYPE_MISMATCH = "relationship-target-type-mismatch"
 # (``supersedes``), which an ordering/replacement relationship must not contain.
 ISSUE_RELATIONSHIP_CYCLE = "relationship-cycle"
 
+# Canonical intrinsic severity per relationship finding (v0.21.14). Referential
+# integrity and graph-shape breakages are errors; advisory consistency findings
+# (self-reference, unsupported edge, retired-target reference) are warnings. This
+# is the single source of truth for the annotation severity: the SARIF renderer
+# and the `rac gate` enforcement layer both read it, so they can never disagree.
+# It is the *intrinsic* severity only — relationship findings still fail
+# `--validate` (and gate, by default) regardless of severity; the enforcement
+# class is decided separately under the corpus policy (ADR-049).
+RELATIONSHIP_SEVERITY: dict[str, str] = {
+    ISSUE_TARGET_NOT_FOUND: "error",
+    ISSUE_TARGET_AMBIGUOUS: "error",
+    ISSUE_TARGET_TYPE_MISMATCH: "error",
+    ISSUE_RELATIONSHIP_CYCLE: "error",
+    ISSUE_DUPLICATE_IDENTIFIER: "error",
+    ISSUE_TARGET_SUPERSEDED: "warning",
+    ISSUE_SELF_REFERENCE: "warning",
+    ISSUE_EDGE_UNSUPPORTED: "warning",
+}
+
 
 def _is_retired_artifact(product: Product, spec: ArtifactSpec | None) -> bool:
     """True when ``product``'s ``## Status`` is one of its type's retired states.

--- a/tests/test_gate.py
+++ b/tests/test_gate.py
@@ -1,0 +1,377 @@
+"""Tests for `rac gate` — policy-aware unified enforcement (v0.21.14, ADR-049).
+
+The gate composes validation, relationships, and review into one enforced verdict
+under the corpus enforcement policy. These tests pin the contract that matters:
+
+- with no policy, ``ok`` equals ``validate.ok AND relationships.ok AND
+  review.ok`` (the v0.21.13 behaviour the policy refines);
+- an ``advisory`` policy entry downgrades a blocking finding so the gate passes
+  while the finding still annotates;
+- an ``off`` entry drops a finding entirely;
+- a malformed ``enforcement`` shape is rejected, not silently ignored;
+- the JSON and SARIF envelopes are valid and deterministic.
+
+Negative and boundary cases (a broken reference, an empty directory, adjacent
+behaviour) are covered per the session-start prompt.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from rac.cli import main
+from rac.output import render_gate_json, render_gate_sarif
+from rac.services.gate import (
+    EMPTY_POLICY,
+    ENFORCEMENT_ADVISORY,
+    ENFORCEMENT_BLOCKING,
+    EnforcementPolicy,
+    build_gate,
+)
+from rac.services.init import MalformedRepositoryConfig, load_enforcement_policy
+from rac.services.relationships import validate_relationships
+from rac.services.review import build_review
+from rac.services.validate import validate_directory
+
+# A minimal valid decision + a roadmap that references it by a resolvable
+# identifier (the filename-derived alias). This corpus is clean: it passes
+# validate, relationships, and review.
+_DECISION = """\
+---
+schema_version: 1
+type: decision
+---
+# Use Markdown
+
+## Status
+
+Accepted
+
+## Context
+
+We need a deterministic, diffable format for product knowledge.
+
+## Decision
+
+We choose Markdown.
+
+## Consequences
+
+It works offline and diffs cleanly.
+"""
+
+_ROADMAP = """\
+---
+schema_version: 1
+type: roadmap
+---
+# v0 Test Roadmap
+
+## Outcomes
+
+- A thing ships.
+
+## Initiatives
+
+### Initiative 1 — Do it
+
+Build the thing.
+
+## Related Decisions
+
+- adr-001-use-markdown
+"""
+
+# A roadmap whose only blocking issue is a reference to a *retired* decision
+# (relationship-target-superseded — a warning-severity but blocking-by-default
+# finding). Pairs with _RETIRED_DECISION below.
+_RETIRED_DECISION = """\
+---
+schema_version: 1
+type: decision
+---
+# Old Choice
+
+## Status
+
+Superseded
+
+## Context
+
+An earlier decision.
+
+## Decision
+
+We chose something we later replaced.
+
+## Consequences
+
+Replaced later.
+"""
+
+_ROADMAP_TO_RETIRED = """\
+---
+schema_version: 1
+type: roadmap
+---
+# v1 Roadmap
+
+## Outcomes
+
+- Another thing ships.
+
+## Initiatives
+
+### Initiative 1 — Do it
+
+Build it.
+
+## Related Decisions
+
+- adr-002-old-choice
+"""
+
+
+def _clean_corpus(tmp_path):
+    (tmp_path / "adr-001-use-markdown.md").write_text(_DECISION, encoding="utf-8")
+    (tmp_path / "v0-test.md").write_text(_ROADMAP, encoding="utf-8")
+    return str(tmp_path)
+
+
+def _broken_corpus(tmp_path):
+    # The decision is present but the roadmap points at a non-existent target,
+    # so relationship validation fails (relationship-target-not-found).
+    (tmp_path / "adr-001-use-markdown.md").write_text(_DECISION, encoding="utf-8")
+    broken = _ROADMAP.replace("- adr-001-use-markdown", "- adr-999-missing")
+    (tmp_path / "v0-test.md").write_text(broken, encoding="utf-8")
+    return str(tmp_path)
+
+
+def _superseded_corpus(tmp_path):
+    # A live roadmap references a retired decision: the only blocking finding is
+    # relationship-target-superseded (a warning-severity, blocking-by-default code).
+    (tmp_path / "adr-002-old-choice.md").write_text(_RETIRED_DECISION, encoding="utf-8")
+    (tmp_path / "v1-test.md").write_text(_ROADMAP_TO_RETIRED, encoding="utf-8")
+    return str(tmp_path)
+
+
+def _write_config(tmp_path, body: str):
+    config_dir = tmp_path / ".rac"
+    config_dir.mkdir(exist_ok=True)
+    (config_dir / "config.yaml").write_text(body, encoding="utf-8")
+
+
+# --- default-policy parity ---------------------------------------------------
+
+
+def test_clean_corpus_passes(tmp_path):
+    directory = _clean_corpus(tmp_path)
+    report = build_gate(directory)
+    assert report.ok
+    assert report.blocking == []
+
+
+def test_default_ok_equals_validate_and_relationships_and_review(tmp_path):
+    directory = _clean_corpus(tmp_path)
+    report = build_gate(directory)
+    expected = (
+        validate_directory(directory).ok
+        and validate_relationships(directory).ok
+        and build_review(directory).ok
+    )
+    assert report.ok == expected is True
+
+
+def test_broken_reference_fails_the_gate(tmp_path):
+    directory = _broken_corpus(tmp_path)
+    report = build_gate(directory)
+    assert not report.ok
+    assert any(f.source == "relationships" for f in report.blocking)
+    # Parity holds on the failing case too.
+    expected = (
+        validate_directory(directory).ok
+        and validate_relationships(directory).ok
+        and build_review(directory).ok
+    )
+    assert report.ok == expected is False
+
+
+def test_broken_corpus_exit_code_is_one(tmp_path):
+    directory = _broken_corpus(tmp_path)
+    assert main(["gate", directory]) == 1
+
+
+def test_clean_corpus_exit_code_is_zero(tmp_path):
+    directory = _clean_corpus(tmp_path)
+    assert main(["gate", directory]) == 0
+
+
+# --- policy: advisory downgrade ---------------------------------------------
+
+
+def test_advisory_policy_downgrades_superseded_so_gate_passes(tmp_path):
+    directory = _superseded_corpus(tmp_path)
+
+    # Without policy, the superseded reference is a blocking finding.
+    default = build_gate(directory)
+    assert not default.ok
+    assert any(f.code == "relationship-target-superseded" for f in default.blocking)
+
+    # Downgrade just that finding to advisory: the gate now passes, but the
+    # finding still appears — as advisory, not dropped.
+    _write_config(tmp_path, "enforcement:\n  advisory:\n    - relationship-target-superseded\n")
+    downgraded = build_gate(directory)
+    assert downgraded.ok
+    superseded = [f for f in downgraded.findings if f.code == "relationship-target-superseded"]
+    assert superseded and all(f.enforcement == ENFORCEMENT_ADVISORY for f in superseded)
+
+
+def test_advisory_finding_still_in_sarif(tmp_path):
+    directory = _superseded_corpus(tmp_path)
+    _write_config(tmp_path, "enforcement:\n  advisory:\n    - relationship-target-superseded\n")
+    report = build_gate(directory)
+    sarif = json.loads(render_gate_sarif(report))
+    rule_ids = {r["ruleId"] for r in sarif["runs"][0]["results"]}
+    assert "relationship-target-superseded" in rule_ids
+
+
+def test_gate_exit_zero_after_advisory_downgrade(tmp_path):
+    directory = _superseded_corpus(tmp_path)
+    _write_config(tmp_path, "enforcement:\n  advisory:\n    - relationship-target-superseded\n")
+    assert main(["gate", directory]) == 0
+
+
+# --- policy: off suppression -------------------------------------------------
+
+
+def test_off_policy_drops_a_finding(tmp_path):
+    directory = _superseded_corpus(tmp_path)
+    _write_config(tmp_path, "enforcement:\n  off:\n    - relationship-target-superseded\n")
+    report = build_gate(directory)
+    assert report.ok
+    assert all(f.code != "relationship-target-superseded" for f in report.findings)
+
+
+# --- policy: blocking promotion ---------------------------------------------
+
+
+def test_blocking_policy_promotes_an_advisory_finding(tmp_path):
+    directory = _clean_corpus(tmp_path)
+    # missing-recommended-sections is advisory by default (review priority 4);
+    # the clean roadmap is missing Assumptions, so this finding exists.
+    default = build_gate(directory)
+    assert default.ok
+    assert any(f.code == "missing-recommended-sections" for f in default.advisory)
+
+    _write_config(tmp_path, "enforcement:\n  blocking:\n    - missing-recommended-sections\n")
+    promoted = build_gate(directory)
+    assert not promoted.ok
+    assert any(f.code == "missing-recommended-sections" for f in promoted.blocking)
+
+
+# --- malformed policy --------------------------------------------------------
+
+
+def test_malformed_enforcement_section_raises(tmp_path):
+    _clean_corpus(tmp_path)
+    _write_config(tmp_path, "enforcement: not-a-mapping\n")
+    with pytest.raises(MalformedRepositoryConfig):
+        load_enforcement_policy(str(tmp_path))
+
+
+def test_malformed_enforcement_key_raises(tmp_path):
+    _clean_corpus(tmp_path)
+    _write_config(tmp_path, "enforcement:\n  blocking: not-a-list\n")
+    with pytest.raises(MalformedRepositoryConfig):
+        load_enforcement_policy(str(tmp_path))
+
+
+def test_malformed_enforcement_entry_raises(tmp_path):
+    _clean_corpus(tmp_path)
+    _write_config(tmp_path, "enforcement:\n  off:\n    - 123\n")
+    with pytest.raises(MalformedRepositoryConfig):
+        load_enforcement_policy(str(tmp_path))
+
+
+def test_build_gate_surfaces_malformed_config_via_cli(tmp_path):
+    directory = _clean_corpus(tmp_path)
+    _write_config(tmp_path, "enforcement: not-a-mapping\n")
+    # cmd_gate catches MalformedRepositoryConfig and returns the failure code.
+    assert main(["gate", directory]) == 1
+
+
+# --- policy model precedence -------------------------------------------------
+
+
+def test_policy_classify_precedence_off_wins():
+    policy = EnforcementPolicy(
+        blocking=frozenset({"x"}), advisory=frozenset({"x"}), off=frozenset({"x"})
+    )
+    assert policy.classify("x", ENFORCEMENT_BLOCKING) is None
+
+
+def test_policy_classify_blocking_beats_advisory():
+    policy = EnforcementPolicy(blocking=frozenset({"x"}), advisory=frozenset({"x"}))
+    assert policy.classify("x", ENFORCEMENT_ADVISORY) == ENFORCEMENT_BLOCKING
+
+
+def test_policy_classify_falls_back_to_default():
+    assert EMPTY_POLICY.classify("x", ENFORCEMENT_ADVISORY) == ENFORCEMENT_ADVISORY
+
+
+def test_absent_config_yields_empty_policy(tmp_path):
+    _clean_corpus(tmp_path)
+    assert load_enforcement_policy(str(tmp_path)) == EMPTY_POLICY
+
+
+# --- envelopes & determinism -------------------------------------------------
+
+
+def test_json_envelope_is_valid_and_deterministic(tmp_path):
+    directory = _broken_corpus(tmp_path)
+    report = build_gate(directory)
+    first = render_gate_json(report)
+    second = render_gate_json(build_gate(directory))
+    assert first == second  # byte-identical across runs (ADR-002)
+    payload = json.loads(first)
+    assert payload["schema_version"] == "1"
+    assert payload["ok"] is False
+    assert payload["blocking_count"] >= 1
+    assert "findings" in payload
+
+
+def test_sarif_envelope_is_valid_and_deterministic(tmp_path):
+    directory = _broken_corpus(tmp_path)
+    report = build_gate(directory)
+    first = render_gate_sarif(report)
+    second = render_gate_sarif(build_gate(directory))
+    assert first == second
+    doc = json.loads(first)
+    assert doc["version"] == "2.1.0"
+    assert doc["runs"][0]["tool"]["driver"]["name"] == "rac"
+
+
+def test_findings_sorted_deterministically(tmp_path):
+    directory = _broken_corpus(tmp_path)
+    report = build_gate(directory)
+    keys = [(f.path, f.line or 0, f.source, f.code, f.message) for f in report.findings]
+    assert keys == sorted(keys)
+
+
+# --- boundary ---------------------------------------------------------------
+
+
+def test_empty_directory_passes(tmp_path):
+    report = build_gate(str(tmp_path))
+    assert report.ok
+    assert report.findings == []
+    assert main(["gate", str(tmp_path)]) == 0
+
+
+def test_not_a_directory_is_usage_error(tmp_path):
+    missing = tmp_path / "nope"
+    with pytest.raises(SystemExit) as exc:
+        main(["gate", str(missing)])
+    assert exc.value.code == 2

--- a/tests/test_no_egress.py
+++ b/tests/test_no_egress.py
@@ -1,0 +1,125 @@
+"""No-egress isolation test — the runnable backing for RAC's posture (v0.21.14).
+
+RAC's security posture (``docs/security.md``, ADR-002) is *offline by design*: the
+CLI and its services make no network calls. This test turns that claim into a
+runnable control. It replaces ``socket.socket`` and ``socket.create_connection``
+with stubs that raise on use, then exercises the core read paths over a temporary
+fixture corpus — validation, relationships, review, gate, search, and export. If
+any path opened a socket, the test fails. This is a v0.21.14 Success Measure: the
+no-egress claim is backed by a runnable isolation test.
+
+The corpus is built in ``tmp_path`` (one decision, one roadmap that references it),
+so the test is hermetic and deterministic — it depends on no committed fixture and
+touches nothing outside the temporary directory.
+"""
+
+from __future__ import annotations
+
+import socket
+
+import pytest
+
+from rac.services.export import build_corpus_export
+from rac.services.gate import build_gate
+from rac.services.relationships import validate_relationships
+from rac.services.resolve import find_artifacts
+from rac.services.review import build_review
+from rac.services.validate import validate_directory
+
+_DECISION = """\
+---
+schema_version: 1
+type: decision
+---
+# Use Markdown
+
+## Status
+
+Accepted
+
+## Context
+
+We need a deterministic, diffable format.
+
+## Decision
+
+We choose Markdown.
+
+## Consequences
+
+It works offline.
+"""
+
+_ROADMAP = """\
+---
+schema_version: 1
+type: roadmap
+---
+# v0 Test Roadmap
+
+## Outcomes
+
+- A thing ships.
+
+## Initiatives
+
+### Initiative 1 — Do it
+
+Build the thing.
+
+## Related Decisions
+
+- adr-001-use-markdown
+"""
+
+
+@pytest.fixture
+def corpus(tmp_path):
+    """A tiny valid corpus: one decision and one roadmap referencing it."""
+    (tmp_path / "adr-001-use-markdown.md").write_text(_DECISION, encoding="utf-8")
+    (tmp_path / "v0-test.md").write_text(_ROADMAP, encoding="utf-8")
+    return str(tmp_path)
+
+
+@pytest.fixture
+def no_network(monkeypatch):
+    """Make any socket creation raise, so a network call fails the test loudly."""
+
+    def _blocked(*args, **kwargs):
+        raise AssertionError("network access attempted")
+
+    # Patch on the ``socket`` module itself so every import path that does
+    # ``socket.socket(...)`` / ``socket.create_connection(...)`` is intercepted.
+    monkeypatch.setattr(socket, "socket", _blocked)
+    monkeypatch.setattr(socket, "create_connection", _blocked)
+
+
+def test_validate_makes_no_network_call(corpus, no_network):
+    result = validate_directory(corpus)
+    assert result.ok
+
+
+def test_relationships_makes_no_network_call(corpus, no_network):
+    result = validate_relationships(corpus)
+    assert result.ok
+
+
+def test_review_makes_no_network_call(corpus, no_network):
+    report = build_review(corpus)
+    assert report.ok
+
+
+def test_gate_makes_no_network_call(corpus, no_network):
+    report = build_gate(corpus)
+    assert report.ok
+
+
+def test_find_makes_no_network_call(corpus, no_network):
+    result = find_artifacts(corpus, "Markdown")
+    # A completed search is enough; the assertion under test is "no socket".
+    assert result is not None
+
+
+def test_export_makes_no_network_call(corpus, no_network):
+    export = build_corpus_export(corpus)
+    assert export is not None

--- a/tests/test_pr_gate_action.py
+++ b/tests/test_pr_gate_action.py
@@ -1,10 +1,11 @@
-"""Structural tests for the RAC PR-gate composite action (v0.21.13).
+"""Structural tests for the RAC PR-gate composite action (v0.21.14).
 
-The action is a thin wrapper that runs `rac validate`, `rac relationships
---validate`, and `rac review` — each with `--sarif` — uploads all three SARIF
-documents, and re-surfaces the worst CLI exit code. Its analysis is owned by the
-(separately tested) CLI; these tests pin the action's *contract* so the wiring
-cannot silently drift (ADR-063: the action computes nothing).
+The action is a thin wrapper that runs a single `rac gate <path> --sarif` — one
+command that composes validation, relationship integrity, and review under the
+corpus enforcement policy — uploads the single SARIF document, and re-surfaces
+the CLI exit code. Its analysis is owned by the (separately tested) CLI; these
+tests pin the action's *contract* so the wiring cannot silently drift (ADR-063:
+the action computes nothing).
 """
 
 from __future__ import annotations
@@ -34,23 +35,26 @@ def test_action_declares_expected_inputs():
     assert inputs["upload-sarif"]["default"] == "true"
 
 
-def test_action_runs_all_three_contract_checks():
+def test_action_runs_single_gate_command():
     run_steps = " ".join(s.get("run", "") for s in _action()["runs"]["steps"])
-    assert "rac validate" in run_steps
-    assert "rac relationships" in run_steps and "--validate" in run_steps
-    assert "rac review" in run_steps
+    assert "rac gate" in run_steps
     assert "--sarif" in run_steps
+    # The three separate checks are now collapsed into the one gate command.
+    assert "rac validate" not in run_steps
+    assert "rac relationships" not in run_steps
+    assert "rac review" not in run_steps
 
 
-def test_action_uploads_sarif():
+def test_action_uploads_single_sarif_once():
     steps = _action()["runs"]["steps"]
     uploads = [s for s in steps if "upload-sarif" in str(s.get("uses", ""))]
-    assert uploads, "no SARIF upload step"
+    assert len(uploads) == 1, "the gate uploads exactly one SARIF document"
     # Upload even on failure so findings still annotate the PR.
     assert "always()" in uploads[0]["if"]
+    assert uploads[0]["with"]["category"] == "rac-gate"
 
 
-def test_action_resurfaces_worst_exit_code():
+def test_action_resurfaces_exit_code():
     run_steps = " ".join(s.get("run", "") for s in _action()["runs"]["steps"])
     assert 'exit "$EXIT_CODE"' in run_steps
 

--- a/tests/test_sbom.py
+++ b/tests/test_sbom.py
@@ -1,0 +1,65 @@
+"""SBOM tests — the verifiable dependency surface (v0.21.14, ADR-002).
+
+The committed ``sbom.json`` is the machine-readable evidence behind RAC's
+security posture (``docs/security.md``). These tests pin two things: the document
+is a well-formed CycloneDX SBOM, and it has not drifted from the runtime
+dependencies declared in ``pyproject.toml`` — so the SBOM can never silently fall
+behind the deps it attests to. Offline and deterministic: the tests read only
+committed files.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SBOM_PATH = REPO_ROOT / "sbom.json"
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+
+_NAME_RE = re.compile(r"^[A-Za-z0-9._-]+")
+
+
+def _sbom() -> dict:
+    return json.loads(SBOM_PATH.read_text(encoding="utf-8"))
+
+
+def _declared_dependency_names() -> list[str]:
+    data = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
+    names = []
+    for requirement in data["project"]["dependencies"]:
+        match = _NAME_RE.match(requirement.strip())
+        assert match, f"cannot parse dependency name from {requirement!r}"
+        names.append(match.group(0))
+    return names
+
+
+def test_sbom_is_cyclonedx():
+    sbom = _sbom()
+    assert sbom["bomFormat"] == "CycloneDX"
+    assert sbom["specVersion"], "specVersion must be present"
+    assert isinstance(sbom["components"], list)
+
+
+def test_sbom_includes_the_package_as_root_component():
+    root = _sbom()["metadata"]["component"]
+    assert root["name"] == "requirements-as-code"
+    assert root["type"] == "library"
+
+
+def test_sbom_covers_every_declared_runtime_dependency():
+    # Drift guard: every dependency declared in pyproject must appear as an SBOM
+    # component, so the SBOM cannot silently fall behind the declared deps.
+    component_names = {c["name"] for c in _sbom()["components"]}
+    for name in _declared_dependency_names():
+        assert name in component_names, f"dependency {name!r} missing from sbom.json"
+
+
+def test_sbom_is_deterministic_no_timestamp():
+    # Determinism (ADR-002): no timestamp, and components sorted by name.
+    sbom = _sbom()
+    assert "timestamp" not in sbom.get("metadata", {})
+    names = [c["name"] for c in sbom["components"]]
+    assert names == sorted(names, key=str.casefold)


### PR DESCRIPTION
# Summary

Implements `rac/roadmaps/v0.21.x-editor/v0.21.14-security-governance-posture.md`.

Turns RAC's local-only posture into an attestable control and makes enforcement
policy a governed, central artifact. Two pillars: a provable no-egress posture,
and policy-as-config that decides blocking-versus-advisory once, consumed by both
the editor and the PR gate.

Adds:
- `rac gate` — one command that runs validation, relationship integrity, and
  review, and classifies every finding blocking/advisory under the corpus
  enforcement policy. One exit code, one SARIF document.
- An `enforcement:` section in `.rac/config.yaml` (additive) mapping finding
  codes to `blocking`/`advisory`/`off`, consumed by the engine (not the action).
- A provable posture: a deterministic CycloneDX SBOM, a runnable no-egress
  isolation test, and a security posture document.
- The PR-gate action reduced to a single `rac gate --sarif` upload, plus
  governance/fleet-readiness docs.

# Roadmap / ADR Trace

Roadmap:
- `rac/roadmaps/v0.21.x-editor/v0.21.14-security-governance-posture.md`

Relevant ADRs:
- `rac/decisions/adr-049-enforcement-is-the-product.md` — enforcement is the
  product; this makes which findings bind a governed corpus artifact.
- `rac/decisions/adr-063-non-python-clients-are-thin.md` — the engine decides
  blocking-versus-advisory; the action and editor render one verdict.
- `rac/decisions/adr-053-validation-config-overrides.md` — the enforcement
  policy is a sibling of the existing severity overrides, in the same file.
- `rac/decisions/adr-002-offline-determinism.md` — the no-egress posture is
  proven by a runnable test, not asserted.
- `rac/decisions/adr-007-additive-json-contract.md` — the gate JSON and the
  `enforcement:` config are additive.

# Scope

## Included
- `src/rac/services/gate.py`: `EnforcementPolicy` (`blocking`/`advisory`/`off`
  code sets with `off` then `blocking` then `advisory` then `default` precedence),
  `GateFinding`, `GateReport`, and `build_gate`. Default enforcement classes are
  chosen so that, with no policy, `gate.ok == validate.ok AND relationships.ok AND
  review.ok` — the v0.21.13 behaviour the policy refines.
- `load_enforcement_policy` in `src/rac/services/init.py` (owns `.rac/config.yaml`),
  parsing an optional `enforcement:` section with the same malformed-shape
  discipline as the severity loader (including the YAML 1.1 `off`→False gotcha).
- `rac gate DIR [--json | --sarif] [--top-level]` with human/JSON/SARIF
  renderers; the single combined SARIF replaces the three-file upload.
- The canonical relationship severity map relocated to the relationships service
  (`RELATIONSHIP_SEVERITY`), imported by both the SARIF renderer and the gate, so
  the two never disagree.
- `pr-gate-action` simplified to one `rac gate --sarif` uploaded under the single
  `rac-gate` Code Scanning category (the v0.21.13 multi-category handling is gone).
- `scripts/generate_sbom.py` + committed `sbom.json` (CycloneDX 1.5, deterministic,
  offline), drift-guarded against `pyproject` runtime deps.
- `tests/test_no_egress.py`: intercepts socket use while running validate,
  relationships, review, gate, find, and export over a fixture corpus.
- `docs/security.md` (posture), `docs/governance.md` (policy + fleet readiness).

## Excluded
- A hosted control plane, per-user analytics, or external certification (roadmap
  Non-Goal) — the posture is self-attestable and offline.
- Changing how `rac` computes validation, relationships, or review — the gate
  composes the existing deterministic services and adds only a pure policy pass.
- Semantic severity scoring — classification is a flat, code-keyed policy map.
- The editor-side consumption of `rac gate --json` ships with the agent-rules
  work; this release lands the engine verdict it will read.

# Product / Architecture Decisions

- Policy lives in the corpus, not the action. The action and editor invoke
  `rac gate` and render its verdict; the blocking decision is the engine's
  (ADR-063). "Central, without per-repository edits" means one governed file
  drives both surfaces — standardizable across repos by sharing it.
- Default classes preserve today's behaviour exactly: validate `error` →
  blocking; every relationship finding → blocking (any issue fails `--validate`
  today); review priority 1–2 → blocking, 3+ → advisory. A policy only ever
  refines this.
- A finding carries both an intrinsic `severity` (drives the SARIF level) and a
  policy-resolved `enforcement` class (drives the exit code), so advisory
  findings still annotate the PR without failing it.
- `rac gate` composing the three services in the engine (rather than the action's
  bash) is what lets the action collapse to a single categorised upload.

# User-Facing Contract

## CLI
- `rac gate rac/` — human summary of blocking/advisory findings.
- `rac gate rac/ --json` — `{schema_version, directory, recursive, ok,
  blocking_count, advisory_count, findings:[{source, code, severity, enforcement,
  path, line, message}]}`.
- `rac gate rac/ --sarif` — one SARIF 2.1.0 document over all findings.

`.rac/config.yaml`:
```
enforcement:
  blocking: [missing-recommended-sections]
  advisory: [relationship-target-superseded]
  off:      [stale-corpus]
```

## Human Output
New `rac gate` summary. Existing `validate`/`relationships`/`review` output
unchanged.

## JSON Output
New additive `rac gate --json` contract. No change to existing contracts.

## Exit Codes
- `rac gate`: `0` nothing blocking · `1` a blocking finding (or a malformed
  `.rac/config.yaml`) · `2` not a directory.

# Verification

## Ran
- `pytest tests/test_gate.py tests/test_sbom.py tests/test_no_egress.py
  tests/test_pr_gate_action.py tests/test_sarif.py tests/test_ci_batteries.py`
  — 55 passed.
- Corpus gates on `rac/`: `validate`, `relationships --validate`, `review`, and
  the new `gate` — all exit `0`.
- Success Measure (central policy changes gate behaviour, no per-tool edits): on
  a corpus whose only blocking issue is a retired-decision reference, a
  `.rac/config.yaml` `enforcement: {advisory: [relationship-target-superseded]}`
  makes `rac gate` exit `0` (finding still present as advisory); removing the
  policy makes it exit `1`.
- Success Measure (no-egress backed by a runnable test + SBOM): `test_no_egress`
  intercepts sockets across the core read paths; `sbom.json` regenerates
  byte-identically and lists every runtime dependency.
- `ruff check` / `ruff format --check` clean; `mypy src/` clean.

## Covered
- Default parity: clean corpus → ok/exit 0; a broken reference → not ok/exit 1.
- Policy: advisory downgrade flips blocking→advisory; `off` drops a finding;
  malformed `enforcement` raises `MalformedRepositoryConfig`.
- Determinism: gate JSON and SARIF render byte-identically on repeat.
- SBOM: CycloneDX shape + every declared runtime dep present (drift guard).
- No-egress: validate/relationships/review/gate/find/export complete with sockets
  blocked.

# Review Path

1. `src/rac/services/gate.py` — policy model, finding normalisation, `build_gate`.
2. `src/rac/services/init.py` — `load_enforcement_policy` and shape validation.
3. `src/rac/services/relationships.py` — `RELATIONSHIP_SEVERITY` as one source.
4. `src/rac/output/{sarif,human,json}.py`, `cli.py` — the `rac gate` surface.
5. `pr-gate-action/action.yml`, `tests/test_pr_gate_action.py` — the thinner action.
6. `scripts/generate_sbom.py`, `sbom.json`, `tests/test_sbom.py`,
   `tests/test_no_egress.py` — the provable posture.
7. `docs/security.md`, `docs/governance.md` — the documented controls.

Plus `rac/roadmaps/.../v0.21.13-...md` flipped to Achieved (ratifying the merged
predecessor, ADR-061).

# Notes For Reviewer

- `gate.py` imports `_relationship_result` lazily (inside the finding mapper) to
  avoid a cycle, since `sarif.py` imports `GateReport` at module top — so the
  gate's relationship messages and anchors reuse the exact SARIF formatter rather
  than a second copy.
- The committed `sbom.json` embeds whatever root-package version the generating
  environment resolves via `importlib.metadata` (a setuptools-scm dev version in
  CI); the drift test guards dependency *names*, not versions, and a release-tag
  regeneration yields the release version.
- This is the first PR in the v0.21.14–v0.21.18 stack; later releases build on
  this branch. Reviewing in numerical order keeps each diff clean.

# Implementation Process

Implemented with AI assistance under the roadmap contract; final scope, review,
and acceptance decisions were made by the maintainer.