### PR TITLE
docs(roadmap): record Wayfinder published as wayfinder-router [roadmap:wayfinder-extraction]

### DIFF
--- a/rac/roadmaps/future/wayfinder-extraction.md
+++ b/rac/roadmaps/future/wayfinder-extraction.md
@@ -54,6 +54,16 @@ Check availability of the `wayfinder` name (PyPI package, trademark, org repo)
 before it is committed to any public surface. If taken, choose an alternative
 here rather than after publishing.
 
+**Done.** The `wayfinder` distribution name is already taken on PyPI by an
+unrelated project, and `wayfinder` is widely used as a navigation/wayfinding
+trademark. The product is therefore named **Wayfinder Router** and the name
+`wayfinder-router` is applied consistently across every surface: the PyPI
+distribution, the `itsthelore/wayfinder-router` repository, the CLI command, the
+`wayfinder_router` import package, the `wayfinder-router.toml` config file, the
+`WAYFINDER_ROUTER_THRESHOLD` env var, and the gateway's `x-wayfinder-router-*`
+response headers. The `-router` suffix keeps the standalone routing identity
+(ADR-069) rather than coupling it to the Lore brand.
+
 ### Initiative 3 — Deprecate and remove `rac route` from RAC
 
 **Done.** Now that Wayfinder exists in the `wayfinder/` subproject at full parity,
@@ -62,8 +72,18 @@ the `rac route` prototype and all its supporting code (`core/complexity.py`,
 renderers, the SDK exports, `tests/test_route.py`, the `route` CI battery, and the
 `docs/cli.md` section) have been removed from RAC by restoring those files to their
 pre-route state. The routing corpus artifacts (this roadmap, ADR-070, ADR-069, and
-the `prompt-complexity-routing` design) are kept as the historical record. What
-remains here is publishing Wayfinder to its own `itsthelore/wayfinder` repository.
+the `prompt-complexity-routing` design) are kept as the historical record.
+
+Publishing is now done: the `wayfinder/` subproject was lifted to repository
+root with its full commit history preserved (`git subtree split`) and pushed to
+`itsthelore/wayfinder-router`, whose `main` is the extracted history. The
+extracted tree was verified standalone — the 115-test suite, `ruff`, and `mypy`
+all pass in a clean environment with no `rac` installed and no `.rac/` on the
+path, `wayfinder-router serve` boots, and CI (Python 3.11/3.12/3.13 plus the
+Docker image build) is green — confirming the zero-dependency invariant
+(ADR-069). The in-RAC `wayfinder/` mirror is now eligible for removal under
+ADR-064's safety contract (the capability is live in its new home); that removal
+is a separate follow-up.
 
 The original plan: once Wayfinder ships and is verified, remove `rac route` and its
 supporting code, with a deprecation note pointing users to Wayfinder, following
@@ -97,7 +117,8 @@ ADR-064's history-preserving cutover discipline.
 
 ## Assumptions
 
-- The `wayfinder` name (or a chosen alternative) is available for public use.
+- The `wayfinder` name was taken on PyPI; the chosen alternative
+  `wayfinder-router` is available and is the public distribution/repository name.
 - Demand for a standalone deterministic prompt router is real but unproven; this
   stays considered until that signal arrives.
 - Reimplementing the ~30 generic lines in Wayfinder is preferable to a shared


### PR DESCRIPTION
# Summary

Implements `rac/roadmaps/future/wayfinder-extraction.md`.

Records the Wayfinder extraction outcome in the roadmap. `main` already carries
the ADR-068 → ADR-070 renumber (landed independently in #145), so this branch was
rebased onto current `main` and reduced to the roadmap record alone.

Adds:
- Roadmap text recording the resolved public name `wayfinder-router` (Initiative 2).
- Roadmap text recording the history-preserving publish to `itsthelore/wayfinder-router` and its standalone verification (Initiative 3).
- An Assumptions update reflecting the resolved name.

# Roadmap / ADR Trace

Roadmap:
- `rac/roadmaps/future/wayfinder-extraction.md`

Relevant ADRs:
- `rac/decisions/adr-069-wayfinder-separate-product.md`
- `rac/decisions/adr-070-prompt-complexity-routing-boundary.md` (already on `main`, via #145)
- `rac/decisions/adr-064-multi-repo-extraction-strategy.md`

# Scope

## Included
- Initiative 2 records that `wayfinder` was taken on PyPI, so the product publishes as `wayfinder-router` consistently across the PyPI distribution, the repository, the CLI command, the `wayfinder_router` import package, the `wayfinder-router.toml` config file, the `WAYFINDER_ROUTER_THRESHOLD` env var, and the `x-wayfinder-router-*` gateway headers.
- Initiative 3 records the history-preserving lift to `itsthelore/wayfinder-router` (its `main` is the extracted history), the standalone verification (115 tests, `ruff`, `mypy`, and CI on 3.11/3.12/3.13 plus the Docker build), and that the in-RAC `wayfinder/` mirror is now eligible for removal under ADR-064.
- Assumptions updated to reflect the resolved name.

## Excluded
- The ADR-068 → ADR-070 renumber — already on `main` via #145; this branch was rebased to drop the duplicate and avoid a conflicting second renumber.
- Removing the in-RAC `wayfinder/` mirror — a separate, now-unblocked follow-up.
- Graduating `wayfinder-extraction` out of `future/` into a versioned plan; it stays `Planned`.

# Product / Architecture Decisions

- Scope was reduced to a documentation record once `main` was found to already carry the ADR-070 renumber (#145). The duplicate fix was dropped rather than re-applied, keeping the renumber single-sourced and avoiding a conflicting second change to the same artifacts.
- The roadmap remains in `future/` with `Status: Planned`. Recording an outcome inside an initiative is deliberately not the same as graduating the roadmap to a versioned, terminal plan (ADR-061 lifecycle), which stays out of scope.
- The record is prose only — no `## Related` reference is added or changed — so corpus resolution and the relationship graph are unaffected.

# User-Facing Contract

Not applicable. This is a documentation-only change to one roadmap artifact; it
adds or changes no CLI command, no human or JSON output, and no exit-code
behavior.

# Verification

## Ran
- `rac validate rac/` → `248 valid, 0 invalid`
- `rac relationships rac/ --validate` → `Validation Issues: 0`
- PR CI (rac-core batteries): `validate`, `smoke`, `pr-gate`, `watchkeeper`, `agent-rules`, `lint`, `rac` — all green.

## Covered
- Documentation edit to `wayfinder-extraction.md`; no references added or changed, so relationship resolution is unaffected and the dogfood corpus gate (`test_corpus_relationships_resolve`, `test_corpus_reviews_ok`) stays green on top of current `main`.

# Review Path

1. `rac/roadmaps/future/wayfinder-extraction.md` — Initiative 2 (name), Initiative 3 (publish + mirror), and the Assumptions update.

# Notes For Reviewer

- One commit, rebased onto current `main`; no conflict.
- The earlier ADR-068 → ADR-070 renumber once carried on this branch is intentionally gone — `main` already has the equivalent from #145.
- The in-RAC `wayfinder/` mirror removal is a separate, now-unblocked follow-up under ADR-064's safety contract.