### PR TITLE
feat(eval): v0.23.0 hardening — Tier 1 (WS1: rac eval grounding benchmark)

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -134,6 +134,32 @@ jobs:
       - name: Check agent-rules freshness
         run: rac export rac/ --agent-rules --check
 
+  # Grounding-eval gate (v0.23.0, WS1, ADR-066): every pull request re-scores the
+  # retrieval tools against the committed fixture corpus and query set and fails
+  # if any gated metric regresses past its floor or baseline tolerance, or a
+  # hard-negative (e.g. a superseded decision) surfaces. `--check` never writes
+  # the baseline; re-baselining is human-only via `rac eval --update-baseline`,
+  # so CI can never silently move the bar. Source install, like the other gates.
+  eval:
+    name: grounding-eval (gate, source install)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install package
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .
+
+      - name: Run the grounding-eval gate
+        run: rac eval --check
+
   # PR-gate dogfood (v0.21.14): every pull request runs the local PR-gate action
   # in source mode — the live end-to-end test of pr-gate-action/action.yml. It
   # carries the full contract via a single `rac gate` command — validation,

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -97,6 +97,8 @@ jobs:
             paths: "tests/test_relationships.py tests/test_relationships_cmd.py tests/test_relationship_validation.py tests/test_relationship_graph.py tests/test_lifecycle_status.py tests/test_rename.py"
           - name: resolve
             paths: "tests/test_resolve.py tests/test_find_decisions.py"
+          - name: eval
+            paths: "tests/test_eval.py"
           - name: review
             paths: "tests/test_review.py tests/test_cadence.py"
           - name: revisions

--- a/rac/requirements/rac-grounding-eval-benchmark.md
+++ b/rac/requirements/rac-grounding-eval-benchmark.md
@@ -8,7 +8,7 @@ tags: [user-facing, eval, retrieval, benchmark, ci]
 
 ## Status
 
-Proposed
+Accepted
 
 Classification: `[user-facing]` — it is the proof the tool works. Scoped to the
 v0.23.0 hardening release (WS1).

--- a/rac/roadmaps/v0.23.x-hardening/v0.23.0-hardening.md
+++ b/rac/roadmaps/v0.23.x-hardening/v0.23.0-hardening.md
@@ -109,7 +109,7 @@ Cross-session progress tracker. Status: `planned` → `in-progress` → `done` /
 
 Tier 1:
 
-- [ ] WS1 grounding-eval-benchmark — `rac eval` + CI gate — `planned`
+- [x] WS1 grounding-eval-benchmark — `rac eval` + CI gate — `done`
 - [ ] WS2 explainable-retrieval — `evidence` + `--explain` — `planned`
 - [ ] WS3 doctor-diagnostic-validator — `rac doctor` — `planned`
 - [ ] WS4 parser-traversal-robustness — caps + fuzz + bounded output — `planned`

--- a/src/rac/cli.py
+++ b/src/rac/cli.py
@@ -30,6 +30,8 @@ Commands:
     rac quickstart [directory] [--key KEY] [--type TYPE] [--json]
     rac resolve <ID> [directory] [--json]
     rac find <query> [directory] [--type TYPE] [--json]
+    rac eval [--check | --update-baseline] [--json]
+             [--root DIR] [--queries PATH] [--baseline PATH] [--config PATH]
     rac migrate metadata <directory> [--dry-run] [--json]
     rac skill install [name] [--dir PATH] [--json]
     rac skill list [--json]
@@ -55,6 +57,8 @@ Exit codes:
        references or duplicate identifiers found; review: invalid artifacts
        or broken relationships found (priority 1-2 issues); new: packaged
        template missing (broken installation) or malformed repository config;
+       eval --check: a gate rule fired (hard-negative violation, a metric below
+       its floor, or a metric below baseline minus tolerance);
        init: established key conflicts with the requested one; resolve:
        artifact not found or duplicate ID; migrate: malformed repository
        config or ID generation exhausted; skill install: any target file
@@ -68,7 +72,8 @@ Exit codes:
        mcp --root not a directory, skill --dir not a directory, unknown
        skill name, export --out without --html/--okf or unwritable, missing or
        corrupt vendored portal shell, watchkeeper revision unknown or
-       directory not inside a git repository)
+       directory not inside a git repository, eval corpus unreadable or query
+       set / baseline / config missing or malformed)
 """
 
 from __future__ import annotations
@@ -98,6 +103,7 @@ from rac.core.templates import (
 )
 from rac.core.validation import has_errors
 from rac.output.portal import PortalSeamMissing, PortalShellMissing
+from rac.services import eval as eval_service
 from rac.services.agent_rules import (
     check_agent_rules,
     generate_agent_rules,
@@ -840,6 +846,42 @@ def cmd_find(args: argparse.Namespace) -> int:
         print(outputs.render_find_human(result))
     # An empty result is a valid outcome, not an error (a query always succeeds).
     return EXIT_OK
+
+
+def cmd_eval(args: argparse.Namespace) -> int:
+    """Score retrieval against the fixture benchmark, or gate against the baseline.
+
+    Three modes (default report / ``--check`` gate / ``--update-baseline``):
+    a clean report exits 0; the gate exits 1 on regression; any usage error
+    (missing baseline, unreadable corpus, malformed query set) exits 2.
+    ``--update-baseline`` is human-only — CI never passes it (REQ-006/REQ-007).
+    """
+    try:
+        scorecard = eval_service.run_eval(args.root, args.queries)
+        if args.update_baseline:
+            Path(args.baseline).write_text(
+                eval_service.render_metrics_json(scorecard.metrics) + "\n", encoding="utf-8"
+            )
+            print(f"rac eval: baseline updated -> {args.baseline}")
+            return EXIT_OK
+        if args.check:
+            baseline = eval_service.load_baseline(args.baseline)
+            config = eval_service.load_config(args.config)
+            failures = eval_service.evaluate_gate(scorecard.metrics, baseline, config)
+            if failures:
+                for failure in failures:
+                    print(failure.render())
+                return EXIT_VALIDATION_FAILED
+            print("rac eval: gate PASS")
+            return EXIT_OK
+        if args.json:
+            print(eval_service.render_scorecard_json(scorecard))
+        else:
+            print(eval_service.render_scorecard_human(scorecard))
+        return EXIT_OK
+    except eval_service.EvalUsageError as exc:
+        print(f"rac eval: {exc}", file=sys.stderr)
+        raise SystemExit(EXIT_USAGE) from None
 
 
 def cmd_migrate(args: argparse.Namespace) -> int:
@@ -1733,6 +1775,53 @@ def build_parser() -> argparse.ArgumentParser:
         help="Recurse into subdirectories (the default; accepted for clarity).",
     )
     p_find.set_defaults(func=cmd_find)
+
+    p_eval = sub.add_parser(
+        "eval",
+        help="Score retrieval against the grounding benchmark; gate CI against the baseline.",
+        parents=[version_parent],
+    )
+    eval_mode = p_eval.add_mutually_exclusive_group()
+    eval_mode.add_argument(
+        "--check",
+        action="store_true",
+        help=(
+            "CI gate: re-score and fail (exit 1) on a hard-negative violation, a "
+            "metric below its floor, or a metric below baseline minus tolerance."
+        ),
+    )
+    eval_mode.add_argument(
+        "--update-baseline",
+        action="store_true",
+        help=(
+            "Human-only re-baseline: overwrite the baseline with the current "
+            "metrics. CI must never pass this."
+        ),
+    )
+    p_eval.add_argument(
+        "--json", action="store_true", help="Emit the full scorecard JSON instead of tables."
+    )
+    p_eval.add_argument(
+        "--root",
+        default=eval_service.DEFAULT_CORPUS,
+        help="Fixture corpus directory (default: tests/eval/corpus).",
+    )
+    p_eval.add_argument(
+        "--queries",
+        default=eval_service.DEFAULT_QUERIES,
+        help="Query set JSON (default: tests/eval/queries.json).",
+    )
+    p_eval.add_argument(
+        "--baseline",
+        default=eval_service.DEFAULT_BASELINE,
+        help="Baseline metrics JSON (default: tests/eval/baseline.json).",
+    )
+    p_eval.add_argument(
+        "--config",
+        default=eval_service.DEFAULT_CONFIG,
+        help="Gate config (floors + tolerance) JSON (default: tests/eval/eval-config.json).",
+    )
+    p_eval.set_defaults(func=cmd_eval)
 
     p_migrate = sub.add_parser(
         "migrate",

--- a/src/rac/mcp/server.py
+++ b/src/rac/mcp/server.py
@@ -55,7 +55,11 @@ from rac.mcp.budget import DEFAULT_BUDGET, serialize
 from rac.mcp.telemetry import TelemetryRecorder
 from rac.services.index import build_repository_index, index_from_corpus
 from rac.services.portfolio import build_portfolio_summary
-from rac.services.relationships import relationships_from_corpus
+from rac.services.relationships import (
+    incoming_references,
+    outgoing_references,
+    relationships_from_corpus,
+)
 from rac.services.resolve import (
     OUTCOME_RESOLVED,
     ResolutionResult,
@@ -140,53 +144,6 @@ def _resolve(root: str, artifact_id: str) -> ResolutionResult:
     return resolve_in_index(entries, artifact_id)
 
 
-def _outgoing_from(relationships: list, path: str) -> dict[str, list[str]]:
-    """The resolved artifact's own relationship sections, references as stored.
-
-    Filters the Core-computed relationship list for references *declared by*
-    ``path`` (ADR-031, presentation-only). Keys are snake_case section names in
-    the artifact's own spec order; ``relationships_from_corpus`` yields
-    references in that order, so a first-seen-wins dict preserves it. References
-    are the raw stored text — the source of truth (ADR-016).
-    """
-    outgoing: dict[str, list[str]] = {}
-    for rel in relationships:
-        if rel.source_path == path:
-            outgoing.setdefault(rel.relationship, []).append(rel.target)
-    return outgoing
-
-
-def _incoming_from(relationships: list, by_path: dict, target_path: str) -> list[dict]:
-    """Artifacts whose declared references resolve to ``target_path``.
-
-    Filters the Core-computed relationship list for references whose
-    ``resolved_path`` is the target — resolution stays Core-owned (ADR-031): a
-    reference is an incoming edge exactly when Core resolved it uniquely to the
-    target. Self-references are excluded. Entries are ordered by source path,
-    then section, matching the deterministic ordering the design pins.
-    """
-    incoming: list[dict] = []
-    for rel in relationships:
-        if rel.resolved_path != target_path:
-            continue
-        if rel.source_path == target_path:
-            continue  # self-references are not incoming edges
-        source = by_path.get(rel.source_path)
-        if source is None:  # pragma: no cover — every relationship source is indexed
-            continue
-        incoming.append(
-            {
-                "id": source.id,
-                "type": source.type,
-                "title": source.title,
-                "path": source.path,
-                "section": rel.relationship,
-            }
-        )
-    incoming.sort(key=lambda e: (e["path"], e["section"]))
-    return incoming
-
-
 def _get_artifact(root: str, artifact_id: str, budget: int) -> str:
     result = _resolve(root, artifact_id)
     if result.outcome != OUTCOME_RESOLVED or result.artifact is None:
@@ -242,12 +199,22 @@ def _get_related(root: str, artifact_id: str, budget: int) -> str:
         return serialize(errors.from_resolution(result), budget)
     artifact = result.artifact
     relationships = relationships_from_corpus(entries)
-    by_path = {entry.path: entry for entry in index}
+    identity_by_path = {entry.path: (entry.id, entry.type, entry.title) for entry in index}
+    incoming = [
+        {
+            "id": ref.id,
+            "type": ref.type,
+            "title": ref.title,
+            "path": ref.path,
+            "section": ref.section,
+        }
+        for ref in incoming_references(relationships, identity_by_path, artifact.path)
+    ]
     payload = {
         "schema_version": "1",
         **artifact.to_dict(),
-        "outgoing": _outgoing_from(relationships, artifact.path),
-        "incoming": _incoming_from(relationships, by_path, artifact.path),
+        "outgoing": outgoing_references(relationships, artifact.path),
+        "incoming": incoming,
     }
     return serialize(payload, budget)
 
@@ -277,7 +244,7 @@ def build_server(
     startup; there is no per-call override. ``recorder`` enables opt-in usage
     telemetry (ADR-040): with ``None`` — the default — nothing is recorded and
     every call is exactly the bare tool body. The returned :class:`FastMCP`
-    instance has the four pinned tools registered and is ready to run over any
+    instance has the five pinned tools registered and is ready to run over any
     transport — the CLI runs it over stdio.
     """
     server: FastMCP = FastMCP(SERVER_NAME)

--- a/src/rac/services/eval.py
+++ b/src/rac/services/eval.py
@@ -1,0 +1,588 @@
+"""Grounding retrieval benchmark — ``rac eval`` (v0.23.0, WS1).
+
+A deterministic, offline benchmark that scores Lore's retrieval surface against
+a versioned fixture corpus and query set, then gates CI against a committed
+baseline. It is the proof that the core claim — "the agent retrieves the right
+recorded decision" — holds and keeps holding (ADR-066, ADR-002).
+
+Determinism is load-bearing. The *scored path* is a pure function of
+``(corpus bytes, query set, retrieval code)``: no network, no API keys, no
+randomness, and no clock (REQ-002). The two clock/identity values a run records
+— ``generated_at`` and ``lore_version`` — live in ``metadata``, which the gate
+excludes from comparison, so a wall clock never fails a build (REQ-005).
+
+The benchmark guards the *real* surface, never a parallel scorer (REQ-002): a
+``search_artifacts`` case scores the exact :func:`rac.services.resolve.search_index`
+order the MCP ``search_artifacts`` tool returns, and a ``get_related`` case
+scores the exact ``incoming`` neighborhood
+:func:`rac.services.relationships.incoming_references` computes — the single
+source of truth the MCP ``get_related`` tool also serializes, so the scored
+surface cannot drift from the served one. Production retrieval order is consumed
+verbatim — no re-sort, no re-rank (REQ-004). Because only returned-id
+*membership* is compared, additive WS2 ``evidence`` fields cannot shift any
+metric (REQ-010).
+
+Metrics are Precision@k and Recall@k at ``k ∈ {1, 3, 5}``, macro-averaged
+(equal weight per case), reported ``overall`` / ``by_category`` / ``by_tool``,
+plus a summed hard-negative ``negative_violations`` count (REQ-003). Floats are
+rounded to a fixed precision so the serialized ``metrics`` block is byte-stable
+across runs on an unchanged corpus.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from rac import __version__
+from rac.core.corpus import walk_corpus
+from rac.core.fs import find_markdown_files
+from rac.services.index import build_repository_index, index_from_corpus
+from rac.services.relationships import incoming_references, relationships_from_corpus
+from rac.services.resolve import OUTCOME_RESOLVED, resolve_in_index, search_index
+
+# The ranks the benchmark reports Precision@k / Recall@k at (REQ-003).
+K_VALUES: tuple[int, ...] = (1, 3, 5)
+# The window a hard-negative violation is judged in: the widest k, i.e. the
+# top-5 an agent actually reads (REQ-003, design "Hard-negative violation").
+NEGATIVE_K: int = max(K_VALUES)
+# Metric floats are rounded to this many decimals so the serialized ``metrics``
+# object is byte-identical across runs (the gate compares with tolerance, far
+# coarser than this precision, so rounding never hides a real regression).
+_PRECISION: int = 6
+
+# Default fixture locations, resolved against the current working directory (the
+# repo root in CI). The in-repo benchmark is a dev/CI surface; ``rac eval`` with
+# no arguments runs it (REQ-001).
+DEFAULT_CORPUS = "tests/eval/corpus"
+DEFAULT_QUERIES = "tests/eval/queries.json"
+DEFAULT_BASELINE = "tests/eval/baseline.json"
+DEFAULT_CONFIG = "tests/eval/eval-config.json"
+
+TOOL_SEARCH = "search_artifacts"
+TOOL_GET_RELATED = "get_related"
+_TOOLS = (TOOL_SEARCH, TOOL_GET_RELATED)
+
+
+class EvalUsageError(Exception):
+    """A usage/IO error — missing baseline, unreadable corpus, malformed input.
+
+    The CLI maps this to exit code 2 (REQ-006), distinct from a gate failure
+    (exit 1) and a clean run (exit 0).
+    """
+
+
+@dataclass(frozen=True)
+class QueryCase:
+    """One scored retrieval case (REQ-008).
+
+    ``query`` is the search string for a ``search_artifacts`` case, or the
+    artifact id to look up for a ``get_related`` case. ``relevant`` has at least
+    one id by construction; ``must_not_return`` is the optional hard-negative
+    set (e.g. a superseded decision that must not surface).
+    """
+
+    id: str
+    tool: str
+    query: str
+    category: str
+    relevant: tuple[str, ...]
+    must_not_return: tuple[str, ...] = ()
+    type: str | None = None  # optional artifact-type filter, search cases only
+
+
+@dataclass
+class CaseResult:
+    """The scored outcome of one :class:`QueryCase` — a ``per_query`` row."""
+
+    case: QueryCase
+    returned: list[str]
+    precision: dict[int, float]
+    recall: dict[int, float]
+    violations: list[str]
+
+    def to_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "id": self.case.id,
+            "tool": self.case.tool,
+            "category": self.case.category,
+            "returned": self.returned,
+            "relevant": list(self.case.relevant),
+        }
+        if self.case.must_not_return:
+            payload["must_not_return"] = list(self.case.must_not_return)
+        for k in K_VALUES:
+            payload[f"p_at_{k}"] = _round(self.precision[k])
+        for k in K_VALUES:
+            payload[f"r_at_{k}"] = _round(self.recall[k])
+        payload["violations"] = self.violations
+        return payload
+
+
+@dataclass
+class Scorecard:
+    """A full benchmark run: gated ``metrics`` plus diagnostic context.
+
+    Only ``metrics`` is compared by the gate; ``metadata`` and ``per_query`` are
+    diagnostic and excluded, so a clock or hash never fails a build (REQ-005).
+    """
+
+    metrics: dict[str, Any]
+    metadata: dict[str, Any]
+    per_query: list[dict[str, Any]]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "metrics": self.metrics,
+            "metadata": self.metadata,
+            "per_query": self.per_query,
+        }
+
+
+def _round(value: float) -> float:
+    """Fixed-precision rounding for byte-stable metric serialization."""
+    return round(value, _PRECISION)
+
+
+# --- Loading committed inputs (usage errors → EvalUsageError) ----------------
+
+
+def _load_json(path: str, what: str) -> Any:
+    p = Path(path)
+    if not p.is_file():
+        raise EvalUsageError(f"{what} not found: {path}")
+    try:
+        return json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError) as exc:
+        raise EvalUsageError(f"cannot read {what}: {path}: {exc}") from None
+    except json.JSONDecodeError as exc:
+        raise EvalUsageError(f"malformed {what}: {path}: {exc}") from None
+
+
+def load_query_set(path: str) -> list[QueryCase]:
+    """Parse the committed query set, validating each case's shape (REQ-008)."""
+    data = _load_json(path, "query set")
+    cases_raw = data.get("cases") if isinstance(data, dict) else data
+    if not isinstance(cases_raw, list) or not cases_raw:
+        raise EvalUsageError(f"malformed query set: {path}: expected a non-empty 'cases' list")
+    cases: list[QueryCase] = []
+    seen_ids: set[str] = set()
+    for i, raw in enumerate(cases_raw):
+        case = _parse_case(raw, path, i)
+        if case.id in seen_ids:
+            raise EvalUsageError(f"malformed query set: {path}: duplicate case id {case.id!r}")
+        seen_ids.add(case.id)
+        cases.append(case)
+    return cases
+
+
+def _parse_case(raw: Any, path: str, index: int) -> QueryCase:
+    if not isinstance(raw, dict):
+        raise EvalUsageError(f"malformed query set: {path}: case {index} is not an object")
+
+    def _require(field_name: str) -> Any:
+        if field_name not in raw:
+            raise EvalUsageError(
+                f"malformed query set: {path}: case {index} missing {field_name!r}"
+            )
+        return raw[field_name]
+
+    case_id = _require("id")
+    tool = _require("tool")
+    query = _require("query")
+    category = _require("category")
+    relevant = _require("relevant")
+    if tool not in _TOOLS:
+        raise EvalUsageError(
+            f"malformed query set: {path}: case {case_id!r} tool must be one of {_TOOLS}"
+        )
+    if not isinstance(relevant, list) or not relevant:
+        raise EvalUsageError(
+            f"malformed query set: {path}: case {case_id!r} 'relevant' must be a non-empty list"
+        )
+    must_not = raw.get("must_not_return", [])
+    if not isinstance(must_not, list):
+        raise EvalUsageError(
+            f"malformed query set: {path}: case {case_id!r} 'must_not_return' must be a list"
+        )
+    artifact_type = raw.get("type")
+    if artifact_type is not None and not isinstance(artifact_type, str):
+        raise EvalUsageError(
+            f"malformed query set: {path}: case {case_id!r} 'type' must be a string"
+        )
+    return QueryCase(
+        id=str(case_id),
+        tool=str(tool),
+        query=str(query),
+        category=str(category),
+        relevant=tuple(str(r) for r in relevant),
+        must_not_return=tuple(str(m) for m in must_not),
+        type=artifact_type,
+    )
+
+
+def load_baseline(path: str) -> dict[str, Any]:
+    """Load the committed baseline ``metrics`` object (REQ-007)."""
+    data = _load_json(path, "baseline")
+    if not isinstance(data, dict) or "overall" not in data:
+        raise EvalUsageError(f"malformed baseline: {path}: expected a metrics object")
+    return data
+
+
+def load_config(path: str) -> dict[str, Any]:
+    """Load the committed gate config — floors and tolerance (REQ-006)."""
+    data = _load_json(path, "config")
+    if not isinstance(data, dict) or "floors" not in data or "tolerance" not in data:
+        raise EvalUsageError(f"malformed config: {path}: expected 'floors' and 'tolerance'")
+    return data
+
+
+# --- Retrieval seam: the real surface, never a parallel scorer (REQ-002) -----
+
+
+def _search_returned(root: str, entries: list, case: QueryCase) -> list[str]:
+    """Returned ids for a ``search_artifacts`` case, production order verbatim.
+
+    Calls :func:`rac.services.resolve.search_index` — the exact function the MCP
+    ``search_artifacts`` tool calls — and consumes its ``(match_rank, path)``
+    order unchanged (REQ-004).
+    """
+    result = search_index(entries, case.query, artifact_type=case.type)
+    return [match.id for match in result.matches]
+
+
+def _related_returned(root: str, case: QueryCase) -> list[str]:
+    """Returned ids for a ``get_related`` case — the tool's ``incoming`` order.
+
+    Builds the 1-hop neighborhood from the same services the MCP ``get_related``
+    tool uses (a fresh corpus walk, the repository index, reference resolution,
+    and :func:`rac.services.relationships.incoming_references`), then reads the
+    ``incoming`` artifacts in the order the tool returns them: the
+    reverse-reference / impact-analysis direction ("what references this
+    artifact"), the highest-value grounding signal. A query that does not
+    resolve to an artifact is a malformed case against this corpus — a usage
+    error, not a silent empty result.
+    """
+    entries = list(walk_corpus(root, recursive=True))
+    index = index_from_corpus(root, entries, recursive=True).artifacts
+    resolution = resolve_in_index(index, case.query)
+    if resolution.outcome != OUTCOME_RESOLVED or resolution.artifact is None:
+        raise EvalUsageError(
+            f"get_related case {case.id!r}: query {case.query!r} did not resolve to an "
+            f"artifact in {root!r}"
+        )
+    relationships = relationships_from_corpus(entries)
+    identity_by_path = {entry.path: (entry.id, entry.type, entry.title) for entry in index}
+    incoming = incoming_references(relationships, identity_by_path, resolution.artifact.path)
+    return [ref.id for ref in incoming]
+
+
+def returned_ids(root: str, entries: list, case: QueryCase) -> list[str]:
+    """The deterministic ranked id list the case's tool returns (REQ-002)."""
+    if case.tool == TOOL_SEARCH:
+        return _search_returned(root, entries, case)
+    return _related_returned(root, case)
+
+
+# --- Per-case scoring --------------------------------------------------------
+
+
+def score_case(returned: list[str], case: QueryCase) -> CaseResult:
+    """Precision@k, Recall@k, and hard-negative violations for one case.
+
+    ``P@k = |Rel ∩ top_k| / k`` (empty slots count against precision);
+    ``R@k = |Rel ∩ top_k| / |Rel|`` (``|Rel| ≥ 1`` by construction). A violation
+    is a ``must_not_return`` id appearing in the top-``NEGATIVE_K`` window
+    (REQ-003).
+    """
+    relevant = set(case.relevant)
+    precision: dict[int, float] = {}
+    recall: dict[int, float] = {}
+    for k in K_VALUES:
+        top_k = returned[:k]
+        hits = sum(1 for rid in top_k if rid in relevant)
+        precision[k] = hits / k
+        recall[k] = hits / len(relevant)
+    negatives = set(case.must_not_return)
+    violations = sorted(rid for rid in returned[:NEGATIVE_K] if rid in negatives)
+    return CaseResult(
+        case=case, returned=returned, precision=precision, recall=recall, violations=violations
+    )
+
+
+# --- Aggregation -------------------------------------------------------------
+
+
+def _mean(values: list[float]) -> float:
+    return sum(values) / len(values) if values else 0.0
+
+
+def _overall(results: list[CaseResult]) -> dict[str, Any]:
+    overall: dict[str, Any] = {}
+    for k in K_VALUES:
+        overall[f"p_at_{k}"] = _round(_mean([r.precision[k] for r in results]))
+    for k in K_VALUES:
+        overall[f"r_at_{k}"] = _round(_mean([r.recall[k] for r in results]))
+    overall["negative_violations"] = sum(len(r.violations) for r in results)
+    return overall
+
+
+def _grouped(results: list[CaseResult], key: Any) -> dict[str, Any]:
+    """``{group -> {p_at_1, r_at_5}}`` macro-averaged within each group.
+
+    The gated breakdown surface (per-category is gated, per-tool diagnostic):
+    p_at_1 and r_at_5 mirror the overall floors the gate enforces (REQ-006).
+    """
+    groups: dict[str, list[CaseResult]] = {}
+    for result in results:
+        groups.setdefault(key(result), []).append(result)
+    out: dict[str, Any] = {}
+    for name in sorted(groups):
+        members = groups[name]
+        out[name] = {
+            "p_at_1": _round(_mean([r.precision[1] for r in members])),
+            "r_at_5": _round(_mean([r.recall[5] for r in members])),
+        }
+    return out
+
+
+# --- Hashing the inputs (diagnostic metadata, excluded from the gate) --------
+
+
+def corpus_hash(root: str) -> str:
+    """A stable ``sha256:…`` over the fixture corpus files (REQ-005).
+
+    Covers exactly the Markdown files the benchmark scores, each prefixed by its
+    repo-relative path, in the corpus walk's sorted order.
+    """
+    root_path = Path(root)
+    digest = hashlib.sha256()
+    for file_path in find_markdown_files(root):
+        rel = file_path.relative_to(root_path).as_posix()
+        digest.update(rel.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(file_path.read_bytes())
+        digest.update(b"\0")
+    return "sha256:" + digest.hexdigest()
+
+
+def query_set_hash(path: str) -> str:
+    """A stable ``sha256:…`` over the query set file bytes (REQ-005)."""
+    digest = hashlib.sha256(Path(path).read_bytes())
+    return "sha256:" + digest.hexdigest()
+
+
+# --- Top-level run -----------------------------------------------------------
+
+
+def run_eval(
+    root: str = DEFAULT_CORPUS,
+    queries_path: str = DEFAULT_QUERIES,
+    *,
+    generated_at: str | None = None,
+) -> Scorecard:
+    """Score the retrieval tools over the corpus and query set (REQ-001..REQ-005).
+
+    Pure over the scored path: ``generated_at`` (a clock) is injected only into
+    diagnostic ``metadata``, never the gated ``metrics``. Raises
+    :class:`EvalUsageError` on an unreadable corpus or a malformed query set.
+    """
+    if not Path(root).is_dir():
+        raise EvalUsageError(f"corpus not found or not a directory: {root}")
+    cases = load_query_set(queries_path)
+    entries = build_repository_index(root, recursive=True).artifacts
+
+    results = [score_case(returned_ids(root, entries, case), case) for case in cases]
+    results.sort(key=lambda r: r.case.id)
+
+    metrics: dict[str, Any] = {
+        "overall": _overall(results),
+        "by_category": _grouped(results, lambda r: r.case.category),
+        "by_tool": _grouped(results, lambda r: r.case.tool),
+    }
+    metadata: dict[str, Any] = {
+        "lore_version": __version__,
+        "corpus_hash": corpus_hash(root),
+        "query_set_hash": query_set_hash(queries_path),
+        "n_queries": len(cases),
+        "generated_at": generated_at if generated_at is not None else _now_iso(),
+    }
+    per_query = [result.to_dict() for result in results]
+    return Scorecard(metrics=metrics, metadata=metadata, per_query=per_query)
+
+
+def _now_iso() -> str:
+    """Wall-clock stamp for diagnostic metadata only (excluded from the gate)."""
+    return datetime.now(UTC).isoformat()
+
+
+# --- The gate (`rac eval --check`) -------------------------------------------
+
+RULE_NEGATIVE = "negative_violations"
+RULE_FLOOR = "floor"
+RULE_REGRESSION = "regression"
+
+
+@dataclass(frozen=True)
+class GateFailure:
+    """One fired gate rule, with the metric and the values that fired it."""
+
+    rule: str
+    metric: str
+    threshold: float
+    current: float
+
+    def render(self) -> str:
+        if self.rule == RULE_NEGATIVE:
+            return (
+                f"FAIL [negative_violations] {self.metric}: "
+                f"limit {self.threshold:.0f}, current {self.current:.0f}"
+            )
+        label = "floor" if self.rule == RULE_FLOOR else "baseline"
+        return (
+            f"FAIL [{self.rule}] {self.metric}: "
+            f"{label} {self.threshold:.6f}, current {self.current:.6f}"
+        )
+
+
+def _gated_pairs(config: dict[str, Any]) -> list[tuple[str, str, str]]:
+    """The (scope, name, metric) triples the gate enforces beyond negatives.
+
+    ``overall`` floors plus each per-category floor declared in config (REQ-006).
+    Per-tool figures are diagnostic this release and are not enumerated here.
+    """
+    pairs: list[tuple[str, str, str]] = []
+    floors = config["floors"]
+    for metric in ("p_at_1", "r_at_5"):
+        if metric in floors.get("overall", {}):
+            pairs.append(("overall", "", metric))
+    for category in sorted(floors.get("by_category", {})):
+        for metric in ("p_at_1", "r_at_5"):
+            if metric in floors["by_category"][category]:
+                pairs.append(("by_category", category, metric))
+    return pairs
+
+
+def _metric_value(metrics: dict[str, Any], scope: str, name: str, metric: str) -> float | None:
+    block = metrics.get(scope, {})
+    if scope == "overall":
+        value = block.get(metric)
+    else:
+        value = block.get(name, {}).get(metric)
+    return float(value) if value is not None else None
+
+
+def evaluate_gate(
+    current: dict[str, Any], baseline: dict[str, Any], config: dict[str, Any]
+) -> list[GateFailure]:
+    """Compare current ``metrics`` against floors and baseline (REQ-006).
+
+    Fires when any of: (a) ``negative_violations > 0``; (b) a gated metric is
+    below its floor; (c) a gated metric is below ``baseline − tolerance``.
+    Returns one :class:`GateFailure` per fired rule, in a deterministic order.
+    """
+    failures: list[GateFailure] = []
+    tolerance = float(config["tolerance"])
+    floors = config["floors"]
+
+    # (a) Hard-negative violations — always gated, floor is the configured max.
+    negatives = int(current.get("overall", {}).get("negative_violations", 0))
+    negatives_max = int(floors.get("negative_violations", 0))
+    if negatives > negatives_max:
+        failures.append(
+            GateFailure(RULE_NEGATIVE, "overall.negative_violations", negatives_max, negatives)
+        )
+
+    for scope, name, metric in _gated_pairs(config):
+        dotted = f"{scope}.{name}.{metric}" if name else f"{scope}.{metric}"
+        value = _metric_value(current, scope, name, metric)
+        if value is None:
+            # A gated metric the current run does not report (e.g. a category
+            # that vanished from the corpus) is itself a regression.
+            missing_floor = _floor(floors, scope, name, metric)
+            failures.append(
+                GateFailure(
+                    RULE_FLOOR, dotted, missing_floor if missing_floor is not None else 0.0, 0.0
+                )
+            )
+            continue
+        floor = _floor(floors, scope, name, metric)
+        if floor is not None and value < floor:
+            failures.append(GateFailure(RULE_FLOOR, dotted, floor, value))
+        base = _metric_value(baseline, scope, name, metric)
+        if base is not None and value < base - tolerance:
+            failures.append(GateFailure(RULE_REGRESSION, dotted, base, value))
+    return failures
+
+
+def _floor(floors: dict[str, Any], scope: str, name: str, metric: str) -> float | None:
+    if scope == "overall":
+        value = floors.get("overall", {}).get(metric)
+    else:
+        value = floors.get(scope, {}).get(name, {}).get(metric)
+    return float(value) if value is not None else None
+
+
+# --- Rendering ---------------------------------------------------------------
+
+
+def render_scorecard_json(scorecard: Scorecard) -> str:
+    """The full scorecard as pretty JSON, key order preserved (REQ-005)."""
+    return json.dumps(scorecard.to_dict(), indent=2, ensure_ascii=False)
+
+
+def render_metrics_json(metrics: dict[str, Any]) -> str:
+    """The gated ``metrics`` block alone — what ``--update-baseline`` writes."""
+    return json.dumps(metrics, indent=2, ensure_ascii=False)
+
+
+def render_scorecard_human(scorecard: Scorecard) -> str:
+    """A terminal-legible summary: overall, by-category, by-tool, Violations."""
+    metrics = scorecard.metrics
+    lines: list[str] = []
+
+    overall = metrics["overall"]
+    lines.append("Overall")
+    header = "  " + "".join(f"{f'P@{k}':>8}{f'R@{k}':>8}" for k in K_VALUES)
+    lines.append(header)
+    overall_row = "  " + "".join(
+        f"{overall[f'p_at_{k}']:>8.3f}{overall[f'r_at_{k}']:>8.3f}" for k in K_VALUES
+    )
+    lines.append(overall_row)
+    lines.append(f"  negative_violations: {overall['negative_violations']}")
+    lines.append("")
+
+    lines.append("By category")
+    lines.extend(_render_group(metrics["by_category"]))
+    lines.append("")
+
+    lines.append("By tool")
+    lines.extend(_render_group(metrics["by_tool"]))
+    lines.append("")
+
+    lines.append("Violations")
+    offenders = [entry for entry in scorecard.per_query if entry["violations"]]
+    if not offenders:
+        lines.append("  none")
+    else:
+        for offender in offenders:
+            lines.append(
+                f"  {offender['id']} ({offender['tool']}): returned {offender['violations']} "
+                f"in top-{NEGATIVE_K} [returned={offender['returned']}]"
+            )
+    return "\n".join(lines)
+
+
+def _render_group(group: dict[str, Any]) -> list[str]:
+    if not group:
+        return ["  (none)"]
+    width = max(len(name) for name in group)
+    lines = [f"  {'':{width}}    P@1     R@5"]
+    for name in group:
+        cell = group[name]
+        lines.append(f"  {name:{width}}  {cell['p_at_1']:>6.3f}  {cell['r_at_5']:>6.3f}")
+    return lines

--- a/src/rac/services/relationships.py
+++ b/src/rac/services/relationships.py
@@ -949,3 +949,80 @@ def relationships_from_corpus(entries: list[CorpusEntry]) -> list[Relationship]:
                     )
                 )
     return relationships
+
+
+# --- 1-hop neighborhood (get_related) ----------------------------------------
+#
+# The references an artifact declares (outgoing) and the artifacts whose
+# references resolve to it (incoming). This is the single source of truth for
+# the ``get_related`` MCP tool's view and for the grounding-eval benchmark that
+# guards it (ADR-031, ADR-067): both consume these functions, so the scored
+# surface cannot drift from the served one. Resolution stays Core-owned — an
+# incoming edge exists exactly when a reference resolved uniquely to the target.
+
+
+@dataclass(frozen=True)
+class IncomingReference:
+    """An artifact whose declared reference resolves to a target artifact.
+
+    The ``get_related`` ``incoming`` shape: the referencing artifact's identity
+    plus the snake_case relationship section the reference sits in.
+    """
+
+    id: str
+    type: str
+    title: str | None
+    path: str
+    section: str
+
+
+def outgoing_references(
+    relationships: list[Relationship], source_path: str
+) -> dict[str, list[str]]:
+    """The references ``source_path`` declares, grouped by section, as stored.
+
+    Keys are snake_case section names in the source artifact's own spec order
+    (``relationships_from_corpus`` yields references in that order, so a
+    first-seen-wins dict preserves it). References are the raw stored text — the
+    source of truth (ADR-016).
+    """
+    outgoing: dict[str, list[str]] = {}
+    for rel in relationships:
+        if rel.source_path == source_path:
+            outgoing.setdefault(rel.relationship, []).append(rel.target)
+    return outgoing
+
+
+def incoming_references(
+    relationships: list[Relationship],
+    identity_by_path: dict[str, tuple[str, str, str | None]],
+    target_path: str,
+) -> list[IncomingReference]:
+    """Artifacts whose declared references resolve uniquely to ``target_path``.
+
+    ``identity_by_path`` maps each artifact path to ``(id, type, title)`` (the
+    caller builds it from the repository index). Self-references are excluded;
+    entries are ordered by source path, then section — the deterministic order
+    the ``get_related`` design pins.
+    """
+    incoming: list[IncomingReference] = []
+    for rel in relationships:
+        if rel.resolved_path != target_path:
+            continue
+        if rel.source_path == target_path:  # self-references are not incoming edges
+            continue
+        identity = identity_by_path.get(rel.source_path)
+        if identity is None:  # pragma: no cover — every relationship source is indexed
+            continue
+        source_id, source_type, source_title = identity
+        incoming.append(
+            IncomingReference(
+                id=source_id,
+                type=source_type,
+                title=source_title,
+                path=rel.source_path,
+                section=rel.relationship,
+            )
+        )
+    incoming.sort(key=lambda e: (e.path, e.section))
+    return incoming

--- a/tests/eval/README.md
+++ b/tests/eval/README.md
@@ -1,0 +1,47 @@
+# Grounding retrieval benchmark fixture (v0.23.0, WS1)
+
+This directory is the versioned fixture the `rac eval` grounding benchmark
+scores. It is a dev/CI surface, not a RAC artifact corpus — nothing here is part
+of the product knowledge under `rac/`.
+
+## Layout
+
+- `corpus/` — a small, schema-valid fixture corpus (`rac validate` exit 0),
+  spanning all five artifact types, modelling a fictional collaborative editor
+  ("Aurora"). It includes:
+  - a **supersession chain**: `decision-token-expiry-v1` (Status: Superseded) is
+    superseded by `decision-token-refresh-v2` (Status: Accepted). The superseded
+    member is the canonical `must_not_return` hard negative — a query about the
+    current policy must surface v2, never v1.
+  - **distractors**: e.g. `decision-rate-limiting` ("token-bucket") shares the
+    word "token" with the auth decisions but must not be confused with them.
+  - an **ambiguous pair**: `design-sidebar-navigation` and
+    `design-mobile-navigation` both concern navigation; a specific query must
+    disambiguate to the right one.
+- `queries.json` — the scored query set. Each case names exactly one tool
+  (`search_artifacts` or `get_related`), a `query` (a search string, or the
+  artifact id to look up for `get_related`), a `category`, the `relevant` ids,
+  and an optional `must_not_return` set.
+- `eval-config.json` — the gate's floors and tolerance. Gated metrics:
+  `overall.p_at_1`, `overall.r_at_5`, `negative_violations`, and each query
+  category's `p_at_1` / `r_at_5`. Per-tool figures are diagnostic.
+- `baseline.json` — the committed `metrics` baseline, written by
+  `rac eval --update-baseline` (human-only; CI never rebaselines).
+
+## Running
+
+```sh
+rac eval                  # human-readable scorecard
+rac eval --json           # full scorecard JSON
+rac eval --check          # CI gate: exit 0 pass / 1 regression / 2 usage error
+rac eval --update-baseline  # human-only re-baseline
+```
+
+## Calibration
+
+The initial floors come from the first green run, on which every category scored
+1.0. Overall floors are the fixed targets (`p_at_1 ≥ 0.90`, `r_at_5 ≥ 0.95`);
+per-category floors sit a margin below their calibrated values, with the
+committed baseline minus the tolerance (`0.02`) providing the tight per-category
+regression guard. When the corpus or query set legitimately changes, re-run
+`rac eval --update-baseline` and commit the new baseline alongside the change.

--- a/tests/eval/baseline.json
+++ b/tests/eval/baseline.json
@@ -1,0 +1,47 @@
+{
+  "overall": {
+    "p_at_1": 1.0,
+    "p_at_3": 0.416667,
+    "p_at_5": 0.25,
+    "r_at_1": 0.902778,
+    "r_at_3": 1.0,
+    "r_at_5": 1.0,
+    "negative_violations": 0
+  },
+  "by_category": {
+    "constraint_check": {
+      "p_at_1": 1.0,
+      "r_at_5": 1.0
+    },
+    "decision_lookup": {
+      "p_at_1": 1.0,
+      "r_at_5": 1.0
+    },
+    "disambiguation": {
+      "p_at_1": 1.0,
+      "r_at_5": 1.0
+    },
+    "feature_lookup": {
+      "p_at_1": 1.0,
+      "r_at_5": 1.0
+    },
+    "impact_analysis": {
+      "p_at_1": 1.0,
+      "r_at_5": 1.0
+    },
+    "supersession": {
+      "p_at_1": 1.0,
+      "r_at_5": 1.0
+    }
+  },
+  "by_tool": {
+    "get_related": {
+      "p_at_1": 1.0,
+      "r_at_5": 1.0
+    },
+    "search_artifacts": {
+      "p_at_1": 1.0,
+      "r_at_5": 1.0
+    }
+  }
+}

--- a/tests/eval/corpus/decision-rate-limiting.md
+++ b/tests/eval/corpus/decision-rate-limiting.md
@@ -1,0 +1,34 @@
+---
+schema_version: 1
+id: EVAL-1DJ9CM8QEXJX
+type: decision
+tags: [gateway, abuse]
+---
+# Token-Bucket Rate Limiting
+
+## Status
+
+Accepted
+
+## Context
+
+The Aurora API gateway needs to throttle abusive clients while letting normal
+editing traffic burst briefly. A naive fixed counter per window punished honest
+bursts at window boundaries.
+
+## Decision
+
+The gateway enforces request limits with a token-bucket algorithm per client.
+Each bucket refills at a steady rate and a request spends one token; an empty
+bucket rejects the request. The bucket here is a rate-limit accounting unit and
+has nothing to do with authentication tokens.
+
+## Consequences
+
+Honest clients can burst up to the bucket size and then settle to the refill
+rate, while sustained abuse is rejected. The gateway tracks one small bucket
+per client key.
+
+## Category
+
+Technical

--- a/tests/eval/corpus/decision-realtime-sync.md
+++ b/tests/eval/corpus/decision-realtime-sync.md
@@ -1,0 +1,33 @@
+---
+schema_version: 1
+id: EVAL-STK2ZW0AWS3V
+type: decision
+tags: [sync, collaboration]
+---
+# CRDT-Based Realtime Sync
+
+## Status
+
+Accepted
+
+## Context
+
+Multiple authors edit the same Aurora document at once. We need concurrent
+edits to converge without a central lock and without losing keystrokes when
+clients reconnect after going offline.
+
+## Decision
+
+Realtime sync is built on conflict-free replicated data types (CRDTs). Each
+client applies edits locally and exchanges operations that merge
+deterministically, so every replica converges to the same document state.
+
+## Consequences
+
+Offline edits merge cleanly on reconnect and no edit is silently dropped. The
+cost is a richer document representation and the memory the CRDT metadata
+carries per document.
+
+## Category
+
+Architecture

--- a/tests/eval/corpus/decision-storage-backend.md
+++ b/tests/eval/corpus/decision-storage-backend.md
@@ -1,0 +1,32 @@
+---
+schema_version: 1
+id: EVAL-1483XGG8THGE
+type: decision
+tags: [storage, infrastructure]
+---
+# Postgres as the Primary Datastore
+
+## Status
+
+Accepted
+
+## Context
+
+Aurora needs a primary datastore for documents, accounts, and sharing metadata.
+The team weighed a managed relational database against a document store.
+
+## Decision
+
+PostgreSQL is the primary datastore. Relational integrity, transactional
+guarantees, and mature operational tooling outweigh the schema flexibility a
+document store would offer at our scale.
+
+## Consequences
+
+The team commits to relational modelling and migrations. Document bodies are
+stored as structured columns rather than opaque blobs, which keeps querying and
+backup straightforward.
+
+## Category
+
+Architecture

--- a/tests/eval/corpus/decision-token-expiry-v1.md
+++ b/tests/eval/corpus/decision-token-expiry-v1.md
@@ -1,0 +1,32 @@
+---
+schema_version: 1
+id: EVAL-KRRRS99DSV9W
+type: decision
+tags: [auth, session]
+---
+# Static Session Token Expiry
+
+## Status
+
+Superseded
+
+## Context
+
+The Aurora editor issues a session token when a user signs in. The first
+release needed a simple, predictable expiry policy that the gateway could
+enforce without coordinating state across services.
+
+## Decision
+
+Session tokens are valid for a fixed one-hour window from issue. When the
+window elapses the user is signed out and must authenticate again.
+
+## Consequences
+
+A fixed window is trivial to reason about, but it forces a hard re-login on
+every active user each hour, which the editor's long writing sessions made
+painful. This policy was replaced once refresh became available.
+
+## Category
+
+Technical

--- a/tests/eval/corpus/decision-token-refresh-v2.md
+++ b/tests/eval/corpus/decision-token-refresh-v2.md
@@ -1,0 +1,37 @@
+---
+schema_version: 1
+id: EVAL-JTDKWHNVD8GG
+type: decision
+tags: [auth, session]
+---
+# Refresh Token Rotation
+
+## Status
+
+Accepted
+
+## Context
+
+Fixed one-hour session expiry signed active writers out mid-session. We need a
+policy that keeps a writing session alive without weakening revocation.
+
+## Decision
+
+Aurora issues a short-lived access token alongside a long-lived refresh token.
+The client silently exchanges the refresh token for a new access token on a
+fixed rotation interval, and each exchange rotates the refresh token so a
+stolen token is usable only until the next rotation.
+
+## Consequences
+
+Active writers stay signed in across long sessions, and revocation still takes
+effect within one rotation interval. The client gains the responsibility of
+storing and rotating the refresh token securely.
+
+## Category
+
+Technical
+
+## Supersedes
+
+- EVAL-KRRRS99DSV9W

--- a/tests/eval/corpus/design-conflict-resolution.md
+++ b/tests/eval/corpus/design-conflict-resolution.md
@@ -1,0 +1,43 @@
+---
+schema_version: 1
+id: EVAL-M8R1BJ63YM1E
+type: design
+tags: [sync, collaboration]
+---
+# Conflict Resolution UX
+
+## Status
+
+Accepted
+
+## Context
+
+When offline edits merge on reconnect, the merged result can surprise a writer
+who did not see the other author's changes. The merge itself is automatic, but
+the writer needs to understand what happened.
+
+## User Need
+
+A writer returning online needs to see what changed while they were away and
+trust that none of their own edits were lost.
+
+## Design
+
+On reconnect, merged-in remote changes are briefly highlighted in the document
+and summarised in a dismissible banner ("3 paragraphs updated by Sam"). No
+modal blocks editing; the merge is already applied and the surface is purely
+explanatory.
+
+## Constraints
+
+The highlight must not alter document content and must fade without leaving
+formatting behind. The summary must be legible to assistive technology.
+
+## Rationale
+
+Because the underlying merge is deterministic and lossless, the UX only has to
+explain the result, not ask the writer to resolve anything by hand.
+
+## Related Decisions
+
+- EVAL-STK2ZW0AWS3V

--- a/tests/eval/corpus/design-mobile-navigation.md
+++ b/tests/eval/corpus/design-mobile-navigation.md
@@ -1,0 +1,38 @@
+---
+schema_version: 1
+id: EVAL-RADN71DPV8KA
+type: design
+tags: [navigation, mobile]
+---
+# Mobile Navigation Drawer
+
+## Status
+
+Accepted
+
+## Context
+
+On phones the editor canvas needs the full screen width, so a persistent
+side panel is not an option. Writers still need to reach folders and documents
+without leaving the document they are editing.
+
+## User Need
+
+A writer on a phone needs to reach folders and documents without permanently
+sacrificing canvas width to a navigation surface.
+
+## Design
+
+Navigation lives in a drawer that slides in from the left edge over the canvas
+and is summoned by a hamburger control or an edge swipe. The drawer dismisses
+on selection or on tapping the dimmed canvas behind it.
+
+## Constraints
+
+The drawer must be reachable one-handed and must not trap focus for assistive
+technology when open.
+
+## Rationale
+
+An overlay drawer preserves full canvas width on small screens while keeping
+navigation one gesture away.

--- a/tests/eval/corpus/design-sidebar-navigation.md
+++ b/tests/eval/corpus/design-sidebar-navigation.md
@@ -1,0 +1,38 @@
+---
+schema_version: 1
+id: EVAL-2ABF382M9AKX
+type: design
+tags: [navigation, desktop]
+---
+# Sidebar Navigation
+
+## Status
+
+Accepted
+
+## Context
+
+On the desktop web app, writers move between documents, folders, and shared
+spaces dozens of times a session. The navigation surface has to stay visible
+without crowding the editor canvas.
+
+## User Need
+
+A writer on a wide screen needs to jump between documents and folders quickly
+while keeping the document they are editing in view.
+
+## Design
+
+A persistent left sidebar lists folders and documents in a collapsible tree.
+The sidebar can be pinned open or collapsed to a thin rail; the editor canvas
+reflows to fill the freed space when it collapses.
+
+## Constraints
+
+The sidebar must not reduce the editor canvas below a readable minimum width,
+and its collapsed state must persist per user.
+
+## Rationale
+
+A pinned sidebar suits wide desktop screens where horizontal space is ample and
+fast lateral movement matters more than canvas width.

--- a/tests/eval/corpus/prompt-release-notes.md
+++ b/tests/eval/corpus/prompt-release-notes.md
@@ -1,0 +1,37 @@
+---
+schema_version: 1
+id: EVAL-44R24W9NH93C
+type: prompt
+tags: [release, docs]
+---
+# Generate Release Notes
+
+## Status
+
+Active
+
+## Objective
+
+Draft human-readable release notes for an Aurora release from the merged pull
+requests in the release, grouped so a reader can scan what changed.
+
+## Input
+
+A list of merged pull request titles and descriptions for the release, plus the
+previous and new version numbers.
+
+## Instructions
+
+Group the changes into Features, Fixes, and Internal. Write one plain-language
+bullet per change describing the user-visible effect, not the implementation.
+Omit purely mechanical changes. Lead with the most user-visible features.
+
+## Output
+
+Markdown release notes: a heading with the new version, then the three grouped
+sections, each a bulleted list. Omit a section that has no entries.
+
+## Constraints
+
+Do not invent changes that are not in the input. Keep each bullet to one
+sentence and avoid internal ticket numbers in user-facing notes.

--- a/tests/eval/corpus/requirement-offline-editing.md
+++ b/tests/eval/corpus/requirement-offline-editing.md
@@ -1,0 +1,32 @@
+---
+schema_version: 1
+id: EVAL-FCTMD6C13A4N
+type: requirement
+tags: [editor, offline]
+---
+# Offline Editing
+
+## Status
+
+Accepted
+
+## Problem
+
+Writers lose connectivity on trains and planes but expect to keep editing. When
+the network drops today the editor goes read-only, which interrupts the writing
+they came to Aurora to do.
+
+## Requirements
+
+- [REQ-001] The editor MUST let a user keep editing a already-open document while offline, queueing edits locally.
+- [REQ-002] On reconnect the editor MUST merge queued offline edits into the shared document without dropping any edit.
+- [REQ-003] The editor MUST show a clear indicator of offline state and of pending unsynced edits.
+
+## Success Metrics
+
+- Zero edits lost across a disconnect/reconnect cycle in the sync test suite.
+- Reconnect merge completes within two seconds for a typical document.
+
+## Related Decisions
+
+- EVAL-STK2ZW0AWS3V

--- a/tests/eval/corpus/requirement-session-auth.md
+++ b/tests/eval/corpus/requirement-session-auth.md
@@ -1,0 +1,32 @@
+---
+schema_version: 1
+id: EVAL-1ZM9RM9559B2
+type: requirement
+tags: [auth, session]
+---
+# Session Authentication
+
+## Status
+
+Accepted
+
+## Problem
+
+Aurora users need to stay signed in across long writing sessions without
+re-entering credentials, while the team needs to be able to revoke a
+compromised session quickly.
+
+## Requirements
+
+- [REQ-001] A signed-in session MUST persist across an extended writing session without an interactive re-login.
+- [REQ-002] The system MUST be able to revoke an active session within one rotation interval.
+- [REQ-003] Session credentials MUST be stored on the client in a way that a stolen credential is short-lived.
+
+## Success Metrics
+
+- No interactive re-login during a continuous eight-hour writing session.
+- A revoked session stops working within one rotation interval in tests.
+
+## Related Decisions
+
+- EVAL-JTDKWHNVD8GG

--- a/tests/eval/corpus/roadmap-v1-launch.md
+++ b/tests/eval/corpus/roadmap-v1-launch.md
@@ -1,0 +1,43 @@
+---
+schema_version: 1
+id: EVAL-BB7BF4CHZEVN
+type: roadmap
+tags: [release, launch]
+---
+# v1 Launch
+
+## Status
+
+Planned
+
+## Context
+
+The v1 launch bundles the capabilities that make Aurora usable for real
+collaborative writing: durable storage, realtime collaboration, resilient
+sessions, and offline editing.
+
+## Outcomes
+
+- Writers can collaborate on a shared document in realtime and never lose an edit.
+- Writers stay signed in across long sessions and can keep working offline.
+
+## Initiatives
+
+- Ship realtime collaboration on the agreed sync foundation.
+- Ship resilient sessions so writers are not signed out mid-session.
+- Ship offline editing with lossless reconnect merges.
+
+## Success Measures
+
+- A pair of writers can co-edit a document for an hour with zero lost edits.
+- A continuous eight-hour session never forces an interactive re-login.
+
+## Related Decisions
+
+- EVAL-STK2ZW0AWS3V
+- EVAL-JTDKWHNVD8GG
+
+## Related Requirements
+
+- EVAL-FCTMD6C13A4N
+- EVAL-1ZM9RM9559B2

--- a/tests/eval/eval-config.json
+++ b/tests/eval/eval-config.json
@@ -1,0 +1,19 @@
+{
+  "description": "Grounding-eval gate config (v0.23.0 WS1). The gate fails (rac eval --check, exit 1) when negative_violations exceeds its limit, a gated metric falls below its floor, or a gated metric falls below baseline minus tolerance. Gated metrics: overall.p_at_1, overall.r_at_5, negative_violations, and each query category's p_at_1 / r_at_5 (REQ-006). Per-tool figures are diagnostic. Overall floors are the fixed initial targets; per-category floors are absolute minimums calibrated from the first green run (all categories scored 1.0; floors sit a margin below, with the committed baseline minus tolerance providing the tight per-category regression guard).",
+  "tolerance": 0.02,
+  "floors": {
+    "negative_violations": 0,
+    "overall": {
+      "p_at_1": 0.9,
+      "r_at_5": 0.95
+    },
+    "by_category": {
+      "constraint_check": {"p_at_1": 0.9, "r_at_5": 0.9},
+      "decision_lookup": {"p_at_1": 0.9, "r_at_5": 0.9},
+      "disambiguation": {"p_at_1": 0.9, "r_at_5": 0.9},
+      "feature_lookup": {"p_at_1": 0.9, "r_at_5": 0.9},
+      "impact_analysis": {"p_at_1": 0.9, "r_at_5": 0.9},
+      "supersession": {"p_at_1": 0.9, "r_at_5": 0.9}
+    }
+  }
+}

--- a/tests/eval/queries.json
+++ b/tests/eval/queries.json
@@ -1,0 +1,94 @@
+{
+  "description": "Grounding retrieval benchmark query set (v0.23.0 WS1). Each case scores exactly one MCP tool (search_artifacts or get_related) against the fixture corpus under tests/eval/corpus. 'query' is the search string for search_artifacts cases, or the artifact id to look up for get_related cases.",
+  "cases": [
+    {
+      "id": "Q01",
+      "tool": "search_artifacts",
+      "category": "supersession",
+      "query": "refresh token rotation",
+      "relevant": ["EVAL-JTDKWHNVD8GG"],
+      "must_not_return": ["EVAL-KRRRS99DSV9W"]
+    },
+    {
+      "id": "Q02",
+      "tool": "search_artifacts",
+      "category": "supersession",
+      "query": "token rotation interval",
+      "relevant": ["EVAL-JTDKWHNVD8GG"],
+      "must_not_return": ["EVAL-KRRRS99DSV9W"]
+    },
+    {
+      "id": "Q03",
+      "tool": "search_artifacts",
+      "category": "constraint_check",
+      "query": "crdt realtime sync",
+      "relevant": ["EVAL-STK2ZW0AWS3V"]
+    },
+    {
+      "id": "Q04",
+      "tool": "search_artifacts",
+      "category": "constraint_check",
+      "query": "token bucket rate limiting",
+      "relevant": ["EVAL-1DJ9CM8QEXJX"],
+      "must_not_return": ["EVAL-JTDKWHNVD8GG"]
+    },
+    {
+      "id": "Q05",
+      "tool": "search_artifacts",
+      "category": "decision_lookup",
+      "query": "postgres datastore",
+      "relevant": ["EVAL-1483XGG8THGE"]
+    },
+    {
+      "id": "Q06",
+      "tool": "search_artifacts",
+      "category": "decision_lookup",
+      "query": "primary datastore",
+      "relevant": ["EVAL-1483XGG8THGE"]
+    },
+    {
+      "id": "Q07",
+      "tool": "search_artifacts",
+      "category": "feature_lookup",
+      "query": "offline editing",
+      "relevant": ["EVAL-FCTMD6C13A4N"]
+    },
+    {
+      "id": "Q08",
+      "tool": "search_artifacts",
+      "category": "feature_lookup",
+      "query": "session authentication",
+      "relevant": ["EVAL-1ZM9RM9559B2"]
+    },
+    {
+      "id": "Q09",
+      "tool": "search_artifacts",
+      "category": "disambiguation",
+      "query": "sidebar navigation",
+      "relevant": ["EVAL-2ABF382M9AKX"],
+      "must_not_return": ["EVAL-RADN71DPV8KA"]
+    },
+    {
+      "id": "Q10",
+      "tool": "search_artifacts",
+      "category": "disambiguation",
+      "query": "mobile navigation drawer",
+      "relevant": ["EVAL-RADN71DPV8KA"],
+      "must_not_return": ["EVAL-2ABF382M9AKX"]
+    },
+    {
+      "id": "Q11",
+      "tool": "get_related",
+      "category": "impact_analysis",
+      "query": "EVAL-STK2ZW0AWS3V",
+      "relevant": ["EVAL-M8R1BJ63YM1E", "EVAL-FCTMD6C13A4N", "EVAL-BB7BF4CHZEVN"]
+    },
+    {
+      "id": "Q12",
+      "tool": "get_related",
+      "category": "impact_analysis",
+      "query": "EVAL-JTDKWHNVD8GG",
+      "relevant": ["EVAL-1ZM9RM9559B2", "EVAL-BB7BF4CHZEVN"]
+    }
+  ]
+}

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -1,0 +1,302 @@
+"""Grounding-eval benchmark battery (v0.23.0, WS1).
+
+Proves the gate is real (ADR-027 per-service battery): the scored ``metrics``
+are byte-stable on an unchanged corpus, ``--check`` exits 0/1/2 correctly, and
+three regression-injection cases each fire a named rule. Tests pass explicit
+fixture paths so they never depend on the working directory.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+from rac import cli
+from rac.services import eval as ev
+
+EVAL_DIR = Path(__file__).parent / "eval"
+CORPUS = EVAL_DIR / "corpus"
+QUERIES = EVAL_DIR / "queries.json"
+BASELINE = EVAL_DIR / "baseline.json"
+CONFIG = EVAL_DIR / "eval-config.json"
+
+# Fixture ids referenced by the regression cases.
+REALTIME_SYNC = "EVAL-STK2ZW0AWS3V"
+TOKEN_REFRESH_V2 = "EVAL-JTDKWHNVD8GG"
+TOKEN_EXPIRY_V1 = "EVAL-KRRRS99DSV9W"
+REQ_OFFLINE = "EVAL-FCTMD6C13A4N"
+
+
+def _run_cli(argv: list[str], capsys) -> tuple[int, str, str]:
+    try:
+        code = cli.main(argv)
+    except SystemExit as exc:
+        code = exc.code if isinstance(exc.code, int) else 1
+    captured = capsys.readouterr()
+    return code, captured.out, captured.err
+
+
+def _check_argv(
+    *,
+    root: str | None = None,
+    queries: str | None = None,
+    baseline: str | None = None,
+    config: str | None = None,
+) -> list[str]:
+    return [
+        "eval",
+        "--check",
+        "--root",
+        root or str(CORPUS),
+        "--queries",
+        queries or str(QUERIES),
+        "--baseline",
+        baseline or str(BASELINE),
+        "--config",
+        config or str(CONFIG),
+    ]
+
+
+# --- Determinism (REQ-002, Acceptance Criteria) ------------------------------
+
+
+def test_metrics_are_byte_identical_across_runs():
+    a = ev.run_eval(str(CORPUS), str(QUERIES))
+    b = ev.run_eval(str(CORPUS), str(QUERIES))
+    assert json.dumps(a.metrics, sort_keys=True) == json.dumps(b.metrics, sort_keys=True)
+
+
+def test_generated_at_lands_only_in_metadata_never_metrics():
+    a = ev.run_eval(str(CORPUS), str(QUERIES), generated_at="2020-01-01T00:00:00+00:00")
+    b = ev.run_eval(str(CORPUS), str(QUERIES), generated_at="2099-12-31T23:59:59+00:00")
+    assert a.metrics == b.metrics
+    assert a.metadata["generated_at"] != b.metadata["generated_at"]
+
+
+# --- Scorecard shape (REQ-005) -----------------------------------------------
+
+
+def test_scorecard_has_exactly_three_top_level_objects():
+    card = ev.run_eval(str(CORPUS), str(QUERIES))
+    assert set(card.to_dict()) == {"metrics", "metadata", "per_query"}
+
+
+def test_metadata_records_versions_hashes_and_count():
+    card = ev.run_eval(str(CORPUS), str(QUERIES))
+    meta = card.metadata
+    assert meta["corpus_hash"].startswith("sha256:")
+    assert meta["query_set_hash"].startswith("sha256:")
+    assert meta["n_queries"] == len(card.per_query)
+    assert "lore_version" in meta and "generated_at" in meta
+
+
+def test_baseline_meets_initial_floors():
+    overall = ev.run_eval(str(CORPUS), str(QUERIES)).metrics["overall"]
+    assert overall["negative_violations"] == 0
+    assert overall["p_at_1"] >= 0.90
+    assert overall["r_at_5"] >= 0.95
+
+
+# --- Gate exit codes (REQ-006) -----------------------------------------------
+
+
+def test_check_passes_on_committed_baseline(capsys):
+    code, out, _ = _run_cli(_check_argv(), capsys)
+    assert code == 0
+    assert "PASS" in out
+
+
+def test_check_missing_baseline_is_usage_error(capsys):
+    code, _, err = _run_cli(_check_argv(baseline="/tmp/does-not-exist.json"), capsys)
+    assert code == 2
+    assert "baseline" in err
+
+
+def test_check_unreadable_corpus_is_usage_error(capsys):
+    code, _, err = _run_cli(_check_argv(root="/tmp/no-such-corpus-dir"), capsys)
+    assert code == 2
+    assert "corpus" in err
+
+
+def test_check_malformed_query_set_is_usage_error(tmp_path, capsys):
+    bad = tmp_path / "bad.json"
+    bad.write_text('{"cases": [{"id": "X", "tool": "search_artifacts"}]}', encoding="utf-8")
+    code, _, err = _run_cli(_check_argv(queries=str(bad)), capsys)
+    assert code == 2
+    assert "malformed query set" in err
+
+
+# --- Three regression-injection proofs (Acceptance Criteria) -----------------
+
+
+def test_injection_1_clean_fixture_passes(capsys):
+    code, out, _ = _run_cli(_check_argv(), capsys)
+    assert code == 0 and "PASS" in out
+
+
+def test_injection_2_removed_relevant_artifact_drops_recall(tmp_path, capsys):
+    corpus = tmp_path / "corpus"
+    shutil.copytree(CORPUS, corpus)
+    # requirement-offline-editing is relevant for a feature_lookup case and an
+    # impact_analysis case; removing it deterministically drops overall.r_at_5.
+    (corpus / "requirement-offline-editing.md").unlink()
+    code, out, _ = _run_cli(_check_argv(root=str(corpus)), capsys)
+    assert code == 1
+    assert "overall.r_at_5" in out
+    assert "[regression]" in out or "[floor]" in out
+
+
+def test_injection_3_forced_hard_negative_fails(tmp_path, capsys):
+    queries = json.loads(QUERIES.read_text(encoding="utf-8"))
+    # A query whose terms are in the *superseded* decision's title forces it into
+    # the top-k, so the hard-negative guard fires.
+    queries["cases"].append(
+        {
+            "id": "QFORCE",
+            "tool": "search_artifacts",
+            "category": "supersession",
+            "query": "static session token expiry",
+            "relevant": [TOKEN_REFRESH_V2],
+            "must_not_return": [TOKEN_EXPIRY_V1],
+        }
+    )
+    forced = tmp_path / "forced.json"
+    forced.write_text(json.dumps(queries), encoding="utf-8")
+    code, out, _ = _run_cli(_check_argv(queries=str(forced)), capsys)
+    assert code == 1
+    assert "[negative_violations]" in out
+    assert "negative_violations" in out
+
+
+# --- Human + JSON output (Acceptance Criteria) -------------------------------
+
+
+def test_human_summary_lists_all_sections(capsys):
+    code, out, _ = _run_cli(["eval", "--root", str(CORPUS), "--queries", str(QUERIES)], capsys)
+    assert code == 0
+    for heading in ("Overall", "By category", "By tool", "Violations"):
+        assert heading in out
+
+
+def test_json_output_is_the_scorecard_shape(capsys):
+    code, out, _ = _run_cli(
+        ["eval", "--json", "--root", str(CORPUS), "--queries", str(QUERIES)], capsys
+    )
+    assert code == 0
+    payload = json.loads(out)
+    assert set(payload) == {"metrics", "metadata", "per_query"}
+    assert payload["metrics"]["overall"]["negative_violations"] == 0
+
+
+# --- Re-baselining is human-gated; CI never rebaselines (REQ-007) ------------
+
+
+def test_update_baseline_writes_the_metrics_object(tmp_path, capsys):
+    out_baseline = tmp_path / "baseline.json"
+    code, _, _ = _run_cli(
+        [
+            "eval",
+            "--update-baseline",
+            "--root",
+            str(CORPUS),
+            "--queries",
+            str(QUERIES),
+            "--baseline",
+            str(out_baseline),
+        ],
+        capsys,
+    )
+    assert code == 0
+    written = json.loads(out_baseline.read_text(encoding="utf-8"))
+    assert written == ev.run_eval(str(CORPUS), str(QUERIES)).metrics
+
+
+def test_ci_workflows_never_rebaseline():
+    """No CI step may run ``--update-baseline`` (REQ-007). Checks executed
+    ``run:`` commands, not comment prose, so the gate job can still explain the
+    rule it enforces."""
+    import yaml
+
+    workflows = Path(__file__).parent.parent / ".github" / "workflows"
+    for wf in workflows.glob("*.yml"):
+        data = yaml.safe_load(wf.read_text(encoding="utf-8")) or {}
+        for job in (data.get("jobs") or {}).values():
+            for step in job.get("steps", []) or []:
+                assert "--update-baseline" not in (step.get("run") or ""), wf.name
+
+
+# --- Real surface, id-membership only (REQ-002, REQ-004, REQ-010) ------------
+
+
+def test_search_case_consumes_production_order_verbatim():
+    from rac.services.index import build_repository_index
+    from rac.services.resolve import search_index
+
+    entries = build_repository_index(str(CORPUS)).artifacts
+    case = ev.QueryCase(
+        id="t",
+        tool=ev.TOOL_SEARCH,
+        query="refresh token rotation",
+        category="c",
+        relevant=(TOKEN_REFRESH_V2,),
+    )
+    expected = [m.id for m in search_index(entries, "refresh token rotation").matches]
+    assert ev.returned_ids(str(CORPUS), entries, case) == expected
+
+
+def test_get_related_scores_incoming_edges():
+    entries = []  # unused for get_related
+    case = ev.QueryCase(
+        id="t",
+        tool=ev.TOOL_GET_RELATED,
+        query=REALTIME_SYNC,
+        category="impact_analysis",
+        relevant=(REQ_OFFLINE,),
+    )
+    returned = ev.returned_ids(str(CORPUS), entries, case)
+    assert REQ_OFFLINE in returned
+    # Only artifacts that reference realtime-sync — the superseded decision is not
+    # an incoming edge and must not appear.
+    assert TOKEN_EXPIRY_V1 not in returned
+
+
+def test_additive_evidence_fields_do_not_shift_membership(monkeypatch):
+    """REQ-010: scoring compares only returned-id membership, so additive WS2
+    evidence/snippet fields on retrieval output cannot move a metric."""
+    from rac.services.index import build_repository_index
+
+    entries = build_repository_index(str(CORPUS)).artifacts
+    case = ev.QueryCase(
+        id="t",
+        tool=ev.TOOL_SEARCH,
+        query="refresh token rotation",
+        category="c",
+        relevant=(TOKEN_REFRESH_V2,),
+    )
+    baseline_ids = ev.returned_ids(str(CORPUS), entries, case)
+
+    real_search_index = ev.search_index
+
+    def _with_evidence(entries_arg, query, artifact_type=None):
+        result = real_search_index(entries_arg, query, artifact_type=artifact_type)
+        for match in result.matches:
+            # Simulate an additive WS2 evidence field hanging off each result.
+            match.evidence = {"field": "title", "terms": ["refresh"], "tier": "title"}
+        return result
+
+    monkeypatch.setattr(ev, "search_index", _with_evidence)
+    assert ev.returned_ids(str(CORPUS), entries, case) == baseline_ids
+
+    # get_related scoring is structurally id-only too: incoming_references yields
+    # IncomingReference records and the eval reads only their ids.
+    related_case = ev.QueryCase(
+        id="t2",
+        tool=ev.TOOL_GET_RELATED,
+        query=REALTIME_SYNC,
+        category="impact_analysis",
+        relevant=(REQ_OFFLINE,),
+    )
+    related_ids = ev.returned_ids(str(CORPUS), entries, related_case)
+    assert all(isinstance(rid, str) for rid in related_ids)
+    assert REQ_OFFLINE in related_ids


### PR DESCRIPTION
# Summary

First workstream of the v0.23.0 "Hardening" release. Per the maintainer's
direction this branch carries the combined Tier-1 effort: **WS1 (grounding
retrieval benchmark) is landed here**, with WS2 (explainable retrieval), WS3
(`rac doctor`), WS4 (parser/traversal robustness), and WS11 (trust model) to
follow as further commits on this branch before merge.

Implements `rac/roadmaps/v0.23.x-hardening/v0.23.0-hardening.md` (WS1),
`rac/requirements/rac-grounding-eval-benchmark.md`.

WS1 adds:
- `rac eval` — a deterministic, offline grounding retrieval benchmark scoring the
  real MCP retrieval surface against a versioned fixture corpus and query set.
- `rac eval --check` — a CI gate that fails the build on a retrieval regression,
  wired into `pr-checks.yml`; `rac eval --update-baseline` for human-only
  re-baselining.
- A stable scorecard JSON contract, a committed baseline + gate config, a live
  fixture corpus spanning all five artifact types, and a regression-injection
  test battery that proves the gate fires.

# Roadmap / ADR Trace

Roadmap:
- `rac/roadmaps/v0.23.x-hardening/v0.23.0-hardening.md`

Requirement / design:
- `rac/requirements/rac-grounding-eval-benchmark.md`
- `rac/designs/grounding-eval-scorecard.md`

Relevant ADRs:
- ADR-066 (deterministic scoring — no embeddings, no LLM judge)
- ADR-002 (AI optional / determinism)
- ADR-037, ADR-038 (token-boundary search, body-text tier — the scored surface)
- ADR-007 (additive, stable JSON contracts)
- ADR-027 (per-service CI batteries)
- ADR-015 / ADR-031 / ADR-032 (Core/services own retrieval; MCP is a stateless consumer)

# Scope

## Included (WS1)
- `rac eval` argparse subcommand (`cmd_eval` + `set_defaults`), default-runs the
  in-repo fixture at `tests/eval/`; `--root/--queries/--baseline/--config`
  overrides; `--json` scorecard; `--check` gate; `--update-baseline`.
- Precision@k and Recall@k at k in {1,3,5}, macro-averaged, reported `overall`,
  `by_category`, `by_tool`, plus a summed hard-negative `negative_violations`
  count (top-5 window).
- Scorecard JSON with exactly three top-level objects — `metrics`, `metadata`,
  `per_query`. Only `metrics` is gated; `metadata` (incl. `lore_version`,
  `corpus_hash`, `query_set_hash`, `generated_at`) and `per_query` are diagnostic
  and excluded from comparison.
- Gate rules: hard-negative violation; any gated metric below its floor; any
  gated metric below baseline minus tolerance. Gated metrics are
  `overall.p_at_1`, `overall.r_at_5`, `negative_violations`, and each query
  category's `p_at_1`/`r_at_5`. Per-tool figures are diagnostic.
- Fixture corpus (`tests/eval/corpus/`, 12 artifacts, all five types,
  `rac validate` clean) with a supersession chain (superseded member = canonical
  `must_not_return`), distractors, and an ambiguous pair; committed query set,
  gate config, and calibrated baseline.
- Eval battery in `tests.yml`; `rac eval --check` gate job in `pr-checks.yml`.

## Excluded (deliberately, this release)
- No change to production retrieval ranking — the eval consumes the existing
  `(match_rank, path)` order verbatim (REQ-004).
- No graded relevance, micro-averaging, or per-tool gating (per-tool stays
  diagnostic; per-category is gated per REQ-006).
- No AI / embeddings / LLM judge / network / clock in the scored path (ADR-066).
- No dependence on the WS8 content-hash short-circuit — `rac eval` is correct and
  deterministic without it (REQ-009); WS8 is a cuttable Tier-2 optimization.
- `rac doctor` corpus-health assertion is deferred until WS3 lands; the fixture
  currently passes `rac validate` (REQ-008 fallback).

# Product / Architecture Decisions

- **Guards the real surface, never a parallel scorer (REQ-002).** Rather than let
  `rac.services` import the MCP server (which the `test_mcp_isolation` boundary
  forbids), the `get_related` 1-hop neighborhood (`outgoing_references`,
  `incoming_references`) was extracted into `rac.services.relationships` as a
  single source of truth that **both** the MCP `get_related` tool and the eval
  consume. The server refactor is behavior-preserving — `get_related` wire output
  is byte-identical.
- **`get_related` cases score the `incoming` (impact-analysis) direction** — "what
  references this artifact" — read in the tool's deterministic `(path, section)`
  order. `search_artifacts` cases score `search_index` order verbatim.
- **`metrics` is byte-stable**: metric floats are rounded to 6 decimals, and the
  clock (`generated_at`) and version (`lore_version`) live only in `metadata`, so
  a clock or hash can never fail the build.
- **Membership-only comparison (REQ-010)**: the gate compares returned-id
  membership in top-k, so additive WS2 `evidence`/snippet fields cannot shift a
  metric.
- **Config split**: `eval-config.json` holds tolerance + floors (incl.
  per-category); `baseline.json` holds only the `metrics` object so
  `--update-baseline` overwrites cleanly. CI never rebaselines (REQ-007,
  enforced by a battery test that scans workflow `run:` steps).
- **"Ambiguous pair" interpreted as topical** (two navigation designs a query
  must disambiguate), keeping the fixture relationship-clean rather than
  introducing identity ambiguity.

# User-Facing Contract

## CLI
```
rac eval                       # human scorecard tables
rac eval --json                # full scorecard JSON
rac eval --check               # CI gate
rac eval --update-baseline     # human-only re-baseline
rac eval [--root DIR] [--queries PATH] [--baseline PATH] [--config PATH]
```

## Human Output
An `Overall` table (P@k/R@k and `negative_violations`), then `By category` and
`By tool` tables, then an explicit `Violations` section listing every violating
case with its returned ids. `--check` prints `rac eval: gate PASS`, or one
`FAIL [rule] metric: ...` line per fired rule.

## JSON Output
`--json` prints the scorecard exactly: `{ "metrics": {...}, "metadata": {...},
"per_query": [...] }`. `metrics.overall` carries `p_at_{1,3,5}`, `r_at_{1,3,5}`,
`negative_violations`; `by_category`/`by_tool` carry `p_at_1`/`r_at_5`.

## Exit Codes
- `0`: report produced, or `--check` passed, or baseline updated.
- `1`: `--check` gate failed (a rule fired).
- `2`: usage/IO error (missing baseline, unreadable corpus, malformed query set
  or config).

# Verification

## Ran
- `rac eval`, `rac eval --json`, `rac eval --check` (exit 0 on the committed
  baseline), `rac eval --update-baseline`.
- `python -m pytest` — full suite, **1463 passed**.
- `python -m pytest tests/test_eval.py` — 18 eval tests.
- `python -m ruff check src/ tests/`, `ruff format --check`, `python -m mypy src/`.
- Corpus gates: `rac validate rac/` (0), `rac relationships rac/ --validate`
  (0 issues), `rac review rac/` (exit 0, health 92), `rac watchkeeper rac --base
  origin/main` (0 regressions).

## Covered
- Determinism: `metrics` byte-identical across two runs on an unchanged corpus;
  `generated_at` differs across runs but `metrics` does not.
- Gate exit codes: 0 on baseline; 2 on missing baseline / unreadable corpus /
  malformed query set.
- Three regression-injection proofs, each asserting exit code and the named fired
  rule: (1) clean fixture passes; (2) a deterministically removed relevant
  artifact drops `overall.r_at_5` -> exit 1; (3) a query forced to surface a
  `must_not_return` id -> `negative_violations` -> exit 1.
- Membership-insensitivity to additive evidence fields (REQ-010); search order
  consumed verbatim; superseded member never an incoming edge.

# Review Path

1. `src/rac/services/eval.py` — scorer, scorecard, gate.
2. `src/rac/services/relationships.py` + `src/rac/mcp/server.py` — the shared
   neighborhood refactor (behavior-preserving).
3. `src/rac/cli.py` — `cmd_eval` and the subparser.
4. `tests/eval/` (corpus, `queries.json`, `eval-config.json`, `baseline.json`)
   and `tests/test_eval.py`.
5. `.github/workflows/tests.yml`, `.github/workflows/pr-checks.yml` — CI wiring.

# Notes For Reviewer

- The committed per-category floors sit a margin below the calibrated 1.0; the
  tight per-category guard is `baseline − tolerance`. Re-run
  `rac eval --update-baseline` and commit the new baseline whenever the corpus or
  query set legitimately changes.
- The fixture corpus models a fictional editor ("Aurora"); see
  `tests/eval/README.md` for the supersession chain, distractors, and ambiguous
  pair.
- WS2–WS11 will land on this branch before merge.

# Implementation Process

Implemented with AI assistance under the v0.23.0 roadmap contract; final scope,
review, and acceptance decisions are the maintainer's.