### PR TITLE
feat(trust): v0.23.0 WS11 — trust model (SECURITY.md + get_artifact provenance.status)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -105,6 +105,8 @@ jobs:
             paths: "tests/test_doctor.py"
           - name: robustness
             paths: "tests/test_robustness.py"
+          - name: trust
+            paths: "tests/test_trust_model.py"
           - name: revisions
             paths: "tests/test_revisions.py"
           - name: recency

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,75 @@
+# Security Model
+
+This document describes the trust and threat model for **RAC Core** and the
+**Lore** read-only MCP server in this repository. It is scoped to that surface:
+it explains what the read-only guarantee does and does not protect, and how to
+report a vulnerability. It deliberately does **not** promise a vulnerability-
+response SLA, a content sanitizer, or any automated per-artifact trust verdict.
+
+## Trust model
+
+RAC stores product knowledge — requirements, decisions (ADRs), designs,
+roadmaps, and prompts — as Markdown artifacts in a git repository. A coding
+agent reads that content through the Lore MCP tools and treats it as
+authoritative grounding.
+
+**Artifact content is authoritative because a human reviewed and merged it in a
+pull request.** Human PR review is the trust boundary (ADR-065). The read-only
+MCP server protects the *store* — it never writes, never executes artifact
+content, and re-reads from disk on every call — but it does **not** vet the
+*meaning* of what it serves. Content that has not been through PR review —
+an unmerged branch, a local working copy, or anything ingested by a machine
+without human acceptance — is **out of scope and must not be treated as
+trusted**.
+
+What the read-only guarantee protects:
+
+- The serving surface cannot modify, delete, or corrupt the repository.
+- Tool output is deterministic and bounded; adversarial input cannot crash,
+  hang, or exhaust memory in the serving path (it is reported as structured
+  data and the corpus walk continues past it).
+
+What it does **not** protect:
+
+- It makes no judgement about whether an artifact's *content* is correct, safe,
+  or non-malicious. That judgement is the human reviewer's and the consuming
+  agent's.
+
+## Threat: the artifact as an attack surface
+
+A poisoned artifact, or a hostile pull request, can carry text engineered to
+steer the consuming agent away from recorded decisions — for example:
+
+- imperative overrides ("ignore the previous instructions…"),
+- impersonation of system / agent / tool instructions,
+- text that argues the agent should disregard a recorded decision.
+
+Because the agent ingests artifact content as grounding, such text is the
+primary attack surface — not the server.
+
+## Mitigation
+
+**The mitigation is human PR review.** Nothing is merged — and therefore nothing
+becomes trusted grounding — without a human accepting it. Two deterministic,
+offline *aids* support that review; neither is a guarantee and neither is a gate:
+
+- **`rac doctor`** flags instruction-like / injection-style content as a
+  WARNING for a human to look at (owned by the doctor diagnostic). It is a
+  heuristic review aid: it never auto-edits content, never hard-fails a run on
+  its own, and makes no claim that flagged content *is* unsafe — only that a
+  human should review it.
+- **`get_artifact`** surfaces the artifact's reviewed `## Status` under its
+  `provenance` object, so a consumer can distinguish a reviewed `Accepted`
+  decision from a `Proposed` draft. This is a *reported fact*, not a
+  trustworthiness score or a safety verdict.
+
+RAC never sanitizes, rewrites, redacts, or filters artifact content. The
+trust boundary stays human PR review (ADR-065); the aids inform that review,
+they do not replace it.
+
+## Reporting a vulnerability
+
+Report suspected vulnerabilities privately through GitHub's **"Report a
+vulnerability"** flow on this repository's **Security** tab (private security
+advisories). Please do not open a public issue for a security report. This is
+the report channel; it does not carry a response-time commitment.

--- a/rac/requirements/rac-artifact-trust-model.md
+++ b/rac/requirements/rac-artifact-trust-model.md
@@ -8,7 +8,7 @@ tags: [user-facing, security, trust, mcp, grounding]
 
 ## Status
 
-Proposed
+Accepted
 
 Classification: `[user-facing]` — assurance the grounding layer is not an
 injection vector. Scoped to the v0.23.0 hardening release (WS11).
@@ -34,7 +34,7 @@ deterministic signal.
 - [REQ-001] The release MUST document the trust model in `SECURITY.md`: artifact content is authoritative because it passed human PR review; the read-only MCP server protects the store, not the agent; unreviewed or machine-ingested content is out of scope and MUST NOT be treated as trusted (ADR-065). `SECURITY.md` is scoped to RAC Core / the Lore read-only MCP server in this repository; it documents the trust model and the existing report channel, and MUST NOT promise a vulnerability-response SLA, a sanitizer, or any per-artifact trust verdict (ADR-034, ADR-065).
 - [REQ-002] `SECURITY.md` MUST state the threat (a poisoned artifact or hostile PR can attempt to steer the consuming agent — imperative overrides, system/agent/tool impersonation, decision-steering text) and the mitigation (human PR review as the boundary, plus the `rac doctor` injection flag and the `get_artifact` review signal as aids), and MUST state plainly that PR review is the trust boundary and that neither aid is a guarantee or a gate (ADR-065).
 - [REQ-003] The `rac doctor` injection-style-content check is owned by WS3 (`rac-doctor-diagnostic-validator`, REQ-004); this requirement MUST NOT re-specify or duplicate it. WS11 owns only the trust model documentation and the `get_artifact` review signal, and references the doctor flag as the authoring-time aid `SECURITY.md` points to.
-- [REQ-004] `get_artifact` MUST surface a review/trust signal additively and backward-compatibly (ADR-007): a top-level `status` string sourced deterministically from the artifact's `## Status` section as already parsed by Core (no new front-matter field, no PR-API call), so a consumer can distinguish a reviewed-`Accepted` decision from a `Proposed`/draft artifact. The signal MUST be derived from repository bytes plus git only and MUST be byte-identical across repeated calls on an unchanged corpus (ADR-032); when the status cannot be determined the field MUST be present with an explicit empty/unknown value rather than omitted.
+- [REQ-004] `get_artifact` MUST surface a review/trust signal additively and backward-compatibly (ADR-007): a `status` string under a nested `provenance` object (the single object get_artifact's additive fields share; WS5 adds author/date/status-history there), sourced deterministically from the artifact's `## Status` section as already parsed by Core (no new front-matter field, no PR-API call), so a consumer can distinguish a reviewed-`Accepted` decision from a `Proposed`/draft artifact. The signal MUST be derived from repository bytes plus git only and MUST be byte-identical across repeated calls on an unchanged corpus (ADR-032); when the status cannot be determined the field MUST be present with an explicit empty/unknown value rather than omitted.
 - [REQ-005] The review signal is a reported fact, not a verdict: `get_artifact` MUST NOT compute or return a "trustworthiness" score, a pass/fail trust judgement, or any per-artifact safety verdict (ADR-034). It surfaces status (and, where WS5 provenance lands, the author/reviewer facts) and leaves the trust judgement to the human reviewer and the consuming agent.
 - [REQ-006] Nothing in this release may auto-edit, sanitize, rewrite, or filter artifact content; the trust boundary remains human PR review and the read-only surface stays byte-stable (ADR-065, ADR-032).
 
@@ -43,7 +43,7 @@ deterministic signal.
 - The trust model is documented in `SECURITY.md`, within the scope of REQ-001,
   and states plainly that PR review is the boundary and the doctor flag and
   review signal are aids, not guarantees.
-- `get_artifact` exposes a top-level `status` field, verified by a test, as an
+- `get_artifact` exposes a `provenance.status` field (nested under `provenance`), verified by a test, as an
   additive backward-compatible field that is byte-identical across repeated
   calls on an unchanged corpus and present-but-empty when status is
   indeterminate.

--- a/rac/roadmaps/v0.23.x-hardening/v0.23.0-hardening.md
+++ b/rac/roadmaps/v0.23.x-hardening/v0.23.0-hardening.md
@@ -113,7 +113,7 @@ Tier 1:
 - [x] WS2 explainable-retrieval — `evidence` + `--explain` — `done`
 - [x] WS3 doctor-diagnostic-validator — `rac doctor` — `done`
 - [x] WS4 parser-traversal-robustness — caps + fuzz + bounded output — `done`
-- [ ] WS11 artifact-trust-model — `SECURITY.md` + injection flag + review signal — `planned`
+- [x] WS11 artifact-trust-model — `SECURITY.md` + injection flag + review signal — `done`
 
 Tier 2 (obey-demo is the non-cuttable success anchor; cut WS10 → WS6 first):
 

--- a/src/rac/mcp/server.py
+++ b/src/rac/mcp/server.py
@@ -50,6 +50,7 @@ from mcp.server.fastmcp import FastMCP
 
 from rac import consent as consent_record
 from rac.core.corpus import walk_corpus
+from rac.core.markdown import parse
 from rac.mcp import errors, ping, telemetry
 from rac.mcp.budget import (
     DEFAULT_BUDGET,
@@ -60,6 +61,7 @@ from rac.mcp.budget import (
     serialize,
 )
 from rac.mcp.telemetry import TelemetryRecorder
+from rac.services.agent_rules import artifact_status
 from rac.services.index import build_repository_index, index_from_corpus
 from rac.services.portfolio import build_portfolio_summary
 from rac.services.relationships import (
@@ -166,6 +168,12 @@ def _get_artifact(root: str, artifact_id: str, budget: int) -> str:
         "schema_version": "1",
         **result.artifact.to_dict(),
         "content": content,
+        # Trust signal (WS11, ADR-065): the artifact's reviewed ``## Status``,
+        # nested under ``provenance`` — the one object get_artifact's additive
+        # fields share (WS5 adds author/date/status-history here later). It is a
+        # reported fact sourced from repository bytes, never a trust verdict
+        # (ADR-034); present-but-empty when the artifact declares no status.
+        "provenance": {"status": artifact_status(parse(content))},
     }
     return serialize(payload, budget)
 

--- a/src/rac/services/agent_rules.py
+++ b/src/rac/services/agent_rules.py
@@ -156,13 +156,23 @@ class AgentRulesProjection:
         }
 
 
-def _first_status_line(product: Product) -> str:
-    """First non-empty line of ``## Status``, casefolded (empty when absent)."""
+def artifact_status(product: Product) -> str:
+    """First non-empty line of ``## Status``, as stored (empty when absent).
+
+    The artifact's review/lifecycle signal exactly as authored — case preserved,
+    so a consumer sees ``Accepted`` rather than ``accepted`` (WS11 trust signal).
+    The casefolded liveness predicates build on this, so there is one reader of
+    the status line.
+    """
     body = product.sections.get("status")
     if not body:
         return ""
-    first = next((line.strip() for line in body.splitlines() if line.strip()), "")
-    return first.casefold()
+    return next((line.strip() for line in body.splitlines() if line.strip()), "")
+
+
+def _first_status_line(product: Product) -> str:
+    """First non-empty line of ``## Status``, casefolded (empty when absent)."""
+    return artifact_status(product).casefold()
 
 
 def _category(product: Product) -> str | None:

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -52,7 +52,17 @@ def call(root: str, tool: str, args: dict, budget: int = DEFAULT_BUDGET) -> dict
 
 def test_get_artifact_resolved_shape():
     payload = call(CORPUS, "get_artifact", {"id": DEC})
-    assert list(payload) == ["schema_version", "id", "type", "title", "path", "content"]
+    # WS11: additive nested `provenance` carrying the reviewed status signal.
+    assert list(payload) == [
+        "schema_version",
+        "id",
+        "type",
+        "title",
+        "path",
+        "content",
+        "provenance",
+    ]
+    assert payload["provenance"] == {"status": "Accepted"}
     assert payload["schema_version"] == "1"
     assert payload["id"] == DEC
     assert payload["type"] == "decision"

--- a/tests/test_trust_model.py
+++ b/tests/test_trust_model.py
@@ -1,0 +1,112 @@
+"""Trust-model battery (v0.23.0, WS11).
+
+Covers the two things WS11 owns: the SECURITY.md trust narrative and the
+additive `get_artifact` review signal (`provenance.status`). The injection-style
+content flag itself is owned and exercised by WS3 (`test_doctor.py`), not here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+from rac.mcp.server import build_server
+
+SECURITY_MD = Path(__file__).parent.parent / "SECURITY.md"
+
+DECISION = (
+    "---\nschema_version: 1\nid: {id}\ntype: decision\n---\n# {title}\n\n"
+    "{status}## Context\n\nWhy.\n\n## Decision\n\nDo it.\n\n## Consequences\n\nFine.\n"
+)
+
+
+def _decision(root: Path, name: str, aid: str, *, status: str | None) -> None:
+    block = f"## Status\n\n{status}\n\n" if status is not None else ""
+    (root / f"{name}.md").write_text(
+        DECISION.format(id=aid, title=name, status=block), encoding="utf-8"
+    )
+
+
+def _get_artifact(root: Path, artifact_id: str) -> dict:
+    server = build_server(str(root))
+    contents, _ = asyncio.run(server.call_tool("get_artifact", {"id": artifact_id}))
+    return json.loads(contents[0].text)
+
+
+# --- SECURITY.md trust narrative (REQ-001, REQ-002) --------------------------
+
+
+def test_security_md_exists():
+    assert SECURITY_MD.is_file()
+
+
+def test_security_md_names_pr_review_as_the_boundary():
+    text = SECURITY_MD.read_text(encoding="utf-8")
+    assert "human PR review" in text
+    assert "trust boundary" in text
+
+
+def test_security_md_states_threat_and_aids_are_not_guarantees():
+    text = SECURITY_MD.read_text(encoding="utf-8").lower()
+    # The threat: steering the consuming agent.
+    assert "steer" in text and ("injection" in text or "poisoned" in text)
+    # The aids are named and explicitly not guarantees / not gates.
+    assert "rac doctor" in text and "get_artifact" in text
+    assert "neither is a guarantee" in text and "neither is a gate" in text
+
+
+def test_security_md_makes_no_sla_or_sanitizer_promise():
+    text = SECURITY_MD.read_text(encoding="utf-8").lower()
+    # It must explicitly disclaim an SLA and a sanitizer, never promise them.
+    assert "does not" in text and "sla" in text
+    assert "sanitiz" in text  # mentioned only to disclaim it
+
+
+# --- get_artifact review signal (REQ-004, REQ-005, REQ-006) ------------------
+
+
+def test_provenance_status_reports_reviewed_status(tmp_path):
+    _decision(tmp_path, "accepted", "RAC-AAAAAAAAAAAA", status="Accepted")
+    payload = _get_artifact(tmp_path, "RAC-AAAAAAAAAAAA")
+    assert payload["provenance"] == {"status": "Accepted"}
+
+
+def test_provenance_status_present_but_empty_when_indeterminate(tmp_path):
+    # A decision with no ## Status section: the field is present and empty,
+    # never omitted (REQ-004).
+    _decision(tmp_path, "draft", "RAC-BBBBBBBBBBBB", status=None)
+    payload = _get_artifact(tmp_path, "RAC-BBBBBBBBBBBB")
+    assert payload["provenance"] == {"status": ""}
+
+
+def test_provenance_status_preserves_authored_case(tmp_path):
+    _decision(tmp_path, "proposed", "RAC-CCCCCCCCCCCC", status="Proposed")
+    payload = _get_artifact(tmp_path, "RAC-CCCCCCCCCCCC")
+    assert payload["provenance"]["status"] == "Proposed"
+
+
+def test_get_artifact_is_byte_identical_across_calls(tmp_path):
+    _decision(tmp_path, "accepted", "RAC-AAAAAAAAAAAA", status="Accepted")
+    server = build_server(str(tmp_path))
+    first = asyncio.run(server.call_tool("get_artifact", {"id": "RAC-AAAAAAAAAAAA"}))[0][0].text
+    second = asyncio.run(server.call_tool("get_artifact", {"id": "RAC-AAAAAAAAAAAA"}))[0][0].text
+    assert first == second
+
+
+def test_content_is_served_verbatim_not_mutated(tmp_path):
+    # Read-only: the served content is the file's bytes exactly, with no
+    # sanitization or rewrite (REQ-006).
+    _decision(tmp_path, "accepted", "RAC-AAAAAAAAAAAA", status="Accepted")
+    payload = _get_artifact(tmp_path, "RAC-AAAAAAAAAAAA")
+    assert payload["content"] == (tmp_path / "accepted.md").read_text(encoding="utf-8")
+
+
+def test_provenance_carries_no_trust_verdict(tmp_path):
+    # The signal is reported status only — never a score or pass/fail verdict
+    # (REQ-005, ADR-034).
+    _decision(tmp_path, "accepted", "RAC-AAAAAAAAAAAA", status="Accepted")
+    payload = _get_artifact(tmp_path, "RAC-AAAAAAAAAAAA")
+    assert set(payload["provenance"]) == {"status"}
+    for forbidden in ("score", "trust", "trusted", "safe", "verdict", "rating"):
+        assert forbidden not in payload["provenance"]


### PR DESCRIPTION
# Summary

Fifth and final Tier-1 workstream of the v0.23.0 "Hardening" release, off `main`
(which now carries WS1–WS4). Names the trust model and gives a consumer one
deterministic signal to tell a reviewed decision from an unreviewed draft.

Implements `rac/roadmaps/v0.23.x-hardening/v0.23.0-hardening.md` (WS11),
`rac/requirements/rac-artifact-trust-model.md`.

Adds:
- `SECURITY.md` documenting the trust model, the threat, and the mitigation.
- `provenance.status` on `get_artifact` — the artifact's reviewed `## Status`,
  nested under a single `provenance` object.

# Roadmap / ADR Trace

Roadmap: `rac/roadmaps/v0.23.x-hardening/v0.23.0-hardening.md`
Requirement: `rac/requirements/rac-artifact-trust-model.md`

Relevant ADRs: ADR-065 (artifact content untrusted; trust boundary is human PR
review), ADR-030 (read-only MCP, additive output), ADR-032 (stateless re-read,
byte-stable), ADR-034 (no trust verdict / score).

# Scope

## Included
- **REQ-001/002** `SECURITY.md`: artifact content is authoritative because it
  passed human PR review; the read-only server protects the store, not the
  agent; unreviewed/machine-ingested content is out of scope. Names the threat
  (a poisoned artifact / hostile PR steering the agent) and the mitigation
  (human PR review, with `rac doctor`'s injection flag and the `get_artifact`
  status signal as aids — explicitly neither a guarantee nor a gate). Promises
  no SLA, sanitizer, or per-artifact verdict.
- **REQ-004** `get_artifact` surfaces `provenance.status` — the `## Status` line
  as parsed by Core, additive and backward-compatible, deterministic and
  byte-identical across calls, present-but-empty when no status is declared.
- **REQ-005/006** The signal is a reported fact, not a verdict; nothing
  sanitizes, rewrites, or filters content — content is served verbatim.

## Excluded (owned elsewhere / descoped)
- The `rac doctor` injection check is owned and exercised by WS3 — referenced
  here, not duplicated (REQ-003).
- The author/date/status-history provenance fields are WS5 (Tier 2); WS11 adds
  only `provenance.status`, and the nested `provenance` object is the shared home
  WS5 extends.
- No fifth MCP tool, no write capability, no PR-API plumbing, no trust score.

# Product / Architecture Decisions

- **Nested `provenance`, not a flat top-level field.** Per the recorded decision
  that `get_artifact`'s additive fields share one `provenance` object, the signal
  is `provenance.status`. REQ-004 (which originally said "top-level") is
  reconciled additively to match — the MUST, determinism, and present-but-empty
  constraints are unchanged; only the placement is made more specific
  (watchkeeper: 0 regressions).
- **One reader of the status line.** A new case-preserving `artifact_status`
  helper is the single source; the casefolded liveness predicates build on it,
  so the trust signal and `find_decisions`/agent-rules can never disagree.
- **Status, never a verdict.** `provenance` carries only `status`; a test asserts
  no score/trust/safe/verdict key ever appears (ADR-034).

# User-Facing Contract

## MCP / JSON
`get_artifact` output gains a trailing `"provenance": {"status": "Accepted"}`
(empty string when the artifact declares no `## Status`). All existing keys keep
their names, types, and order. No CLI surface change; the MCP surface stays the
five read-only tools.

# Verification

## Ran
- `python -m pytest` — full suite, **1526 passed**; `tests/test_trust_model.py`
  — 10 tests.
- `python -m ruff check`, `ruff format --check`, `python -m mypy src/` — clean.
- `rac/` gates: validate (0), relationships --validate (0), review (0),
  doctor (0), **watchkeeper (0 regressions on the REQ-004 rewording)**.

## Covered
- SECURITY.md names PR review as the boundary, states the threat, names both
  aids as non-guarantees, and disclaims an SLA/sanitizer.
- `provenance.status` reports the reviewed status, preserves authored case, is
  present-but-empty when indeterminate, is byte-identical across calls, serves
  content verbatim, and carries no trust verdict.
- `get_artifact` shape contract updated for the additive `provenance` object.

# Review Path

1. `SECURITY.md` — the trust narrative.
2. `src/rac/mcp/server.py` (`_get_artifact`) + `src/rac/services/agent_rules.py`
   (`artifact_status`) — the signal.
3. `tests/test_trust_model.py` and the updated `get_artifact` shape test.
4. `rac/requirements/rac-artifact-trust-model.md` — the additive REQ-004
   reconciliation.

# Notes For Reviewer

- This completes Tier 1 (WS1 #153, WS2 #154, WS3 #155, WS4 #156 all merged; WS11
  here). The Tier-2 success anchor (the obey-demo) and the rest of Tier 2 remain.
- The injection heuristic SECURITY.md points to already lives on `main` (WS3);
  WS11 only references it.