### PR TITLE
feat(mcp): v0.23.0 WS5 — provenance surfacing on get_artifact

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -110,7 +110,7 @@ jobs:
           - name: revisions
             paths: "tests/test_revisions.py"
           - name: recency
-            paths: "tests/test_recency.py"
+            paths: "tests/test_recency.py tests/test_provenance.py"
           - name: skill
             paths: "tests/test_skill.py"
           - name: hook

--- a/rac/requirements/rac-provenance-surfacing.md
+++ b/rac/requirements/rac-provenance-surfacing.md
@@ -8,10 +8,15 @@ tags: [user-facing, provenance, git, mcp]
 
 ## Status
 
-Proposed
+Accepted
 
 Classification: `[user-facing]` — the agent can cite who decided and when.
-Scoped to the v0.23.0 hardening release (WS5).
+Scoped to the v0.23.0 hardening release (WS5). Implemented on the existing
+`provenance` object: WS5 keeps the WS11 `status` field as the present-status
+signal and adds the five git-derived fields beside it (`last_committed`,
+`last_author`, `first_committed`, `first_author`, `status_history`), reconciled
+additively from the original `current_status` wording to stay backward-compatible
+(ADR-007).
 
 ## Problem
 
@@ -25,10 +30,10 @@ type); the rest exists in git history. None of it is on the tool surface.
 
 ## Requirements
 
-- [REQ-001] `get_artifact` MUST expose, additively and backward-compatibly, at minimum: author(s) plus last-commit author, relevant dates, and status history (Proposed → Accepted → Superseded), sourced from front matter plus git. It does so by gaining one additive `provenance` object on its JSON payload; the existing keys are unchanged and the object is *added*, never reshaped (ADR-007). It carries exactly these fields: `current_status` (string — present lifecycle status, sourced from parsed front-matter-section metadata (`metadata["status"]`), not git; `null` when the type declares no status enum or the section is absent); `last_committed` (ISO-8601 timezone-aware string, or `null` — the most recent commit time for the file, from git (ADR-045), reusing `recency.py` `_last_committed`); `last_author` (string `Name <email>`, or `null` — the author of that most recent commit, same `git log -1` record); `first_committed` / `first_author` (ISO-8601 string and `Name <email>`, or `null` — the creation commit, reusing `recency.py` `_first_committed`, the accountable original author); and `status_history` (ordered list of `{status, committed, author}` entries, or an empty list, derived from git by reading the `## Status` value at each commit that changed it; see REQ-003).
+- [REQ-001] `get_artifact` MUST expose, additively and backward-compatibly, at minimum: author(s) plus last-commit author, relevant dates, and status history (Proposed → Accepted → Superseded), sourced from front matter plus git. It does so through the additive `provenance` object on its JSON payload; the existing top-level keys are unchanged and the `provenance` object — introduced by WS11 — gains fields, never has its existing keys reshaped or removed (ADR-007). For the present lifecycle status it reuses the field WS11 already ships on this object — `status` (string — the reviewed `## Status`, sourced from parsed front-matter-section metadata (`metadata["status"]`), not git; present-but-empty (`""`), never omitted, when the section is absent) — rather than adding a renamed or duplicate `current_status`, so the object stays backward-compatible. It then adds these git-derived fields: `last_committed` (ISO-8601 timezone-aware string, or `null` — the most recent commit time for the file, from git (ADR-045), reusing `recency.py` `_last_committed`); `last_author` (string `Name <email>`, or `null` — the author of that most recent commit, same `git log -1` record); `first_committed` / `first_author` (ISO-8601 string and `Name <email>`, or `null` — the creation commit, reusing `recency.py` `_first_committed`, the accountable original author); and `status_history` (ordered list of `{status, committed, author}` entries, or an empty list, derived from git by reading the `## Status` value at each commit that changed it; see REQ-003).
 - [REQ-002] Provenance MUST be derived from git rather than stored dates in front matter (ADR-045); a `reviewers` front-matter field MAY be used to power the WS11 review signal. Concretely, provenance dates and authorship MUST be derived from git, never from stored front-matter dates (ADR-045); no front-matter field is added and `schema_version` is not bumped. Status *value* is read from parsed metadata, not git; only its *history* is reconstructed from git. The `reviewers` front-matter field is the seam the future WS11 review signal MAY use, recorded here only to reserve the name; it is not introduced this release.
 - [REQ-003] `status_history` MUST be derived deterministically and offline by walking the file's git history (e.g. `git log --reverse` plus reading the `## Status` section at each revision) and emitting one entry each time the parsed status value changes, oldest first. Reuse the `recency.py`/`revisions.py` git boundary (ADR-043); WS5 MUST NOT add a third git touchpoint or import a git library (ADR-045 alternatives).
-- [REQ-004] All git-sourced fields MUST degrade to `null` (or, for `status_history`, an empty list) — never raise — when git is unavailable: outside a repository, in a shallow clone where the relevant commits are absent, or for an untracked or uncommitted file. `current_status` still populates from metadata in every case, so an artifact in a non-git directory still reports its status. No exception crosses the service boundary (ADR-045).
+- [REQ-004] All git-sourced fields MUST degrade to `null` (or, for `status_history`, an empty list) — never raise — when git is unavailable: outside a repository, in a shallow clone where the relevant commits are absent, or for an untracked or uncommitted file. The present `status` still populates from metadata in every case, so an artifact in a non-git directory still reports its status. No exception crosses the service boundary (ADR-045).
 - [REQ-005] Provenance fields SHOULD be surfaced in search/explain output where useful, but `get_artifact` is the only required surface this release.
 - [REQ-006] Full PR-reviewer extraction — squash-merge attribution, review-thread mining, any GitHub PR-API plumbing — is explicitly out of scope for v0.23.0. Provenance is git-and-metadata only; no network call, no key, no fifth tool.
 

--- a/rac/roadmaps/v0.23.x-hardening/v0.23.0-hardening.md
+++ b/rac/roadmaps/v0.23.x-hardening/v0.23.0-hardening.md
@@ -119,7 +119,7 @@ Tier 2 (obey-demo is the non-cuttable success anchor; cut WS10 → WS6 first):
 
 - [ ] obey-demo-grounding-proof — recorded manual demo (success anchor, not a gate) — `planned`
 - [ ] WS6 single-schema-agreement — cross-consumer agreement test — `planned`
-- [ ] WS5 provenance-surfacing — author/date/status-history on `get_artifact` — `planned`
+- [x] WS5 provenance-surfacing — author/date/status-history on `get_artifact` — `done`
 - [ ] WS8 idempotent-content-hash-processing — short-circuit + byte-stability — `planned`
 - [ ] WS10 honest-changelog-tiered-tests — tiers + CHANGELOG + tag — `planned`
 

--- a/src/rac/mcp/server.py
+++ b/src/rac/mcp/server.py
@@ -64,6 +64,7 @@ from rac.mcp.telemetry import TelemetryRecorder
 from rac.services.agent_rules import artifact_status
 from rac.services.index import build_repository_index, index_from_corpus
 from rac.services.portfolio import build_portfolio_summary
+from rac.services.recency import artifact_provenance
 from rac.services.relationships import (
     incoming_references,
     outgoing_references,
@@ -168,12 +169,17 @@ def _get_artifact(root: str, artifact_id: str, budget: int) -> str:
         "schema_version": "1",
         **result.artifact.to_dict(),
         "content": content,
-        # Trust signal (WS11, ADR-065): the artifact's reviewed ``## Status``,
-        # nested under ``provenance`` — the one object get_artifact's additive
-        # fields share (WS5 adds author/date/status-history here later). It is a
-        # reported fact sourced from repository bytes, never a trust verdict
-        # (ADR-034); present-but-empty when the artifact declares no status.
-        "provenance": {"status": artifact_status(parse(content))},
+        # Provenance (WS11 + WS5, ADR-065/ADR-045): the one additive object
+        # get_artifact's review/accountability fields share. ``status`` is the
+        # reviewed ``## Status`` from parsed bytes (WS11 trust signal,
+        # present-but-empty when none); the rest is git-derived authorship and
+        # the reconstructed status history (WS5), each ``null``/``[]`` when git
+        # cannot answer. All reported facts sourced from the repository, never a
+        # trust verdict or score (ADR-034).
+        "provenance": {
+            "status": artifact_status(parse(content)),
+            **artifact_provenance(root, result.artifact.path).to_dict(),
+        },
     }
     return serialize(payload, budget)
 

--- a/src/rac/services/recency.py
+++ b/src/rac/services/recency.py
@@ -19,11 +19,18 @@ cadence nudge, v0.13.3) stay inside ADR-017.
 from __future__ import annotations
 
 import subprocess
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 
+from rac.core.markdown import parse
+from rac.services.agent_rules import artifact_status
 from rac.services.index import build_repository_index
+
+# Field separator for combined ``git log --format`` records. The unit-separator
+# control byte never appears in a commit date, author name, or email, so a
+# single ``--format`` call can carry several fields and be split unambiguously.
+_FIELD_SEP = "\x1f"
 
 
 def _run_git(args: list[str], cwd: str) -> subprocess.CompletedProcess[str] | None:
@@ -183,3 +190,135 @@ def artifact_recency(
             )
         )
     return RecencyReport(directory=directory, recursive=recursive, artifacts=artifacts)
+
+
+# --- Provenance (v0.23.0, WS5, ADR-045) --------------------------------------
+#
+# get_artifact surfaces who decided and when. Authorship and dates are *derived*
+# from git, never stored in front matter (ADR-045), through this same narrow git
+# touchpoint — WS5 adds no third git module and imports no git library (REQ-003).
+# Every git read degrades to ``None`` / ``[]`` rather than raising when git is
+# unavailable, the directory is not a repository, or the file is untracked
+# (REQ-004); the current status still comes from parsed metadata regardless.
+
+
+def _commit_record(
+    repo_root: str, path: str, *, earliest: bool
+) -> tuple[datetime | None, str | None]:
+    """``(commit time, "Name <email>")`` for one boundary commit touching ``path``.
+
+    ``earliest`` selects the creation commit (``git log --reverse``, first line);
+    otherwise the most recent change (``git log -1``). One ``--format`` call
+    carries both fields. Returns ``(None, None)`` when git does not know.
+    """
+    fmt = f"--format=%cI{_FIELD_SEP}%an <%ae>"
+    args = ["log", "--reverse", fmt] if earliest else ["log", "-1", fmt]
+    args += ["--", _pathspec(repo_root, path)]
+    result = _run_git(args, cwd=repo_root)
+    if result is None or result.returncode != 0:
+        return None, None
+    for line in result.stdout.splitlines():
+        if line.strip():
+            stamp, _, author = line.partition(_FIELD_SEP)
+            return _parse_stamp(stamp), (author.strip() or None)
+    return None, None
+
+
+def _status_history(repo_root: str, path: str) -> list[StatusChange]:
+    """The artifact's ``## Status`` value at each commit that changed it, oldest first.
+
+    Walks the file's history once (``git log --reverse``), then reads the parsed
+    status at each revision (``git show <rev>:<path>``), emitting one entry every
+    time the value changes from the previous one (REQ-003). Absent / empty status
+    is the baseline and yields no entry, so the history is the meaningful
+    lifecycle (e.g. ``Proposed`` → ``Accepted``). O(commits touching the file);
+    a missing or unreadable revision is skipped, never raised.
+    """
+    pathspec = _pathspec(repo_root, path)
+    walk = _run_git(
+        ["log", "--reverse", f"--format=%H{_FIELD_SEP}%cI{_FIELD_SEP}%an <%ae>", "--", pathspec],
+        cwd=repo_root,
+    )
+    if walk is None or walk.returncode != 0:
+        return []
+    history: list[StatusChange] = []
+    last_status = ""
+    for line in walk.stdout.splitlines():
+        if not line.strip():
+            continue
+        sha, stamp, author = line.split(_FIELD_SEP, 2)
+        shown = _run_git(["show", f"{sha}:{pathspec}"], cwd=repo_root)
+        if shown is None or shown.returncode != 0:
+            continue
+        status = artifact_status(parse(shown.stdout))
+        if status and status != last_status:
+            history.append(
+                StatusChange(
+                    status=status, committed=_parse_stamp(stamp), author=author.strip() or None
+                )
+            )
+            last_status = status
+    return history
+
+
+@dataclass
+class StatusChange:
+    """One lifecycle transition reconstructed from git: when the parsed
+    ``## Status`` value changed, and the author of the commit that changed it."""
+
+    status: str
+    committed: datetime | None
+    author: str | None
+
+    def to_dict(self) -> dict:
+        return {
+            "status": self.status,
+            "committed": self.committed.isoformat() if self.committed else None,
+            "author": self.author,
+        }
+
+
+@dataclass
+class ArtifactProvenance:
+    """One artifact's git-derived provenance: creation and last-change
+    author/time plus the reconstructed status history. Every field is ``None``
+    / ``[]`` when git cannot answer (ADR-045); the *current* status is sourced
+    from parsed metadata by the caller, not from git, so it is not carried here."""
+
+    last_committed: datetime | None = None
+    last_author: str | None = None
+    first_committed: datetime | None = None
+    first_author: str | None = None
+    status_history: list[StatusChange] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "last_committed": self.last_committed.isoformat() if self.last_committed else None,
+            "last_author": self.last_author,
+            "first_committed": self.first_committed.isoformat() if self.first_committed else None,
+            "first_author": self.first_author,
+            "status_history": [change.to_dict() for change in self.status_history],
+        }
+
+
+def artifact_provenance(directory: str, path: str) -> ArtifactProvenance:
+    """Git-derived provenance for one artifact at ``path`` within ``directory``.
+
+    Reuses the recency git boundary (no new touchpoint, no git library; REQ-003)
+    and never raises: outside a repository, in a shallow clone missing the
+    commits, or for an untracked file, every field degrades to ``None`` / ``[]``
+    (REQ-004). The current lifecycle status is read from parsed metadata by the
+    caller and is deliberately not part of this git-only object.
+    """
+    repo_root = _repository_root(directory)
+    if repo_root is None:
+        return ArtifactProvenance()
+    last_committed, last_author = _commit_record(repo_root, path, earliest=False)
+    first_committed, first_author = _commit_record(repo_root, path, earliest=True)
+    return ArtifactProvenance(
+        last_committed=last_committed,
+        last_author=last_author,
+        first_committed=first_committed,
+        first_author=first_author,
+        status_history=_status_history(repo_root, path),
+    )

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -52,7 +52,9 @@ def call(root: str, tool: str, args: dict, budget: int = DEFAULT_BUDGET) -> dict
 
 def test_get_artifact_resolved_shape():
     payload = call(CORPUS, "get_artifact", {"id": DEC})
-    # WS11: additive nested `provenance` carrying the reviewed status signal.
+    # WS11 + WS5: additive nested `provenance` — the reviewed status signal
+    # (WS11) plus git-derived authorship/dates and status history (WS5). The
+    # top-level keys are unchanged from before WS5 (purely additive, ADR-007).
     assert list(payload) == [
         "schema_version",
         "id",
@@ -62,7 +64,21 @@ def test_get_artifact_resolved_shape():
         "content",
         "provenance",
     ]
-    assert payload["provenance"] == {"status": "Accepted"}
+    prov = payload["provenance"]
+    assert set(prov) == {
+        "status",
+        "last_committed",
+        "last_author",
+        "first_committed",
+        "first_author",
+        "status_history",
+    }
+    assert prov["status"] == "Accepted"
+    # The fixture is git-tracked, so the git fields populate from its real
+    # history; pin their shape (string-or-null, list), never the volatile values.
+    assert isinstance(prov["status_history"], list)
+    for git_field in ("last_committed", "last_author", "first_committed", "first_author"):
+        assert prov[git_field] is None or isinstance(prov[git_field], str)
     assert payload["schema_version"] == "1"
     assert payload["id"] == DEC
     assert payload["type"] == "decision"

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -1,0 +1,216 @@
+"""Provenance battery (v0.23.0, WS5).
+
+`get_artifact` surfaces who decided and when, derived from git rather than from
+stored front-matter dates (ADR-045). These tests pin the git-derived fields
+against a throwaway repository with known commits, prove they degrade to
+``null``/``[]`` when git cannot answer (REQ-004), and prove the addition is
+purely additive over the WS11 `provenance` object (REQ-001, ADR-007).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import subprocess
+from datetime import datetime
+from pathlib import Path
+
+from rac.mcp.server import build_server
+from rac.services.recency import artifact_provenance
+
+DECISION = (
+    "---\nschema_version: 1\nid: {id}\ntype: decision\n---\n# {title}\n\n"
+    "## Status\n\n{status}\n\n## Context\n\nWhy.\n\n## Decision\n\nDo it.\n\n"
+    "## Consequences\n\nFine.\n"
+)
+
+# Two distinct authors and fixed commit times, so every git-derived field is
+# deterministic and assertable.
+AUTHOR_A = ("Ada Lovelace", "ada@example.com")
+AUTHOR_B = ("Grace Hopper", "grace@example.com")
+DATE_A = "2026-01-02T03:04:05+00:00"
+DATE_B = "2026-03-04T05:06:07+00:00"
+
+
+def _write_decision(path: Path, aid: str, *, status: str) -> None:
+    path.write_text(DECISION.format(id=aid, title=path.stem, status=status), encoding="utf-8")
+
+
+def _git(
+    args: list[str], cwd: Path, *, author: tuple[str, str] | None = None, date: str | None = None
+) -> None:
+    env = dict(os.environ)
+    if author is not None:
+        env["GIT_AUTHOR_NAME"], env["GIT_AUTHOR_EMAIL"] = author
+        env["GIT_COMMITTER_NAME"], env["GIT_COMMITTER_EMAIL"] = author
+    if date is not None:
+        env["GIT_AUTHOR_DATE"] = date
+        env["GIT_COMMITTER_DATE"] = date
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, text=True, env=env)
+
+
+def _commit(repo: Path, message: str, *, author: tuple[str, str], date: str) -> None:
+    _git(["add", "-A"], repo)
+    _git(["commit", "-m", message], repo, author=author, date=date)
+
+
+def _get_artifact(root: Path, artifact_id: str) -> dict:
+    server = build_server(str(root))
+    contents, _ = asyncio.run(server.call_tool("get_artifact", {"id": artifact_id}))
+    return json.loads(contents[0].text)
+
+
+def _expected_author(author: tuple[str, str]) -> str:
+    return f"{author[0]} <{author[1]}>"
+
+
+# --- git-derived fields against known commits (REQ-001, REQ-003) -------------
+
+
+def test_provenance_fields_match_known_commits(tmp_path):
+    _git(["init"], tmp_path)
+    decision = tmp_path / "event-bus.md"
+
+    _write_decision(decision, "RAC-PR0VENANCE01", status="Proposed")
+    _commit(tmp_path, "add decision (proposed)", author=AUTHOR_A, date=DATE_A)
+
+    _write_decision(decision, "RAC-PR0VENANCE01", status="Accepted")
+    _commit(tmp_path, "accept decision", author=AUTHOR_B, date=DATE_B)
+
+    prov = artifact_provenance(str(tmp_path), str(decision))
+
+    # Creation commit is author A at DATE_A; the last change is author B at DATE_B.
+    assert prov.first_author == _expected_author(AUTHOR_A)
+    assert prov.first_committed == datetime.fromisoformat(DATE_A)
+    assert prov.last_author == _expected_author(AUTHOR_B)
+    assert prov.last_committed == datetime.fromisoformat(DATE_B)
+
+    # status_history records one entry per change, oldest first.
+    assert [c.status for c in prov.status_history] == ["Proposed", "Accepted"]
+    assert [c.author for c in prov.status_history] == [
+        _expected_author(AUTHOR_A),
+        _expected_author(AUTHOR_B),
+    ]
+    assert [c.committed for c in prov.status_history] == [
+        datetime.fromisoformat(DATE_A),
+        datetime.fromisoformat(DATE_B),
+    ]
+
+
+def test_status_history_emits_only_on_change(tmp_path):
+    # A commit that does not change the status value adds no history entry.
+    _git(["init"], tmp_path)
+    decision = tmp_path / "stable.md"
+
+    _write_decision(decision, "RAC-PR0VENANCE02", status="Accepted")
+    _commit(tmp_path, "add decision", author=AUTHOR_A, date=DATE_A)
+
+    # Body edit, status unchanged.
+    decision.write_text(
+        DECISION.format(id="RAC-PR0VENANCE02", title="stable", status="Accepted").replace(
+            "Do it.", "Do it carefully."
+        ),
+        encoding="utf-8",
+    )
+    _commit(tmp_path, "expand decision body", author=AUTHOR_B, date=DATE_B)
+
+    prov = artifact_provenance(str(tmp_path), str(decision))
+    assert [c.status for c in prov.status_history] == ["Accepted"]
+    # The body edit still moves last-change authorship.
+    assert prov.first_author == _expected_author(AUTHOR_A)
+    assert prov.last_author == _expected_author(AUTHOR_B)
+
+
+# --- graceful degradation when git cannot answer (REQ-004) -------------------
+
+
+def test_provenance_degrades_outside_repository(tmp_path):
+    # tmp_path is not a git work tree: every git-derived field is null/empty.
+    decision = tmp_path / "orphan.md"
+    _write_decision(decision, "RAC-PR0VENANCE03", status="Accepted")
+
+    prov = artifact_provenance(str(tmp_path), str(decision))
+    assert prov.last_committed is None
+    assert prov.last_author is None
+    assert prov.first_committed is None
+    assert prov.first_author is None
+    assert prov.status_history == []
+
+
+def test_provenance_degrades_for_untracked_file(tmp_path):
+    # git is available and the directory is a repo, but the file was never
+    # committed (the shallow-clone / uncommitted case): fields still degrade.
+    _git(["init"], tmp_path)
+    decision = tmp_path / "uncommitted.md"
+    _write_decision(decision, "RAC-PR0VENANCE04", status="Accepted")
+
+    prov = artifact_provenance(str(tmp_path), str(decision))
+    assert prov.last_committed is None
+    assert prov.first_committed is None
+    assert prov.status_history == []
+
+
+# --- get_artifact surface: additive, status always populates (REQ-001/004) ---
+
+
+def test_get_artifact_status_populates_without_git(tmp_path):
+    # Outside a repo the current status still comes from parsed metadata, while
+    # the git-derived fields are null/empty (REQ-004).
+    decision = tmp_path / "accepted.md"
+    _write_decision(decision, "RAC-PR0VENANCE05", status="Accepted")
+
+    prov = _get_artifact(tmp_path, "RAC-PR0VENANCE05")["provenance"]
+    assert prov["status"] == "Accepted"
+    assert prov["last_committed"] is None
+    assert prov["last_author"] is None
+    assert prov["first_committed"] is None
+    assert prov["first_author"] is None
+    assert prov["status_history"] == []
+
+
+def test_get_artifact_provenance_is_purely_additive(tmp_path):
+    # The top-level keys are unchanged from before WS5; provenance keeps the
+    # WS11 `status` key and gains exactly the five git-derived fields (ADR-007).
+    decision = tmp_path / "accepted.md"
+    _write_decision(decision, "RAC-PR0VENANCE06", status="Accepted")
+
+    payload = _get_artifact(tmp_path, "RAC-PR0VENANCE06")
+    assert list(payload) == [
+        "schema_version",
+        "id",
+        "type",
+        "title",
+        "path",
+        "content",
+        "provenance",
+    ]
+    assert set(payload["provenance"]) == {
+        "status",
+        "last_committed",
+        "last_author",
+        "first_committed",
+        "first_author",
+        "status_history",
+    }
+
+
+def test_get_artifact_with_git_history_is_byte_identical_across_calls(tmp_path):
+    # Determinism (ADR-032): a committed artifact's get_artifact output, git
+    # provenance included, is byte-identical on repeated reads of an unchanged
+    # repository.
+    _git(["init"], tmp_path)
+    decision = tmp_path / "event-bus.md"
+    _write_decision(decision, "RAC-PR0VENANCE07", status="Proposed")
+    _commit(tmp_path, "add decision", author=AUTHOR_A, date=DATE_A)
+    _write_decision(decision, "RAC-PR0VENANCE07", status="Accepted")
+    _commit(tmp_path, "accept decision", author=AUTHOR_B, date=DATE_B)
+
+    server = build_server(str(tmp_path))
+    first = asyncio.run(server.call_tool("get_artifact", {"id": "RAC-PR0VENANCE07"}))[0][0].text
+    second = asyncio.run(server.call_tool("get_artifact", {"id": "RAC-PR0VENANCE07"}))[0][0].text
+    assert first == second
+    prov = json.loads(first)["provenance"]
+    assert prov["status"] == "Accepted"
+    assert prov["last_author"] == _expected_author(AUTHOR_B)
+    assert [c["status"] for c in prov["status_history"]] == ["Proposed", "Accepted"]

--- a/tests/test_trust_model.py
+++ b/tests/test_trust_model.py
@@ -69,7 +69,11 @@ def test_security_md_makes_no_sla_or_sanitizer_promise():
 def test_provenance_status_reports_reviewed_status(tmp_path):
     _decision(tmp_path, "accepted", "RAC-AAAAAAAAAAAA", status="Accepted")
     payload = _get_artifact(tmp_path, "RAC-AAAAAAAAAAAA")
-    assert payload["provenance"] == {"status": "Accepted"}
+    # The reviewed status is reported (WS11). WS5's git fields share the object
+    # but degrade to null/[] here, because tmp_path is not a git repository.
+    assert payload["provenance"]["status"] == "Accepted"
+    assert payload["provenance"]["last_committed"] is None
+    assert payload["provenance"]["status_history"] == []
 
 
 def test_provenance_status_present_but_empty_when_indeterminate(tmp_path):
@@ -77,7 +81,7 @@ def test_provenance_status_present_but_empty_when_indeterminate(tmp_path):
     # never omitted (REQ-004).
     _decision(tmp_path, "draft", "RAC-BBBBBBBBBBBB", status=None)
     payload = _get_artifact(tmp_path, "RAC-BBBBBBBBBBBB")
-    assert payload["provenance"] == {"status": ""}
+    assert payload["provenance"]["status"] == ""
 
 
 def test_provenance_status_preserves_authored_case(tmp_path):
@@ -103,10 +107,18 @@ def test_content_is_served_verbatim_not_mutated(tmp_path):
 
 
 def test_provenance_carries_no_trust_verdict(tmp_path):
-    # The signal is reported status only — never a score or pass/fail verdict
+    # The object carries reported facts only — reviewed status (WS11) plus
+    # git-derived authorship/history (WS5) — never a score or pass/fail verdict
     # (REQ-005, ADR-034).
     _decision(tmp_path, "accepted", "RAC-AAAAAAAAAAAA", status="Accepted")
     payload = _get_artifact(tmp_path, "RAC-AAAAAAAAAAAA")
-    assert set(payload["provenance"]) == {"status"}
+    assert set(payload["provenance"]) == {
+        "status",
+        "last_committed",
+        "last_author",
+        "first_committed",
+        "first_author",
+        "status_history",
+    }
     for forbidden in ("score", "trust", "trusted", "safe", "verdict", "rating"):
         assert forbidden not in payload["provenance"]


### PR DESCRIPTION
# Summary

First Tier-2 workstream of the v0.23.0 "Hardening" release, off `main` (which
now carries all of Tier 1). An agent grounding on a decision can now cite who
made it, when, and how its status moved — sourced from git, with no AI and no
network.

Implements `rac/roadmaps/v0.23.x-hardening/v0.23.0-hardening.md` (WS5),
`rac/requirements/rac-provenance-surfacing.md`.

Extends the `get_artifact` `provenance` object (introduced by WS11) with five
additive git-derived fields beside the existing reviewed `status`:

- `last_committed` / `last_author` — the most recent commit touching the file
- `first_committed` / `first_author` — the creation commit (the accountable
  original author)
- `status_history` — the parsed `## Status` value at each commit that changed
  it, oldest first, one `{status, committed, author}` entry per change

# Roadmap / ADR Trace

Roadmap: `rac/roadmaps/v0.23.x-hardening/v0.23.0-hardening.md`
Requirement: `rac/requirements/rac-provenance-surfacing.md`

Relevant ADRs: ADR-045 (recency derived from git, never stored dates), ADR-007
(additive, backward-compatible output), ADR-032 (stateless re-read, byte-stable),
ADR-034 (reported facts, never a trust verdict/score), ADR-043 (the single git
boundary).

# Product / Architecture Decisions

- **Reuse the WS11 `status` field, do not rename or duplicate.** WS11 already
  ships `provenance.status` (public on `main`). Removing it would break
  backward-compat (ADR-007), and a duplicate `current_status` would be a
  redundant key. So the present-status field stays `status`; WS5 adds only the
  five git fields. REQ-001 (which originally said `current_status`) is reconciled
  additively to match — the MUST and determinism constraints are unchanged
  (watchkeeper: 0 regressions).
- **No third git touchpoint.** Authorship, dates, and status-history
  reconstruction all run through the existing `recency.py` git boundary
  (ADR-043/ADR-045) — no new git module, no git library (REQ-003). One history
  walk per artifact (`git log --reverse`), then the parsed `## Status` is read at
  each revision; `status_history` emits one entry per change.
- **Status from metadata, history from git.** The *current* `status` is read
  from parsed front-matter-section metadata (the single status reader,
  `artifact_status`); only its *history* is reconstructed from git.
- **Graceful, never raising.** Outside a repository, in a shallow clone missing
  the commits, or for an untracked file, every git field degrades to `null` /
  `[]`. The present `status` still populates from metadata in every case
  (REQ-004).

# User-Facing Contract

## MCP / JSON
`get_artifact` `provenance` gains `last_committed`, `last_author`,
`first_committed`, `first_author` (ISO-8601 strings / author-and-email strings,
or `null`) and `status_history` (ordered list, possibly empty). All existing
top-level keys and the WS11 `provenance.status` key keep their names, types, and
placement. No CLI surface change; the MCP surface stays the five read-only tools.

# Scope

## Included
- **REQ-001/002/003** the five git-derived provenance fields and the
  status-history reconstruction, through the recency boundary.
- **REQ-004** graceful degradation to `null`/`[]` when git cannot answer; the
  present `status` always populates from metadata.

## Excluded (owned elsewhere / descoped)
- **REQ-005** surfacing provenance in search/explain output is a SHOULD;
  `get_artifact` is the only required surface this release — kept minimal.
- **REQ-006** PR-reviewer extraction / GitHub PR-API plumbing — out of scope; no
  network, no key, no fifth tool. The `reviewers` front-matter field name is
  reserved only, not introduced.

# Verification

## Ran
- `python -m pytest` — full suite, **1533 passed**; new provenance battery — 7
  tests.
- `python -m ruff check`, `ruff format --check`, `python -m mypy src/` — clean.
- `rac/` gates: validate (0 invalid), relationships --validate (0), review
  (no Priority 1–2), **watchkeeper (Broken 0 → 0 on the REQ-001 reconciliation)**.

## Covered
- Git fields match known commits/authors in a throwaway repo; `status_history`
  is `Proposed → Accepted` with matching authors/dates and emits only on change.
- Every git field degrades to `null`/`[]` outside a repo and for an untracked
  file; the present `status` still reports from metadata.
- `get_artifact` output is byte-identical across calls with git history present;
  the addition is purely additive over the WS11 object.

# Review Path

1. `src/rac/services/recency.py` — `artifact_provenance` and the
   `_commit_record` / `_status_history` git reads (the boundary extension).
2. `src/rac/mcp/server.py` (`_get_artifact`) — merging the git fields onto the
   WS11 `provenance` object.
3. `tests/test_provenance.py` — the new battery.
4. `rac/requirements/rac-provenance-surfacing.md` — the additive REQ-001
   reconciliation.

# Notes For Reviewer

- This is the first of the Tier-2 workstreams (WS6, WS8, the obey-demo success
  anchor, and WS10 to follow, each as its own PR). Tier 1 (WS1–WS4, WS11) is all
  merged on `main`.
- The provenance read adds per-call git work to `get_artifact`; it stays
  stateless and re-reads per call (ADR-032) — no cache. WS8's content-hash
  short-circuit is CLI-only and deliberately never touches the serving path.