### PR TITLE
docs(roadmap): close out v0.22.x — defer v0.22.6, mark v0.22.3–.5 Achieved

### DIFF
--- a/rac/roadmaps/v0.22.x-housekeeping/v0.22.3-ts-sdk-npm-publishable.md
+++ b/rac/roadmaps/v0.22.x-housekeeping/v0.22.3-ts-sdk-npm-publishable.md
@@ -8,7 +8,7 @@ tags: [structure, org, distribution, release]
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/rac/roadmaps/v0.22.x-housekeeping/v0.22.4-extract-decisiongrounding.md
+++ b/rac/roadmaps/v0.22.x-housekeeping/v0.22.4-extract-decisiongrounding.md
@@ -8,7 +8,7 @@ tags: [structure, org, distribution, release]
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/rac/roadmaps/v0.22.x-housekeeping/v0.22.5-extract-typescript-stack.md
+++ b/rac/roadmaps/v0.22.x-housekeeping/v0.22.5-extract-typescript-stack.md
@@ -8,7 +8,7 @@ tags: [structure, org, distribution, release]
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/rac/roadmaps/v0.22.x-housekeeping/v0.22.6-split-actions.md
+++ b/rac/roadmaps/v0.22.x-housekeeping/v0.22.6-split-actions.md
@@ -10,6 +10,15 @@ tags: [structure, org, distribution, release]
 
 Planned
 
+**Deferred.** The extraction remains the recorded intent
+(ADR-064/ADR-068) but is parked: the actions are thin CLI-versioned wrappers,
+the in-repo source-install dogfood gives a stronger CI signal than a
+post-split PyPI-only run, and there is no near-term need for the standalone
+branded repos. Revisit when a trigger appears — a Marketplace listing for the
+gate, independent action release cadence, or a third-party consumer pinning
+the branded path — and a PyPI engine release is available for
+`lore-gatekeeper`'s `rac gate`.
+
 ## Context
 
 ADR-068 amends ADR-064: the GitHub Actions split into two product-branded repos,
@@ -21,6 +30,10 @@ the consumer-breaking cutover: it changes the `uses:` paths downstream workflows
 reference, so it runs after the org repos are seeded, behind versioned
 references. "Enforcement is the product" (ADR-049) — the gate is the headline
 surface, hence its own branded repo.
+
+The series effectively completes at v0.22.5; this item is parked (see Status),
+not incomplete or abandoned, and the Outcomes, Initiatives, and Implementation
+Contract below describe the work to resume if a trigger arrives.
 
 ## Outcomes
 


### PR DESCRIPTION
# Summary

Corpus-only close-out of the `v0.22.x-housekeeping` series. Two changes, no
code:

1. **Defer v0.22.6 (split the GitHub Actions).** The extraction stays the
   recorded intent (ADR-064/ADR-068) but is parked: the actions are thin
   CLI-versioned wrappers, the in-repo source-install dogfood gives a stronger
   CI signal than a post-split PyPI-only run, and there is no near-term need for
   the standalone `lore-watchkeeper`/`lore-gatekeeper` repos. Status stays
   `Planned` (the schema has no "Deferred"; status is a knowledge lifecycle, not
   work state — ADR-051/ADR-061) with a **Deferred** note and explicit unblock
   triggers. The three action sources (`action.yml`, `pr-gate-action/`,
   `validate-action/`) remain in `rac-core`.
2. **Mark v0.22.3, v0.22.4, v0.22.5 `Achieved`** (ADR-061). All three are
   delivered and merged to `main` (#142, #148, #149): the TS SDK is published as
   `@itsthelore/rac-sdk@0.1.0`, `decisiongrounding` lives in
   `itsthelore/decisiongrounding`, and the TypeScript stack lives in
   `rac-sdk-ts` + `lore-vscode`. Each prior PR deliberately left the
   Planned→Achieved flip as a maintainer call; this lands it.

# Roadmap / ADR Trace

- `rac/roadmaps/v0.22.x-housekeeping/v0.22.6-split-actions.md` — deferred
- `rac/roadmaps/v0.22.x-housekeeping/v0.22.{3,4,5}-*.md` — Achieved
- ADR-061 (Achieved terminal lifecycle), ADR-051 (status is lifecycle, not work
  state), ADR-064/ADR-068 (the extraction topology v0.22.6 still records)

# Scope

## Included
- `v0.22.6`: `## Status` deferral note + one Context sentence noting the series
  completes at v0.22.5 while this item is parked. Outcomes/Initiatives/Contract
  left intact for if/when it resumes.
- `v0.22.3/.4/.5`: `## Status` `Planned` → `Achieved` (one line each).

## Excluded
- No ADR changes; ADR-064/068/058 are untouched (the extraction decision stands,
  it is only deferred).
- No action sources moved or removed; no `pr-checks.yml` change.
- Org-side housekeeping (promote the `rac-sdk-ts`/`lore-vscode` seed branches to
  `main` + branch protection, the extension `publisher` id, Marketplace/OpenVSX
  secrets) — maintainer tasks, out of scope here.

# User-Facing Contract

No change. Corpus documentation only — no CLI, human/JSON output, or exit-code
surface is touched.

# Verification

- `rac validate rac/` → 249 valid, 0 invalid (exit 0)
- `rac relationships rac/ --validate` → 0 issues (exit 0)
- `rac review rac/` → no priority 1–2 findings, health 92/100 (exit 0)

Rebased onto current `main` so the diff is exactly the four roadmap files (the
v0.22.5 TS-removal content is already on `main` via #149).

# Notes For Reviewer

- One follow-up thread if you ever decide to *keep* the actions in `rac-core`
  permanently rather than defer: ADR-068's actions-split slice and ADR-058 would
  then need amending. A defer leaves them as-is.