### PR TITLE
feat(core): v0.23.0 WS8 — idempotent content-hash corpus short-circuit

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -105,6 +105,8 @@ jobs:
             paths: "tests/test_doctor.py"
           - name: robustness
             paths: "tests/test_robustness.py"
+          - name: idempotent
+            paths: "tests/test_idempotent.py"
           - name: trust
             paths: "tests/test_trust_model.py"
           - name: revisions

--- a/rac/requirements/rac-idempotent-content-hash-processing.md
+++ b/rac/requirements/rac-idempotent-content-hash-processing.md
@@ -8,10 +8,18 @@ tags: [internal, performance, determinism, hashing]
 
 ## Status
 
-Proposed
+Accepted
 
 Classification: `[internal]`. Scoped to the v0.23.0 hardening release (WS8,
-core only).
+core only). Implemented as `CorpusCache` on the `collect_corpus` seam
+(`core/corpus.py`): a per-invocation, in-memory, content-hash-keyed snapshot
+reuse, with `content_hash` over full on-disk source bytes. `rac doctor` — the
+multi-phase command — shares one cache across its validation, relationship, and
+degree/injection passes, so each artifact is parsed once per run; the additive
+`cache` parameter on `validate_directory` / `validate_relationships` is the seam
+it threads through. The MCP serving path is deliberately untouched and re-reads
+per call (REQ-004); single-phase commands (`rac validate`, `rac eval`) gain the
+parameter but see no within-run reuse, which is correct.
 
 ## Problem
 

--- a/rac/roadmaps/v0.23.x-hardening/v0.23.0-hardening.md
+++ b/rac/roadmaps/v0.23.x-hardening/v0.23.0-hardening.md
@@ -120,7 +120,7 @@ Tier 2 (obey-demo is the non-cuttable success anchor; cut WS10 → WS6 first):
 - [ ] obey-demo-grounding-proof — recorded manual demo (success anchor, not a gate) — `planned`
 - [x] WS6 single-schema-agreement — cross-consumer agreement test — `done`
 - [x] WS5 provenance-surfacing — author/date/status-history on `get_artifact` — `done`
-- [ ] WS8 idempotent-content-hash-processing — short-circuit + byte-stability — `planned`
+- [x] WS8 idempotent-content-hash-processing — short-circuit + byte-stability — `done`
 - [ ] WS10 honest-changelog-tiered-tests — tiers + CHANGELOG + tag — `planned`
 
 ## Success Measures

--- a/src/rac/core/corpus.py
+++ b/src/rac/core/corpus.py
@@ -15,6 +15,7 @@ errors keep bubbling to the caller, matching the loops this replaces.
 
 from __future__ import annotations
 
+import hashlib
 from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
@@ -75,3 +76,67 @@ def collect_corpus(
         if on_progress is not None:
             on_progress(Progress(phase="scan", completed=completed, total=total))
     return entries
+
+
+def content_hash(path: Path) -> str:
+    """SHA-256 of an artifact's full on-disk source bytes (front matter + body).
+
+    Source content only — never derived output, never mtime (WS8, REQ-002) — so
+    any edit (whitespace or front-matter included) changes the digest and forces
+    a reprocess, while touching a file without changing its bytes does not. An
+    unreadable file hashes to a stable sentinel rather than raising, so the walk
+    continues past it (the next read decides whether it changed).
+    """
+    try:
+        return hashlib.sha256(path.read_bytes()).hexdigest()
+    except OSError:
+        return hashlib.sha256(b"\x00rac-unreadable-artifact").hexdigest()
+
+
+class CorpusCache:
+    """Per-invocation, content-hash-keyed corpus snapshot reuse (v0.23.0, WS8).
+
+    Within ONE CLI invocation several phases each want the parsed corpus — the
+    doctor pass runs validation, relationship integrity, and its own degree /
+    injection checks, each of which would otherwise re-walk and re-parse every
+    artifact. This cache hashes each artifact's on-disk source bytes through the
+    ``collect_corpus`` seam ADR-032 names and, when a later phase requests an
+    artifact whose hash is unchanged from an earlier phase of the same run,
+    returns the already-parsed :class:`CorpusEntry` instead of reparsing it
+    (REQ-001).
+
+    It is in-memory and invocation-scoped: it persists no state to disk and
+    survives no process boundary (REQ-001), and it is deliberately NOT used by
+    the MCP serving path, which re-reads from disk on every tool call (ADR-032,
+    REQ-004). Because identical source bytes always reparse to the same
+    ``Product``, reusing an entry yields byte-identical derived output to
+    reprocessing it (REQ-003); ``reprocessed`` / ``reused`` are exposed only so
+    tests can prove the short-circuit fires.
+    """
+
+    def __init__(self) -> None:
+        self._by_path: dict[Path, tuple[str, CorpusEntry]] = {}
+        self.reprocessed = 0
+        self.reused = 0
+
+    def collect(self, directory: str, *, recursive: bool = True) -> list[CorpusEntry]:
+        """Return the corpus snapshot, reparsing only artifacts whose bytes changed.
+
+        Deterministic and order-stable: files arrive in ``find_markdown_files``
+        order, exactly as :func:`walk_corpus`. Every call still reads each file to
+        hash it (cheap); only the parse + classify is short-circuited.
+        """
+        entries: list[CorpusEntry] = []
+        for path in find_markdown_files(directory, recursive=recursive):
+            digest = content_hash(path)
+            cached = self._by_path.get(path)
+            if cached is not None and cached[0] == digest:
+                self.reused += 1
+                entries.append(cached[1])
+                continue
+            product = parse_file(str(path))
+            entry = CorpusEntry(path=path, product=product, classification=classify(product))
+            self._by_path[path] = (digest, entry)
+            self.reprocessed += 1
+            entries.append(entry)
+        return entries

--- a/src/rac/services/doctor.py
+++ b/src/rac/services/doctor.py
@@ -35,7 +35,7 @@ from pathlib import Path
 from typing import Any
 
 from rac.core.artifacts import spec_for
-from rac.core.corpus import CorpusEntry, walk_corpus
+from rac.core.corpus import CorpusCache, CorpusEntry
 from rac.services.relationships import (
     ISSUE_DUPLICATE_IDENTIFIER,
     ISSUE_RELATIONSHIP_CYCLE,
@@ -165,11 +165,19 @@ class DoctorReport:
 def diagnose(
     directory: str, recursive: bool = True, hub_threshold: int = DEFAULT_HUB_THRESHOLD
 ) -> DoctorReport:
-    """Run validation, relationship integrity, and the two new checks in one pass."""
-    entries = list(walk_corpus(directory, recursive=recursive))
+    """Run validation, relationship integrity, and the two new checks in one pass.
+
+    All four phases share one per-invocation :class:`CorpusCache` (WS8), so each
+    artifact is parsed once for the whole run rather than re-parsed by the
+    validation, relationship, and degree/injection phases independently. The
+    short-circuit is a performance path only — the report is byte-identical to a
+    full reprocess (REQ-003).
+    """
+    cache = CorpusCache()
+    entries = cache.collect(directory, recursive=recursive)
     findings: list[DoctorFinding] = []
-    findings.extend(_validation_findings(directory, recursive))
-    findings.extend(_relationship_findings(directory, recursive))
+    findings.extend(_validation_findings(directory, recursive, cache))
+    findings.extend(_relationship_findings(directory, recursive, cache))
     findings.extend(_degree_findings(entries, hub_threshold))
     findings.extend(_injection_findings(entries))
     # Deterministic order: errors before warnings, then path, code, problem.
@@ -177,13 +185,15 @@ def diagnose(
     return DoctorReport(directory=directory, hub_threshold=hub_threshold, findings=findings)
 
 
-def _validation_findings(directory: str, recursive: bool) -> list[DoctorFinding]:
+def _validation_findings(
+    directory: str, recursive: bool, cache: CorpusCache | None = None
+) -> list[DoctorFinding]:
     """One finding per structurally invalid artifact, reusing the validator.
 
     The validator owns the defect detail; doctor surfaces the verdict and points
     at `rac validate <path>` for the full report (REQ-001, REQ-003).
     """
-    result = validate_directory(directory, recursive=recursive)
+    result = validate_directory(directory, recursive=recursive, cache=cache)
     findings: list[DoctorFinding] = []
     for file in result.files:
         if file.status != STATUS_INVALID:
@@ -202,14 +212,16 @@ def _validation_findings(directory: str, recursive: bool) -> list[DoctorFinding]
     return findings
 
 
-def _relationship_findings(directory: str, recursive: bool) -> list[DoctorFinding]:
+def _relationship_findings(
+    directory: str, recursive: bool, cache: CorpusCache | None = None
+) -> list[DoctorFinding]:
     """One finding per relationship-integrity issue, reusing the engine.
 
     Cycles, duplicate ids, broken / ambiguous / type-mismatch / retired / self
     references all come from `relationships --validate` (REQ-002, REQ-004);
     intrinsic severity is the recorded source of truth (`RELATIONSHIP_SEVERITY`).
     """
-    result = validate_relationships(directory, recursive=recursive)
+    result = validate_relationships(directory, recursive=recursive, cache=cache)
     findings: list[DoctorFinding] = []
     for issue in result.issues:
         findings.append(

--- a/src/rac/services/relationships.py
+++ b/src/rac/services/relationships.py
@@ -21,7 +21,7 @@ from dataclasses import dataclass, field
 
 from rac.core.artifacts import ArtifactSpec, spec_for
 from rac.core.classification import classify
-from rac.core.corpus import CorpusEntry, walk_corpus
+from rac.core.corpus import CorpusCache, CorpusEntry, walk_corpus
 from rac.core.identity import artifact_identifier, artifact_identifiers
 from rac.core.limits import MAX_RELATED_EDGES
 from rac.core.markdown import parse_file
@@ -725,8 +725,19 @@ def _validate(
     )
 
 
-def validate_relationships(directory: str, recursive: bool = True) -> RelationshipValidation:
-    """Validate explicit relationship references across a directory."""
+def validate_relationships(
+    directory: str, recursive: bool = True, *, cache: CorpusCache | None = None
+) -> RelationshipValidation:
+    """Validate explicit relationship references across a directory.
+
+    When a per-invocation ``cache`` is supplied, the corpus is served through it
+    so artifacts already parsed in an earlier phase of the same run are not
+    reparsed (WS8); the result is byte-identical to the uncached walk.
+    """
+    if cache is not None:
+        return validation_from_corpus(
+            directory, cache.collect(directory, recursive=recursive), recursive
+        )
     items = _corpus_items(directory, recursive)
     return _validate(directory, items, recursive)
 

--- a/src/rac/services/validate.py
+++ b/src/rac/services/validate.py
@@ -16,7 +16,7 @@ from dataclasses import asdict, dataclass
 
 from rac.core.artifacts import spec_for
 from rac.core.classification import classify
-from rac.core.corpus import CorpusEntry, walk_corpus
+from rac.core.corpus import CorpusCache, CorpusEntry, walk_corpus
 from rac.core.models import Issue, Product
 from rac.core.overrides import SeverityOverrides, apply_overrides
 from rac.core.validation import has_errors, validate
@@ -197,13 +197,22 @@ def validate_product(product: Product, start: str = ".") -> list[Issue]:
     return apply_overrides(validate(product), classify(product).type, load_overrides(start))
 
 
-def validate_directory(directory: str, recursive: bool = True) -> DirectoryValidation:
+def validate_directory(
+    directory: str, recursive: bool = True, *, cache: CorpusCache | None = None
+) -> DirectoryValidation:
     """Validate every recognized artifact under ``directory``.
 
     Files are processed in sorted path order (``walk_corpus``), so the
-    result — and everything rendered from it — is deterministic.
+    result — and everything rendered from it — is deterministic. When a
+    per-invocation ``cache`` is supplied, the walk is served through it so an
+    artifact already parsed in an earlier phase of the same run is not reparsed
+    (WS8); the result is byte-identical either way.
     """
-    entries = list(walk_corpus(directory, recursive=recursive))
+    entries = (
+        cache.collect(directory, recursive=recursive)
+        if cache is not None
+        else list(walk_corpus(directory, recursive=recursive))
+    )
     overrides = load_overrides(directory)
     return validate_corpus(directory, entries, recursive=recursive, overrides=overrides)
 

--- a/tests/test_idempotent.py
+++ b/tests/test_idempotent.py
@@ -1,0 +1,158 @@
+"""Idempotent content-hash processing (v0.23.0, WS8).
+
+Within one CLI invocation a `CorpusCache` content-hashes each artifact (full
+on-disk source bytes; ADR-032's collect_corpus seam) so phases after the first
+reuse the parsed snapshot instead of reparsing — a per-invocation performance
+path only. These tests pin: the hash is source-only and mtime-independent
+(REQ-002); the short-circuit reuses unchanged artifacts and reprocesses only an
+edited one (REQ-001); derived output is byte-identical to a full reprocess and
+stable across runs (REQ-003); and the MCP serving path is never cached — it
+re-reads on every call (REQ-004, ADR-032).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+
+from rac.core.corpus import CorpusCache, content_hash, walk_corpus
+from rac.mcp.server import build_server
+from rac.services.doctor import diagnose
+from rac.services.relationships import validate_relationships
+from rac.services.validate import validate_directory
+
+DECISION = (
+    "---\nschema_version: 1\nid: {id}\ntype: decision\n---\n# {title}\n\n"
+    "## Status\n\n{status}\n\n## Context\n\nWhy.\n\n## Decision\n\nDo it.\n\n"
+    "## Consequences\n\nFine.\n"
+)
+
+
+def _decision(root, name: str, aid: str, *, status: str = "Accepted") -> None:
+    (root / f"{name}.md").write_text(
+        DECISION.format(id=aid, title=name, status=status), encoding="utf-8"
+    )
+
+
+def _corpus(root) -> None:
+    _decision(root, "alpha", "RAC-HASHAAAAAAA1")
+    _decision(root, "bravo", "RAC-HASHAAAAAAA2")
+    _decision(root, "charlie", "RAC-HASHAAAAAAA3")
+
+
+# --- content hash: source-only, mtime-independent (REQ-002) ------------------
+
+
+def test_content_hash_is_source_only_and_mtime_independent(tmp_path):
+    path = tmp_path / "a.md"
+    path.write_text("hello world", encoding="utf-8")
+    original = content_hash(path)
+
+    # Touching the file (new mtime, same bytes) does not change the hash.
+    future = 2_000_000_000.0
+    os.utime(path, (future, future))
+    assert content_hash(path) == original
+
+    # A whitespace-only edit changes the hash (any byte change does).
+    path.write_text("hello world ", encoding="utf-8")
+    assert content_hash(path) != original
+
+
+def test_content_hash_degrades_for_unreadable_path(tmp_path):
+    # A path that cannot be read hashes to a stable sentinel rather than raising.
+    missing = tmp_path / "gone.md"
+    assert content_hash(missing) == content_hash(missing)
+
+
+# --- short-circuit: reuse unchanged, reprocess only the edited (REQ-001) -----
+
+
+def test_cache_reuses_unchanged_and_reprocesses_only_edited(tmp_path):
+    _corpus(tmp_path)
+    cache = CorpusCache()
+
+    first = cache.collect(str(tmp_path))
+    assert len(first) == 3
+    assert cache.reprocessed == 3
+    assert cache.reused == 0
+
+    # Second collect on an unchanged corpus reparses nothing; entries are reused
+    # by identity (the very objects parsed on the first pass).
+    reprocessed_before = cache.reprocessed
+    second = cache.collect(str(tmp_path))
+    assert cache.reprocessed - reprocessed_before == 0
+    assert cache.reused == 3
+    assert all(s is f for s, f in zip(second, first, strict=True))
+
+    # Editing exactly one artifact reprocesses exactly that one.
+    reprocessed_before = cache.reprocessed
+    _decision(tmp_path, "bravo", "RAC-HASHAAAAAAA2", status="Superseded")
+    third = cache.collect(str(tmp_path))
+    assert cache.reprocessed - reprocessed_before == 1
+    # alpha and charlie are still the original objects; bravo is freshly parsed.
+    assert third[0] is first[0]
+    assert third[2] is first[2]
+    assert third[1] is not first[1]
+
+
+# --- byte-identical to a full reprocess, stable across runs (REQ-003) --------
+
+
+def test_short_circuit_output_is_byte_identical_to_full_reprocess(tmp_path):
+    _corpus(tmp_path)
+    cache = CorpusCache()
+    cache.collect(str(tmp_path))  # warm: every entry now reused on the cached path
+
+    # Validation: cached snapshot vs a fresh full walk.
+    assert (
+        validate_directory(str(tmp_path), cache=cache).to_dict()
+        == validate_directory(str(tmp_path)).to_dict()
+    )
+
+    # Relationship integrity: cached snapshot vs a fresh full walk.
+    cached_rel = validate_relationships(str(tmp_path), cache=cache)
+    fresh_rel = validate_relationships(str(tmp_path))
+    assert cached_rel.relationships_checked == fresh_rel.relationships_checked
+    assert cached_rel.issues == fresh_rel.issues
+
+
+def test_doctor_report_is_idempotent_across_runs(tmp_path):
+    # diagnose shares one cache across its phases; its report is byte-stable on
+    # repeated runs over an unchanged corpus.
+    _corpus(tmp_path)
+    assert diagnose(str(tmp_path)).to_dict() == diagnose(str(tmp_path)).to_dict()
+
+
+def test_cached_snapshot_matches_fresh_walk(tmp_path):
+    # The short-circuit never alters the snapshot: cached entries classify and
+    # parse identically to a fresh walk, in the same order.
+    _corpus(tmp_path)
+    cache = CorpusCache()
+    cache.collect(str(tmp_path))
+    cached = cache.collect(str(tmp_path))  # fully reused
+    fresh = list(walk_corpus(str(tmp_path)))
+    assert [(e.path, e.artifact_type) for e in cached] == [(e.path, e.artifact_type) for e in fresh]
+    assert [e.product.sections for e in cached] == [e.product.sections for e in fresh]
+
+
+# --- the MCP serving path is never cached (REQ-004, ADR-032) -----------------
+
+
+def test_mcp_serving_path_reflects_interleaved_edit(tmp_path):
+    # The server re-reads on every call and does not use the WS8 cache: an edit
+    # between two calls is visible in the second response.
+    _decision(tmp_path, "delta", "RAC-HASHAAAAAAA4", status="Proposed")
+    server = build_server(str(tmp_path))
+
+    before = json.loads(
+        asyncio.run(server.call_tool("get_artifact", {"id": "RAC-HASHAAAAAAA4"}))[0][0].text
+    )
+    _decision(tmp_path, "delta", "RAC-HASHAAAAAAA4", status="Accepted")
+    after = json.loads(
+        asyncio.run(server.call_tool("get_artifact", {"id": "RAC-HASHAAAAAAA4"}))[0][0].text
+    )
+
+    assert "Proposed" in before["content"]
+    assert "Accepted" in after["content"]
+    assert before["content"] != after["content"]


### PR DESCRIPTION
# Summary

Tier-2 internal workstream of the v0.23.0 "Hardening" release, off `main`. Keeps
the inner loop and CI fast on an ICP-sized corpus and reinforces the determinism
the eval benchmark rests on: identical source bytes always produce byte-identical
derived output. A per-invocation content-hash lets the multi-phase `rac doctor`
parse each artifact once per run instead of once per phase.

Implements `rac/roadmaps/v0.23.x-hardening/v0.23.0-hardening.md` (WS8),
`rac/requirements/rac-idempotent-content-hash-processing.md`.

# Roadmap / ADR Trace

Roadmap: `rac/roadmaps/v0.23.x-hardening/v0.23.0-hardening.md`
Requirement: `rac/requirements/rac-idempotent-content-hash-processing.md`

Relevant ADRs: ADR-032 (`collect_corpus` is the named optimization seam; the MCP
serving path re-reads per call and is never cached), ADR-011/ADR-013 (file-first,
derived data is always rebuildable).

# What it adds

- **`content_hash(path)`** — SHA-256 over an artifact's full on-disk source bytes
  (front matter + body), never derived output and never mtime (REQ-002). Any edit
  changes the digest; touching a file without changing its bytes does not.
- **`CorpusCache`** on the `collect_corpus` seam — a per-invocation, in-memory,
  content-hash-keyed snapshot reuse. When a later phase of the same run requests
  an artifact whose hash is unchanged, it returns the already-parsed
  `CorpusEntry` instead of reparsing it (REQ-001). It persists no state to disk
  and survives no process boundary.
- **`rac doctor` shares one cache** across its validation, relationship-integrity,
  and degree/injection passes, so each artifact is parsed once per run rather than
  three times. The additive `cache` parameter on `validate_directory` /
  `validate_relationships` is the seam it threads through (backward-compatible;
  default `None` preserves the existing walk).

# Scope

## Included
- **REQ-001** per-invocation, hash-keyed, in-memory short-circuit on the
  `collect_corpus` seam; no disk state, no process-boundary survival.
- **REQ-002** hash over full source bytes only — not derived output, not mtime.
- **REQ-003** derived output is idempotent and byte-stable, and byte-identical
  between the short-circuit path and a full reprocess (a test asserts both).
- **REQ-004** the MCP serving path is untouched and re-reads per call; the
  interleaved-edit contract (ADR-032) is preserved and re-asserted.

## Out of scope
- **REQ-005** resumability / crash-safe incremental jobs, on-disk cross-invocation
  caches — explicitly deferred (T3-C). This is a per-invocation optimization only.
- Single-phase commands (`rac validate`, `rac eval`) gain the `cache` parameter
  but see no within-run reuse, which is correct — there is no earlier phase to
  short-circuit from.

# Verification

## Ran
- `python -m pytest` — full suite, **1533 passed**; the idempotent battery — 7
  tests.
- `python -m ruff check`, `ruff format --check`, `python -m mypy src/` — clean.
- `rac/` gates: validate (0 invalid), relationships --validate (0), review (no
  Priority 1–2), watchkeeper (Broken 0 → 0).

## Covered
- `content_hash` is source-only and mtime-independent; an unreadable path hashes
  to a stable sentinel rather than raising.
- The cache reuses unchanged artifacts by identity and reprocesses **only** an
  edited one (the acceptance test edits one of three and asserts exactly one
  reparse).
- Validation and relationship output over the cached snapshot are byte-identical
  to a fresh full walk; the doctor report is idempotent across runs.
- The MCP server reflects an edit made between two `get_artifact` calls — it is
  never served from the cache (REQ-004, ADR-032).

# Review Path

1. `src/rac/core/corpus.py` — `content_hash` and `CorpusCache` (the mechanism).
2. `src/rac/services/doctor.py` — one cache shared across `diagnose`'s phases.
3. `src/rac/services/validate.py` / `relationships.py` — the additive `cache`
   parameter (the threading seam).
4. `tests/test_idempotent.py` — the battery.

# Notes For Reviewer

- Third Tier-2 PR. WS5 (#158) and WS6 (#159) are open in parallel; this branch is
  off `main` and ticks only its own roadmap line. The obey-demo success anchor and
  WS10 follow.
- No new dependency: hashing is stdlib `hashlib`; the cache is a plain dict keyed
  by path to (digest, entry).