### PR TITLE
chore(release): make the TS SDK publishable as @itsthelore/rac-sdk (v0.22.3)

### DIFF
--- a/.github/workflows/sdk-release.yml
+++ b/.github/workflows/sdk-release.yml
@@ -1,0 +1,65 @@
+name: SDK Release
+
+# Build, test, and — only on an `sdk-v*` release tag — publish the TypeScript
+# client SDK to npm as `@itsthelore/rac-sdk` (a public scoped package).
+# Publishing is the last step and is reached only after build and test are
+# green. A manual `workflow_dispatch` run does everything except publish
+# (a dry run that builds, tests, packs the tarball, and uploads it as an
+# artifact).
+#
+# Required repository secret for publishing: NPM_TOKEN (an npm automation
+# token with publish rights to the @itsthelore scope). Without it the publish
+# step fails; the build/test/pack steps need it not. The package is published
+# public via `publishConfig.access` in typescript/rac-sdk/package.json.
+on:
+  push:
+    tags:
+      - "sdk-v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sdk-release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: build · test · publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: SDK — build and test
+        working-directory: typescript/rac-sdk
+        run: |
+          npm ci
+          npm run build
+          npm test
+
+      # ---- dry run: pack the tarball so a workflow_dispatch run verifies
+      #      the package is publishable without publishing ----
+      - name: Pack tarball
+        working-directory: typescript/rac-sdk
+        run: npm pack
+
+      - name: Upload tarball artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: rac-sdk-tarball
+          path: typescript/rac-sdk/*.tgz
+          retention-days: 14
+
+      # ---- publish (release tags only, after build/test are green) ----
+      - name: Publish to npm
+        if: startsWith(github.ref, 'refs/tags/sdk-v')
+        working-directory: typescript/rac-sdk
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish

--- a/rac/roadmaps/v0.22.x-housekeeping/v0.22.2-rac-core-identity.md
+++ b/rac/roadmaps/v0.22.x-housekeeping/v0.22.2-rac-core-identity.md
@@ -8,7 +8,7 @@ tags: [structure, org, distribution, release]
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -8,8 +8,8 @@ They version independently of the Python package.
 
 | Package | What it is |
 | --- | --- |
-| [`rac-sdk`](./rac-sdk) (`@rac/sdk`) | The thin Node client: `RacClient` over `rac … --json`, a `RacError` hierarchy, an injectable runner for tests. |
-| [`rac-vscode`](./rac-vscode) | The VS Code / Cursor extension: live validation, hover, and go-to-definition. Consumes `@rac/sdk`. |
+| [`rac-sdk`](./rac-sdk) (`@itsthelore/rac-sdk`) | The thin Node client: `RacClient` over `rac … --json`, a `RacError` hierarchy, an injectable runner for tests. |
+| [`rac-vscode`](./rac-vscode) | The VS Code / Cursor extension: live validation, hover, and go-to-definition. Consumes `@itsthelore/rac-sdk`. |
 
 ## Develop
 

--- a/typescript/rac-sdk/README.md
+++ b/typescript/rac-sdk/README.md
@@ -1,4 +1,4 @@
-# @rac/sdk
+# @itsthelore/rac-sdk
 
 A thin TypeScript client for [RAC](../../README.md) (requirements-as-code).
 
@@ -23,13 +23,13 @@ any Node program (custom CI gates, dashboards, scripts).
 ## Install
 
 ```sh
-npm install @rac/sdk
+npm install @itsthelore/rac-sdk
 ```
 
 ## Usage
 
 ```ts
-import { RacClient, RacNotFoundError, isResolved } from "@rac/sdk";
+import { RacClient, RacNotFoundError, isResolved } from "@itsthelore/rac-sdk";
 
 const rac = new RacClient({ cwd: workspaceRoot }); // cwd resolves .rac/config.yaml
 

--- a/typescript/rac-sdk/package.json
+++ b/typescript/rac-sdk/package.json
@@ -1,9 +1,17 @@
 {
-  "name": "@rac/sdk",
+  "name": "@itsthelore/rac-sdk",
   "version": "0.1.0",
   "description": "Thin TypeScript client for RAC (requirements-as-code): typed access to the rac CLI's JSON contracts. Shells out to the installed rac binary; it never reimplements the engine (ADR-063).",
   "license": "MIT",
   "type": "module",
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/itsthelore/rac-core.git",
+    "directory": "typescript/rac-sdk"
+  },
   "engines": {
     "node": ">=18"
   },

--- a/typescript/rac-sdk/src/index.ts
+++ b/typescript/rac-sdk/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * `@rac/sdk` — a thin TypeScript client for RAC (requirements-as-code).
+ * `@itsthelore/rac-sdk` — a thin TypeScript client for RAC (requirements-as-code).
  *
  * It shells out to the installed `rac` binary and deserializes its stable
  * `--json` contracts (ADR-007) into typed results. It reimplements none of
@@ -7,7 +7,7 @@
  * so a consumer (the VS Code / Cursor extension is the first) always agrees
  * with `rac` on the command line.
  *
- *     import { RacClient, RacNotFoundError } from "@rac/sdk";
+ *     import { RacClient, RacNotFoundError } from "@itsthelore/rac-sdk";
  *
  *     const rac = new RacClient({ cwd: workspaceRoot });
  *     try {

--- a/typescript/rac-vscode/README.md
+++ b/typescript/rac-vscode/README.md
@@ -1,7 +1,7 @@
 # RAC for VS Code / Cursor
 
 Inline validation for [RAC](../../README.md) (requirements-as-code) artifacts,
-powered by the [`@rac/sdk`](../rac-sdk/README.md) thin client.
+powered by the [`@itsthelore/rac-sdk`](../rac-sdk/README.md) thin client.
 
 Open or save a RAC artifact (a Markdown file with `schema_version` frontmatter)
 and validation findings appear as diagnostics — the same findings `rac validate`
@@ -72,7 +72,7 @@ Content-Security-Policy (no network, no remote code, no eval).
 ## Develop
 
 ```sh
-npm install        # links @rac/sdk from ../rac-sdk (build it first: cd ../rac-sdk && npm run build)
+npm install        # links @itsthelore/rac-sdk from ../rac-sdk (build it first: cd ../rac-sdk && npm run build)
 npm run check-types
 npm run compile    # esbuild → dist/extension.js
 ```

--- a/typescript/rac-vscode/esbuild.mjs
+++ b/typescript/rac-vscode/esbuild.mjs
@@ -1,4 +1,4 @@
-// Bundle the extension (and its @rac/sdk dependency) into a single CommonJS file
+// Bundle the extension (and its @itsthelore/rac-sdk dependency) into a single CommonJS file
 // for the VS Code extension host. `vscode` is provided by the host at runtime,
 // so it stays external.
 import * as esbuild from "esbuild";

--- a/typescript/rac-vscode/package-lock.json
+++ b/typescript/rac-vscode/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
-        "@rac/sdk": "file:../rac-sdk",
+        "@itsthelore/rac-sdk": "file:../rac-sdk",
         "@types/mocha": "^10.0.10",
         "@types/node": "^22.0.0",
         "@types/vscode": "^1.85.0",
@@ -26,7 +26,7 @@
       }
     },
     "../rac-sdk": {
-      "name": "@rac/sdk",
+      "name": "@itsthelore/rac-sdk",
       "version": "0.1.0",
       "dev": true,
       "license": "MIT",
@@ -799,6 +799,10 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/@itsthelore/rac-sdk": {
+      "resolved": "../rac-sdk",
+      "link": true
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -1128,10 +1132,6 @@
       "engines": {
         "node": ">=14"
       }
-    },
-    "node_modules/@rac/sdk": {
-      "resolved": "../rac-sdk",
-      "link": true
     },
     "node_modules/@secretlint/config-creator": {
       "version": "10.2.2",

--- a/typescript/rac-vscode/package.json
+++ b/typescript/rac-vscode/package.json
@@ -131,7 +131,7 @@
     "package": "vsce package"
   },
   "devDependencies": {
-    "@rac/sdk": "file:../rac-sdk",
+    "@itsthelore/rac-sdk": "file:../rac-sdk",
     "@types/mocha": "^10.0.10",
     "@types/node": "^22.0.0",
     "@types/vscode": "^1.85.0",

--- a/typescript/rac-vscode/src/extension.ts
+++ b/typescript/rac-vscode/src/extension.ts
@@ -1,7 +1,7 @@
 /**
  * RAC VS Code / Cursor extension.
  *
- * Wires the `@rac/sdk` thin client to the editor. All analysis stays in `rac`
+ * Wires the `@itsthelore/rac-sdk` thin client to the editor. All analysis stays in `rac`
  * (ADR-063); this extension maps its output into the editor:
  *
  *  - per-file validation diagnostics, live as you type (the unsaved buffer is
@@ -44,7 +44,7 @@ import {
   type ResolveResult,
   type ResolvedArtifact,
   type SchemaReference,
-} from "@rac/sdk";
+} from "@itsthelore/rac-sdk";
 
 import {
   CLAUDE_SETTINGS_RELPATH,


### PR DESCRIPTION
# Summary

Implements `rac/roadmaps/v0.22.x-housekeeping/v0.22.3-ts-sdk-npm-publishable.md`.

Makes the TypeScript client SDK a **publishable npm package** —
`@rac/sdk` → **`@itsthelore/rac-sdk`** (public, scoped) — with a release workflow.
Publishing it decouples the extension from the `file:../rac-sdk` path and is the
foundation for per-client integration repos (ADR-068). The SDK stays in the
monorepo for now; the actual extraction to `rac-sdk-ts` is v0.22.5, and the first
publish is you pushing an `sdk-v*` tag once `NPM_TOKEN` is set.

# Roadmap / ADR Trace

Roadmap:
- `rac/roadmaps/v0.22.x-housekeeping/v0.22.3-ts-sdk-npm-publishable.md`

Relevant ADRs:
- `rac/decisions/adr-068-*` — the TS SDK is npm-published (`rac-sdk-ts`).
- `rac/decisions/adr-063-*` — the SDK is a thin client over the `rac` contract.

# Scope

## Included
- `typescript/rac-sdk/package.json`: `name` `@rac/sdk` → `@itsthelore/rac-sdk`;
  `publishConfig.access: "public"`; `repository` (rac-core, `directory:
  typescript/rac-sdk`). `version` stays `0.1.0`; `main`/`types`/`exports`/`files`/
  `license` unchanged. README updated to the scoped name.
- `.github/workflows/sdk-release.yml`: build/test on `sdk-v*` tags (+
  `workflow_dispatch` dry-run with an `npm pack` artifact); `npm publish` gated on
  the tag with `NODE_AUTH_TOKEN: secrets.NPM_TOKEN`. Header documents the required
  secret.
- `typescript/rac-vscode/package.json`: dependency **key** `@rac/sdk` →
  `@itsthelore/rac-sdk` (so it equals the package name, which npm requires);
  **value kept as `file:../rac-sdk`**. `package-lock.json` regenerated;
  `src/extension.ts` import + the `esbuild.mjs`/README references updated.

## Excluded
- Switching the extension to the **published** SDK version — that's v0.22.5 (after
  the first publish and the extraction). It still consumes the local SDK by path.
- Extracting the SDK to its own `rac-sdk-ts` repo (v0.22.5).
- Bumping the version or publishing — the first publish is your `sdk-v*` tag.

# Product / Architecture Decisions

- The dependency **key must equal the package name** for npm to resolve a `file:`
  dependency, so both move to `@itsthelore/rac-sdk` together while the value stays
  local — the extension builds identically, just under the new name.
- `publishConfig.access: "public"` is required because scoped packages default to
  restricted.
- The publish is tag-gated and `workflow_dispatch` is a dry run, so the workflow is
  safe to merge before `NPM_TOKEN` exists — nothing publishes until you tag.

# User-Facing Contract

- New (once you publish): `npm install @itsthelore/rac-sdk`. No change to the
  `rac` CLI or any Python surface.

# Verification

## Ran
- SDK: `npm ci` + `npm run build` + `npm run typecheck` clean; `npm test` — 25
  passed (8 integration skipped, no `RAC_BIN`). `npm pack --dry-run` →
  `@itsthelore/rac-sdk@0.1.0`, 23 files incl. `dist/`, `README.md`, `LICENSE`.
- Extension: `npm ci` (after lockfile regen) + `npm run check-types` +
  `npm run compile` clean — the renamed `file:` dependency resolves because the
  key now equals the package name.
- No stale `@rac/sdk` remains in tracked source (the SDK's own `src/index.ts`
  docstring and the monorepo `typescript/README.md` were updated; `dist/` is
  gitignored and rebuilt in CI).
- Corpus gates on `rac/`: `validate`, `relationships --validate`, `gate`,
  `export rac/ --agent-rules --check` — all exit `0`.

## Covered
- The package is publishable (`npm pack` contents verified).
- The extension still builds against the local SDK under the new name.

# Review Path

1. `typescript/rac-sdk/package.json` — the scoped name + `publishConfig`.
2. `.github/workflows/sdk-release.yml` — the tag-gated publish.
3. `typescript/rac-vscode/package.json` + `src/extension.ts` — the dep-key repoint
   (value still `file:`).

Plus `rac/roadmaps/.../v0.22.2-...md` flipped to Achieved (ADR-061).

# Notes For Reviewer

- Stacked on `claude/v0.22.2-rac-core-identity` (base); retargets to `main` as the
  series merges.
- **This is the last v0.22.x release deliverable without org action.** v0.22.4–.6
  (extract `decisiongrounding`, the TS stack, the actions) need you to create and
  `git filter-repo`-seed the target repos first — see
  `docs/v0.22-housekeeping-runbook.md`.
- Before merging: add the **`NPM_TOKEN`** secret and confirm the **npm scope**
  `@itsthelore` exists, so a later `sdk-v0.1.0` tag can publish.

# Implementation Process

Implemented with AI assistance under the roadmap contract; final scope, review,
and acceptance decisions were made by the maintainer.