### PR TITLE
docs(roadmap): open v0.24.0 — Visibility (planning artifacts only)

### DIFF
--- a/rac/decisions/adr-046-cli-usage-telemetry.md
+++ b/rac/decisions/adr-046-cli-usage-telemetry.md
@@ -209,7 +209,7 @@ one quarter after release if no user has opted in.
 
 ## Related Roadmaps
 
-- agent-usage-readback
+- v0.24.0-visibility
 
 ## Related Designs
 

--- a/rac/designs/agent-usage-surface.md
+++ b/rac/designs/agent-usage-surface.md
@@ -183,4 +183,4 @@ before submitting.
 
 ## Related Roadmaps
 
-- agent-usage-readback
+- v0.24.0-visibility

--- a/rac/requirements/rac-agent-usage-readback.md
+++ b/rac/requirements/rac-agent-usage-readback.md
@@ -1,0 +1,79 @@
+---
+schema_version: 1
+id: RAC-KVH2PNQBMEWM
+type: requirement
+tags: [user-facing, telemetry, read-back, local-first, privacy]
+---
+# Requirement: Agent Usage Read-Back
+
+## Status
+
+Proposed
+
+Classification: `[user-facing]` — the team can see how agents consult Lore. Scoped to the
+v0.24.0 visibility release (WS-E). Promotes the future placeholder
+`rac/roadmaps/future/agent-usage-readback.md` (now Superseded). Builds on the existing
+local, content-free telemetry (ADR-040, ADR-041); its CLI-usage leg depends on ADR-046
+(currently Proposed).
+
+## Problem
+
+RAC already records local, content-free Guide telemetry (ADR-040) and exposes it through
+`rac mcp-stats`, but the signal is a diagnostic dump scoped to the four Guide MCP tools
+during `rac mcp --telemetry` sessions. A maintainer who wants to *see grounding
+happening* — which decisions agents read, how often, with what errors and truncations,
+and whether usage is trending — has no read-back surface, and CLI usage (validate,
+review, find, gate) is not recorded at all. The gap is a usable read-back over the
+signals RAC may legitimately keep, without adding hosted infrastructure or recording any
+content.
+
+## Requirements
+
+- [REQ-001] RAC MUST provide a read-back surface that summarises recorded agent Lore usage — per-tool/per-command counts, error and truncation counts, session count, and a recent-activity trend over the last N days — reading the existing local telemetry log and working within ADR-040's pinned, content-free event schema.
+- [REQ-002] The read-back MUST remain content-free: it MUST NOT record or display argv, file paths, artifact IDs, query strings, or flag values — only the pinned, non-identifying fields (command/tool name, outcome, duration) (ADR-040, ADR-041).
+- [REQ-003] Widening the recorded source to all `rac` CLI commands MUST be gated by the single existing consent record (no new consent mechanism), MUST record one content-free event per completed command to a separate local log, and MUST land only once ADR-046 (CLI Usage Telemetry) is Accepted; until then the read-back covers the Guide log only.
+- [REQ-004] Telemetry MUST stay opt-in and default-off; with consent absent or declined, nothing is recorded and the read-back reports an empty result without error (ADR-040).
+- [REQ-005] Sharing MUST reuse the existing local-first, user-submitted flow: a `--share` option builds a prefilled GitHub issue URL/string that the user reviews and submits in their own browser; RAC MUST NOT transmit telemetry itself beyond the existing opt-in anonymous ping (ADR-041, ADR-035).
+
+## Acceptance Criteria
+
+- The read-back command summarises the Guide log (counts, errors, truncations, sessions,
+  N-day trend) deterministically and content-free.
+- With consent off, the command records nothing and reports an empty read-back without
+  error.
+- `--share` produces a prefilled issue the user submits; no telemetry is sent by RAC.
+- The CLI-usage leg is present only behind an Accepted ADR-046; absent that, only Guide
+  usage is read back.
+
+## Success Metrics
+
+- A maintainer can answer "are agents actually consulting our decisions, and which
+  ones?" from one local command, with no hosted infrastructure and no content captured.
+
+## Risks
+
+- Scope creep into content capture or a hosted dashboard. Mitigation: REQ-002 / REQ-005
+  and the roadmap Non-Goals.
+- Shipping CLI-usage recording ahead of its decision. Mitigation: REQ-003 gates it on
+  ADR-046 acceptance.
+
+## Assumptions
+
+- ADR-040's pinned schema is sufficient for a useful Guide read-back without a schema
+  change.
+- ADR-046 will be accepted before the CLI-usage leg ships.
+
+## Related Decisions
+
+- adr-040
+- adr-041
+- adr-046
+- adr-035
+
+## Related Requirements
+
+- rac-trust-transparency
+
+## Related Roadmaps
+
+- v0.24.0-visibility

--- a/rac/requirements/rac-multi-hop-relationship-traversal.md
+++ b/rac/requirements/rac-multi-hop-relationship-traversal.md
@@ -1,0 +1,76 @@
+---
+schema_version: 1
+id: RAC-KVH2PMJYV9FY
+type: requirement
+tags: [internal, relationships, traversal, mcp, determinism]
+---
+# Requirement: Bounded Multi-Hop Relationship Traversal
+
+## Status
+
+Proposed
+
+Classification: `[internal]` — richer relationship answers. Scoped to the v0.24.0
+visibility release (WS-D, Tier 2, cut-first). Extends the existing 1-hop
+`get_related` to a bounded N-hop neighbourhood; no new MCP tool, additive output
+(ADR-007).
+
+## Problem
+
+`get_related` (and `rac relationships`) returns one hop: an artifact's immediate
+neighbours. Real questions an agent asks — "what decisions ultimately constrain this
+requirement, including the ones reached through a design or a parent requirement?" —
+span more than one edge. v0.23.0 deliberately kept traversal 1-hop (a Non-Goal), and
+`rac-parser-traversal-robustness` REQ-010 pre-committed that any future multi-hop
+traversal MUST add explicit depth, frontier, visited-set, and work-budget caps before
+shipping. The gap is a *bounded* N-hop traversal that honours those caps and the ADR-033
+response budget.
+
+## Requirements
+
+- [REQ-001] `get_related` MUST accept a bounded depth parameter (default `1`, preserving today's behaviour) that returns artifacts reachable within N hops, with N capped at a small documented maximum.
+- [REQ-002] Traversal MUST enforce all four caps from `rac-parser-traversal-robustness` REQ-010 — maximum depth, maximum frontier size per level, a visited-set that prevents revisiting a node (cycle-safe), and a total work budget — and MUST terminate deterministically when any cap is reached, emitting a stable truncation marker consistent with ADR-033.
+- [REQ-003] The full multi-hop response MUST stay within the ADR-033 response budget, truncating whole items (never mid-JSON) in a deterministic order; output MUST be byte-identical across repeated calls on an unchanged corpus.
+- [REQ-004] Each returned artifact MUST carry its hop distance from the origin, and results MUST be ordered deterministically (by depth, then the existing relationship-type and ascending-id tie-break) so truncation is stable.
+- [REQ-005] Traversal MUST remain stateless per call — re-read from disk, no session cursor or persisted graph (ADR-032) — and offline/deterministic, with no AI and no relevance ranking (ADR-002).
+
+## Acceptance Criteria
+
+- `get_related(id, depth=1)` is byte-identical to today's output.
+- `get_related(id, depth=2)` on a fixture returns the 2-hop neighbourhood with per-item
+  hop distances, deterministically ordered.
+- A dense/cyclic fixture cannot exceed the depth, frontier, visited, or work caps, and
+  produces a stable truncation marker.
+- Repeated calls on an unchanged corpus are byte-identical; no network access occurs.
+
+## Success Metrics
+
+- An agent can retrieve a bounded transitive decision neighbourhood in one call, within
+  budget, with no traversal blow-up on a hostile graph.
+
+## Risks
+
+- Combinatorial blow-up on dense graphs. Mitigation: the four REQ-010 caps as a hard
+  precondition, fuzzed before ship.
+- Budget truncation hides the nearest relevant hop. Mitigation: depth-ordered results
+  surface nearer hops first; ordering stays deterministic, not relevance-scored.
+
+## Assumptions
+
+- The v0.23.0 relationship graph and response budget are sound foundations.
+- A small depth cap (e.g. 2–3) covers the real questions without needing unbounded
+  traversal.
+
+## Related Decisions
+
+- adr-033
+- adr-055
+- adr-032
+
+## Related Requirements
+
+- rac-parser-traversal-robustness
+
+## Related Roadmaps
+
+- v0.24.0-visibility

--- a/rac/requirements/rac-traceability-coverage-report.md
+++ b/rac/requirements/rac-traceability-coverage-report.md
@@ -1,0 +1,64 @@
+---
+schema_version: 1
+id: RAC-KVJ6XB5MTVV4
+type: requirement
+tags: [user-facing, traceability, coverage, relationships, determinism]
+---
+# Requirement: Traceability Coverage Report
+
+## Status
+
+Proposed
+
+Classification: `[user-facing]` — see where the knowledge graph is incomplete. Scoped to the v0.24.0 visibility release (WS-F). A deterministic report of typed traceability gaps over the existing relationship graph; no new schema, no AI, additive output (ADR-007).
+
+## Problem
+
+RAC detects relationship *integrity* problems — broken, cyclic, and orphaned references (`rac doctor`, `rac relationships`) — and counts artifacts by type (`rac stats`, `rac portfolio`). What no command reports is typed *coverage*: where the knowledge graph is incomplete by the team's own model. A requirement that no roadmap schedules is unimplemented intent; a decision that no requirement or roadmap applies is an unenforced choice; a roadmap that references no requirements is unscoped. These are valid, well-formed artifacts — they may carry other edges, so they are not orphans — yet each has a hole in the traceability chain (decision ← requirement ← roadmap). A maintainer who wants to ask "what have we decided but never built on?" or "what requirements are not on any roadmap?" has no answer short of reading the whole corpus by hand.
+
+## Requirements
+
+- [REQ-001] RAC MUST produce a deterministic coverage report identifying typed traceability gaps over the corpus relationship graph, covering at least: requirements referenced by no roadmap (unscheduled), decisions referenced by no requirement or roadmap (unapplied), and roadmaps that reference no requirements (unscoped). Gap classes MUST be derived from the existing relationship graph (incoming/outgoing references) and artifact types, not from a new schema field.
+- [REQ-002] Coverage MUST be distinct from orphan detection and MUST NOT duplicate `rac doctor`'s `orphaned-artifact` finding: an artifact with inbound or outbound edges of other kinds can still be a coverage gap if it lacks the specific expected traceability edge. The report reports typed completeness, not generic reachability.
+- [REQ-003] The report MUST be deterministic and offline: identical corpus bytes produce an identical, ordered gap list across repeated runs, with no AI/LLM/embeddings and no network (ADR-002).
+- [REQ-004] The report MUST be exposed as a CLI surface (a `rac` subcommand or an additive section of an existing report) with human and JSON output (ADR-007); each gap MUST name the artifact path, its type, and the missing coverage relationship, and the JSON MUST be a stable, additive contract.
+- [REQ-005] Coverage gaps MUST be advisory, never blocking: they are completeness signals for human judgement, not validation errors, so the report MUST NOT fail a build on a coverage gap alone (a roadmap may legitimately precede its requirements, a decision may be recorded before anything applies it). Coverage is informational and stays out of the `rac gate` enforcement path (ADR-049).
+- [REQ-006] The typed coverage rules SHOULD derive their expected-edge expectations from the artifact specs and the relationship-type registry (ADR-055) rather than a hand-maintained per-type table, so adding an artifact type or relationship kind does not silently leave a coverage rule stale.
+
+## Acceptance Criteria
+
+- A fixture corpus with a requirement that no roadmap references reports exactly that requirement as an unscheduled-requirement gap; adding a roadmap reference to it clears the gap.
+- A decision referenced only by another decision (not by any requirement or roadmap) is reported as an unapplied-decision gap — proving coverage is not orphan detection, since the decision has an inbound edge.
+- The report exits `0` even when gaps are present (advisory).
+- Output is byte-identical across repeated runs on an unchanged corpus; no network access occurs.
+
+## Success Metrics
+
+- A maintainer can list every unscheduled requirement, unapplied decision, and unscoped roadmap in one command, deterministically, without reading the corpus by hand.
+
+## Risks
+
+- The coverage rules become a brittle per-type table that drifts from the schema. Mitigation: REQ-006 derives expectations from the specs and the relationship registry.
+- Coverage gaps are mistaken for errors and pressure teams into busywork. Mitigation: REQ-005 keeps them advisory and out of the enforcement gate.
+- Intentionally standalone artifacts produce noisy "gaps". Mitigation: advisory framing now; an explicit opt-out marker is a possible later refinement, out of scope here.
+
+## Assumptions
+
+- The relationship graph (incoming/outgoing references) and artifact types are sufficient to compute typed coverage without a new schema field.
+- Coverage is advisory: teams decide which gaps matter; RAC surfaces them, it does not enforce them.
+
+## Related Decisions
+
+- adr-055
+- adr-016
+- adr-020
+- adr-002
+- adr-007
+
+## Related Requirements
+
+- rac-traceability-self-relationships
+
+## Related Roadmaps
+
+- v0.24.0-visibility

--- a/rac/roadmaps/future/agent-usage-readback.md
+++ b/rac/roadmaps/future/agent-usage-readback.md
@@ -7,9 +7,10 @@ type: roadmap
 
 ## Status
 
-Planned
+Superseded
 
-Unscheduled — captured as future intent, not yet on a release.
+Superseded by `v0.24.0-visibility`, which schedules this intent into the v0.24.0
+release (WS-E — Agent usage read-back). Retained as the originating record.
 
 ## Context
 
@@ -154,3 +155,7 @@ string-only, user-submits flow.
 ## Related Designs
 
 - agent-usage-surface
+
+## Related Roadmaps
+
+- v0.24.0-visibility

--- a/rac/roadmaps/v0.24.x-visibility/v0.24.0-visibility.md
+++ b/rac/roadmaps/v0.24.x-visibility/v0.24.0-visibility.md
@@ -1,0 +1,204 @@
+---
+schema_version: 1
+id: RAC-KVH2PJ7KKTZV
+type: roadmap
+tags: [visibility, telemetry, read-back, traversal, coverage, relationships]
+---
+# RAC v0.24.0 — Visibility
+
+## Status
+
+Planned
+
+## Context
+
+Lore grounds coding agents in a team's recorded decisions, served deterministically over
+five read-only MCP tools. v0.23.0 proved grounding works (the obey-demo), and RAC already
+*enforces* it: `rac gate` (v0.21.14, ADR-049) runs validation, relationship integrity,
+and review over a corpus, classifies every finding `blocking`/`advisory`/`off` under a
+corpus policy, exits non-zero on a blocking finding, and is wired as the PR gate on every
+pull request. A live artifact that references a retired decision, declares an illegal
+edge, or carries a broken/cyclic link already *fails that build*. Structural
+code-vs-decision enforcement is therefore **already shipped**, and semantic enforcement
+(judging that code contradicts a decision's *meaning*) is barred by decision (ADR-034 no
+verdict tool, ADR-002 / ADR-066 no AI). There is no enforcement gap left to build.
+
+What is missing is **visibility**. A maintainer cannot easily see how agents actually
+consult Lore — which decisions are read, how often, with what errors; cannot see where
+the knowledge graph is *incomplete* — which decisions nothing applies, which requirements
+no roadmap schedules; and an agent's relationship questions stop at one hop, so "what
+decisions ultimately constrain this requirement?" takes several manual calls. v0.24.0
+makes that visible three ways: a content-free, local-first read-back of agent usage, a
+deterministic traceability-coverage report, and a bounded multi-hop relationship
+traversal. Like v0.23.0 it adds no AI to the core, no new MCP tool, no write capability,
+and no new infrastructure — every capability is a CLI surface or an additive output change
+(ADR-007, ADR-002).
+
+## Outcomes
+
+User-felt outcomes (the release narrative leads only with these):
+
+- **Visible grounding** — a maintainer runs one command and sees how agents actually
+  consult Lore over time (which decisions are read, how often, with what errors and
+  truncations), content-free and local-first (WS-E).
+- **Visible coverage** — a maintainer can list where the knowledge graph is incomplete:
+  requirements no roadmap schedules, decisions nothing applies, roadmaps with no
+  requirements — deterministic and advisory, distinct from the integrity checks `rac
+  doctor` already runs (WS-F).
+- **Richer relationship answers** — `get_related` can return a bounded multi-hop
+  neighbourhood, not just immediate neighbours, within the existing response budget, so a
+  transitive decision constraint is one call away (WS-D).
+
+Internal plumbing that is *not* built this release (schema-migration, resumability) is
+documented as deferred intent, not headlined.
+
+## Initiatives
+
+### Tier 1 — this is the release
+
+- **WS-E — Agent usage read-back** `[user-facing]`. A read-back surface over the local,
+  content-free telemetry RAC already records (ADR-040), widened — gated by the *existing*
+  consent — toward all CLI usage (ADR-046, currently Proposed), so the team can see
+  grounding happening. Local-first, user-submitted `--share`; no hosted dashboard.
+  Promoted from `rac/roadmaps/future/agent-usage-readback.md`.
+- **WS-F — Traceability coverage report** `[user-facing]`. A deterministic report of typed
+  coverage gaps over the existing relationship graph — unscheduled requirements, unapplied
+  decisions, unscoped roadmaps — derived from the relationship-type registry (ADR-055,
+  ADR-016), not a new schema. Advisory, never blocking: it informs human judgement and
+  stays out of the `rac gate` enforcement path. The bounded first slice of the `rac
+  analyze` vision and the growth-programme's traceability-gap audit.
+
+### Tier 2 — keep, scope down (cut first if the release runs short)
+
+- **WS-D — Bounded multi-hop relationship traversal** `[internal]`. Extend `get_related`
+  (and `rac relationships`) from 1-hop to a bounded N-hop neighbourhood with the four caps
+  `rac-parser-traversal-robustness` REQ-010 already mandates — depth, frontier size,
+  visited set, and work budget — staying within the ADR-033 response budget and
+  deterministic per stateless call (ADR-032, ADR-055).
+
+### Tier 3 — deferred / documented (not built this release)
+
+Captured as intent and cut-first; neither has a concrete trigger yet, so building either
+now would be speculative infrastructure against RAC's ruthlessly-scoped ethos.
+
+- **WS-B — Schema-migration framework**. `schema_version: 1` already exists (ADR-025); no
+  v1→v2 migration exists to drive a framework. Revisit when a real schema change forces a
+  migration path — until then the contract stays additive (ADR-007).
+- **WS-C — Resumability / crash-safe jobs**. The cancellation primitives exist
+  (`CancelToken` / `checkpoint` / `Progress`) but there is no long-running interruptible
+  operation to resume, and the per-invocation content-hash short-circuit (v0.23.0 WS8)
+  already covers re-run cost. Revisit when a genuinely long job appears (ADR-032).
+
+## Workstream Checklist
+
+Cross-session progress tracker. Status: `planned` → `in-progress` → `done` /
+`descoped`. This roadmap is the canonical tracker.
+
+Tier 1:
+
+- [ ] WS-E agent-usage-readback — content-free local read-back surface — `planned`
+- [ ] WS-F traceability-coverage-report — typed, advisory coverage gaps — `planned`
+
+Tier 2 (cut first):
+
+- [ ] WS-D multi-hop-relationship-traversal — bounded N-hop, four caps — `planned`
+
+## Success Measures
+
+- The read-back surface reports agent Lore usage (per-tool/per-command counts, errors,
+  truncations, an N-day trend) content-free, and `--share` produces a prefilled issue the
+  user submits themselves.
+- With telemetry consent absent, the read-back records nothing and reports an empty result
+  without error.
+- The coverage report lists every unscheduled requirement, unapplied decision, and
+  unscoped roadmap deterministically, exits `0` (advisory), and never duplicates `rac
+  doctor`'s orphan finding — a decision with a non-traceability inbound edge is still
+  reported as unapplied.
+- `get_related(depth>1)` returns a bounded, deterministic neighbourhood under the ADR-033
+  budget, and a traversal-bomb fixture cannot exceed the depth/frontier/visited/work caps.
+- The full suite passes in CI; the MCP surface stays the five read-only tools, with only
+  additive output changes.
+
+## Constraints
+
+Non-negotiable guardrails, each a recorded decision:
+
+- No AI/LLM, embeddings, or vector search in any serving, traversal, coverage, or
+  telemetry path (ADR-002). Everything runs offline with no keys.
+- No new MCP tool and no write capability; the five read-only tools stay read-only, with
+  additive output only (ADR-007).
+- Telemetry stays opt-in, default-off, local-only, and content-free, under the single
+  existing consent record; no new consent mechanism, no hosted store, no recording of
+  argv/paths/queries/content, and no RAC-side transmission (ADR-040, ADR-041, ADR-046,
+  ADR-035).
+- Coverage is advisory, never an enforcement gate; it reports typed completeness over the
+  relationship graph and registry, not a new schema field (ADR-055, ADR-016).
+- Traversal stays bounded and stateless: explicit depth/frontier/visited/work caps and the
+  response budget bound every multi-hop answer (ADR-033, ADR-032,
+  `rac-parser-traversal-robustness` REQ-010).
+- Artifact content is untrusted input; the trust boundary is human PR review (ADR-065).
+  Roadmap lifecycle follows ADR-061.
+
+## Non-Goals
+
+- **No new enforcement.** `rac gate` (ADR-049) already delivers structural
+  code-vs-decision enforcement as the PR gate — a build already fails when an artifact
+  references a retired decision, declares an illegal edge, or carries a broken/cyclic link.
+  v0.24.0 adds no enforcement, coverage gaps stay advisory, and semantic code-vs-intent
+  judgement stays barred (ADR-034, ADR-002, ADR-066).
+- **No hosted telemetry or dashboard, and no content recording** (ADR-040, ADR-041).
+- **No unbounded or relevance-ranked traversal** — depth and work are capped, ordering is
+  deterministic (ADR-033).
+- **No schema-migration framework and no resumable-job machinery this release** (Tier 3,
+  deferred).
+
+## Risks
+
+- **Read-back tempts scope creep into content or a hosted store.** Mitigation: the
+  content-free, local-first, user-submitted constraints (ADR-040, ADR-041) are restated as
+  Non-Goals; ADR-046 must be accepted before its CLI-usage leg ships.
+- **Coverage gaps are mistaken for errors and pressure teams into busywork.** Mitigation:
+  WS-F coverage is advisory and stays out of the `rac gate` enforcement path — it informs
+  human judgement, it does not block; intentionally standalone artifacts are tolerated.
+- **Multi-hop traversal explodes combinatorially.** Mitigation: the four REQ-010 caps are a
+  hard precondition, fuzzed with a dense-graph fixture before ship.
+
+## Assumptions
+
+- ADR-046 (CLI usage telemetry) will be accepted before WS-E's CLI-usage leg lands; until
+  then WS-E ships only the Guide read-back over the existing ADR-040 schema.
+- The relationship graph, response budget, and relationship-type registry from prior
+  releases are sound foundations for bounded traversal (WS-D) and typed coverage (WS-F).
+- Structural enforcement via `rac gate` is sufficient; coverage is advisory and no further
+  enforcement is wanted this release.
+
+## Related Decisions
+
+- adr-040
+- adr-041
+- adr-046
+- adr-035
+- adr-033
+- adr-055
+- adr-016
+- adr-020
+- adr-032
+- adr-049
+- adr-034
+- adr-066
+- adr-002
+- adr-007
+- adr-061
+- adr-065
+
+## Related Requirements
+
+- rac-agent-usage-readback
+- rac-traceability-coverage-report
+- rac-multi-hop-relationship-traversal
+
+## Related Roadmaps
+
+- v0.23.0-hardening
+- v0.14.0-enforcement-foundation
+- v0.14.1-status-consistency


### PR DESCRIPTION
# Summary

Implements `rac/roadmaps/v0.24.x-visibility/v0.24.0-visibility.md`.

Opens the v0.23.0 follow-on ideas into a `Planned`, tiered **v0.24.0 roadmap** plus a requirement per *scoped* workstream. **Planning artifacts only — no code, no feature.** The workstreams land later as scoped PRs, as v0.23.0's did.

> **Reframed after review.** The original draft headlined a "code-vs-decision enforcement gate" (WS-A). On a closer read, `rac gate` (v0.21.14, ADR-049) **already** ships that — it runs validate + relationships + review, classifies findings `blocking`/`advisory`/`off`, exits non-zero on a blocking finding, and is wired as the PR gate, so a build already fails when an artifact references a retired decision / illegal edge / broken-or-cyclic link. WS-A was dropped as already-shipped; the release now leads on **visibility**. A third workstream (**WS-F**, coverage) was added after verifying it is genuinely new (no traceability/coverage analysis exists today). The branch name still says `enforcement-gate`; only the working label is stale — the artifacts are all `v0.24.0-visibility`.

The "Visibility" triad: **how agents use Lore** (WS-E) · **where the graph is incomplete** (WS-F) · **how far the graph reaches** (WS-D).

Adds:
- A tiered v0.24.0 roadmap (`Status: Planned`).
- `rac-agent-usage-readback` (WS-E), `rac-traceability-coverage-report` (WS-F), `rac-multi-hop-relationship-traversal` (WS-D) requirements.
- Supersedes the `future/agent-usage-readback.md` placeholder and repoints its two inbound references.

# Roadmap / ADR Trace

Roadmap: `rac/roadmaps/v0.24.x-visibility/v0.24.0-visibility.md`

Relevant ADRs (all referenced, all resolve):
- Telemetry (WS-E): ADR-040, ADR-041, ADR-046 *(Proposed)*, ADR-035
- Coverage (WS-F): ADR-055, ADR-016, ADR-020
- Traversal (WS-D): ADR-033, ADR-055, ADR-032
- Enforcement context (why there's no WS-A): ADR-049, ADR-034, ADR-066
- Cross-cutting: ADR-002 (no AI), ADR-007 (additive), ADR-061 (lifecycle), ADR-065 (trust boundary)

# Scope

## Included
- **WS-E agent usage read-back (Tier 1, user-facing)** — content-free, local-first read-back over existing telemetry; CLI-usage leg gated on ADR-046 acceptance. Promoted from the `future/` placeholder.
- **WS-F traceability coverage report (Tier 1, user-facing)** — a deterministic, **advisory** report of typed coverage gaps (unscheduled requirements, unapplied decisions, unscoped roadmaps) over the relationship-type registry. Verified **not** redundant with `rac stats`/`doctor`/`portfolio` (those do counts/health/orphans; no coverage analysis exists) and **distinct from** `doctor`'s generic orphan check.
- **WS-D bounded multi-hop traversal (Tier 2, cut-first, internal)** — N-hop `get_related` with the four caps `rac-parser-traversal-robustness` REQ-010 mandates.

## Excluded
- **Enforcement (the former WS-A) — already shipped.** `rac gate` delivers structural code-vs-decision enforcement as the PR gate; coverage (WS-F) stays advisory and out of that path. Semantic code-vs-intent judgement stays barred (ADR-034 / ADR-002 / ADR-066).
- **WS-B schema-migration** and **WS-C resumability** — Tier 3, **documented-deferred, not built**.
- All implementation: this PR is the contract, not the code.

# Product / Architecture Decisions

- **No enforcement workstream, by inspection.** Verified `src/rac/services/gate.py` + `pr-checks.yml`: relationship findings are blocking by default and run on every PR.
- **WS-F is verified-new.** Grepped `src/rac/` for coverage/traceability-gap logic — none exists. WS-F reports *typed* completeness (an artifact can be non-orphan yet still have a coverage hole), so it does not duplicate `doctor`'s `orphaned-artifact` finding; kept advisory so it never becomes a back-door enforcement gate.
- **Renamed series `enforcement-gate` → `visibility`** to match the content. Name is the maintainer's to finalise.
- **WS-E promotes, doesn't duplicate.** The `future/agent-usage-readback.md` placeholder is `Superseded` and points forward to `v0.24.0-visibility`; its two inbound references — `adr-046` (Proposed) and the `agent-usage-surface` design — are repointed so no live artifact references a retired roadmap.

# User-Facing Contract

N/A for this PR — no CLI, output, or exit-code change. The artifacts *describe* contracts the workstreams will deliver (WS-E's read-back + `--share`; WS-F's coverage report exit-0/advisory + JSON; WS-D's `depth` on `get_related`); those land with their implementation PRs.

# Verification

## Ran
```
rac validate rac/                  # PASS — 253 valid, 0 invalid
rac relationships rac/ --validate  # 1127 checked, 0 issues, exit 0
rac review rac/                    # no Priority 1–2, exit 0
rac doctor rac/                    # 0 errors (advisory warnings only)
python -m pytest -q tests/test_dogfood.py tests/test_golden.py   # 40 passed
```

## Covered
- Every ADR reference and roadmap↔requirement slug resolves (relationships exit 0); the `enforcement-gate`→`visibility` rename is clean (no stray slug anywhere in `rac/`).
- The supersede introduced zero status-consistency violations after repointing the two inbound references.
- `doctor` reports 0 errors; the orphan warnings are pre-existing/advisory and unrelated.

# Review Path

1. `rac/roadmaps/v0.24.x-visibility/v0.24.0-visibility.md` — Context (why no enforcement WS), Initiatives (the Tier-1 pair + Tier-2), Non-Goals.
2. `rac/requirements/rac-traceability-coverage-report.md` — confirm WS-F stays advisory and distinct from orphans (REQ-002, REQ-005).
3. `rac/requirements/rac-agent-usage-readback.md` and `rac-multi-hop-relationship-traversal.md`.
4. The supersede: `rac/roadmaps/future/agent-usage-readback.md` + the two repointed references (`adr-046`, `agent-usage-surface`).

# Notes For Reviewer

- **Two decisions are yours, flagged not taken:** the `visibility` series name (rename freely), and **ADR-046** (CLI usage telemetry) is still *Proposed* — WS-E's CLI-usage leg (REQ-003) is gated on accepting it; nothing flipped it here.
- **The repoint touches two existing artifacts** (`adr-046`, `agent-usage-surface`) beyond the new files — a necessary consequence of superseding the placeholder, one line each.
- **Branch label is stale** (`claude/rac-v0.24.0-enforcement-gate`); the artifacts are all `v0.24.0-visibility`. Left as-is to avoid churning the PR; say the word and I'll recreate it on a renamed branch.
- Status is `Planned`; no release, tag, or implementation is implied.

# Implementation Process

Authored with AI assistance under the v0.24.0 roadmap contract. The reframe (dropping WS-A once `rac gate` was shown to already cover it; adding WS-F after verifying it is new) and final acceptance are the maintainer's.