### PR TITLE
test(schema): v0.23.0 WS6 — single-schema cross-consumer agreement

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,7 +56,7 @@ jobs:
         # enforced by tests/test_ci_batteries.py in the core battery.
         battery:
           - name: core
-            paths: "tests/test_validate.py tests/test_validate_corpus_stdin.py tests/test_okf_conformance.py tests/test_overrides.py tests/test_requirement_standards.py tests/test_sarif.py tests/test_parser.py tests/test_schema.py tests/test_identity.py tests/test_frontmatter.py tests/test_metadata_identity.py tests/test_idgen.py tests/test_ci_batteries.py tests/test_corpus.py tests/test_operations.py tests/test_sdk_surface.py tests/test_sbom.py"
+            paths: "tests/test_validate.py tests/test_validate_corpus_stdin.py tests/test_okf_conformance.py tests/test_overrides.py tests/test_requirement_standards.py tests/test_sarif.py tests/test_parser.py tests/test_schema.py tests/test_schema_agreement.py tests/test_identity.py tests/test_frontmatter.py tests/test_metadata_identity.py tests/test_idgen.py tests/test_ci_batteries.py tests/test_corpus.py tests/test_operations.py tests/test_sdk_surface.py tests/test_sbom.py"
           - name: cli
             paths: "tests/test_cli.py"
           - name: compare

--- a/rac/requirements/rac-single-schema-agreement.md
+++ b/rac/requirements/rac-single-schema-agreement.md
@@ -8,9 +8,15 @@ tags: [internal, schema, contract, mcp, tui]
 
 ## Status
 
-Proposed
+Accepted
 
 Classification: `[internal]`. Scoped to the v0.23.0 hardening release (WS6).
+Delivered as a single pure-Python agreement test (`tests/test_schema_agreement.py`)
+in the core battery; the consumers (validator `spec_for`, the classifier
+`score_artifacts`, the portfolio type tally, the relationship vocabulary, and the
+TUI `schema_reference`/`available_schemas`) were already deriving from the single
+sources, so no ad-hoc schema logic needed folding back (REQ-005 satisfied with no
+source change).
 
 ## Problem
 

--- a/rac/roadmaps/v0.23.x-hardening/v0.23.0-hardening.md
+++ b/rac/roadmaps/v0.23.x-hardening/v0.23.0-hardening.md
@@ -118,7 +118,7 @@ Tier 1:
 Tier 2 (obey-demo is the non-cuttable success anchor; cut WS10 → WS6 first):
 
 - [ ] obey-demo-grounding-proof — recorded manual demo (success anchor, not a gate) — `planned`
-- [ ] WS6 single-schema-agreement — cross-consumer agreement test — `planned`
+- [x] WS6 single-schema-agreement — cross-consumer agreement test — `done`
 - [x] WS5 provenance-surfacing — author/date/status-history on `get_artifact` — `done`
 - [ ] WS8 idempotent-content-hash-processing — short-circuit + byte-stability — `planned`
 - [ ] WS10 honest-changelog-tiered-tests — tiers + CHANGELOG + tag — `planned`

--- a/tests/test_schema_agreement.py
+++ b/tests/test_schema_agreement.py
@@ -1,0 +1,212 @@
+"""Single-schema cross-consumer agreement (v0.23.0, WS6).
+
+The artifact schema is defined once in code (ADR-052, ADR-049): the front-matter
+*envelope* (`_SUPPORTED_FIELDS` in `core/frontmatter.py`, `ArtifactMetadata` in
+`core/metadata.py`) and the per-type *structure* (`ARTIFACT_SPECS` in
+`core/artifacts.py`), with the relationship-kind vocabulary in
+`RELATIONSHIP_SECTIONS` (`services/relationships.py`).
+
+Four code paths consume that schema and must never drift from it:
+
+- the **validator** — `spec_for`;
+- the **four MCP serializers** — `get_artifact` / `search_artifacts` /
+  `get_related` report a `type` produced by the classifier (`score_artifacts`),
+  `get_summary` enumerates types via `build_portfolio_summary`, and `get_related`
+  keys relationships by `RELATIONSHIP_SECTIONS`;
+- the **TUI adapter** — `available_schemas` / `schema_reference`.
+
+These tests assert each consumer derives its artifact types, status enums,
+relationship kinds, and section sets from those single sources — *membership*,
+not value formatting (REQ-003) — and fail loudly, naming the consumer and the
+diverging field, when one drifts (REQ-004). They introduce no parallel schema
+framework and depend on no fixture corpus (REQ-001/004).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from rac.core.artifacts import ARTIFACT_SPECS, spec_for
+from rac.core.classification import score_artifacts
+from rac.core.frontmatter import _SUPPORTED_FIELDS
+from rac.core.markdown import parse
+from rac.core.metadata import ArtifactMetadata
+from rac.core.schema import available_schemas, schema_reference
+from rac.services.portfolio import build_portfolio_summary
+from rac.services.relationships import RELATED_SECTIONS, RELATIONSHIP_SECTIONS
+
+# --- single sources of truth -------------------------------------------------
+
+TYPES = frozenset(spec.name for spec in ARTIFACT_SPECS)
+
+
+def _sections(spec) -> set[str]:
+    return {*spec.required, *spec.recommended, *spec.optional}
+
+
+def _status_enum(spec) -> tuple[str, ...]:
+    return spec.metadata.get("status", ())
+
+
+def _agree(consumer: str, dimension: str, got, want) -> None:
+    """Assert ``consumer``'s view of ``dimension`` matches the single source.
+
+    Fails loudly with a diagnostic naming the consumer and exactly which members
+    it invented (present in the consumer, absent from the source) or dropped
+    (declared by the source, missing from the consumer) — REQ-004.
+    """
+    got, want = set(got), set(want)
+    invented, dropped = got - want, want - got
+    assert not invented and not dropped, (
+        f"consumer {consumer!r} drifted from the single schema source on "
+        f"{dimension}: invented={sorted(invented)} dropped={sorted(dropped)}"
+    )
+
+
+# --- artifact types ----------------------------------------------------------
+
+
+def test_artifact_types_agree_across_consumers(tmp_path):
+    # Validator: spec_for resolves exactly the source types and nothing else.
+    resolved = {spec.name for spec in ARTIFACT_SPECS if spec_for(spec.name) is not None}
+    _agree("validate.spec_for", "artifact types", resolved, TYPES)
+    assert spec_for("not-a-type") is None
+    assert spec_for("") is None
+
+    # TUI adapter: the explorer's schema list is whatever available_schemas() returns.
+    _agree("explorer.available_schemas", "artifact types", available_schemas(), TYPES)
+
+    # MCP get_artifact / search_artifacts / get_related: every `type` they report
+    # comes from the classifier, whose candidate vocabulary is score_artifacts'
+    # per-spec names (plus the out-of-band "unknown" for non-artifacts).
+    candidates = {score.name for score in score_artifacts(parse(""))}
+    _agree("mcp.classify", "artifact types", candidates, TYPES)
+
+    # MCP get_summary: the portfolio seeds its by-type tally from the source
+    # (plus "unknown"); an empty directory exposes the vocabulary with no corpus.
+    summary = build_portfolio_summary(str(tmp_path), recursive=True)
+    _agree("mcp.get_summary", "artifact types", set(summary.by_type) - {"unknown"}, TYPES)
+
+
+# --- status enums ------------------------------------------------------------
+
+
+def test_status_enums_agree_across_consumers():
+    for spec in ARTIFACT_SPECS:
+        ref = schema_reference(spec.name)
+        assert ref is not None, spec.name
+        # TUI: the schema reference exposes the same status enum the spec declares.
+        _agree(
+            f"explorer.schema_reference[{spec.name}]",
+            "status enum",
+            ref.metadata.get("status", []),
+            _status_enum(spec),
+        )
+        # Source self-consistency (ADR-051): retired statuses are a subset of the
+        # declared status enum — a retired value outside the enum is undetectable.
+        assert set(spec.retired_status) <= set(_status_enum(spec)), (
+            f"{spec.name}: retired_status {spec.retired_status} not within "
+            f"status enum {_status_enum(spec)}"
+        )
+
+
+# --- relationship kinds ------------------------------------------------------
+
+
+def test_relationship_kinds_agree_across_consumers():
+    # The vocabulary is RELATED_SECTIONS (the per-type "related X" kinds) plus the
+    # standalone "supersedes"; get_related keys its `outgoing` object by it.
+    assert RELATIONSHIP_SECTIONS == RELATED_SECTIONS + ("supersedes",)
+
+    # No spec invents a relationship section outside the vocabulary, and none of
+    # the vocabulary is orphaned: the relationship sections appearing across the
+    # specs are exactly RELATIONSHIP_SECTIONS.
+    spec_relationship_sections = {
+        section
+        for spec in ARTIFACT_SPECS
+        for section in _sections(spec)
+        if section in RELATIONSHIP_SECTIONS
+    }
+    _agree(
+        "artifacts.ARTIFACT_SPECS",
+        "relationship kinds",
+        spec_relationship_sections,
+        RELATIONSHIP_SECTIONS,
+    )
+
+    # Each artifact type has a matching "related <type>s" kind, tying the
+    # relationship vocabulary to the type vocabulary: adding a type without its
+    # relationship section (or vice versa) breaks this.
+    _agree(
+        "relationships.RELATED_SECTIONS",
+        "per-type relationship kinds",
+        RELATED_SECTIONS,
+        {f"related {spec.name}s" for spec in ARTIFACT_SPECS},
+    )
+
+
+# --- required / recommended / optional sections ------------------------------
+
+
+def test_section_sets_agree_across_consumers():
+    for spec in ARTIFACT_SPECS:
+        ref = schema_reference(spec.name)
+        assert ref is not None, spec.name
+        # TUI: the schema reference's section sets match the spec's, membership-wise.
+        _agree(
+            f"explorer.schema_reference[{spec.name}]",
+            "required sections",
+            ref.required,
+            spec.required,
+        )
+        _agree(
+            f"explorer.schema_reference[{spec.name}]",
+            "recommended sections",
+            ref.recommended,
+            spec.recommended,
+        )
+        _agree(
+            f"explorer.schema_reference[{spec.name}]",
+            "optional sections",
+            ref.optional,
+            spec.optional,
+        )
+        # Source self-consistency: required / recommended / optional are disjoint,
+        # so a section never lands in two buckets for one type.
+        total = len(spec.required) + len(spec.recommended) + len(spec.optional)
+        assert total == len(_sections(spec)), f"{spec.name}: overlapping section buckets"
+
+
+# --- front-matter envelope ---------------------------------------------------
+
+
+def test_envelope_fields_agree():
+    # The parser's accepted front-matter fields and the typed envelope agree.
+    # `provenance` is a derived internal marker (source vs ingested), not a
+    # front-matter field; every other envelope field is a supported field.
+    metadata_fields = {f.name for f in dataclasses.fields(ArtifactMetadata)}
+    _agree(
+        "frontmatter._SUPPORTED_FIELDS",
+        "envelope fields",
+        metadata_fields - {"provenance"},
+        set(_SUPPORTED_FIELDS),
+    )
+
+
+# --- the gate itself fires (REQ-004) -----------------------------------------
+
+
+def test_drift_is_detected_with_consumer_named_diagnostic():
+    # An invented member (consumer adds a type the source never declared).
+    with pytest.raises(AssertionError) as invented:
+        _agree("explorer.available_schemas", "artifact types", TYPES | {"invented_type"}, TYPES)
+    assert "explorer.available_schemas" in str(invented.value)
+    assert "invented_type" in str(invented.value)
+
+    # A dropped member (consumer silently omits a type the source declares).
+    with pytest.raises(AssertionError) as dropped:
+        _agree("validate.spec_for", "artifact types", TYPES - {"design"}, TYPES)
+    assert "validate.spec_for" in str(dropped.value)
+    assert "design" in str(dropped.value)


### PR DESCRIPTION
# Summary

Tier-2 internal workstream of the v0.23.0 "Hardening" release, off `main`. Closes
the one gap in RAC's single-source schema story: the schema is already defined
once in code, but nothing *asserted* that its consumers still agree with it, so
drift would be silent. WS6 adds one cross-consumer agreement test and nothing
else — no Pydantic, no JSON-Schema source of truth, no rewrite, no new dependency.

Implements `rac/roadmaps/v0.23.x-hardening/v0.23.0-hardening.md` (WS6),
`rac/requirements/rac-single-schema-agreement.md`.

# Roadmap / ADR Trace

Roadmap: `rac/roadmaps/v0.23.x-hardening/v0.23.0-hardening.md`
Requirement: `rac/requirements/rac-single-schema-agreement.md`

Relevant ADRs: ADR-052 / ADR-049 (the schema is defined once, in code, as the
front-matter envelope plus the per-type specs), ADR-007 (additive output detail
the test does not police).

# What it asserts

The artifact schema has two code-owned sources: the front-matter **envelope**
(`_SUPPORTED_FIELDS` in `core/frontmatter.py`, `ArtifactMetadata` in
`core/metadata.py`) and the per-type **structure** (`ARTIFACT_SPECS` in
`core/artifacts.py`), with the relationship-kind vocabulary in
`RELATIONSHIP_SECTIONS` (`services/relationships.py`).

`tests/test_schema_agreement.py` asserts each consumer derives from those sources
— membership, not value formatting (REQ-003):

- **Artifact types** — the validator (`spec_for`), the classifier behind
  `get_artifact`/`search_artifacts`/`get_related` (`score_artifacts`),
  `get_summary` (the portfolio by-type tally), and the TUI (`available_schemas`)
  all enumerate exactly the `ARTIFACT_SPECS` types.
- **Status enums** — the TUI `schema_reference` exposes each type's declared
  status enum; `retired_status` is a subset of it (ADR-051 self-consistency).
- **Relationship kinds** — `RELATIONSHIP_SECTIONS` = the per-type "related X"
  kinds plus `supersedes`; every kind is claimed by a spec and none is invented,
  and each type has a matching per-type "related" kind (tying the relationship
  vocabulary to the type vocabulary).
- **Section sets** — `schema_reference`'s required/recommended/optional match the
  spec's, and the three buckets are disjoint per type.
- **Envelope fields** — `ArtifactMetadata`'s fields (minus the derived
  `provenance` marker) equal `_SUPPORTED_FIELDS`.

A drift-detection test feeds a deliberately drifted set through the comparison
helper and asserts it fails loudly, naming both the consumer and the diverging
field, for an invented member and a dropped member (REQ-004).

# Scope

## Included
- **REQ-001** the schema stays defined once in code; no parallel framework, no
  new dependency.
- **REQ-002/003** one agreement test over the validator, the four MCP
  serializers, and the TUI adapter; membership of types / statuses / relationship
  kinds / section sets.
- **REQ-004** loud, deterministic, consumer-named drift failure; a pure-Python
  unit test in the core battery, no network, no AI, no fixture corpus.

## Out of scope / findings
- **REQ-005** any residual ad-hoc schema logic SHOULD be folded into the sources.
  None was found — the validator, classifier, portfolio, relationship vocabulary,
  and TUI all already derive from the single sources — so the test is purely
  additive with **no source change**.
- Whether to extend coverage to the fifth tool (`find_decisions`) is left as the
  open maintainer decision the requirement names; this test stays on the four
  contract serializers.

# Verification

## Ran
- `python -m pytest` — full suite, **1532 passed**; the agreement battery — 6
  tests (5 dimensions + the drift-detection test).
- `python -m ruff check`, `ruff format --check`, `python -m mypy src/` — clean.
- `rac/` gates: validate (0 invalid), relationships --validate (0), review (no
  Priority 1–2), watchkeeper (Broken 0 → 0).

# Review Path

1. `tests/test_schema_agreement.py` — the agreement test (the whole change).
2. `.github/workflows/tests.yml` — registered in the `core` battery.
3. `rac/requirements/rac-single-schema-agreement.md` — flipped to Accepted with
   the REQ-005 "nothing to fold" finding noted.

# Notes For Reviewer

- Second Tier-2 PR. WS5 (#158) is open in parallel; this branch is off `main` and
  ticks only its own roadmap line (the WS5 tick rides #158). WS8, the obey-demo
  success anchor, and WS10 follow.
- The test depends on no corpus and adds no markers — it introspects the source
  modules and each consumer's pure derivation functions directly.