### PR TITLE
docs(requirement): gate per-category eval floors in WS1 [roadmap:v0.23.0]

### DIFF
--- a/rac/requirements/rac-grounding-eval-benchmark.md
+++ b/rac/requirements/rac-grounding-eval-benchmark.md
@@ -29,7 +29,7 @@ there is no gate that fails the build when it happens.
 - [REQ-003] `rac eval` MUST compute Precision@k and Recall@k at `k ∈ {1, 3, 5}` as macro-averages (equal weight per case), reported `overall`, `by_category`, and `by_tool`, and MUST count hard-negative violations (a `must_not_return` id appearing in the top-k returned ids). `P@k = |Rel ∩ top_k| / k` (empty slots count against precision); `R@k = |Rel ∩ top_k| / |Rel|` with `|Rel| ≥ 1` by construction. Each query case is scored against exactly one named tool (`search_artifacts` or `get_related`).
 - [REQ-004] The scored ranked list MUST be the production retrieval order unchanged. `search_index` already orders by `(match_rank, path)`, which is total and byte-stable; `rac eval` MUST consume that order verbatim and MUST NOT re-sort, re-rank, or alter production retrieval. The ADR-066 ascending-artifact-id tie-break is satisfied as recorded only if production order is path-stable; because it already is, this release adds NO production sort change. (If a future equal-`(rank, path)` collision is possible, it is resolved by ascending artifact id at the eval read seam only.)
 - [REQ-005] `rac eval` MUST write a scorecard JSON with exactly three top-level objects — `metrics`, `metadata`, `per_query` — matching the `grounding-eval-scorecard` design shape. `metadata` MUST record `lore_version`, `corpus_hash` (`sha256:…` over the fixture corpus files), `query_set_hash` (`sha256:…` over the query set), `n_queries`, and `generated_at`. ONLY `metrics` is compared by the gate; `metadata` and `per_query` are diagnostic and excluded from comparison so a clock or hash never fails a build. Scorecard JSON is an additive, stable contract (ADR-007).
-- [REQ-006] RAC MUST provide a `rac eval --check` CI gate that re-runs scoring and FAILS (exit 1) if any of: (a) `negative_violations > 0`; (b) any gated metric `< floor`; (c) any gated metric `< baseline_value − tolerance`. It MUST print one line per fired rule naming the rule, metric, baseline value, and current value. A clean run exits 0; a usage error (missing baseline, unreadable corpus, malformed query set) exits 2. Floors and tolerance live in committed config alongside the baseline (initial: `negative_violations == 0` always, `overall.p_at_1 ≥ 0.90`, `overall.r_at_5 ≥ 0.95`, tolerance `T = 0.02`). Gated metrics are `overall.p_at_1`, `overall.r_at_5`, and `negative_violations`; per-category/per-tool figures are diagnostic this release.
+- [REQ-006] RAC MUST provide a `rac eval --check` CI gate that re-runs scoring and FAILS (exit 1) if any of: (a) `negative_violations > 0`; (b) any gated metric `< floor`; (c) any gated metric `< baseline_value − tolerance`. It MUST print one line per fired rule naming the rule, metric, baseline value, and current value. A clean run exits 0; a usage error (missing baseline, unreadable corpus, malformed query set) exits 2. Floors and tolerance live in committed config alongside the baseline (initial: `negative_violations == 0` always, `overall.p_at_1 ≥ 0.90`, `overall.r_at_5 ≥ 0.95`, tolerance `T = 0.02`; plus a per-category floor on each query category's `p_at_1` and `r_at_5`, calibrated from the first green run and committed alongside the overall floors). Gated metrics are `overall.p_at_1`, `overall.r_at_5`, `negative_violations`, and each query category's `p_at_1` / `r_at_5` floor; per-tool figures remain diagnostic this release.
 - [REQ-007] Re-baselining MUST be human-gated via `rac eval --update-baseline`, which overwrites `tests/eval/baseline.json` with the current `metrics` object; CI MUST NEVER pass `--update-baseline` and MUST NEVER write the baseline.
 - [REQ-008] The fixture corpus MUST live under `tests/eval/corpus/`, be schema-valid (`rac validate` exit 0), pass `rac doctor` (WS3) clean, span all five artifact types, and include a supersession chain (the superseded member is the canonical `must_not_return` case), distractors, and an ambiguous pair. The query set MUST live under `tests/eval/queries.json` (or equivalent committed file), each case declaring `id`, `tool`, `query`/`id` input, `category`, `relevant` (≥1 id), and optional `must_not_return`.
 - [REQ-009] The eval SHOULD reuse the WS8 content-hash short-circuit to skip unchanged artifacts on re-runs, but MUST NOT depend on it: WS8 is a cuttable Tier-2 workstream, so `rac eval` MUST be correct and deterministic without it, with the short-circuit a pure performance optimization that never changes scored output.
@@ -57,8 +57,9 @@ there is no gate that fails the build when it happens.
 ## Success Metrics
 
 - The committed baseline meets the initial floors (`negative_violations == 0`,
-  `overall.p_at_1 ≥ 0.90`, `overall.r_at_5 ≥ 0.95`), calibrated from the first
-  green run and committed with the baseline.
+  `overall.p_at_1 ≥ 0.90`, `overall.r_at_5 ≥ 0.95`, plus the per-category
+  `p_at_1` / `r_at_5` floors), calibrated from the first green run and committed
+  with the baseline.
 - A deliberately introduced retrieval regression is caught by CI rather than by
   a human noticing later.
 
@@ -77,9 +78,10 @@ there is no gate that fails the build when it happens.
 
 This requirement is one workstream (WS1) inside the single v0.23.0 release and
 does not split into further versions. Explicitly out of scope this release:
-graded relevance, micro-averaging, per-category/per-tool gating (diagnostic
-only), any change to production retrieval ranking, and any dependence on WS8 for
-correctness (REQ-009 makes the content-hash short-circuit optional).
+graded relevance, micro-averaging, per-tool gating (diagnostic only;
+per-category floors ARE gated per REQ-006), any change to production retrieval
+ranking, and any dependence on WS8 for correctness (REQ-009 makes the
+content-hash short-circuit optional).
 
 ## Assumptions
 


### PR DESCRIPTION
# Summary

One-line-of-intent corpus fix: **gate per-category floors in the WS1 grounding
benchmark**, reconciling `rac-grounding-eval-benchmark.md` with the maintainer
decision made during the v0.23.0 spec. The merged requirement had per-category
figures marked **diagnostic-only** (REQ-006 + Descope), which contradicted the
decision to *add per-category floors* to the eval gate. This lands before WS1
implementation starts so the new session builds to a self-consistent spec.

## Change (additive — watchkeeper-safe)

- **REQ-006** gated-metrics set now includes **each query category's `p_at_1` /
  `r_at_5` floor** (calibrated from the first green run and committed alongside
  the overall floors, exactly like the overall floors). Per-tool figures stay
  diagnostic this release. Every existing `MUST` clause is preserved unchanged.
- **Descope** now lists only *per-tool* gating as out-of-scope (was
  per-category/per-tool); notes per-category floors are gated per REQ-006.
- **Success Metrics** notes the per-category floors in the committed baseline.

No REQ id renumbered, no mandatory wording removed or weakened.

## Verification

- `rac watchkeeper rac --base origin/main` → **0 regressions** (no
  `constraint_removed`, no `specificity_regression`), exit 0
- `rac validate rac/` → 249 valid, 0 invalid (exit 0)
- `rac relationships rac/ --validate` → 0 issues (exit 0)
- `rac review rac/` → no Priority 1–2 findings

## Scope

- **Included:** `rac/requirements/rac-grounding-eval-benchmark.md` only.
- **Excluded:** no code, no other artifacts; per-tool gating intentionally
  left diagnostic.