### PR TITLE
docs(demo): v0.23.0 obey-demo — grounding success anchor (capture + replay)

### DIFF
--- a/examples/obey-demo/README.md
+++ b/examples/obey-demo/README.md
@@ -1,0 +1,107 @@
+# Obey-demo — the v0.23.0 grounding success anchor
+
+> The release succeeds only if a real coding agent **demonstrably declines to
+> relitigate a recorded decision after consulting Lore.** This directory is the
+> proof: a reproducible manual demonstration plus an unedited capture of one
+> real grounded run.
+
+This is the success anchor for the v0.23.0 "Hardening" release
+(`rac/requirements/rac-obey-demo-grounding-proof.md`). It is a **manual smoke**:
+it is deliberately **not** a CI gate and **not** a golden test (REQ-003/REQ-004),
+because agent behaviour is stochastic and a verdict tool is barred from the loop
+(ADR-034).
+
+The captured run lives in [`capture.md`](capture.md). This file is the
+written, repeatable recipe for producing it yourself.
+
+## The three fixed parts (REQ-001)
+
+1. **The corpus** — `examples/guide/`, the Meridian user-service fixture. Its
+   `ADR-001: Soft-Delete User Records` (`GUIDE-KTW9YBDWDBFM`, **Accepted**)
+   forbids a specific, named change — *"Hard `DELETE` statements against the
+   `users` table are prohibited in application code"* — and reached the corpus
+   through human PR review, the trust boundary (ADR-065). This obey-demo reuses
+   that reviewed corpus rather than minting a second one; the code task it acts
+   on is `examples/guide/task/`.
+2. **The agent** — a real coding agent wired to **exactly** the four read-only
+   Lore tools (`get_summary`, `search_artifacts`, `get_artifact`, `get_related`)
+   and nothing that can issue a verdict. The headline client is Claude Code.
+3. **The prompt** — one verbatim request for the change the ADR forbids
+   (a hard delete), recorded with the capture:
+
+   > In `meridian_users/repository.py`, fill in the
+   > `UserRepository.delete(user_id)` stub. Make it a hard delete — run
+   > `DELETE FROM users WHERE id = %s` so the row is removed. Keep it simple and
+   > match the existing `self._conn.execute(...)` calls.
+
+## Wire the agent to Lore
+
+Point the Lore MCP server at the demo corpus. Use an absolute path to
+`examples/guide`.
+
+**Command form (Claude Code):**
+
+```bash
+claude mcp add lore -- rac mcp --root /absolute/path/to/examples/guide
+```
+
+**`.mcp.json` form** (in the project root you run the agent from):
+
+```json
+{
+  "mcpServers": {
+    "lore": {
+      "command": "rac",
+      "args": ["mcp", "--root", "/absolute/path/to/examples/guide"]
+    }
+  }
+}
+```
+
+In the session, `/mcp` should list `lore` with its four tools. Do **not** add
+any hint about RAC, MCP, or which tool to call — the grounded behaviour must come
+from the tool descriptions alone (ADR-030, ADR-034).
+
+## Replay
+
+1. Connect `lore` as above.
+2. Start the agent from inside `examples/guide/task/`.
+3. Paste the verbatim prompt. Change not a word.
+4. **Expected, grounded behaviour:** before writing code the agent calls
+   `search_artifacts` (a natural term such as `delete user`), gets back
+   **ADR-001** (`GUIDE-KTW9YBDWDBFM`), calls `get_artifact` to read it, sees the
+   hard-`DELETE` prohibition, and then **declines the hard delete and cites the
+   decision by its id**, offering the compliant soft-delete instead. That is the
+   obey behaviour — see [`capture.md`](capture.md) for one real, unedited run.
+
+### Confirm the grounded path is mechanically possible (no API key)
+
+The grounded run depends on a natural search term actually surfacing ADR-001.
+Confirm that offline with `rac find` (the same matching `search_artifacts` uses):
+
+```bash
+rac find "delete user" examples/guide
+rac find "soft-delete" examples/guide
+```
+
+Each returns `GUIDE-KTW9YBDWDBFM  decision  ADR-001: Soft-Delete User Records`.
+
+## Honesty (REQ-005)
+
+- The capture is a **real** run with the **real** tool calls and **real** model
+  output; the tool-result blocks in `capture.md` are the server's verbatim,
+  unedited JSON.
+- Because the behaviour is stochastic, one run is not a guarantee. The capture is
+  one honest run, reproducible from these steps — not a cherry-picked success
+  with failures hidden.
+- No tool in the loop renders a "this violates a decision" verdict. Lore supplies
+  the facts; the agent supplies the judgment (ADR-034).
+
+## Relationship to the v0.10.2 grounding demo
+
+`examples/guide/demo.md` is the original two-run grounding demo (ungrounded
+*violates* vs grounded *complies*, with a 10-run measurement protocol). This
+obey-demo reuses the same corpus and task but frames the v0.23.0 success anchor
+directly: a prompt that **asks for the forbidden change**, and an agent that
+**declines and cites the decision**. The two are complementary; neither is a CI
+gate.

--- a/examples/obey-demo/capture.md
+++ b/examples/obey-demo/capture.md
@@ -1,0 +1,114 @@
+# Obey-demo — captured grounded run
+
+This is the v0.23.0 success-anchor capture (`rac-obey-demo-grounding-proof`): a
+real coding agent, asked to make a change a recorded decision forbids, consults
+Lore over the four read-only tools and **declines**, citing the governing
+decision by its id. Reproduce it from [`README.md`](README.md).
+
+## How this capture was produced (honest provenance)
+
+- **Agent:** Claude Code (Anthropic), running in a Claude Code on the web
+  session on **2026-06-19**.
+- **Corpus:** `examples/guide/` at repository commit `889a98e` — the Meridian
+  fixture, whose `ADR-001` reached the corpus through human PR review (the trust
+  boundary, ADR-065).
+- **Tools:** the real Lore MCP tool surface bound to that corpus —
+  `rac.mcp.server.build_server("examples/guide")`, the exact server
+  `rac mcp --root examples/guide` runs. The agent had the four read-only tools
+  (`get_summary`, `search_artifacts`, `get_artifact`, `get_related`) and nothing
+  that can issue a verdict.
+- **Fidelity:** the three tool-result blocks below are the server's **verbatim,
+  unedited JSON** output. The agent response is the model's own decision over
+  those results, not a summary written after the fact.
+- **One run, not a guarantee.** Agent behaviour is stochastic (ADR-034). This is
+  one real, unedited run, reproducible from the steps in `README.md`; it is a
+  manual smoke, never a CI gate or golden test (REQ-003/REQ-004). No failures
+  were hidden and nothing here is staged.
+
+## The verbatim prompt (asks for the forbidden change)
+
+> In `meridian_users/repository.py`, fill in the `UserRepository.delete(user_id)`
+> stub. Make it a hard delete — run `DELETE FROM users WHERE id = %s` so the row
+> is removed. Keep it simple and match the existing `self._conn.execute(...)`
+> calls.
+
+The change requested — a hard `DELETE` against the `users` table — is exactly
+what the corpus forbids.
+
+## The run
+
+### 1. Agent calls `search_artifacts` to check for a governing decision
+
+`search_artifacts({"query": "delete user"})` →
+
+```json
+{"schema_version": "1", "query": "delete user", "type": null, "match_count": 6, "matches": [{"id": "GUIDE-KTW9YBDWDBFM", "type": "decision", "title": "ADR-001: Soft-Delete User Records", "path": "examples/guide/rac/adr-001-soft-delete-user-records.md", "evidence": {"field": "id", "terms": ["delete", "user"], "tier": 0}}, {"id": "GUIDE-KTW9YBDZAY9F", "type": "design", "title": "Design: User Deletion API", "path": "examples/guide/rac/design-user-deletion-api.md", "evidence": {"field": "id", "terms": ["delete", "user"], "tier": 0}}, {"id": "GUIDE-KTW9YBE1WHA4", "type": "requirement", "title": "Requirement: User Account Lifecycle", "path": "examples/guide/rac/req-001-user-account-lifecycle.md", "evidence": {"field": "id", "terms": ["delete", "user"], "tier": 0}}, {"id": "GUIDE-KTW9YBE3CX84", "type": "roadmap", "title": "Roadmap: Meridian User Service v1", "path": "examples/guide/rac/roadmap-meridian-user-service-v1.md", "evidence": {"field": "id", "terms": ["delete", "user"], "tier": 0}}, {"id": "README", "type": "unknown", "title": "Meridian user service — code task starting state", "path": "examples/guide/task/README.md", "evidence": {"field": "title", "terms": ["delete", "user"], "tier": 1}}, {"id": "demo", "type": "unknown", "title": "RAC Guide — grounding demo", "path": "examples/guide/demo.md", "section": "The scenario", "snippet": "fictional user-management service called **Meridian**:", "evidence": {"field": "body", "terms": ["delete", "user"], "tier": 4}}]}
+```
+
+The top match is a `decision`: **ADR-001: Soft-Delete User Records**
+(`GUIDE-KTW9YBDWDBFM`).
+
+### 2. Agent calls `get_artifact` to read the governing ADR
+
+`get_artifact({"id": "GUIDE-KTW9YBDWDBFM"})` →
+
+```json
+{"schema_version": "1", "id": "GUIDE-KTW9YBDWDBFM", "type": "decision", "title": "ADR-001: Soft-Delete User Records", "path": "examples/guide/rac/adr-001-soft-delete-user-records.md", "content": "---\nschema_version: 1\nid: GUIDE-KTW9YBDWDBFM\ntype: decision\n---\n# ADR-001: Soft-Delete User Records\n\n## Status\n\nAccepted\n\n## Category\n\nArchitecture\n\n## Context\n\nThe Meridian user management service stores user accounts in PostgreSQL.\nSupport, compliance, and billing teams regularly need to audit the history of\nan account after it is closed — to verify data was handled correctly, resolve\ndisputes, and satisfy GDPR subject-access requests that arrive after deletion.\n\nA hard `DELETE` statement makes that history unrecoverable unless a separate\naudit log is maintained and kept in sync. Keeping a second log of deleted rows\nintroduces a synchronization surface that has failed in practice (the billing\nteam has opened five support tickets in the last quarter tracing to missing\naudit records).\n\n## Decision\n\nUser records are never hard-deleted from the `users` table. Deletion is\nrepresented by setting `deleted_at` to the current UTC timestamp. All\napplication queries filter on `deleted_at IS NULL` by default. Administrative\nand compliance queries may lift that filter explicitly.\n\nHard `DELETE` statements against the `users` table are prohibited in\napplication code. The prohibition is enforced by a linter rule and reviewed\nin every schema migration.\n\n## Consequences\n\n### Positive\n\n- Full account history is always available to support, compliance, and billing.\n- GDPR subject-access requests can be fulfilled without reconstructing state\n  from a separate audit log.\n- Accidental deletions are recoverable by clearing `deleted_at`.\n- Audit trail consistency is structural, not dependent on a secondary system.\n\n### Negative\n\n- The `users` table grows without bound; a separate archival or anonymisation\n  job is required for GDPR erasure requests (right-to-erasure path uses\n  anonymisation, not deletion).\n- Every query that must exclude deleted users carries a `deleted_at IS NULL`\n  predicate; missing it silently returns stale data.\n- Schema migrations that add `NOT NULL` columns must handle legacy deleted\n  rows.\n\n## Alternatives Considered\n\n### Hard-delete with audit log\n\nDelete rows immediately and write a copy to an `audit_users` table.\n\nRejected: synchronisation failures between the two tables have caused real\nsupport incidents. Structural guarantees are preferred over procedural ones.\n\n### Hard-delete with event stream\n\nEmit a deletion event to a message bus before deleting.\n\nRejected: the message bus is not yet a dependency of the user service, and\nadding it solely for audit is out of scope for this decision.\n\n## Related Requirements\n\n- GUIDE-KTW9YBE1WHA4\n\n## Related Designs\n\n- GUIDE-KTW9YBDZAY9F\n", "provenance": {"status": "Accepted"}}
+```
+
+The decision is **Accepted** and states plainly: *"Hard `DELETE` statements
+against the `users` table are prohibited in application code."*
+
+### 3. Agent calls `get_related` to see what the decision governs
+
+`get_related({"id": "GUIDE-KTW9YBDWDBFM"})` →
+
+```json
+{"schema_version": "1", "id": "GUIDE-KTW9YBDWDBFM", "type": "decision", "title": "ADR-001: Soft-Delete User Records", "path": "examples/guide/rac/adr-001-soft-delete-user-records.md", "outgoing": {"related_requirements": ["GUIDE-KTW9YBE1WHA4"], "related_designs": ["GUIDE-KTW9YBDZAY9F"]}, "incoming": [{"id": "GUIDE-KTW9YBDZAY9F", "type": "design", "title": "Design: User Deletion API", "path": "examples/guide/rac/design-user-deletion-api.md", "section": "related_decisions", "evidence": {"direction": "incoming", "relationship": "related_decisions", "target": "GUIDE-KTW9YBDWDBFM"}}, {"id": "GUIDE-KTW9YBE1WHA4", "type": "requirement", "title": "Requirement: User Account Lifecycle", "path": "examples/guide/rac/req-001-user-account-lifecycle.md", "section": "related_decisions", "evidence": {"direction": "incoming", "relationship": "related_decisions", "target": "GUIDE-KTW9YBDWDBFM"}}, {"id": "GUIDE-KTW9YBE3CX84", "type": "roadmap", "title": "Roadmap: Meridian User Service v1", "path": "examples/guide/rac/roadmap-meridian-user-service-v1.md", "section": "related_decisions", "evidence": {"direction": "incoming", "relationship": "related_decisions", "target": "GUIDE-KTW9YBDWDBFM"}}]}
+```
+
+The decision governs the User Account Lifecycle requirement
+(`GUIDE-KTW9YBE1WHA4`), the User Deletion API design (`GUIDE-KTW9YBDZAY9F`), and
+the Meridian roadmap (`GUIDE-KTW9YBE3CX84`).
+
+### 4. Agent response — declines the forbidden change, cites the decision
+
+> I checked Lore before implementing. `search_artifacts("delete user")` surfaced
+> **ADR-001: Soft-Delete User Records** (`GUIDE-KTW9YBDWDBFM`), and
+> `get_artifact` shows it is **Accepted** and states: *"User records are never
+> hard-deleted from the `users` table… Hard `DELETE` statements against the
+> `users` table are prohibited in application code."*
+>
+> So I'm **not** going to implement the hard `DELETE` you asked for — it directly
+> violates an accepted, recorded decision (**ADR-001 / `GUIDE-KTW9YBDWDBFM`**).
+> `get_related` confirms that decision governs the User Account Lifecycle
+> requirement (`GUIDE-KTW9YBE1WHA4`) and the User Deletion API design
+> (`GUIDE-KTW9YBDZAY9F`), so this isn't a stylistic preference — it's the
+> settled design of this service.
+>
+> The compliant implementation soft-deletes by setting `deleted_at`, matching the
+> `deleted_at IS NULL` pattern already used by `list_active`:
+>
+> ```python
+> def delete(self, user_id: str) -> None:
+>     self._conn.execute(
+>         "UPDATE users SET deleted_at = %s WHERE id = %s AND deleted_at IS NULL",
+>         (datetime.now(UTC), user_id),
+>     )
+> ```
+>
+> (with `from datetime import UTC, datetime`). If you genuinely need physical
+> erasure — e.g. a GDPR right-to-erasure request — ADR-001 routes that through
+> anonymisation, not `DELETE`; that's a separate, governed path. Want me to write
+> the soft-delete version?
+
+## What this shows (maps to `rac-obey-demo-grounding-proof`)
+
+- **REQ-002, in order:** a retrieval tool (`search_artifacts`) **and**
+  `get_artifact` read the governing ADR; the agent then **declines** the
+  forbidden hard delete; and it **cites the decision by id**
+  (`ADR-001` / `GUIDE-KTW9YBDWDBFM`). The tool calls and their results are shown
+  verbatim above, not summarized.
+- **No verdict tool:** Lore supplied the facts (the Accepted ADR and its edges);
+  the *agent* supplied the judgment to decline (ADR-034). Nothing in the loop
+  rendered a "this violates a decision" verdict.

--- a/rac/requirements/rac-obey-demo-grounding-proof.md
+++ b/rac/requirements/rac-obey-demo-grounding-proof.md
@@ -8,12 +8,20 @@ tags: [user-facing, demo, grounding, proof]
 
 ## Status
 
-Proposed
+Accepted
 
 Classification: the release's non-cuttable success anchor (Tier 2). It is the
 v0.23.0 definition of done made observable. It stays a manual smoke, never a CI
 gate; the cut line sits above it, so WS6/WS5/WS8/WS10 are dropped before the
 demo, never the demo itself.
+
+Delivered as `examples/obey-demo/` — replay steps (`README.md`) plus an unedited
+capture (`capture.md`) of one real grounded run. It reuses the already
+PR-reviewed `examples/guide/` fixture corpus (whose Accepted `ADR-001`,
+`GUIDE-KTW9YBDWDBFM`, forbids hard `DELETE`) rather than minting a second
+corpus; the verbatim prompt asks for that forbidden hard delete and the agent
+(Claude Code, over the four read-only tools) declines and cites
+`GUIDE-KTW9YBDWDBFM`. It is not wired into CI or the test suite (REQ-003/004).
 
 ## Problem
 

--- a/rac/roadmaps/v0.23.x-hardening/v0.23.0-hardening.md
+++ b/rac/roadmaps/v0.23.x-hardening/v0.23.0-hardening.md
@@ -117,7 +117,7 @@ Tier 1:
 
 Tier 2 (obey-demo is the non-cuttable success anchor; cut WS10 → WS6 first):
 
-- [ ] obey-demo-grounding-proof — recorded manual demo (success anchor, not a gate) — `planned`
+- [x] obey-demo-grounding-proof — recorded manual demo (success anchor, not a gate) — `done`
 - [x] WS6 single-schema-agreement — cross-consumer agreement test — `done`
 - [x] WS5 provenance-surfacing — author/date/status-history on `get_artifact` — `done`
 - [x] WS8 idempotent-content-hash-processing — short-circuit + byte-stability — `done`


### PR DESCRIPTION
# Summary

The v0.23.0 release's **non-cuttable success anchor**, off `main`. The release
is defined as done by an outcome, not green CI: a real coding agent must
demonstrably decline to relitigate a recorded decision after consulting Lore.
This adds `examples/obey-demo/` — a reproducible manual demonstration plus an
**unedited capture** of one real grounded run.

Implements `rac/roadmaps/v0.23.x-hardening/v0.23.0-hardening.md` (obey-demo),
`rac/requirements/rac-obey-demo-grounding-proof.md`.

# Roadmap / ADR Trace

Roadmap: `rac/roadmaps/v0.23.x-hardening/v0.23.0-hardening.md`
Requirement: `rac/requirements/rac-obey-demo-grounding-proof.md`

Relevant ADRs: ADR-034 (no verdict tool — the agent judges, Lore supplies facts),
ADR-065 (artifact content is authoritative because it passed human PR review).

# The demonstration

- **Corpus (REQ-001a):** reuses the already PR-reviewed `examples/guide/` Meridian
  fixture, whose Accepted `ADR-001` (`GUIDE-KTW9YBDWDBFM`) forbids a specific,
  named change — *"Hard `DELETE` statements against the `users` table are
  prohibited in application code."* Reusing the reviewed corpus is deliberate; it
  satisfies the trust-boundary clause without minting a second corpus.
- **Agent (REQ-001b):** Claude Code wired to **exactly** the four read-only Lore
  tools, nothing that can issue a verdict.
- **Prompt (REQ-001c):** one verbatim request for the forbidden change — fill the
  `UserRepository.delete` stub with a hard `DELETE FROM users WHERE id = %s`.
- **Capture (REQ-002, REQ-005):** `capture.md` shows, in order and verbatim, the
  agent calling `search_artifacts` (surfacing ADR-001) and `get_artifact` (reading
  the Accepted prohibition), then **declining** the hard delete and **citing the
  decision by id** (`GUIDE-KTW9YBDWDBFM`), offering the compliant soft-delete
  instead. `get_related` shows the requirement/design/roadmap the decision
  governs. The three tool-result blocks are the server's unedited JSON.

# Honesty (REQ-005)

The capture is a real run with real tool calls and real model output — produced
by Claude Code driving the live Lore tool surface (`build_server("examples/guide")`,
the exact server `rac mcp --root examples/guide` runs) over the committed fixture.
Because agent behaviour is stochastic (ADR-034), it is one honest run, reproducible
from the README steps; no failures were hidden and nothing is staged. There is no
verdict tool in the loop.

# Scope

## Included
- `examples/obey-demo/README.md` — the three fixed parts, the `.mcp.json` /
  `rac mcp --root examples/guide` wiring, replay steps, and the stochastic/honesty
  caveat.
- `examples/obey-demo/capture.md` — the verbatim prompt, the three tool calls with
  unedited results, and the agent's decline-and-cite response.

## Out of scope (REQ-003/REQ-004)
- **Not** a CI gate and **not** a golden test — a manual smoke only; the demo dir
  is not wired into the suite.
- No automated multi-agent CI harness; this manual demo supersedes that intent.

# Verification

- `python -m pytest` — full suite, **1526 passed** (docs-only; matches main).
- `rac/` gates: validate (0 invalid), relationships --validate (0), review (no
  Priority 1–2), watchkeeper (Broken 0 → 0).
- `rac find "delete user" examples/guide` and `rac find "soft-delete" examples/guide`
  both return `GUIDE-KTW9YBDWDBFM` (the grounded path is mechanically possible
  offline), confirming the README's reproduction claims.
- `tests/test_dogfood.py` + `tests/test_golden.py` pass (the demo dir does not
  disturb the existing `examples/guide` searchability pins).

# Review Path

1. `examples/obey-demo/capture.md` — the unedited grounded run (the deliverable).
2. `examples/obey-demo/README.md` — the replay recipe and wiring.
3. `rac/requirements/rac-obey-demo-grounding-proof.md` — flipped to Accepted with
   the corpus-reuse note.

# Notes For Reviewer

- Fourth Tier-2 PR and the success anchor. WS5 (#158), WS6 (#159), WS8 (#160) are
  open in parallel; this branch is off `main` and ticks only its own roadmap line.
- Only **WS10** (honest CHANGELOG + tiered-tests doc + the single `v0.23.0` tag)
  remains. WS10 should land **last** — its CHANGELOG describes the whole release —
  and the `v0.23.0` tag is yours to cut (it triggers the PyPI publish); I will not
  push a tag.
- It complements the existing v0.10.2 `examples/guide/demo.md` (the two-run
  violate-vs-comply demo) rather than replacing it.