### PR TITLE
feat(export): agent context & rules generation (v0.21.15)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,7 +68,7 @@ jobs:
           - name: diff
             paths: "tests/test_diff.py"
           - name: export
-            paths: "tests/test_export_cmd.py tests/test_export_okf.py"
+            paths: "tests/test_export_cmd.py tests/test_export_okf.py tests/test_agent_rules.py"
           - name: improve
             paths: "tests/test_improve.py"
           - name: index

--- a/rac/roadmaps/v0.21.x-editor/v0.21.14-security-governance-posture.md
+++ b/rac/roadmaps/v0.21.x-editor/v0.21.14-security-governance-posture.md
@@ -8,7 +8,7 @@ tags: [sdk, typescript, editor, security, governance]
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/src/rac/cli.py
+++ b/src/rac/cli.py
@@ -16,7 +16,8 @@ Commands:
                     [--no-annotate]
     rac portfolio <directory> [--json] [--top-level]
     rac index [directory] [--json] [--top-level]
-    rac export [directory] [--json | --html | --okf] [--out PATH]
+    rac export [directory] [--json | --html | --okf | --agent-rules [--check]]
+               [--client CLIENT ...] [--out PATH]
     rac explorer [directory] [--top-level]
     rac mcp [--root PATH] [--telemetry]
     rac mcp-stats [--json | --share]
@@ -95,6 +96,11 @@ from rac.core.templates import (
 )
 from rac.core.validation import has_errors
 from rac.output.portal import PortalSeamMissing, PortalShellMissing
+from rac.services.agent_rules import (
+    check_agent_rules,
+    generate_agent_rules,
+    unknown_clients,
+)
 from rac.services.create import (
     IdGenerationExhausted,
     MissingRepositoryConfig,
@@ -512,9 +518,42 @@ def cmd_index(args: argparse.Namespace) -> int:
     return EXIT_OK
 
 
+def _agent_rules_root(directory: str, out: str | None) -> Path:
+    """The directory the agent-rules files are written into.
+
+    Explicit ``--out`` wins. Otherwise default to the corpus's repo root: the
+    parent of a ``rac/`` directory (so ``rac export rac/ --agent-rules`` writes
+    CLAUDE.md/AGENTS.md beside it), else the directory itself. A bare ``rac``
+    with no parent component falls back to the current directory.
+    """
+    if out is not None:
+        return Path(out)
+    path = Path(directory.rstrip("/"))
+    if path.name == "rac":
+        return path.parent if str(path.parent) not in ("", ".") else Path(".")
+    return path
+
+
 def cmd_export(args: argparse.Namespace) -> int:
     if not Path(args.directory).is_dir():
         print(f"rac: not a directory: {args.directory}", file=sys.stderr)
+        raise SystemExit(EXIT_USAGE)
+
+    # Agent-rules is a distinct mode (ADR-067): a distilled, drift-guarded
+    # projection of live decisions into per-client managed blocks. It owns --out
+    # (the output root), --client (target selectors), --check (the drift gate),
+    # and --json (machine output) — none of the export-payload modes apply.
+    if args.agent_rules:
+        return _cmd_agent_rules(args)
+    if args.check:
+        print("rac: --check requires --agent-rules", file=sys.stderr)
+        raise SystemExit(EXIT_USAGE)
+    if args.client:
+        print("rac: --client requires --agent-rules", file=sys.stderr)
+        raise SystemExit(EXIT_USAGE)
+
+    if args.json and (args.html or args.okf):
+        print("rac: --json cannot combine with --html or --okf", file=sys.stderr)
         raise SystemExit(EXIT_USAGE)
     if args.out is not None and not (args.html or args.okf):
         print("rac: --out requires --html or --okf (--json writes to stdout)", file=sys.stderr)
@@ -559,6 +598,40 @@ def cmd_export(args: argparse.Namespace) -> int:
         raise SystemExit(EXIT_USAGE) from None
     edges = len(export.relationships)
     print(f"wrote {out} — {export.artifact_count} artifact(s), {edges} relationship(s)")
+    return EXIT_OK
+
+
+def _cmd_agent_rules(args: argparse.Namespace) -> int:
+    """`rac export --agent-rules [--check]` (v0.21.15, ADR-067).
+
+    Generates (or, under --check, verifies) the drift-guarded managed block in
+    each per-client agent-context file. --check never writes and exits non-zero
+    on drift (a stale or missing block) — the CI gate. Output is human by
+    default; --json emits the machine contract.
+    """
+    bad = unknown_clients(args.client)
+    if bad:
+        valid = "claude, agents, cursor, copilot"
+        print(f"rac: unknown --client: {', '.join(bad)} (choose from {valid})", file=sys.stderr)
+        raise SystemExit(EXIT_USAGE)
+
+    root = _agent_rules_root(args.directory, args.out)
+    try:
+        if args.check:
+            result = check_agent_rules(args.directory, str(root), clients=args.client)
+        else:
+            result = generate_agent_rules(args.directory, str(root), clients=args.client)
+    except OSError as exc:
+        print(f"rac: cannot write under {root}: {exc}", file=sys.stderr)
+        raise SystemExit(EXIT_USAGE) from None
+
+    if args.json:
+        print(outputs.render_agent_rules_json(result))
+    else:
+        print(outputs.render_agent_rules_human(result))
+
+    if args.check and result.drifted:
+        return EXIT_VALIDATION_FAILED
     return EXIT_OK
 
 
@@ -1257,11 +1330,17 @@ def build_parser() -> argparse.ArgumentParser:
         default=".",
         help="Directory to scan recursively for *.md (default: current directory).",
     )
+    # --html / --okf / --agent-rules are the mutually-exclusive write modes; the
+    # default (none of them) writes the JSON payload to stdout. --json is *not*
+    # in this group: for the default mode it is the explicit no-op it always was,
+    # and for --agent-rules it toggles JSON vs human output (so --agent-rules
+    # --json is valid). --json with --html/--okf is rejected in cmd_export.
     export_mode = p_export.add_mutually_exclusive_group()
-    export_mode.add_argument(
+    p_export.add_argument(
         "--json",
         action="store_true",
-        help="Write the export JSON to stdout (the default; explicit for pipelines).",
+        help="Emit JSON instead of human-readable text (the default export mode "
+        "writes JSON to stdout regardless; with --agent-rules, selects JSON output).",
     )
     export_mode.add_argument(
         "--html",
@@ -1275,11 +1354,34 @@ def build_parser() -> argparse.ArgumentParser:
         help="Write a derived OKF v0.1 bundle (one Markdown file per artifact, "
         "plus index.md and log.md) to a directory.",
     )
+    export_mode.add_argument(
+        "--agent-rules",
+        action="store_true",
+        help="Write per-client agent-context files (CLAUDE.md, AGENTS.md, "
+        ".cursor/rules, .github/copilot-instructions.md) with a drift-guarded "
+        "managed block distilled from live decisions (ADR-067).",
+    )
+    p_export.add_argument(
+        "--check",
+        action="store_true",
+        help="With --agent-rules: verify committed files match the corpus "
+        "without writing; exit non-zero on drift (the CI gate).",
+    )
+    p_export.add_argument(
+        "--client",
+        action="append",
+        choices=["claude", "agents", "cursor", "copilot"],
+        metavar="CLIENT",
+        help="With --agent-rules: restrict to specific clients "
+        "(claude|agents|cursor|copilot); repeatable. Default: all four.",
+    )
     p_export.add_argument(
         "--out",
         default=None,
-        help="Where --html writes the Portal (default: lore-export.html) or "
-        "--okf writes the bundle directory (default: okf-bundle). "
+        help="Where --html writes the Portal (default: lore-export.html), "
+        "--okf writes the bundle directory (default: okf-bundle), or "
+        "--agent-rules writes the per-client files (default: the corpus's repo "
+        "root — the parent of a rac/ directory). "
         "Exports are build artifacts: existing output is overwritten.",
     )
     p_export.set_defaults(func=cmd_export)

--- a/src/rac/output/__init__.py
+++ b/src/rac/output/__init__.py
@@ -8,6 +8,7 @@ without depending on the internal split between human/json/templates.
 
 from .github import render_watchkeeper_github, watchkeeper_annotations
 from .human import (
+    render_agent_rules_human,
     render_diff_human,
     render_dir_inspect_human,
     render_find_human,
@@ -40,6 +41,7 @@ from .human import (
     render_watchkeeper_human,
 )
 from .json import (
+    render_agent_rules_json,
     render_diff_json,
     render_dir_inspect_json,
     render_export_json,
@@ -82,6 +84,8 @@ from .sarif import (
 from .templates import render_improve_template, render_schema_template
 
 __all__ = [
+    "render_agent_rules_human",
+    "render_agent_rules_json",
     "render_diff_human",
     "render_diff_json",
     "render_find_human",

--- a/src/rac/output/human.py
+++ b/src/rac/output/human.py
@@ -16,6 +16,14 @@ from rac.core.hooks import HookSpec
 from rac.core.models import Diff, Issue, Product
 from rac.core.schema import SchemaReference
 from rac.core.skills import SkillSpec
+from rac.services.agent_rules import (
+    STATE_IN_SYNC,
+    STATE_MISSING,
+    STATE_STALE,
+    STATE_UPDATED,
+    STATE_WRITTEN,
+    AgentRulesResult,
+)
 from rac.services.compare import (
     CHANGE_ADDED,
     CHANGE_MODIFIED,
@@ -1184,4 +1192,55 @@ def render_watchkeeper_human(report: WatchkeeperReport) -> str:
     else:
         lines.append(f"  {_green('✓ Nothing requiring attention.')}")
 
+    return "\n".join(lines)
+
+
+# Per-file state icons for `rac export --agent-rules` (v0.21.15). A drift state
+# (stale/missing under --check) is the red failure; a write/update is a neutral
+# bullet; in-sync is the green clear.
+_AGENT_RULES_ICONS = {
+    STATE_WRITTEN: lambda: "+",
+    STATE_UPDATED: lambda: "~",
+    STATE_IN_SYNC: lambda: _green("✓"),
+    STATE_STALE: lambda: _red("✗"),
+    STATE_MISSING: lambda: _red("✗"),
+}
+
+
+def render_agent_rules_human(result: AgentRulesResult) -> str:
+    """Human-readable `rac export --agent-rules [--check]` output (v0.21.15).
+
+    Lists each target file with its outcome — written/updated/in-sync for a
+    generate run, in-sync/stale/missing for a check run — then a verdict line.
+    Under --check, drift (any stale or missing block) is the red failure the CLI
+    turns into a non-zero exit (the vendored-shell drift gate, ADR-067).
+    """
+    checking = result.mode == "check"
+    title = "Agent Rules — drift check" if checking else "Agent Rules"
+    lines = [
+        _bold(title),
+        "=" * len(title),
+        "",
+        f"Corpus digest: {result.digest}",
+        f"Output root:   {result.root}",
+        "",
+    ]
+    for f in result.files:
+        icon = _AGENT_RULES_ICONS.get(f.state, lambda: "·")()
+        lines.append(f"  {icon} {f.path}  [{f.state}]")
+
+    lines.append("")
+    if checking:
+        if result.drifted:
+            stale = [f.path for f in result.files if f.state in (STATE_STALE, STATE_MISSING)]
+            lines.append(_red(f"✗ Drift — {len(stale)} file(s) stale or missing the block."))
+            lines.append("  Regenerate: rac export --agent-rules")
+        else:
+            lines.append(_green("✓ In sync — every present target matches the corpus."))
+    else:
+        written = sum(1 for f in result.files if f.state in (STATE_WRITTEN, STATE_UPDATED))
+        if written:
+            lines.append(_green(f"✓ Wrote/updated {written} file(s)."))
+        else:
+            lines.append(_green("✓ All targets already in sync — nothing to write."))
     return "\n".join(lines)

--- a/src/rac/output/json.py
+++ b/src/rac/output/json.py
@@ -15,6 +15,7 @@ from rac.core.hooks import HookSpec
 from rac.core.models import Diff, Issue, Product
 from rac.core.schema import SchemaReference
 from rac.core.skills import SkillSpec
+from rac.services.agent_rules import AgentRulesResult
 from rac.services.create import CreatedArtifact
 from rac.services.export import CorpusExport
 from rac.services.gate import GateReport
@@ -287,6 +288,15 @@ def render_export_json(export: CorpusExport) -> str:
     external viewers consume (ADR-014).
     """
     return json.dumps(export.to_dict(), indent=2)
+
+
+def render_agent_rules_json(result: AgentRulesResult) -> str:
+    """JSON `rac export --agent-rules [--check]` output (stable contract, ADR-007).
+
+    The editor and CI consume this: ``mode``, the corpus ``digest``, the output
+    ``root``, and per-target ``files`` with their ``state``.
+    """
+    return json.dumps(result.to_dict(), indent=2)
 
 
 # --- create (rac new / rac templates, v0.7.10) -------------------------------

--- a/src/rac/services/agent_rules.py
+++ b/src/rac/services/agent_rules.py
@@ -1,0 +1,419 @@
+"""Agent-rules projection — `rac export --agent-rules [--check]` (v0.21.15).
+
+Distils the *live* corpus into a small, stable "managed block" that committed
+per-client agent-context files (``CLAUDE.md``, ``AGENTS.md``, ``.cursor/rules``,
+``.github/copilot-instructions.md``) carry, so an AI coding agent sees the
+decisions the team has already settled and stops re-litigating them (roadmap
+v0.21.15; governed by ADR-067).
+
+ADR-067 fixes the boundary this service must honour exactly:
+
+- The projection is **distilled**, not the whole corpus: one pointer line per
+  live decision (its canonical identifier + title, optionally its category) —
+  the "what did we already decide / what is ruled out" digest — never the
+  decision bodies. Inlining the corpus is an explicit non-goal (attention
+  budget; the agent reaches the ``lore`` MCP tools for ground truth).
+- "Live" is deterministic and structural (ADR-002): a decision is live when its
+  ``## Status`` is *Accepted* and it is not retired (Superseded/Deprecated).
+  Retired states come from the type spec (``spec.retired_status``), so the rule
+  is spec-driven, never a hard-coded set — the same definition relationship
+  validation already uses (ADR-051). No semantic verdict enters the engine.
+- The block is **drift-guarded**: it embeds a provenance digest (sha256 over the
+  canonical projection), and ``--check`` re-derives the digest from the live
+  corpus and fails when a committed file's embedded digest differs or is absent.
+  The digest — not a timestamp — is the freshness signal, so two generations of
+  the same corpus are byte-identical (ADR-002).
+
+This is a pure projection over the corpus walk; it computes nothing semantic and
+holds no model. Generation only ever *replaces the managed block*; any prose a
+user keeps outside the markers in their own ``CLAUDE.md`` is preserved verbatim.
+
+JSON shapes returned here are a stable public contract (ADR-007).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from rac.core.artifacts import spec_for
+from rac.core.corpus import walk_corpus
+from rac.core.identity import artifact_identifier
+from rac.core.models import Product
+
+# The artifact type whose live members the block distils. ADR-067 scopes the
+# managed block to decisions (bans + closed-decision pointers); roadmap scope
+# fences are an optional future addition and are deliberately not projected here
+# (kept minimal and deterministic — see the roadmap's Initiative 1 note).
+_DECISION_TYPE = "decision"
+
+# The canonical "live" status for a decision: structural, case-insensitive, the
+# first non-empty line of ``## Status`` (the same first-line rule inspect and
+# relationship validation use). Not a semantic judgement — a string match.
+_LIVE_STATUS = "accepted"
+
+# Stable managed-block markers. HTML comments survive Markdown rendering, so the
+# block stays invisible in a rendered CLAUDE.md while remaining machine-locatable.
+# The BEGIN marker carries the provenance digest so ``--check`` can compare
+# without re-deriving the file's own content hash.
+_BEGIN_PREFIX = "<!-- BEGIN RAC MANAGED BLOCK (digest: "
+_BEGIN_SUFFIX = ") -->"
+_END_MARKER = "<!-- END RAC MANAGED BLOCK -->"
+
+# A short header inside the block, so a human opening the file knows what owns it
+# and how to regenerate it. Deterministic — no timestamp.
+_GENERATED_HEADER = (
+    "<!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here;"
+    " content outside this block is preserved. -->"
+)
+
+
+@dataclass(frozen=True)
+class AgentRulesTarget:
+    """One per-client agent-context file the managed block is written into.
+
+    ``client`` is the stable selector value (``--client``); ``path`` is the
+    file's location relative to the output root.
+    """
+
+    client: str
+    path: str
+
+    def to_dict(self) -> dict:
+        return {"client": self.client, "path": self.path}
+
+
+# The four targets ADR-067 / the roadmap name, in deterministic (selector) order.
+# Cursor uses a single ``.cursor/rules`` file (a plain rules file carrying the
+# managed block); the others are Markdown.
+TARGETS: tuple[AgentRulesTarget, ...] = (
+    AgentRulesTarget("agents", "AGENTS.md"),
+    AgentRulesTarget("claude", "CLAUDE.md"),
+    AgentRulesTarget("copilot", ".github/copilot-instructions.md"),
+    AgentRulesTarget("cursor", ".cursor/rules"),
+)
+
+_TARGET_BY_CLIENT = {t.client: t for t in TARGETS}
+
+
+def targets_for(clients: list[str] | None) -> list[AgentRulesTarget]:
+    """Resolve ``--client`` selectors to targets (all four when ``None``).
+
+    Order is always the deterministic ``TARGETS`` order, regardless of the order
+    selectors were given, so output never depends on argument order.
+    """
+    if not clients:
+        return list(TARGETS)
+    wanted = set(clients)
+    return [t for t in TARGETS if t.client in wanted]
+
+
+def unknown_clients(clients: list[str] | None) -> list[str]:
+    """Selectors with no matching target (caller turns these into a usage error)."""
+    if not clients:
+        return []
+    return sorted({c for c in clients if c not in _TARGET_BY_CLIENT})
+
+
+@dataclass(frozen=True)
+class AgentRulesEntry:
+    """One distilled live-decision pointer (identifier + title, optional category).
+
+    A pointer, never a body: this is the "already decided / ruled out" digest the
+    agent reads, with the decision itself reachable through the ``lore`` tools.
+    """
+
+    identifier: str
+    title: str
+    category: str | None = None
+
+    def to_dict(self) -> dict:
+        return {
+            "identifier": self.identifier,
+            "title": self.title,
+            "category": self.category,
+        }
+
+
+@dataclass
+class AgentRulesProjection:
+    """The deterministic projection of the live corpus (entries + digest).
+
+    ``digest`` is a sha256 over the *canonical* serialization of the ordered
+    entries (formatting-independent), so the same corpus state yields the same
+    digest regardless of how the block is rendered for a given client.
+    """
+
+    entries: list[AgentRulesEntry] = field(default_factory=list)
+    digest: str = ""
+
+    def to_dict(self) -> dict:
+        return {
+            "digest": self.digest,
+            "entries": [entry.to_dict() for entry in self.entries],
+        }
+
+
+def _first_status_line(product: Product) -> str:
+    """First non-empty line of ``## Status``, casefolded (empty when absent)."""
+    body = product.sections.get("status")
+    if not body:
+        return ""
+    first = next((line.strip() for line in body.splitlines() if line.strip()), "")
+    return first.casefold()
+
+
+def _category(product: Product) -> str | None:
+    """First non-empty line of ``## Category`` (the decision's classification)."""
+    body = product.sections.get("category")
+    if not body:
+        return None
+    return next((line.strip() for line in body.splitlines() if line.strip()), None) or None
+
+
+def _is_live_decision(entry_product: Product) -> bool:
+    """True when a decision is Accepted and not retired (Superseded/Deprecated).
+
+    Spec-driven retirement (ADR-051): retired states come from the decision
+    spec, so the rule honours every retired status the type declares rather than
+    a hard-coded pair. Structural only — no semantics.
+    """
+    status = _first_status_line(entry_product)
+    if status != _LIVE_STATUS:
+        return False
+    spec = spec_for(_DECISION_TYPE)
+    retired = {s.casefold() for s in (spec.retired_status if spec else ())}
+    return status not in retired
+
+
+def _canonical_payload(entries: list[AgentRulesEntry]) -> str:
+    """Canonical, formatting-independent serialization the digest hashes.
+
+    ``sort_keys`` + ``separators`` pin byte-for-byte stability; the entries are
+    already ordered by identifier, so the digest depends only on corpus content.
+    """
+    return json.dumps(
+        [entry.to_dict() for entry in entries],
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    )
+
+
+def build_agent_rules_block(directory: str, recursive: bool = True) -> AgentRulesProjection:
+    """Distil the live corpus under ``directory`` into the agent-rules projection.
+
+    Walks the corpus once, keeps every live (Accepted, non-retired) decision as a
+    one-line pointer, orders deterministically by canonical identifier, and
+    computes the provenance digest. An empty corpus yields an empty projection
+    with the digest of an empty entry list (a valid, stable state).
+    """
+    entries: list[AgentRulesEntry] = []
+    for entry in walk_corpus(directory, recursive=recursive):
+        if entry.artifact_type != _DECISION_TYPE:
+            continue
+        if not _is_live_decision(entry.product):
+            continue
+        spec = spec_for(_DECISION_TYPE)
+        identifier = artifact_identifier(entry.product, spec, str(entry.path))
+        entries.append(
+            AgentRulesEntry(
+                identifier=identifier,
+                title=entry.product.title or identifier,
+                category=_category(entry.product),
+            )
+        )
+
+    # Deterministic order: by identifier (case-insensitive, then exact for ties).
+    entries.sort(key=lambda e: (e.identifier.casefold(), e.identifier))
+    digest = hashlib.sha256(_canonical_payload(entries).encode("utf-8")).hexdigest()
+    return AgentRulesProjection(entries=entries, digest=digest)
+
+
+def render_managed_block(projection: AgentRulesProjection) -> str:
+    """The managed-block text (markers + distilled pointers), client-independent.
+
+    Identical for every target: the block is plain Markdown that lives equally
+    well inside a ``.md`` file or a Cursor rules file. The digest rides in the
+    BEGIN marker so ``--check`` can read it without re-hashing the file.
+    """
+    lines = [
+        f"{_BEGIN_PREFIX}{projection.digest}{_BEGIN_SUFFIX}",
+        _GENERATED_HEADER,
+        "## Settled decisions (RAC)",
+        "",
+        "These decisions are already accepted. Do not re-open or contradict them;"
+        " ask the `lore` MCP tools (`get_artifact`, `search_artifacts`) for the"
+        " full text before proposing a change that touches one.",
+        "",
+    ]
+    if not projection.entries:
+        lines.append("_No live decisions recorded yet._")
+    else:
+        for entry in projection.entries:
+            suffix = f" _({entry.category})_" if entry.category else ""
+            lines.append(f"- **{entry.identifier}** — {entry.title}{suffix}")
+    lines.append(_END_MARKER)
+    return "\n".join(lines)
+
+
+def embedded_digest(file_text: str) -> str | None:
+    """The digest carried in a file's BEGIN marker, or ``None`` when no block.
+
+    Reads only the marker, never re-hashes the file — the cheap comparison the
+    ``--check`` drift gate relies on.
+    """
+    start = file_text.find(_BEGIN_PREFIX)
+    if start == -1:
+        return None
+    after = start + len(_BEGIN_PREFIX)
+    end = file_text.find(_BEGIN_SUFFIX, after)
+    if end == -1:
+        return None
+    return file_text[after:end].strip() or None
+
+
+def merge_managed_block(existing: str | None, block: str) -> str:
+    """Splice ``block`` into ``existing``, preserving everything outside the markers.
+
+    When the file already has a managed block, only that span is replaced — the
+    user's own prose before and after is kept byte-for-byte. When there is no
+    block, the new one is appended after the existing content (or stands alone in
+    a fresh file). The result always ends with a single trailing newline.
+    """
+    if existing is None or existing.strip() == "":
+        return block + "\n"
+
+    begin = existing.find(_BEGIN_PREFIX)
+    end = existing.find(_END_MARKER)
+    if begin != -1 and end != -1 and end > begin:
+        end += len(_END_MARKER)
+        before = existing[:begin]
+        after = existing[end:]
+        merged = f"{before}{block}{after}"
+        if not merged.endswith("\n"):
+            merged += "\n"
+        return merged
+
+    # No managed block yet: append one, separated by a blank line.
+    body = existing.rstrip("\n")
+    return f"{body}\n\n{block}\n"
+
+
+# --- Generate / check results -------------------------------------------------
+
+# Per-file outcome states (stable JSON contract, ADR-007).
+STATE_WRITTEN = "written"  # the file did not exist; created with the block
+STATE_UPDATED = "updated"  # the file existed; its managed block changed
+STATE_IN_SYNC = "in-sync"  # the file's embedded digest already matches
+STATE_STALE = "stale"  # (--check) embedded digest differs from the corpus
+STATE_MISSING = "missing"  # (--check) the file or its managed block is absent
+
+
+@dataclass(frozen=True)
+class AgentRulesFileResult:
+    """The outcome for one target file in a generate or check run."""
+
+    client: str
+    path: str
+    state: str
+
+    def to_dict(self) -> dict:
+        return {"client": self.client, "path": self.path, "state": self.state}
+
+
+@dataclass
+class AgentRulesResult:
+    """The outcome of a ``--agent-rules`` generate or check run.
+
+    ``mode`` is ``"generate"`` or ``"check"``; ``digest`` is the live projection
+    digest; ``files`` are the per-target outcomes in deterministic order.
+    """
+
+    mode: str
+    digest: str
+    root: str
+    files: list[AgentRulesFileResult] = field(default_factory=list)
+
+    @property
+    def drifted(self) -> bool:
+        """True when any checked file is stale or missing its block (gate fails)."""
+        return any(f.state in (STATE_STALE, STATE_MISSING) for f in self.files)
+
+    def to_dict(self) -> dict:
+        return {
+            "mode": self.mode,
+            "digest": self.digest,
+            "root": self.root,
+            "files": [f.to_dict() for f in self.files],
+        }
+
+
+def generate_agent_rules(
+    directory: str,
+    root: str,
+    clients: list[str] | None = None,
+    recursive: bool = True,
+) -> AgentRulesResult:
+    """Write/update the managed block in each target under ``root``.
+
+    Derives the projection once, then for each target merges the rendered block
+    into the file (preserving outside content), reporting whether each file was
+    created, updated, or already in sync. Writes are skipped when the file's
+    embedded digest already matches — generation is idempotent and byte-stable.
+    """
+    projection = build_agent_rules_block(directory, recursive=recursive)
+    block = render_managed_block(projection)
+    root_path = Path(root)
+
+    results: list[AgentRulesFileResult] = []
+    for target in targets_for(clients):
+        dest = root_path / target.path
+        existing = dest.read_text(encoding="utf-8") if dest.exists() else None
+
+        if existing is not None and embedded_digest(existing) == projection.digest:
+            results.append(AgentRulesFileResult(target.client, target.path, STATE_IN_SYNC))
+            continue
+
+        merged = merge_managed_block(existing, block)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(merged, encoding="utf-8")
+        state = STATE_WRITTEN if existing is None else STATE_UPDATED
+        results.append(AgentRulesFileResult(target.client, target.path, state))
+
+    return AgentRulesResult("generate", projection.digest, str(root_path), results)
+
+
+def check_agent_rules(
+    directory: str,
+    root: str,
+    clients: list[str] | None = None,
+    recursive: bool = True,
+) -> AgentRulesResult:
+    """Compare each committed target's embedded digest to the live projection.
+
+    Never writes. A target is ``in-sync`` when its embedded digest matches the
+    freshly derived projection digest, ``stale`` when it differs, and ``missing``
+    when the file or its managed block is absent. ``result.drifted`` is the gate:
+    true when any target is stale or missing (the caller exits non-zero).
+    """
+    projection = build_agent_rules_block(directory, recursive=recursive)
+    root_path = Path(root)
+
+    results: list[AgentRulesFileResult] = []
+    for target in targets_for(clients):
+        dest = root_path / target.path
+        if not dest.exists():
+            results.append(AgentRulesFileResult(target.client, target.path, STATE_MISSING))
+            continue
+        digest = embedded_digest(dest.read_text(encoding="utf-8"))
+        if digest is None:
+            results.append(AgentRulesFileResult(target.client, target.path, STATE_MISSING))
+        elif digest == projection.digest:
+            results.append(AgentRulesFileResult(target.client, target.path, STATE_IN_SYNC))
+        else:
+            results.append(AgentRulesFileResult(target.client, target.path, STATE_STALE))
+
+    return AgentRulesResult("check", projection.digest, str(root_path), results)

--- a/tests/test_agent_rules.py
+++ b/tests/test_agent_rules.py
@@ -1,0 +1,343 @@
+"""Tests for `rac export --agent-rules [--check]` (roadmap v0.21.15, ADR-067).
+
+The agent-rules projection is a distilled, drift-guarded view of the *live*
+corpus. These tests pin the boundary ADR-067 fixes:
+
+- the projection lists live (Accepted) decisions and excludes retired
+  (Superseded/Deprecated) ones and non-decision artifacts;
+- the digest is deterministic for a fixed corpus and changes when the live set
+  changes (a decision added or retired);
+- generate writes a managed block carrying the digest, preserves content
+  outside the block on regeneration, and is idempotent;
+- --check exits zero in sync, non-zero on drift or a missing block, and never
+  writes;
+- the four per-client files have the expected names/paths;
+- the empty-corpus boundary yields an empty block and a clean check.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from rac.cli import main
+from rac.services.agent_rules import (
+    STATE_IN_SYNC,
+    STATE_MISSING,
+    STATE_STALE,
+    STATE_UPDATED,
+    STATE_WRITTEN,
+    build_agent_rules_block,
+    check_agent_rules,
+    embedded_digest,
+    generate_agent_rules,
+    render_managed_block,
+)
+
+# --- corpus fixtures ---------------------------------------------------------
+
+# No frontmatter ``id`` — identity falls back to the filename prefix (e.g.
+# ``adr-001``), which keeps the fixtures readable without minting valid ULIDs.
+_DECISION = """---
+schema_version: 1
+type: decision
+---
+# {title}
+
+## Status
+
+{status}
+
+## Category
+
+{category}
+
+## Context
+
+Context.
+
+## Decision
+
+Decision.
+
+## Consequences
+
+Consequences.
+"""
+
+_REQUIREMENT = """---
+schema_version: 1
+type: requirement
+---
+# A Requirement
+
+## Status
+
+Active
+
+## Description
+
+A requirement, not a decision — must never appear in the projection.
+"""
+
+
+def _write_decision(
+    directory: Path, slug: str, title: str, status: str, category: str = "Architecture"
+) -> None:
+    (directory / f"{slug}.md").write_text(
+        _DECISION.format(title=title, status=status, category=category),
+        encoding="utf-8",
+    )
+
+
+def _corpus(tmp_path: Path) -> Path:
+    """A small corpus: two live decisions, one superseded, one deprecated, one
+    requirement — enough to exercise inclusion, exclusion, and ordering."""
+    rac_dir = tmp_path / "rac"
+    decisions = rac_dir / "decisions"
+    decisions.mkdir(parents=True)
+    _write_decision(decisions, "adr-001-alpha", "ADR-001: Alpha", "Accepted")
+    _write_decision(decisions, "adr-002-beta", "ADR-002: Beta", "Accepted", category="Product")
+    _write_decision(decisions, "adr-003-old", "ADR-003: Old", "Superseded")
+    _write_decision(decisions, "adr-004-dead", "ADR-004: Dead", "Deprecated")
+    (decisions / "req.md").write_text(_REQUIREMENT, encoding="utf-8")
+    return rac_dir
+
+
+# --- projection: inclusion / exclusion / ordering ----------------------------
+
+
+def test_projection_lists_live_excludes_retired_and_non_decisions(tmp_path):
+    projection = build_agent_rules_block(str(_corpus(tmp_path)))
+    ids = [e.identifier for e in projection.entries]
+    # Only the two Accepted decisions, deterministically ordered by identifier.
+    assert ids == ["adr-001", "adr-002"]
+    titles = {e.title for e in projection.entries}
+    assert "ADR-003: Old" not in titles  # superseded excluded
+    assert "ADR-004: Dead" not in titles  # deprecated excluded
+    assert all("Requirement" not in t for t in titles)  # non-decision excluded
+
+
+def test_projection_carries_category(tmp_path):
+    projection = build_agent_rules_block(str(_corpus(tmp_path)))
+    by_id = {e.identifier: e for e in projection.entries}
+    assert by_id["adr-001"].category == "Architecture"
+    assert by_id["adr-002"].category == "Product"
+
+
+# --- digest: determinism and sensitivity -------------------------------------
+
+
+def test_digest_is_deterministic(tmp_path):
+    corpus = str(_corpus(tmp_path))
+    assert build_agent_rules_block(corpus).digest == build_agent_rules_block(corpus).digest
+
+
+def test_digest_changes_when_a_live_decision_is_added(tmp_path):
+    rac_dir = _corpus(tmp_path)
+    before = build_agent_rules_block(str(rac_dir)).digest
+    _write_decision(rac_dir / "decisions", "adr-005-new", "ADR-005: New", "Accepted")
+    after = build_agent_rules_block(str(rac_dir)).digest
+    assert before != after
+
+
+def test_digest_changes_when_a_live_decision_is_retired(tmp_path):
+    rac_dir = _corpus(tmp_path)
+    before = build_agent_rules_block(str(rac_dir)).digest
+    # Retire one of the live decisions.
+    _write_decision(rac_dir / "decisions", "adr-001-alpha", "ADR-001: Alpha", "Superseded")
+    after = build_agent_rules_block(str(rac_dir)).digest
+    assert before != after
+
+
+# --- managed block rendering -------------------------------------------------
+
+
+def test_managed_block_embeds_digest_and_lists_entries(tmp_path):
+    projection = build_agent_rules_block(str(_corpus(tmp_path)))
+    block = render_managed_block(projection)
+    assert embedded_digest(block) == projection.digest
+    assert "adr-001" in block
+    assert "ADR-003: Old" not in block  # retired never rendered
+
+
+# --- generate ----------------------------------------------------------------
+
+
+def test_generate_writes_four_client_files_with_the_digest(tmp_path):
+    rac_dir = _corpus(tmp_path)
+    root = tmp_path / "repo"
+    root.mkdir()
+    result = generate_agent_rules(str(rac_dir), str(root))
+
+    paths = {f.path for f in result.files}
+    assert paths == {
+        "CLAUDE.md",
+        "AGENTS.md",
+        ".cursor/rules",
+        ".github/copilot-instructions.md",
+    }
+    for f in result.files:
+        assert f.state == STATE_WRITTEN
+        text = (root / f.path).read_text(encoding="utf-8")
+        assert embedded_digest(text) == result.digest
+
+
+def test_generate_preserves_content_outside_the_block(tmp_path):
+    rac_dir = _corpus(tmp_path)
+    root = tmp_path / "repo"
+    root.mkdir()
+    generate_agent_rules(str(rac_dir), str(root))
+
+    claude = root / "CLAUDE.md"
+    original = claude.read_text(encoding="utf-8")
+    claude.write_text(f"# My header\n\nUser prose.\n\n{original}\nUser footer.\n", encoding="utf-8")
+
+    # Add a live decision so the block must be regenerated.
+    _write_decision(rac_dir / "decisions", "adr-005-new", "ADR-005: New", "Accepted")
+    result = generate_agent_rules(str(rac_dir), str(root))
+
+    updated = claude.read_text(encoding="utf-8")
+    assert updated.startswith("# My header\n\nUser prose.\n")
+    assert updated.rstrip().endswith("User footer.")
+    assert "adr-005" in updated  # new block content present
+    claude_result = next(f for f in result.files if f.path == "CLAUDE.md")
+    assert claude_result.state == STATE_UPDATED
+
+
+def test_generate_is_idempotent(tmp_path):
+    rac_dir = _corpus(tmp_path)
+    root = tmp_path / "repo"
+    root.mkdir()
+    generate_agent_rules(str(rac_dir), str(root))
+    first = (root / "CLAUDE.md").read_text(encoding="utf-8")
+    second_result = generate_agent_rules(str(rac_dir), str(root))
+    assert (root / "CLAUDE.md").read_text(encoding="utf-8") == first
+    assert all(f.state == STATE_IN_SYNC for f in second_result.files)
+
+
+def test_generate_respects_client_filter(tmp_path):
+    rac_dir = _corpus(tmp_path)
+    root = tmp_path / "repo"
+    root.mkdir()
+    result = generate_agent_rules(str(rac_dir), str(root), clients=["claude"])
+    assert [f.path for f in result.files] == ["CLAUDE.md"]
+    assert (root / "CLAUDE.md").exists()
+    assert not (root / "AGENTS.md").exists()
+
+
+# --- check -------------------------------------------------------------------
+
+
+def test_check_passes_when_in_sync_and_does_not_write(tmp_path):
+    rac_dir = _corpus(tmp_path)
+    root = tmp_path / "repo"
+    root.mkdir()
+    generate_agent_rules(str(rac_dir), str(root))
+
+    before = {
+        f.path: (root / f.path).read_text(encoding="utf-8")
+        for f in check_agent_rules(str(rac_dir), str(root)).files
+    }
+    result = check_agent_rules(str(rac_dir), str(root))
+    assert not result.drifted
+    assert all(f.state == STATE_IN_SYNC for f in result.files)
+    # No file changed.
+    for path, text in before.items():
+        assert (root / path).read_text(encoding="utf-8") == text
+
+
+def test_check_fails_on_drift_when_corpus_changed(tmp_path):
+    rac_dir = _corpus(tmp_path)
+    root = tmp_path / "repo"
+    root.mkdir()
+    generate_agent_rules(str(rac_dir), str(root))
+
+    # Corpus changes but files are not regenerated.
+    _write_decision(rac_dir / "decisions", "adr-005-new", "ADR-005: New", "Accepted")
+    result = check_agent_rules(str(rac_dir), str(root))
+    assert result.drifted
+    assert all(f.state == STATE_STALE for f in result.files)
+
+
+def test_check_fails_when_block_missing(tmp_path):
+    rac_dir = _corpus(tmp_path)
+    root = tmp_path / "repo"
+    root.mkdir()
+    # No files generated at all -> all targets missing.
+    result = check_agent_rules(str(rac_dir), str(root))
+    assert result.drifted
+    assert all(f.state == STATE_MISSING for f in result.files)
+
+
+def test_check_reports_file_without_managed_block_as_missing(tmp_path):
+    rac_dir = _corpus(tmp_path)
+    root = tmp_path / "repo"
+    root.mkdir()
+    (root / "CLAUDE.md").write_text("# Just prose, no managed block.\n", encoding="utf-8")
+    result = check_agent_rules(str(rac_dir), str(root), clients=["claude"])
+    assert result.files[0].state == STATE_MISSING
+    assert result.drifted
+
+
+# --- empty-corpus boundary ---------------------------------------------------
+
+
+def test_empty_corpus_yields_empty_block_and_clean_check(tmp_path):
+    rac_dir = tmp_path / "rac"
+    rac_dir.mkdir()
+    root = tmp_path / "repo"
+    root.mkdir()
+
+    projection = build_agent_rules_block(str(rac_dir))
+    assert projection.entries == []
+    block = render_managed_block(projection)
+    assert "No live decisions recorded yet" in block
+
+    generate_agent_rules(str(rac_dir), str(root))
+    result = check_agent_rules(str(rac_dir), str(root))
+    assert not result.drifted
+
+
+# --- CLI integration ---------------------------------------------------------
+
+
+def test_cli_generate_then_check_roundtrip(tmp_path, capsys):
+    rac_dir = _corpus(tmp_path)
+    root = tmp_path / "repo"
+    root.mkdir()
+
+    assert main(["export", str(rac_dir), "--agent-rules", "--out", str(root)]) == 0
+    capsys.readouterr()
+    assert main(["export", str(rac_dir), "--agent-rules", "--check", "--out", str(root)]) == 0
+    capsys.readouterr()
+
+    # Retire a live decision -> the committed files drift -> check exits non-zero.
+    _write_decision(rac_dir / "decisions", "adr-001-alpha", "ADR-001: Alpha", "Superseded")
+    assert main(["export", str(rac_dir), "--agent-rules", "--check", "--out", str(root)]) == 1
+
+
+def test_cli_agent_rules_json_output(tmp_path, capsys):
+    rac_dir = _corpus(tmp_path)
+    root = tmp_path / "repo"
+    root.mkdir()
+    rc = main(["export", str(rac_dir), "--agent-rules", "--json", "--out", str(root)])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["mode"] == "generate"
+    assert {f["path"] for f in payload["files"]} == {
+        "CLAUDE.md",
+        "AGENTS.md",
+        ".cursor/rules",
+        ".github/copilot-instructions.md",
+    }
+
+
+def test_cli_check_without_agent_rules_is_usage_error(tmp_path, capsys):
+    rac_dir = _corpus(tmp_path)
+    try:
+        main(["export", str(rac_dir), "--check"])
+        raised = False
+    except SystemExit as exc:
+        raised = exc.code == 2
+    assert raised

--- a/typescript/rac-sdk/src/client.ts
+++ b/typescript/rac-sdk/src/client.ts
@@ -8,6 +8,7 @@
 import { RacExecError, RacNotFoundError, RacOutputError } from "./errors.js";
 import { defaultRunner, type RacRunner, type RunResult } from "./runner.js";
 import type {
+  AgentRulesResult,
   CorpusExport,
   CreatedArtifact,
   DirectoryValidation,
@@ -166,6 +167,29 @@ export class RacClient {
     if (result.code !== 0) {
       throw new RacExecError(args, result.code, result.stderr);
     }
+  }
+
+  /**
+   * `rac export <dir> --agent-rules [--check] --json` — generate (or, with
+   * `check`, verify) the drift-guarded per-client agent-context files
+   * (`CLAUDE.md`, `AGENTS.md`, `.cursor/rules`, `.github/copilot-instructions.md`)
+   * distilled from the live corpus (ADR-067). The engine owns all logic; this
+   * client only shells the command and deserializes the result (ADR-063).
+   *
+   * `out` sets the output root (default: the corpus's repo root). `clients`
+   * restricts the targets. Under `check`, a non-zero exit (drift) is expected
+   * and surfaced through `result.files[].state` ("stale" / "missing") rather
+   * than thrown — `json()` returns the payload on exit code 1.
+   */
+  agentRules(
+    directory: string,
+    options: { out?: string; check?: boolean; clients?: string[] } = {},
+  ): Promise<AgentRulesResult> {
+    const args = ["export", directory, "--agent-rules", "--json"];
+    if (options.check) args.push("--check");
+    if (options.out !== undefined) args.push("--out", options.out);
+    for (const client of options.clients ?? []) args.push("--client", client);
+    return this.json<AgentRulesResult>(args);
   }
 
   /** `rac --version` — the installed RAC version string. */

--- a/typescript/rac-sdk/src/index.ts
+++ b/typescript/rac-sdk/src/index.ts
@@ -68,4 +68,6 @@ export type {
   ExportArtifact,
   ExportRelationship,
   CorpusExport,
+  AgentRulesFile,
+  AgentRulesResult,
 } from "./types.js";

--- a/typescript/rac-sdk/src/types.ts
+++ b/typescript/rac-sdk/src/types.ts
@@ -245,3 +245,22 @@ export interface CorpusExport {
   artifacts: ExportArtifact[];
   relationships: ExportRelationship[];
 }
+
+/** One target file's outcome in an agent-rules generate or check run (v0.21.15). */
+export interface AgentRulesFile {
+  client: string;
+  path: string;
+  /** "written" | "updated" | "in-sync" | "stale" | "missing". */
+  state: string;
+}
+
+/** The result of `rac export --agent-rules [--check] --json` (ADR-067). */
+export interface AgentRulesResult {
+  /** "generate" or "check". */
+  mode: string;
+  /** sha256 of the live projection — the freshness signal, not a timestamp. */
+  digest: string;
+  /** The output root the per-client files were written to / checked under. */
+  root: string;
+  files: AgentRulesFile[];
+}

--- a/typescript/rac-sdk/test/client.test.ts
+++ b/typescript/rac-sdk/test/client.test.ts
@@ -208,6 +208,54 @@ describe("exportHtml", () => {
   });
 });
 
+describe("agentRules", () => {
+  it("generates and parses the per-client file states", async () => {
+    const { runner, calls } = fakeRunner({
+      stdout: JSON.stringify({
+        mode: "generate",
+        digest: "abc123",
+        root: "/w",
+        files: [
+          { client: "claude", path: "CLAUDE.md", state: "written" },
+          { client: "agents", path: "AGENTS.md", state: "in-sync" },
+        ],
+      }),
+    });
+    const result = await new RacClient({ runner }).agentRules("rac", { out: "/w" });
+    expect(result.mode).toBe("generate");
+    expect(result.digest).toBe("abc123");
+    expect(result.files[0]?.state).toBe("written");
+    expect(calls[0]).toEqual(["export", "rac", "--agent-rules", "--json", "--out", "/w"]);
+  });
+
+  it("passes --check and restricts clients, returning drift on exit 1", async () => {
+    const { runner, calls } = fakeRunner({
+      code: 1,
+      stdout: JSON.stringify({
+        mode: "check",
+        digest: "def456",
+        root: "/w",
+        files: [{ client: "claude", path: "CLAUDE.md", state: "stale" }],
+      }),
+    });
+    const result = await new RacClient({ runner }).agentRules("rac", {
+      check: true,
+      clients: ["claude"],
+    });
+    expect(result.mode).toBe("check");
+    expect(result.files[0]?.state).toBe("stale");
+    expect(calls[0]).toEqual([
+      "export",
+      "rac",
+      "--agent-rules",
+      "--json",
+      "--check",
+      "--client",
+      "claude",
+    ]);
+  });
+});
+
 describe("error mapping", () => {
   it("raises RacNotFoundError when the binary cannot be spawned", async () => {
     const runner: RacRunner = async () => {

--- a/typescript/rac-vscode/package.json
+++ b/typescript/rac-vscode/package.json
@@ -52,6 +52,10 @@
       {
         "command": "rac.setupWorkspace",
         "title": "RAC: Set Up Workspace"
+      },
+      {
+        "command": "rac.setupAgentIntegration",
+        "title": "RAC: Set Up Agent Integration"
       }
     ],
     "walkthroughs": [

--- a/typescript/rac-vscode/src/extension.ts
+++ b/typescript/rac-vscode/src/extension.ts
@@ -110,6 +110,9 @@ export function activate(context: vscode.ExtensionContext): void {
     vscode.commands.registerCommand("rac.newArtifact", newArtifact),
     vscode.commands.registerCommand("rac.showExplorer", showExplorer),
     vscode.commands.registerCommand("rac.setupWorkspace", setupWorkspace),
+    vscode.commands.registerCommand("rac.setupAgentIntegration", () =>
+      setupAgentIntegration(context),
+    ),
     vscode.commands.registerCommand("rac.installRac", installRac),
     vscode.languages.registerHoverProvider(selector, { provideHover }),
     vscode.languages.registerDefinitionProvider(selector, { provideDefinition }),
@@ -1199,4 +1202,213 @@ async function setupWorkspace(): Promise<void> {
       `RAC: setup failed: ${err instanceof Error ? err.message : String(err)}`,
     );
   }
+}
+
+// --- agent integration (roadmap v0.21.15, ADR-067) --------------------------
+//
+// "RAC: Set up agent integration" wires the corpus into the workspace's AI
+// agents. It computes nothing (ADR-063): `rac export --agent-rules` generates
+// the drift-guarded per-client rules files, and the extension only registers
+// the `lore` MCP server and offers regeneration when the corpus changes.
+//
+// The `lore` MCP server is launched as `rac mcp --root <corpus>` (the same read
+// tools the agent queries, ADR-030). Consent stays the user's: VS Code surfaces
+// the registered server for the user to enable; per-client config files
+// (.cursor/mcp.json, .mcp.json) are written but never auto-enabled (ADR-067
+// non-goal: no auto-enable without consent).
+
+// Track the active rules watcher so re-running setup (or deactivation) replaces
+// rather than stacks watchers.
+let agentRulesWatcher: vscode.FileSystemWatcher | undefined;
+let loreMcpProvider: vscode.Disposable | undefined;
+
+/** The `rac` binary the SDK resolves for a folder (config override, else PATH). */
+function racBinaryFor(folder: vscode.WorkspaceFolder): string {
+  const configured = vscode.workspace
+    .getConfiguration("rac", folder.uri)
+    .get<string>("path")
+    ?.trim();
+  return configured ? configured : "rac";
+}
+
+/**
+ * Register the `lore` MCP server (`rac mcp --root <corpus>`) so MCP-capable
+ * clients (Claude Code, Cursor) can query the corpus. Returns true when the
+ * VS Code MCP API was available and the registration was made. Consent is the
+ * user's: registration only *offers* the server; the user enables it.
+ */
+function registerLoreMcp(
+  context: vscode.ExtensionContext,
+  folder: vscode.WorkspaceFolder,
+): boolean {
+  const lm = vscode.lm as unknown as {
+    registerMcpServerDefinitionProvider?: (
+      id: string,
+      provider: vscode.McpServerDefinitionProvider,
+    ) => vscode.Disposable;
+  };
+  if (typeof lm.registerMcpServerDefinitionProvider !== "function") {
+    // Older VS Code / Cursor without the MCP provider API: fall back to the
+    // generated per-client config files only.
+    return false;
+  }
+
+  loreMcpProvider?.dispose();
+  const command = racBinaryFor(folder);
+  loreMcpProvider = lm.registerMcpServerDefinitionProvider("rac.lore", {
+    provideMcpServerDefinitions: () => [
+      new vscode.McpStdioServerDefinition(
+        "lore",
+        command,
+        ["mcp", "--root", folder.uri.fsPath],
+      ),
+    ],
+  });
+  context.subscriptions.push(loreMcpProvider);
+  return true;
+}
+
+/**
+ * Write a per-client MCP config (Cursor's `.cursor/mcp.json`, the generic
+ * `.mcp.json` Claude Code reads) describing the `lore` stdio server. These are
+ * inert until the user opts in — RAC does not auto-enable them (ADR-067).
+ */
+async function writeMcpConfigFiles(folder: vscode.WorkspaceFolder): Promise<void> {
+  const command = racBinaryFor(folder);
+  const server = {
+    command,
+    args: ["mcp", "--root", folder.uri.fsPath],
+  };
+  // Cursor reads `.cursor/mcp.json` ({ mcpServers: { … } }); Claude Code reads a
+  // project `.mcp.json` with the same shape. One payload, two destinations.
+  const payload = JSON.stringify({ mcpServers: { lore: server } }, null, 2) + "\n";
+  const targets = [
+    vscode.Uri.joinPath(folder.uri, ".cursor", "mcp.json"),
+    vscode.Uri.joinPath(folder.uri, ".mcp.json"),
+  ];
+  const encoder = new TextEncoder();
+  for (const uri of targets) {
+    try {
+      await vscode.workspace.fs.writeFile(uri, encoder.encode(payload));
+    } catch (err) {
+      log(`could not write MCP config ${uri.fsPath}`, err);
+    }
+  }
+}
+
+/**
+ * Watch the corpus and offer regeneration when an artifact changes, so the
+ * committed rules files do not silently drift (ADR-067). The watcher only
+ * *offers* — the user runs the regeneration, keeping the generated files an
+ * explicit, reviewable change.
+ */
+function watchCorpusForDrift(
+  context: vscode.ExtensionContext,
+  folder: vscode.WorkspaceFolder,
+): void {
+  agentRulesWatcher?.dispose();
+  const pattern = new vscode.RelativePattern(folder, "rac/**/*.md");
+  const watcher = vscode.workspace.createFileSystemWatcher(pattern);
+  let pending: ReturnType<typeof setTimeout> | undefined;
+  let prompting = false;
+
+  const offerRegen = (): void => {
+    if (prompting) return;
+    if (pending) clearTimeout(pending);
+    pending = setTimeout(() => {
+      prompting = true;
+      const REGEN = "Regenerate";
+      void vscode.window
+        .showInformationMessage(
+          "RAC: the corpus changed. Regenerate the agent rules files so they don't drift?",
+          REGEN,
+        )
+        .then((choice) => {
+          prompting = false;
+          if (choice === REGEN) void generateAgentRules(folder, { silent: true });
+        });
+    }, AWARENESS_DEBOUNCE_MS);
+  };
+
+  watcher.onDidChange(offerRegen);
+  watcher.onDidCreate(offerRegen);
+  watcher.onDidDelete(offerRegen);
+  agentRulesWatcher = watcher;
+  context.subscriptions.push(watcher);
+}
+
+/** Run `rac export --agent-rules` for a folder; report what was written. */
+async function generateAgentRules(
+  folder: vscode.WorkspaceFolder,
+  options: { silent?: boolean } = {},
+): Promise<boolean> {
+  try {
+    const result = await clientFor(folder).agentRules(folder.uri.fsPath, {
+      out: folder.uri.fsPath,
+    });
+    const changed = result.files.filter(
+      (f) => f.state === "written" || f.state === "updated",
+    );
+    if (!options.silent) {
+      const summary =
+        changed.length === 0
+          ? "agent rules already up to date"
+          : `agent rules updated (${changed.map((f) => f.path).join(", ")})`;
+      void vscode.window.showInformationMessage(`RAC: ${summary}.`);
+    }
+    return true;
+  } catch (err) {
+    if (err instanceof RacNotFoundError) {
+      warnMissingOnce();
+      return false;
+    }
+    log("agent-rules generation failed", err);
+    if (!options.silent) {
+      void vscode.window.showErrorMessage(
+        `RAC: could not generate agent rules: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+    return false;
+  }
+}
+
+/**
+ * The "RAC: Set up agent integration" command. Detects which agent targets are
+ * present, generates the rules files via `rac`, registers the `lore` MCP server
+ * (and writes per-client MCP configs), starts a drift watcher, and ends with
+ * the first-run nudge (Initiative 3).
+ */
+async function setupAgentIntegration(context: vscode.ExtensionContext): Promise<void> {
+  const folder = vscode.workspace.workspaceFolders?.[0];
+  if (!folder) {
+    void vscode.window.showErrorMessage("RAC: open a folder first, then set up agent integration.");
+    return;
+  }
+
+  // Detect present agent targets (for the report only — generation always writes
+  // all four so coverage is universal, ADR-067).
+  const present: string[] = [];
+  for (const rel of ["CLAUDE.md", "AGENTS.md", ".cursor", ".github"]) {
+    try {
+      await vscode.workspace.fs.stat(vscode.Uri.joinPath(folder.uri, rel));
+      present.push(rel);
+    } catch {
+      // not present — generation will create it
+    }
+  }
+  log(`agent integration: detected ${present.length ? present.join(", ") : "no existing targets"}`);
+
+  if (!(await generateAgentRules(folder))) return;
+
+  const mcpRegistered = registerLoreMcp(context, folder);
+  await writeMcpConfigFiles(folder);
+  watchCorpusForDrift(context, folder);
+
+  // First-run nudge (Initiative 3): point the user at the first MCP moment.
+  const mcpHint = mcpRegistered
+    ? "Enable the `lore` MCP server when your editor prompts, then ask your agent: "
+    : "Your agent now sees the rules files. Once `lore` MCP is enabled, ask your agent: ";
+  void vscode.window.showInformationMessage(
+    `RAC: agent integration ready. ${mcpHint}"what did we decide about X?"`,
+  );
 }


### PR DESCRIPTION
# Summary

Implements `rac/roadmaps/v0.21.x-editor/v0.21.15-agent-context-generation.md`.

The editor enforces against the human, but the AI agent that re-litigates settled
decisions never sees the corpus. Per ADR-067 the wedge is committed, drift-guarded
agent-rules files generated by `rac` from the live corpus — they reach every agent
(including Copilot) with zero per-developer setup and are reviewable in a PR.

Adds:
- `rac export --agent-rules [--check]` — distils the live (Accepted, non-retired)
  decisions into a small managed block written to each client format, carrying a
  sha256 provenance digest; `--check` is the CI drift gate.
- The SDK `agentRules()` method and a `RAC: Set up agent integration` editor
  command that generates the files and registers the `lore` MCP server per client.

# Roadmap / ADR Trace

Roadmap:
- `rac/roadmaps/v0.21.x-editor/v0.21.15-agent-context-generation.md`

Relevant ADRs:
- `rac/decisions/adr-067-agent-integration-boundary.md` — committed, drift-guarded
  context files from live decisions; distilled, not the whole corpus; provenance
  hash + `--check`; structural retrieval only, no semantic verdict in the engine.
- `rac/decisions/adr-063-non-python-clients-are-thin.md` — generation and all
  corpus logic live in `rac`; the extension shells the command and registers MCP.
- `rac/decisions/adr-007-additive-json-contract.md` — the new verb is additive.
- `rac/decisions/adr-030-*.md` — identity/MCP grounding the projection draws on.

# Scope

## Included
- `src/rac/services/agent_rules.py`: a pure projection distilling live decisions
  into ordered one-line pointers (identifier + title + category), a sha256 digest
  over the canonical projection, and per-client managed-block rendering.
- `rac export DIR --agent-rules [--check] [--out DIR] [--client claude|agents|cursor|copilot ...] [--json]`.
- Targets: `CLAUDE.md`, `AGENTS.md`, `.cursor/rules`, `.github/copilot-instructions.md`.
- A fenced managed block delimited by HTML-comment markers carrying the digest;
  content outside the block is preserved byte-for-byte on regeneration; a fresh
  file gets just the block plus a generated-by header.
- `--check` re-derives the digest and exits non-zero on drift or a missing block,
  writing nothing — the staleness gate.
- SDK `agentRules()` (shells the command) and the `rac.setupAgentIntegration`
  editor command that detects present targets, generates the files, and registers
  the `lore` MCP server per client (consent stays the user's).

## Excluded
- A semantic verdict in the engine (ADR-067) — the projection is structural
  retrieval; the agent judges contradiction.
- Inlining the whole corpus — the block is distilled bans plus closed-decision
  pointers only.
- Scope-fence (roadmap version) projection — intentionally decisions-only this
  release (the roadmap permits restricting to decisions); keeps the digest
  deterministic and the block small.
- Auto-enabling MCP servers without user consent — the provider only offers
  `lore`; the config is inert until opted in.

# Product / Architecture Decisions

- The managed block is delimited by `BEGIN/END RAC MANAGED BLOCK` HTML comments
  with the digest in the BEGIN marker, so `--check` compares without re-parsing
  the whole file and a user's own prose around the block survives regeneration.
- Freshness is a digest, not a timestamp (ADR-002 determinism): the same corpus
  state yields a byte-identical block, so `--check` is a pure function of corpus
  content.
- `--json` was pulled out of the export mode group: in default export mode it is
  the explicit no-op it always was (with a guard rejecting `--json` with
  `--html`/`--okf`); with `--agent-rules` it toggles JSON vs human output.
- `--check` and `--client` are only valid with `--agent-rules` (else a usage
  error), and `--client` is repeatable.
- Default `--out` root is the corpus's repo root (the parent of a `rac/`
  directory), so `rac export rac/ --agent-rules` writes the four files beside
  `rac/`.

# User-Facing Contract

## CLI
- `rac export rac/ --agent-rules` — write/update the four managed blocks.
- `rac export rac/ --agent-rules --check` — fail if any committed block is stale
  or missing (CI gate); writes nothing.
- `rac export rac/ --agent-rules --client claude --client cursor` — restrict
  targets.
- `rac export rac/ --agent-rules --json` — machine-readable result (files
  written/updated/in-sync/stale, the digest).

## Human Output
New agent-rules generate/check summaries. Existing export output unchanged.

## JSON Output
New additive agent-rules result contract under `--agent-rules --json`.

## Exit Codes
- generate: `0` on success.
- `--check`: `0` all present targets in sync · `1` drift or a missing block.
- `2` usage error (`--check`/`--client` without `--agent-rules`; `--json` with
  `--html`/`--okf`).

# Verification

## Ran
- `pytest tests/test_agent_rules.py tests/test_export*.py tests/test_ci_batteries.py`
  — green (18 new agent-rules tests).
- Corpus gates on `rac/`: `validate`, `relationships --validate`, `review`,
  `gate` — all exit `0`.
- Round-trip on a fixture corpus: generate writes four files with a managed block;
  adding user prose then `--check` exits `0` (in sync); retiring the only decision
  then `--check` exits `1` (drift) and writes nothing; regenerating preserves the
  user prose; `--check` without `--agent-rules` exits `2`.
- TypeScript: SDK builds, typechecks, and vitest pass (2 new `agentRules` cases);
  extension `tsc --noEmit` + esbuild compile clean.
- `ruff check` / `ruff format --check` clean; `mypy src/rac/services/agent_rules.py`
  clean.

## Covered
- Projection: live (Accepted) decisions only; retired excluded; deterministic
  digest that shifts when a decision is added or retired.
- Generation: managed block carries the digest; surrounding prose preserved.
- Drift gate: in-sync `0`, drift `1`, missing block `1`.
- Boundary: empty corpus yields an empty block, exit `0`.

# Review Path

1. `src/rac/services/agent_rules.py` — the projection, digest, and managed-block
   rendering.
2. `src/rac/cli.py`, `src/rac/output/{human,json}.py` — the `--agent-rules`
   surface.
3. `tests/test_agent_rules.py` — projection and drift-gate coverage.
4. `typescript/rac-sdk/*` — `agentRules()` and its tests.
5. `typescript/rac-vscode/src/extension.ts`, `package.json` — the setup command.

Plus `rac/roadmaps/.../v0.21.14-...md` flipped to Achieved (ratifying the
predecessor on this stacked branch, ADR-061).

# Notes For Reviewer

- This PR is stacked on `claude/v0.21.14-security-governance` (its base), so the
  diff shows only v0.21.15. It retargets to `main` automatically once v0.21.14
  merges.
- No agent-rules files were dogfooded into this repo, so `rac export
  --agent-rules --check rac/` reports drift/missing by design until a consumer
  commits the files and wires a CI job — that wiring lands in v0.21.16
  (Initiative 3).
- TypeScript verified by typecheck/esbuild/vitest; the runtime MCP registration
  UX and the `rac/**` watcher prompt need a live VS Code to exercise. All corpus
  logic stays in `rac`; the command only shells `rac export --agent-rules` and
  registers `lore`.

# Implementation Process

Implemented with AI assistance under the roadmap contract; final scope, review,
and acceptance decisions were made by the maintainer.