### PR TITLE
feat(find): decision query & post-edit guard (v0.21.16)

### DIFF
--- a/.cursor/rules
+++ b/.cursor/rules
@@ -1,28 +1,3 @@
-# RAC — agent session context
-
-This file is a router. Canonical agent guidance lives in `rac/prompts/`,
-where the RAC corpus gates validate it. Do not add rules here — add them
-to the corpus artifact and they load through the imports below.
-
-## Loaded every session
-
-@rac/prompts/rac-agent-session-start.md
-@rac/prompts/rac-agent-commit-guidelines.md
-
-## Situational prompts — read when the task calls for it, do not import
-
-- Pull request preparation: `rac/prompts/rac-agent-pr-guidelines.md`
-- Minor release gate: `rac/prompts/rac-agent-release-gate-minor.md`
-- Major release gate: `rac/prompts/rac-agent-release-gate-major.md`
-- Refactoring and simplification: `rac/prompts/rac-agent-simplification-guidelines.md`
-- Context compression: `rac/prompts/rac-agent-compression.md`
-
-## Working corpus
-
-- Current series: `rac/roadmaps/v0.13.x-welcome/` (next up: v0.13.0)
-- Previous series: `rac/roadmaps/v0.12.x-watchkeeper/` (complete through v0.12.3)
-- Decisions (ADRs): `rac/decisions/`
-
 <!-- BEGIN RAC MANAGED BLOCK (digest: 9d7bf182c3691dd2e94a159ad425800c2e7cede6dde8e56486e7f277bc168a28) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,28 +1,3 @@
-# RAC — agent session context
-
-This file is a router. Canonical agent guidance lives in `rac/prompts/`,
-where the RAC corpus gates validate it. Do not add rules here — add them
-to the corpus artifact and they load through the imports below.
-
-## Loaded every session
-
-@rac/prompts/rac-agent-session-start.md
-@rac/prompts/rac-agent-commit-guidelines.md
-
-## Situational prompts — read when the task calls for it, do not import
-
-- Pull request preparation: `rac/prompts/rac-agent-pr-guidelines.md`
-- Minor release gate: `rac/prompts/rac-agent-release-gate-minor.md`
-- Major release gate: `rac/prompts/rac-agent-release-gate-major.md`
-- Refactoring and simplification: `rac/prompts/rac-agent-simplification-guidelines.md`
-- Context compression: `rac/prompts/rac-agent-compression.md`
-
-## Working corpus
-
-- Current series: `rac/roadmaps/v0.13.x-welcome/` (next up: v0.13.0)
-- Previous series: `rac/roadmaps/v0.12.x-watchkeeper/` (complete through v0.12.3)
-- Decisions (ADRs): `rac/decisions/`
-
 <!-- BEGIN RAC MANAGED BLOCK (digest: 9d7bf182c3691dd2e94a159ad425800c2e7cede6dde8e56486e7f277bc168a28) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -107,6 +107,33 @@ jobs:
           install-from: source
           upload-sarif: ${{ !github.event.pull_request.head.repo.fork }}
 
+  # Agent-rules drift gate (v0.21.16, ADR-067): every pull request re-derives the
+  # live-decision digest from the corpus and fails if any committed agent-context
+  # file (CLAUDE.md, AGENTS.md, .cursor/rules, .github/copilot-instructions.md) is
+  # stale or missing its managed block. `--check` never writes; this is the
+  # Success Measure "a stale rules file fails CI", so the generated projection
+  # cannot silently rot relative to rac/. Source install, like the other dogfood
+  # jobs.
+  agent-rules:
+    name: agent-rules (drift check, source install)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install package
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .
+
+      - name: Check agent-rules freshness
+        run: rac export rac/ --agent-rules --check
+
   # PR-gate dogfood (v0.21.14): every pull request runs the local PR-gate action
   # in source mode — the live end-to-end test of pr-gate-action/action.yml. It
   # carries the full contract via a single `rac gate` command — validation,

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -96,7 +96,7 @@ jobs:
           - name: relationships
             paths: "tests/test_relationships.py tests/test_relationships_cmd.py tests/test_relationship_validation.py tests/test_relationship_graph.py tests/test_lifecycle_status.py"
           - name: resolve
-            paths: "tests/test_resolve.py"
+            paths: "tests/test_resolve.py tests/test_find_decisions.py"
           - name: review
             paths: "tests/test_review.py tests/test_cadence.py"
           - name: revisions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,28 +1,3 @@
-# RAC — agent session context
-
-This file is a router. Canonical agent guidance lives in `rac/prompts/`,
-where the RAC corpus gates validate it. Do not add rules here — add them
-to the corpus artifact and they load through the imports below.
-
-## Loaded every session
-
-@rac/prompts/rac-agent-session-start.md
-@rac/prompts/rac-agent-commit-guidelines.md
-
-## Situational prompts — read when the task calls for it, do not import
-
-- Pull request preparation: `rac/prompts/rac-agent-pr-guidelines.md`
-- Minor release gate: `rac/prompts/rac-agent-release-gate-minor.md`
-- Major release gate: `rac/prompts/rac-agent-release-gate-major.md`
-- Refactoring and simplification: `rac/prompts/rac-agent-simplification-guidelines.md`
-- Context compression: `rac/prompts/rac-agent-compression.md`
-
-## Working corpus
-
-- Current series: `rac/roadmaps/v0.13.x-welcome/` (next up: v0.13.0)
-- Previous series: `rac/roadmaps/v0.12.x-watchkeeper/` (complete through v0.12.3)
-- Decisions (ADRs): `rac/decisions/`
-
 <!-- BEGIN RAC MANAGED BLOCK (digest: 9d7bf182c3691dd2e94a159ad425800c2e7cede6dde8e56486e7f277bc168a28) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)

--- a/rac/roadmaps/v0.21.x-editor/v0.21.15-agent-context-generation.md
+++ b/rac/roadmaps/v0.21.x-editor/v0.21.15-agent-context-generation.md
@@ -8,7 +8,7 @@ tags: [sdk, typescript, editor, agent, enforcement]
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/src/rac/cli.py
+++ b/src/rac/cli.py
@@ -137,6 +137,7 @@ from rac.services.resolve import (
     OUTCOME_DUPLICATE,
     OUTCOME_RESOLVED,
     find_artifacts,
+    find_decisions,
     resolve_artifact,
 )
 from rac.services.review import DEFAULT_STALE_AFTER_DAYS, build_review
@@ -737,17 +738,28 @@ def cmd_find(args: argparse.Namespace) -> int:
     if not Path(args.directory).is_dir():
         print(f"rac: not a directory: {args.directory}", file=sys.stderr)
         raise SystemExit(EXIT_USAGE)
-    result = find_artifacts(
-        args.directory,
-        args.query,
-        artifact_type=args.type,
-        recursive=not args.top_level,
-    )
+    if args.decisions:
+        # `--decisions` is the live decision query (ADR-067): it implies the
+        # decision type filter *and* restricts to live (Accepted, non-retired)
+        # decisions — the deterministic "what did we decide about X" retrieval.
+        # `--type` is redundant with it and mutually exclusive at the parser.
+        result = find_decisions(
+            args.directory,
+            args.query,
+            recursive=not args.top_level,
+        )
+    else:
+        result = find_artifacts(
+            args.directory,
+            args.query,
+            artifact_type=args.type,
+            recursive=not args.top_level,
+        )
     if args.json:
         print(outputs.render_find_json(result))
     else:
         print(outputs.render_find_human(result))
-    # An empty result is a valid outcome, not an error.
+    # An empty result is a valid outcome, not an error (a query always succeeds).
     return EXIT_OK
 
 
@@ -1579,9 +1591,21 @@ def build_parser() -> argparse.ArgumentParser:
         default=".",
         help="Directory to scan recursively for *.md (default: current directory).",
     )
-    p_find.add_argument(
+    # `--type` and `--decisions` both narrow the search; `--decisions` is the
+    # live decision query (decision type + Accepted/non-retired filter), so the
+    # two are mutually exclusive (ADR-067).
+    find_scope = p_find.add_mutually_exclusive_group()
+    find_scope.add_argument(
         "--type",
         help="Only match artifacts of this type (requirement, decision, ...).",
+    )
+    find_scope.add_argument(
+        "--decisions",
+        action="store_true",
+        help=(
+            "Only live decisions (Accepted, non-retired) — the 'what did we "
+            "decide about X / is X ruled out' query (ADR-067)."
+        ),
     )
     p_find.add_argument(
         "--json", action="store_true", help="Emit JSON instead of human-readable text."

--- a/src/rac/mcp/server.py
+++ b/src/rac/mcp/server.py
@@ -1,10 +1,13 @@
-"""RAC Guide MCP server — the four-tool surface (v0.10.0).
+"""RAC Guide MCP server — the read-tool surface (v0.10.0; v0.21.16).
 
 This module is the FastMCP application: it builds a server bound to a
-repository root and registers the four read-only tools the
-``guide-tool-surface`` design pins (``get_artifact``, ``search_artifacts``,
-``get_related``, ``get_summary``). Tool descriptions ship verbatim from that
-design; changing them is a contract change (ADR-030).
+repository root and registers the read-only tools the agent queries. The
+original four the ``guide-tool-surface`` design pins (``get_artifact``,
+``search_artifacts``, ``get_related``, ``get_summary``) ship their descriptions
+verbatim from that design; changing them is a contract change (ADR-030).
+v0.21.16 adds ``find_decisions`` — the live decision query (ADR-067):
+deterministic retrieval of the Accepted, non-retired decisions binding a topic,
+so an agent consults what the team already settled instead of re-litigating it.
 
 The server is a *consumer* of RAC Core (ADR-015, ADR-031): every tool calls
 read-only service functions — resolution, search, relationships, portfolio —
@@ -56,6 +59,7 @@ from rac.services.relationships import relationships_from_corpus
 from rac.services.resolve import (
     OUTCOME_RESOLVED,
     ResolutionResult,
+    find_decisions,
     resolve_in_index,
     search_index,
 )
@@ -93,6 +97,19 @@ DESC_GET_RELATED = (
     "it. Call this after retrieving an artifact, and before changing anything "
     "it covers, to find the decisions, requirements, designs, and roadmaps the "
     "change could affect."
+)
+
+DESC_FIND_DECISIONS = (
+    "Find the team's already-settled decisions about a topic. Call this whenever "
+    "the user (or you) asks 'what did we decide about X', 'is X ruled out', 'did "
+    "we already decide this', 'what's our policy on X', or before proposing, "
+    "changing, or arguing for anything a prior decision might have settled — so "
+    "you respect recorded decisions instead of re-litigating them. Returns the "
+    "live (Accepted, non-retired) decisions ranked by relevance to the topic, "
+    "each with its identifier, title, path, category, and a snippet. It tells you "
+    "which decisions bind the topic; read them and judge for yourself — it does "
+    "not decide whether a change contradicts them. Use get_artifact to read a "
+    "decision's full text."
 )
 
 DESC_GET_SUMMARY = (
@@ -195,6 +212,23 @@ def _search_artifacts(root: str, query: str, artifact_type: str | None, budget: 
     return serialize(result.to_dict(), budget)
 
 
+def _find_decisions(root: str, topic: str, budget: int) -> str:
+    """Ranked live decisions binding ``topic`` (ADR-067, deterministic retrieval).
+
+    Calls the same ``find_decisions`` service the CLI ``--decisions`` face uses
+    (one source of truth): structural search restricted to live decisions, no
+    semantic verdict. The payload is the search contract plus the live-filter
+    intent in ``type``/``filter`` so a reader knows the result is the *settled*
+    decisions, not every match.
+    """
+    result = find_decisions(root, topic, recursive=True)
+    payload = result.to_dict()
+    # Make the live-decision intent explicit on the wire (additive, ADR-007): the
+    # type is always "decision" and the result is filtered to live decisions.
+    payload["filter"] = "live-decisions"
+    return serialize(payload, budget)
+
+
 def _get_related(root: str, artifact_id: str, budget: int) -> str:
     # One corpus walk feeds resolution, outgoing, and incoming, so the whole
     # response reflects a single atomic snapshot of the repository (ADR-032):
@@ -256,6 +290,12 @@ def build_server(
     def search_artifacts(query: str, type: str | None = None) -> str:
         return telemetry.observe(
             recorder, "search_artifacts", lambda: _search_artifacts(root, query, type, budget)
+        )
+
+    @server.tool(name="find_decisions", description=DESC_FIND_DECISIONS)
+    def find_decisions_tool(topic: str) -> str:
+        return telemetry.observe(
+            recorder, "find_decisions", lambda: _find_decisions(root, topic, budget)
         )
 
     @server.tool(name="get_related", description=DESC_GET_RELATED)

--- a/src/rac/services/agent_rules.py
+++ b/src/rac/services/agent_rules.py
@@ -188,6 +188,17 @@ def _is_live_decision(entry_product: Product) -> bool:
     return status not in retired
 
 
+def is_live_decision(product: Product) -> bool:
+    """Public liveness predicate — Accepted and not retired (ADR-067, ADR-051).
+
+    The single source of truth for "is this decision live", shared by the
+    agent-rules projection and the live decision query (``find_decisions``) so
+    the two surfaces can never disagree on what is settled. Structural only — a
+    status string match, never a semantic judgement.
+    """
+    return _is_live_decision(product)
+
+
 def _canonical_payload(entries: list[AgentRulesEntry]) -> str:
     """Canonical, formatting-independent serialization the digest hashes.
 

--- a/src/rac/services/resolve.py
+++ b/src/rac/services/resolve.py
@@ -27,8 +27,9 @@ from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Protocol
 
+from rac.core.corpus import walk_corpus
 from rac.core.models import SearchSection
-from rac.services.index import build_repository_index
+from rac.services.index import build_repository_index, index_from_corpus
 
 OUTCOME_RESOLVED = "resolved"
 OUTCOME_NOT_FOUND = "not-found"
@@ -325,6 +326,53 @@ def find_artifacts(
     """
     entries = build_repository_index(directory, recursive=recursive).artifacts
     return search_index(entries, query, artifact_type=artifact_type)
+
+
+# --- Live decision query (v0.21.16, ADR-067) ---------------------------------
+#
+# The deterministic "what did we decide about X / is X ruled out" retrieval. The
+# engine asserts *which live decisions bind a topic* — structural search filtered
+# to decisions, then to the live ones — and stops there. It never asserts that a
+# change is *wrong*: semantic contradiction stays in the consuming agent, which
+# reads the engine-supplied decisions and judges (ADR-067). No scoring enters the
+# engine; ranking is the same explainable tiered ladder `rac find` already uses.
+
+# Decisions are the artifact type the query answers over. The same constant the
+# agent-rules projection scopes to, named locally so the dependency reads cleanly.
+_DECISION_TYPE = "decision"
+
+
+def find_decisions(directory: str, topic: str, recursive: bool = True) -> SearchResult:
+    """Search *live* decisions under ``directory`` for ``topic`` (ADR-067).
+
+    Two deterministic filters compose over the existing tiered search: the type
+    filter restricts to decisions, and a liveness filter — the same Accepted,
+    non-retired predicate the agent-rules projection uses (one source of truth,
+    never duplicated) — drops superseded/deprecated decisions even when their
+    text matches the topic. Ranking is the explainable id/title/path/heading/body
+    ladder (ADR-037/ADR-038); an empty result is a valid answer (a query always
+    succeeds), not an error.
+
+    This is structural retrieval, not a verdict: it returns the decisions that
+    bind the topic and lets the agent judge contradiction (ADR-067). No semantic
+    score is computed here or anywhere downstream.
+    """
+    # Reuse the liveness predicate from the agent-rules projection rather than
+    # re-deriving "Accepted and not retired" — the definition must not fork
+    # (the same rule the committed rules block is built from).
+    from rac.services.agent_rules import is_live_decision
+
+    entries = list(walk_corpus(directory, recursive=recursive))
+    live_paths = {
+        str(entry.path)
+        for entry in entries
+        if entry.artifact_type == _DECISION_TYPE and is_live_decision(entry.product)
+    }
+    index = index_from_corpus(directory, entries, recursive=recursive).artifacts
+    result = search_index(index, topic, artifact_type=_DECISION_TYPE)
+    # Drop matches that are decisions but not live; ranking/order is preserved.
+    result.matches = [m for m in result.matches if m.path in live_paths]
+    return result
 
 
 def search_index(

--- a/tests/test_find_decisions.py
+++ b/tests/test_find_decisions.py
@@ -1,0 +1,248 @@
+"""Live decision query — `find_decisions` / `rac find --decisions` (v0.21.16).
+
+ADR-067 fixes the boundary these tests pin: the engine retrieves *which live
+decisions bind a topic* — structural search restricted to decisions, then to the
+Accepted, non-retired ones — and asserts nothing about whether a change is wrong
+(no semantic verdict, no score). A retired decision (Superseded/Deprecated) is
+excluded even when its text matches; a non-decision is excluded; a topic with no
+match is a valid empty answer (exit 0), not an error. Ranking is the existing
+tiered ladder, and the `--json` shape is the stable `SearchResult` contract
+(ADR-007), so it stays byte-deterministic across runs.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from rac.cli import main
+from rac.services.resolve import find_decisions
+
+# An Accepted decision about caching — the live, matchable target.
+LIVE_CACHE = """---
+schema_version: 1
+id: RAC-CACHE0000001
+type: decision
+---
+# Cache invalidation strategy
+
+## Context
+
+We need a caching policy for the read path.
+
+## Decision
+
+Use a write-through cache keyed by artifact id.
+
+## Consequences
+
+Reads stay fresh; writes pay a small cost.
+
+## Status
+
+Accepted
+"""
+
+# A Superseded decision that *also* mentions caching: it must be excluded from
+# the live query even though it matches the topic on every text tier.
+RETIRED_CACHE = """---
+schema_version: 1
+id: RAC-RETRD0000001
+type: decision
+---
+# Old cache approach
+
+## Context
+
+An earlier cache design we have since replaced.
+
+## Decision
+
+Cache everything in memory forever.
+
+## Consequences
+
+It leaked; we moved on.
+
+## Status
+
+Superseded
+"""
+
+# A Deprecated decision mentioning caching — the second retired state, proving
+# the filter is spec-driven (not a single hard-coded status).
+DEPRECATED_CACHE = """---
+schema_version: 1
+id: RAC-DPRCT0000001
+type: decision
+---
+# Deprecated cache note
+
+## Context
+
+A cache convenience helper, now deprecated.
+
+## Decision
+
+Stop using the cache helper.
+
+## Consequences
+
+Removed in a later release.
+
+## Status
+
+Deprecated
+"""
+
+# A requirement that mentions caching — a non-decision, excluded by the type
+# filter regardless of how well it matches.
+CACHE_REQUIREMENT = """---
+schema_version: 1
+id: RAC-CACHEREQ0001
+type: requirement
+---
+# Caching requirement
+
+## Description
+
+The system shall cache reads.
+
+## Rationale
+
+Performance.
+
+## Acceptance Criteria
+
+- Reads are cached.
+"""
+
+
+@pytest.fixture
+def repo(tmp_path):
+    d = tmp_path / "rac"
+    (d / "decisions").mkdir(parents=True)
+    (d / "requirements").mkdir(parents=True)
+    (d / "decisions" / "live-cache.md").write_text(LIVE_CACHE, encoding="utf-8")
+    (d / "decisions" / "retired-cache.md").write_text(RETIRED_CACHE, encoding="utf-8")
+    (d / "decisions" / "deprecated-cache.md").write_text(DEPRECATED_CACHE, encoding="utf-8")
+    (d / "requirements" / "cache-req.md").write_text(CACHE_REQUIREMENT, encoding="utf-8")
+    return d
+
+
+# --- service: structural retrieval + live filter -----------------------------
+
+
+def test_live_decision_matching_topic_is_returned(repo):
+    result = find_decisions(str(repo), "cache")
+    ids = [m.id for m in result.matches]
+    assert "RAC-CACHE0000001" in ids
+
+
+def test_retired_decisions_are_excluded(repo):
+    # Superseded and Deprecated both match the topic but must not appear: the
+    # query returns *settled, live* decisions only (ADR-067).
+    result = find_decisions(str(repo), "cache")
+    ids = {m.id for m in result.matches}
+    assert "RAC-RETRD0000001" not in ids
+    assert "RAC-DPRCT0000001" not in ids
+
+
+def test_non_decisions_are_excluded(repo):
+    # The requirement matches "cache" but is not a decision.
+    result = find_decisions(str(repo), "cache")
+    assert all(m.type == "decision" for m in result.matches)
+    assert "RAC-CACHEREQ0001" not in {m.id for m in result.matches}
+
+
+def test_only_the_live_decision_remains(repo):
+    result = find_decisions(str(repo), "cache")
+    assert [m.id for m in result.matches] == ["RAC-CACHE0000001"]
+
+
+def test_topic_with_no_match_is_empty_not_an_error(repo):
+    result = find_decisions(str(repo), "telemetry")
+    assert result.matches == []
+    assert result.match_count == 0
+
+
+def test_ranking_is_deterministic(repo, tmp_path):
+    # A second live decision whose *title* matches ranks above a body-only match,
+    # and equal-tier ties break by sorted path — the existing tiered ladder.
+    second = """---
+schema_version: 1
+id: RAC-CACHE0000002
+type: decision
+---
+# Cache topic title hit
+
+## Context
+
+Body only mentions something else.
+
+## Decision
+
+A cache title decision.
+
+## Consequences
+
+None.
+
+## Status
+
+Accepted
+"""
+    (repo / "decisions" / "aaa-title-cache.md").write_text(second, encoding="utf-8")
+    first = find_decisions(str(repo), "cache").matches
+    again = find_decisions(str(repo), "cache").matches
+    assert [m.id for m in first] == [m.id for m in again]  # deterministic
+    # The title hit (RAC-CACHE0000002) outranks the body hit (RAC-CACHE0000001).
+    assert [m.id for m in first] == ["RAC-CACHE0000002", "RAC-CACHE0000001"]
+
+
+# --- CLI face: `rac find <topic> --decisions [--json]` ------------------------
+
+
+def test_cli_decisions_flag_exits_zero_on_match(repo, capsys):
+    code = main(["find", "cache", str(repo), "--decisions"])
+    assert code == 0
+    out = capsys.readouterr().out
+    assert "RAC-CACHE0000001" in out
+    assert "RAC-RETRD0000001" not in out
+
+
+def test_cli_decisions_flag_exits_zero_on_no_match(repo, capsys):
+    # Finding nothing is a valid query outcome, not a failure.
+    code = main(["find", "telemetry", str(repo), "--decisions"])
+    assert code == 0
+
+
+def test_cli_decisions_json_shape_is_stable(repo, capsys):
+    code = main(["find", "cache", str(repo), "--decisions", "--json"])
+    assert code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["schema_version"] == "1"
+    assert payload["query"] == "cache"
+    assert payload["type"] == "decision"
+    assert payload["match_count"] == 1
+    match = payload["matches"][0]
+    assert match["id"] == "RAC-CACHE0000001"
+    assert match["type"] == "decision"
+    assert match["path"].endswith("decisions/live-cache.md")
+
+
+def test_cli_decisions_json_is_byte_deterministic(repo, capsys):
+    main(["find", "cache", str(repo), "--decisions", "--json"])
+    first = capsys.readouterr().out
+    main(["find", "cache", str(repo), "--decisions", "--json"])
+    second = capsys.readouterr().out
+    assert first == second
+
+
+def test_cli_decisions_and_type_are_mutually_exclusive(repo):
+    # --decisions implies the decision type + live filter; pairing it with
+    # --type is a usage error argparse rejects.
+    with pytest.raises(SystemExit) as exc:
+        main(["find", "cache", str(repo), "--decisions", "--type", "requirement"])
+    assert exc.value.code != 0

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,11 +1,12 @@
 """Guide server wiring — factory, CLI registration, exit codes (v0.10.0).
 
 Covers the construction and CLI surface of ``rac mcp``: that the factory builds
-a server with the four pinned tools and verbatim descriptions, that the
+a server with the pinned read tools and verbatim descriptions, that the
 subcommand is registered and defaults ``--root`` to the current directory, and
 that a bad ``--root`` exits with the usage code without ever starting the
 server. The tool *contracts* (output shapes, truncation, errors) live in
-``test_mcp_tools``.
+``test_mcp_tools``. v0.21.16 adds ``find_decisions`` — the live decision query
+(ADR-067) — to the surface.
 """
 
 from __future__ import annotations
@@ -22,8 +23,15 @@ from rac.mcp.server import build_server, run_server
 
 CORPUS = fixture_path("mcp", "corpus")
 
-# The exact four tool names the surface pins (ADR-030); order-independent.
-EXPECTED_TOOLS = {"get_artifact", "search_artifacts", "get_related", "get_summary"}
+# The exact tool names the surface pins (ADR-030); order-independent. The four
+# original read tools plus find_decisions (v0.21.16, ADR-067).
+EXPECTED_TOOLS = {
+    "get_artifact",
+    "search_artifacts",
+    "find_decisions",
+    "get_related",
+    "get_summary",
+}
 
 
 def _tools(root: str):
@@ -31,7 +39,7 @@ def _tools(root: str):
     return {t.name: t for t in asyncio.run(server.list_tools())}
 
 
-def test_factory_registers_exactly_the_four_tools():
+def test_factory_registers_exactly_the_pinned_tools():
     assert set(_tools(CORPUS)) == EXPECTED_TOOLS
 
 
@@ -44,6 +52,7 @@ def test_tool_descriptions_ship_verbatim():
     tools = _tools(CORPUS)
     assert tools["get_artifact"].description == mcp_server.DESC_GET_ARTIFACT
     assert tools["search_artifacts"].description == mcp_server.DESC_SEARCH_ARTIFACTS
+    assert tools["find_decisions"].description == mcp_server.DESC_FIND_DECISIONS
     assert tools["get_related"].description == mcp_server.DESC_GET_RELATED
     assert tools["get_summary"].description == mcp_server.DESC_GET_SUMMARY
 
@@ -55,6 +64,11 @@ def test_descriptions_name_the_trigger_moment():
     assert "Call this before designing or implementing" in mcp_server.DESC_SEARCH_ARTIFACTS
     assert "Call this after retrieving an artifact" in mcp_server.DESC_GET_RELATED
     assert "Call this once at the start of a session" in mcp_server.DESC_GET_SUMMARY
+    # find_decisions must fire on the "what did we decide / is X ruled out"
+    # prompts the roadmap names, and must not claim a verdict (ADR-067).
+    assert "what did we decide about X" in mcp_server.DESC_FIND_DECISIONS
+    assert "is X ruled out" in mcp_server.DESC_FIND_DECISIONS
+    assert "judge for yourself" in mcp_server.DESC_FIND_DECISIONS
 
 
 def test_cli_registers_the_mcp_subcommand():

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -28,7 +28,7 @@ from rac.mcp.budget import (
 from rac.mcp.server import build_server
 from rac.output import json as json_output
 from rac.services.portfolio import build_portfolio_summary
-from rac.services.resolve import find_artifacts, resolve_artifact
+from rac.services.resolve import find_artifacts, find_decisions, resolve_artifact
 
 CORPUS = fixture_path("mcp", "corpus")
 DUPLICATE = fixture_path("mcp", "duplicate")
@@ -168,6 +168,107 @@ def test_search_snippet_match_truncates_as_whole_item():
         assert set(m) <= {"id", "type", "title", "path", "section", "snippet"}
         if "snippet" in m or "section" in m:
             assert "section" in m and "snippet" in m
+
+
+# --- find_decisions (v0.21.16, ADR-067) --------------------------------------
+
+
+# A live and a retired decision sharing a topic token, so the live filter is the
+# only thing that can separate them — pins the boundary, not just the search.
+_LIVE_DECISION = """---
+schema_version: 1
+id: RAC-FD0000000001
+type: decision
+---
+# Vault encryption policy
+
+## Status
+
+Accepted
+
+## Context
+
+Secrets need encryption at rest.
+
+## Decision
+
+Encrypt the vault with envelope keys.
+
+## Consequences
+
+Reads decrypt on access.
+"""
+
+_RETIRED_DECISION = """---
+schema_version: 1
+id: RAC-FD0000000002
+type: decision
+---
+# Old vault approach
+
+## Status
+
+Superseded
+
+## Context
+
+An earlier vault design we replaced.
+
+## Decision
+
+Store the vault in plaintext.
+
+## Consequences
+
+Replaced.
+"""
+
+
+def _two_decision_corpus(tmp_path) -> str:
+    root = tmp_path / "rac"
+    (root / "decisions").mkdir(parents=True)
+    (root / "decisions" / "live.md").write_text(_LIVE_DECISION, encoding="utf-8")
+    (root / "decisions" / "old.md").write_text(_RETIRED_DECISION, encoding="utf-8")
+    return str(root)
+
+
+def test_find_decisions_shape_matches_search_contract():
+    # The payload is the search contract plus the additive live-filter marker
+    # (ADR-007): same keys search_artifacts returns, with type pinned to decision.
+    payload = call(CORPUS, "find_decisions", {"topic": "event"})
+    assert {"schema_version", "query", "type", "match_count", "matches"} <= set(payload)
+    assert payload["type"] == "decision"
+    assert payload["filter"] == "live-decisions"
+
+
+def test_find_decisions_returns_live_decision_for_topic():
+    # The fixture decision ("Use an Event Bus") is Accepted, so it is returned.
+    payload = call(CORPUS, "find_decisions", {"topic": "event"})
+    assert DEC in [m["id"] for m in payload["matches"]]
+
+
+def test_find_decisions_excludes_retired(tmp_path):
+    root = _two_decision_corpus(tmp_path)
+    payload = call(root, "find_decisions", {"topic": "vault"})
+    ids = [m["id"] for m in payload["matches"]]
+    assert "RAC-FD0000000001" in ids
+    assert "RAC-FD0000000002" not in ids  # Superseded — excluded
+
+
+def test_find_decisions_matches_service_one_source_of_truth(tmp_path):
+    # The tool serializes exactly what the find_decisions service returns, plus
+    # the additive filter marker — no second retrieval path (ADR-031).
+    root = _two_decision_corpus(tmp_path)
+    payload = call(root, "find_decisions", {"topic": "vault"})
+    service = find_decisions(root, "vault").to_dict()
+    assert {k: v for k, v in payload.items() if k != "filter"} == service
+
+
+def test_find_decisions_empty_topic_is_not_an_error():
+    payload = call(CORPUS, "find_decisions", {"topic": "no-such-token"})
+    assert payload["match_count"] == 0
+    assert payload["matches"] == []
+    assert "error" not in payload
 
 
 # --- get_related -------------------------------------------------------------

--- a/typescript/rac-sdk/src/client.ts
+++ b/typescript/rac-sdk/src/client.ts
@@ -96,6 +96,20 @@ export class RacClient {
     return this.json<FindResult>(args);
   }
 
+  /**
+   * `rac find <topic> [dir] --decisions --json` — the live decision query
+   * (ADR-067): ranked *live* (Accepted, non-retired) decisions binding a topic,
+   * the "what did we decide about X / is X ruled out" retrieval. Structural only
+   * — the engine returns which decisions bind, never a verdict. An empty result
+   * is a valid answer, not an error.
+   */
+  findDecisions(topic: string, dir?: string): Promise<FindResult> {
+    const args = ["find", topic];
+    if (dir !== undefined) args.push(dir);
+    args.push("--decisions", "--json");
+    return this.json<FindResult>(args);
+  }
+
   /** `rac relationships <dir> --validate --json` — resolve declared references. */
   validateRelationships(
     directory: string,

--- a/typescript/rac-sdk/test/client.test.ts
+++ b/typescript/rac-sdk/test/client.test.ts
@@ -134,6 +134,38 @@ describe("find", () => {
   });
 });
 
+describe("findDecisions", () => {
+  it("passes --decisions and parses the live decisions", async () => {
+    const { runner, calls } = fakeRunner({
+      stdout: JSON.stringify({
+        schema_version: "1",
+        query: "caching",
+        type: "decision",
+        match_count: 1,
+        matches: [{ id: "RAC-9", type: "decision", title: "Cache policy", path: "d.md" }],
+      }),
+    });
+    const result = await new RacClient({ runner }).findDecisions("caching", "rac");
+    expect(result.type).toBe("decision");
+    expect(result.matches[0].id).toBe("RAC-9");
+    expect(calls[0]).toEqual(["find", "caching", "rac", "--decisions", "--json"]);
+  });
+
+  it("omits the directory when not given", async () => {
+    const { runner, calls } = fakeRunner({
+      stdout: JSON.stringify({
+        schema_version: "1",
+        query: "x",
+        type: "decision",
+        match_count: 0,
+        matches: [],
+      }),
+    });
+    await new RacClient({ runner }).findDecisions("x");
+    expect(calls[0]).toEqual(["find", "x", "--decisions", "--json"]);
+  });
+});
+
 describe("validateRelationships", () => {
   it("parses relationship issues", async () => {
     const { runner, calls } = fakeRunner({

--- a/typescript/rac-vscode/package.json
+++ b/typescript/rac-vscode/package.json
@@ -56,6 +56,10 @@
       {
         "command": "rac.setupAgentIntegration",
         "title": "RAC: Set Up Agent Integration"
+      },
+      {
+        "command": "rac.findDecisions",
+        "title": "RAC: What did we decide about…?"
       }
     ],
     "walkthroughs": [

--- a/typescript/rac-vscode/src/extension.ts
+++ b/typescript/rac-vscode/src/extension.ts
@@ -35,6 +35,7 @@ import {
   type DirectoryValidation,
   type ExportArtifact,
   type FileValidation,
+  type FindMatch,
   type Issue,
   type RelationshipIssue,
   type RelationshipValidation,
@@ -84,6 +85,15 @@ export function activate(context: vscode.ExtensionContext): void {
       // diagnostic for it to avoid duplicates.
       workspaceDiagnostics.delete(doc.uri);
     }),
+    // Save-time structural backstop (v0.21.16, Initiative 2; ADR-067). A save is
+    // a save regardless of which agent wrote the change, so this catches a
+    // structural contradiction — a reference to a retired or missing decision —
+    // *as* the file is committed to disk, before the bad state solidifies. It is
+    // non-blocking (it warns; it never vetoes the save) and strictly structural
+    // (no semantic scoring): the engine computes the finding via `rac validate`.
+    vscode.workspace.onWillSaveTextDocument((e) => {
+      e.waitUntil(saveGate(e.document));
+    }),
     vscode.workspace.onDidSaveTextDocument((doc) => {
       void validateDocument(doc);
       scheduleRelationshipsFor(doc);
@@ -113,6 +123,8 @@ export function activate(context: vscode.ExtensionContext): void {
     vscode.commands.registerCommand("rac.setupAgentIntegration", () =>
       setupAgentIntegration(context),
     ),
+    vscode.commands.registerCommand("rac.findDecisions", findDecisionsCommand),
+    vscode.commands.registerCommand("rac.openArtifactFile", openArtifactFile),
     vscode.commands.registerCommand("rac.installRac", installRac),
     vscode.languages.registerHoverProvider(selector, { provideHover }),
     vscode.languages.registerDefinitionProvider(selector, { provideDefinition }),
@@ -205,6 +217,37 @@ async function validateDocument(doc: vscode.TextDocument): Promise<void> {
     }
     log("validation failed", err);
   }
+}
+
+// The save-time backstop (v0.21.16, Initiative 2; ADR-067). Runs the engine's
+// own structural validation on the buffer being saved (`rac validate -` via the
+// thin client — no logic here) and, if it finds a blocking structural issue,
+// informs the user as the save lands. It returns no edits, so it never blocks or
+// mutates the save: a save is a save, and the gate is a backstop, not a veto
+// (the diagnostics model already surfaces the same findings inline). Strictly
+// structural — there is no semantic scoring anywhere in this path.
+async function saveGate(doc: vscode.TextDocument): Promise<vscode.TextEdit[]> {
+  if (!isEnabled()) return [];
+  if (doc.languageId !== "markdown" || doc.uri.scheme !== "file") return [];
+  if (!looksLikeRacArtifact(doc.getText())) return [];
+  const folder = vscode.workspace.getWorkspaceFolder(doc.uri);
+  if (!folder) return [];
+
+  try {
+    const result = await clientFor(folder).validateText(doc.getText());
+    if (result.errors.length > 0) {
+      const first = result.errors[0];
+      void vscode.window.showWarningMessage(
+        `RAC: saved with ${result.errors.length} structural issue(s) — ${first.message}. ` +
+          "See the Problems panel.",
+      );
+    }
+  } catch (err) {
+    if (err instanceof RacNotFoundError) warnMissingOnce();
+    else log("save-gate validation failed", err);
+  }
+  // Always resolve with no edits — the save proceeds unmodified.
+  return [];
 }
 
 function toDiagnostics(result: FileValidation): vscode.Diagnostic[] {
@@ -674,6 +717,18 @@ async function provideCompletions(
   return items;
 }
 
+// Reference-validation codes a reference-site quick-fix acts on (v0.21.16,
+// Initiative 2). A retired-target reference is the headline structural
+// contradiction the save-gate surfaces; a not-found/ambiguous reference is a
+// broken link. Both anchor at the reference token, so the quick-fix can offer to
+// open the (resolvable) target or remove the offending reference line.
+const REFERENCE_FIX_CODES = new Set([
+  "relationship-target-superseded",
+  "relationship-target-not-found",
+  "relationship-target-ambiguous",
+  "relationship-target-type-mismatch",
+]);
+
 function provideCodeActions(
   doc: vscode.TextDocument,
   _range: vscode.Range,
@@ -682,6 +737,44 @@ function provideCodeActions(
   const actions: vscode.CodeAction[] = [];
   for (const diagnostic of context.diagnostics) {
     if (diagnostic.source !== "rac" || typeof diagnostic.code !== "string") continue;
+
+    // Reference-site quick-fix layered over the relationship diagnostics. The
+    // target token is the diagnostic range's text; offer to open it (when it
+    // resolves, e.g. a retired but still-present decision) and to remove the
+    // broken/retired reference line. Removal is the structural repair — no
+    // semantic rewrite (ADR-067).
+    if (REFERENCE_FIX_CODES.has(diagnostic.code)) {
+      const target = doc.getText(diagnostic.range).trim();
+
+      if (diagnostic.code === "relationship-target-superseded" && target) {
+        // The retired target still exists, so offer to open it for the human to
+        // pick a live replacement.
+        const open = new vscode.CodeAction(
+          `Open referenced decision (${target})`,
+          vscode.CodeActionKind.QuickFix,
+        );
+        open.diagnostics = [diagnostic];
+        open.command = {
+          command: "rac.openArtifactFile",
+          title: "Open referenced decision",
+          arguments: [doc.uri, target],
+        };
+        actions.push(open);
+      }
+
+      const remove = new vscode.CodeAction(
+        `Remove reference to ${target || "this artifact"}`,
+        vscode.CodeActionKind.QuickFix,
+      );
+      remove.diagnostics = [diagnostic];
+      const edit = new vscode.WorkspaceEdit();
+      // Delete the whole list line bearing the reference (a "- adr-007" item),
+      // newline included, so the section is left structurally clean.
+      edit.delete(doc.uri, fullLineRange(doc, diagnostic.range.start.line));
+      remove.edit = edit;
+      actions.push(remove);
+      continue;
+    }
 
     if (diagnostic.code === "missing-title") {
       // A title is a top-level `# ` heading, not a `## ` section — insert it
@@ -732,6 +825,17 @@ function titleInsertPosition(doc: vscode.TextDocument): vscode.Position {
 
 function endOfDocument(doc: vscode.TextDocument): vscode.Position {
   return doc.lineAt(doc.lineCount - 1).range.end;
+}
+
+// The full range of a line including its trailing newline, so deleting it leaves
+// no blank gap (used by the reference-removal quick-fix).
+function fullLineRange(doc: vscode.TextDocument, line: number): vscode.Range {
+  const start = new vscode.Position(line, 0);
+  const end =
+    line + 1 < doc.lineCount
+      ? new vscode.Position(line + 1, 0)
+      : doc.lineAt(line).range.end;
+  return new vscode.Range(start, end);
 }
 
 async function newArtifact(): Promise<void> {
@@ -1200,6 +1304,100 @@ async function setupWorkspace(): Promise<void> {
     log("setupWorkspace failed", err);
     void vscode.window.showErrorMessage(
       `RAC: setup failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+// --- live decision query (roadmap v0.21.16, Initiative 1; ADR-067) ----------
+//
+// "RAC: What did we decide about…?" prompts for a topic and runs the engine's
+// `rac find <topic> --decisions` (the live decision query), showing the ranked
+// live decisions in a quick-pick. Selecting one opens its file. The extension
+// computes nothing (ADR-063): the engine retrieves which live decisions bind the
+// topic; the human reads them and judges. No verdict, no scoring.
+
+interface DecisionPick extends vscode.QuickPickItem {
+  match: FindMatch;
+}
+
+async function findDecisionsCommand(): Promise<void> {
+  const folder = vscode.workspace.workspaceFolders?.[0];
+  if (!folder) {
+    void vscode.window.showErrorMessage("RAC: open a workspace folder first.");
+    return;
+  }
+  const topic = await vscode.window.showInputBox({
+    prompt: "What did we decide about…?",
+    placeHolder: "Topic, e.g. caching, telemetry, identity",
+  });
+  if (!topic) return;
+
+  let matches: FindMatch[];
+  try {
+    const result = await clientFor(folder).findDecisions(topic, folder.uri.fsPath);
+    matches = result.matches;
+  } catch (err) {
+    if (err instanceof RacNotFoundError) {
+      warnMissingOnce();
+      return;
+    }
+    log("find-decisions failed", err);
+    void vscode.window.showErrorMessage(
+      `RAC: decision query failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return;
+  }
+
+  if (matches.length === 0) {
+    // An empty result is a valid answer, not an error — say so plainly.
+    void vscode.window.showInformationMessage(
+      `RAC: no live decision matches "${topic}".`,
+    );
+    return;
+  }
+
+  const picks: DecisionPick[] = matches.map((m) => ({
+    label: m.title || m.id,
+    description: m.id,
+    detail: m.snippet ? `${m.section ? `${m.section}: ` : ""}${m.snippet}` : m.path,
+    match: m,
+  }));
+  const chosen = await vscode.window.showQuickPick(picks, {
+    placeHolder: `Live decisions about "${topic}" — select one to open`,
+    matchOnDescription: true,
+    matchOnDetail: true,
+  });
+  if (!chosen) return;
+  await openArtifactPath(folder, chosen.match.path);
+}
+
+// Open an artifact file by its engine-reported path, confined to the workspace
+// folder. Shared by the decision quick-pick and the reference quick-fix.
+async function openArtifactPath(
+  folder: vscode.WorkspaceFolder,
+  artifactPath: string,
+): Promise<void> {
+  const uri = artifactUri(folder, artifactPath);
+  try {
+    const doc = await vscode.workspace.openTextDocument(uri);
+    await vscode.window.showTextDocument(doc);
+  } catch {
+    void vscode.window.showErrorMessage(`RAC: could not open ${artifactPath}.`);
+  }
+}
+
+// Command target for the reference-site "Open referenced decision" quick-fix:
+// resolve a reference token against the corpus and open the artifact it points
+// at. Resolution stays the engine's (ADR-063); the extension only navigates.
+async function openArtifactFile(docUri: vscode.Uri, token: string): Promise<void> {
+  const folder = vscode.workspace.getWorkspaceFolder(docUri);
+  if (!folder) return;
+  const result = await resolveToken(folder, token);
+  if (result && isResolved(result)) {
+    await openArtifactPath(folder, result.path);
+  } else {
+    void vscode.window.showInformationMessage(
+      `RAC: "${token}" does not resolve to an artifact.`,
     );
   }
 }


### PR DESCRIPTION
# Summary

Implements `rac/roadmaps/v0.21.x-editor/v0.21.16-decision-query-and-guard.md`.

With context supplied (v0.21.15), an agent can consult the corpus; this release
adds the live decision query — the "what did we decide about X?" surface — and an
honest post-edit guard, plus the CI rules-staleness gate. Per ADR-067 the engine
retrieves live decisions deterministically and the agent judges contradiction —
no semantic verdict ships in the engine.

Adds:
- `find_decisions` — ranked live (Accepted, non-retired) decisions for a topic —
  across the CLI (`rac find --decisions`), an MCP `lore` tool, and the SDK.
- A save-time structural backstop, a reference-site quick-fix, and a
  "What did we decide about…?" palette command.
- A dogfooded set of agent-rules files plus a CI `--agent-rules --check` gate so
  the generated projection cannot silently rot.

# Roadmap / ADR Trace

Roadmap:
- `rac/roadmaps/v0.21.x-editor/v0.21.16-decision-query-and-guard.md`

Relevant ADRs:
- `rac/decisions/adr-067-agent-integration-boundary.md` — structural retrieval,
  not a semantic verdict; the post-edit guard is structural; CI drift gate.
- `rac/decisions/adr-063-non-python-clients-are-thin.md` — the query is the
  engine's; the extension and SDK only shell it.
- `rac/decisions/adr-049-enforcement-is-the-product.md` — the rules-staleness gate.
- `rac/decisions/adr-030-*.md` — the MCP grounding the `find_decisions` tool joins.

# Scope

## Included
- `find_decisions(directory, topic)` in `src/rac/services/resolve.py`: search
  filtered to `type=decision` and restricted to live decisions (liveness reuses
  the v0.21.15 `is_live_decision` predicate — one source of truth), ranked by the
  existing tiered relevance.
- CLI: `rac find TOPIC rac/ --decisions [--json]` (`--decisions` is exclusive with
  `--type` and implies decision-type + live filter); a query always exits `0`.
- MCP: a `find_decisions` `lore` tool over the same service, with a description
  engineered to fire on "what did we decide / is X ruled out / what's our policy".
- SDK `findDecisions(topic)`; an `onWillSaveTextDocument` structural save-gate; a
  reference-site quick-fix (open the referenced decision / remove a broken
  reference); a `RAC: What did we decide about…?` palette command.
- Dogfood: this repo's per-client managed blocks (`CLAUDE.md`, `AGENTS.md`,
  `.cursor/rules`, `.github/copilot-instructions.md`) generated from the corpus,
  and a CI `agent-rules` job running `rac export rac/ --agent-rules --check`.

## Excluded
- Semantic contradiction scoring (ADR-067) — retrieval only; the agent judges.
- Pre-edit interception of agent edits (no cross-platform API) — that is the
  Claude Code hook in v0.21.17; other clients use this post-edit guard.
- The save-gate hard-blocking a save — it warns on structural findings;
  enforcement at the merge gate stays the binding control.

# Product / Architecture Decisions

- `find_decisions` lives in `resolve.py` (reuses `SearchResult`, `search_index`,
  `index_from_corpus`) rather than a new module — cohesive with search.
- The MCP tool description is the discovery surface: it explicitly says it "tells
  you which decisions bind the topic; read them and judge for yourself — it does
  not decide whether a change contradicts them", keeping it on the structural side
  of the ADR-067 boundary.
- Liveness is the v0.21.15 predicate exposed as `is_live_decision`, so the query
  and the agent-rules projection agree on what "live" means.
- The repo dogfoods its own agent-rules files so the CI `--check` gate is real and
  green; `CLAUDE.md`'s existing router content and `@import` lines are preserved —
  only the managed block is appended.

# User-Facing Contract

## CLI
- `rac find TOPIC rac/ --decisions` — ranked live decisions for a topic.
- `rac find TOPIC rac/ --decisions --json` — the stable `SearchResult` JSON.

## MCP
- `find_decisions(topic)` `lore` tool → ranked live decisions
  (identifier, title, path, category, snippet) plus a `"filter": "live-decisions"`
  marker (additive).

## Human Output
Reuses the `rac find` renderers. Existing output unchanged.

## Exit Codes
- `rac find --decisions`: `0` always (a query with no matches is valid).
- The CI `agent-rules` job fails (`1`) when a committed managed block has drifted.

# Verification

## Ran
- `pytest tests/test_find_decisions.py tests/test_mcp_tools.py tests/test_resolve.py
  tests/test_ci_batteries.py tests/test_agent_rules.py` — 114 passed.
- Corpus gates on `rac/`: `validate`, `relationships --validate`, `review`,
  `gate`, and `export rac/ --agent-rules --check` — all exit `0`.
- `CLAUDE.md` original content verified byte-identical above the managed block
  (router prose + both `@import` lines intact).
- `rac find markdown rac/ --decisions` returns ranked live decisions; tests
  confirm retired decisions are excluded.
- TypeScript: SDK typecheck/build/vitest (22) pass; extension `tsc --noEmit` +
  esbuild compile clean.
- `ruff check` / `ruff format --check` clean; `mypy` clean on changed modules.

## Covered
- Query: live decisions ranked; retired and non-decisions excluded; empty topic →
  empty result, exit `0`; deterministic JSON.
- MCP tool: returns live decisions, excludes retired.
- Drift gate: `--agent-rules --check` exits `0` in sync (the CI job), `1` on drift
  (covered by v0.21.15's tests).

# Review Path

1. `src/rac/services/resolve.py` + `src/rac/services/agent_rules.py` —
   `find_decisions` and the shared `is_live_decision`.
2. `src/rac/cli.py` — the `--decisions` flag.
3. `src/rac/mcp/server.py` — the `find_decisions` tool and its description.
4. `tests/test_find_decisions.py`, `tests/test_mcp_tools.py` — coverage.
5. `typescript/` — SDK `findDecisions`, save-gate, quick-fix, palette command.
6. `CLAUDE.md`/`AGENTS.md`/`.cursor/rules`/`.github/copilot-instructions.md` +
   `.github/workflows/pr-checks.yml` — the dogfood and CI gate.

Plus `rac/roadmaps/.../v0.21.15-...md` flipped to Achieved (ADR-061).

# Notes For Reviewer

- Stacked on `claude/v0.21.15-agent-context` (base); the diff shows only v0.21.16
  and retargets to `main` once v0.21.15 merges.
- The dogfooded managed blocks list every live Accepted decision (one pointer
  each); they regenerate deterministically, and the CI `agent-rules` job keeps
  them honest. Editing a decision in `rac/` without regenerating will now fail CI
  — by design.
- TypeScript verified by typecheck/esbuild/vitest; the save-gate, code-action, and
  quick-pick UX need a live VS Code (the `@vscode/test-electron` suite can't fetch
  VS Code offline here).

# Implementation Process

Implemented with AI assistance under the roadmap contract; final scope, review,
and acceptance decisions were made by the maintainer.