### PR TITLE
fix(decisions): renumber the routing ADR to ADR-070 (resolve ADR-068 collision)

### DIFF
--- a/rac/decisions/adr-069-wayfinder-separate-product.md
+++ b/rac/decisions/adr-069-wayfinder-separate-product.md
@@ -15,7 +15,7 @@ Product
 
 ## Context
 
-`rac route` (ADR-068) was built as an exploration: a deterministic, structural
+`rac route` (ADR-070) was built as an exploration: a deterministic, structural
 prompt-complexity scorer that recommends a local or cloud model. It works, but it
 sits *outside* the product line every other decision has drawn. Lore is recorded
 team knowledge served to agents — "no AI in the core, no inference, no guessing"
@@ -48,7 +48,7 @@ dependency on it.**
   block (the ~17-line, import-free `split_frontmatter`) and a config-file walk-up
   (~10 lines, pointed at Wayfinder's own `wayfinder.toml` / env / flags, never
   `.rac/`).
-- ADR-068's boundary carries into Wayfinder unchanged: it scores deterministically
+- ADR-070's boundary carries into Wayfinder unchanged: it scores deterministically
   and recommends; it never invokes a model, selects a provider, reads a
   credential, or tokenizes per a vendor model. The caller runs inference.
 - The in-RAC `rac route` stays for now and is **earmarked for removal** once
@@ -133,7 +133,7 @@ Full independence is selected.
 
 ## Related Decisions
 
-- adr-068
+- adr-070
 - adr-064
 - adr-036
 - adr-035

--- a/rac/decisions/adr-070-prompt-complexity-routing-boundary.md
+++ b/rac/decisions/adr-070-prompt-complexity-routing-boundary.md
@@ -3,7 +3,7 @@ schema_version: 1
 id: RAC-KV8WY8XAJ55S
 type: decision
 ---
-# ADR-068: Prompt-Complexity Routing Boundary
+# ADR-070: Prompt-Complexity Routing Boundary
 
 ## Status
 

--- a/rac/designs/prompt-complexity-routing.md
+++ b/rac/designs/prompt-complexity-routing.md
@@ -15,7 +15,7 @@ type: design
 This design is the *how* for the `complexity-based-model-routing` future
 roadmap item: a deterministic way to score a prompt's complexity and recommend
 a `local` or `cloud` model, without RAC ever calling a model. The boundary it
-implements is ADR-068; the determinism and AI-optional posture it inherits are
+implements is ADR-070; the determinism and AI-optional posture it inherits are
 ADR-002 and ADR-034; the rule that RAC never owns inference is ADR-035.
 
 The mechanism already exists in spirit. `core/classification.py` scores a
@@ -94,7 +94,7 @@ caller can see *why* — and recalibrate — rather than trust an opaque verdict
 RAC stops at the recommendation. It does not invoke a model, select a provider
 or model, read a credential, or tokenize per a vendor model. The caller maps
 `local`/`cloud` onto its own configured endpoints and runs inference. This is
-the ADR-068 line, drawn here so the surface cannot quietly grow a model call.
+the ADR-070 line, drawn here so the surface cannot quietly grow a model call.
 
 ## Constraints
 
@@ -154,7 +154,7 @@ handle the prompt.
 ## Related Decisions
 
 - adr-069
-- adr-068
+- adr-070
 - adr-002
 - adr-034
 - adr-035

--- a/rac/roadmaps/future/complexity-based-model-routing.md
+++ b/rac/roadmaps/future/complexity-based-model-routing.md
@@ -38,7 +38,7 @@ So the honest split this item explores: RAC computes a reproducible complexity
 score over a prompt's structure and maps it to a `local`/`cloud` recommendation
 against a configurable threshold; the consuming agent or skill takes that
 recommendation and invokes its own configured model. RAC stops at the
-recommendation. The boundary is drawn in ADR-068; this item records the product
+recommendation. The boundary is drawn in ADR-070; this item records the product
 intent. It is considered, not scheduled — when scheduled it graduates out of
 `future/` into a versioned series and grows an implementation contract.
 
@@ -111,7 +111,7 @@ capability without a RAC release.
 - Per-vendor tokenization or a model-specific token count.
 - A semantic verdict on prompt difficulty, or any promise that the structural
   score predicts which model can actually handle the prompt — that correlation
-  is the caller's empirical calibration (see ADR-068).
+  is the caller's empirical calibration (see ADR-070).
 
 ## Success Measures
 
@@ -120,7 +120,7 @@ capability without a RAC release.
 - A stored Prompt artifact and the same text on stdin produce the same score.
 - Moving the configured threshold moves the `local`/`cloud` recommendation
   predictably, with no other behavior change.
-- Feature requests for an "LLM router" inside RAC are answered by ADR-068 rather
+- Feature requests for an "LLM router" inside RAC are answered by ADR-070 rather
   than by scope drift.
 
 ## Assumptions
@@ -136,16 +136,16 @@ capability without a RAC release.
 ## Risks
 
 - The score is mistaken for a capability verdict ("cloud means the prompt is too
-  hard for local"). Mitigation: ADR-068 names it a structural proxy; output
+  hard for local"). Mitigation: ADR-070 names it a structural proxy; output
   reports the contributing features so the recommendation is inspectable.
 - Pressure to "just add the model call" so `rac route` also runs the prompt.
-  Mitigation: ADR-068 makes invocation an explicit boundary RAC does not cross;
+  Mitigation: ADR-070 makes invocation an explicit boundary RAC does not cross;
   crossing it requires superseding the ADR, not drifting.
 
 ## Related Decisions
 
 - adr-069
-- adr-068
+- adr-070
 - adr-002
 - adr-034
 - adr-035

--- a/rac/roadmaps/future/wayfinder-extraction.md
+++ b/rac/roadmaps/future/wayfinder-extraction.md
@@ -13,7 +13,7 @@ Unscheduled — captured as future intent, not yet on a release.
 
 ## Context
 
-`rac route` (ADR-068) is a deterministic prompt-complexity router built inside
+`rac route` (ADR-070) is a deterministic prompt-complexity router built inside
 RAC as an exploration. ADR-069 decides it should not live here: it is a runtime
 *inference* concern, divergent from Lore's recorded-knowledge product line, and
 belongs in its own product — **Wayfinder** — as a sibling repo under the
@@ -30,7 +30,7 @@ of `future/` into a versioned plan.
 - Wayfinder exists as its own repository and package, **fully independent of RAC**
   — no `rac` import, no `requirements-as-code` dependency, no reading of `.rac/`.
 - Wayfinder reaches behavior parity with `rac route`: the same structural score,
-  features, and local/cloud recommendation, with ADR-068's boundary intact (score
+  features, and local/cloud recommendation, with ADR-070's boundary intact (score
   deterministically; never invoke a model).
 - `rac route` is removed from RAC after the cutover, with history preserved, so
   the engine carries no long-term out-of-domain command.
@@ -61,7 +61,7 @@ the `rac route` prototype and all its supporting code (`core/complexity.py`,
 `services/route.py`, the routing config loader in `services/init.py`, the route
 renderers, the SDK exports, `tests/test_route.py`, the `route` CI battery, and the
 `docs/cli.md` section) have been removed from RAC by restoring those files to their
-pre-route state. The routing corpus artifacts (this roadmap, ADR-068, ADR-069, and
+pre-route state. The routing corpus artifacts (this roadmap, ADR-070, ADR-069, and
 the `prompt-complexity-routing` design) are kept as the historical record. What
 remains here is publishing Wayfinder to its own `itsthelore/wayfinder` repository.
 
@@ -73,7 +73,7 @@ ADR-064's history-preserving cutover discipline.
 
 - Independence (ADR-069): Wayfinder has zero runtime dependency on RAC and never
   reads the `.rac/` namespace.
-- Routing boundary (ADR-068): deterministic, offline scoring and a recommendation
+- Routing boundary (ADR-070): deterministic, offline scoring and a recommendation
   only; Wayfinder never invokes a model, selects a provider, reads a credential,
   or tokenizes per a vendor model.
 - Safety contract (ADR-064): nothing is removed from RAC until Wayfinder ships and
@@ -114,7 +114,7 @@ ADR-064's history-preserving cutover discipline.
 ## Related Decisions
 
 - adr-069
-- adr-068
+- adr-070
 - adr-064
 
 ## Related Roadmaps


### PR DESCRIPTION
# Summary

Resolves an **ADR-068 numbering collision on `main`**. Two parallel workstreams
each created an `adr-068`:
- `adr-068-extension-sdk-and-brand-architecture.md` — the v0.22.x topology/brand
  decision (`RAC-KVA44M…`).
- `adr-068-prompt-complexity-routing-boundary.md` — the Wayfinder routing boundary
  (`RAC-KV8WY8…`).

They share the `adr-068` alias, so every `adr-068` reference is **ambiguous** —
which breaks `relationships --validate` and `review`, and the dogfood gates, on
`main` itself (and blocks #144's merge CI).

This renumbers the **routing** decision to **ADR-070** (069 is taken by
`wayfinder-separate-product`); the **extension/brand** decision keeps ADR-068.

# Scope

## Included
- `git mv` `adr-068-prompt-complexity-routing-boundary.md` →
  `adr-070-prompt-complexity-routing-boundary.md`; retitle `# ADR-068:` →
  `# ADR-070:`.
- Repoint the **routing-domain** referrers from `adr-068` → `adr-070`:
  `rac/designs/prompt-complexity-routing.md`,
  `rac/roadmaps/future/wayfinder-extraction.md`,
  `rac/roadmaps/future/complexity-based-model-routing.md`, and
  `rac/decisions/adr-069-wayfinder-separate-product.md`.

## Excluded / preserved
- The extension/brand ADR keeps **ADR-068**; the v0.22.x referrers
  (`repo-extraction-programme`, the `v0.22.x-housekeeping/*` roadmaps) are
  untouched — their `adr-068` now resolves unambiguously to it.
- The routing ADR's canonical id (`RAC-KV8WY8…`) is unchanged; only the
  number/alias moves.

# Verification

## Ran
- `rac resolve adr-068 rac/` → uniquely the extension ADR (`RAC-KVA44M…`);
  `rac resolve adr-070 rac/` → the routing ADR (`RAC-KV8WY8…`).
- Corpus gates on `rac/`: `validate`, `relationships --validate`, `review`,
  `gate`, `export rac/ --agent-rules --check` — **all exit 0**.
- The routing ADR is `Proposed` (not a live decision), so the agent-rules digest
  is unaffected and `--check` stays green.

# Notes For Reviewer

- This is a `main`-level fix independent of the v0.22.x stack: it turns `main`'s
  red corpus gates green. Once merged, **#144** (land v0.22.1–v0.22.3) goes green
  too, since its merge CI no longer hits the duplicate `adr-068`.
- The collision arose because the v0.22.x and Wayfinder branches both minted
  `adr-068` independently before either reached `main`.

# Implementation Process

Implemented with AI assistance; final scope, review, and acceptance decisions were
made by the maintainer.