### PR TITLE
docs(roadmap): refine v0.23.0 hardening scope — red-team and tighten 10 workstreams

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,7 @@
 {
   "attribution": {
     "commit": "",
-    "pr": ""
+    "pr": "",
+    "sessionUrl": false
   }
 }

--- a/rac/decisions/adr-030-guide-tools-only-surface.md
+++ b/rac/decisions/adr-030-guide-tools-only-surface.md
@@ -133,6 +133,10 @@ Tools only, exactly four, is selected.
   identifiers the resolver owns.
 - ADR-029 defines how Guide ships; this decision defines what it exposes.
 - ADR-034 bounds what the tools may compute.
+- ADR-067 additively extends this surface with a fifth read-only tool,
+  `find_decisions` — the additive-extension path this decision anticipated (see
+  Risks). The tools-only surface and the four foundational tools above remain in
+  force; this is an extension, not a supersession.
 
 ## Success Measures
 

--- a/rac/requirements/rac-artifact-trust-model.md
+++ b/rac/requirements/rac-artifact-trust-model.md
@@ -22,37 +22,77 @@ from recorded decisions. This was the red-team's highest-priority gap — we
 assert artifacts are trustworthy without recording why, or giving a consumer any
 signal to distinguish a reviewed decision from an unreviewed draft.
 
+Concretely, the `get_artifact` serializer today emits only
+`schema_version`, the index entry's `id` / `type` / `title` / `path` /
+`aliases`, and the raw `content`; it carries no status or review field, so a
+consumer cannot tell an `Accepted` decision from a `Proposed` draft from tool
+output. This workstream owns naming the trust model and adding that one
+deterministic signal.
+
 ## Requirements
 
-- [REQ-001] The release MUST document the trust model in `SECURITY.md`: artifact content is authoritative because it passed human PR review; the read-only MCP server protects the store, not the agent; unreviewed or machine-ingested content is out of scope and MUST NOT be treated as trusted (ADR-065).
-- [REQ-002] `SECURITY.md` MUST state the threat (a poisoned artifact or hostile PR can attempt to steer the consuming agent) and the mitigation (PR review plus the `rac doctor` injection flag).
-- [REQ-003] `rac doctor` MUST flag instruction-like / injection-style content in artifacts (shared with WS3).
-- [REQ-004] `get_artifact` MUST surface a review/trust signal — at minimum the artifact's status — additively, so a consumer can distinguish a reviewed-`Accepted` decision from a `Proposed`/draft artifact.
-- [REQ-005] Nothing in this release may auto-edit artifact content; the trust boundary remains human PR review.
+- [REQ-001] The release MUST document the trust model in `SECURITY.md`: artifact content is authoritative because it passed human PR review; the read-only MCP server protects the store, not the agent; unreviewed or machine-ingested content is out of scope and MUST NOT be treated as trusted (ADR-065). `SECURITY.md` is scoped to RAC Core / the Lore read-only MCP server in this repository; it documents the trust model and the existing report channel, and MUST NOT promise a vulnerability-response SLA, a sanitizer, or any per-artifact trust verdict (ADR-034, ADR-065).
+- [REQ-002] `SECURITY.md` MUST state the threat (a poisoned artifact or hostile PR can attempt to steer the consuming agent — imperative overrides, system/agent/tool impersonation, decision-steering text) and the mitigation (human PR review as the boundary, plus the `rac doctor` injection flag and the `get_artifact` review signal as aids), and MUST state plainly that PR review is the trust boundary and that neither aid is a guarantee or a gate (ADR-065).
+- [REQ-003] The `rac doctor` injection-style-content check is owned by WS3 (`rac-doctor-diagnostic-validator`, REQ-004); this requirement MUST NOT re-specify or duplicate it. WS11 owns only the trust model documentation and the `get_artifact` review signal, and references the doctor flag as the authoring-time aid `SECURITY.md` points to.
+- [REQ-004] `get_artifact` MUST surface a review/trust signal additively and backward-compatibly (ADR-007): a top-level `status` string sourced deterministically from the artifact's `## Status` section as already parsed by Core (no new front-matter field, no PR-API call), so a consumer can distinguish a reviewed-`Accepted` decision from a `Proposed`/draft artifact. The signal MUST be derived from repository bytes plus git only and MUST be byte-identical across repeated calls on an unchanged corpus (ADR-032); when the status cannot be determined the field MUST be present with an explicit empty/unknown value rather than omitted.
+- [REQ-005] The review signal is a reported fact, not a verdict: `get_artifact` MUST NOT compute or return a "trustworthiness" score, a pass/fail trust judgement, or any per-artifact safety verdict (ADR-034). It surfaces status (and, where WS5 provenance lands, the author/reviewer facts) and leaves the trust judgement to the human reviewer and the consuming agent.
+- [REQ-006] Nothing in this release may auto-edit, sanitize, rewrite, or filter artifact content; the trust boundary remains human PR review and the read-only surface stays byte-stable (ADR-065, ADR-032).
 
 ## Acceptance Criteria
 
-- The trust model is documented in `SECURITY.md`.
-- `rac doctor` flags a planted injection-style fixture, and a test asserts the
-  flag fires.
-- `get_artifact` exposes review status, verified by a test, as an additive
-  backward-compatible field.
+- The trust model is documented in `SECURITY.md`, within the scope of REQ-001,
+  and states plainly that PR review is the boundary and the doctor flag and
+  review signal are aids, not guarantees.
+- `get_artifact` exposes a top-level `status` field, verified by a test, as an
+  additive backward-compatible field that is byte-identical across repeated
+  calls on an unchanged corpus and present-but-empty when status is
+  indeterminate.
+- The injection-style-content flag itself is exercised by WS3's tests, not
+  duplicated here; WS11's tests cover only the `SECURITY.md` claims and the
+  `get_artifact` review signal.
+- No code path in this release writes, rewrites, or filters artifact content;
+  the MCP surface stays exactly four read-only tools with additive output only.
 
 ## Success Metrics
 
 - A user can articulate, from the docs, exactly what the read-only guarantee
   does and does not protect.
-- A consumer can tell reviewed decisions apart from drafts via tool output.
+- A consumer can tell reviewed decisions apart from drafts via the `status`
+  field in `get_artifact` output.
+
+## Non-Goals
+
+Explicit descopes for this release, so the boundary against ADR-034 and the
+sibling workstreams stays legible:
+
+- No per-artifact trust score, safety verdict, or pass/fail trust judgement on
+  any tool — the signal is reported status, not a verdict (ADR-034).
+- No content sanitizer, rewrite, redaction, or filtering on the serving path;
+  the read-only surface stays byte-stable (ADR-065, ADR-032).
+- No fifth MCP tool, no write capability, no PR-API / review-thread plumbing
+  this release; the review signal is derived from repository bytes plus git
+  only.
+- WS11 does not re-implement the `rac doctor` injection check (owned by WS3,
+  `rac-doctor-diagnostic-validator`) nor the author/date/status-history
+  provenance fields (owned by WS5, `rac-provenance-surfacing`); it consumes
+  them and supplies the trust narrative and the `status` signal.
 
 ## Risks
 
-- A reader mistakes the doctor flag for a guarantee. Mitigation: `SECURITY.md`
-  states plainly that PR review is the boundary and the flag is an aid.
+- A reader mistakes the doctor flag or the `status` signal for a guarantee.
+  Mitigation: `SECURITY.md` states plainly that PR review is the boundary and
+  both are aids, not gates (ADR-065).
+- The `status` field collides or overlaps with the WS5 provenance fields and the
+  WS3 doctor output on `get_artifact`. Mitigation: WS11 adds only the top-level
+  `status` string; WS5 adds the author/date/status-history fields; the two are
+  additive and namespaced so they compose without duplication (ADR-007).
 
 ## Assumptions
 
-- Front-matter status plus the provenance fields (WS5) carry enough signal to
-  power the review/trust distinction without PR-API plumbing this release.
+- The `## Status` section parsed by Core, plus the provenance fields (WS5),
+  carry enough signal to power the review/trust distinction without PR-API
+  plumbing this release; status is not a front-matter field today and this
+  release does not make it one.
 
 ## Related Decisions
 

--- a/rac/requirements/rac-doctor-diagnostic-validator.md
+++ b/rac/requirements/rac-doctor-diagnostic-validator.md
@@ -15,45 +15,78 @@ v0.23.0 hardening release (WS3).
 
 ## Problem
 
-`rac validate` answers pass/fail per file. When a repository is unhealthy — a
-broken reference, a dangling relationship, a duplicate id, a decision left
-`Accepted` that a later `Accepted` decision supersedes — a user is told *that*
-something is wrong but not *where* or *how to fix it*. A new adopter pointing
-Lore at a real, years-old corpus needs a single command that diagnoses health
-and hands back actionable, paste-ready fixes.
+RAC already *detects* most corpus defects, but the detection is spread across
+three commands a new adopter does not yet know to chain. `rac validate` answers
+pass/fail per file; `rac relationships --validate` reports broken, ambiguous,
+self-referencing, type-mismatched, retired-target, duplicate-identifier, and
+cyclic references; `rac review`/`rac portfolio` aggregate validation, broken
+relationships, and orphans into a prioritized list. A person pointing Lore at a
+real, years-old corpus must run several commands, reconcile their output, and
+already know which one finds what. There is also no single command that answers
+the WS11 trust question — "does any artifact contain text engineered to steer a
+consuming agent?" — nor one that names the **high-fan-out hubs** WS4 must bound
+at runtime. The gap is not detection; it is one front door that returns a single
+health verdict with a paste-ready next step for each finding.
 
 ## Requirements
 
-- [REQ-001] RAC MUST provide a `rac doctor` CLI subcommand that diagnoses repository health across malformed/invalid front matter, dangling or broken typed relationships, orphaned artifacts, duplicate ids, schema drift, and deterministically detectable contradictions.
-- [REQ-002] For every finding, `rac doctor` MUST print the exact file, the problem, and a paste-ready fix command or edit.
-- [REQ-003] `rac doctor` MUST flag relationship cycles and high-fan-out hubs, so authors fix the data that WS4 bounds at runtime.
-- [REQ-004] `rac doctor` MUST flag instruction-like / injection-style content — imperative overrides, impersonation of system/agent/tool instructions, or content steering the agent away from recorded decisions (supports WS11).
-- [REQ-005] `rac doctor` MUST exit non-zero on errors and zero when only warnings are present, and MUST be deterministic.
-- [REQ-006] `rac doctor` MUST be wired into CI alongside existing validation, and SHOULD reuse existing validation and relationship-integrity logic rather than re-deriving it (ADR-055, ADR-049).
+- [REQ-001] RAC MUST provide a `rac doctor <dir>` CLI subcommand that runs the existing validation and relationship-integrity checks over a corpus and returns one aggregated health report, reusing `rac.services` (validate, relationships, portfolio/review) rather than re-deriving any defect class it already detects (ADR-049, ADR-055, ADR-060).
+- [REQ-002] `rac doctor` MUST add the two diagnostics no existing command provides: high-fan-out relationship hubs (a node whose inbound-plus-outbound resolved-edge degree exceeds a configurable threshold), and a heuristic injection-style content flag (REQ-005); it MUST NOT reimplement cycle, duplicate-ID, orphan, broken-reference, or schema-drift detection, which remain owned by `validate` and `relationships --validate`.
+- [REQ-003] For every finding, `rac doctor` MUST print the source path, a stable finding code, the problem, and a deterministic paste-ready fix — a runnable `rac` command (e.g. `rac relationships <dir> --validate`, `rac validate <path>`) or a literal edit instruction — never an auto-applied change (REQ-007, ADR-065).
+- [REQ-004] `rac doctor` MUST flag relationship cycles and high-fan-out hubs in its report so authors can fix the data WS4 bounds at runtime; the cycle data is read from `relationships --validate`, and only the hub computation is doctor's own.
+- [REQ-005] `rac doctor` MUST flag instruction-like / injection-style content — for example imperative overrides, impersonation of system/agent/tool instructions, or text steering an agent away from recorded decisions — as a deterministic, offline heuristic WARNING for human review (supports WS11); it MUST NOT auto-edit content, hard-fail a run on its own, or claim the content is unsafe — only that a human should look (ADR-065).
+- [REQ-006] `rac doctor` MUST run fully deterministically and offline, with no AI, LLM, embeddings, or network access in any check (ADR-002, ADR-034, ADR-066); repeated runs on an unchanged corpus MUST produce byte-identical output.
+- [REQ-007] `rac doctor` MUST exit non-zero only when a validation or relationship-integrity *error* is present, exit zero when the report holds only warnings (including every injection and hub finding), provide a `--json` mode emitting a `schema_version`-gated, additive contract (ADR-007), and be wired into CI alongside the existing validation gate.
 
 ## Acceptance Criteria
 
-- `rac doctor` detects each defect class, covered by fixtures, and prints
-  actionable fixes.
-- Output is deterministic across runs on an unchanged repo.
+- `rac doctor` runs validate + relationships + the two new checks in one pass and
+  prints, per finding, path, code, problem, and a paste-ready fix.
+- A fixture exercising each defect class (malformed front matter, broken/cyclic
+  relationship, duplicate ID, orphan, high-fan-out hub, injection-style content)
+  produces the expected finding and fix.
+- A planted injection-style fixture is flagged as a WARNING; the run still exits
+  zero when no error-severity finding is present (a test asserts both the flag
+  fires and the warning alone does not fail the run).
+- Output is byte-identical across repeated runs on an unchanged corpus.
 - A malformed artifact yields a clear `doctor` error rather than crashing
   `get_artifact` / `search_artifacts` (with WS4).
 
 ## Success Metrics
 
-- A user can take a real repository from "unknown health" to "clean" by
-  following `rac doctor` output without reading RAC's source.
+- A user can take a real repository from "unknown health" to "clean" by running
+  one command and following its output, without reading RAC's source or knowing
+  which of validate/relationships/review finds what.
 
 ## Risks
 
 - The injection-content heuristic can false-positive. Mitigation: it is a
-  reviewable warning for a human, never an auto-edit or a standalone hard
-  failure (ADR-065).
+  reviewable WARNING for a human, never an auto-edit and never a standalone hard
+  failure (REQ-005, ADR-065).
+- Aggregating existing services could drift from their own output. Mitigation:
+  doctor calls those services rather than copying their logic, so a finding it
+  surfaces is the same finding `validate` / `relationships --validate` report.
 
 ## Assumptions
 
-- The validator and relationship engine already detect most defect classes;
-  doctor aggregates and explains them with fixes rather than re-implementing.
+- The validator and relationship engine already detect every defect class except
+  high-fan-out hubs and injection-style content; doctor aggregates and explains
+  them with fixes, and adds only those two checks.
+- The single-file `--corpus` resolution seam and the existing identifier index
+  give doctor everything it needs to compute hub degree without a second model.
+
+## Out of Scope
+
+- Re-implementing any check `validate` or `relationships --validate` already owns
+  (cycles, duplicates, orphans, broken/ambiguous/type-mismatch references, schema
+  drift). Doctor composes them.
+- Auto-editing, rewriting, or quarantining artifact content; doctor only reports
+  and suggests (ADR-065).
+- Treating the injection flag as a security guarantee or a CI hard-fail; the
+  trust boundary stays human PR review (WS11, ADR-065).
+- Any AI/LLM/embedding-based classification of "malicious" content.
+- Multi-hop graph analysis beyond the one-hop degree count; traversal bounding is
+  WS4's runtime concern (REQ-004).
 
 ## Related Decisions
 

--- a/rac/requirements/rac-explainable-retrieval.md
+++ b/rac/requirements/rac-explainable-retrieval.md
@@ -23,19 +23,38 @@ relationship edge surfaced it, which undermines trust in the grounding.
 
 ## Requirements
 
-- [REQ-001] Each `search_artifacts` result MUST carry a deterministic, non-empty `evidence` structure stating which field matched (id / title / path / heading / body), the matched term(s), and the retrieval tier.
-- [REQ-002] `get_related` results SHOULD carry evidence identifying the relationship edge (section and target) that surfaced the artifact.
-- [REQ-003] The `evidence` structure MUST be an additive, backward-compatible field on the existing tool output; the response schema and tool count MUST NOT otherwise change (ADR-007, ADR-030).
-- [REQ-004] RAC MUST provide a `rac find --explain` mode that prints per-stage match attribution for a query.
-- [REQ-005] The explanation MUST be a faithful description of the real match reason, derived from the existing token-tier match data (ADR-037, ADR-038), not a separate heuristic.
+- [REQ-001] Each `search_artifacts` result MUST carry a deterministic, non-empty `evidence` structure stating which field matched (id / title / path / heading / body), the matched term(s), and the retrieval tier. This `evidence` object is additive on each `search_artifacts` / `rac find` match and its shape is fixed: `field` (string — the winning tier, exactly one of `id` / `title` / `path` / `heading` / `body`, the matcher's existing rank `_RANK_ID`..`_RANK_BODY` (0–4) projected to its tier name, no new computation); `terms` (array of strings — the query terms that matched, in query order, each as the already-tokenized casefolded form the matcher compared, never empty since AND semantics guarantee every term matched somewhere); and `tier` (integer 0–4 — the numeric rank, so a consumer can sort or compare without re-deriving it from `field`). For a `heading` or `body` win, `evidence` MUST NOT duplicate the existing `section` / `snippet` fields; those stay where they are and `evidence` references the same data. For an `id` / `title` / `path` win there is no snippet and `evidence` carries `field` + `terms` + `tier` only.
+- [REQ-002] `get_related` results SHOULD carry evidence identifying the relationship edge (section and target) that surfaced the artifact: `direction` (`incoming` / `outgoing`), `relationship` (the section name, e.g. `related_decisions`), and `target` (the reference as stored). This is the edge the serializer already filters on, surfaced rather than recomputed; no term/tier fields apply (a relationship is not a text match).
+- [REQ-003] The `evidence` structure MUST be an additive, backward-compatible field on the existing tool output; the response schema and tool count MUST NOT otherwise change (ADR-007, ADR-030). Present keys keep their names, types, and order; the metadata-match JSON shape stays byte-identical to today except for the added `evidence` key. The MCP surface stays read-only with no tool added or removed (ADR-030). `evidence` is always present on a match (it is never null/absent), unlike the conditional `section`/`snippet`.
+- [REQ-004] RAC MUST provide a `rac find --explain` mode that prints per-stage match attribution for a query. Human mode appends one indented attribution line per match — `field=<tier> terms=<t1,t2> [section: snippet]` — under the existing match row, leaving the non-`--explain` output unchanged. `--explain` with `--json` MUST emit the same `evidence` object the MCP path emits (one source of truth); the two faces never diverge.
+- [REQ-005] The explanation MUST be a faithful description of the real match reason, derived from the existing token-tier match data (ADR-037, ADR-038), not a separate heuristic. It is read off the existing matcher (`_Match.rank` and its matched terms) — not a second heuristic, not a re-scan, not a relevance score. The matched-terms set the matcher already computes (today discarded) is surfaced; no new matching logic is introduced.
+- [REQ-006] `--explain` MUST be compatible with `--type`, `--decisions`, `--top-level`, and `--recursive`. `rac find` MUST keep returning exit 0 for an empty result (a query always succeeds); `--explain` adds no new exit codes and does not change exit 2 (usage) for a bad directory.
+- [REQ-007] `evidence` MUST be deterministic and offline: a pure function of (corpus snapshot, query), byte-stable across repeated runs on an unchanged corpus, with no clock, randomness, network, or model in the path (ADR-002, ADR-034). Term order follows query order; `field`/`tier` follow the fixed ladder.
 
 ## Acceptance Criteria
 
-- Every search result includes a non-empty, accurate, deterministic explanation,
-  and a test asserts the explanation matches the real match reason.
-- `rac find --explain` works from the CLI and prints per-stage attribution.
+- Every search match carries a non-empty `evidence` object whose `field`/`tier`/`terms`
+  are asserted to equal the matcher's actual winning rank and matched terms; a
+  test pins the id/title/path/heading/body cases and the empty-result case.
+- A test asserts the metadata-match JSON is byte-identical to the pre-change
+  shape except for the additive `evidence` key, and that the MCP `--json`
+  evidence equals the `rac find --explain --json` evidence for the same query.
+- `rac find --explain` prints per-match attribution; without `--explain` the
+  output is unchanged; `--explain` composes with `--type` / `--decisions`.
 - Existing MCP contract and golden tests still pass with the additive field
   present (backward compatibility verified).
+
+## Descope
+
+- No relevance score, ranking weight, or confidence number — `evidence`
+  describes the structural match only (ADR-034, ADR-066).
+- No new field on `get_artifact` (that is WS5 provenance, a separate
+  requirement) and no fifth MCP tool (ADR-030).
+- No multi-term match map — `terms` is a flat list, not a per-field
+  attribution; the winning tier is the artifact's best rank, matching how
+  the matcher already ranks. Per-term-per-field attribution is out of scope.
+- No body-snippet change — snippet extraction stays exactly ADR-038's
+  whole-line rule; `evidence` references it, never alters it.
 
 ## Success Metrics
 
@@ -50,8 +69,12 @@ relationship edge surfaced it, which undermines trust in the grounding.
 
 ## Assumptions
 
-- The existing matcher already computes the tier and matched terms, so evidence
-  is surfacing existing data rather than recomputing it.
+- The existing matcher (`_match_entry` in `services/resolve.py`) already computes
+  the winning rank, the matched-terms set, and the heading/body section+snippet;
+  `evidence` surfaces this existing data rather than recomputing it. The
+  matched-terms set is computed today but discarded — this work returns it.
+- `get_related`'s serializer already carries the relationship section and target
+  per edge; `evidence` names the existing edge, adding no traversal.
 
 ## Related Decisions
 

--- a/rac/requirements/rac-grounding-eval-benchmark.md
+++ b/rac/requirements/rac-grounding-eval-benchmark.md
@@ -24,45 +24,74 @@ there is no gate that fails the build when it happens.
 
 ## Requirements
 
-- [REQ-001] RAC MUST provide a `rac eval` CLI subcommand that scores the retrieval tools against a versioned fixture corpus and query set.
-- [REQ-002] Eval scoring MUST be deterministic and offline: a pure function of `(corpus, query set, retrieval code)`, with no network, no API keys, no randomness, no clock in the scored path, and no embeddings or LLM judge (ADR-066).
-- [REQ-003] `rac eval` MUST compute Precision@k and Recall@k at `k ∈ {1, 3, 5}` as macro-averages reported `overall`, `by_category`, and `by_tool`, and MUST count hard-negative violations (a `must_not_return` id appearing in top-k).
-- [REQ-004] Ranking MUST be byte-stable: equal-scored artifacts order by ascending artifact id, layered on the existing deterministic retrieval sort.
-- [REQ-005] `rac eval` MUST write a scorecard with `metrics`, `metadata`, and `per_query` objects, and MUST record a `corpus_hash` and `query_set_hash`; only `metrics` is compared by the gate.
-- [REQ-006] RAC MUST provide a `rac eval --check` CI gate that FAILS on any hard-negative violation, any gated metric below an absolute floor, or any gated metric below `baseline − tolerance`, printing which rule fired with the metric, baseline, and current values.
-- [REQ-007] Re-baselining MUST be human-gated via `rac eval --update-baseline`; CI MUST NOT ever update the baseline.
-- [REQ-008] The fixture corpus MUST be schema-valid, pass `rac doctor`, span all five artifact types, and include a supersession chain, distractors, and an ambiguous pair.
-- [REQ-009] The eval SHOULD reuse the WS8 content-hash short-circuit so re-runs skip unchanged artifacts.
+- [REQ-001] RAC MUST provide a `rac eval` CLI subcommand (argparse subcommand, `cmd_eval` + `set_defaults(func=...)`, same shape as `rac find`) that scores the retrieval tools against a versioned fixture corpus and query set rooted at `tests/eval/` and runs without arguments against that in-repo fixture by default.
+- [REQ-002] Eval scoring MUST be deterministic and offline: a pure function of `(corpus, query set, retrieval code)`, with no network, no API keys, no randomness, no clock in the scored path, and no embeddings or LLM judge (ADR-066). The scored path MUST call the same `search_index` / relationship-resolution functions the MCP `search_artifacts` / `get_related` tools call (`src/rac/services/resolve.py`, `src/rac/mcp/server.py`), so the benchmark guards the real surface, never a parallel scorer.
+- [REQ-003] `rac eval` MUST compute Precision@k and Recall@k at `k ∈ {1, 3, 5}` as macro-averages (equal weight per case), reported `overall`, `by_category`, and `by_tool`, and MUST count hard-negative violations (a `must_not_return` id appearing in the top-k returned ids). `P@k = |Rel ∩ top_k| / k` (empty slots count against precision); `R@k = |Rel ∩ top_k| / |Rel|` with `|Rel| ≥ 1` by construction. Each query case is scored against exactly one named tool (`search_artifacts` or `get_related`).
+- [REQ-004] The scored ranked list MUST be the production retrieval order unchanged. `search_index` already orders by `(match_rank, path)`, which is total and byte-stable; `rac eval` MUST consume that order verbatim and MUST NOT re-sort, re-rank, or alter production retrieval. The ADR-066 ascending-artifact-id tie-break is satisfied as recorded only if production order is path-stable; because it already is, this release adds NO production sort change. (If a future equal-`(rank, path)` collision is possible, it is resolved by ascending artifact id at the eval read seam only.)
+- [REQ-005] `rac eval` MUST write a scorecard JSON with exactly three top-level objects — `metrics`, `metadata`, `per_query` — matching the `grounding-eval-scorecard` design shape. `metadata` MUST record `lore_version`, `corpus_hash` (`sha256:…` over the fixture corpus files), `query_set_hash` (`sha256:…` over the query set), `n_queries`, and `generated_at`. ONLY `metrics` is compared by the gate; `metadata` and `per_query` are diagnostic and excluded from comparison so a clock or hash never fails a build. Scorecard JSON is an additive, stable contract (ADR-007).
+- [REQ-006] RAC MUST provide a `rac eval --check` CI gate that re-runs scoring and FAILS (exit 1) if any of: (a) `negative_violations > 0`; (b) any gated metric `< floor`; (c) any gated metric `< baseline_value − tolerance`. It MUST print one line per fired rule naming the rule, metric, baseline value, and current value. A clean run exits 0; a usage error (missing baseline, unreadable corpus, malformed query set) exits 2. Floors and tolerance live in committed config alongside the baseline (initial: `negative_violations == 0` always, `overall.p_at_1 ≥ 0.90`, `overall.r_at_5 ≥ 0.95`, tolerance `T = 0.02`). Gated metrics are `overall.p_at_1`, `overall.r_at_5`, and `negative_violations`; per-category/per-tool figures are diagnostic this release.
+- [REQ-007] Re-baselining MUST be human-gated via `rac eval --update-baseline`, which overwrites `tests/eval/baseline.json` with the current `metrics` object; CI MUST NEVER pass `--update-baseline` and MUST NEVER write the baseline.
+- [REQ-008] The fixture corpus MUST live under `tests/eval/corpus/`, be schema-valid (`rac validate` exit 0), pass `rac doctor` (WS3) clean, span all five artifact types, and include a supersession chain (the superseded member is the canonical `must_not_return` case), distractors, and an ambiguous pair. The query set MUST live under `tests/eval/queries.json` (or equivalent committed file), each case declaring `id`, `tool`, `query`/`id` input, `category`, `relevant` (≥1 id), and optional `must_not_return`.
+- [REQ-009] The eval SHOULD reuse the WS8 content-hash short-circuit to skip unchanged artifacts on re-runs, but MUST NOT depend on it: WS8 is a cuttable Tier-2 workstream, so `rac eval` MUST be correct and deterministic without it, with the short-circuit a pure performance optimization that never changes scored output.
+- [REQ-010] The scorecard `metrics` comparison MUST be insensitive to additive WS2 `evidence`/snippet fields on retrieval output (ADR-007): the gate compares only returned-id membership in top-k, so explainability fields added to `search_artifacts` / `get_related` results MUST NOT shift any metric.
 
 ## Acceptance Criteria
 
-- `rac eval` runs offline with no network or keys; the `metrics` object is
-  byte-identical across repeated runs on an unchanged corpus.
-- Three regression-injection tests prove the gate is real: a clean corpus
-  passes; a deterministically removed relevant artifact drops `r_at_5` and fails
-  the gate; a forced `must_not_return` id in top-k fails the gate on violations.
-- The human-readable summary prints overall, by-category, and by-tool tables and
-  lists every violating case with its returned ids.
-- The gate is wired into CI and fails the build on regression.
+- `rac eval` runs offline with no network or keys against `tests/eval/`; the
+  `metrics` object is byte-identical across repeated runs on an unchanged corpus
+  (asserted by a byte-equality test on the serialized `metrics` block).
+- `rac eval --check` exits 0 on the committed baseline, exits 1 on any gate
+  failure, and exits 2 on usage errors (missing/unreadable baseline, corpus, or
+  query set).
+- Three regression-injection tests prove the gate is real: (1) the clean fixture
+  corpus passes; (2) a deterministically removed relevant artifact drops
+  `overall.r_at_5` and fails `rac eval --check` with exit 1; (3) a query forced
+  to surface a `must_not_return` id in top-k fails on `negative_violations > 0`
+  with exit 1. Each test asserts both the exit code and the named fired rule.
+- The human-readable summary prints an overall table, then by-category and
+  by-tool tables, then an explicit "Violations" section listing every violating
+  case with its returned ids; `--json` prints the scorecard shape exactly.
+- The gate is wired into CI (per ADR-027 per-service batteries) and fails the
+  build on regression; CI never runs `--update-baseline`.
 
 ## Success Metrics
 
 - The committed baseline meets the initial floors (`negative_violations == 0`,
-  `overall.p_at_1 ≥ 0.90`, `overall.r_at_5 ≥ 0.95`).
+  `overall.p_at_1 ≥ 0.90`, `overall.r_at_5 ≥ 0.95`), calibrated from the first
+  green run and committed with the baseline.
 - A deliberately introduced retrieval regression is caught by CI rather than by
   a human noticing later.
 
 ## Risks
 
 - Floors mis-calibrated before the first green run. Mitigation: calibrate from
-  the first run, commit the baseline, gate on `baseline − tolerance` thereafter.
+  the first run, commit the baseline, gate on `baseline − tolerance` thereafter;
+  CI never rebaselines (REQ-007).
 - A fixture corpus that drifts from real retrieval. Mitigation: source cases
   from real or partner-representative repos and grow from design-partner usage.
+- Scope creep into a production retrieval-ranking change. Mitigation: REQ-004
+  fixes the eval to the existing `(rank, path)` order; no production sort changes
+  this release.
+
+## Descope
+
+This requirement is one workstream (WS1) inside the single v0.23.0 release and
+does not split into further versions. Explicitly out of scope this release:
+graded relevance, micro-averaging, per-category/per-tool gating (diagnostic
+only), any change to production retrieval ranking, and any dependence on WS8 for
+correctness (REQ-009 makes the content-hash short-circuit optional).
 
 ## Assumptions
 
 - The existing deterministic retrieval surfaces (`search_artifacts`,
-  `get_related`) are the right thing to benchmark and guard.
+  `get_related`, via `search_index` and relationship resolution) are the right
+  thing to benchmark and guard, and their current `(rank, path)` ordering is
+  byte-stable enough to score without modification.
+- WS3 `rac doctor` is available for the REQ-008 corpus-health check; if WS3 is
+  not yet landed when WS1 is built, the corpus health check falls back to
+  `rac validate` and the `doctor` clean-run assertion is added once WS3 lands.
+- WS2 explainability fields on retrieval output are additive (ADR-007) and do
+  not perturb the id-membership metrics the gate compares (REQ-010).
 
 ## Related Decisions
 

--- a/rac/requirements/rac-honest-changelog-tiered-tests.md
+++ b/rac/requirements/rac-honest-changelog-tiered-tests.md
@@ -14,41 +14,108 @@ Classification: `[internal]`. Scoped to the v0.23.0 hardening release (WS10).
 
 ## Problem
 
-A hardening release needs trust signals and fast feedback loops. The test suite
-runs as 24 CI batteries but is not organized into documented tiers a developer
-can run locally, and a release with significant deferred scope needs a changelog
-that is honest about what shipped, what was deferred, and what the known limits
-are — without overclaiming.
+A hardening release needs trust signals and fast feedback loops. RAC's CI test
+topology already runs in three concrete layers (ADR-027) — a PR pre-merge tier,
+a merge-gated full grid, and a release gate — but those layers are an emergent
+property of the workflow YAML, not something a developer can map to a local
+command. WS10 documents the tiers as they actually run, adds an honest CHANGELOG
+entry for a release with significant deferred scope, and tags the single
+`v0.23.0` release. The documentation must describe what runs today; it MUST NOT
+restructure the suite, add batteries, or change the trigger policy recorded in
+ADR-027.
+
+This requirement is the packaging workstream: it ships only after every other
+v0.23.0 workstream has landed, because the CHANGELOG entry and the tag describe
+the whole release. It is `[internal]` plumbing and is the first Tier 2 item cut
+if the week runs short (the obey-demo is the non-cuttable anchor above it).
 
 ## Requirements
 
-- [REQ-001] The release MUST structure the test suite into three documented tiers — a unit-test inner loop, a pre-push verify gate, and a full local CI command — and document each tier's command.
-- [REQ-002] The release MUST add a CHANGELOG entry with honest scope notes: what shipped, what is deferred, and known limits — explicitly that the MCP server is pull-based and that code-vs-decision CI enforcement is a future release.
-- [REQ-003] The CHANGELOG user-facing headline MUST lead only with the user-facing items (explainable retrieval, `rac doctor`, provenance, the trust model) plus "provably works"; internal plumbing MUST NOT be headlined.
-- [REQ-004] The release version MUST be set to `v0.23.0` via the git tag (setuptools-scm); there is no VERSION file to edit.
+- [REQ-001] The release MUST document the three test tiers defined in **Test Tiers** below, each mapped to the concrete test group and CI job that runs it and given a copy-paste local command.
+- [REQ-002] Documentation MUST describe the existing topology only — no new pytest markers, no new taxonomy, and no change to the ADR-027 trigger policy; any added command is a thin convenience wrapper over the file lists already in the workflows.
+- [REQ-003] The release MUST add ONE CHANGELOG entry under the next version heading covering, honestly, the **What shipped**, **What is deferred**, and **Known limits** content specified in **Changelog Contract** below.
+- [REQ-004] The CHANGELOG headline MUST lead only with the user-facing items (explainable retrieval, `rac doctor`, provenance, the trust model) plus "provably works"; internal plumbing (WS6, WS8, WS10) MUST NOT be headlined.
+- [REQ-005] The release MUST be cut as a single `v0.23.0` git tag — one PyPI version, no source edit — from which setuptools-scm derives the version (`pyproject.toml` declares `dynamic = ["version"]`; there is no VERSION file). It MUST NOT be split across multiple tags or versions.
+
+## Test Tiers
+
+The tiers below document the topology ADR-027 already runs; they are a reading of
+the workflows, not a new structure.
+
+1. **Inner loop (smoke)** — the smoke set run pre-merge by the `smoke` job in
+   `.github/workflows/pr-checks.yml` (`core` + `golden` + `dogfood` on py3.11).
+   Local: `pytest -q` over that file list. Fastest signal; catches
+   output-contract drift and corpus damage.
+2. **Pre-push (PR tier)** — what a pull request actually runs: `pr-checks.yml`'s
+   `lint` (`ruff check`, `ruff format --check`, `mypy src/`) plus the smoke job,
+   plus the dogfood actions (watchkeeper, validate, agent-rules, pr-gate). Local
+   equivalent: `rac gate rac/` plus the lint trio plus the smoke set.
+3. **Full local CI (merge grid)** — the complete per-service battery × Python
+   grid from the reusable `.github/workflows/tests.yml` (every `tests/test_*.py`
+   belongs to exactly one battery, enforced by `tests/test_ci_batteries.py`).
+   Local: `pytest -q` over the whole suite. This is the grid that gates `main`
+   (`ci.yml`) and releases (`python-publish.yml`, `needs: test`).
+
+## Changelog Contract
+
+The single entry MUST cover, honestly:
+
+- **What shipped** — the user-facing workstreams (WS1 grounding benchmark +
+  `rac eval --check`, WS2 explainable retrieval, WS3 `rac doctor`, WS5
+  provenance, WS11 trust model + `SECURITY.md`) and that they are
+  regression-guarded ("provably works").
+- **What is deferred** — the Tier 3 carve-outs and the named Non-Goals: no
+  multi-agent CI harness (the obey-demo is a manual smoke, not a gate), no
+  schema-migration framework, no resumability, no multi-hop traversal.
+- **Known limits** — explicitly that the MCP server is pull-based / read-only
+  (the agent must consult it; nothing is pushed) and that full CI enforcement of
+  code-vs-decision conflicts is a future release.
 
 ## Acceptance Criteria
 
-- The three test tiers exist and are documented with their commands.
-- The CHANGELOG entry is specific and honest about scope, tradeoffs, and limits.
-- The version is bumped to `v0.23.0` at release via tag.
+- The three tiers are documented, each mapped to its real CI job
+  (`pr-checks.yml` smoke, `pr-checks.yml` lint+smoke+dogfood, `tests.yml` grid)
+  with a copy-paste local command; no new pytest markers or taxonomy introduced.
+- ONE CHANGELOG entry names the shipped user-facing workstreams, the deferrals
+  (Tier 3 + Non-Goals), and the two known limits (pull-based MCP server;
+  code-vs-decision enforcement deferred), with the headline leading on
+  user-facing items only.
+- A single `v0.23.0` tag is cut; the build version derives from it via
+  setuptools-scm with no source edit.
 
 ## Success Metrics
 
-- A developer can run the right test tier for the change at hand without reading
-  CI internals.
-- A reader of the CHANGELOG understands exactly what this release does and does
-  not deliver.
+- A developer can run the right tier for the change at hand from the documented
+  command without reading workflow YAML.
+- A reader of the CHANGELOG understands exactly what `v0.23.0` does and does not
+  deliver, including the pull-based-server and deferred-enforcement limits.
 
 ## Risks
 
 - Headlining internal items would misrepresent the release as feature-heavy.
-  Mitigation: the narrative discipline is encoded in REQ-003.
+  Mitigation: the narrative discipline is encoded in REQ-004.
+- Documenting tiers that diverge from the workflows would mislead developers and
+  rot on the next CI edit. Mitigation: REQ-001/REQ-002 bind the docs to the
+  existing `pr-checks.yml` / `tests.yml` jobs rather than a parallel taxonomy.
+- Splitting the work into more than one version would break the one-release
+  scope fence. Mitigation: REQ-005 fixes a single `v0.23.0` tag.
 
 ## Assumptions
 
-- The existing 24-battery structure can be grouped into three documented tiers
-  without restructuring the tests themselves.
+- The existing per-service battery grid (ADR-027) and `pr-checks.yml` smoke tier
+  can be *documented* as three developer tiers without restructuring the tests
+  or changing the trigger policy.
+- All other v0.23.0 workstreams have landed before this one runs, so the
+  CHANGELOG and tag describe the complete release.
+
+## Out of Scope
+
+- Restructuring the suite, adding or renaming batteries, or introducing pytest
+  markers (the grid is an explicit static enumeration per ADR-027).
+- Changing the ADR-027 trigger policy (no new `pull_request` full-grid trigger,
+  no coverage threshold gate).
+- Any second version or tag; CI enforcement of code-vs-decision conflicts (a
+  future release, only *noted* here).
 
 ## Related Decisions
 

--- a/rac/requirements/rac-idempotent-content-hash-processing.md
+++ b/rac/requirements/rac-idempotent-content-hash-processing.md
@@ -18,22 +18,36 @@ core only).
 Lore's buyers are teams with years of accumulated decisions, not a tiny repo on
 day one. The inner loop and CI must stay fast on an ICP-sized corpus, and the
 determinism guarantee that underpins the eval benchmark (WS1) needs reinforcing:
-the same input must always produce identical derived output. Today, validation,
-eval, and doctor reprocess everything every run.
+the same input must always produce identical derived output. Today the
+per-invocation corpus walk (`walk_corpus` / `collect_corpus`) reparses and
+reprocesses every artifact on every run of validation — and will do the same for
+the WS1 eval and WS3 doctor passes once they land — even when nothing changed.
+No content hash exists in any processing path today.
+
+This is a per-invocation optimization, not a cross-invocation one. ADR-032
+already names `collect_corpus` (v0.8.0) as "the optimization seam if scale ever
+demands one"; this requirement uses that seam and no other.
 
 ## Requirements
 
-- [REQ-001] RAC MUST content-hash every artifact and short-circuit unchanged artifacts in validation, eval, and doctor processing.
-- [REQ-002] Derived output MUST be idempotent and byte-stable: the same input produces identical output, underpinning WS1's byte-stability.
-- [REQ-003] The short-circuit MUST apply to CLI processing only and MUST NOT introduce a persistent cache into the MCP serving path, which re-reads per call (ADR-032).
-- [REQ-004] Resumability and crash-safe incremental job machinery (partial-run resumption, two-phase persistence) are explicitly out of scope; there is no long-running interruptible operation yet.
+- [REQ-001] Within a single CLI invocation, RAC MUST content-hash every walked artifact so validation, the WS1 `rac eval` pass, and the WS3 `rac doctor` pass can short-circuit an artifact whose hash is unchanged from an earlier phase of the same run rather than reparsing/reprocessing it per phase; the short-circuit is an in-memory reuse keyed on the snapshot's per-artifact hash that persists no state to disk and survives no process boundary.
+- [REQ-002] The hash MUST be computed over the artifact's full on-disk source bytes (front matter plus body) so any edit — whitespace or front-matter-only included — changes the hash and forces reprocessing; the hash covers source content only, never derived output and never mtime or other filesystem metadata (mtime invalidation is rejected by ADR-032).
+- [REQ-003] The short-circuit MUST apply to CLI processing only and MUST NOT introduce a persistent cache into the MCP serving path, which re-reads per call (ADR-032). Derived output (validation results, the eval `metrics` object, the doctor report) MUST therefore be idempotent and byte-stable — identical source bytes produce byte-identical derived output across repeated runs regardless of run history — and the short-circuit MUST NOT alter output versus a full reprocess; it is a performance path only, and a test MUST assert the two are byte-identical.
+- [REQ-004] The short-circuit MUST apply to CLI processing only and MUST NOT add any persistent cache, file watcher, or session state to the MCP serving path, which re-reads the repository from disk on every tool call (`walk_corpus` per call; ADR-032); the existing interleaved-edit contract tests pinning ADR-032 MUST continue to pass so a repository edit between tool calls is reflected in the next response.
+- [REQ-005] Resumability and crash-safe incremental job machinery — partial-run resumption, two-phase persistence, and on-disk cross-invocation caches — are explicitly out of scope (T3-C, deferred); there is no long-running interruptible operation yet and cross-invocation speedups are not part of this release.
 
 ## Acceptance Criteria
 
-- Re-running on an unchanged repo does near-zero work and is provably idempotent
-  (test).
-- Changing one artifact reprocesses only that artifact.
-- Outputs are byte-stable across runs.
+- Re-running validation/eval/doctor across phases of one invocation on an
+  unchanged snapshot does near-zero redundant reprocessing and is provably
+  idempotent (test).
+- Changing one artifact's source bytes reprocesses only that artifact; a test
+  edits one artifact and asserts exactly one artifact is reprocessed.
+- Derived output (validation results, eval `metrics`, doctor report) is
+  byte-stable across repeated runs, and byte-identical between the short-circuit
+  path and a forced full reprocess.
+- A test interleaving a repository edit with MCP tool calls observes the edit in
+  the next response (ADR-032 unbroken).
 
 ## Success Metrics
 
@@ -42,12 +56,20 @@ eval, and doctor reprocess everything every run.
 ## Risks
 
 - A hash short-circuit could mask a real change. Mitigation: hash over full
-  artifact content; cover with tests that change one artifact and assert only it
-  reprocesses.
+  on-disk source bytes (REQ-002); cover with a test that changes one artifact
+  and asserts only it reprocesses, and a test asserting short-circuit output is
+  byte-identical to a full reprocess.
+- A contributor extends the hash into the MCP path as an innocent-looking cache,
+  reintroducing staleness. Mitigation: REQ-004 plus the ADR-032 interleaved-edit
+  tests fail if the serving path stops re-reading per call.
 
 ## Assumptions
 
-- The source of truth stays in markdown/git; derived data is always rebuildable.
+- The source of truth stays in markdown/git; derived data is always rebuildable,
+  so an absent or stale in-memory hash only costs a reprocess, never correctness.
+- `collect_corpus` is the single seam the short-circuit attaches to (ADR-032);
+  consumers (WS1 eval, WS3 doctor) read the hashed snapshot rather than
+  re-walking.
 
 ## Related Decisions
 

--- a/rac/requirements/rac-obey-demo-grounding-proof.md
+++ b/rac/requirements/rac-obey-demo-grounding-proof.md
@@ -10,47 +10,67 @@ tags: [user-facing, demo, grounding, proof]
 
 Proposed
 
-Classification: the release's success proof. Scoped to the v0.23.0 hardening
-release (T3-A).
+Classification: the release's non-cuttable success anchor (Tier 2). It is the
+v0.23.0 definition of done made observable. It stays a manual smoke, never a CI
+gate; the cut line sits above it, so WS6/WS5/WS8/WS10 are dropped before the
+demo, never the demo itself.
 
 ## Problem
 
 The release's definition of done is an outcome, not green CI: a real coding
-agent must demonstrably stop relitigating a recorded decision. An automated
-multi-agent CI harness to prove this would be non-deterministic, slow, costly,
-and only half-automatable in a week. What is needed instead is one reproducible,
-honest manual demonstration.
+agent must demonstrably stop relitigating a recorded decision after consulting
+Lore. An automated multi-agent CI harness to prove this would be
+non-deterministic, slow, costly, and only half-automatable in a week, and a
+verdict tool that decides "this violates a decision" is barred from core
+(ADR-034). What is needed instead is one reproducible, honest manual
+demonstration in which the agent — not RAC — recognizes the conflict and cites
+the governing decision.
+
+This artifact pins the recording down concretely so it is turnkey to produce
+once the release's features exist: it exercises WS1's fixture corpus, WS2's
+explainable retrieval, WS3's `rac doctor`, WS5's provenance fields, and WS11's
+trust model, driven by one live agent over the four read-only tools.
 
 ## Requirements
 
-- [REQ-001] The release MUST produce one reproducible manual demonstration: a fixture or partner-representative repo with an `Accepted` ADR forbidding a change, a real coding agent wired to the four tools, and a prompt that would violate the decision.
-- [REQ-002] The demonstration MUST capture a recording or log showing the agent consulted Lore and did NOT perform the forbidden change.
-- [REQ-003] The demonstration MUST ship with written, repeatable steps and MUST NOT be a CI gate.
-- [REQ-004] The release MUST NOT build an automated multi-agent CI harness; this manual obey-demo supersedes that intent.
-- [REQ-005] Results MUST be genuine; faked or staged outcomes are unacceptable.
+- [REQ-001] The release MUST produce one reproducible manual demonstration with three fixed parts: (a) a fixture or partner-representative repo whose corpus contains an `Accepted` ADR that forbids a specific, named change and that itself reached the corpus through human PR review (the trust boundary, ADR-065); (b) a real coding agent wired to exactly the four read-only MCP tools (`get_artifact`, `search_artifacts`, `get_related`, `get_summary`) and nothing that can issue a verdict; (c) one verbatim prompt that asks for the change the ADR forbids, recorded alongside the demo.
+- [REQ-002] The captured recording or log MUST show, in order: the agent calling at least one retrieval tool (`search_artifacts` and/or `get_related`) and `get_artifact` to read the governing ADR; the agent then DECLINING the forbidden change; and the agent citing the governing decision by its id (e.g. `RAC-…` / `ADR-0xx`) as the reason. The tool calls and their results MUST be visible in the capture, not summarized after the fact.
+- [REQ-003] The demonstration MUST ship with written, repeatable steps (the fixture path, the exact prompt, the agent and its tool wiring, and how to replay) and MUST NOT be a CI gate or a golden test.
+- [REQ-004] The release MUST NOT build an automated multi-agent CI harness; this manual obey-demo supersedes that intent. No tool in the loop renders a conflict verdict — the agent supplies the judgment, Lore supplies the facts (ADR-034).
+- [REQ-005] Results MUST be genuine. The recording MUST be of a real run with the real tool calls and real model output; faked, staged, or hand-edited transcripts are unacceptable. Because the behaviour is stochastic (ADR-034), the steps MUST describe how the run was obtained honestly (e.g. the run is reproducible from the written steps and the capture is unedited); cherry-picking a lone success while hiding failures is a faked result.
 
 ## Acceptance Criteria
 
-- A recorded, repeatable demo plus written steps exists.
-- It is explicitly a manual smoke, not a CI gate, with no faked results.
+- A recorded, unedited capture plus written replay steps exists, showing the
+  tool calls, the declined change, and the cited decision id.
+- The forbidding ADR is `Accepted` and entered the corpus via human PR review.
+- It is explicitly a manual smoke, not a CI gate or golden test, with no faked
+  results and no verdict tool in the loop.
 - Setup notes for additional agents (Cursor, Codex) MAY be documented but are
   not required.
 
 ## Success Metrics
 
-- The release success criterion is met: a real or partner-representative agent
-  does not relitigate the forbidden decision after consulting Lore.
+- The release success criterion is met: a real or partner-representative agent,
+  given the recorded prompt, consults Lore and declines the forbidden change
+  while citing the governing decision id — with no verdict tool involved.
 
 ## Risks
 
 - A single demo may not generalize. Mitigation: source the scenario from a real
   or partner-representative decision and document the steps so it can be re-run
   and extended.
+- The behaviour is stochastic, so one run is not a guarantee (ADR-034).
+  Mitigation: keep the capture unedited and the steps replayable; report the
+  run honestly rather than presenting a cherry-picked success as typical.
 
 ## Assumptions
 
 - A real coding agent wired to the four read-only tools is sufficient to
   demonstrate grounding without bespoke harness infrastructure.
+- The fixture corpus, explainable-retrieval output, provenance fields, and
+  trust-model docs from the Tier 1 / Tier 2 workstreams exist before the demo
+  is recorded.
 
 ## Related Decisions
 

--- a/rac/requirements/rac-parser-traversal-robustness.md
+++ b/rac/requirements/rac-parser-traversal-robustness.md
@@ -17,44 +17,107 @@ front of a partner. Scoped to the v0.23.0 hardening release (WS4).
 
 The MCP server sits in an agent's critical path. A malformed artifact, an
 oversized field, or a pathological relationship graph must never crash, hang, or
-exhaust memory. The front-matter/markdown parser currently has no input-size
-caps and no fuzz coverage, and while `get_related` is one-hop and the ADR-033
-response budget bounds its output, those guarantees are not yet asserted against
-adversarial input.
+exhaust memory. Red-teaming the current code (`src/rac/core/markdown.py`,
+`src/rac/core/frontmatter.py`, `src/rac/services/relationships.py`,
+`src/rac/mcp/server.py`, `src/rac/mcp/budget.py`) surfaced concrete gaps:
+
+- **No input-size cap anywhere.** `parse_file` does `fh.read()` on the whole
+  file and `split_frontmatter` does `text.split("\n")` over it; a multi-gigabyte
+  `.md` file (or one with millions of lines) is read fully into memory before any
+  guard runs. The corpus walk (`walk_corpus`) parses every discovered file with
+  no per-file ceiling.
+- **No front-matter size or shape cap.** `parse_frontmatter` hands the raw block
+  to PyYAML's `SafeLoader`. `SafeLoader` blocks arbitrary object construction and
+  the `_StrictLoader` subclass rejects duplicate keys, but neither caps a huge
+  scalar, a deeply nested mapping/sequence, or an alias-expansion ("billion
+  laughs") blow-up — those still allocate before validation sees them.
+- **Body-text fields are uncapped.** Parsed section bodies, `search_sections`,
+  and requirement lines accumulate every line of the body with no per-field
+  ceiling, so an oversized field survives into the served `Product`.
+- **ReDoS surface is small but unaudited.** The parser/validator regexes
+  (`_BRACKET_RE`, `_CANONICAL_ID_RE`, `ID_RE`, `_AMBIGUOUS_RE`, `_NORMATIVE_RE`,
+  `_QUARTER_RE`) are anchored literal-alternation patterns with no nested
+  quantifiers, so none is currently catastrophic — but this release must *assert*
+  that property so a future pattern (e.g. a doctor heuristic) cannot regress it.
+- **`get_related` ordering is path-based, not the budget's documented order.**
+  `_incoming_from` sorts `incoming` by `(path, section)` and `_outgoing_from`
+  preserves declaration order; the ADR-033 budget then truncates whole `incoming`
+  entries from the tail. Output is bounded and deterministic, but the kept set is
+  ordered by filesystem path rather than the (relationship type, ascending id)
+  order REQ-004 requires, so truncation can drop edges in a surprising order.
+- **High-fan-out / cyclic graphs are bounded only by the response budget.**
+  `relationships_from_corpus` is a single pass (no recursion, so no cycle hazard
+  for 1-hop), but a hub artifact with thousands of incoming edges builds the full
+  `incoming` list in memory before the budget truncates it — bounded output, but
+  not bounded work.
+
+While `get_related` is one-hop and the ADR-033 response budget bounds its
+*output*, none of the above is asserted against adversarial input, and input
+work is not yet bounded ahead of that budget.
 
 ## Requirements
 
-- [REQ-001] The parser MUST cap input sizes per-file and per-field, and MUST guard any user-defined regex/pattern features against catastrophic backtracking (ReDoS).
-- [REQ-002] A single malformed artifact MUST degrade gracefully — reported and skipped — and MUST NOT crash `get_artifact` / `search_artifacts` or fail CI uninformatively.
-- [REQ-003] The release MUST add fuzz/property tests over the parser covering malformed YAML, oversized fields, unicode, deep nesting, and binary junk.
-- [REQ-004] `get_related` output MUST remain bounded by the ADR-033 response budget, with a deterministic result cap and ordering (relationship type, then ascending artifact id) and a backward-compatible truncation signal.
-- [REQ-005] When any cap truncates output, the kept items MUST be selected and ordered deterministically so output stays byte-stable.
-- [REQ-006] Any future multi-hop traversal MUST add explicit depth, frontier, visited-set, and work-budget caps before shipping; this release does not add multi-hop traversal.
+- [REQ-001] The parser MUST enforce a per-file byte cap in `parse_file` before the file is read fully into memory (size-check the path, then read at most the cap), and the in-memory `parse` entrypoint MUST reject input longer than the same cap before tokenizing; the cap is a module-level constant (default 1 MiB, overridable via `RAC_MAX_FILE_BYTES`), measured in bytes so it is unicode-width-independent, and over-cap input is reported as a structured oversize issue, never an exception.
+- [REQ-002] `parse_frontmatter` MUST cap the raw front-matter block before it reaches PyYAML — a byte cap (default 64 KiB) plus bounded nesting depth and rejection of alias expansion ("billion laughs") — so deeply nested or alias-bombed YAML is reported as a structured `malformed-frontmatter` issue without unbounded allocation; the existing `SafeLoader` and duplicate-key rejection are retained and these bounds are added on top.
+- [REQ-003] Each captured body field (per-section bodies, requirement lines, `search_sections`) MUST be bounded by a per-field length and total captured-line cap so a single oversized field cannot dominate the served `Product`; the field is marked truncated rather than failing the whole parse, and this parser-level cap is independent of the ADR-033 response budget.
+- [REQ-004] `get_related` output MUST remain bounded by the ADR-033 response budget, with a deterministic result cap and ordering (relationship type, then ascending artifact id) and a backward-compatible truncation signal. Separately, every regex applied to artifact content (`_BRACKET_RE`, `_CANONICAL_ID_RE`, `ID_RE`, `_AMBIGUOUS_RE`, `_NORMATIVE_RE`, `_EARS_IF_RE`, `_THEN_RE`, `_QUARTER_RE`) MUST be linear-time (anchored, no nested quantifiers, no overlapping alternation) with a test asserting bounded-time termination on a pathological string; no new content-applied regex may use unbounded backtracking, and user/query input MUST stay matched by literal token comparison, never compiled as a regex.
+- [REQ-005] A single malformed or oversize artifact MUST degrade gracefully — reported and skipped — and MUST NOT crash `get_artifact` / `search_artifacts` / `get_related`, abort the corpus walk, or fail CI uninformatively; the walk MUST continue past it, surfacing a structured issue that feeds WS3 `doctor` and validation.
+- [REQ-006] `get_related` output MUST remain bounded by the ADR-033 response budget, with the kept set ordered before truncation by relationship type (the artifact's own spec/section order) then ascending artifact id, so tail-truncation drops the lowest-priority edges deterministically; the truncation signal stays the existing additive `truncated` / `omitted` / `hint` marker (ADR-007) and the `incoming` ordering change is additive-compatible.
+- [REQ-007] `get_related` MUST bound work, not only output: incoming and outgoing edge collection MUST stop building after a per-call edge cap (default 1000) is reached, recording the overflow via the same truncation marker, so a high-fan-out hub cannot force an unbounded in-memory list before the response budget trims it.
+- [REQ-008] When any cap truncates output, the kept items MUST be selected and ordered deterministically so output stays byte-stable across repeated runs on unchanged input.
+- [REQ-009] The release MUST add fuzz/property tests over the parser and the serving path covering malformed YAML, oversized files and fields, alias bombs, deep nesting, unicode (invalid/partial sequences and width edge cases), and binary junk, and the harness MUST be deterministic in CI — a fixed seed, a bounded committed fixture corpus (or a seeded generator with a pinned iteration count and time budget), and no network — so a failure is reproducible from the recorded seed.
+- [REQ-010] Any future multi-hop traversal MUST add explicit depth, frontier, visited-set, and work-budget caps before shipping; this release does not add multi-hop traversal and `get_related` stays 1-hop.
 
 ## Acceptance Criteria
 
-- Parser fuzz tests pass; a malformed artifact yields a clear `doctor` error and
-  does not crash `get_artifact` / `search_artifacts`.
-- Graph fuzz fixtures — cycles, self-references, deep chains, and a high-fan-out
-  hub — all terminate within budget with well-formed, deterministically
-  truncated output and the truncation signal set.
-- A test asserts traversal/serving over an adversarial graph completes within
-  the budget with no unbounded time or memory.
+- A file over `RAC_MAX_FILE_BYTES` and a front-matter block over its cap each
+  yield a structured oversize / `malformed-frontmatter` issue and do NOT crash or
+  hang `parse_file`, `get_artifact`, `search_artifacts`, or `get_related`; the
+  corpus walk continues past them.
+- An alias-bomb / deeply nested YAML front matter is rejected as a structured
+  issue without unbounded allocation (asserted under a bounded memory/time
+  budget), not raised as an uncaught exception.
+- A ReDoS-style adversarial string against each content-applied regex completes
+  within a bounded time assertion; a test enumerates the regexes so a new one
+  cannot be added without coverage.
+- `get_related` over fuzz graph fixtures — cycles, self-references, deep chains,
+  and a high-fan-out hub (more incoming edges than the edge cap) — terminates
+  within the edge cap and the ADR-033 budget, emits well-formed JSON with the
+  `truncated` / `omitted` / `hint` marker set, and the kept `incoming` set is
+  ordered by relationship type then ascending id.
+- A test asserts `get_related` serialized output is byte-identical across
+  repeated runs on an unchanged adversarial corpus, with no unbounded time or
+  memory.
+- Parser fuzz tests pass deterministically from a recorded seed / committed
+  fixture corpus, with no network access.
 
 ## Success Metrics
 
-- No input — malformed file or pathological graph — can hang, crash, or OOM the
-  serving path.
+- No input — oversized file, malformed/alias-bombed front matter, oversized
+  field, or pathological graph — can hang, crash, or OOM any parse or serving
+  path; every such input is reported as structured data.
+- `get_related` output for any corpus is bounded by both the per-call edge cap
+  and the ADR-033 character budget, and is byte-stable.
 
 ## Risks
 
-- Over-tight caps could reject legitimately large artifacts. Mitigation: caps
-  are configurable with safe defaults proven against adversarial input.
+- Over-tight caps could reject legitimately large artifacts or fan-out hubs.
+  Mitigation: caps are module-level constants with safe defaults (1 MiB file,
+  64 KiB front matter, 1000 edges) proven against the fixture corpus; the
+  file-byte cap is overridable via `RAC_MAX_FILE_BYTES` for repos with genuinely
+  large artifacts.
+- Re-ordering `incoming` by (type, id) changes the serialized order versus the
+  current (path, section) order. Mitigation: the change is additive-compatible
+  per ADR-007 (field shape unchanged, only ordering) and is pinned by a contract
+  test; no client depends on the prior order.
 
 ## Assumptions
 
-- The ADR-033 budget already bounds response size; this release proves and
-  extends that guarantee rather than re-architecting serving.
+- The ADR-033 budget already bounds response *size*; this release proves that
+  guarantee against adversarial input and adds the missing *work* bounds (input
+  size, field size, edge count) ahead of it, rather than re-architecting serving.
+- The parser stays single-threaded (ADR-059's shared parser instance holds), so
+  per-call caps need no locking.
 
 ## Related Decisions
 

--- a/rac/requirements/rac-provenance-surfacing.md
+++ b/rac/requirements/rac-provenance-surfacing.md
@@ -16,38 +16,55 @@ Scoped to the v0.23.0 hardening release (WS5).
 ## Problem
 
 Lore claims every decision has an accountable human author, but `get_artifact`
-does not surface that accountability. An agent grounding on a decision cannot
-cite who made it, when, or whether it has moved from proposed to accepted to
-superseded. The information already exists in front matter and git history; it
-is simply not exposed on the tool surface.
+does not surface that accountability. Today its payload is
+`{schema_version, id, type, title, path, outgoing, incoming}` — no author, no
+date, no status. An agent grounding on a decision cannot cite who made it, when,
+or whether it has moved from proposed to accepted to superseded. The lifecycle
+`status` already exists as parsed metadata (the `## Status` section, enum per
+type); the rest exists in git history. None of it is on the tool surface.
 
 ## Requirements
 
-- [REQ-001] `get_artifact` MUST expose, additively and backward-compatibly, at minimum: author(s) plus last-commit author, relevant dates, and status history (Proposed → Accepted → Superseded), sourced from front matter plus git.
-- [REQ-002] Provenance MUST be derived from git rather than stored dates in front matter (ADR-045); a `reviewers` front-matter field MAY be used to power the WS11 review signal.
-- [REQ-003] Provenance fields SHOULD be surfaced in search/explain output where useful.
-- [REQ-004] Full PR-reviewer extraction (squash-merge handling, review threads) is out of scope for this release.
+- [REQ-001] `get_artifact` MUST expose, additively and backward-compatibly, at minimum: author(s) plus last-commit author, relevant dates, and status history (Proposed → Accepted → Superseded), sourced from front matter plus git. It does so by gaining one additive `provenance` object on its JSON payload; the existing keys are unchanged and the object is *added*, never reshaped (ADR-007). It carries exactly these fields: `current_status` (string — present lifecycle status, sourced from parsed front-matter-section metadata (`metadata["status"]`), not git; `null` when the type declares no status enum or the section is absent); `last_committed` (ISO-8601 timezone-aware string, or `null` — the most recent commit time for the file, from git (ADR-045), reusing `recency.py` `_last_committed`); `last_author` (string `Name <email>`, or `null` — the author of that most recent commit, same `git log -1` record); `first_committed` / `first_author` (ISO-8601 string and `Name <email>`, or `null` — the creation commit, reusing `recency.py` `_first_committed`, the accountable original author); and `status_history` (ordered list of `{status, committed, author}` entries, or an empty list, derived from git by reading the `## Status` value at each commit that changed it; see REQ-003).
+- [REQ-002] Provenance MUST be derived from git rather than stored dates in front matter (ADR-045); a `reviewers` front-matter field MAY be used to power the WS11 review signal. Concretely, provenance dates and authorship MUST be derived from git, never from stored front-matter dates (ADR-045); no front-matter field is added and `schema_version` is not bumped. Status *value* is read from parsed metadata, not git; only its *history* is reconstructed from git. The `reviewers` front-matter field is the seam the future WS11 review signal MAY use, recorded here only to reserve the name; it is not introduced this release.
+- [REQ-003] `status_history` MUST be derived deterministically and offline by walking the file's git history (e.g. `git log --reverse` plus reading the `## Status` section at each revision) and emitting one entry each time the parsed status value changes, oldest first. Reuse the `recency.py`/`revisions.py` git boundary (ADR-043); WS5 MUST NOT add a third git touchpoint or import a git library (ADR-045 alternatives).
+- [REQ-004] All git-sourced fields MUST degrade to `null` (or, for `status_history`, an empty list) — never raise — when git is unavailable: outside a repository, in a shallow clone where the relevant commits are absent, or for an untracked or uncommitted file. `current_status` still populates from metadata in every case, so an artifact in a non-git directory still reports its status. No exception crosses the service boundary (ADR-045).
+- [REQ-005] Provenance fields SHOULD be surfaced in search/explain output where useful, but `get_artifact` is the only required surface this release.
+- [REQ-006] Full PR-reviewer extraction — squash-merge attribution, review-thread mining, any GitHub PR-API plumbing — is explicitly out of scope for v0.23.0. Provenance is git-and-metadata only; no network call, no key, no fifth tool.
 
 ## Acceptance Criteria
 
-- Provenance populates for this release's dogfooded ADRs (ADR-065, ADR-066).
-- Tests assert the fields populate from front matter plus git.
-- The new fields are additive; existing `get_artifact` consumers are unaffected.
+- The `provenance` object populates for this release's dogfooded ADRs (ADR-065,
+  ADR-066), including a multi-entry `status_history`.
+- A test in a throwaway repository asserts each git-sourced field matches the
+  known commit, and a second asserts that outside a repo (and in a shallow clone
+  missing the history) every git field is `null`/empty while `current_status`
+  still populates from metadata.
+- The pre-WS5 `get_artifact` keys are byte-identical; a contract test asserts
+  the addition is purely additive (ADR-007), consistent with the WS6 agreement
+  test over the four serializers.
 
 ## Success Metrics
 
-- An agent can cite an accountable author and the status of a decision directly
-  from tool output.
+- An agent can cite the accountable original author and the current status of a
+  decision directly from `get_artifact` output, with no AI and no network.
 
 ## Risks
 
-- Git plumbing can balloon. Mitigation: limit to author/last-commit-author,
-  dates, and status history; defer PR-reviewer extraction.
+- Git plumbing can balloon, and per-commit status reconstruction is O(commits
+  touching the file). Mitigation: limit fields to those in REQ-001, walk history
+  once per artifact through the existing boundary, and defer all PR-reviewer
+  extraction (REQ-006).
+- `status_history` reflects history rewriting (rebase/squash moves commit time),
+  as ADR-045 already accepts for recency. Accepted: "when the status last
+  changed in history" is the intent, not forensic authorship.
 
 ## Assumptions
 
-- Git history and front matter carry enough provenance for this release without
-  a PR-API integration.
+- Git history plus parsed status metadata carry enough provenance for this
+  release without any PR-API integration (roadmap WS5 assumption, ADR-045).
+- The existing `recency.py`/`revisions.py` git boundary can host the
+  author/history reads without a new dependency.
 
 ## Related Decisions
 

--- a/rac/requirements/rac-single-schema-agreement.md
+++ b/rac/requirements/rac-single-schema-agreement.md
@@ -14,39 +14,71 @@ Classification: `[internal]`. Scoped to the v0.23.0 hardening release (WS6).
 
 ## Problem
 
-The artifact schema — front-matter fields, types, relationship kinds, status
-enums, required sections — is consumed by the validator, the four MCP tool
-serializers, and the TUI. If those consumers could drift apart, a field valid in
-one surface might be mis-served in another. RAC already defines the schema once,
-in code, as the front-matter envelope (ADR-052, ADR-049); the gap is that no
-test *asserts* the consumers still agree, so drift would be silent.
+The artifact schema is consumed by four code paths: the validator
+(`services/validate.py`, via `spec_for`), the MCP tool serializers
+(`mcp/server.py` — `get_artifact`, `search_artifacts`, `get_related`,
+`get_summary`), and the TUI adapter (`explorer/adapter.py`, via
+`schema_reference` and `load_repository`). If those consumers could drift apart,
+a field, type, status, or relationship kind valid in one surface might be
+mis-served, dropped, or invented in another.
+
+RAC already defines the schema once, in code, in two code-owned sources (ADR-052,
+ADR-049): the front-matter *envelope* — `_SUPPORTED_FIELDS` in
+`core/frontmatter.py` and `ArtifactMetadata` in `core/metadata.py` — and the
+per-type *structure* — `ARTIFACT_SPECS` in `core/artifacts.py` (types, required /
+recommended / optional sections, status enums, `retired_status`), with the
+relationship-kind vocabulary in `RELATIONSHIP_SECTIONS`
+(`services/relationships.py`). The gap is that no test *asserts* the consumers
+still agree with these sources, so drift would be silent. WS6 closes that gap
+with one cross-consumer agreement test and nothing else: no Pydantic, no
+JSON-Schema source of truth, no rewrite of the envelope or the specs.
 
 ## Requirements
 
-- [REQ-001] The schema MUST remain defined once as the code-defined envelope; this release MUST NOT introduce a parallel schema framework such as a new Pydantic model layer or a JSON-Schema source of truth (ADR-052, ADR-049).
-- [REQ-002] The release MUST add a test asserting the validator, the four MCP serializers, and the TUI adapter all agree with the single schema definition for types, statuses, relationship kinds, and required sections.
-- [REQ-003] Any residual ad-hoc schema logic found on those consumer paths SHOULD be removed in favor of the single definition.
-- [REQ-004] Changing a field in the single definition MUST propagate to every consumer that reads it, demonstrated by the agreement test.
+- [REQ-001] The schema MUST remain defined once in code — the front-matter envelope (`core/frontmatter.py`, `core/metadata.py`) and the per-type specs (`core/artifacts.py`, `services/relationships.py`). This release MUST NOT introduce a parallel schema framework: no new Pydantic model layer, no JSON-Schema source of truth, no rewrite of the envelope or the specs, and no new runtime dependency (ADR-052, ADR-049).
+- [REQ-002] The release MUST add one cross-consumer agreement test asserting that the validator, the four MCP serializers (`get_artifact`, `search_artifacts`, `get_related`, `get_summary`), and the TUI adapter all derive their schema knowledge from the single sources for: artifact types, status enums, relationship kinds, and required / recommended / optional sections.
+- [REQ-003] The agreement test MUST assert that every field and section name each consumer serializes or validates traces back to the single sources — no consumer invents a field, type, status, or relationship kind not in the sources, and no consumer silently drops one the sources declare. Membership, not value formatting, is what is asserted.
+- [REQ-004] The agreement test MUST fail loudly and deterministically when a consumer drifts: adding, removing, or renaming a type, status, relationship kind, envelope field, or required section in one place without the others MUST break the test with a diagnostic naming the consumer and the field that diverged. It is a pure-Python unit test in the standard battery, with no network, no AI, and no fixture corpus dependency.
+- [REQ-005] Any residual ad-hoc schema logic found on those consumer paths SHOULD be folded back into the single sources rather than special-cased in the test.
 
 ## Acceptance Criteria
 
-- Exactly one schema source exists.
-- A test asserts the validator, MCP output, and TUI agree with it.
-- Changing a field in one place propagates everywhere it is consumed.
+- The envelope and the per-type specs remain the only schema sources; no new schema framework or runtime dependency is added.
+- One agreement test asserts the validator, the four MCP serializers, and the TUI adapter agree with those sources on types, statuses, relationship kinds, and section sets.
+- Adding or removing a type, status, relationship kind, or required section in the source without updating a consumer fails the agreement test with a consumer-named diagnostic.
+- No consumer serializes a field absent from the sources, and none drops a declared one.
 
 ## Success Metrics
 
-- A schema change cannot ship without the agreement test reflecting it across
-  all consumers.
+- A schema change cannot ship green without the agreement test reflecting it
+  across all named consumers; a deliberately drifted consumer fails the test.
 
 ## Risks
 
 - The TUI could lag the schema. Mitigation: the TUI already consumes Core via
-  `load_repository`, so the agreement test covers it without a migration.
+  `load_repository` and `schema_reference`, so the agreement test covers it
+  without a migration.
+- A fifth read tool (`find_decisions`) now exists in `mcp/server.py`. Mitigation:
+  the test scope stays the four contract tools named in REQ-002; whether to
+  extend coverage to `find_decisions` is an open maintainer decision, not a scope
+  expansion for this release.
 
 ## Assumptions
 
-- The code-defined envelope is, and remains, the authoritative schema (ADR-052).
+- The code-defined envelope and the per-type specs are, and remain, the
+  authoritative schema (ADR-052); this release guards them, it does not replace
+  them.
+
+## Out of Scope
+
+- No Pydantic model layer, JSON-Schema source of truth, or any schema rewrite —
+  the agreement test is additive (ADR-052, ADR-049).
+- `schema_version` migration is out (T3-B): `schema_version: 1` already exists;
+  no migration framework, no v1→v2 path, is built or assumed here.
+- The test asserts membership agreement only; it does not normalize the wire
+  representation (for example the serializers' `schema_version: "1"` string is
+  left as-is, an additive contract detail under ADR-007, not a drift this test
+  polices).
 
 ## Related Decisions
 

--- a/rac/roadmaps/v0.23.x-hardening/v0.23.0-hardening.md
+++ b/rac/roadmaps/v0.23.x-hardening/v0.23.0-hardening.md
@@ -71,6 +71,14 @@ tiered tests) ships quietly; there is no user-facing "hardening release."
 
 ### Tier 2 — keep, scope down (cut from the bottom if the week runs short)
 
+- **Obey-demo — grounding proof (the success anchor)** `[user-facing]`. One
+  reproducible *manual* demo of a real (or partner-representative) coding agent
+  declining a forbidden change after consulting Lore; a captured recording/log
+  is the deliverable. Promoted from a Tier 3 carve-out because it is the
+  release's defining success outcome (see Success Measures). It stays a manual
+  smoke, never a CI gate (`rac-obey-demo-grounding-proof`, REQ-003), and it is
+  the one Tier 2 item that is *not* cuttable: the cut line sits above it, so
+  WS6/WS5/WS8/WS10 are dropped before the demo, never the demo itself.
 - **WS6 — Contract-first single schema** `[internal]`. The schema is already
   single-sourced as the code-defined envelope (ADR-052, ADR-049); add a
   cross-consumer agreement test across the validator, the four MCP serializers,
@@ -84,12 +92,13 @@ tiered tests) ships quietly; there is no user-facing "hardening release."
 - **WS10 — Honest changelog + tiered tests** `[internal]`. Three documented test
   tiers; an honest CHANGELOG entry; the `v0.23.0` tag.
 
-### Tier 3 — deferred / cut (only the two carve-outs)
+### Tier 3 — deferred / cut (the two remaining carve-outs)
 
-- **T3-A — Obey-demo** (the success proof). One reproducible *manual* demo of a
-  real agent declining a forbidden change after consulting Lore. Not a CI gate.
 - **T3-B — `schema_version`**. Already present (`schema_version: 1`); no work.
 - **T3-C — Resumability / crash-safe jobs**. Not built.
+
+The obey-demo, formerly the third carve-out here, is promoted to Tier 2 above
+as the non-cuttable success anchor.
 
 ## Workstream Checklist
 
@@ -105,22 +114,19 @@ Tier 1:
 - [ ] WS4 parser-traversal-robustness — caps + fuzz + bounded output — `planned`
 - [ ] WS11 artifact-trust-model — `SECURITY.md` + injection flag + review signal — `planned`
 
-Tier 2:
+Tier 2 (obey-demo is the non-cuttable success anchor; cut WS10 → WS6 first):
 
+- [ ] obey-demo-grounding-proof — recorded manual demo (success anchor, not a gate) — `planned`
 - [ ] WS6 single-schema-agreement — cross-consumer agreement test — `planned`
 - [ ] WS5 provenance-surfacing — author/date/status-history on `get_artifact` — `planned`
 - [ ] WS8 idempotent-content-hash-processing — short-circuit + byte-stability — `planned`
 - [ ] WS10 honest-changelog-tiered-tests — tiers + CHANGELOG + tag — `planned`
 
-Tier 3 (carve-outs only):
-
-- [ ] T3-A obey-demo-grounding-proof — recorded manual demo — `planned`
-
 ## Success Measures
 
-The release succeeds only if the **obey-demo (T3-A)** shows a real or
-partner-representative coding agent *demonstrably declining to relitigate at
-least one real decision* after consulting Lore. Green CI and the new eval gate
+The release succeeds only if the **obey-demo** (the Tier 2 success anchor)
+shows a real or partner-representative coding agent *demonstrably declining to
+relitigate at least one real decision* after consulting Lore. Green CI and the new eval gate
 are necessary but not sufficient — if every workstream is complete but that one
 outcome cannot be shown, the release is not done.
 

--- a/rac/roadmaps/v0.23.x-hardening/v0.23.0-hardening.md
+++ b/rac/roadmaps/v0.23.x-hardening/v0.23.0-hardening.md
@@ -13,7 +13,8 @@ Planned
 ## Context
 
 Lore (the product) grounds coding agents in a team's recorded decisions, served
-deterministically over four read-only MCP tools (ADR-030, ADR-032, ADR-034). The
+deterministically over five read-only MCP tools (ADR-030, ADR-067, ADR-032,
+ADR-034). The
 core claim — "the agent stops relitigating settled decisions" — rests on three
 properties we assert but have never *proven* in the repository: that retrieval
 returns the right artifact, that the serving path cannot be crashed or flooded
@@ -21,10 +22,10 @@ by hostile input, and that the artifact content an agent ingests as authoritativ
 is trustworthy because a human reviewed it.
 
 This release hardens those properties and makes them legible to a user. It is
-ruthlessly scoped to one week. It adds **no AI to the core**, **no fifth tool**,
+ruthlessly scoped to one week. It adds **no AI to the core**, **no new tool**,
 **no write capability**, and **no new infrastructure** — every capability ships
-as a CLI subcommand or CI check, or as additive fields on the existing four
-tools' output (ADR-007). A prior ten-item plan was red-teamed; this is the
+as a CLI subcommand or CI check, or as additive fields on the existing
+read-only tools' output (ADR-007). A prior ten-item plan was red-teamed; this is the
 surviving, re-tiered scope, reconciled against the decisions RAC has already
 recorded rather than re-deciding them.
 
@@ -81,7 +82,7 @@ tiered tests) ships quietly; there is no user-facing "hardening release."
   WS6/WS5/WS8/WS10 are dropped before the demo, never the demo itself.
 - **WS6 — Contract-first single schema** `[internal]`. The schema is already
   single-sourced as the code-defined envelope (ADR-052, ADR-049); add a
-  cross-consumer agreement test across the validator, the four MCP serializers,
+  cross-consumer agreement test across the validator, the five MCP serializers,
   and the TUI. No Pydantic, no rewrite.
 - **WS5 — Provenance (minimal)** `[user-facing]`. Additive author/date/status-
   history fields on `get_artifact`, from front matter + git (ADR-045).
@@ -138,8 +139,8 @@ Supporting measures:
 - `rac doctor` detects every defect class on fixtures, deterministically, with
   paste-ready fixes.
 - The full test suite plus the new eval gate and `doctor` pass in CI; the MCP
-  surface is still exactly four read-only tools, with only additive output
-  changes.
+  surface stays the five read-only tools (no new tool this release), with only
+  additive output changes.
 
 ## Constraints
 
@@ -148,9 +149,10 @@ Non-negotiable guardrails, each a recorded decision:
 - Determinism is load-bearing: no AI/LLM, RAG, embeddings, or vector search in
   any serving, validation, eval-scoring, doctor, or indexing path (ADR-002,
   ADR-034, ADR-066). Everything runs offline with no keys.
-- The MCP tool surface is locked at exactly four tools — `get_artifact`,
-  `search_artifacts`, `get_related`, `get_summary` — and stays read-only
-  (ADR-030, ADR-032).
+- The MCP tool surface gains no new tool this release and stays read-only; the
+  five existing tools are `get_artifact`, `search_artifacts`, `get_related`,
+  `get_summary`, and `find_decisions` — the fifth added by ADR-067, which
+  ADR-030 anticipated as an additive extension (ADR-030, ADR-067, ADR-032).
 - Humans author and review; nothing auto-edits artifact content. Artifact
   content is untrusted input; the trust boundary is human PR review (ADR-065).
 - The schema is defined once, in code, as the front-matter envelope
@@ -163,7 +165,8 @@ Non-negotiable guardrails, each a recorded decision:
 
 - No Pydantic schema rewrite — the code-defined envelope already is the single
   source (ADR-052); WS6 adds an agreement test only.
-- No automated multi-agent CI harness — replaced by the manual obey-demo (T3-A),
+- No automated multi-agent CI harness — replaced by the manual obey-demo (the
+  Tier 2 success anchor),
   which is deterministic to reproduce and honest about being a manual smoke.
 - No schema-migration framework — reduced to the existing `schema_version`
   field (T3-B); revisit when a real v1→v2 migration exists.


### PR DESCRIPTION
# Summary

Corpus-only refinement of the **v0.23.0 "Hardening"** release scope (plus one
small tooling-config commit, noted under Scope). No product code. This takes the
ten `Proposed` workstream requirements from "drafted" to "red-teamed and
tightened," promotes the obey-demo to the release's success anchor, and
reconciles the MCP tool-surface count with what the server actually ships. All
requirements stay `Status: Proposed` — this sharpens the contracts, it does not
implement them.

Each requirement was reviewed against the real `src/rac/` code and the ADRs it
cites — surfacing genuine scope/feasibility issues, not rubber-stamping:

- **WS3 `rac doctor`** as drafted largely duplicated existing
  `validate`/`relationships`/`review`; narrowed to an aggregator + two
  genuinely new checks (high-fan-out hubs, injection heuristic).
- **WS1 eval** — removed a tiebreak that would have forced an out-of-scope
  production sort change; gated metrics pinned.
- **WS2 / WS5 / WS11** all touch the `get_artifact` serializer; reconciled to
  compose additively under one nested `provenance` object.
- **WS6** — the "single schema" is actually two code-owned sources (the
  front-matter envelope + the per-type spec); the agreement test now covers all
  five MCP serializers.
- **WS4** — `get_related` ordering made semantic so response-budget truncation
  drops edges predictably.

## Obey-demo → Tier 2

Promoted from a Tier 3 carve-out to the **non-cuttable success anchor**: the
release succeeds only if a real coding agent demonstrably declines a forbidden
change after consulting Lore. The recording spec is pinned (the agent must call
a retrieval tool + `get_artifact`, decline the change, and cite the governing
ADR by id, with the tool calls visible in the capture), recorded across Claude
Code, Cursor, and Codex against a real `Accepted` ADR, with cherry-picking
forbidden.

## Maintainer decisions integrated

1. MCP surface recognized as **five** read-only tools (`find_decisions`,
   ADR-067) — not four.
2. `get_artifact` provenance fields grouped under a **nested object**.
3. `get_related` reordered to `(type, id)` for predictable truncation.
4. `rac doctor` hub threshold: a **fixed default (~20), configurable**.
5. Status-history: the **full** history via a single `git log -p` subprocess
   (depth-insensitive, ~45 ms measured), with a generous response-budget cap.
6. Grounding-eval gate adds **per-category floors**.
7. Obey-demo recorded across **multiple agents** (Claude / Cursor / Codex).
8. Forbidden-change scenario uses a **real `Accepted` RAC ADR**.

## Tool-surface reconciliation

`find_decisions` is the fifth read-only tool, added in v0.21.16 under ADR-067 —
which ADR-030 explicitly anticipated as an additive, non-breaking extension.
The roadmap's stale "exactly four / no fifth tool" language is corrected to
"five read-only tools; this release adds no new tool," and WS6's agreement test
now covers five serializers. ADR-030 gains a one-line note that ADR-067 extends
it (kept `Accepted`, not superseded — its tools-only decision stands).

## Scope

- **Included:** the 10 `rac/requirements/*` workstream artifacts +
  `rac/roadmaps/v0.23.x-hardening/v0.23.0-hardening.md` + the one-line ADR-030
  extension note. Plus one tooling commit: `.claude/settings.json` sets
  `attribution.sessionUrl: false` so the harness stops appending the
  `claude.ai/code` session link to commits/PRs, enforcing the repo's
  no-tool-attribution commit guideline.
- **Excluded:** no `src/` changes, no ADR status changes, no new artifacts.

## Verification

- `rac validate rac/` → 249 valid, 0 invalid (exit 0)
- `rac relationships rac/ --validate` → 0 issues (exit 0)
- `rac watchkeeper rac --base origin/main` → 0 regressions (exit 0)
- `rac review rac/` → no Priority 1–2 findings

History was rebased so the watchkeeper fix is folded into the requirement-refine
commit (no failing intermediate states); the four commits are individually
clean.