### PR TITLE
refactor(gate): single-walk gate & performance guards (v0.21.19)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,7 +88,7 @@ jobs:
           - name: portfolio
             paths: "tests/test_portfolio.py"
           - name: repository
-            paths: "tests/test_repository.py tests/test_repository_perf.py"
+            paths: "tests/test_repository.py tests/test_repository_perf.py tests/test_gate_perf.py"
           - name: explorer
             paths: "tests/test_explorer_adapter.py tests/test_explorer_app.py tests/test_explorer_cli.py tests/test_explorer_commands.py tests/test_explorer_editor.py tests/test_explorer_isolation.py tests/test_explorer_workspace.py"
           - name: mcp

--- a/rac/roadmaps/v0.21.x-editor/v0.21.18-safe-rename-refactor.md
+++ b/rac/roadmaps/v0.21.x-editor/v0.21.18-safe-rename-refactor.md
@@ -8,7 +8,7 @@ tags: [sdk, typescript, editor, authoring]
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/rac/roadmaps/v0.21.x-editor/v0.21.19-gate-performance.md
+++ b/rac/roadmaps/v0.21.x-editor/v0.21.19-gate-performance.md
@@ -1,0 +1,122 @@
+---
+schema_version: 1
+id: RAC-KV94BWWGJTV6
+type: roadmap
+tags: [performance, gate, enforcement, tooling]
+---
+# RAC v0.21.19 — Gate Single-Walk & Performance Guards
+
+## Status
+
+Planned
+
+## Context
+
+`rac gate` is the single PR enforcement entry point (v0.21.14): it composes
+validation, relationship integrity, and review into one report, one exit code,
+one SARIF document. Today each of those three services independently walks and
+re-parses the whole corpus, so the gate pays for three full corpus walks. On the
+real 248-file corpus this measures ~2.77s — roughly 3× the ~0.93s cost of a
+single walk. The engine already exposes snapshot ("from_corpus") entry points
+built for exactly this: walk once, feed several analyses from one snapshot (the
+repository model already consumes them this way). The pre-edit hook path
+(`validate_stdin_against_corpus`, v0.21.17) is a per-edit hot path that walks the
+whole corpus per edit and scales linearly, so it is worth a standing guard too.
+This release collapses the gate to a single walk and adds perf guards, with no
+observable behaviour change (ADR-023: a clean-break internal refactor; ADR-002:
+the same corpus state yields a byte-identical report).
+
+## Outcomes
+
+- `rac gate` walks the corpus once instead of three times, cutting gate latency
+  on a real corpus toward the single-walk floor.
+- The gate's JSON, SARIF, and human renderings stay byte-identical — the
+  optimization is invisible to every consumer (ADR-007).
+- Pathological slowdowns in `rac gate` and the pre-edit hook are caught by
+  standing perf-guard tests before they reach a release.
+
+## Initiatives
+
+### Initiative 1 — Single-walk gate
+
+Refactor `build_gate` to walk the corpus once (`walk_corpus`) and feed the one
+snapshot to the validation, relationship, and review/portfolio snapshot entry
+points (`*_from_corpus`), preserving every default, severity override (ADR-053),
+finding normalization, and deterministic sort exactly.
+
+### Initiative 2 — Performance guards
+
+Add session-scoped synthetic-corpus perf guards for `rac gate` and the pre-edit
+hook, mirroring the existing repository-perf test style: generous wall-clock
+ceilings that catch pathological regressions, not micro-benchmarks, plus an
+output-equivalence assertion so a future change cannot silently alter gate
+semantics while "optimizing".
+
+## Constraints
+
+- No observable behaviour change: the gate report, JSON, SARIF, and human output
+  must be byte-identical to the multi-walk implementation (ADR-007).
+- Deterministic and offline (ADR-002): the same corpus state yields the same
+  report, including finding order and counts.
+- Clean-break internal refactor (ADR-023): only corpus acquisition changes, from
+  three walks to one; classification and enforcement logic are untouched.
+- Severity overrides (ADR-053) and all defaults are loaded once and applied
+  identically.
+
+## Non-Goals
+
+- Changing any finding code, severity, enforcement default, or sort order.
+- Incremental or cached corpus walks across invocations.
+- Optimizing the standalone `rac validate` / `rac relationships` / `rac review`
+  commands (each still walks once on its own).
+- A benchmarking harness or published performance numbers.
+
+## Implementation Contract
+
+- `build_gate(directory, recursive=True, policy=None)` walks the corpus once and
+  feeds the snapshot to `validate_corpus`, `validation_from_corpus`, and the
+  review-from-portfolio (`portfolio_from_corpus` + `review_from_portfolio`)
+  paths; the signature is unchanged.
+- `build_gate`'s `to_dict()`, SARIF, and human output are byte-identical to the
+  previous implementation for the same corpus, including finding order and
+  `ok`/counts.
+- New perf guards in `tests/test_gate_perf.py`: a scale guard for `build_gate`,
+  an output-equivalence guard, and a scale guard for
+  `validate_stdin_against_corpus`, each with a generous ceiling.
+- `tests/test_gate_perf.py` is registered in the CI battery topology
+  (ADR-027) and the existing gate contract tests pass unchanged.
+
+## Success Measures
+
+- `rac gate rac/` produces byte-identical JSON before and after the refactor.
+- The existing `tests/test_gate.py` contract suite passes unchanged.
+- Gate latency on the 248-file corpus drops measurably toward the single-walk
+  floor (~3 walks → ~1).
+- The perf guards pass well within their ceilings and fail loudly on a
+  pathological regression.
+
+## Assumptions
+
+- Every analysis the gate needs has a snapshot (`*_from_corpus`) entry point that
+  yields the identical result to its directory counterpart.
+- Severity overrides are repository-wide and can be loaded once from the
+  directory, as the directory entry points already do.
+
+## Risks
+
+- An incomplete snapshot path could drift from the directory entry point.
+  Mitigated by the output-equivalence guard and the unchanged contract suite.
+- A future "optimization" could silently change gate semantics. Mitigated by the
+  equivalence assertion comparing single-walk output to the component-assembled
+  result.
+
+## Related Decisions
+
+- adr-002
+- adr-023
+- adr-007
+
+## Related Roadmaps
+
+- v0.21.14-security-governance-posture
+- v0.21.17-claude-code-pre-edit-hook

--- a/src/rac/services/gate.py
+++ b/src/rac/services/gate.py
@@ -24,18 +24,20 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
-from rac.services.init import load_enforcement_policy
+from rac.core.corpus import walk_corpus
+from rac.services.init import load_enforcement_policy, load_overrides
+from rac.services.portfolio import portfolio_from_corpus
 from rac.services.relationships import (
     RELATIONSHIP_SEVERITY,
     RelationshipIssue,
-    validate_relationships,
+    validation_from_corpus,
 )
 from rac.services.review import (
     PRIORITY_BROKEN_RELATIONSHIP,
     ReviewIssue,
-    build_review,
+    review_from_portfolio,
 )
-from rac.services.validate import DirectoryValidation, validate_directory
+from rac.services.validate import DirectoryValidation, validate_corpus
 
 # The two enforcement classes a finding can carry, plus the suppressed marker
 # (``off`` drops the finding entirely). Sources name where a finding originated.
@@ -221,13 +223,27 @@ def build_gate(
     applied — findings the policy turns ``off`` are dropped. Findings are sorted
     deterministically by ``(path, line, source, code, message)`` so the report,
     JSON, and SARIF are byte-stable (ADR-002).
+
+    Single corpus walk (v0.21.19): the three analyses share one pre-walked corpus
+    snapshot via the engine's ``*_from_corpus`` snapshot seams instead of each
+    re-walking and re-parsing the tree, so the gate pays one walk, not three. The
+    result is byte-identical to the prior multi-walk composition — only corpus
+    acquisition changed (ADR-023). Severity overrides (ADR-053) are loaded once
+    from the directory and applied identically by every snapshot path.
     """
     if policy is None:
         policy = load_enforcement_policy(directory)
 
-    validation = validate_directory(directory, recursive=recursive)
-    relationships = validate_relationships(directory, recursive=recursive)
-    review = build_review(directory, recursive=recursive)
+    # One walk feeds every analysis (v0.21.19). The snapshot seams produce results
+    # identical to their directory entry points (validate_directory /
+    # validate_relationships / build_review), which themselves walk once each.
+    entries = list(walk_corpus(directory, recursive=recursive))
+    overrides = load_overrides(directory)
+
+    validation = validate_corpus(directory, entries, recursive=recursive, overrides=overrides)
+    relationships = validation_from_corpus(directory, entries, recursive=recursive)
+    portfolio = portfolio_from_corpus(directory, entries, recursive=recursive)
+    review = review_from_portfolio(directory, portfolio, recursive=recursive)
 
     findings: list[GateFinding] = []
 

--- a/tests/test_gate_perf.py
+++ b/tests/test_gate_perf.py
@@ -1,0 +1,218 @@
+"""`rac gate` and the pre-edit hook at scale — the single-walk perf guards (v0.21.19).
+
+`build_gate` (v0.21.14) composes validation, relationships, and review. Until
+v0.21.19 each of those re-walked and re-parsed the whole corpus, so the gate paid
+three corpus walks; v0.21.19 collapses it to one walk fed to the snapshot
+(``*_from_corpus``) seams, with byte-identical output (ADR-023 / ADR-007).
+
+These tests guard two things:
+
+1. **Output equivalence** — the single-walk gate result equals the report
+   assembled the old way from the three separate directory services, so a future
+   "optimization" cannot silently change gate semantics.
+2. **Pathological-slowdown ceilings** — ``build_gate`` and the per-edit hot path
+   ``validate_stdin_against_corpus`` (v0.21.17) complete within a generous
+   wall-clock ceiling on a 1000+ artifact corpus. The ceilings are deliberately
+   loose: CI runners are noisy and the goal is catching a regression that
+   reintroduces redundant walks, not benchmarking. They mirror the
+   repository-perf budget (~60s for 1200 artifacts) — a single gate walk does
+   strictly less work than the repository model, so the same order-of-magnitude
+   ceiling is generous here.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from rac.core.markdown import parse
+from rac.services.gate import build_gate
+from rac.services.relationships import validate_relationships
+from rac.services.review import build_review
+from rac.services.validate import validate_directory, validate_stdin_against_corpus
+
+DECISIONS = 600
+REQUIREMENTS = 600
+BROKEN_REFS = 10
+TOTAL = DECISIONS + REQUIREMENTS
+
+# Generous wall-clock ceilings (seconds). These catch a pathological regression
+# (e.g. a reintroduced redundant corpus walk), not micro-benchmark drift; CI
+# runners are noisy, so they are a small multiple of the observed cost and mirror
+# the repository-perf 60s-for-1200-artifacts philosophy.
+GATE_CEILING_SECONDS = 60
+HOOK_CEILING_SECONDS = 30
+
+
+def _decision(i: int) -> str:
+    return (
+        f"# ADR-{i:04d} Decision {i}\n\n"
+        "## Status\n\nAccepted\n\n"
+        "## Context\n\nGenerated corpus entry.\n\n"
+        "## Decision\n\nUse the generated approach.\n\n"
+        "## Consequences\n\nNone — synthetic fixture.\n"
+    )
+
+
+def _requirement(i: int, reference: str) -> str:
+    return (
+        f"# Feature {i}\n\n"
+        "## Problem\n\nGenerated corpus entry.\n\n"
+        "## Requirements\n\n"
+        f"[REQ-{i:04d}] The system shall handle case {i}.\n\n"
+        "## Related Decisions\n\n"
+        f"- {reference}\n"
+    )
+
+
+@pytest.fixture(scope="session")
+def large_corpus(tmp_path_factory) -> str:
+    """A 1200-artifact synthetic corpus with some clean links and a few broken refs.
+
+    Mirrors the generator in ``tests/test_repository_perf.py`` so the gate is
+    exercised over a corpus that carries findings (broken relationships) as well
+    as clean structure.
+    """
+    root = tmp_path_factory.mktemp("gate_large_corpus")
+    for i in range(DECISIONS):
+        (root / f"adr-{i:04d}.md").write_text(_decision(i), encoding="utf-8")
+    for i in range(REQUIREMENTS):
+        if i >= REQUIREMENTS - BROKEN_REFS:
+            reference = f"ADR-MISSING-{i:04d}"
+        else:
+            reference = f"ADR-{i % DECISIONS:04d}"
+        (root / f"req-{i:04d}.md").write_text(_requirement(i, reference), encoding="utf-8")
+    return str(root)
+
+
+def test_gate_scale(large_corpus):
+    """``build_gate`` over a 1200-artifact corpus completes within a generous ceiling.
+
+    Generous ceiling: catch pathological slowdowns only (a reintroduced redundant
+    walk), not benchmark drift.
+    """
+    started = time.monotonic()
+    report = build_gate(large_corpus)
+    elapsed = time.monotonic() - started
+
+    # Well-formed: the broken references are blocking relationship findings, so the
+    # gate fails and surfaces them.
+    assert report.directory == large_corpus
+    assert report.recursive is True
+    assert not report.ok
+    assert len(report.blocking) >= BROKEN_REFS
+    payload = report.to_dict()
+    assert payload["ok"] is False
+    assert payload["blocking_count"] == len(report.blocking)
+    assert payload["advisory_count"] == len(report.advisory)
+
+    assert elapsed < GATE_CEILING_SECONDS
+
+
+def test_gate_single_walk_no_slower_than_components(large_corpus):
+    """The single-walk gate result equals the report assembled the old way.
+
+    Builds the "expected" finding set by running the three separate directory
+    services (``validate_directory`` + ``validate_relationships`` + ``build_review``)
+    and mapping them through the gate's own normalization, exactly as the
+    pre-v0.21.19 multi-walk ``build_gate`` did. The single-walk ``build_gate`` must
+    produce a byte-identical ``to_dict()``. The key intent is OUTPUT EQUIVALENCE:
+    a future change cannot silently alter gate semantics while "optimizing" the
+    corpus walk away.
+    """
+    from rac.services.gate import (
+        _VALIDATE_DEFAULT,
+        EMPTY_POLICY,
+        ENFORCEMENT_ADVISORY,
+        ENFORCEMENT_BLOCKING,
+        PRIORITY_BROKEN_RELATIONSHIP,
+        SOURCE_RELATIONSHIPS,
+        SOURCE_REVIEW,
+        SOURCE_VALIDATE,
+        GateFinding,
+        GateReport,
+        _relationship_finding,
+        _review_finding,
+        _validate_findings,
+    )
+
+    # Recompose the report the multi-walk way, with no policy (the synthetic
+    # corpus declares no .rac/config.yaml, so EMPTY_POLICY matches build_gate).
+    validation = validate_directory(large_corpus)
+    relationships = validate_relationships(large_corpus)
+    review = build_review(large_corpus)
+
+    findings: list[GateFinding] = []
+
+    def add(source, code, severity, path, line, message, default):
+        enforcement = EMPTY_POLICY.classify(code, default)
+        if enforcement is None:
+            return
+        findings.append(
+            GateFinding(
+                source=source,
+                code=code,
+                severity=severity,
+                enforcement=enforcement,
+                path=path,
+                line=line,
+                message=message,
+            )
+        )
+
+    for code, severity, path, line, message in _validate_findings(validation):
+        add(
+            SOURCE_VALIDATE,
+            code,
+            severity,
+            path,
+            line,
+            message,
+            _VALIDATE_DEFAULT.get(severity, ENFORCEMENT_ADVISORY),
+        )
+    for rel_issue in relationships.issues:
+        code, severity, path, line, message = _relationship_finding(rel_issue)
+        add(SOURCE_RELATIONSHIPS, code, severity, path, line, message, ENFORCEMENT_BLOCKING)
+    for review_issue in review.issues:
+        code, severity, path, line, message = _review_finding(review_issue)
+        default = (
+            ENFORCEMENT_BLOCKING
+            if review_issue.priority <= PRIORITY_BROKEN_RELATIONSHIP
+            else ENFORCEMENT_ADVISORY
+        )
+        add(SOURCE_REVIEW, code, severity, path, line, message, default)
+
+    findings.sort(key=lambda f: (f.path, f.line or 0, f.source, f.code, f.message))
+    expected = GateReport(directory=large_corpus, recursive=True, findings=findings)
+
+    actual = build_gate(large_corpus)
+
+    # OUTPUT EQUIVALENCE — the single walk reproduced the multi-walk result exactly.
+    assert actual.to_dict() == expected.to_dict()
+    # And determinism: re-running yields the identical report (ADR-002).
+    assert build_gate(large_corpus).to_dict() == actual.to_dict()
+
+
+def test_preedit_hook_scale(large_corpus):
+    """``validate_stdin_against_corpus`` (the per-edit hot path) stays within budget.
+
+    The pre-edit hook (v0.21.17) walks the whole corpus per edit; on a
+    1200-artifact corpus a single hook invocation must complete within a generous
+    ceiling. A representative proposed document references an existing decision so
+    the resolution path is exercised end to end.
+    """
+    proposed = parse(_requirement(9999, "ADR-0001"), source_path="-")
+
+    started = time.monotonic()
+    result = validate_stdin_against_corpus(proposed, large_corpus, source_path="-")
+    elapsed = time.monotonic() - started
+
+    # Well-formed: the proposed document's reference resolves against the live
+    # corpus, so the hot path that matters here (cross-artifact resolution)
+    # produces no relationship finding. Structural lint warnings on the synthetic
+    # fixture are not this guard's concern.
+    assert result.source_path == "-"
+    assert result.relationship_issues == []
+
+    assert elapsed < HOOK_CEILING_SECONDS


### PR DESCRIPTION
# Summary

Implements `rac/roadmaps/v0.21.x-editor/v0.21.19-gate-performance.md`.

A performance release prompted by re-benchmarking after the v0.21.14–v0.21.18
work: `rac gate` walked and re-parsed the whole corpus three times (validation +
relationships + review each independently), measured at ~3× the cost of one walk.
This collapses it to a single walk and adds scale guards for the two new hot
paths. No observable behavior changes (ADR-002, ADR-023).

Adds:
- `build_gate` walks the corpus once and feeds the snapshot to the existing
  `*_from_corpus` service seams — ~2.3× faster end-to-end, byte-identical output.
- Performance guards for `rac gate` and the per-edit pre-edit-hook path, plus an
  output-equivalence test.

# Roadmap / ADR Trace

Roadmap:
- `rac/roadmaps/v0.21.x-editor/v0.21.19-gate-performance.md`

Relevant ADRs:
- `rac/decisions/adr-002-offline-determinism.md` — determinism preserved; the same
  corpus yields byte-identical output before and after.
- `rac/decisions/adr-023-clean-break-internal-refactors.md` — an internal
  refactor with no behavior change.
- `rac/decisions/adr-007-additive-json-contract.md` — the gate JSON/SARIF contract
  is unchanged.

# Scope

## Included
- `src/rac/services/gate.py`: `build_gate` now calls `walk_corpus` once and feeds
  the entry list to `validate_corpus` (with overrides loaded once),
  `validation_from_corpus` (relationships), and `portfolio_from_corpus` +
  `review_from_portfolio`. The classification, normalization, and deterministic
  sort are untouched — only corpus acquisition changes.
- `tests/test_gate_perf.py`: a scale corpus with generous wall-clock ceilings for
  `build_gate` and `validate_stdin_against_corpus`, plus an output-equivalence
  test (single-walk gate `to_dict()` equals the three separate services through
  the same normalization) and a determinism re-run.

## Excluded
- Any change to gate semantics, output, exit codes, or the enforcement policy —
  the byte-identical guarantee is the whole point.
- Micro-optimization beyond the redundant walk; the ceilings catch pathological
  regressions, not benchmark deltas.
- New snapshot APIs — all the `*_from_corpus` seams already existed (built for the
  repository model); none needed adding.

# Product / Architecture Decisions

- The optimization is purely the corpus-acquisition path: walk once, reuse the
  snapshot. Severity overrides (ADR-053) are loaded once and passed to
  `validate_corpus`; the portfolio loads the same overrides internally, so
  behavior is identical. The old `build_gate` called `build_review` without
  `stale_after_days`, which `review_from_portfolio` reproduces exactly (no cadence
  finding).
- Correctness is pinned by an output-equivalence test, not just timing, so a
  future "optimization" can't silently alter what the gate reports.
- Perf ceilings follow `test_repository_perf.py`'s philosophy: a single gate walk
  does strictly less work than the repository model, so the same generous 60s/1200
  ceiling is safe; the hook guard is 30s for one per-edit walk at scale.

# User-Facing Contract

No change. `rac gate` (human / `--json` / `--sarif`), its exit codes, and the
enforcement policy are identical — only faster.

# Verification

## Ran
- `pytest tests/test_gate.py tests/test_gate_perf.py tests/test_portfolio.py
  tests/test_review.py tests/test_validate_corpus_stdin.py
  tests/test_repository_perf.py tests/test_ci_batteries.py` — 157 passed.
- **Byte-identical guarantee:** `rac gate rac/ --json` captured before and after
  the refactor — both 45,609 bytes, `diff` empty (exit 0). The output hash and
  byte count reproduce here.
- **Timing** (`rac gate rac/`, full process, 248-file corpus): before ~3.0s,
  after ~1.3s (~2.3× faster); the redundant walk/parse is eliminated.
- Corpus gates on `rac/`: `validate`, `relationships --validate`, `review`,
  `gate`, `export rac/ --agent-rules --check` — all exit `0`.
- `ruff check` / `ruff format --check` clean; `mypy` clean on `gate.py`.

## Covered
- Output equivalence: single-walk gate `to_dict()` equals the three-service
  composition; determinism on repeat.
- Scale guards: `build_gate` and `validate_stdin_against_corpus` under generous
  ceilings on a 1,200-artifact corpus.
- The existing `tests/test_gate.py` contract tests pass unchanged.

# Review Path

1. `src/rac/services/gate.py` — the single-walk `build_gate` (the only behavior-
   relevant diff; confirm the snapshot seams reproduce the directory services).
2. `tests/test_gate_perf.py` — equivalence + scale guards.
3. `rac/roadmaps/.../v0.21.19-gate-performance.md` — the contract.

Plus `rac/roadmaps/.../v0.21.18-...md` flipped to Achieved (ADR-061).

# Notes For Reviewer

- This stacks on `claude/v0.21.18-safe-rename` (base) and retargets to `main` as
  the series merges; it is #137, on top of the v0.21.14–v0.21.18 stack.
- The headline check is the empty `diff` between the pre- and post-refactor
  `rac gate rac/ --json` (both 45,609 bytes) — the refactor changes speed, not
  semantics.
- It also re-confirms the core engine was untouched: `test_repository_perf.py`
  (the existing core guard) still passes, and each individual command remains one
  corpus walk.

# Implementation Process

Implemented with AI assistance under the roadmap contract; final scope, review,
and acceptance decisions were made by the maintainer.