### PR TITLE
docs(decision): topology, naming & release decision (v0.22.0)

### DIFF
--- a/.cursor/rules
+++ b/.cursor/rules
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: 9d7bf182c3691dd2e94a159ad425800c2e7cede6dde8e56486e7f277bc168a28) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: b3f1ad9cb7d425608c113cea71b5e77c4497cbe4f85d73888f540fec03bc37fa) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -49,4 +49,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KV6KFBDZ4D23** — ADR-065: Artifact Content Is Untrusted Input; the Trust Boundary Is Human PR Review _(Architecture)_
 - **RAC-KV6KFCC8MHTM** — ADR-066: Grounding Eval Scoring Is Deterministic — No Embeddings, No LLM Judge _(Technical)_
 - **RAC-KV80WX94GY8A** — ADR-067: Agent Integration is Context-Supply and Post-Edit Enforcement, Not Pre-Edit Interception _(Architecture)_
+- **RAC-KVA44MVMDXXX** — ADR-068: Extension, SDK, and Brand Architecture _(Architecture)_
 <!-- END RAC MANAGED BLOCK -->

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: 9d7bf182c3691dd2e94a159ad425800c2e7cede6dde8e56486e7f277bc168a28) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: b3f1ad9cb7d425608c113cea71b5e77c4497cbe4f85d73888f540fec03bc37fa) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -49,4 +49,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KV6KFBDZ4D23** — ADR-065: Artifact Content Is Untrusted Input; the Trust Boundary Is Human PR Review _(Architecture)_
 - **RAC-KV6KFCC8MHTM** — ADR-066: Grounding Eval Scoring Is Deterministic — No Embeddings, No LLM Judge _(Technical)_
 - **RAC-KV80WX94GY8A** — ADR-067: Agent Integration is Context-Supply and Post-Edit Enforcement, Not Pre-Edit Interception _(Architecture)_
+- **RAC-KVA44MVMDXXX** — ADR-068: Extension, SDK, and Brand Architecture _(Architecture)_
 <!-- END RAC MANAGED BLOCK -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: 9d7bf182c3691dd2e94a159ad425800c2e7cede6dde8e56486e7f277bc168a28) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: b3f1ad9cb7d425608c113cea71b5e77c4497cbe4f85d73888f540fec03bc37fa) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -49,4 +49,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KV6KFBDZ4D23** — ADR-065: Artifact Content Is Untrusted Input; the Trust Boundary Is Human PR Review _(Architecture)_
 - **RAC-KV6KFCC8MHTM** — ADR-066: Grounding Eval Scoring Is Deterministic — No Embeddings, No LLM Judge _(Technical)_
 - **RAC-KV80WX94GY8A** — ADR-067: Agent Integration is Context-Supply and Post-Edit Enforcement, Not Pre-Edit Interception _(Architecture)_
+- **RAC-KVA44MVMDXXX** — ADR-068: Extension, SDK, and Brand Architecture _(Architecture)_
 <!-- END RAC MANAGED BLOCK -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,11 +19,11 @@ to the corpus artifact and they load through the imports below.
 
 ## Working corpus
 
-- Current series: `rac/roadmaps/v0.13.x-welcome/` (next up: v0.13.0)
-- Previous series: `rac/roadmaps/v0.12.x-watchkeeper/` (complete through v0.12.3)
+- Current series: `rac/roadmaps/v0.22.x-housekeeping/` (next up: v0.22.0)
+- Previous series: `rac/roadmaps/v0.21.x-editor/` (complete)
 - Decisions (ADRs): `rac/decisions/`
 
-<!-- BEGIN RAC MANAGED BLOCK (digest: 9d7bf182c3691dd2e94a159ad425800c2e7cede6dde8e56486e7f277bc168a28) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: b3f1ad9cb7d425608c113cea71b5e77c4497cbe4f85d73888f540fec03bc37fa) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -74,4 +74,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KV6KFBDZ4D23** — ADR-065: Artifact Content Is Untrusted Input; the Trust Boundary Is Human PR Review _(Architecture)_
 - **RAC-KV6KFCC8MHTM** — ADR-066: Grounding Eval Scoring Is Deterministic — No Embeddings, No LLM Judge _(Technical)_
 - **RAC-KV80WX94GY8A** — ADR-067: Agent Integration is Context-Supply and Post-Edit Enforcement, Not Pre-Edit Interception _(Architecture)_
+- **RAC-KVA44MVMDXXX** — ADR-068: Extension, SDK, and Brand Architecture _(Architecture)_
 <!-- END RAC MANAGED BLOCK -->

--- a/rac/decisions/adr-068-extension-sdk-and-brand-architecture.md
+++ b/rac/decisions/adr-068-extension-sdk-and-brand-architecture.md
@@ -74,7 +74,7 @@ ADR-039): PyPI `requirements-as-code`, CLI `rac`, import `rac`, server `lore`.
 | `rac-core` | The engine `src/rac/` (incl. the Python SDK surface, ADR-062), the dogfood corpus `rac/`, `examples/`, and the vendored viewer dir `rac-localview/` | The engine and its build-coupled internals. PyPI name stays `requirements-as-code` (ADR-036). |
 | `rac-localview` | The local Portal / graph viewer, vendored into the engine via a build script + drift-guard | Build-coupled internal of the engine; not separately installed while vendored. |
 | `rac-sdk-ts` | The TypeScript client `@rac/sdk`, published to npm as `@itsthelore/rac-sdk` | A typed client mirroring the engine contract (ADR-063). |
-| `lore-extensions` | The VS Code / Cursor extension — one VSIX to Marketplace + OpenVSX | A surface a user installs. |
+| `lore-vscode` | The VS Code extension — one VSIX to Marketplace + OpenVSX; runs in VS Code and, as a fork, Cursor | A surface a user installs (the first per-client repo). |
 | `lore-watchkeeper` | The Watchkeeper action (root `action.yml`) | A surface a team installs into CI. |
 | `lore-gatekeeper` | The gate action = `pr-gate-action` (`rac gate`); the older `validate-action` is folded in / deprecated by it (ADR-058 moves with the gate) | A surface a team installs into CI; the real enforcement gate (ADR-049). |
 | `decisiongrounding` | The reproducible benchmark (ADR-064, unchanged) | Established name; neither prefix. |
@@ -86,13 +86,31 @@ publish/vendor contract exists. Publishing `@rac/sdk` to npm decouples the
 extension from the current `file:../rac-sdk` path and is the foundation for
 per-client repositories.
 
+### Per-client integration repositories
+
+Each client integration is **its own `lore-<client>` repository**, consuming the
+published `@itsthelore/rac-sdk` — never engine internals (ADR-063). One repo per
+client is the model; a single `lore-extensions` container is rejected (it fights
+independent per-client cadence and ownership). Today there is exactly one:
+`lore-vscode`. Planned siblings — created when each is built, and **not part of
+this decision's scope or the v0.22.x series** — include:
+
+- **`lore-cursor`** — a Cursor-*native* integration (its rules and MCP surfaces).
+  Cursor can install the `lore-vscode` VSIX as a fork, but a dedicated repo gives
+  the richer native experience, so the two are separate from the start.
+- **`lore-codex`, `lore-claude`, `lore-jetbrains`, …** — one per agent or editor.
+
+The first repo is named for the editor (`lore-vscode`) because a VS Code
+extension's VSIX format is shared across VS Code and its forks; the rest are named
+for the agent or tool they integrate. The asymmetry is intentional.
+
 ### Release-management model
 
 Per-repo, tag-driven; consumers pin a major where they consume an action:
 
 - `rac-core` → PyPI on a version tag.
 - `rac-sdk-ts` → npm on `sdk-v*`.
-- `lore-extensions` → Marketplace + OpenVSX on `vscode-v*`.
+- `lore-vscode` → Marketplace + OpenVSX on `vscode-v*`.
 - `lore-watchkeeper` / `lore-gatekeeper` → `@v1` (consumers pin major).
 - `rac-localview` → vendored; no publish while it lives in `rac-core`.
 
@@ -107,7 +125,7 @@ supersession — most of ADR-064 holds:
    `pr-gate` / `rac gate` — the real gatekeeper. ADR-058 moves with the gate.
 2. **New surfaces.** The VS Code / Cursor extension and the TypeScript SDK,
    which post-date ADR-064, are added to the topology: the extension as
-   `lore-extensions`, the SDK as `rac-sdk-ts` published to npm.
+   `lore-vscode`, the SDK as `rac-sdk-ts` published to npm.
 3. **Viewer rename.** `lore-web` is renamed `rac-localview` **in-repo**
    (standalone extraction remains deferred per ADR-064).
 

--- a/rac/decisions/adr-068-extension-sdk-and-brand-architecture.md
+++ b/rac/decisions/adr-068-extension-sdk-and-brand-architecture.md
@@ -1,0 +1,218 @@
+---
+schema_version: 1
+id: RAC-KVA44MVMDXXX
+type: decision
+tags: [structure, org, distribution, branding]
+---
+# ADR-068: Extension, SDK, and Brand Architecture
+
+## Status
+
+Accepted
+
+## Category
+
+Architecture
+
+## Context
+
+ADR-064 settled the first repository topology for the `itsthelore`
+organisation: extract `decisiongrounding` and the GitHub Actions, keep the
+engine, its shipped resources, the dogfood corpus, and `examples/` in
+`itsthelore/requirements-as-code`, and defer `lore-web`. Since that decision
+was recorded the product has grown two surfaces that did not exist when ADR-064
+was written: a VS Code / Cursor **extension** (`typescript/rac-vscode`) and a
+TypeScript **client SDK** (`typescript/rac-sdk`, `@rac/sdk`), which the
+extension consumes today over a `file:../rac-sdk` path. The Actions story has
+also sharpened: there are now three composite actions — Watchkeeper (root
+`action.yml`), the older single-purpose `validate-action/`, and the real gate
+`pr-gate-action/` (`rac gate`) — not the two ADR-064 assumed.
+
+Naming has drifted with the growth. Some surfaces are branded **Lore** (the
+installable product), others are named after the **RAC** engine, with no stated
+rule for which prefix a new repository takes. Without a principle, every new
+repo re-litigates its own name.
+
+Several decisions fence this one and must not be contradicted:
+
+- **ADR-029** freezes the engine and its MCP server (`rac mcp`) into a *single*
+  package and release pipeline. No split of engine from server.
+- **ADR-036** and **ADR-039** freeze the shipped distribution names: PyPI
+  `requirements-as-code`, CLI `rac`, server identity `lore`. Repository renames
+  must not rename these.
+- **ADR-062** fixes the Python SDK's public surface as `rac.__all__`, shipped
+  inside the engine package — the Python SDK is not a separable artifact.
+- **ADR-058** governs the validation GitHub Action.
+- **ADR-049** — "enforcement is the product"; the gate is the headline surface.
+- **ADR-063** — non-Python clients are thin clients over the contract.
+
+This ADR settles the naming principle and the full target topology, including
+the surfaces that post-date ADR-064, and amends ADR-064 where the Actions and
+viewer picture has changed. The `repo-extraction-programme` roadmap and the
+`v0.22.x-housekeeping` series sequence the moves.
+
+## Decision
+
+### Naming principle
+
+A repository's prefix is decided by what it is to a user, not by who wrote it:
+
+- **`lore-*`** — anything a user or team **installs**: the branded product
+  surfaces (the editor extension, the CI actions). These are what someone adopts
+  when they "use Lore".
+- **`rac-*`** — the **engine** and its build-coupled internals: the package, the
+  vendored viewer, and the typed client that mirrors the engine contract.
+
+`decisiongrounding` keeps its established name (it is neither, and ADR-064 fixed
+it). The shipped names stay frozen regardless of repository name (ADR-036,
+ADR-039): PyPI `requirements-as-code`, CLI `rac`, import `rac`, server `lore`.
+
+### Target topology
+
+| Repository | Holds | Prefix rationale |
+| --- | --- | --- |
+| `rac-core` | The engine `src/rac/` (incl. the Python SDK surface, ADR-062), the dogfood corpus `rac/`, `examples/`, and the vendored viewer dir `rac-localview/` | The engine and its build-coupled internals. PyPI name stays `requirements-as-code` (ADR-036). |
+| `rac-localview` | The local Portal / graph viewer, vendored into the engine via a build script + drift-guard | Build-coupled internal of the engine; not separately installed while vendored. |
+| `rac-sdk-ts` | The TypeScript client `@rac/sdk`, published to npm as `@itsthelore/rac-sdk` | A typed client mirroring the engine contract (ADR-063). |
+| `lore-extensions` | The VS Code / Cursor extension — one VSIX to Marketplace + OpenVSX | A surface a user installs. |
+| `lore-watchkeeper` | The Watchkeeper action (root `action.yml`) | A surface a team installs into CI. |
+| `lore-gatekeeper` | The gate action = `pr-gate-action` (`rac gate`); the older `validate-action` is folded in / deprecated by it (ADR-058 moves with the gate) | A surface a team installs into CI; the real enforcement gate (ADR-049). |
+| `decisiongrounding` | The reproducible benchmark (ADR-064, unchanged) | Established name; neither prefix. |
+
+`rac-core` is the rename of the `requirements-as-code` GitHub repository.
+`rac-localview` is the `lore-web/` directory **renamed in-repo**; its
+standalone-repo *extraction* stays **deferred** (ADR-064) until a viewer
+publish/vendor contract exists. Publishing `@rac/sdk` to npm decouples the
+extension from the current `file:../rac-sdk` path and is the foundation for
+per-client repositories.
+
+### Release-management model
+
+Per-repo, tag-driven; consumers pin a major where they consume an action:
+
+- `rac-core` → PyPI on a version tag.
+- `rac-sdk-ts` → npm on `sdk-v*`.
+- `lore-extensions` → Marketplace + OpenVSX on `vscode-v*`.
+- `lore-watchkeeper` / `lore-gatekeeper` → `@v1` (consumers pin major).
+- `rac-localview` → vendored; no publish while it lives in `rac-core`.
+
+### Amendments to ADR-064
+
+This ADR **amends** ADR-064 on three points and is recorded as a sibling, not a
+supersession — most of ADR-064 holds:
+
+1. **Actions topology.** The GitHub Actions split into **two product-branded
+   repos**, `lore-watchkeeper` + `lore-gatekeeper`, rather than the single
+   `rac-actions` repo ADR-064 named, and now cover **three** actions including
+   `pr-gate` / `rac gate` — the real gatekeeper. ADR-058 moves with the gate.
+2. **New surfaces.** The VS Code / Cursor extension and the TypeScript SDK,
+   which post-date ADR-064, are added to the topology: the extension as
+   `lore-extensions`, the SDK as `rac-sdk-ts` published to npm.
+3. **Viewer rename.** `lore-web` is renamed `rac-localview` **in-repo**
+   (standalone extraction remains deferred per ADR-064).
+
+This ADR **does not change** ADR-064's decisions that the dogfood corpus and
+`examples/` stay in the engine repo, that `decisiongrounding` extracts, or that
+standalone viewer extraction is deferred until a publish/vendor contract exists.
+
+## Consequences
+
+### Positive
+
+- Every future repository name is decided by one rule (install vs engine), so
+  new surfaces no longer re-litigate their prefix.
+- The full surface — engine, viewer, SDK, extension, two actions, benchmark —
+  has a recorded home and a per-repo release trigger, removing ambiguity about
+  where a change lands and how it ships.
+- Publishing `@rac/sdk` to npm makes the extension consume a versioned package
+  instead of a relative path, hardening the thin-client contract (ADR-063) and
+  unlocking per-client repositories.
+
+### Negative
+
+- More repositories to create, permission, and maintain than ADR-064 foresaw
+  (two action repos instead of one, plus extension and SDK repos).
+- Splitting the actions and repointing the extension are consumer-breaking
+  cutovers that require versioned references and documentation updates, not
+  silent moves.
+
+### Risks
+
+- **Cross-repo drift.** Surfaces that leave the engine repo can lag its
+  contract. Mitigation: each consumes the *published* package, the public CLI,
+  or the published `@rac/sdk` — never engine internals — and pins a version.
+- **Stranded references.** Consumers pinned to the old action `uses:` path or to
+  `file:../rac-sdk` break on cutover. Mitigation: the series sequences the
+  breaking moves last, behind versioned references and deprecation notes.
+- **Brand confusion during transition.** Mid-migration, some repos carry the old
+  name. Mitigation: the principle is recorded here and the rename of the engine
+  repo to `rac-core` is an explicit, documented org action.
+
+## Alternatives Considered
+
+### One `rac-actions` repository (ADR-064's original)
+
+Keep the Actions in a single repo with per-action subdirectories.
+
+#### Disadvantages
+
+- The actions are what a team *installs*, so they are product surfaces and read
+  more clearly as `lore-watchkeeper` and `lore-gatekeeper`. A single
+  engine-prefixed repo buries the gate (the headline enforcement surface,
+  ADR-049) in a subdirectory and mixes the install brand with the engine brand.
+  Rejected in favour of per-action product-branded repos.
+
+### Unify every repository under one prefix
+
+Name everything `rac-*` (or everything `lore-*`).
+
+#### Disadvantages
+
+- Loses the signal that distinguishes an installable product surface from the
+  engine and its internals. A single prefix tells a reader nothing about whether
+  a repo is a thing they adopt or a thing the engine builds from. Rejected for
+  brand/engine clarity.
+
+### The Python SDK as its own repository
+
+Lift the Python SDK out of the engine package into a `rac-sdk-py` repo.
+
+#### Disadvantages
+
+- The Python SDK's public surface *is* `rac.__all__`, shipped inside the engine
+  package (ADR-062), and the engine and its server are a single package
+  (ADR-029). Separating the Python SDK would fragment that package. Rejected;
+  only the TypeScript client — a thin client over the contract (ADR-063) — gets
+  its own repo.
+
+## Related Decisions
+
+- adr-064
+- adr-029
+- adr-036
+- adr-039
+- adr-049
+- adr-058
+- adr-062
+- adr-063
+
+## Related Roadmaps
+
+- repo-extraction-programme
+- v0.22.0-topology-and-release-decision
+
+## Success Measures
+
+- Every repository in the target topology exists under `itsthelore` with the
+  prefix the naming principle dictates, and no new surface's name is decided
+  ad hoc.
+- The extension consumes the published `@rac/sdk`, and no consumer reference
+  traces to a stranded action `uses:` path or a `file:../rac-sdk` path.
+- The frozen shipped names (PyPI `requirements-as-code`, CLI `rac`, server
+  `lore`) are unchanged after every rename.
+
+## Review Date
+
+Revisit when the `rac-localview` viewer gains a publish/vendor contract (then
+decide its standalone extraction, the trigger ADR-064 set), or when a per-client
+SDK ecosystem beyond TypeScript begins and the prefix principle needs hardening.

--- a/rac/roadmaps/future/repo-extraction-programme.md
+++ b/rac/roadmaps/future/repo-extraction-programme.md
@@ -79,7 +79,7 @@ thin client over the engine contract (ADR-063), so it takes the `rac-*` prefix
 and moves to `itsthelore/rac-sdk-ts`, **published to npm** as
 `@itsthelore/rac-sdk`. The VS Code / Cursor extension is a surface a user
 installs, so it takes the `lore-*` prefix and moves to
-`itsthelore/lore-extensions` (one VSIX to Marketplace + OpenVSX). Sequencing:
+`itsthelore/lore-vscode` (one VSIX to Marketplace + OpenVSX). Sequencing:
 publish the SDK first, then repoint the extension from `file:../rac-sdk` to the
 published package and remove the in-repo `typescript/` stack and its CI.
 
@@ -148,8 +148,8 @@ root `action.yml` into `lore-watchkeeper`. ADR-058 moves with the gatekeeper.
 Add a README documenting the new `uses:` references, tag each `v1`, and push.
 
 **Seed the TypeScript repos** (`itsthelore/rac-sdk-ts`,
-`itsthelore/lore-extensions`) after the SDK is npm-publishable (v0.22.3): publish
-`@itsthelore/rac-sdk` from `rac-sdk-ts`, then seed `lore-extensions` and repoint
+`itsthelore/lore-vscode`) after the SDK is npm-publishable (v0.22.3): publish
+`@itsthelore/rac-sdk` from `rac-sdk-ts`, then seed `lore-vscode` and repoint
 it to the published package.
 
 **Removal + rewire PRs on `rac-core`**: remove `decisiongrounding/`, the
@@ -167,7 +167,7 @@ and `pytest` passes.
 
 ## Success Measures
 
-- Every extraction target (`decisiongrounding`, `rac-sdk-ts`, `lore-extensions`,
+- Every extraction target (`decisiongrounding`, `rac-sdk-ts`, `lore-vscode`,
   `lore-gatekeeper`, `lore-watchkeeper`) lives in its own repo and consumes only
   the published package, the published `@rac/sdk`, or the public CLI; none
   imports engine internals.

--- a/rac/roadmaps/future/repo-extraction-programme.md
+++ b/rac/roadmaps/future/repo-extraction-programme.md
@@ -14,17 +14,23 @@ Planned
 
 ADR-064 records the decision to adopt a small multi-repo topology under the
 `itsthelore` organisation: extract the standalone components and keep the
-engine, its shipped resources, and its governing corpus in
-`itsthelore/requirements-as-code`. This programme sequences those extractions.
-It is a non-versioned `future/` item because the work is structural and
-cross-cutting, not a feature release on the current series.
+engine, its shipped resources, and its governing corpus in `itsthelore/rac-core`
+(the renamed `requirements-as-code` repository). ADR-068 extends that topology
+for the surfaces that post-date ADR-064 — the editor extension and the
+TypeScript SDK — and sharpens the Actions picture. This programme sequences the
+moves. It is a non-versioned `future/` item because the work is structural and
+cross-cutting, not a feature release on the current series. The
+`v0.22.x-housekeeping` series schedules the execution.
 
-Two components extract; `examples/` is explicitly kept (ADR-064), since
-`examples/guide` is the grounding demo and the dashboards are test fixtures.
-The two extraction targets differ in risk. `decisiongrounding` imports no
-engine code and can move with no consumer impact. The GitHub Actions are the
+The extraction targets differ in risk. `decisiongrounding` imports no engine
+code and can move with no consumer impact. The TypeScript stack (extension +
+SDK) depends on the SDK being published to npm first. The GitHub Actions are the
 consumer-breaking target: extraction changes the `uses:` path that downstream
 workflows reference, so they come last and behind a versioned cutover.
+`examples/` is explicitly kept (ADR-064), since `examples/guide` is the
+grounding demo and the dashboards are test fixtures. `lore-web` is renamed
+`rac-localview` in-repo (ADR-068); its standalone extraction stays deferred
+(ADR-064) until a publish/vendor contract exists.
 
 ## Outcomes
 
@@ -48,21 +54,43 @@ no code changes are needed; remove the directory from the monorepo and update
 any references to it (including the v0.20.1 roadmap's "mirrors
 `decisiongrounding/`" note, which becomes a cross-repo reference).
 
-### Initiative 2 — Extract the GitHub Actions to `itsthelore/rac-actions`
+### Initiative 2 — Split the GitHub Actions into two product-branded repos
 
-Move `validate-action/action.yml` and the root `action.yml` (Watchkeeper) into
-a single `itsthelore/rac-actions` repository, each action in its own
-subdirectory: `gatekeeper/` (the `validate` action, **renamed Gatekeeper** — it
-holds the gate on corpus validity, a sibling to Watchkeeper) and
-`watchkeeper/`. This changes the `uses:` path consumers reference, so it ships
-behind a versioned cutover: publish the new location, document the new `uses:`
-references (`itsthelore/rac-actions/gatekeeper@v1`,
-`itsthelore/rac-actions/watchkeeper@v1`), leave a deprecation note for the old
-`itsthelore/requirements-as-code/validate-action@ref` path, and update this
-repository's own `.github/workflows/` to the new location. ADR-058 governs the
-validation action and moves with it.
+ADR-068 amends ADR-064's single `rac-actions` repo here. The Actions are
+what a team *installs*, so they take the `lore-*` prefix and split into two
+repositories covering **three** actions:
 
-### Initiative 3 — Keep `examples/`; adopt the per-repo examples convention
+- `itsthelore/lore-gatekeeper` — the real gate, `pr-gate-action` (`rac gate`).
+  The older single-purpose `validate-action` is folded in and **deprecated** by
+  it. ADR-058 governs the gate and moves with it. The gate is the headline
+  enforcement surface (ADR-049).
+- `itsthelore/lore-watchkeeper` — the Watchkeeper action (root `action.yml`).
+
+This changes the `uses:` path consumers reference, so it ships last, behind a
+versioned cutover: publish the new locations, document the new `uses:`
+references (`itsthelore/lore-gatekeeper@v1`, `itsthelore/lore-watchkeeper@v1`),
+leave a deprecation note for the old paths, and repoint this repository's own
+`.github/workflows/` to the new locations.
+
+### Initiative 3 — Extract the TypeScript stack (extension + SDK)
+
+The surfaces that post-date ADR-064. The TypeScript SDK (`@rac/sdk`) is a typed
+thin client over the engine contract (ADR-063), so it takes the `rac-*` prefix
+and moves to `itsthelore/rac-sdk-ts`, **published to npm** as
+`@itsthelore/rac-sdk`. The VS Code / Cursor extension is a surface a user
+installs, so it takes the `lore-*` prefix and moves to
+`itsthelore/lore-extensions` (one VSIX to Marketplace + OpenVSX). Sequencing:
+publish the SDK first, then repoint the extension from `file:../rac-sdk` to the
+published package and remove the in-repo `typescript/` stack and its CI.
+
+### Initiative 4 — Rename the viewer `rac-localview` in-repo
+
+`lore-web` is the local Portal / graph viewer, vendored into `src/rac/` — a
+build-coupled internal of the engine, so it takes the `rac-*` prefix and is
+renamed `rac-localview/` **in-repo** (ADR-068). Standalone-repo extraction stays
+deferred (ADR-064) until a publish/vendor contract exists.
+
+### Initiative 5 — Keep `examples/`; adopt the per-repo examples convention
 
 `examples/` is **not** extracted. `examples/guide` is the grounding demo and
 the dashboards are test fixtures, so they stay in the engine repo (ADR-064).
@@ -86,17 +114,24 @@ this programme.
 
 - Extracting `examples/` or creating a `rac-examples` repo — examples stays in
   the engine repo (ADR-064).
-- Extracting `lore-web` — deferred by ADR-064 until its Portal-shell vendoring
-  has a publish/vendor contract.
+- Extracting `rac-localview` (the renamed `lore-web`) to its own repo — deferred
+  by ADR-064 until its Portal-shell vendoring has a publish/vendor contract. The
+  in-repo rename (ADR-068) is in scope; the standalone extraction is not.
 - Renaming the package, CLI, or server.
 - Creating the org repositories as part of this corpus task; the repos are
   created when each initiative is executed.
 
 ## Implementation Contract
 
+**Scheduling.** The `v0.22.x-housekeeping` series sequences the execution: the
+in-repo viewer rename (v0.22.1) and `rac-core` identity updates (v0.22.2), the
+SDK publish prerequisite (v0.22.3), then the extractions — `decisiongrounding`
+(v0.22.4), the TypeScript stack (v0.22.5), and the consumer-breaking Actions
+split last (v0.22.6).
+
 **Safety sequencing.** Populate each destination repo with preserved history
 and confirm it *before* removing anything from the engine repo. Never delete
-from `requirements-as-code` until the content lives elsewhere.
+from `rac-core` until the content lives elsewhere.
 
 **Seed `itsthelore/decisiongrounding`** (history-preserving):
 
@@ -106,27 +141,25 @@ git filter-repo --path decisiongrounding/ --path-rename decisiongrounding/:
 git remote add origin <decisiongrounding-url> && git push -u origin main
 ```
 
-**Seed `itsthelore/rac-actions`** (history-preserving, two subdirs):
+**Seed the two action repos** (`itsthelore/lore-gatekeeper`,
+`itsthelore/lore-watchkeeper`), history-preserving: filter `pr-gate-action/`
+(folding in / deprecating `validate-action/`) into `lore-gatekeeper`, and the
+root `action.yml` into `lore-watchkeeper`. ADR-058 moves with the gatekeeper.
+Add a README documenting the new `uses:` references, tag each `v1`, and push.
 
-```bash
-git clone <engine-url> acts && cd acts
-git filter-repo --path validate-action/ --path action.yml \
-  --path-rename validate-action/:gatekeeper/ \
-  --path-rename action.yml:watchkeeper/action.yml
-```
+**Seed the TypeScript repos** (`itsthelore/rac-sdk-ts`,
+`itsthelore/lore-extensions`) after the SDK is npm-publishable (v0.22.3): publish
+`@itsthelore/rac-sdk` from `rac-sdk-ts`, then seed `lore-extensions` and repoint
+it to the published package.
 
-Then rename the validate action to **Gatekeeper** inside
-`gatekeeper/action.yml` (the `name:` field and header comment), add a README
-documenting the new `uses:` references, tag `v1`, and push.
-
-**Removal + rewire PR on `requirements-as-code`** (one PR for the whole
-carve-out): remove `decisiongrounding/`, `validate-action/`, and the root
-`action.yml`; repoint the engine's own self-tests in
-`.github/workflows/pr-checks.yml` (`uses: ./` → `…/rac-actions/watchkeeper@v1`;
-`uses: ./validate-action` → `…/rac-actions/gatekeeper@v1`); update or remove
-`tests/test_validate_action.py` and `tests/test_watchkeeper.py`; update
-`docs/watchkeeper.md`, `docs/validation.md` (grep for others) to the new repo
-and add a deprecation note for the old path; keep `examples/` untouched.
+**Removal + rewire PRs on `rac-core`**: remove `decisiongrounding/`, the
+`typescript/` stack, the root `action.yml`, `validate-action/`, and
+`pr-gate-action/` once each lives elsewhere; repoint the engine's own self-tests
+in `.github/workflows/pr-checks.yml` (`uses: ./` → `…/lore-watchkeeper@v1`;
+`uses: ./pr-gate-action` → `…/lore-gatekeeper@v1`); update or remove
+`tests/test_*_action.py`; update `docs/watchkeeper.md`, `docs/validation.md`
+(grep for others) and add a deprecation note for the old paths; keep `examples/`
+untouched.
 
 After the removals the engine repository's `rac validate rac/`,
 `rac relationships rac/ --validate`, and `rac review rac/` gates stay green,
@@ -134,11 +167,14 @@ and `pytest` passes.
 
 ## Success Measures
 
-- Both extraction targets (`decisiongrounding`, `rac-actions`) live in their
-  own repos and consume only the published package or public CLI; neither
+- Every extraction target (`decisiongrounding`, `rac-sdk-ts`, `lore-extensions`,
+  `lore-gatekeeper`, `lore-watchkeeper`) lives in its own repo and consumes only
+  the published package, the published `@rac/sdk`, or the public CLI; none
   imports engine internals.
-- No issue traces to a stranded `uses:` path or a missing relocated component.
-- The engine repository's corpus gates remain green throughout.
+- No issue traces to a stranded `uses:` path, a `file:../rac-sdk` path, or a
+  missing relocated component.
+- The engine repository's corpus gates remain green throughout, and the dogfood
+  corpus and `examples/` stay in `rac-core`.
 
 ## Assumptions
 
@@ -148,8 +184,11 @@ and `pytest` passes.
   `PATH`, so its move needs no code change (DG-ADR-0001 holds).
 - The extracted actions consume only the public `rac` CLI, not engine
   internals, so they run from any repo once published.
-- `lore-web` stays in this repository until its vendoring contract exists, so
-  no Portal-shell drift-guard breaks during this programme.
+- The extracted TypeScript SDK and extension consume the published
+  `@itsthelore/rac-sdk` and the public CLI, never engine internals.
+- `rac-localview` (the renamed `lore-web`) stays in this repository until its
+  vendoring contract exists, so no Portal-shell drift-guard breaks during this
+  programme.
 
 ## Risks
 
@@ -165,11 +204,14 @@ and `pytest` passes.
 ## Related Decisions
 
 - adr-064
+- adr-068
 - adr-058
+- adr-063
 
 ## Related Roadmaps
 
 - v0.20.1-python-sdk-docs
+- v0.22.0-topology-and-release-decision
 
 ## Related Requirements
 

--- a/rac/roadmaps/v0.21.x-editor/v0.21.19-gate-performance.md
+++ b/rac/roadmaps/v0.21.x-editor/v0.21.19-gate-performance.md
@@ -8,7 +8,7 @@ tags: [performance, gate, enforcement, tooling]
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/rac/roadmaps/v0.22.x-housekeeping/v0.22.0-topology-and-release-decision.md
+++ b/rac/roadmaps/v0.22.x-housekeeping/v0.22.0-topology-and-release-decision.md
@@ -38,7 +38,7 @@ principle as artifacts before any code moves.
 
 Author `adr-068-extension-sdk-and-brand-architecture` (Accepted, Architecture):
 the naming principle, the target topology (`rac-core`, `rac-localview`,
-`rac-sdk-ts`, `lore-extensions`, `lore-watchkeeper`, `lore-gatekeeper`,
+`rac-sdk-ts`, `lore-vscode`, `lore-watchkeeper`, `lore-gatekeeper`,
 `decisiongrounding`), the per-repo tag-driven release model, and the three
 amendments to ADR-064 — referencing ADR-064, not superseding it.
 

--- a/rac/roadmaps/v0.22.x-housekeeping/v0.22.0-topology-and-release-decision.md
+++ b/rac/roadmaps/v0.22.x-housekeeping/v0.22.0-topology-and-release-decision.md
@@ -1,0 +1,116 @@
+---
+schema_version: 1
+id: RAC-KVA46RJE43ZJ
+type: roadmap
+tags: [structure, org, distribution, release]
+---
+# RAC v0.22.0 — Topology & Release Decision
+
+## Status
+
+Planned
+
+## Context
+
+The product has grown two surfaces — a VS Code / Cursor extension and a
+TypeScript client SDK — that did not exist when ADR-064 set the first
+repository topology, and the GitHub Actions picture has sharpened to three
+actions (Watchkeeper, the legacy `validate-action`, and the real gate
+`pr-gate-action` / `rac gate`). Naming has drifted between the `lore` product
+brand and the `rac` engine brand with no stated rule. RAC's core principle is
+that durable, cross-cutting structural decisions live in the corpus where the
+gates validate them, so this release records the settled topology and naming
+principle as artifacts before any code moves.
+
+## Outcomes
+
+- ADR-068 records the naming principle (`lore-*` = installed surfaces, `rac-*`
+  = engine and build-coupled internals), the full target topology, the per-repo
+  release model, and the explicit amendments to ADR-064.
+- The `v0.22.x-housekeeping` series scaffolds the execution roadmaps (v0.22.1
+  through v0.22.6) so each move has a scoped home.
+- The `repo-extraction-programme` future roadmap is refreshed to match ADR-068,
+  and the `CLAUDE.md` series pointer names the new series.
+
+## Initiatives
+
+### Initiative 1 — Record ADR-068
+
+Author `adr-068-extension-sdk-and-brand-architecture` (Accepted, Architecture):
+the naming principle, the target topology (`rac-core`, `rac-localview`,
+`rac-sdk-ts`, `lore-extensions`, `lore-watchkeeper`, `lore-gatekeeper`,
+`decisiongrounding`), the per-repo tag-driven release model, and the three
+amendments to ADR-064 — referencing ADR-064, not superseding it.
+
+### Initiative 2 — Scaffold the series
+
+Create the six execution roadmaps (v0.22.1–v0.22.6) as Planned artifacts that
+sequence the renames and extractions, each cross-referencing ADR-068 and its
+predecessor releases.
+
+### Initiative 3 — Refresh the programme and the router
+
+Update `repo-extraction-programme` to reflect ADR-068 (two action repos, the
+extension and SDK extractions, the in-repo viewer rename) and point the
+`CLAUDE.md` "Current series" router line at `v0.22.x-housekeeping`.
+
+## Constraints
+
+- Corpus-only: this release records decisions and roadmaps; no engine code
+  changes.
+- The shipped names stay frozen (ADR-036, ADR-039): PyPI
+  `requirements-as-code`, CLI `rac`, server identity `lore`.
+- ADR-064 is amended, not superseded — the corpus must keep it Accepted and
+  resolvable.
+
+## Non-Goals
+
+- Performing any rename, extraction, or org repository creation — those are the
+  later releases in the series and org actions.
+- Changing engine behaviour or the public contract.
+
+## Implementation Contract
+
+- `adr-068-extension-sdk-and-brand-architecture` lands as Accepted with the
+  naming principle, topology table, release model, and ADR-064 amendments.
+- The six v0.22.x execution roadmaps land as Planned with full sections.
+- `repo-extraction-programme` is refreshed; `CLAUDE.md` "Current series" points
+  at `v0.22.x-housekeeping`.
+- The agent-rules managed blocks are regenerated so ADR-068 appears in the
+  projection and `rac export --agent-rules --check` is clean.
+- `rac validate`, `rac relationships --validate`, `rac review`, and `rac gate`
+  over `rac/` exit 0.
+
+## Success Measures
+
+- ADR-068 and the six execution roadmaps validate, and every cross-reference
+  resolves.
+- `rac review rac/` reports no priority 1-2 findings.
+- The managed agent-rules blocks include ADR-068 and the `--check` gate is
+  green.
+
+## Risks
+
+- An ADR-064 amendment recorded as a contradiction rather than a sibling could
+  confuse the topology history. Mitigation: ADR-068 enumerates the amendments
+  explicitly and references ADR-064 as Related.
+- Series scope creep into actually moving repos. Mitigation: the Non-Goals fence
+  this release to the decision and scaffolding only.
+
+## Assumptions
+
+- The maintainer has approved the naming principle, topology, and release model
+  recorded here.
+- The later releases (v0.22.1–v0.22.6) and the org repository creation will be
+  executed when each is scheduled.
+
+## Related Decisions
+
+- adr-068
+- adr-064
+
+## Related Roadmaps
+
+- repo-extraction-programme
+- v0.22.1-rename-viewer-rac-localview
+- v0.22.6-split-actions

--- a/rac/roadmaps/v0.22.x-housekeeping/v0.22.1-rename-viewer-rac-localview.md
+++ b/rac/roadmaps/v0.22.x-housekeeping/v0.22.1-rename-viewer-rac-localview.md
@@ -1,0 +1,99 @@
+---
+schema_version: 1
+id: RAC-KVA46W84APRT
+type: roadmap
+tags: [structure, org, distribution, release]
+---
+# RAC v0.22.1 — Rename Viewer to rac-localview
+
+## Status
+
+Planned
+
+## Context
+
+ADR-068 renames the local Portal / graph viewer `lore-web/` to `rac-localview/`
+in-repo — it is a build-coupled internal of the engine (the `rac-*` prefix),
+vendored into `src/rac/` through a build script and guarded by a drift test.
+This release performs the in-repo directory rename and rewires every reference
+to it. Standalone-repo extraction of the viewer stays deferred (ADR-064) until
+a publish/vendor contract exists; this is a rename, not an extraction.
+
+## Outcomes
+
+- The viewer directory is `rac-localview/`, and every script, test, CI step,
+  provenance record, and doc reference points at the new path.
+- The vendoring path still works: `vendor:shell` re-runs and the drift-guard
+  test passes against the renamed source.
+
+## Initiatives
+
+### Initiative 1 — Rename and rewire the vendor path
+
+Rename `lore-web/` to `rac-localview/`; update the vendor script
+(`scripts/vendor-portal-shell.mjs`) and the `vendor:shell` npm script to read
+the new path, and the `provenance.json` `vendored_with` field.
+
+### Initiative 2 — Rewire the drift-guard and CI
+
+Update the drift-guard test (`tests/test_export_cmd.py`, the `LORE_WEB` path),
+the CI workflows (`lore-web-build.yml`, and the viewer step in
+`extension-release.yml`), and landing/docs references to the new directory name.
+
+### Initiative 3 — Re-vendor and verify
+
+Re-run `vendor:shell` so the vendored shell is regenerated from
+`rac-localview/`, and confirm the drift-guard test passes.
+
+## Constraints
+
+- Rename only — extraction stays deferred (ADR-064, ADR-068).
+- The vendored output must be byte-identical after the rename; the drift-guard
+  is the gate.
+- No engine behaviour or public-surface change.
+
+## Non-Goals
+
+- Extracting the viewer to its own repository.
+- Renaming any shipped name (ADR-036, ADR-039).
+
+## Implementation Contract
+
+- `lore-web/` → `rac-localview/`; `scripts/vendor-portal-shell.mjs` and the
+  `vendor:shell` script read the new path; `provenance.json` `vendored_with`
+  updated.
+- `tests/test_export_cmd.py` `LORE_WEB` path, `lore-web-build.yml`, and the
+  `extension-release.yml` viewer step point at `rac-localview/`; landing/docs
+  references updated.
+- `vendor:shell` re-run; the drift-guard test passes; `pytest` green.
+
+## Success Measures
+
+- No reference to `lore-web/` remains for the viewer directory.
+- The drift-guard test passes against `rac-localview/` and the vendored shell is
+  unchanged.
+
+## Risks
+
+- A missed reference strands the vendor path or CI. Mitigation: grep the repo
+  for `lore-web` and rewire every hit; the drift-guard fails loudly if the path
+  is wrong.
+- Re-vendoring introduces an unintended diff. Mitigation: verify the vendored
+  output is unchanged after the rename.
+
+## Assumptions
+
+- The viewer stays vendored in this repository; no publish/vendor contract
+  exists yet, so extraction remains deferred.
+- The vendor script and drift-guard are the only coupling points to the viewer
+  directory name.
+
+## Related Decisions
+
+- adr-068
+- adr-064
+
+## Related Roadmaps
+
+- v0.22.0-topology-and-release-decision
+- repo-extraction-programme

--- a/rac/roadmaps/v0.22.x-housekeeping/v0.22.2-rac-core-identity.md
+++ b/rac/roadmaps/v0.22.x-housekeeping/v0.22.2-rac-core-identity.md
@@ -1,0 +1,96 @@
+---
+schema_version: 1
+id: RAC-KVA46ZZE7Y7K
+type: roadmap
+tags: [structure, org, distribution, release]
+---
+# RAC v0.22.2 — rac-core Identity
+
+## Status
+
+Planned
+
+## Context
+
+ADR-068 renames the `requirements-as-code` GitHub repository to `rac-core` under
+`itsthelore`. The rename of the repo itself is an org action; this release is
+the *code side* — the roughly twenty in-repo references that hard-code the old
+repository URL or identity and must point at `rac-core` / `itsthelore`. The
+shipped names stay frozen (ADR-036, ADR-039): PyPI `requirements-as-code`, CLI
+`rac`, import `rac`, server identity `lore` — none of those change; only
+repository-URL and project-identity references do.
+
+## Outcomes
+
+- Every in-repo reference to the old repository URL or identity points at the
+  `rac-core` / `itsthelore` location.
+- The frozen shipped names are untouched.
+
+## Initiatives
+
+### Initiative 1 — Packaging and docs-site identity
+
+Update `pyproject.toml` project URLs, the `mkdocs.yml` `site_url` / `repo_url`,
+and README badges and links to the `rac-core` repository.
+
+### Initiative 2 — Output and telemetry references
+
+Update the SARIF `informationUri` in `src/rac/output/sarif.py`, the telemetry
+issue URL, and `server.json` to the new identity.
+
+### Initiative 3 — Cross-links
+
+Update docs cross-links and any remaining references that name the old
+repository URL.
+
+## Constraints
+
+- Frozen shipped names stay frozen: PyPI `requirements-as-code`, CLI `rac`,
+  import `rac`, server `lore` (ADR-036, ADR-039) — do not touch them.
+- This is the code side only; the GitHub repository rename is a separate org
+  action.
+- No engine behaviour change.
+
+## Non-Goals
+
+- Renaming the PyPI package, the CLI, the import path, or the server identity.
+- Performing the GitHub repository rename (org action).
+
+## Implementation Contract
+
+- `pyproject.toml` URLs, `mkdocs.yml` `site_url` / `repo_url`, README
+  badges/links, `src/rac/output/sarif.py` `informationUri`, the telemetry issue
+  URL, `server.json`, and docs cross-links point at `rac-core` / `itsthelore`.
+- The frozen names (`requirements-as-code`, `rac`, `lore`) are unchanged.
+- `pytest` passes; the SARIF and `server.json` outputs validate against their
+  schemas.
+
+## Success Measures
+
+- No in-repo reference resolves to the old repository URL or identity.
+- The PyPI name, CLI name, import path, and server identity are unchanged.
+
+## Risks
+
+- Touching a frozen name by mistake. Mitigation: the constraint is explicit and
+  the change is scoped to URL/identity references, not package/CLI/server names.
+- A missed reference. Mitigation: grep for the old repository URL across the
+  repo and update every hit.
+
+## Assumptions
+
+- The GitHub repository rename to `rac-core` is performed (or scheduled) as an
+  org action; this release prepares the code to match.
+- SARIF `informationUri`, telemetry URL, and `server.json` are the
+  identity-bearing engine outputs.
+
+## Related Decisions
+
+- adr-068
+- adr-036
+- adr-039
+
+## Related Roadmaps
+
+- v0.22.0-topology-and-release-decision
+- v0.22.1-rename-viewer-rac-localview

--- a/rac/roadmaps/v0.22.x-housekeeping/v0.22.3-ts-sdk-npm-publishable.md
+++ b/rac/roadmaps/v0.22.x-housekeeping/v0.22.3-ts-sdk-npm-publishable.md
@@ -1,0 +1,91 @@
+---
+schema_version: 1
+id: RAC-KVA473N2V6W9
+type: roadmap
+tags: [structure, org, distribution, release]
+---
+# RAC v0.22.3 — TypeScript SDK npm-Publishable
+
+## Status
+
+Planned
+
+## Context
+
+ADR-068 makes the TypeScript client SDK its own repository, `rac-sdk-ts`,
+published to npm as `@itsthelore/rac-sdk`. Today the extension consumes the SDK
+over a `file:../rac-sdk` relative path, which couples the two and blocks
+per-client repositories. This release makes `@rac/sdk` npm-publishable so the
+extension — and future per-client repos — consume the published package. It
+precedes v0.22.5 (the extraction of the TypeScript stack), which repoints the
+extension to the published package.
+
+## Outcomes
+
+- `@rac/sdk` builds and publishes to npm under the scoped name
+  `@itsthelore/rac-sdk`, with a tag-driven publish workflow.
+- The extension can consume the published package instead of a relative path.
+
+## Initiatives
+
+### Initiative 1 — Package configuration
+
+Set the scoped package name `@itsthelore/rac-sdk`, add `publishConfig` for
+public scoped publishing, and confirm the build output and `exports` map are
+correct for consumers.
+
+### Initiative 2 — Publish workflow
+
+Add an `sdk-v*` tag-driven publish workflow that builds and publishes the SDK to
+npm, matching the per-repo tag-driven release model (ADR-068).
+
+## Constraints
+
+- Thin client (ADR-063): the SDK mirrors the engine contract; it reimplements no
+  engine logic.
+- Publishing must not change the SDK's public API surface or the engine
+  contract.
+- The package stays a typed client over the contract; it carries no engine code.
+
+## Non-Goals
+
+- Removing the `file:../rac-sdk` path or repointing the extension — that is
+  v0.22.5 (after the stack is extracted).
+- Creating the `rac-sdk-ts` org repository (org action).
+
+## Implementation Contract
+
+- `@rac/sdk` is named `@itsthelore/rac-sdk` with `publishConfig` and a verified
+  build / `exports` map.
+- An `sdk-v*` publish workflow builds and publishes to npm.
+- The SDK's public API and the engine contract are unchanged; existing SDK
+  tests pass.
+
+## Success Measures
+
+- A dry-run (or first) publish under `@itsthelore/rac-sdk` succeeds from an
+  `sdk-v*` tag.
+- The published package exposes the same API the extension consumes today.
+
+## Risks
+
+- A scoped-package publish misconfiguration (private vs public). Mitigation:
+  `publishConfig` sets public access and a dry-run verifies it.
+- Drift between the SDK and the engine contract once published. Mitigation: the
+  SDK stays a thin client (ADR-063) pinned to a contract version.
+
+## Assumptions
+
+- The npm scope `@itsthelore` is available and the maintainer can publish to it.
+- The SDK already builds cleanly as a standalone package, needing only naming
+  and publish configuration.
+
+## Related Decisions
+
+- adr-068
+- adr-063
+
+## Related Roadmaps
+
+- v0.22.0-topology-and-release-decision
+- v0.22.5-extract-typescript-stack

--- a/rac/roadmaps/v0.22.x-housekeeping/v0.22.4-extract-decisiongrounding.md
+++ b/rac/roadmaps/v0.22.x-housekeeping/v0.22.4-extract-decisiongrounding.md
@@ -1,0 +1,93 @@
+---
+schema_version: 1
+id: RAC-KVA477F748WN
+type: roadmap
+tags: [structure, org, distribution, release]
+---
+# RAC v0.22.4 — Extract decisiongrounding
+
+## Status
+
+Planned
+
+## Context
+
+ADR-064 records that `decisiongrounding/` extracts to its own
+`itsthelore/decisiongrounding` repository, and ADR-068 leaves that decision
+unchanged. It is the cleanest target: the benchmark imports no engine code and
+treats `rac` as an external CLI on `PATH` (DG-ADR-0001), so it moves with no
+consumer impact. This release is the engine-side removal that follows the
+history-preserving seed of the org repository.
+
+## Outcomes
+
+- `decisiongrounding/` no longer lives in the engine repository; the benchmark
+  lives in `itsthelore/decisiongrounding` with its history preserved.
+- Every in-repo reference to `decisiongrounding/` becomes a cross-repo reference
+  or is removed.
+
+## Initiatives
+
+### Initiative 1 — Seed the org repository (precondition)
+
+Before any engine-side removal, populate `itsthelore/decisiongrounding` with
+history preserved (carrying its `pyproject.toml`, tests, LICENSE, Makefile, and
+its `decisions/` ADRs from DG-ADR-0001 onward) and confirm it stands alone.
+
+### Initiative 2 — Engine-side removal and reference update
+
+Remove `decisiongrounding/` from this repository and update references to it
+(including the v0.20.1 roadmap's "mirrors `decisiongrounding/`" note, which
+becomes a cross-repo reference).
+
+## Constraints
+
+- Never delete from the engine repo until the content lives elsewhere
+  (history-preserving seed first).
+- The benchmark consumes only the public `rac` CLI on `PATH`, not engine
+  internals (DG-ADR-0001).
+- No engine behaviour or public-surface change.
+
+## Non-Goals
+
+- Extracting `examples/` — it stays in the engine repo (ADR-064).
+- Changing the benchmark's own contract or version.
+
+## Implementation Contract
+
+- `itsthelore/decisiongrounding` is seeded with preserved history and verified
+  standalone *before* removal.
+- `decisiongrounding/` is removed from this repository; references (incl. the
+  v0.20.1 cross-reference) are updated.
+- After removal `rac validate rac/`, `rac relationships rac/ --validate`, and
+  `rac review rac/` stay green and `pytest` passes.
+
+## Success Measures
+
+- The benchmark lives only in `itsthelore/decisiongrounding` and consumes the
+  public CLI, not engine internals.
+- No issue traces to a stranded reference to the removed directory.
+- The engine repository's corpus gates stay green after removal.
+
+## Risks
+
+- Removing before the seed is confirmed loses provenance. Mitigation: the
+  contract mandates a verified history-preserving seed first.
+- A stranded reference to `decisiongrounding/`. Mitigation: grep and update
+  every reference, including the v0.20.1 roadmap note.
+
+## Assumptions
+
+- The maintainer can create and seed `itsthelore/decisiongrounding`.
+- DG-ADR-0001 holds — the benchmark needs no code change to run from its own
+  repo.
+
+## Related Decisions
+
+- adr-064
+- adr-068
+
+## Related Roadmaps
+
+- v0.22.0-topology-and-release-decision
+- repo-extraction-programme

--- a/rac/roadmaps/v0.22.x-housekeeping/v0.22.5-extract-typescript-stack.md
+++ b/rac/roadmaps/v0.22.x-housekeeping/v0.22.5-extract-typescript-stack.md
@@ -12,7 +12,7 @@ Planned
 
 ## Context
 
-ADR-068 places the VS Code / Cursor extension in `lore-extensions` and the
+ADR-068 places the VS Code / Cursor extension in `lore-vscode` and the
 TypeScript SDK in `rac-sdk-ts` (published to npm). This release is the
 engine-side cutover after those org repositories are seeded: it repoints the
 extension to the published `@rac/sdk` (made publishable in v0.22.3), removes the
@@ -23,13 +23,13 @@ the SDK npm-publishable.
 
 - The extension consumes the published `@rac/sdk` instead of `file:../rac-sdk`.
 - The in-repo `typescript/rac-vscode` and `typescript/rac-sdk` directories and
-  their CI are removed; the stack lives in `lore-extensions` and `rac-sdk-ts`.
+  their CI are removed; the stack lives in `lore-vscode` and `rac-sdk-ts`.
 
 ## Initiatives
 
 ### Initiative 1 — Repoint the extension
 
-After `lore-extensions` and `rac-sdk-ts` are seeded, repoint the extension's
+After `lore-vscode` and `rac-sdk-ts` are seeded, repoint the extension's
 dependency from `file:../rac-sdk` to the published `@rac/sdk`
 (`@itsthelore/rac-sdk`).
 
@@ -71,7 +71,7 @@ update docs that reference the in-repo stack.
 
 ## Risks
 
-- Removing before `lore-extensions` / `rac-sdk-ts` are seeded loses provenance.
+- Removing before `lore-vscode` / `rac-sdk-ts` are seeded loses provenance.
   Mitigation: the contract requires verified seeds first.
 - The extension breaks against the published SDK. Mitigation: v0.22.3 verifies
   the published package exposes the consumed API before this cutover.
@@ -79,7 +79,7 @@ update docs that reference the in-repo stack.
 ## Assumptions
 
 - v0.22.3 has published `@rac/sdk` as `@itsthelore/rac-sdk`.
-- `lore-extensions` and `rac-sdk-ts` are seeded with preserved history before
+- `lore-vscode` and `rac-sdk-ts` are seeded with preserved history before
   the engine-side removal.
 
 ## Related Decisions

--- a/rac/roadmaps/v0.22.x-housekeeping/v0.22.5-extract-typescript-stack.md
+++ b/rac/roadmaps/v0.22.x-housekeeping/v0.22.5-extract-typescript-stack.md
@@ -1,0 +1,93 @@
+---
+schema_version: 1
+id: RAC-KVA47B6MSAZR
+type: roadmap
+tags: [structure, org, distribution, release]
+---
+# RAC v0.22.5 — Extract the TypeScript Stack
+
+## Status
+
+Planned
+
+## Context
+
+ADR-068 places the VS Code / Cursor extension in `lore-extensions` and the
+TypeScript SDK in `rac-sdk-ts` (published to npm). This release is the
+engine-side cutover after those org repositories are seeded: it repoints the
+extension to the published `@rac/sdk` (made publishable in v0.22.3), removes the
+in-repo TypeScript stack, and drops its CI. It depends on v0.22.3 having made
+the SDK npm-publishable.
+
+## Outcomes
+
+- The extension consumes the published `@rac/sdk` instead of `file:../rac-sdk`.
+- The in-repo `typescript/rac-vscode` and `typescript/rac-sdk` directories and
+  their CI are removed; the stack lives in `lore-extensions` and `rac-sdk-ts`.
+
+## Initiatives
+
+### Initiative 1 — Repoint the extension
+
+After `lore-extensions` and `rac-sdk-ts` are seeded, repoint the extension's
+dependency from `file:../rac-sdk` to the published `@rac/sdk`
+(`@itsthelore/rac-sdk`).
+
+### Initiative 2 — Remove the in-repo stack and CI
+
+Remove `typescript/rac-vscode` and `typescript/rac-sdk`; remove the
+`extension-release.yml` and `typescript.yml` workflows; drop their CI batteries;
+update docs that reference the in-repo stack.
+
+## Constraints
+
+- The published SDK must exist first (v0.22.3) and the org repos must be seeded
+  before removal.
+- Never delete from the engine repo until the stack lives elsewhere.
+- Thin client (ADR-063): the extension consumes the published package; it
+  reimplements no engine logic.
+
+## Non-Goals
+
+- Making the SDK publishable — that is v0.22.3.
+- Splitting the GitHub Actions — that is v0.22.6.
+
+## Implementation Contract
+
+- The extension depends on `@itsthelore/rac-sdk` (published), not
+  `file:../rac-sdk`.
+- `typescript/rac-vscode` and `typescript/rac-sdk` are removed; the
+  `extension-release.yml` and `typescript.yml` workflows and their CI batteries
+  are removed; docs are updated.
+- After removal `rac validate rac/`, `rac relationships rac/ --validate`, and
+  `rac review rac/` stay green and `pytest` passes.
+
+## Success Measures
+
+- The extension builds against the published `@rac/sdk` with no relative-path
+  dependency.
+- No in-repo reference traces to the removed `typescript/` stack or its
+  workflows.
+
+## Risks
+
+- Removing before `lore-extensions` / `rac-sdk-ts` are seeded loses provenance.
+  Mitigation: the contract requires verified seeds first.
+- The extension breaks against the published SDK. Mitigation: v0.22.3 verifies
+  the published package exposes the consumed API before this cutover.
+
+## Assumptions
+
+- v0.22.3 has published `@rac/sdk` as `@itsthelore/rac-sdk`.
+- `lore-extensions` and `rac-sdk-ts` are seeded with preserved history before
+  the engine-side removal.
+
+## Related Decisions
+
+- adr-068
+- adr-063
+
+## Related Roadmaps
+
+- v0.22.3-ts-sdk-npm-publishable
+- v0.22.0-topology-and-release-decision

--- a/rac/roadmaps/v0.22.x-housekeeping/v0.22.6-split-actions.md
+++ b/rac/roadmaps/v0.22.x-housekeeping/v0.22.6-split-actions.md
@@ -1,0 +1,104 @@
+---
+schema_version: 1
+id: RAC-KVA47EZCCEZC
+type: roadmap
+tags: [structure, org, distribution, release]
+---
+# RAC v0.22.6 — Split the GitHub Actions
+
+## Status
+
+Planned
+
+## Context
+
+ADR-068 amends ADR-064: the GitHub Actions split into two product-branded repos,
+`lore-watchkeeper` (the Watchkeeper action, root `action.yml`) and
+`lore-gatekeeper` (the gate action `pr-gate-action`, `rac gate`), and the older
+single-purpose `validate-action` is folded in and deprecated by the gate
+(ADR-058 moves with the gate). This is the **last** release in the series and
+the consumer-breaking cutover: it changes the `uses:` paths downstream workflows
+reference, so it runs after the org repos are seeded, behind versioned
+references. "Enforcement is the product" (ADR-049) — the gate is the headline
+surface, hence its own branded repo.
+
+## Outcomes
+
+- This repository's dogfood jobs consume `…/lore-watchkeeper@v1` and
+  `…/lore-gatekeeper@v1`; the in-repo action sources are removed.
+- The legacy `validate-action` is deprecated with a redirect to the gate, and no
+  consumer is silently broken.
+
+## Initiatives
+
+### Initiative 1 — Seed the action repos (precondition)
+
+Seed `lore-watchkeeper` and `lore-gatekeeper` with preserved history and tag
+each `v1` before any engine-side rewire.
+
+### Initiative 2 — Repoint dogfood jobs and remove sources
+
+In `pr-checks.yml`, repoint `uses: ./` → `…/lore-watchkeeper@v1` and
+`uses: ./pr-gate-action` → `…/lore-gatekeeper@v1`; remove the root `action.yml`,
+`validate-action/`, and `pr-gate-action/`.
+
+### Initiative 3 — Deprecate and document
+
+Deprecate `validate-action` with a redirect note to `lore-gatekeeper`; update
+`tests/test_*_action.py` and docs; ADR-058 moves with the gate.
+
+## Constraints
+
+- Last in the series and consumer-breaking: run only after the action repos are
+  seeded and tagged `@v1`.
+- Consumers pin a major (`@v1`); the cutover is versioned, not silent.
+- The actions consume only the public `rac` CLI, not engine internals.
+
+## Non-Goals
+
+- Extracting the TypeScript stack — that is v0.22.5.
+- Changing the gate or Watchkeeper behaviour; this is a relocation and rewire.
+
+## Implementation Contract
+
+- `lore-watchkeeper` and `lore-gatekeeper` are seeded with preserved history and
+  tagged `v1` *before* the rewire.
+- `pr-checks.yml` consumes `…/lore-watchkeeper@v1` and `…/lore-gatekeeper@v1`;
+  the root `action.yml`, `validate-action/`, and `pr-gate-action/` are removed.
+- `validate-action` carries a deprecation/redirect note to `lore-gatekeeper`;
+  `tests/test_*_action.py` and docs are updated; ADR-058 moves with the gate.
+- After the rewire `rac validate rac/`, `rac relationships rac/ --validate`, and
+  `rac review rac/` stay green and `pytest` passes.
+
+## Success Measures
+
+- This repository's dogfood CI passes against the extracted `@v1` actions.
+- No consumer reference traces to a stranded in-repo action path, and the
+  legacy `validate-action` path carries a redirect.
+- The corpus gates stay green after the rewire.
+
+## Risks
+
+- Stranded `uses:` references break consumers. Mitigation: this release runs
+  last, behind seeded `@v1` repos with a deprecation note on the old path.
+- Removing before the action repos are seeded loses provenance. Mitigation: the
+  contract requires verified seeds tagged `v1` first.
+
+## Assumptions
+
+- `lore-watchkeeper` and `lore-gatekeeper` are seeded and tagged `v1` before the
+  rewire.
+- The actions consume only the public `rac` CLI, so they run from any repo once
+  published.
+
+## Related Decisions
+
+- adr-064
+- adr-058
+- adr-068
+- adr-049
+
+## Related Roadmaps
+
+- v0.22.0-topology-and-release-decision
+- v0.22.5-extract-typescript-stack


### PR DESCRIPTION
# Summary

Implements `rac/roadmaps/v0.22.x-housekeeping/v0.22.0-topology-and-release-decision.md`.

Opens the **v0.22.x-housekeeping** series by *recording the decision* before any
moves: a governed ADR + the seven-release roadmap series that sequence the repo
topology, naming, and publication cleanup. This PR is **corpus-only** — no engine
code changes.

Adds:
- **ADR-068** — the `lore-*`/`rac-*` naming principle, the full target topology,
  the **per-client repo model**, the per-repo tag-driven release model, and an
  explicit amendment of ADR-064.
- The **`v0.22.x-housekeeping`** roadmap series (v0.22.0 → v0.22.6).
- A refreshed `repo-extraction-programme.md`, the `CLAUDE.md` series pointer, and
  regenerated agent-rules blocks.

# Roadmap / ADR Trace

Roadmap:
- `rac/roadmaps/v0.22.x-housekeeping/v0.22.0-topology-and-release-decision.md`
  (+ the v0.22.1–v0.22.6 items this PR scaffolds)

Relevant ADRs:
- `rac/decisions/adr-068-extension-sdk-and-brand-architecture.md` — **new** (this PR).
- `rac/decisions/adr-064-*` — amended (as a sibling, not superseded).
- Fences cited and not contradicted: `adr-029` (engine+MCP one package),
  `adr-036`/`adr-039` (frozen PyPI/CLI/server names), `adr-062` (Python SDK =
  `rac.__all__`), `adr-058` (validation action), `adr-049` (enforcement is the
  product), `adr-063` (thin clients).

# Scope

## Included
- **ADR-068 (Accepted, Architecture):** the naming principle (`lore-*` = anything a
  user/team installs; `rac-*` = the engine and its build-coupled internals); the
  topology — `rac-core`, `rac-localview`, `rac-sdk-ts`, `lore-vscode`,
  `lore-watchkeeper`, `lore-gatekeeper`, `decisiongrounding`; the **per-client
  repo model** (one repo per client integration consuming the published
  `@itsthelore/rac-sdk`; `lore-vscode` is the first, with `lore-cursor` /
  `lore-codex` / `lore-claude` as planned future siblings, out of v0.22.x scope);
  the per-repo tag-driven release model; and an "Amendments to ADR-064" section.
  Recorded as a **sibling** of ADR-064, which stays Accepted.
- **The v0.22.x-housekeeping series (7 roadmaps):** v0.22.0 decision · v0.22.1
  viewer rename · v0.22.2 `rac-core` identity (URL updates) · v0.22.3 TS SDK
  npm-publishable · v0.22.4 extract `decisiongrounding` · v0.22.5 extract the TS
  stack · v0.22.6 split the actions (consumer-breaking cutover, last).
- Refreshed `repo-extraction-programme.md`; `CLAUDE.md` current-series pointer
  moved to v0.22.x; regenerated agent-rules managed blocks.

## Excluded
- Any engine/code change, repo rename, or content move — those land in the later
  v0.22.x releases (each gated on its org-side repo being seeded with history
  first, per ADR-064's "never delete before the content lives elsewhere").
- Retiring ADR-064 — most of it holds (corpus + `examples/` stay,
  `decisiongrounding` extracts, standalone viewer extraction stays deferred); this
  ADR amends, it does not supersede.
- Renaming the PyPI package / CLI / import / server (frozen, ADR-036/039).
- Building the future per-client repos (`lore-cursor`, `lore-codex`, …) — recorded
  in the principle but not part of this series.

# Product / Architecture Decisions

- **Amendment, not supersession.** ADR-064 stays Accepted and is cited as Related;
  ADR-068 enumerates exactly what it changes, so the history stays legible and the
  unchanged ADR-064 decisions keep their authority.
- **The naming principle is the load-bearing output** — every future repo name is
  decided by one rule (install vs engine), so new surfaces don't re-litigate.
- **One repo per client.** A single `lore-extensions` container is rejected; the
  VS Code extension is `lore-vscode` (its VSIX also runs in Cursor as a fork), and
  a dedicated `lore-cursor` is planned for Cursor-native rules/MCP. Publishing the
  TS SDK to npm is the foundation that lets each client repo consume a versioned
  package.
- **`rac-localview` is an in-repo rename now**; standalone extraction stays
  deferred until a viewer publish/vendor contract exists (the ADR-064 trigger).

# User-Facing Contract

None. Corpus-only; no CLI, JSON, or behaviour change.

# Verification

## Ran
- Corpus gates on `rac/`: `validate` (243 valid, 0 invalid), `relationships
  --validate` (1047 checked, 0 issues), `review` (no priority 1-2; health 92/100),
  `gate` (nothing blocking), and `export rac/ --agent-rules --check` (in sync) —
  **all exit 0**.
- ADR-068's cross-references resolve.
- Agent-rules regenerated: ADR-068 appears in all four managed blocks; the drift
  digest advanced and `--check` is green.

## Covered
- Validity and reference-resolution of the new ADR + 7 roadmaps.
- The agent-rules drift gate stays green after adding a live decision.

# Review Path

1. `rac/decisions/adr-068-extension-sdk-and-brand-architecture.md` — the decision
   (start at "Per-client integration repositories" and "Amendments to ADR-064").
2. `rac/roadmaps/v0.22.x-housekeeping/` — the series (v0.22.0 first).
3. `rac/roadmaps/future/repo-extraction-programme.md` — the refreshed programme.
4. `CLAUDE.md` + the three other agent-rules blocks — pointer + regenerated digest.

Plus `rac/roadmaps/.../v0.21.19-...md` flipped to Achieved (ratifying the merged
predecessor, ADR-061).

# Notes For Reviewer

- First PR of the v0.22.x-housekeeping series; intentionally decision-only — it
  commits us to the topology before any move, so the later releases (and the
  org-level repo creations) execute against a recorded contract.
- Two items stay confirm-at-execution: the Marketplace **publisher id** (`rac` vs
  `lore`/`itsthelore`), and whether to do the engine GitHub-repo rename to
  `rac-core` before or after the in-repo URL updates (v0.22.2).

# Implementation Process

Implemented with AI assistance under the roadmap contract; final scope, review,
and acceptance decisions were made by the maintainer.