### PR TITLE
feat(find): v0.23.0 WS2 — explainable retrieval (evidence + rac find --explain)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -96,7 +96,7 @@ jobs:
           - name: relationships
             paths: "tests/test_relationships.py tests/test_relationships_cmd.py tests/test_relationship_validation.py tests/test_relationship_graph.py tests/test_lifecycle_status.py tests/test_rename.py"
           - name: resolve
-            paths: "tests/test_resolve.py tests/test_find_decisions.py"
+            paths: "tests/test_resolve.py tests/test_find_decisions.py tests/test_explain.py"
           - name: eval
             paths: "tests/test_eval.py"
           - name: review

--- a/rac/requirements/rac-explainable-retrieval.md
+++ b/rac/requirements/rac-explainable-retrieval.md
@@ -8,7 +8,7 @@ tags: [user-facing, retrieval, explainability, mcp]
 
 ## Status
 
-Proposed
+Accepted
 
 Classification: `[user-facing]` — the user sees *why* the agent grounded. Scoped
 to the v0.23.0 hardening release (WS2).

--- a/rac/roadmaps/v0.23.x-hardening/v0.23.0-hardening.md
+++ b/rac/roadmaps/v0.23.x-hardening/v0.23.0-hardening.md
@@ -110,7 +110,7 @@ Cross-session progress tracker. Status: `planned` → `in-progress` → `done` /
 Tier 1:
 
 - [x] WS1 grounding-eval-benchmark — `rac eval` + CI gate — `done`
-- [ ] WS2 explainable-retrieval — `evidence` + `--explain` — `planned`
+- [x] WS2 explainable-retrieval — `evidence` + `--explain` — `done`
 - [ ] WS3 doctor-diagnostic-validator — `rac doctor` — `planned`
 - [ ] WS4 parser-traversal-robustness — caps + fuzz + bounded output — `planned`
 - [ ] WS11 artifact-trust-model — `SECURITY.md` + injection flag + review signal — `planned`

--- a/src/rac/cli.py
+++ b/src/rac/cli.py
@@ -29,7 +29,7 @@ Commands:
     rac init [directory] [--key KEY] [--json]
     rac quickstart [directory] [--key KEY] [--type TYPE] [--json]
     rac resolve <ID> [directory] [--json]
-    rac find <query> [directory] [--type TYPE] [--json]
+    rac find <query> [directory] [--type TYPE] [--json] [--explain]
     rac eval [--check | --update-baseline] [--json]
              [--root DIR] [--queries PATH] [--baseline PATH] [--config PATH]
     rac migrate metadata <directory> [--dry-run] [--json]
@@ -841,9 +841,9 @@ def cmd_find(args: argparse.Namespace) -> int:
             recursive=not args.top_level,
         )
     if args.json:
-        print(outputs.render_find_json(result))
+        print(outputs.render_find_json(result, explain=args.explain))
     else:
-        print(outputs.render_find_human(result))
+        print(outputs.render_find_human(result, explain=args.explain))
     # An empty result is a valid outcome, not an error (a query always succeeds).
     return EXIT_OK
 
@@ -1763,6 +1763,14 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p_find.add_argument(
         "--json", action="store_true", help="Emit JSON instead of human-readable text."
+    )
+    p_find.add_argument(
+        "--explain",
+        action="store_true",
+        help=(
+            "Show why each match was retrieved: the matched field, terms, and "
+            "tier (additive `evidence`, ADR-037/ADR-038)."
+        ),
     )
     p_find.add_argument(
         "--top-level",

--- a/src/rac/mcp/server.py
+++ b/src/rac/mcp/server.py
@@ -207,6 +207,15 @@ def _get_related(root: str, artifact_id: str, budget: int) -> str:
             "title": ref.title,
             "path": ref.path,
             "section": ref.section,
+            # Edge evidence (WS2, additive): the relationship edge that surfaced
+            # this artifact, named rather than recomputed (REQ-002). A relationship
+            # is not a text match, so it carries direction/relationship/target,
+            # not field/terms/tier.
+            "evidence": {
+                "direction": "incoming",
+                "relationship": ref.section,
+                "target": ref.target,
+            },
         }
         for ref in incoming_references(relationships, identity_by_path, artifact.path)
     ]

--- a/src/rac/output/human.py
+++ b/src/rac/output/human.py
@@ -996,12 +996,19 @@ def render_resolve_human(result: ResolutionResult) -> str:
     )
 
 
-def render_find_human(result: SearchResult) -> str:
-    """Human `rac find` output: aligned match rows, or a valid empty result."""
+def render_find_human(result: SearchResult, *, explain: bool = False) -> str:
+    """Human `rac find` output: aligned match rows, or a valid empty result.
+
+    ``explain`` (WS2) appends one indented attribution line per match —
+    ``field=<tier> terms=<t1,t2> [section: snippet]`` — under the existing row,
+    read off the matcher's evidence (ADR-037). Without it the output is
+    unchanged (REQ-004).
+    """
     if not result.matches:
         return f"No artifacts match {result.query!r}."
     id_w = max(len(m.id) for m in result.matches)
     type_w = max(len(m.type) for m in result.matches)
+    indent = f"{' ' * id_w}  {' ' * type_w}  "
     lines: list[str] = []
     for m in result.matches:
         lines.append(f"{m.id:<{id_w}}  {m.type:<{type_w}}  {m.title or '—'}")
@@ -1010,7 +1017,13 @@ def render_find_human(result: SearchResult) -> str:
         # the file (ADR-038). Metadata matches have no snippet and stay one line.
         if m.snippet is not None:
             section = f"{m.section}: " if m.section else ""
-            lines.append(f"{' ' * id_w}  {' ' * type_w}  ↳ {section}{m.snippet}")
+            lines.append(f"{indent}↳ {section}{m.snippet}")
+        if explain and m.evidence is not None:
+            attribution = f"field={m.evidence['field']} terms={','.join(m.evidence['terms'])}"
+            if m.snippet is not None:
+                where = f"{m.section}: " if m.section else ""
+                attribution += f" [{where}{m.snippet}]"
+            lines.append(f"{indent}• {attribution}")
     lines.append("")
     lines.append(f"{result.match_count} match(es) for {result.query!r}.")
     return "\n".join(lines)

--- a/src/rac/output/json.py
+++ b/src/rac/output/json.py
@@ -354,9 +354,15 @@ def render_resolve_json(result: ResolutionResult) -> str:
     return json.dumps(result.to_dict(), indent=2)
 
 
-def render_find_json(result: SearchResult) -> str:
-    """JSON `rac find` output (stable contract, ADR-007)."""
-    return json.dumps(result.to_dict(), indent=2)
+def render_find_json(result: SearchResult, *, explain: bool = False) -> str:
+    """JSON `rac find` output (stable contract, ADR-007).
+
+    ``explain`` adds the additive per-match ``evidence`` object (WS2). It is
+    off by default so the standard ``rac find --json`` shape stays byte-stable;
+    ``rac find --explain --json`` emits the same ``evidence`` the MCP
+    ``search_artifacts`` tool emits (one source of truth, REQ-004).
+    """
+    return json.dumps(result.to_dict(include_evidence=explain), indent=2)
 
 
 # --- migrate (v0.7.13) ----------------------------------------------------------

--- a/src/rac/services/relationships.py
+++ b/src/rac/services/relationships.py
@@ -965,8 +965,9 @@ def relationships_from_corpus(entries: list[CorpusEntry]) -> list[Relationship]:
 class IncomingReference:
     """An artifact whose declared reference resolves to a target artifact.
 
-    The ``get_related`` ``incoming`` shape: the referencing artifact's identity
-    plus the snake_case relationship section the reference sits in.
+    The ``get_related`` ``incoming`` shape: the referencing artifact's identity,
+    the snake_case relationship section the reference sits in, and ``target`` —
+    the reference text as stored (WS2 evidence: the edge that surfaced it).
     """
 
     id: str
@@ -974,6 +975,7 @@ class IncomingReference:
     title: str | None
     path: str
     section: str
+    target: str
 
 
 def outgoing_references(
@@ -1022,6 +1024,7 @@ def incoming_references(
                 title=source_title,
                 path=rel.source_path,
                 section=rel.relationship,
+                target=rel.target,
             )
         )
     incoming.sort(key=lambda e: (e.path, e.section))

--- a/src/rac/services/resolve.py
+++ b/src/rac/services/resolve.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 import re
 from collections.abc import Sequence
 from dataclasses import dataclass, field
-from typing import Protocol
+from typing import Any, Protocol
 
 from rac.core.corpus import walk_corpus
 from rac.core.models import SearchSection
@@ -65,6 +65,16 @@ _RANK_TITLE = 1
 _RANK_PATH = 2
 _RANK_HEADING = 3
 _RANK_BODY = 4
+
+# Tier number -> field name, the projection ADR-037's ladder exposes as match
+# evidence (WS2 explainable retrieval): the winning rank named, no new compute.
+_RANK_NAMES: dict[int, str] = {
+    _RANK_ID: "id",
+    _RANK_TITLE: "title",
+    _RANK_PATH: "path",
+    _RANK_HEADING: "heading",
+    _RANK_BODY: "body",
+}
 
 # A token is a maximal run that is neither a non-alphanumeric boundary nor a
 # camelCase transition. We split on both: ``_TOKEN_SPLIT`` breaks on runs of
@@ -113,9 +123,15 @@ class ResolvedArtifact:
     path: str
     section: str | None = None
     snippet: str | None = None
+    # Match evidence (v0.23.0, WS2, additive): the winning field/tier and matched
+    # terms for a *search* hit — ``{field, terms, tier}`` (ADR-037/ADR-038). None
+    # for resolution and absent from ``to_dict`` then, so the exact-lookup shape
+    # is unchanged. Always set for a search match; the gate it answers to is
+    # ``include_evidence`` so the CLI's default ``rac find`` JSON stays byte-stable.
+    evidence: dict | None = None
 
-    def to_dict(self) -> dict:
-        payload = {
+    def to_dict(self, *, include_evidence: bool = True) -> dict:
+        payload: dict[str, Any] = {
             "id": self.id,
             "type": self.type,
             "title": self.title,
@@ -125,6 +141,8 @@ class ResolvedArtifact:
             payload["section"] = self.section
         if self.snippet is not None:
             payload["snippet"] = self.snippet
+        if include_evidence and self.evidence is not None:
+            payload["evidence"] = self.evidence
         return payload
 
     @classmethod
@@ -134,6 +152,7 @@ class ResolvedArtifact:
         *,
         section: str | None = None,
         snippet: str | None = None,
+        evidence: dict | None = None,
     ) -> ResolvedArtifact:
         return cls(
             id=entry.id,
@@ -142,6 +161,7 @@ class ResolvedArtifact:
             path=entry.path,
             section=section,
             snippet=snippet,
+            evidence=evidence,
         )
 
 
@@ -180,13 +200,13 @@ class SearchResult:
     def match_count(self) -> int:
         return len(self.matches)
 
-    def to_dict(self) -> dict:
+    def to_dict(self, *, include_evidence: bool = True) -> dict:
         return {
             "schema_version": "1",
             "query": self.query,
             "type": self.artifact_type,
             "match_count": self.match_count,
-            "matches": [m.to_dict() for m in self.matches],
+            "matches": [m.to_dict(include_evidence=include_evidence) for m in self.matches],
         }
 
 
@@ -230,11 +250,26 @@ def resolve_in_index(entries: Sequence[SearchableArtifact], artifact_id: str) ->
 
 @dataclass
 class _Match:
-    """A search hit: the winning tier plus snippet text for heading/body tiers."""
+    """A search hit: the winning tier, snippet for heading/body, matched terms.
+
+    ``terms`` is the matched-terms set the matcher already computes (WS2), kept
+    in query order and surfaced as evidence rather than recomputed (ADR-037).
+    """
 
     rank: int
     section: str | None = None
     snippet: str | None = None
+    terms: list[str] = field(default_factory=list)
+
+
+def _evidence(match: _Match) -> dict:
+    """The additive match ``evidence`` object for a search hit (WS2, ADR-037).
+
+    ``{field, terms, tier}``: the winning field name, the matched query terms in
+    query order, and the numeric tier — read off the matcher's existing rank and
+    matched-terms set, never a second heuristic or a relevance score (ADR-034).
+    """
+    return {"field": _RANK_NAMES[match.rank], "terms": list(match.terms), "tier": match.rank}
 
 
 def _id_tokens(entry: SearchableArtifact) -> list[str]:
@@ -304,11 +339,17 @@ def _match_entry(entry: SearchableArtifact, terms: Sequence[str]) -> _Match | No
     if best_rank is None:
         return None
 
+    # Matched terms in query order (deduped) — the evidence the matcher already
+    # has (WS2). AND semantics make this every distinct query term.
+    ordered_terms = [term for term in dict.fromkeys(terms) if term in matched_terms]
+
     if best_rank == _RANK_HEADING and heading_hit is not None:
-        return _Match(rank=best_rank, section=heading_hit[0], snippet=heading_hit[1])
+        return _Match(
+            rank=best_rank, section=heading_hit[0], snippet=heading_hit[1], terms=ordered_terms
+        )
     if best_rank == _RANK_BODY and body_hit is not None:
-        return _Match(rank=best_rank, section=body_hit[0], snippet=body_hit[1])
-    return _Match(rank=best_rank)
+        return _Match(rank=best_rank, section=body_hit[0], snippet=body_hit[1], terms=ordered_terms)
+    return _Match(rank=best_rank, terms=ordered_terms)
 
 
 def find_artifacts(
@@ -399,7 +440,9 @@ def search_index(
         query=query,
         artifact_type=artifact_type,
         matches=[
-            ResolvedArtifact.from_entry(e, section=m.section, snippet=m.snippet)
+            ResolvedArtifact.from_entry(
+                e, section=m.section, snippet=m.snippet, evidence=_evidence(m)
+            )
             for _, _, e, m in ranked
         ],
     )

--- a/tests/test_explain.py
+++ b/tests/test_explain.py
@@ -1,0 +1,224 @@
+"""Explainable retrieval battery (v0.23.0, WS2).
+
+Pins the additive ``evidence`` object on search results: the winning field,
+tier, and matched terms read off the matcher (ADR-037/ADR-038), never a second
+heuristic. A controlled corpus isolates each tier (id / title / path / heading /
+body) so the reported field is asserted against the matcher's real rank. Also
+pins the `rac find --explain` faces and the one-source-of-truth equality between
+the MCP search payload and `rac find --explain --json`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+from rac import cli
+from rac.mcp.server import build_server
+from rac.output import json as json_output
+from rac.services.index import build_repository_index
+from rac.services.resolve import find_artifacts, search_index
+
+# One decision authored so each query term is unique to one match tier. The
+# filename stem ("aaa") is an id alias, so no content word may collide with it.
+ARTIFACT = """\
+---
+schema_version: 1
+id: RAC-AAAAAAAAAAAA
+type: decision
+---
+# Photosynthesis Charter
+
+## Status
+
+Accepted
+
+## Context
+
+The mitochondria powerhouse keeps the lights on.
+
+## Decision
+
+Adopt the charter.
+
+## Consequences
+
+Workable.
+
+## Eviction Heuristics
+
+Spell out the rules.
+"""
+
+
+def _corpus(tmp_path: Path) -> Path:
+    # The parent directory name ("catalog") is a path-only token.
+    root = tmp_path / "catalog"
+    root.mkdir()
+    (root / "aaa.md").write_text(ARTIFACT, encoding="utf-8")
+    return root
+
+
+def _evidence_for(root: Path, query: str) -> dict:
+    result = find_artifacts(str(root), query)
+    assert result.match_count == 1, f"{query!r} -> {result.match_count} matches"
+    return result.matches[0].evidence
+
+
+# --- one case per tier (Acceptance: id/title/path/heading/body) --------------
+
+
+def test_title_tier_evidence(tmp_path):
+    assert _evidence_for(_corpus(tmp_path), "photosynthesis") == {
+        "field": "title",
+        "terms": ["photosynthesis"],
+        "tier": 1,
+    }
+
+
+def test_path_tier_evidence(tmp_path):
+    # "catalog" is only in the directory path — not the id, title, headings, or body.
+    assert _evidence_for(_corpus(tmp_path), "catalog") == {
+        "field": "path",
+        "terms": ["catalog"],
+        "tier": 2,
+    }
+
+
+def test_heading_tier_evidence(tmp_path):
+    # "eviction" appears only in the "Eviction Heuristics" section heading.
+    ev = _evidence_for(_corpus(tmp_path), "eviction")
+    assert ev["field"] == "heading" and ev["tier"] == 3
+    assert ev["terms"] == ["eviction"]
+
+
+def test_body_tier_evidence(tmp_path):
+    # "mitochondria" appears only in the Context body line.
+    ev = _evidence_for(_corpus(tmp_path), "mitochondria")
+    assert ev["field"] == "body" and ev["tier"] == 4
+    assert ev["terms"] == ["mitochondria"]
+
+
+def test_id_tier_evidence(tmp_path):
+    ev = _evidence_for(_corpus(tmp_path), "RAC-AAAAAAAAAAAA")
+    assert ev["field"] == "id" and ev["tier"] == 0
+    assert ev["terms"] == ["rac", "aaaaaaaaaaaa"]
+
+
+def test_terms_follow_query_order(tmp_path):
+    # Two terms, both in the title; evidence lists them in query order.
+    ev = _evidence_for(_corpus(tmp_path), "charter photosynthesis")
+    assert ev["terms"] == ["charter", "photosynthesis"]
+
+
+# --- evidence is always present and never null on a search match -------------
+
+
+def test_every_search_match_carries_non_empty_evidence(tmp_path):
+    root = _corpus(tmp_path)
+    for query in ("photosynthesis", "catalog", "eviction", "mitochondria"):
+        for match in find_artifacts(str(root), query).matches:
+            assert match.evidence is not None
+            assert match.evidence["terms"]
+            assert match.evidence["field"] in {"id", "title", "path", "heading", "body"}
+
+
+# --- additive + backward compatible (REQ-003) --------------------------------
+
+
+def test_evidence_is_purely_additive_to_the_metadata_shape(tmp_path):
+    match = find_artifacts(str(_corpus(tmp_path)), "photosynthesis").matches[0]
+    with_ev = match.to_dict(include_evidence=True)
+    without_ev = match.to_dict(include_evidence=False)
+    # The default JSON shape (no evidence) is the pre-WS2 shape; evidence is the
+    # only added key, and it sits last.
+    assert list(with_ev) == [*without_ev, "evidence"]
+    assert {k: with_ev[k] for k in without_ev} == without_ev
+
+
+def test_default_find_json_is_evidence_free_but_explain_adds_it(tmp_path):
+    result = find_artifacts(str(_corpus(tmp_path)), "photosynthesis")
+    plain = json.loads(json_output.render_find_json(result))
+    explained = json.loads(json_output.render_find_json(result, explain=True))
+    assert "evidence" not in plain["matches"][0]
+    assert "evidence" in explained["matches"][0]
+
+
+# --- determinism (REQ-007) ---------------------------------------------------
+
+
+def test_evidence_is_byte_stable_across_runs(tmp_path):
+    root = _corpus(tmp_path)
+    entries = build_repository_index(str(root)).artifacts
+    a = json.dumps(search_index(entries, "photosynthesis").to_dict(), sort_keys=True)
+    b = json.dumps(search_index(entries, "photosynthesis").to_dict(), sort_keys=True)
+    assert a == b
+
+
+# --- one source of truth: MCP payload == rac find --explain --json (REQ-004) -
+
+
+def test_mcp_search_payload_equals_find_explain_json(tmp_path):
+    root = str(_corpus(tmp_path))
+    server = build_server(root)
+    contents, _ = asyncio.run(server.call_tool("search_artifacts", {"query": "photosynthesis"}))
+    mcp_payload = json.loads(contents[0].text)
+    cli_payload = json.loads(
+        json_output.render_find_json(find_artifacts(root, "photosynthesis"), explain=True)
+    )
+    assert mcp_payload == cli_payload
+    assert mcp_payload["matches"][0]["evidence"]["field"] == "title"
+
+
+# --- CLI --explain faces (REQ-004, REQ-006) ----------------------------------
+
+
+def _run(argv: list[str], capsys) -> tuple[int, str]:
+    try:
+        code = cli.main(argv)
+    except SystemExit as exc:
+        code = exc.code if isinstance(exc.code, int) else 1
+    return code, capsys.readouterr().out
+
+
+def test_find_explain_human_appends_attribution(tmp_path, capsys):
+    root = str(_corpus(tmp_path))
+    code, out = _run(["find", "photosynthesis", root, "--explain"], capsys)
+    assert code == 0
+    assert "field=title" in out and "terms=photosynthesis" in out
+
+
+def test_find_without_explain_is_unchanged(tmp_path, capsys):
+    root = str(_corpus(tmp_path))
+    _, plain = _run(["find", "photosynthesis", root], capsys)
+    assert "field=" not in plain
+
+
+def test_explain_composes_with_type_and_decisions(tmp_path, capsys):
+    root = str(_corpus(tmp_path))
+    code_t, out_t = _run(
+        ["find", "photosynthesis", root, "--type", "decision", "--explain"], capsys
+    )
+    assert code_t == 0 and "field=title" in out_t
+    code_d, out_d = _run(["find", "photosynthesis", root, "--decisions", "--explain"], capsys)
+    assert code_d == 0 and "field=title" in out_d
+
+
+def test_explain_empty_result_still_exits_zero(tmp_path, capsys):
+    root = str(_corpus(tmp_path))
+    code, out = _run(["find", "no-such-token-xyz", root, "--explain"], capsys)
+    assert code == 0
+    assert "No artifacts match" in out
+
+
+def test_explain_json_matches_mcp_evidence_shape(tmp_path, capsys):
+    root = str(_corpus(tmp_path))
+    code, out = _run(["find", "photosynthesis", root, "--explain", "--json"], capsys)
+    assert code == 0
+    payload = json.loads(out)
+    assert payload["matches"][0]["evidence"] == {
+        "field": "title",
+        "terms": ["photosynthesis"],
+        "tier": 1,
+    }

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -106,7 +106,9 @@ def test_search_artifacts_shape_and_order():
     assert payload["type"] is None
     assert payload["match_count"] == 3
     for match in payload["matches"]:
-        assert list(match) == ["id", "type", "title", "path"]
+        # WS2: search results carry an additive `evidence` object (always present).
+        assert list(match) == ["id", "type", "title", "path", "evidence"]
+        assert set(match["evidence"]) == {"field", "terms", "tier"}
     assert "truncated" not in payload
 
 
@@ -118,7 +120,11 @@ def test_search_artifacts_type_filter():
 
 def test_search_artifacts_matches_cli_find_json():
     payload = call(CORPUS, "search_artifacts", {"query": "messaging"})
-    cli = json.loads(json_output.render_find_json(find_artifacts(CORPUS, "messaging")))
+    # MCP search always carries evidence; the equal CLI face is `--explain --json`
+    # (REQ-004, one source of truth).
+    cli = json.loads(
+        json_output.render_find_json(find_artifacts(CORPUS, "messaging"), explain=True)
+    )
     assert payload == cli
 
 
@@ -139,7 +145,7 @@ def test_search_artifacts_body_match_carries_snippet():
     assert match["id"] == REQ
     assert match["section"] == "Problem"
     assert match["snippet"] == "Services are tightly coupled."
-    cli = json.loads(json_output.render_find_json(find_artifacts(CORPUS, "tightly")))
+    cli = json.loads(json_output.render_find_json(find_artifacts(CORPUS, "tightly"), explain=True))
     assert payload == cli
 
 
@@ -148,7 +154,13 @@ def test_search_artifacts_metadata_match_omits_snippet_fields():
     # (ADR-007): no section/snippet keys appear.
     payload = call(CORPUS, "search_artifacts", {"query": "decoupled", "type": "requirement"})
     assert [m["id"] for m in payload["matches"]] == [REQ]
-    assert list(payload["matches"][0]) == ["id", "type", "title", "path"]
+    # No section/snippet on a metadata match; `evidence` is still additive.
+    assert list(payload["matches"][0]) == ["id", "type", "title", "path", "evidence"]
+    assert payload["matches"][0]["evidence"] == {
+        "field": "title",
+        "terms": ["decoupled"],
+        "tier": 1,
+    }
 
 
 def test_search_snippet_match_truncates_as_whole_item():
@@ -164,8 +176,8 @@ def test_search_snippet_match_truncates_as_whole_item():
     # Every kept entry is structurally complete: either a metadata shape or a
     # metadata-plus-snippet shape, never a fragment.
     for m in payload["matches"]:
-        assert {"id", "type", "title", "path"} <= set(m)
-        assert set(m) <= {"id", "type", "title", "path", "section", "snippet"}
+        assert {"id", "type", "title", "path", "evidence"} <= set(m)
+        assert set(m) <= {"id", "type", "title", "path", "section", "snippet", "evidence"}
         if "snippet" in m or "section" in m:
             assert "section" in m and "snippet" in m
 
@@ -288,6 +300,7 @@ def test_get_related_outgoing_and_incoming_shape():
     # outgoing: the artifact's own sections, snake_case, references as stored.
     assert payload["outgoing"] == {"related_requirements": [REQ]}
     # incoming: artifacts whose references resolve here, ordered by path/section.
+    edge = {"direction": "incoming", "relationship": "related_decisions", "target": DEC}
     assert payload["incoming"] == [
         {
             "id": REQ,
@@ -295,6 +308,7 @@ def test_get_related_outgoing_and_incoming_shape():
             "title": "Decoupled Messaging",
             "path": fixture_path("mcp", "corpus", "requirement.md"),
             "section": "related_decisions",
+            "evidence": edge,
         },
         {
             "id": RDM,
@@ -302,6 +316,7 @@ def test_get_related_outgoing_and_incoming_shape():
             "title": "Messaging Roadmap",
             "path": fixture_path("mcp", "corpus", "roadmap.md"),
             "section": "related_decisions",
+            "evidence": edge,
         },
     ]
 
@@ -387,7 +402,7 @@ def test_search_truncates_whole_matches_with_marker():
     assert payload["omitted"] == 3 - len(payload["matches"])
     # Every kept match is a complete entry (never mid-element).
     for match in payload["matches"]:
-        assert set(match) == {"id", "type", "title", "path"}
+        assert set(match) == {"id", "type", "title", "path", "evidence"}
     assert len(serialize(payload, budget)) <= budget or payload["matches"] == []
 
 
@@ -398,7 +413,7 @@ def test_related_truncates_whole_incoming_entries():
     assert payload["hint"] == HINT_RELATED
     assert payload["omitted"] == 2 - len(payload["incoming"])
     for entry in payload["incoming"]:
-        assert set(entry) == {"id", "type", "title", "path", "section"}
+        assert set(entry) == {"id", "type", "title", "path", "section", "evidence"}
 
 
 def test_artifact_truncates_content_tail():

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -296,10 +296,13 @@ def test_body_only_match_carries_snippet(tmp_path):
 
 
 def test_metadata_match_has_no_snippet_fields(repo):
-    # An id/title/path match's dict is byte-identical to the pre-v0.10.3 shape.
+    # An id/title/path match carries no section/snippet. The pre-v0.10.3 shape is
+    # recovered by excluding the additive WS2 evidence (REQ-003).
     match = find_artifacts(str(repo), CANONICAL_ID).matches[0]
     assert match.section is None and match.snippet is None
-    assert set(match.to_dict()) == {"id", "type", "title", "path"}
+    assert set(match.to_dict(include_evidence=False)) == {"id", "type", "title", "path"}
+    # Evidence is the only additive key on the search shape.
+    assert set(match.to_dict()) == {"id", "type", "title", "path", "evidence"}
 
 
 def test_body_snippet_is_first_matching_line_in_document_order(tmp_path):


### PR DESCRIPTION
# Summary

Second Tier-1 workstream of the v0.23.0 "Hardening" release, on its own PR now
that WS1 (#153) is merged. Makes Lore's retrieval *explainable*: a search result
states why it was retrieved.

Implements `rac/roadmaps/v0.23.x-hardening/v0.23.0-hardening.md` (WS2),
`rac/requirements/rac-explainable-retrieval.md`.

Adds:
- An additive `evidence` object on every `search_artifacts` result —
  `{field, terms, tier}` — read off the existing tiered matcher, not recomputed.
- Edge `evidence` on `get_related` incoming results —
  `{direction, relationship, target}` — naming the relationship that surfaced
  the artifact.
- `rac find --explain` (human attribution line + JSON evidence), composing with
  `--type`, `--decisions`, `--top-level`, `--recursive`.

# Roadmap / ADR Trace

Roadmap:
- `rac/roadmaps/v0.23.x-hardening/v0.23.0-hardening.md`

Requirement:
- `rac/requirements/rac-explainable-retrieval.md`

Relevant ADRs:
- ADR-037, ADR-038 (token-boundary tiered matching — the data evidence reads off)
- ADR-007 (additive, backward-compatible JSON contract)
- ADR-030 (read-only MCP surface, no tool added or removed)
- ADR-034 (structural match, never a relevance/semantic verdict)

# Scope

## Included
- The matcher already computes the winning tier and a matched-terms set, then
  discards the terms. WS2 keeps them: `_Match` carries the matched terms in query
  order; `_evidence` projects the rank to `{field, terms, tier}`.
- `evidence` is `None` for exact resolution (`rac resolve` shape unchanged) and
  always set for a search match.
- MCP `search_artifacts` always carries `evidence`; `get_related` incoming
  entries carry edge `evidence`. `find_decisions` (which reuses the same matcher)
  carries it too.
- `rac find --explain`: human appends an attribution line per match;
  `--explain --json` emits the same `evidence` the MCP path emits (one source of
  truth).

## Excluded (deliberately)
- No relevance score, ranking weight, or confidence number — structural match
  only (ADR-034, ADR-066).
- No change to ranking, tokenization, or snippet extraction (ADR-037/ADR-038);
  evidence references the existing `section`/`snippet`, never alters them.
- No new `get_artifact` field (that is WS5) and no new MCP tool (ADR-030).
- `rac find --json` *without* `--explain` stays byte-stable (golden-pinned); the
  CLI gates evidence behind `--explain`, while the MCP tool always carries it.

# Product / Architecture Decisions

- **CLI default stays evidence-free; MCP always carries it.** `find_json.txt`
  golden pins `rac find --json`, so evidence is `--explain`-gated in the CLI; the
  agent-facing MCP contract always includes it (REQ-003). `rac find --explain
  --json` equals the MCP payload (REQ-004), proven by a test.
- **`terms` follows query order, deduped.** AND semantics guarantee every query
  term matched, so `terms` is the distinct query terms in order.
- **`get_related` evidence is edge-shaped, not text-shaped** — a relationship is
  not a token match, so it carries `direction`/`relationship`/`target`, surfaced
  from the edge the serializer already filters on (REQ-002).
- **`field` can be `id` when a filename-stem alias matched** — faithful to the
  matcher (the stem is an id-tier alias, ADR-037), not a heuristic.

# User-Facing Contract

## CLI
`rac find QUERY [dir] [--type T | --decisions] [--json] [--explain] [--top-level]`

## Human Output
With `--explain`, an indented line per match: `• field=title terms=foo,bar`
(plus a trailing `[Section: snippet]` for heading/body hits). Without
`--explain`, unchanged.

## JSON Output
Search match (always in MCP; in CLI only with `--explain`): the existing
`id, type, title, path` (and `section`/`snippet` for heading/body) plus a
trailing `"evidence": {"field": "title", "terms": ["foo"], "tier": 1}`.
`get_related` incoming entries gain `"evidence": {"direction": "incoming",
"relationship": "related_decisions", "target": "RAC-..."}`.

## Exit Codes
Unchanged: `rac find` returns 0 including for an empty result; `--explain` adds
no new codes; a bad directory is still exit 2.

# Verification

## Ran
- `rac find --explain` and `--explain --json` (human attribution + evidence).
- `python -m pytest tests/test_explain.py tests/test_mcp_tools.py tests/test_resolve.py tests/test_find_decisions.py` (and full suite on the source branch: 1479 passed).
- `python -m ruff check src/ tests/`, `ruff format --check`, `python -m mypy src/`.
- `rac eval --check` (WS1 gate) still passes — evidence is gate-neutral (REQ-010).

## Covered
- A controlled corpus isolates each tier (id/title/path/heading/body); evidence
  `field`/`tier`/`terms` is asserted against the matcher's real rank.
- Additive shape: the default match dict is the pre-WS2 shape; `evidence` is the
  only added key and it sits last. Determinism (byte-stable across runs).
- MCP `search_artifacts` payload equals `rac find --explain --json`; the empty
  result still exits 0; `--explain` composes with `--type`/`--decisions`.
- Updated MCP/resolve shape assertions for the additive key; `get_related`
  incoming carries edge evidence.

# Review Path

1. `src/rac/services/resolve.py` — matcher evidence (`_Match.terms`, `_evidence`,
   `ResolvedArtifact.evidence`, `to_dict(include_evidence=...)`).
2. `src/rac/output/json.py`, `src/rac/output/human.py`, `src/rac/cli.py` —
   `rac find --explain`.
3. `src/rac/mcp/server.py`, `src/rac/services/relationships.py` — MCP search +
   get_related edge evidence.
4. `tests/test_explain.py` and the updated `tests/test_mcp_tools.py` /
   `tests/test_resolve.py`.

# Notes For Reviewer

- Built on the WS1 branch as a combined Tier-1 PR originally; re-split onto its
  own branch off `main` after #153 merged. The five commits are the WS2 work only.
- `find_decisions` results now also carry search evidence (it shares the
  matcher); its existing equivalence tests already compare like-for-like.

# Implementation Process

Implemented with AI assistance under the v0.23.0 roadmap contract; final scope,
review, and acceptance decisions are the maintainer's.