### PR TITLE
feat(robustness): v0.23.0 WS4 — parser and bounded-traversal hardening

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -103,6 +103,8 @@ jobs:
             paths: "tests/test_review.py tests/test_cadence.py"
           - name: doctor
             paths: "tests/test_doctor.py"
+          - name: robustness
+            paths: "tests/test_robustness.py"
           - name: revisions
             paths: "tests/test_revisions.py"
           - name: recency

--- a/rac/requirements/rac-parser-traversal-robustness.md
+++ b/rac/requirements/rac-parser-traversal-robustness.md
@@ -8,7 +8,7 @@ tags: [internal, robustness, parser, traversal, mcp]
 
 ## Status
 
-Proposed
+Accepted
 
 Classification: `[internal]` — invisible, but the server must never crash in
 front of a partner. Scoped to the v0.23.0 hardening release (WS4).

--- a/rac/roadmaps/v0.23.x-hardening/v0.23.0-hardening.md
+++ b/rac/roadmaps/v0.23.x-hardening/v0.23.0-hardening.md
@@ -112,7 +112,7 @@ Tier 1:
 - [x] WS1 grounding-eval-benchmark — `rac eval` + CI gate — `done`
 - [x] WS2 explainable-retrieval — `evidence` + `--explain` — `done`
 - [x] WS3 doctor-diagnostic-validator — `rac doctor` — `done`
-- [ ] WS4 parser-traversal-robustness — caps + fuzz + bounded output — `planned`
+- [x] WS4 parser-traversal-robustness — caps + fuzz + bounded output — `done`
 - [ ] WS11 artifact-trust-model — `SECURITY.md` + injection flag + review signal — `planned`
 
 Tier 2 (obey-demo is the non-cuttable success anchor; cut WS10 → WS6 first):

--- a/src/rac/cli.py
+++ b/src/rac/cli.py
@@ -172,15 +172,20 @@ EXIT_USAGE = 2
 
 
 def _read(path: str) -> Product:
-    """Parse a file, or print an error and exit with EXIT_USAGE."""
-    try:
-        return parse_file(path)
-    except FileNotFoundError:
+    """Parse a single named file, or print an error and exit with EXIT_USAGE.
+
+    A directly named file that is missing or unreadable is a usage error here —
+    distinct from the corpus walk, where ``parse_file`` degrades such inputs
+    gracefully so one bad file never aborts the walk (WS4, REQ-005).
+    """
+    if not Path(path).is_file():
         print(f"rac: file not found: {path}", file=sys.stderr)
         raise SystemExit(EXIT_USAGE) from None
-    except OSError as exc:
-        print(f"rac: cannot read {path}: {exc}", file=sys.stderr)
+    product = parse_file(path)
+    if any(issue.code == "unreadable-artifact" for issue in product.parse_issues):
+        print(f"rac: cannot read {path}", file=sys.stderr)
         raise SystemExit(EXIT_USAGE) from None
+    return product
 
 
 def _read_validate_input(target: str) -> Product:

--- a/src/rac/core/frontmatter.py
+++ b/src/rac/core/frontmatter.py
@@ -18,7 +18,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 import yaml
+from yaml.nodes import Node
 
+from .limits import MAX_FRONTMATTER_BYTES, MAX_FRONTMATTER_DEPTH, exceeds_byte_cap
 from .metadata import (
     SUPPORTED_SCHEMA_VERSIONS,
     ArtifactMetadata,
@@ -57,6 +59,38 @@ def _no_duplicates(loader: _StrictLoader, node: yaml.MappingNode) -> dict:
 
 
 _StrictLoader.add_constructor(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, _no_duplicates)
+
+
+class _BoundedLoader(_StrictLoader):
+    """Strict loading plus WS4 adversarial-input bounds (REQ-002).
+
+    Forbids YAML aliases — which kills the "billion laughs" alias-expansion bomb
+    at its source — and caps nesting depth so deeply nested input is rejected as
+    a structured ``malformed-frontmatter`` issue before PyYAML recurses. Inherits
+    ``_StrictLoader``'s duplicate-key rejection and ``SafeLoader``'s refusal to
+    construct arbitrary objects.
+    """
+
+    # Per-instance nesting depth; the class default seeds each fresh loader.
+    _depth = 0
+
+    def compose_node(self, parent: Node | None, index: int) -> Node | None:
+        if self.check_event(yaml.events.AliasEvent):
+            event = self.peek_event()
+            raise yaml.MarkedYAMLError(
+                problem="YAML aliases are not permitted in frontmatter",
+                problem_mark=event.start_mark,
+            )
+        self._depth += 1
+        if self._depth > MAX_FRONTMATTER_DEPTH:
+            self._depth -= 1
+            raise yaml.MarkedYAMLError(
+                problem=f"frontmatter nesting exceeds the {MAX_FRONTMATTER_DEPTH}-level cap"
+            )
+        try:
+            return super().compose_node(parent, index)
+        finally:
+            self._depth -= 1
 
 
 @dataclass
@@ -101,8 +135,17 @@ def parse_frontmatter(raw: str) -> tuple[ArtifactMetadata | None, list[Issue]]:
     callers can still read what parsed.
     """
     issues: list[Issue] = []
+    # Cap the raw block before PyYAML sees it (WS4, REQ-002), so an oversized
+    # front matter cannot allocate unbounded ahead of validation.
+    if exceeds_byte_cap(raw, MAX_FRONTMATTER_BYTES):
+        return None, [
+            _issue(
+                "malformed-frontmatter",
+                f"frontmatter exceeds the {MAX_FRONTMATTER_BYTES}-byte cap",
+            )
+        ]
     try:
-        data = yaml.load(raw, Loader=_StrictLoader)
+        data = yaml.load(raw, Loader=_BoundedLoader)
     except yaml.MarkedYAMLError as exc:
         if exc.problem and "duplicate frontmatter key" in exc.problem:
             return None, [_issue("duplicate-frontmatter-key", exc.problem)]
@@ -111,6 +154,9 @@ def parse_frontmatter(raw: str) -> tuple[ArtifactMetadata | None, list[Issue]]:
         ]
     except yaml.YAMLError as exc:
         return None, [_issue("malformed-frontmatter", f"frontmatter is not valid YAML: {exc}")]
+    except RecursionError:
+        # Depth cap should pre-empt this, but never propagate a crash (REQ-002).
+        return None, [_issue("malformed-frontmatter", "frontmatter nesting too deep to parse")]
 
     if not isinstance(data, dict):
         return None, [

--- a/src/rac/core/limits.py
+++ b/src/rac/core/limits.py
@@ -1,0 +1,69 @@
+"""Robustness limits — the input-size and traversal caps (v0.23.0, WS4).
+
+The MCP server sits in an agent's critical path (ADR-032/ADR-033): a malformed
+artifact, an oversized field, an alias-bombed front matter, or a high-fan-out
+hub must never crash, hang, or exhaust memory. These module-level caps bound
+*work* ahead of the ADR-033 response budget, with safe defaults proven against
+the fixture corpus. They are measured in bytes where width-independence matters,
+so the bound is the same regardless of unicode content.
+
+The per-file byte cap is overridable via ``RAC_MAX_FILE_BYTES`` for repositories
+with genuinely large artifacts; the rest are fixed constants. Reading an
+environment variable is configuration, not I/O against the artifact, so the
+parse path stays deterministic for a given environment (ADR-002).
+"""
+
+from __future__ import annotations
+
+import os
+
+# Per-file / per-parse byte cap (REQ-001). Default 1 MiB; override with
+# RAC_MAX_FILE_BYTES. A non-positive or unparseable override falls back to the
+# default rather than disabling the guard.
+DEFAULT_MAX_FILE_BYTES = 1 << 20  # 1 MiB
+_MAX_FILE_BYTES_ENV = "RAC_MAX_FILE_BYTES"
+
+# Raw front-matter block byte cap, before PyYAML sees it (REQ-002).
+MAX_FRONTMATTER_BYTES = 64 << 10  # 64 KiB
+# Maximum YAML nesting depth permitted in front matter (REQ-002): deeper input
+# is rejected as malformed before PyYAML recurses.
+MAX_FRONTMATTER_DEPTH = 32
+
+# Per-field captured-body caps (REQ-003), independent of the ADR-033 response
+# budget. A single oversized field is truncated, never allowed to dominate the
+# served Product. Generous enough that no real artifact is affected.
+MAX_FIELD_CHARS = 256 << 10  # 256 KiB of text per ## section / field
+MAX_CAPTURED_LINES = 50_000  # total non-blank body lines captured per document
+
+# Per-call relationship edge cap for get_related (REQ-007): incoming/outgoing
+# edge collection stops building after this many, so a high-fan-out hub cannot
+# force an unbounded in-memory list before the response budget trims it.
+MAX_RELATED_EDGES = 1000
+
+
+def max_file_bytes() -> int:
+    """The per-file byte cap, honoring ``RAC_MAX_FILE_BYTES`` (REQ-001)."""
+    raw = os.environ.get(_MAX_FILE_BYTES_ENV)
+    if raw is not None:
+        try:
+            value = int(raw)
+        except ValueError:
+            return DEFAULT_MAX_FILE_BYTES
+        if value > 0:
+            return value
+    return DEFAULT_MAX_FILE_BYTES
+
+
+def exceeds_byte_cap(text: str, cap: int) -> bool:
+    """True when ``text`` exceeds ``cap`` UTF-8 bytes, encoding only if needed.
+
+    A character count is a cheap lower bound (``bytes >= chars``) and upper bound
+    (``bytes <= 4 * chars``), so the costly ``encode`` runs only for inputs near
+    the cap — never for the common small artifact.
+    """
+    length = len(text)
+    if length > cap:
+        return True
+    if length <= cap // 4:
+        return False
+    return len(text.encode("utf-8")) > cap

--- a/src/rac/core/markdown.py
+++ b/src/rac/core/markdown.py
@@ -11,11 +11,18 @@ Heading matching is case-insensitive and whitespace-trimmed, so ``## problem`` a
 
 from __future__ import annotations
 
+import os
 import re
 
 from markdown_it import MarkdownIt
 
 from .frontmatter import parse_frontmatter, split_frontmatter
+from .limits import (
+    MAX_CAPTURED_LINES,
+    MAX_FIELD_CHARS,
+    exceeds_byte_cap,
+    max_file_bytes,
+)
 from .models import Issue, MalformedRequirement, Product, Requirement, SearchSection
 
 # A single shared parser, built once and reused for every ``parse`` call.
@@ -76,6 +83,17 @@ def _classify_requirement_line(text: str, line: int) -> Requirement | MalformedR
     return Requirement(id=req_id, text=desc, line=line)
 
 
+def _degraded_product(source_path: str, issues: list[Issue]) -> Product:
+    """A minimal Product carrying only parse-level issues (WS4, REQ-005).
+
+    Returned when input is rejected before the body is parsed (oversize, or an
+    unreadable file): an empty artifact that classifies as Unknown and fails
+    validation via its ``parse_issues``, so the defect is reported and the
+    corpus walk continues past it rather than crashing.
+    """
+    return Product(title=None, source_path=source_path, parse_issues=issues)
+
+
 def parse(text: str, source_path: str = "") -> Product:
     """Parse Markdown ``text`` into a :class:`Product`.
 
@@ -84,7 +102,26 @@ def parse(text: str, source_path: str = "") -> Product:
     number reported downstream is offset back to the original file so
     diagnostics stay file-accurate. Documents without frontmatter are parsed
     exactly as before.
+
+    Input over the per-parse byte cap (REQ-001) is rejected before tokenizing
+    and returned as a structured oversize issue, never an exception.
     """
+    cap = max_file_bytes()
+    if exceeds_byte_cap(text, cap):
+        return _degraded_product(
+            source_path,
+            [
+                Issue(
+                    "error",
+                    "artifact-oversize",
+                    f"artifact exceeds the {cap}-byte parse cap "
+                    "(set RAC_MAX_FILE_BYTES to raise it)",
+                    1,
+                )
+            ],
+        )
+
+    parse_issues: list[Issue] = []
     split = split_frontmatter(text)
     offset = split.line_offset
     metadata = None
@@ -118,6 +155,13 @@ def parse(text: str, source_path: str = "") -> Product:
     risk_lines: list[str] = []
     # Generic body text per ## section: {normalized heading -> [stripped lines]}.
     section_bodies: dict[str, list[str]] = {}
+    # Body-capture caps (WS4, REQ-003): per-section char budget and a total
+    # captured-line ceiling so one oversized field cannot dominate the Product.
+    # Generous enough that no real artifact is affected; inert below the caps.
+    section_chars: dict[str, int] = {}
+    captured_lines = 0
+    truncated_fields: set[str] = set()
+    body_truncated = False
 
     has = {
         "problem": False,
@@ -162,16 +206,31 @@ def parse(text: str, source_path: str = "") -> Product:
         if i > 0 and tokens[i - 1].type == "heading_open":
             continue
 
+        # Once the total captured-line ceiling is hit, stop capturing any further
+        # body (generic or recognized): the document is reported truncated and the
+        # parse completes rather than accumulating unboundedly (WS4, REQ-003).
+        if body_truncated:
+            continue
+
         # Generic body capture for every ## section (the canonical content map).
         if current_h2 is not None:
             for raw in tok.content.split("\n"):
                 stripped = raw.strip()
-                if stripped:
-                    section_bodies.setdefault(current_h2, []).append(stripped)
-                    if current_search is not None:
-                        current_search.lines.append(stripped)
+                if not stripped:
+                    continue
+                if captured_lines >= MAX_CAPTURED_LINES:
+                    body_truncated = True
+                    break
+                if section_chars.get(current_h2, 0) + len(stripped) > MAX_FIELD_CHARS:
+                    truncated_fields.add(current_h2)
+                    continue
+                section_bodies.setdefault(current_h2, []).append(stripped)
+                section_chars[current_h2] = section_chars.get(current_h2, 0) + len(stripped) + 1
+                captured_lines += 1
+                if current_search is not None:
+                    current_search.lines.append(stripped)
 
-        if section is None or section == "other":
+        if body_truncated or section is None or section == "other":
             continue
 
         start_line = (tok.map[0] + offset) if tok.map else 0
@@ -200,6 +259,27 @@ def parse(text: str, source_path: str = "") -> Product:
 
     sections = {h: "\n".join(lines) for h, lines in section_bodies.items()}
 
+    # Body-cap findings (WS4, REQ-003): a truncated field or document is reported
+    # as a warning — the artifact is served partial, not failed outright.
+    for heading in sorted(truncated_fields):
+        parse_issues.append(
+            Issue(
+                "warning",
+                "field-truncated",
+                f"section {heading!r} exceeds the {MAX_FIELD_CHARS}-char field cap "
+                "and was truncated",
+            )
+        )
+    if body_truncated:
+        parse_issues.append(
+            Issue(
+                "warning",
+                "body-truncated",
+                f"document body exceeds the {MAX_CAPTURED_LINES}-line capture cap "
+                "and was truncated",
+            )
+        )
+
     return Product(
         title=title,
         extra_title_lines=extra_title_lines,
@@ -217,10 +297,51 @@ def parse(text: str, source_path: str = "") -> Product:
         source_path=source_path,
         metadata=metadata,
         metadata_issues=metadata_issues,
+        parse_issues=parse_issues,
     )
 
 
 def parse_file(path: str) -> Product:
-    """Read ``path`` and parse it into a :class:`Product`."""
-    with open(path, encoding="utf-8") as fh:
-        return parse(fh.read(), source_path=path)
+    """Read ``path`` and parse it into a :class:`Product` (WS4-hardened).
+
+    Bounds work before reading the whole file into memory (REQ-001) and degrades
+    gracefully on adversarial input (REQ-005): an oversize file, an unreadable
+    file, or non-UTF-8 bytes yields a structured issue, never an exception that
+    would crash a serving path or abort the corpus walk.
+    """
+    cap = max_file_bytes()
+    try:
+        # Size-check the path first, then read at most the cap (+1 to detect a
+        # file that grew between stat and read, or a symlink to something larger).
+        size = os.path.getsize(path)
+        if size > cap:
+            return _degraded_product(path, [_oversize_issue(cap)])
+        with open(path, "rb") as fh:
+            data = fh.read(cap + 1)
+    except OSError as exc:
+        return _degraded_product(
+            path, [Issue("error", "unreadable-artifact", f"cannot read artifact: {exc}", 1)]
+        )
+    if len(data) > cap:
+        return _degraded_product(path, [_oversize_issue(cap)])
+
+    try:
+        text = data.decode("utf-8")
+        product = parse(text, source_path=path)
+    except UnicodeDecodeError:
+        # Non-UTF-8 / partial sequences: decode lossily so the parse still
+        # completes, and report the encoding defect for review (REQ-005, REQ-009).
+        product = parse(data.decode("utf-8", errors="replace"), source_path=path)
+        product.parse_issues.append(
+            Issue("warning", "non-utf8-content", "artifact is not valid UTF-8; decoded lossily", 1)
+        )
+    return product
+
+
+def _oversize_issue(cap: int) -> Issue:
+    return Issue(
+        "error",
+        "artifact-oversize",
+        f"artifact exceeds the {cap}-byte file cap (set RAC_MAX_FILE_BYTES to raise it)",
+        1,
+    )

--- a/src/rac/core/models.py
+++ b/src/rac/core/models.py
@@ -93,6 +93,11 @@ class Product:
     # Frontmatter parse/schema findings, surfaced by validation. Kept separate
     # from body analysis: the envelope and the artifact are distinct concerns.
     metadata_issues: list[Issue] = field(default_factory=list)
+    # Parser-level robustness findings (v0.23.0, WS4): oversize input, a
+    # truncated body field, non-UTF-8 content, or an unreadable file. Surfaced by
+    # validation alongside metadata_issues so a degraded artifact is reported
+    # (and skipped) rather than crashing a parse or serving path (REQ-005).
+    parse_issues: list[Issue] = field(default_factory=list)
 
 
 @dataclass

--- a/src/rac/core/validation.py
+++ b/src/rac/core/validation.py
@@ -168,7 +168,7 @@ def _validate_metadata(product: Product) -> list[Issue]:
     declaration) is detected here because it needs the classified spec. RAC
     never silently picks one identity (Initiative 7).
     """
-    issues = list(product.metadata_issues)
+    issues = list(product.metadata_issues) + list(product.parse_issues)
     spec = spec_for(classify(product).type)
     conflict = identity_conflict(product, spec)
     if conflict is not None:

--- a/src/rac/mcp/server.py
+++ b/src/rac/mcp/server.py
@@ -51,7 +51,14 @@ from mcp.server.fastmcp import FastMCP
 from rac import consent as consent_record
 from rac.core.corpus import walk_corpus
 from rac.mcp import errors, ping, telemetry
-from rac.mcp.budget import DEFAULT_BUDGET, serialize
+from rac.mcp.budget import (
+    DEFAULT_BUDGET,
+    HINT_RELATED,
+    MARKER_HINT,
+    MARKER_OMITTED,
+    MARKER_TRUNCATED,
+    serialize,
+)
 from rac.mcp.telemetry import TelemetryRecorder
 from rac.services.index import build_repository_index, index_from_corpus
 from rac.services.portfolio import build_portfolio_summary
@@ -200,6 +207,8 @@ def _get_related(root: str, artifact_id: str, budget: int) -> str:
     artifact = result.artifact
     relationships = relationships_from_corpus(entries)
     identity_by_path = {entry.path: (entry.id, entry.type, entry.title) for entry in index}
+    outgoing = outgoing_references(relationships, artifact.path)
+    incoming_result = incoming_references(relationships, identity_by_path, artifact.path)
     incoming = [
         {
             "id": ref.id,
@@ -217,14 +226,26 @@ def _get_related(root: str, artifact_id: str, budget: int) -> str:
                 "target": ref.target,
             },
         }
-        for ref in incoming_references(relationships, identity_by_path, artifact.path)
+        for ref in incoming_result.items
     ]
     payload = {
         "schema_version": "1",
         **artifact.to_dict(),
-        "outgoing": outgoing_references(relationships, artifact.path),
+        "outgoing": outgoing.by_section,
         "incoming": incoming,
     }
+    # Per-call edge cap overflow (WS4, REQ-007): when collection hit the cap, mark
+    # the response truncated up front. The ADR-033 response budget then enforces
+    # the character cap on top; if it must drop further incoming entries it
+    # recomputes the marker (budget.serialize), so the response is always bounded
+    # and carries the additive truncated/omitted/hint signal (REQ-006).
+    edge_overflow = (incoming_result.total - len(incoming_result.items)) + (
+        outgoing.total - outgoing.kept
+    )
+    if edge_overflow > 0:
+        payload[MARKER_TRUNCATED] = True
+        payload[MARKER_OMITTED] = edge_overflow
+        payload[MARKER_HINT] = HINT_RELATED
     return serialize(payload, budget)
 
 

--- a/src/rac/services/eval.py
+++ b/src/rac/services/eval.py
@@ -278,7 +278,7 @@ def _related_returned(root: str, case: QueryCase) -> list[str]:
     relationships = relationships_from_corpus(entries)
     identity_by_path = {entry.path: (entry.id, entry.type, entry.title) for entry in index}
     incoming = incoming_references(relationships, identity_by_path, resolution.artifact.path)
-    return [ref.id for ref in incoming]
+    return [ref.id for ref in incoming.items]
 
 
 def returned_ids(root: str, entries: list, case: QueryCase) -> list[str]:

--- a/src/rac/services/relationships.py
+++ b/src/rac/services/relationships.py
@@ -23,6 +23,7 @@ from rac.core.artifacts import ArtifactSpec, spec_for
 from rac.core.classification import classify
 from rac.core.corpus import CorpusEntry, walk_corpus
 from rac.core.identity import artifact_identifier, artifact_identifiers
+from rac.core.limits import MAX_RELATED_EDGES
 from rac.core.markdown import parse_file
 from rac.core.models import Product
 from rac.core.relationship_types import REGISTRY, edge_spec
@@ -961,6 +962,19 @@ def relationships_from_corpus(entries: list[CorpusEntry]) -> list[Relationship]:
 # incoming edge exists exactly when a reference resolved uniquely to the target.
 
 
+# Canonical relationship-section order (snake_case), for deterministic
+# get_related ordering (WS4, REQ-006): incoming edges sort by their section's
+# position in the artifact's spec/section vocabulary, then ascending id.
+_RELATIONSHIP_ORDER: dict[str, int] = {
+    _snake(section): index for index, section in enumerate(RELATIONSHIP_SECTIONS)
+}
+
+
+def _relationship_order(section: str) -> int:
+    """Rank of a snake_case relationship section in the canonical order."""
+    return _RELATIONSHIP_ORDER.get(section, len(_RELATIONSHIP_ORDER))
+
+
 @dataclass(frozen=True)
 class IncomingReference:
     """An artifact whose declared reference resolves to a target artifact.
@@ -978,36 +992,82 @@ class IncomingReference:
     target: str
 
 
+@dataclass(frozen=True)
+class IncomingReferences:
+    """Capped, ordered incoming edges plus the full pre-cap count (WS4).
+
+    ``items`` is ordered by relationship type then ascending id (REQ-006) and
+    capped at the per-call edge limit (REQ-007); ``total`` is the full count so a
+    caller can signal overflow via the truncation marker.
+    """
+
+    items: list[IncomingReference]
+    total: int
+
+
+@dataclass(frozen=True)
+class OutgoingReferences:
+    """Capped outgoing references grouped by section, plus the full count (WS4)."""
+
+    by_section: dict[str, list[str]]
+    total: int
+
+    @property
+    def kept(self) -> int:
+        return sum(len(targets) for targets in self.by_section.values())
+
+
 def outgoing_references(
-    relationships: list[Relationship], source_path: str
-) -> dict[str, list[str]]:
+    relationships: list[Relationship],
+    source_path: str,
+    *,
+    limit: int | None = None,
+) -> OutgoingReferences:
     """The references ``source_path`` declares, grouped by section, as stored.
 
     Keys are snake_case section names in the source artifact's own spec order
     (``relationships_from_corpus`` yields references in that order, so a
     first-seen-wins dict preserves it). References are the raw stored text — the
-    source of truth (ADR-016).
+    source of truth (ADR-016). Collection stops after ``limit`` edges so a
+    pathological artifact cannot build an unbounded list (WS4, REQ-007); the
+    default resolves to :data:`MAX_RELATED_EDGES` at call time.
     """
-    outgoing: dict[str, list[str]] = {}
+    if limit is None:
+        limit = MAX_RELATED_EDGES
+    by_section: dict[str, list[str]] = {}
+    total = 0
+    kept = 0
     for rel in relationships:
-        if rel.source_path == source_path:
-            outgoing.setdefault(rel.relationship, []).append(rel.target)
-    return outgoing
+        if rel.source_path != source_path:
+            continue
+        total += 1
+        if kept < limit:
+            by_section.setdefault(rel.relationship, []).append(rel.target)
+            kept += 1
+    return OutgoingReferences(by_section=by_section, total=total)
 
 
 def incoming_references(
     relationships: list[Relationship],
     identity_by_path: dict[str, tuple[str, str, str | None]],
     target_path: str,
-) -> list[IncomingReference]:
+    *,
+    limit: int | None = None,
+) -> IncomingReferences:
     """Artifacts whose declared references resolve uniquely to ``target_path``.
 
     ``identity_by_path`` maps each artifact path to ``(id, type, title)`` (the
-    caller builds it from the repository index). Self-references are excluded;
-    entries are ordered by source path, then section — the deterministic order
-    the ``get_related`` design pins.
+    caller builds it from the repository index). Self-references are excluded.
+    Collection stops storing after ``limit`` edges to bound work (WS4, REQ-007),
+    while the full count is still tallied so overflow can be signalled; the kept
+    edges are ordered by relationship type then ascending id (REQ-006) so
+    tail-truncation drops the lowest-priority edges deterministically (REQ-008).
+    The default resolves to :data:`MAX_RELATED_EDGES` at call time.
     """
+    if limit is None:
+        limit = MAX_RELATED_EDGES
     incoming: list[IncomingReference] = []
+    total = 0
     for rel in relationships:
         if rel.resolved_path != target_path:
             continue
@@ -1016,16 +1076,18 @@ def incoming_references(
         identity = identity_by_path.get(rel.source_path)
         if identity is None:  # pragma: no cover — every relationship source is indexed
             continue
-        source_id, source_type, source_title = identity
-        incoming.append(
-            IncomingReference(
-                id=source_id,
-                type=source_type,
-                title=source_title,
-                path=rel.source_path,
-                section=rel.relationship,
-                target=rel.target,
+        total += 1
+        if len(incoming) < limit:
+            source_id, source_type, source_title = identity
+            incoming.append(
+                IncomingReference(
+                    id=source_id,
+                    type=source_type,
+                    title=source_title,
+                    path=rel.source_path,
+                    section=rel.relationship,
+                    target=rel.target,
+                )
             )
-        )
-    incoming.sort(key=lambda e: (e.path, e.section))
-    return incoming
+    incoming.sort(key=lambda e: (_relationship_order(e.section), e.id, e.path))
+    return IncomingReferences(items=incoming, total=total)

--- a/tests/test_explorer_adapter.py
+++ b/tests/test_explorer_adapter.py
@@ -60,13 +60,31 @@ def test_load_translates_progress_with_labels():
     ]
 
 
-def test_failures_become_recoverable_error_state(tmp_path):
-    (tmp_path / "bad.md").write_bytes(b"\xff\xfe not utf-8 \xff")
+def test_failures_become_recoverable_error_state(tmp_path, monkeypatch):
+    # A genuine, unexpected core failure surfaces as a recoverable error state.
+    # The injection is at the load boundary because a malformed/non-UTF-8
+    # artifact no longer aborts the load — WS4 degrades it gracefully.
+    import rac.explorer.adapter as adapter_mod
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("core exploded")
+
+    monkeypatch.setattr(adapter_mod, "load_repository", _boom)
     result = ExplorerAdapter(str(tmp_path)).load()
     assert isinstance(result, LoadErrorState)
     assert result.can_retry
     assert result.title == "Could not load repository"
-    assert "UnicodeDecodeError" in result.detail
+    assert "RuntimeError" in result.detail
+
+
+def test_non_utf8_artifact_loads_gracefully_after_ws4(tmp_path):
+    # WS4 (REQ-005): a non-UTF-8 artifact no longer crashes the load; the walk
+    # continues and the file is surfaced as a (degraded) artifact, not a global
+    # load error.
+    (tmp_path / "bad.md").write_bytes(b"\xff\xfe not utf-8 \xff")
+    result = ExplorerAdapter(str(tmp_path)).load()
+    assert isinstance(result, RepositorySummaryState)
+    assert result.artifact_total == 1
 
 
 def test_empty_directory_is_a_summary_not_an_error(tmp_path):

--- a/tests/test_explorer_app.py
+++ b/tests/test_explorer_app.py
@@ -93,8 +93,16 @@ async def test_broken_references_surface_in_summary():
 
 
 @pytest.mark.asyncio
-async def test_core_failure_renders_recoverable_error_state(tmp_path):
-    (tmp_path / "bad.md").write_bytes(b"\xff\xfe not utf-8 \xff")
+async def test_core_failure_renders_recoverable_error_state(tmp_path, monkeypatch):
+    # A genuine core failure renders the recoverable error screen. WS4 makes a
+    # malformed/non-UTF-8 artifact degrade gracefully, so the failure is injected
+    # at the load boundary rather than via bad file content.
+    import rac.explorer.adapter as adapter_mod
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("core exploded")
+
+    monkeypatch.setattr(adapter_mod, "load_repository", _boom)
     app = ExplorerApp(str(tmp_path))
     async with app.run_test() as pilot:
         text = await _settled_panel_text(app, pilot)
@@ -103,15 +111,25 @@ async def test_core_failure_renders_recoverable_error_state(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_reload_binding_recovers_after_repair(tmp_path):
-    bad = tmp_path / "bad.md"
-    bad.write_bytes(b"\xff\xfe not utf-8 \xff")
+async def test_reload_binding_recovers_after_repair(tmp_path, monkeypatch):
+    import rac.explorer.adapter as adapter_mod
+
+    real_load = adapter_mod.load_repository
+    state = {"broken": True}
+
+    def _maybe(*args, **kwargs):
+        if state["broken"]:
+            raise RuntimeError("core exploded")
+        return real_load(*args, **kwargs)
+
+    monkeypatch.setattr(adapter_mod, "load_repository", _maybe)
+    (tmp_path / "note.md").write_text("# Repaired Note\n", encoding="utf-8")
     app = ExplorerApp(str(tmp_path))
     async with app.run_test() as pilot:
         text = await _settled_panel_text(app, pilot)
         assert "Could not load repository" in text
 
-        bad.write_text("# Repaired Note\n", encoding="utf-8")
+        state["broken"] = False  # the operator repairs the underlying failure
         await pilot.press("r")
         text = await _settled_panel_text(app, pilot)
         assert "Artifacts      1" in text
@@ -1615,9 +1633,16 @@ async def test_watcher_is_quiet_while_paused_and_before_first_load(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_watcher_does_not_run_after_a_load_error(tmp_path):
-    bad = tmp_path / "bad.md"
-    bad.write_bytes(b"\xff\xfe not utf-8 \xff")
+async def test_watcher_does_not_run_after_a_load_error(tmp_path, monkeypatch):
+    # A genuine load failure (WS4: not a malformed artifact, which now degrades
+    # gracefully) leaves the watcher with no baseline; a file change does not
+    # auto-recover — only `r` does.
+    import rac.explorer.adapter as adapter_mod
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("core exploded")
+
+    monkeypatch.setattr(adapter_mod, "load_repository", _boom)
     app = ExplorerApp(str(tmp_path))
     async with app.run_test() as pilot:
         screen = app.screen
@@ -1625,7 +1650,7 @@ async def test_watcher_does_not_run_after_a_load_error(tmp_path):
         await _settled_panel_text(app, pilot)
         assert screen._watch_baseline is None  # load failed: nothing to compare
 
-        bad.write_text("# Repaired Note\n", encoding="utf-8")
+        (tmp_path / "note.md").write_text("# Repaired Note\n", encoding="utf-8")
         screen._watch_tick()
         await app.workers.wait_for_complete()
         await pilot.pause()

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -299,17 +299,10 @@ def test_get_related_outgoing_and_incoming_shape():
     ]
     # outgoing: the artifact's own sections, snake_case, references as stored.
     assert payload["outgoing"] == {"related_requirements": [REQ]}
-    # incoming: artifacts whose references resolve here, ordered by path/section.
+    # incoming: ordered by relationship type then ascending id (WS4, REQ-006).
+    # Both edges are related_decisions, so RDM (...RDM...) precedes REQ (...REQ...).
     edge = {"direction": "incoming", "relationship": "related_decisions", "target": DEC}
     assert payload["incoming"] == [
-        {
-            "id": REQ,
-            "type": "requirement",
-            "title": "Decoupled Messaging",
-            "path": fixture_path("mcp", "corpus", "requirement.md"),
-            "section": "related_decisions",
-            "evidence": edge,
-        },
         {
             "id": RDM,
             "type": "roadmap",
@@ -318,13 +311,25 @@ def test_get_related_outgoing_and_incoming_shape():
             "section": "related_decisions",
             "evidence": edge,
         },
+        {
+            "id": REQ,
+            "type": "requirement",
+            "title": "Decoupled Messaging",
+            "path": fixture_path("mcp", "corpus", "requirement.md"),
+            "section": "related_decisions",
+            "evidence": edge,
+        },
     ]
 
 
-def test_get_related_incoming_ordered_by_path_then_section():
+def test_get_related_incoming_ordered_by_relationship_then_id():
+    # WS4 (REQ-006): incoming is ordered by relationship type (canonical section
+    # order) then ascending id, so budget tail-truncation is deterministic. Both
+    # edges here are related_decisions, so ids ascend within that type.
     payload = call(CORPUS, "get_related", {"id": DEC})
-    keys = [(e["path"], e["section"]) for e in payload["incoming"]]
-    assert keys == sorted(keys)
+    incoming = payload["incoming"]
+    assert all(e["section"] == "related_decisions" for e in incoming)
+    assert [e["id"] for e in incoming] == sorted(e["id"] for e in incoming)
 
 
 def test_get_related_no_incoming_yields_empty_list():

--- a/tests/test_robustness.py
+++ b/tests/test_robustness.py
@@ -1,0 +1,281 @@
+"""Parser and bounded-traversal robustness battery (v0.23.0, WS4).
+
+Adversarial input must never crash, hang, or exhaust memory: oversize files and
+fields, alias-bombed / deeply nested front matter, non-UTF-8 bytes, ReDoS-style
+strings, and high-fan-out / cyclic relationship graphs are all reported as
+structured data and bounded. Determinism is load-bearing — the fuzz pass runs
+from a fixed seed with a pinned iteration count and no network (REQ-009).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import random
+import time
+
+from rac.core import markdown as md_mod
+from rac.core.frontmatter import parse_frontmatter
+from rac.core.markdown import _BRACKET_RE, _CANONICAL_ID_RE, parse, parse_file
+from rac.core.metadata import ID_RE
+from rac.core.validation import (
+    _AMBIGUOUS_RE,
+    _EARS_IF_RE,
+    _NORMATIVE_RE,
+    _QUARTER_RE,
+    _THEN_RE,
+)
+from rac.mcp.server import build_server
+from rac.services import relationships as rel_mod
+from rac.services.resolve import find_artifacts
+
+DECISION = (
+    "---\nschema_version: 1\nid: {id}\ntype: decision\n---\n# {title}\n\n"
+    "## Status\n\nAccepted\n\n## Context\n\n{context}\n\n## Decision\n\nDo it.\n\n"
+    "## Consequences\n\nFine.\n{supersedes}"
+)
+REQUIREMENT = (
+    "---\nschema_version: 1\nid: {id}\ntype: requirement\n---\n# {title}\n\n"
+    "## Problem\n\nx\n\n## Requirements\n\n- [REQ-001] The system MUST do it.\n{related}"
+)
+
+
+def _decision(root, name, aid, *, context="Background.", supersedes=None):
+    body = DECISION.format(
+        id=aid,
+        title=name,
+        context=context,
+        supersedes=f"\n## Supersedes\n\n- {supersedes}\n" if supersedes else "",
+    )
+    (root / f"{name}.md").write_text(body, encoding="utf-8")
+
+
+def _requirement(root, name, aid, *, related=None):
+    rel = (
+        "\n## Related Decisions\n\n" + "\n".join(f"- {r}" for r in related) + "\n"
+        if related
+        else ""
+    )
+    (root / f"{name}.md").write_text(
+        REQUIREMENT.format(id=aid, title=name, related=rel), encoding="utf-8"
+    )
+
+
+def _suffix(i: int) -> str:
+    # A valid 12-char Crockford suffix (no I/L/O/U) from an index.
+    alphabet = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+    out = ""
+    n = i
+    for _ in range(12):
+        out = alphabet[n % 32] + out
+        n //= 32
+    return out
+
+
+def _get_related(root, artifact_id, budget=1_000_000_000):
+    server = build_server(str(root), budget=budget)
+    contents, _ = asyncio.run(server.call_tool("get_related", {"id": artifact_id}))
+    return json.loads(contents[0].text)
+
+
+# --- REQ-001: per-file / per-parse byte cap ----------------------------------
+
+
+def test_oversize_file_is_reported_not_raised(tmp_path, monkeypatch):
+    monkeypatch.setenv("RAC_MAX_FILE_BYTES", "512")
+    big = tmp_path / "big.md"
+    big.write_text("# T\n\n" + ("x " * 1000), encoding="utf-8")
+    product = parse_file(str(big))  # must not raise
+    assert [i.code for i in product.parse_issues] == ["artifact-oversize"]
+    assert product.parse_issues[0].severity == "error"
+
+
+def test_in_memory_parse_rejects_oversize(monkeypatch):
+    monkeypatch.setattr(md_mod, "max_file_bytes", lambda: 256)
+    product = parse("# T\n\n" + ("word " * 500))
+    assert any(i.code == "artifact-oversize" for i in product.parse_issues)
+
+
+def test_normal_file_has_no_parse_issues(tmp_path):
+    _decision(tmp_path, "ok", "RAC-AAAAAAAAAAAA")
+    assert parse_file(str(tmp_path / "ok.md")).parse_issues == []
+
+
+# --- REQ-002: front-matter caps (size, depth, alias bomb) --------------------
+
+
+def test_alias_bomb_is_reported_not_raised():
+    bomb = "a: &x [1, 1, 1, 1]\nb: *x\nc: *x\n"
+    metadata, issues = parse_frontmatter(bomb)
+    assert metadata is None
+    assert [i.code for i in issues] == ["malformed-frontmatter"]
+
+
+def test_billion_laughs_terminates_quickly():
+    # Classic alias-expansion bomb; aliases are forbidden, so it is rejected
+    # immediately instead of expanding.
+    lol = "a: &a [x,x,x,x,x,x,x,x,x]\n" + "".join(
+        f"{c}: [&{c} *{chr(ord(c) - 1)}]\n" for c in "bcdefgh"
+    )
+    start = time.monotonic()
+    metadata, issues = parse_frontmatter(lol)
+    assert time.monotonic() - start < 1.0
+    assert metadata is None and issues
+
+
+def test_deep_nesting_is_reported_not_raised():
+    deep = "k: " + ("[" * 500) + "1" + ("]" * 500) + "\n"
+    metadata, issues = parse_frontmatter(deep)
+    assert metadata is None
+    assert [i.code for i in issues] == ["malformed-frontmatter"]
+
+
+def test_oversize_frontmatter_is_reported():
+    raw = "schema_version: 1\nblob: " + ("a" * (70 << 10)) + "\n"
+    metadata, issues = parse_frontmatter(raw)
+    assert metadata is None
+    assert [i.code for i in issues] == ["malformed-frontmatter"]
+
+
+def test_duplicate_key_rejection_still_works():
+    metadata, issues = parse_frontmatter("schema_version: 1\nschema_version: 2\n")
+    assert metadata is None
+    assert issues[0].code == "duplicate-frontmatter-key"
+
+
+# --- REQ-003: body field caps ------------------------------------------------
+
+
+def test_oversized_field_is_truncated_not_failed(monkeypatch):
+    monkeypatch.setattr(md_mod, "MAX_FIELD_CHARS", 100)
+    text = "# T\n\n## Context\n\n" + "\n".join(f"line {i} " * 5 for i in range(50))
+    product = parse(text)
+    assert any(i.code == "field-truncated" for i in product.parse_issues)
+
+
+def test_total_line_cap_truncates_body(monkeypatch):
+    monkeypatch.setattr(md_mod, "MAX_CAPTURED_LINES", 10)
+    text = "# T\n\n## Context\n\n" + "\n".join(f"x{i}" for i in range(100))
+    product = parse(text)
+    assert any(i.code == "body-truncated" for i in product.parse_issues)
+
+
+# --- REQ-004: regex linearity + query input is never a regex -----------------
+
+_CONTENT_REGEXES = {
+    "_BRACKET_RE": _BRACKET_RE,
+    "_CANONICAL_ID_RE": _CANONICAL_ID_RE,
+    "ID_RE": ID_RE,
+    "_AMBIGUOUS_RE": _AMBIGUOUS_RE,
+    "_NORMATIVE_RE": _NORMATIVE_RE,
+    "_EARS_IF_RE": _EARS_IF_RE,
+    "_THEN_RE": _THEN_RE,
+    "_QUARTER_RE": _QUARTER_RE,
+}
+
+
+def test_content_regexes_are_linear_time():
+    # A pathological string against each content-applied regex must terminate
+    # fast — none uses nested quantifiers or overlapping alternation (REQ-004).
+    adversarial = ("a" * 50_000) + " shall if then Q1 " + ("!" * 50_000)
+    for name, pattern in _CONTENT_REGEXES.items():
+        start = time.monotonic()
+        pattern.search(adversarial)
+        pattern.match(adversarial)
+        assert time.monotonic() - start < 0.5, name
+
+
+def test_query_input_is_matched_literally_not_compiled(tmp_path):
+    # A regex-bomb query must be tokenized and compared literally, never compiled
+    # — so it cannot hang the matcher or raise re.error (REQ-004).
+    _decision(tmp_path, "alpha", "RAC-AAAAAAAAAAAA")
+    start = time.monotonic()
+    result = find_artifacts(str(tmp_path), "(a+)+$" + ("a" * 1000))
+    assert time.monotonic() - start < 1.0
+    assert result.match_count == 0  # no artifact contains those tokens
+
+
+# --- REQ-005: graceful degradation; the walk continues -----------------------
+
+
+def test_walk_continues_past_malformed_and_binary(tmp_path, monkeypatch):
+    from rac.core.corpus import walk_corpus
+
+    monkeypatch.setenv("RAC_MAX_FILE_BYTES", "2048")
+    _decision(tmp_path, "good", "RAC-AAAAAAAAAAAA")
+    (tmp_path / "binary.md").write_bytes(b"\xff\xfe\x00\x01 not utf8 \x80\x81")
+    (tmp_path / "huge.md").write_text("# H\n\n" + ("z " * 4000), encoding="utf-8")
+    entries = list(walk_corpus(str(tmp_path)))  # must not raise
+    assert len(entries) == 3
+    # The good artifact parsed cleanly; the bad ones carry structured issues.
+    by_name = {e.path.name: e for e in entries}
+    assert by_name["good.md"].product.parse_issues == []
+    assert any(i.code == "non-utf8-content" for i in by_name["binary.md"].product.parse_issues)
+    assert any(i.code == "artifact-oversize" for i in by_name["huge.md"].product.parse_issues)
+
+
+def test_get_related_does_not_crash_on_corpus_with_malformed(tmp_path):
+    _decision(tmp_path, "good", "RAC-AAAAAAAAAAAA")
+    (tmp_path / "binary.md").write_bytes(b"\xff\xfe rubbish \x80")
+    payload = _get_related(tmp_path, "RAC-AAAAAAAAAAAA")  # must not raise
+    assert payload["id"] == "RAC-AAAAAAAAAAAA"
+    assert payload["incoming"] == []
+
+
+# --- REQ-006/007/008: bounded, ordered get_related ---------------------------
+
+
+def test_high_fan_out_hub_is_capped_and_marked(tmp_path, monkeypatch):
+    monkeypatch.setattr(rel_mod, "MAX_RELATED_EDGES", 3)
+    _decision(tmp_path, "hub", "RAC-AAAAAAAAAAAA")
+    referrers = 8
+    for i in range(referrers):
+        _requirement(tmp_path, f"ref{i}", f"RAC-{_suffix(i + 1)}", related=["RAC-AAAAAAAAAAAA"])
+    payload = _get_related(tmp_path, "RAC-AAAAAAAAAAAA")
+    assert len(payload["incoming"]) == 3  # capped
+    assert payload["truncated"] is True
+    assert payload["omitted"] == referrers - 3
+    # Ordered by relationship type then ascending id (REQ-006), byte-stable.
+    ids = [e["id"] for e in payload["incoming"]]
+    assert ids == sorted(ids)
+
+
+def test_get_related_byte_identical_on_adversarial_corpus(tmp_path):
+    # A cycle (mutual supersedes), a self-reference attempt, and a small hub.
+    _decision(tmp_path, "one", "RAC-AAAAAAAAAAAA", supersedes="RAC-BBBBBBBBBBBB")
+    _decision(tmp_path, "two", "RAC-BBBBBBBBBBBB", supersedes="RAC-AAAAAAAAAAAA")
+    for i in range(5):
+        _requirement(tmp_path, f"r{i}", f"RAC-{_suffix(i + 1)}", related=["RAC-AAAAAAAAAAAA"])
+    first = _get_related(tmp_path, "RAC-AAAAAAAAAAAA")
+    second = _get_related(tmp_path, "RAC-AAAAAAAAAAAA")
+    assert json.dumps(first, sort_keys=True) == json.dumps(second, sort_keys=True)
+
+
+# --- REQ-009: deterministic fuzz, no network ---------------------------------
+
+
+def test_parser_fuzz_never_raises():
+    rng = random.Random(1337)  # fixed seed -> reproducible from the recorded value
+    alphabet = "abcXYZ-_:[]{}&*#\n \t01é中"
+    for _ in range(300):
+        n = rng.randint(0, 4000)
+        text = "".join(rng.choice(alphabet) for _ in range(n))
+        # Half the cases get a frontmatter-ish leading block.
+        if rng.random() < 0.5:
+            text = (
+                "---\n"
+                + "".join(rng.choice(alphabet) for _ in range(rng.randint(0, 200)))
+                + "\n---\n"
+                + text
+            )
+        product = parse(text)  # must never raise
+        assert product is not None
+        # And the raw frontmatter parser tolerates arbitrary bytes-as-text.
+        parse_frontmatter(text[:2000])
+
+
+def test_parser_fuzz_handles_binary_decoded_text():
+    rng = random.Random(7)
+    for _ in range(100):
+        blob = bytes(rng.randint(0, 255) for _ in range(rng.randint(0, 2000)))
+        parse(blob.decode("utf-8", errors="replace"))  # must never raise


### PR DESCRIPTION
# Summary

Fourth Tier-1 workstream of the v0.23.0 "Hardening" release (`[internal]`), off
`main`. Proves the parser and serving path cannot be crashed, hung, or
OOM'd by adversarial input, and bounds work ahead of the ADR-033 response budget.

Implements `rac/roadmaps/v0.23.x-hardening/v0.23.0-hardening.md` (WS4),
`rac/requirements/rac-parser-traversal-robustness.md`.

Adds:
- Input-size caps (per-file, front matter, body fields) with structured,
  reported degradation instead of exceptions.
- A bounded YAML loader that forbids aliases (kills "billion laughs") and caps
  nesting depth.
- `get_related` ordered by `(relationship type, ascending id)` and bounded by a
  per-call edge cap plus the response budget.
- A deterministic, offline fuzz/property battery.

# Roadmap / ADR Trace

Roadmap: `rac/roadmaps/v0.23.x-hardening/v0.23.0-hardening.md`
Requirement: `rac/requirements/rac-parser-traversal-robustness.md`

Relevant ADRs: ADR-033 (response budget), ADR-032 (stateless re-read),
ADR-055 (acyclic edges), ADR-002/ADR-034 (deterministic, offline),
ADR-007 (additive contract), ADR-059 (single parser instance).

# Scope

## Included
- **REQ-001** per-file byte cap (1 MiB, `RAC_MAX_FILE_BYTES`): `parse_file`
  size-checks then reads at most the cap; `parse` rejects oversize text before
  tokenizing — reported as an `artifact-oversize` issue, never an exception.
- **REQ-002** front matter: a 64 KiB byte cap, a 32-level depth cap, and YAML
  aliases forbidden, all before PyYAML allocates — reported `malformed-frontmatter`.
  Duplicate-key rejection and `SafeLoader` are retained.
- **REQ-003** body fields: per-field char cap and total captured-line cap; an
  oversized field/document is marked truncated, not failed.
- **REQ-004/006/007/008** `get_related`: incoming ordered by relationship type
  then ascending id; incoming/outgoing collection stops at the edge cap (1000)
  and records overflow via the additive `truncated`/`omitted`/`hint` marker;
  output stays budget-bounded and byte-stable. Every content-applied regex is
  enumerated and asserted linear-time; query input stays literal-token-matched,
  never compiled.
- **REQ-005** graceful degradation: a malformed / oversize / non-UTF-8 artifact
  becomes a structured `parse_issue` surfaced by validation and `doctor`; the
  corpus walk, `get_artifact`, `search_artifacts`, and `get_related` continue
  past it.
- **REQ-009** a seeded, pinned-iteration, offline fuzz battery over the parser
  and serving path.

## Excluded
- **REQ-010**: no multi-hop traversal this release — `get_related` stays 1-hop.
- No re-architecture of serving; the response budget is unchanged, work bounds
  are added ahead of it.

# Product / Architecture Decisions

- **Degradation vs. usage error.** During the corpus walk a missing/unreadable/
  non-UTF-8 file degrades gracefully (the walk continues). A *directly named*
  file that is missing or unreadable stays a CLI usage error (exit 2) — the
  check moved to the `_read` single-file seam so the walk and the CLI diverge
  intentionally.
- **`get_related` ordering is now `(type, id)`.** This changes the serialized
  `incoming` order from the prior `(path, section)`; additive-compatible per
  ADR-007 (field shape unchanged, only order), pinned by a contract test.
- **Edge cap bounds memory; budget bounds characters.** Collection stops storing
  after the cap (memory bound) while still counting the total (so `omitted` is
  exact); the kept set is `(type, id)`-ordered and the ADR-033 budget trims its
  tail.
- **`parse_issues` is a new additive Product field** surfaced by `validate`
  alongside `metadata_issues`, so a degraded artifact is reported by `validate`
  and `doctor`.

# User-Facing Contract

Internal release — no new CLI surface. Behavior changes: `get_related` incoming
order; oversize/malformed/non-UTF-8 artifacts reported (not crashed);
`RAC_MAX_FILE_BYTES` env override.

# Verification

## Ran
- `python -m pytest` — full suite, **1516 passed**; `tests/test_robustness.py` —
  18 tests; explorer batteries (166) updated and green.
- `python -m ruff check`, `ruff format --check`, `python -m mypy src/` — clean.
- `rac/` gates: validate (0), relationships --validate (0), review (0),
  doctor (0), watchkeeper (0 regressions); `rac eval --check` still passes
  (incoming reorder is metric-neutral: relevant sets are full neighborhoods).

## Covered
- Oversize file / front matter / field → structured issue, no exception.
- Alias bomb + deep nesting → `malformed-frontmatter`, bounded time, no OOM.
- Every content regex linear-time on a pathological string (enumerated); a
  regex-bomb query is tokenized, never compiled.
- Walk continues past binary + oversize files; `get_related` does not crash on a
  corpus containing a malformed artifact.
- High-fan-out hub capped, marked, `(type, id)`-ordered; `get_related`
  byte-identical across runs on an adversarial corpus (cycle + self-ref + hub).
- Seeded parser fuzz never raises (300 iterations + 100 binary-decoded).

# Review Path

1. `src/rac/core/limits.py` — the caps.
2. `src/rac/core/markdown.py`, `frontmatter.py`, `models.py`, `validation.py`,
   `cli.py` — input bounds + graceful degradation + `parse_issues`.
3. `src/rac/services/relationships.py`, `src/rac/mcp/server.py`,
   `src/rac/services/eval.py` — `get_related` ordering + edge cap.
4. `tests/test_robustness.py`; the updated `get_related` order tests and explorer
   error-recovery tests.

# Notes For Reviewer

- The explorer error-recovery tests now inject a genuine load failure at the
  `load_repository` boundary, because a malformed artifact no longer aborts the
  load (the prior trigger). A new adapter test asserts the graceful path.
- Built off `main` after #154/#155 merged, so its `get_related` change layers
  cleanly on WS2's `evidence` fields.

# Implementation Process

Implemented with AI assistance under the v0.23.0 roadmap contract; final scope,
review, and acceptance decisions are the maintainer's.