### PR TITLE
docs(release): v0.23.0 WS10 — test tiers + honest CHANGELOG (tag is the maintainer's)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,43 @@ User-visible changes to RAC, by release. Follows the spirit of
 [Keep a Changelog](https://keepachangelog.com/): user impact over implementation
 details, release history over commit history.
 
+## v0.23.0 — Hardening
+
+The release that turns the grounding claim from "trust us" into something proven
+and legible. Everything a user feels:
+
+- **Explainable retrieval.** A search result now shows *why* it was retrieved —
+  which field matched, which term, which relationship edge — on
+  `search_artifacts` / `get_related`, and via `rac find --explain`.
+- **`rac doctor`.** One command diagnoses a corpus and emits paste-ready fixes
+  for malformed front matter, broken or cyclic relationships, orphans, duplicate
+  ids, contradictions, and injection-style content.
+- **Provenance on `get_artifact`.** The agent can cite who decided and when:
+  git-derived author and dates plus the reconstructed status history, additive
+  and backward-compatible.
+- **A documented trust model.** `SECURITY.md` records that artifact content is
+  untrusted input made authoritative by human PR review — the read-only server
+  protects the store, the PR gate protects the agent — and `get_artifact`
+  surfaces the reviewed status.
+- **Provably works, and stays working.** A gated grounding benchmark
+  (`rac eval --check`: deterministic Precision@k / Recall@k with a hard-negative
+  check and a committed baseline) and parser/traversal robustness (input caps,
+  graceful degradation, a bounded `get_related`) turn the claim into a CI
+  regression guard. A reproducible obey-demo (`examples/obey-demo/`) captures a
+  real agent declining a forbidden change after consulting Lore.
+
+**What is deferred.** No automated multi-agent CI harness — the obey-demo is a
+manual smoke, never a gate (the agent supplies the judgment, Lore the facts). No
+schema-migration framework (`schema_version: 1` already exists). No resumability
+or crash-safe job machinery. No multi-hop relationship traversal — `get_related`
+stays 1-hop, bounded by the response budget.
+
+**Known limits.** The MCP server is **pull-based and read-only**: the agent must
+consult it — nothing is pushed — and it never writes to or mutates the
+repository. Full CI enforcement of code-vs-decision conflicts is *not* in this
+release: the obey-demo demonstrates the behaviour, but a build does not yet fail
+when code contradicts a decision. That is a future release.
+
 ## Unreleased
 
 ### Changed

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -53,6 +53,59 @@ plain service boundary, and `tests/test_explorer_isolation.py` enforces the laye
 rules with AST checks — `rac.core`/`rac.services` never import Textual or the
 Explorer, and widgets never import Core internals (ADR-015).
 
+## Test tiers
+
+CI already runs in three concrete layers (ADR-027). These are a *reading* of the
+existing workflows, not a new structure — there are no pytest markers or taxonomy
+to learn, and each tier maps to a real CI job and a copy-paste local command. Run
+the tier that matches the change at hand.
+
+### 1. Inner loop (smoke) — fastest signal
+
+The `smoke` job in [`.github/workflows/pr-checks.yml`](../.github/workflows/pr-checks.yml)
+(`core` subset + `golden` + `dogfood`, py3.11). Catches output-contract drift and
+corpus damage in seconds:
+
+```bash
+.venv/bin/python -m pytest -q \
+  tests/test_validate.py tests/test_parser.py tests/test_schema.py \
+  tests/test_identity.py tests/test_frontmatter.py \
+  tests/test_metadata_identity.py tests/test_idgen.py \
+  tests/test_ci_batteries.py tests/test_corpus.py \
+  tests/test_operations.py \
+  tests/test_golden.py tests/test_dogfood.py
+```
+
+### 2. Pre-push (PR tier) — what a pull request actually runs
+
+Everything `pr-checks.yml` runs on a PR: the `lint` job (`ruff check`,
+`ruff format --check`, `mypy src/` — see [Lint, format, and types](#lint-format-and-types)),
+the `smoke` job above, and the dogfood action jobs (`watchkeeper`, `validate`,
+`agent-rules`, `grounding-eval`, `doctor`, `pr-gate`). Local equivalent — the
+lint trio, the smoke set, plus the dogfood gates:
+
+```bash
+.venv/bin/python -m ruff check src/ tests/
+.venv/bin/python -m ruff format --check src/ tests/
+.venv/bin/python -m mypy src/
+.venv/bin/rac gate rac/        # validate + relationships + review, one command
+.venv/bin/rac eval --check     # grounding-eval gate
+.venv/bin/rac doctor rac/      # doctor dogfood
+```
+
+### 3. Full local CI (merge grid) — the complete suite
+
+The per-service battery × Python-version grid from the reusable
+[`.github/workflows/tests.yml`](../.github/workflows/tests.yml). Every
+`tests/test_*.py` belongs to exactly one battery (enforced by
+`tests/test_ci_batteries.py`). This is the grid that gates `main` (`ci.yml`) and
+releases (`python-publish.yml`, `needs: test`). Locally it is just the whole
+suite:
+
+```bash
+.venv/bin/python -m pytest        # the full suite, every battery
+```
+
 ## Lint, format, and types
 
 CI gates on ruff and mypy (configured in `pyproject.toml`); run them locally

--- a/rac/requirements/rac-honest-changelog-tiered-tests.md
+++ b/rac/requirements/rac-honest-changelog-tiered-tests.md
@@ -8,9 +8,18 @@ tags: [internal, changelog, testing, release]
 
 ## Status
 
-Proposed
+Accepted
 
 Classification: `[internal]`. Scoped to the v0.23.0 hardening release (WS10).
+Delivered as the **Test tiers** section of `docs/testing.md` (the three tiers
+mapped to their real CI jobs and copy-paste local commands — documenting the
+existing ADR-027 topology, no new markers or taxonomy) and one honest v0.23.0
+CHANGELOG entry (What shipped / What is deferred / Known limits, headlining
+user-facing items only). REQ-005 — cutting the single `v0.23.0` git tag from
+which setuptools-scm derives the version — is the maintainer's release action,
+not performed here (the same human-only release-tail pattern as the v0.10.2
+guide demo); this workstream ships only after every other v0.23.0 workstream has
+landed.
 
 ## Problem
 

--- a/rac/roadmaps/v0.23.x-hardening/v0.23.0-hardening.md
+++ b/rac/roadmaps/v0.23.x-hardening/v0.23.0-hardening.md
@@ -121,7 +121,7 @@ Tier 2 (obey-demo is the non-cuttable success anchor; cut WS10 → WS6 first):
 - [x] WS6 single-schema-agreement — cross-consumer agreement test — `done`
 - [x] WS5 provenance-surfacing — author/date/status-history on `get_artifact` — `done`
 - [x] WS8 idempotent-content-hash-processing — short-circuit + byte-stability — `done`
-- [ ] WS10 honest-changelog-tiered-tests — tiers + CHANGELOG + tag — `planned`
+- [x] WS10 honest-changelog-tiered-tests — tiers + CHANGELOG (tag: maintainer release step) — `done`
 
 ## Success Measures
 


### PR DESCRIPTION
# Summary

The fifth and final Tier-2 workstream — the release-packaging step, off `main`.
It documents RAC's test tiers as they actually run and adds one honest CHANGELOG
entry for v0.23.0. **It must merge last** (its CHANGELOG describes the whole
release), and the single `v0.23.0` git tag is the maintainer's release action —
**not done here**.

Implements `rac/roadmaps/v0.23.x-hardening/v0.23.0-hardening.md` (WS10),
`rac/requirements/rac-honest-changelog-tiered-tests.md`.

# Roadmap / ADR Trace

Roadmap: `rac/roadmaps/v0.23.x-hardening/v0.23.0-hardening.md`
Requirement: `rac/requirements/rac-honest-changelog-tiered-tests.md`

Relevant ADRs: ADR-027 (the CI test topology this documents), ADR-007 (additive).

# What it adds

- **`docs/testing.md` → Test tiers.** The three layers ADR-027 already runs, each
  mapped to its real CI job and a copy-paste local command:
  1. **Inner loop (smoke)** — the `pr-checks.yml` `smoke` job (core subset +
     golden + dogfood, py3.11).
  2. **Pre-push (PR tier)** — `lint` (ruff + mypy) + `smoke` + the dogfood gates
     (`rac gate`, `rac eval --check`, `rac doctor`).
  3. **Full local CI (merge grid)** — the `tests.yml` battery × version grid
     (`pytest`), which gates `main` and releases.
  Documents the existing topology only — no new pytest markers, no taxonomy, no
  trigger-policy change (REQ-001/002).
- **`CHANGELOG.md` → one honest v0.23.0 "Hardening" entry**, under a dedicated
  `## v0.23.0 — Hardening` heading above the `Unreleased` backlog:
  - **What shipped** — explainable retrieval, `rac doctor`, provenance, the trust
    model, and "provably works" (the gated benchmark + robustness + obey-demo).
  - **What is deferred** — no multi-agent CI harness (obey-demo is a manual
    smoke), no schema-migration framework, no resumability, no multi-hop traversal.
  - **Known limits** — the MCP server is pull-based / read-only; full CI
    enforcement of code-vs-decision conflicts is a future release.
  The headline leads on user-facing items only; internal plumbing (WS6, WS8, this)
  is not headlined (REQ-003/004).

# Scope

## Out of scope (the maintainer's release action)
- **REQ-005 — the single `v0.23.0` git tag.** Cutting it (setuptools-scm derives
  the version from it; `pyproject.toml` is `dynamic = ["version"]`, no source
  edit) triggers the PyPI publish and is yours to cut. I have not pushed a tag.

# Verification

- `python -m pytest` — full suite, **1526 passed** (docs-only; matches main).
- `rac/` gates: validate (0 invalid), relationships --validate (0), review (no
  Priority 1–2), watchkeeper (Broken 0 → 0).
- `tests/test_dogfood.py` + `tests/test_golden.py` pass; no test references the
  CHANGELOG, so the new heading does not disturb any output pin.

# Review Path

1. `docs/testing.md` — the **Test tiers** section.
2. `CHANGELOG.md` — the v0.23.0 "Hardening" entry.
3. `rac/requirements/rac-honest-changelog-tiered-tests.md` — flipped to Accepted,
   with REQ-005 (the tag) noted as your release step.

# Notes For Reviewer

- **Merge order:** this PR should land **last**, after #158 (WS5), #159 (WS6),
  #160 (WS8), and #161 (obey-demo), so the CHANGELOG describes the complete
  release. Each Tier-2 PR ticks only its own roadmap line; on the 2nd–5th merge
  you may hit a one-line conflict on the Tier-2 checklist (adjacent `[x]` lines) —
  say the word and I'll rebase the open branches so they apply cleanly.
- **CHANGELOG placement:** per your call, the v0.23.0 entry is a dedicated
  `## v0.23.0 — Hardening` heading above the `Unreleased` backlog (no date — add
  it when you cut the tag). The v0.20–v0.22 items remain under `Unreleased` for
  you to promote/fold as you see fit.
- This completes all five Tier-2 workstreams as PRs.