### PR TITLE
chore(release): relicense to Apache 2.0 and adopt DCO sign-off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,17 @@ details, release history over commit history.
   releases — cross-artifact enforcement, authoring aids, navigation, awareness,
   visualization, and release hardening.
 
+### Changed
+
+- **License: RAC is now under the Apache License 2.0 (previously MIT).** The
+  package, CLI, and TypeScript stack carry `Apache-2.0` metadata, and a `NOTICE`
+  file ships alongside `LICENSE`. Apache 2.0 adds an express patent grant and an
+  explicit trademark non-grant over MIT; it remains a permissive license, so
+  existing usage rights are unaffected. Contributions now require a Developer
+  Certificate of Origin sign-off (`git commit -s`); there is no CLA. Distribution
+  names are unchanged (PyPI `requirements-as-code`, CLI `rac`, server identity
+  `lore`). See `rac/decisions/adr-071-apache-2-relicense-and-dco.md`.
+
 ## v0.19.0 — 2026-06-15
 
 The kitchen-sink release. Everything since v0.7.3 lands at once. Over this

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,18 @@ Follow [`rac/prompts/rac-agent-commit-guidelines.md`](rac/prompts/rac-agent-comm
 with `type` one of `feat`, `fix`, `test`, `docs`, `refactor`, `chore`. Keep
 commits small and single-purpose.
 
-## License
+## License and sign-off
 
-By contributing you agree your contributions are licensed under the
-[MIT License](LICENSE).
+RAC is licensed under the [Apache License 2.0](LICENSE). By contributing you
+agree your contributions are licensed under the same terms.
+
+Contributions must carry a [Developer Certificate of Origin](https://developercertificate.org/)
+sign-off: certify that you wrote the change (or have the right to submit it)
+by adding a `Signed-off-by` trailer to each commit. Git adds it for you:
+
+```bash
+git commit -s
+```
+
+This produces a `Signed-off-by: Your Name <you@example.com>` line matching your
+commit author identity. There is no CLA.

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,201 @@
-MIT License
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Copyright (c) 2026 tcballard
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   1. Definitions.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Tom Ballard
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,4 @@
+RAC (requirements-as-code)
+Copyright 2026 Tom Ballard
+
+This product is licensed under the Apache License, Version 2.0 (see LICENSE).

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <img alt="Lore — agents that know why. Deterministic. Read-only. No RAG, no guessing." src="https://raw.githubusercontent.com/itsthelore/rac-core/main/rac/assets/images/lore-header-light.png">
 </picture>
 
-[![CI](https://github.com/itsthelore/rac-core/actions/workflows/ci.yml/badge.svg)](https://github.com/itsthelore/rac-core/actions/workflows/ci.yml) [![PyPI](https://img.shields.io/pypi/v/requirements-as-code)](https://pypi.org/project/requirements-as-code/) [![Python](https://img.shields.io/pypi/pyversions/requirements-as-code)](https://pypi.org/project/requirements-as-code/) [![License: MIT](https://img.shields.io/pypi/l/requirements-as-code)](https://github.com/itsthelore/rac-core/blob/main/LICENSE)
+[![CI](https://github.com/itsthelore/rac-core/actions/workflows/ci.yml/badge.svg)](https://github.com/itsthelore/rac-core/actions/workflows/ci.yml) [![PyPI](https://img.shields.io/pypi/v/requirements-as-code)](https://pypi.org/project/requirements-as-code/) [![Python](https://img.shields.io/pypi/pyversions/requirements-as-code)](https://pypi.org/project/requirements-as-code/) [![License: Apache 2.0](https://img.shields.io/pypi/l/requirements-as-code)](https://github.com/itsthelore/rac-core/blob/main/LICENSE)
 
 > **Give your coding agent the decisions your team already made — so it stops re-doing things you ruled out.**
 
@@ -93,4 +93,4 @@ Lore is early and evolving quickly. The MCP server ships today. Contributions, i
 
 ## License
 
-MIT
+[Apache License 2.0](LICENSE).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,8 @@ dynamic = ["version"]
 description = "RAC — lint and diff product requirements written in Markdown."
 readme = "README.md"
 requires-python = ">=3.11"
-license = "MIT"
-license-files = ["LICENSE"]
+license = "Apache-2.0"
+license-files = ["LICENSE", "NOTICE"]
 authors = [{ name = "tcballard" }]
 keywords = ["requirements", "product-management", "markdown", "linter", "cli", "diff"]
 dependencies = ["markdown-it-py>=3.0", "pyyaml>=6.0", "mcp>=1.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 license = "Apache-2.0"
 license-files = ["LICENSE", "NOTICE"]
-authors = [{ name = "tcballard" }]
+authors = [{ name = "Tom Ballard" }]
 keywords = ["requirements", "product-management", "markdown", "linter", "cli", "diff"]
 dependencies = ["markdown-it-py>=3.0", "pyyaml>=6.0", "mcp>=1.0"]
 classifiers = [

--- a/rac/decisions/adr-071-apache-2-relicense-and-dco.md
+++ b/rac/decisions/adr-071-apache-2-relicense-and-dco.md
@@ -1,0 +1,145 @@
+---
+schema_version: 1
+id: RAC-KVCJFDSTMPH9
+type: decision
+---
+# ADR-071: Apache 2.0 Relicensing and DCO Contribution Sign-Off
+
+## Context
+
+Every RAC artifact ships MIT today: the engine package
+(`requirements-as-code`), the TypeScript SDK, and the editor extension all
+declare MIT. The multi-repo extraction programme (ADR-064, ADR-068) is about
+to create five sibling repositories under the `itsthelore`
+organisation — `decisiongrounding`, `rac-sdk-ts`, `lore-vscode`,
+`lore-gatekeeper`, `lore-watchkeeper` — alongside the renamed `rac-core`
+engine. We want one deliberate licensing posture set across the whole org
+*before* those repos start attracting outside contributors, while the
+maintainer is still effectively the sole copyright holder and a relicense
+costs no consent-gathering.
+
+MIT has two gaps that matter at this stage:
+
+- **No express patent grant.** MIT conveys no patent licence and no
+  retaliation clause. Apache 2.0 grants contributors' patents to users and
+  terminates the grant for anyone who brings a patent suit (§3) — the single
+  most common reason organisations prefer Apache over MIT, and a protection
+  for users and the project rather than a commercial lever.
+- **Silence on trademarks.** As the `lore` / `rac` brand identity is built
+  out (ADR-036, ADR-039, ADR-068), Apache 2.0's explicit trademark non-grant
+  (§6) keeps the marks reserved; MIT says nothing.
+
+Apache 2.0 is also the license enterprise legal policies most reliably
+whitelist, which aids the broad adoption ADR-012 optimises for.
+
+A licensing change must not be mistaken for a commercial moat. ADR-012
+(Open Core) already locates commercial value in a *separate* repository-scale
+or hosted layer, not in restricting the core. Apache 2.0 is permissive: it
+grants hosting and commercial use to everyone, exactly like MIT. The moat in
+ADR-012 is architectural, and this decision does not change it.
+
+The genuine "if needed" lever is retaining the right to relicense later. A
+permissive license plus external contributors and no contribution agreement
+removes the ability to dual-license down the road, because the maintainer no
+longer holds or controls all rights. That is a contribution-process question,
+not a license-text question, so it is decided here alongside the relicense.
+
+## Decision
+
+Relicense the entire `itsthelore` org from MIT to the **Apache License 2.0**,
+and adopt a **Developer Certificate of Origin (DCO)** sign-off on all
+contributions. No CLA at this time.
+
+- **Scope.** `rac-core` (engine, including the in-process MCP server and all
+  shipped skills, templates, and hooks) and every extracted repo —
+  `decisiongrounding`, `rac-sdk-ts`, `lore-vscode`, `lore-gatekeeper`,
+  `lore-watchkeeper`.
+- **Mechanics.** Each repo carries the Apache 2.0 `LICENSE` text plus a
+  `NOTICE` file; SPDX identifier `Apache-2.0` in `pyproject.toml` and every
+  `package.json`; README license badges updated. Per-file Apache header
+  blocks are permitted but not required.
+- **Contributions.** Require a DCO `Signed-off-by` line (`git commit -s`).
+  A CLA is explicitly *not* adopted now.
+- **Identity unchanged.** Distribution names stay frozen (ADR-036, ADR-039):
+  PyPI `requirements-as-code`, CLI `rac`, server identity `lore`. This
+  changes license terms, not identity.
+- **Open-core posture unchanged.** This complements ADR-012; it does not
+  alter which capabilities are open. Commercial value remains a separate
+  repository-scale / hosted layer, never a restriction of the core.
+
+## Consequences
+
+### Positive
+
+- Express patent grant and retaliation clause protect users and the project.
+- Explicit trademark non-grant reserves the `lore` / `rac` marks as the brand
+  is established.
+- Enterprise-friendly: the license most corporate legal reviews pre-approve.
+- One consistent posture across all six repos.
+- Done while the maintainer is effectively sole copyright holder, so the
+  permissive-to-permissive relicense needs no contributor consent thicket —
+  cheapest it will ever be.
+- DCO keeps contribution provenance clean at near-zero friction.
+
+### Negative / trade-offs
+
+- Apache 2.0 is more ceremony than MIT: `NOTICE` files and the header
+  convention to maintain across repos.
+- It creates no competitive moat — intentionally; that is ADR-012's job, not
+  the license's.
+- DCO without a CLA means no unilateral future relicense once external
+  contributors land. Accepted: if true dual-licensing optionality is later
+  required, a CLA is the follow-up lever, recorded as its own decision.
+
+### Risks
+
+- License/`NOTICE`/header drift across six repos. Mitigation: a fixed
+  per-repo checklist applied in the same change as the metadata update.
+- Package metadata mismatch (SPDX vs `LICENSE`). Mitigation: update SPDX in
+  `pyproject.toml` / `package.json` in the same commit as the `LICENSE` swap.
+
+## Status
+
+Proposed
+
+## Category
+
+Process
+
+## Alternatives Considered
+
+### Stay on MIT
+
+Simplest and already in place. Rejected: it forgoes the patent grant and the
+trademark non-grant, and it misses the pre-contributor window in which a
+relicense is essentially free.
+
+### Source-available (BSL / SSPL) or copyleft (AGPL) for "commercial protection"
+
+Would genuinely restrict third-party commercial/hosted reuse. Rejected: it
+directly contradicts ADR-012's adoption thesis (the Git → GitHub,
+Terraform → Terraform Cloud pattern), chilling ecosystem growth and standard
+adoption. The intended moat is the separate hosted layer, not a restrictive
+license on the core.
+
+### Apache 2.0 with a CLA now
+
+Maximises future optionality (the maintainer could dual-license later). Deferred:
+a CLA adds contributor friction and asks for a copyright-assignment trust step
+that is premature at this stage. DCO is chosen as the low-friction default; a
+CLA is revisitable when a commercial offering is first actively considered —
+the same trigger ADR-012 sets for its own review.
+
+## Related Decisions
+
+- adr-012
+- adr-036
+- adr-039
+- adr-064
+- adr-068
+
+## Review Date
+
+Revisit when a commercial or dual-license offering is first actively
+considered (aligning with ADR-012's review trigger), or if a contribution
+arrives whose provenance a DCO cannot adequately cover.

--- a/typescript/rac-sdk/package.json
+++ b/typescript/rac-sdk/package.json
@@ -2,7 +2,7 @@
   "name": "@itsthelore/rac-sdk",
   "version": "0.1.0",
   "description": "Thin TypeScript client for RAC (requirements-as-code): typed access to the rac CLI's JSON contracts. Shells out to the installed rac binary; it never reimplements the engine (ADR-063).",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "type": "module",
   "publishConfig": {
     "access": "public"

--- a/typescript/rac-vscode/package.json
+++ b/typescript/rac-vscode/package.json
@@ -5,7 +5,7 @@
   "version": "0.1.0",
   "publisher": "rac",
   "icon": "icon.png",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/itsthelore/rac-core.git",


### PR DESCRIPTION
# Summary

Implements the licensing decision in `rac/decisions/adr-071-apache-2-relicense-and-dco.md`:
relicense the project from MIT to Apache 2.0 and adopt a DCO contribution
sign-off (no CLA), ahead of the v0.22.4+ repo extractions.

Adds:
- ADR-071, the decision record (Status: Proposed).
- Apache License 2.0 `LICENSE` text and a new `NOTICE` file, replacing MIT.
- SPDX `Apache-2.0` metadata across `pyproject.toml` and the TypeScript
  package manifests; author metadata aligned to the maintainer's real name.
- Apache 2.0 + DCO sign-off contribution terms in `CONTRIBUTING.md`; README
  license badge and section updated; a `CHANGELOG.md` Unreleased entry.

# Roadmap / ADR Trace

Roadmap:
- None. This is an ADR-driven governance change, not a versioned roadmap item.
  It precedes and supports the `v0.22.x-housekeeping` extraction series.

Relevant ADRs:
- `rac/decisions/adr-071-apache-2-relicense-and-dco.md` — the decision implemented here.
- `rac/decisions/adr-012-open-core-strategy.md` — the moat stays a separate
  hosted/org layer; this relicense does not change which capabilities are open.
- `rac/decisions/adr-036-lore-product-identity.md`,
  `rac/decisions/adr-039-lore-server-identity.md` — distribution names stay
  frozen (PyPI `requirements-as-code`, CLI `rac`, server identity `lore`).
- `rac/decisions/adr-064-multi-repo-extraction-strategy.md`,
  `rac/decisions/adr-068-extension-sdk-and-brand-architecture.md` — the
  extraction topology these terms will apply to per-repo.

# Scope

## Included
- MIT → Apache 2.0 across `rac-core`: `LICENSE`, `NOTICE`, `pyproject.toml`
  (`license = "Apache-2.0"`, `license-files = ["LICENSE", "NOTICE"]`), both
  `typescript/*/package.json` license fields, README badge + License section.
- DCO sign-off documented in `CONTRIBUTING.md` (`git commit -s`), explicit
  "no CLA".
- Author metadata changed from the `tcballard` handle to `Tom Ballard`,
  matching the LICENSE/NOTICE copyright holder and commit identity.
- `CHANGELOG.md` Unreleased `Changed` entry recording the relicense, the NOTICE
  file, the DCO requirement, and the unchanged distribution names.

## Excluded
- No CLA. DCO only; a CLA is the deferred lever recorded in ADR-071, revisited
  at the same trigger as ADR-012 (first active commercial offering).
- No source-available or copyleft terms — rejected in ADR-071 as contrary to
  ADR-012's adoption thesis.
- No per-file Apache header blocks (permitted by the ADR, not required; not
  added here).
- The sibling extraction repos are not relicensed here; each carries the same
  `LICENSE`/`NOTICE`/SPDX/DCO when it is seeded (v0.22.4+).
- Third-party `license: MIT` entries in `rac-localview/package-lock.json` are
  dependency metadata and are deliberately untouched.

# Product / Architecture Decisions
- Apache 2.0 chosen over staying on MIT for its express patent grant and
  retaliation clause (§3) and explicit trademark non-grant (§6) — protections
  for users and the `lore`/`rac` marks, not a commercial moat.
- DCO over CLA: clean provenance at near-zero contributor friction while the
  maintainer is effectively sole copyright holder and no commercial offering
  is on the table.
- Done before the extraction repos attract outside contributors, while a
  permissive-to-permissive relicense needs no contributor consent.
- Copyright holder recorded as `Tom Ballard` (real name) rather than the
  `tcballard` handle, so LICENSE, NOTICE, package author, and commit identity
  agree.

# User-Facing Contract

## CLI
No change. No command, flag, argument, or subcommand is added, removed, or
altered.

## Human Output
No change to any command's terminal output.

## JSON Output
No change. No `to_dict` shape or `schema_version` is touched.

## Exit Codes
Unchanged for every command.

## Packaging / Project Metadata (the only user-facing change)
- Distributed license is now `Apache-2.0` (was `MIT`) in the Python package and
  both npm manifests; the wheel/sdist ship `LICENSE` and `NOTICE`.
- Contribution terms now require a DCO `Signed-off-by` (no CLA).
- Distribution names are unchanged: PyPI `requirements-as-code`, CLI `rac`,
  server identity `lore`.

# Verification

## Ran
- `rac validate rac/` — PASS, 249 valid, 0 invalid.
- `rac relationships rac/ --validate` — 1086 checked, 0 issues (all ADR-071
  references resolve).
- `rac review rac/` — no priority findings against ADR-071; corpus health 92/100.
- `python3 -c "import tomllib; ..."` — `pyproject.toml` parses; `license` and
  `license-files` are as expected; both npm manifests parse with `Apache-2.0`.
- Grepped the project's own license surface — no remaining MIT reference.

## Covered
- Positive: new ADR validates structurally and its cross-references resolve;
  package metadata (Python + both npm manifests) declares `Apache-2.0`.
- Boundary: `LICENSE` is the verbatim canonical Apache 2.0 text; `NOTICE` is
  present and shipped via `license-files`.
- Negative (non-regression): no CLI/JSON/golden surface changed, so the smoke
  and golden batteries pass unmodified — confirming this is metadata-only.

# Review Path
1. `rac/decisions/adr-071-apache-2-relicense-and-dco.md` — the decision, its
   rationale, alternatives, and review trigger.
2. `LICENSE` + `NOTICE` — the license text swap and attribution file.
3. `pyproject.toml`, `typescript/*/package.json` — SPDX + author metadata.
4. `CONTRIBUTING.md`, `README.md`, `CHANGELOG.md` — contribution terms, surfaced
   license, and the release note.

# Notes For Reviewer
- ADR-071 is `Proposed`; merging this PR is the act that accepts it. Flip the
  status to `Accepted` in the same merge or a follow-up if you prefer an
  explicit acceptance commit.
- The `authors` email is intentionally omitted; say if you want it on PyPI.
- The relicense is recorded under `CHANGELOG.md` `## Unreleased` as a `Changed`
  entry, so it travels into the next release's notes.

# Implementation Process
Implemented with AI assistance under the ADR contract; final scope, review,
and acceptance decisions are the maintainer's.