### PR TITLE
docs(roadmap): record Lore's external memory and RAG export direction

### DIFF
--- a/rac/designs/lore-supermemory-interplay.md
+++ b/rac/designs/lore-supermemory-interplay.md
@@ -1,0 +1,219 @@
+---
+schema_version: 1
+id: RAC-KVJJ8RSWP0SV
+type: design
+---
+# Lore × Supermemory Interplay
+
+## Status
+
+Proposed
+
+Exploratory — this records the implementation approach for a possible
+integration so the reasoning lives in the corpus, not a tool's scratch space
+(ADR-047). It is not an accepted build; the unscheduled umbrella is the future
+roadmap `lore-supermemory-grounding`.
+
+## Context
+
+Supermemory (github.com/supermemoryai/supermemory, MIT) is a semantic memory
+and context-management layer for LLM agents: hybrid vector + keyword search, an
+ingestion step that uses an LLM to rewrite raw input into extracted "memories",
+recency decay, `containerTag` namespacing, an MCP server (`addMemory` /
+`search`), Python and TypeScript SDKs, and an OpenAI-compatible memory-router
+proxy. It is self-hostable and can run fully offline with local embeddings.
+
+Lore is the agent-facing surface of RAC: five read-only MCP tools
+(`get_artifact`, `search_artifacts`, `find_decisions`, `get_related`,
+`get_summary`) over a deterministic, byte-stable engine, with stateless reads
+(ADR-032) and a bounded response (ADR-033). RAC's recorded decisions draw a hard
+line around what the engine may do: no embeddings, vector index, or LLM judge in
+the scored/served path (ADR-002, ADR-066); no semantic verdicts in the engine
+(ADR-067); RAC is not a content store (ADR-024); non-Python clients are thin
+clients over the published contract (ADR-063); companion products live in
+`lore-*` repos, not in `rac-core` (ADR-068).
+
+The two products sit at opposite ends of one axis — **determinism**. Lore is the
+deterministic system-of-record; Supermemory is fuzzy, associative working
+memory. They are therefore complementary, not competing, and the recorded
+decisions point to exactly one safe shape: run them side by side and feed Lore's
+knowledge *into* Supermemory one-way, never the reverse, and never by putting a
+fuzzy component inside Lore's serving path.
+
+## User Need
+
+An agent (and its operator) working a task wants two different things:
+
+- **Authority** — "what has this team already decided about X, in its exact,
+  current wording?" That is Lore's job, and its value is that the answer is
+  deterministic and auditable.
+- **Recall** — "have we touched anything *near* this idea?", asked in loose
+  natural language that may share no keywords with the recorded decision. Lore's
+  native search is deterministic but token-boundary / keyword-tier
+  (ADR-037, ADR-038), so it misses paraphrases and synonyms. Supermemory's
+  semantic search closes that gap.
+
+The need is to get recall **without** surrendering authority — to add fuzzy
+discovery as a clearly-separate surface, so the agent always knows which results
+are authoritative (Lore) and which are merely associative (Supermemory).
+
+## Design
+
+### Topology — co-mount, no coupling
+
+The agent session mounts **both** MCP servers: `lore` (read-only, deterministic)
+and `supermemory` (`addMemory` / `search`). This is configuration, not code —
+nothing in `rac-core` changes to make it possible. Lore stays the authority;
+Supermemory is an associative index alongside it.
+
+### The loop — fuzzy find, deterministic verify
+
+The interaction pattern the whole design optimizes for:
+
+1. The agent asks Supermemory in natural language and gets semantically-near
+   candidates, each carrying the canonical Lore artifact `id` in its metadata.
+2. The agent re-fetches the authoritative, *current* text from Lore by that `id`
+   (`get_artifact`), and uses `find_decisions` so a retired or superseded
+   decision can never be mistaken for live guidance.
+3. The agent acts on Lore's verbatim text — never on Supermemory's
+   LLM-rewritten copy.
+
+Recall comes from the fuzzy layer; correctness is restored by the deterministic
+one. Supermemory's stored "memory" is treated strictly as a *pointer/index into
+Lore*, never as a source of truth.
+
+### The feed — a one-way ingest adapter
+
+A small companion, `lore-supermemory` (a `lore-*` repo per ADR-068, never inside
+`rac-core`):
+
+- runs `rac export --json` (the deterministic `CorpusExport`, a stable additive
+  contract per ADR-007 / ADR-063) or reads the Markdown + frontmatter on disk;
+- for each artifact, calls Supermemory
+  `add({ content, containerTag: <repo>, metadata: { id, type, status } })`;
+- re-syncs on change (a CI step or git hook), idempotent on the canonical opaque
+  `id` so re-ingesting an edited artifact updates rather than duplicates;
+- emits **only** decision/requirement/design/roadmap/prompt content the corpus
+  already exposes — it adds no new disclosure surface.
+
+Data flows one way: RAC → Supermemory. RAC never reads back from Supermemory,
+never calls it, never depends on it. `rac-core` requires no change; the export
+already carries `id`, `type`, and `status`.
+
+## Constraints
+
+- **AI stays optional, determinism stays intact (ADR-002, ADR-066).** The
+  embeddings, the LLM rewrite, and the fuzzy ranking all live in Supermemory.
+  Lore's served order and text remain a pure function of the corpus; the
+  grounding-eval benchmark still scores exactly what Lore serves.
+- **No semantic component in Lore's serving path (ADR-067).** The fuzzy layer is
+  a *parallel* surface the agent queries directly, never an interceptor or
+  re-ranker between Lore and the agent.
+- **One-way only.** RAC must not gain a dependency on, or a read path from,
+  Supermemory. The trust and determinism guarantees are Lore's alone to keep.
+- **Metadata is load-bearing.** Every ingested memory must carry the canonical
+  `id` and `status`, or the verify-in-Lore step and the retired-decision filter
+  break.
+- **Supermemory's copy is non-authoritative by construction.** Its ingest
+  rewrites content with an LLM, so its text is an index, never a citation;
+  authoritative text is always re-fetched from Lore.
+- **Companion, not core (ADR-068, ADR-024).** Any build is a `lore-*` repo. RAC
+  does not store, serve, or re-import the embedded copy; it is not becoming a
+  content store.
+
+## Rationale
+
+The adapter is the only shape that adds semantic recall while keeping every
+recorded guardrail. It is outbound-only and contract-based, so it cannot regress
+Lore's determinism, its AI-optional posture, or its auditability. It is also
+small: a script over a stable published surface, with no `rac-core` change.
+
+Crucially, it captures the benefit that pulls toward the rejected alternatives —
+better recall over recorded decisions — *without* their cost. The real weakness
+it addresses is that Lore's keyword search misses paraphrases (ADR-037,
+ADR-038); the adapter fixes that by adding a parallel, explicitly-fuzzy surface,
+leaving Lore's authoritative output untouched and clearly labelled as the
+authority.
+
+## Alternatives
+
+- **Semantic re-rank of Lore's results (rejected).** Let Supermemory reorder
+  `search_artifacts` / `get_related` output by semantic similarity before the
+  agent sees it. Rejected: it makes the agent-consumed order non-deterministic
+  and desynchronized from the grounding-eval (ADR-066 scores the exact order
+  Lore serves — a re-ranker means the benchmark scores one order and the agent
+  consumes another, varying by model version). It erodes Lore's entire
+  differentiator: an answer you can audit and reproduce.
+- **Memory-router proxy in the serving path (rejected).** Front the model with
+  Supermemory's OpenAI-compatible router, auto-injecting recalled context with
+  Lore as one source. Rejected: it places a fuzzy, LLM-rewriting,
+  possibly-cloud component on the critical path (contra ADR-002) and inverts the
+  dependency so memory becomes the front door and Lore a backend — the opposite
+  of Lore's positioning (ADR-036, ADR-039).
+- **Serve decisions *from* Supermemory (rejected).** Replace or shadow Lore's
+  reads with Supermemory search. Rejected outright: it discards determinism,
+  auditability, the retired-decision filter, and ADR-024 in one move.
+- **Do nothing (the honest baseline).** Lore already works; the paraphrase gap
+  is a real but bounded weakness. Acceptable until evidence shows agents miss
+  decisions for lack of semantic recall — which is the signal that would
+  schedule the adapter.
+
+The narrow door left open: a re-rank or router *experiment* could be revisited
+far later, fenced inside a `lore-*` companion and never in core, only if the
+adapter's parallel-surface recall proves insufficient. It is recorded as
+deferred-with-rationale in the roadmap, not adopted here.
+
+## Accessibility
+
+This surface is consumed by agents and read by their operators, so legibility
+means *provenance* legibility: results must never blur which layer they came
+from. Authoritative answers (Lore, by `id`, verbatim, with lifecycle status)
+stay visually and structurally distinct from associative candidates
+(Supermemory, fuzzy, advisory). An operator auditing an agent's reasoning must
+be able to tell, at a glance, that the decision it acted on was the verbatim
+Lore artifact, not the rewritten memory.
+
+## Style Guidance
+
+- Name the companion `lore-supermemory` (the `lore-*` brand convention, ADR-068),
+  not `rac-*`; it is a Lore-brand integration, not an engine component.
+- Vocabulary separates the layers: Lore *grounds* and is *authoritative*;
+  Supermemory *recalls* and is *associative*. Never describe Supermemory output
+  as a decision or a citation.
+- The export the adapter consumes is the published contract surface; it grows
+  only additively (ADR-007). The adapter depends on `id`/`type`/`status`,
+  nothing private.
+
+## Open Questions
+
+- Sync cadence and idempotency key beyond the canonical `id` — CI step vs git
+  hook vs on-demand, and how aggressively to prune memories for deleted
+  artifacts.
+- Whether to ingest all artifact types or scope to decisions first, given
+  decisions are the highest-value recall target.
+- How an agent prompt or skill should encode the "verify-in-Lore" discipline so
+  the fuzzy-find/deterministic-verify loop is followed reliably rather than by
+  convention.
+- Whether the eventual `containerTag` scheme should be per-repo, per-series, or
+  per-artifact-type.
+
+## Related Requirements
+
+- rac-agent-context-guide
+
+## Related Decisions
+
+- ADR-002
+- ADR-007
+- ADR-024
+- ADR-032
+- ADR-037
+- ADR-038
+- ADR-063
+- ADR-066
+- ADR-067
+- ADR-068
+
+## Related Roadmaps
+
+- lore-supermemory-grounding

--- a/rac/roadmaps/future/corpus-export-to-rag-backends.md
+++ b/rac/roadmaps/future/corpus-export-to-rag-backends.md
@@ -1,0 +1,163 @@
+---
+schema_version: 1
+id: RAC-KVJMA3FF260P
+type: roadmap
+---
+# Corpus Export to External Memory and RAG Backends (Future)
+
+## Status
+
+Planned
+
+Unscheduled — captured as future intent, not yet on a release. This is the
+umbrella that generalizes the `lore-supermemory-grounding` item: Supermemory
+becomes the first reference adapter under a broader export capability. Gated on
+adoption signal; it must not displace nearer-term committed work.
+
+## Context
+
+The agent ecosystem has many places teams push knowledge into "for reference":
+fact-extracting memory layers (Supermemory, Mem0, Zep, Letta, Cognee), raw
+vector stores (Pinecone, Weaviate, Qdrant, Chroma, Milvus, pgvector, LanceDB),
+knowledge-graph / GraphRAG systems (Microsoft GraphRAG, Neo4j, Zep's Graphiti,
+Cognee), and managed RAG pipelines (LlamaIndex / LlamaCloud, LangChain, R2R,
+Ragie, Vectara). Almost all of them accept the same ingestion shape —
+*documents = text + metadata + id* — and the graph-native ones additionally
+accept *nodes + typed edges*.
+
+RAC already emits the deterministic source for this: `rac export --json` is a
+stable, additive contract (ADR-007, ADR-063), and RAC additionally owns a typed,
+validated relationship graph (ADR-055: artifacts are nodes, `supersedes` /
+`related_*` are edges). The differentiator is exactly that graph: GraphRAG-style
+systems spend LLM effort *inferring* a knowledge graph from raw prose and get it
+fuzzily, whereas RAC can hand them the curated, validated decision graph
+directly.
+
+So the capability is not "build N backend integrations into the engine" — that
+would fight thin-client (ADR-063), not-a-content-store (ADR-024), and
+companion-repo (ADR-068) decisions. It is: make the *export* the product (one
+stable, ingestion-shaped projection for documents and one for nodes/edges), ship
+a small number of reference `lore-*` adapters, and let everyone else consume the
+contract. The interplay design `lore-supermemory-interplay` already works out the
+one-way, "fuzzy find / deterministic verify" shape this generalizes.
+
+## Outcomes
+
+- RAC can export its corpus — and its relationship graph — to external memory,
+  vector, and context-graph backends, one-way, via a stable export contract plus
+  reference `lore-*` adapters, with no engine dependency on any backend (ADR-002,
+  ADR-068).
+- **Published documentation names the supported export targets explicitly, by
+  name** (which memory layers, vector stores, and graph/RAG systems an adapter or
+  the documented export shape covers), so a reader knows exactly what they can
+  push to — never a vague "works with vector databases".
+- **Published documentation explains the post-recall validation loop**: how, once
+  an agent has used Supermemory (or any backend) for fuzzy recall, it gets the
+  "real" answer — re-fetching the authoritative, current artifact from Lore by its
+  canonical `id` and filtering retired decisions, so the backend's
+  (possibly LLM-rewritten) copy is only ever a pointer, never the citation.
+- The graph-native projection (nodes + typed edges) is a first-class output, so
+  GraphRAG/Neo4j/Graphiti/Cognee users get RAC's real decision graph instead of
+  an inferred one.
+
+## Initiatives
+
+### Initiative 1 — Ingestion-shaped export projections
+
+Provide a stable export suited to ingestion: a flat *documents* projection
+(`{ id, type, status, content, metadata }`, JSONL-friendly) for memory/vector/RAG
+backends, and a *nodes + edges* projection for graph backends, both derived from
+the existing deterministic export (ADR-007). Embeddings are never computed in RAC
+— they live in the target (ADR-002, ADR-066).
+
+### Initiative 2 — Reference `lore-*` adapters
+
+Ship a small, honest set of reference adapters as `lore-*` companions (ADR-068),
+not an exhaustive matrix: Supermemory first (per `lore-supermemory-grounding`),
+plus at least one graph-native target (e.g. Neo4j / Graphiti / Cognee) to prove
+the nodes+edges projection. Each is outbound-only; RAC never reads back.
+
+### Initiative 3 — Documentation that names targets and the validation loop
+
+A published documentation page is part of the deliverable, not an afterthought.
+It must:
+
+- **enumerate the supported export targets by name**, grouped (memory layers,
+  vector stores, graph/RAG systems), stating for each whether it is covered by a
+  shipped adapter or by the documented generic export shape;
+- **document the "verify-in-Lore" loop** end to end: fuzzy recall from the
+  backend → re-fetch the authoritative artifact from Lore by canonical `id` →
+  retired-decision filtering → act on Lore's verbatim text. The doc makes explicit
+  that the backend provides recall and RAC provides the authoritative answer, and
+  that RAC does not validate the backend's store — verification happens on read,
+  in Lore.
+
+## Constraints
+
+- One-way / outbound only: RAC never depends on, calls, or reads back from any
+  backend; the engine stays AI-optional and deterministic (ADR-002, ADR-066).
+- Adapters are `lore-*` companions, never engine code (ADR-068); RAC does not
+  store, serve, or re-import the embedded copy (ADR-024).
+- Export grows only additively over the published contract (ADR-007, ADR-063).
+- Claims are honest: documentation does not imply RAC verifies or syncs the
+  backend's contents; the only guarantee is that the authoritative answer is
+  re-fetched from Lore on read.
+
+## Non-Goals
+
+- Building bespoke backend clients into `rac-core` (a maintenance trap and
+  contrary to ADR-063 / ADR-024).
+- Re-ranking, serving from, or otherwise depending on any backend at read time —
+  carried over as a non-goal from `lore-supermemory-grounding` (it breaks
+  determinism and the grounding-eval guarantee, ADR-066).
+- Computing or storing embeddings inside RAC (ADR-066).
+
+## Success Measures
+
+- A reader of the published docs can name, without ambiguity, every backend the
+  capability exports to and which are shipped adapters vs generic-export targets.
+- An agent can complete the documented loop: recall a candidate from a backend,
+  re-fetch the authoritative artifact from Lore by `id`, and detect a retired
+  decision — with the doc's steps alone.
+- A graph backend ingests RAC's nodes+edges projection and reflects the real
+  `supersedes` / `related_*` topology, not an inferred one.
+- The whole capability ships without an engine dependency on any backend.
+
+## Assumptions
+
+- `rac export --json` remains a stable, additive contract carrying `id`, `type`,
+  `status`, and the relationship graph (ADR-007, ADR-055, ADR-063).
+- The "documents + metadata + id" ingestion shape remains the de-facto common
+  denominator across memory/vector/RAG backends, so one documents projection
+  serves most targets.
+- Adoption signal justifies the build before it is scheduled out of `future/`.
+
+## Risks
+
+- **Target sprawl.** Chasing every backend is unbounded. Mitigation: ship reference
+  adapters only; make the documented export shape the product, named targets
+  notwithstanding.
+- **Staleness across the boundary.** An exported copy drifts from the corpus.
+  Mitigation: re-sync on change and the verify-in-Lore loop, which makes the
+  exported copy a pointer rather than a source of truth.
+- **Over-claiming in docs.** Readers may assume RAC validates the backend.
+  Mitigation: the documentation explicitly scopes verification to on-read
+  re-fetch from Lore (a named outcome above).
+
+## Related Decisions
+
+- ADR-002
+- ADR-007
+- ADR-024
+- ADR-055
+- ADR-063
+- ADR-066
+- ADR-068
+
+## Related Roadmaps
+
+- lore-supermemory-grounding
+
+## Related Designs
+
+- lore-supermemory-interplay

--- a/rac/roadmaps/future/lore-supermemory-grounding.md
+++ b/rac/roadmaps/future/lore-supermemory-grounding.md
@@ -1,0 +1,139 @@
+---
+schema_version: 1
+id: RAC-KVJJ8T5ARA28
+type: roadmap
+---
+# Lore × Supermemory — Complementary Grounding (Future)
+
+## Status
+
+Planned
+
+Unscheduled — captured as future intent, not yet on a release. This is a
+considered direction gated on adoption signal; it must not displace nearer-term
+committed work.
+
+## Context
+
+The agent-memory field — Supermemory, Mem0, Zep, Letta — is converging on
+*fuzzy* memory: vector recall, LLM-rewritten "memories", recency decay. All of
+it trades determinism for associative reach. Lore is the opposite: a
+deterministic, auditable system-of-record for the decisions a team has already
+made (ADR-066, ADR-002), built on the open-source RAC engine and shipped under
+the Lore brand (ADR-036, ADR-039, ADR-068).
+
+That contrast is the opportunity. Rather than compete with memory tools, Lore
+can be **the authority they ground against** — the layer a fuzzy memory cites so
+its agents stop guessing. Supermemory (MIT, self-hostable, with an MCP server
+and SDKs) is the natural first partner: an agent can co-mount both, recall
+loosely from Supermemory, then verify verbatim in Lore.
+
+The companion design `lore-supermemory-interplay` works out the *how* and
+settles the safe shape: a one-way RAC → Supermemory ingest adapter plus a
+"fuzzy find, deterministic verify" agent loop, with re-rank and memory-router
+couplings explicitly rejected because they would put a non-deterministic
+component in Lore's serving path. This roadmap records the *what and why*: the
+product intent and the positioning, kept as recorded intent rather than a
+scheduled release.
+
+## Outcomes
+
+- Agents gain semantic recall over a team's recorded decisions — closing Lore's
+  keyword-search paraphrase gap (ADR-037, ADR-038) — **without** losing the
+  determinism and auditability that are Lore's whole value.
+- Lore is positioned in the memory market as the deterministic system-of-record
+  that fuzzy memory tools ground against, not as one more memory tool (ADR-024,
+  ADR-017) — owning the correctness/governance axis the category lacks.
+- A shippable, low-effort integration (a `lore-*` companion, ADR-068) lets Lore
+  ride a partner's distribution while reinforcing its own authority niche.
+
+## Initiatives
+
+### Initiative 1 — One-way ingest adapter (a `lore-*` companion)
+
+Build `lore-supermemory`: read `rac export --json` and push each artifact into
+Supermemory (`add` with `containerTag` and `metadata` carrying the canonical
+`id`, `type`, `status`), re-syncing on change. Outbound-only — RAC never depends
+on or reads back from Supermemory, and `rac-core` needs no change. The
+implementation contract lives in the design `lore-supermemory-interplay`.
+
+### Initiative 2 — Positioning and the co-marketing recipe
+
+Publish an integration recipe ("ground Supermemory in your team's decisions")
+and the positioning that frames Lore as *the authority memory tools cite*. The
+wedge: ride Supermemory's larger distribution while sharpening Lore's distinct
+category — **"memory you can audit."** Vocabulary stays disciplined: Lore
+*grounds* and is authoritative; memory tools *recall* and are associative.
+
+### Initiative 3 — Deferred: re-rank / memory-router experiment
+
+Recorded as considered and **deferred**, not adopted. A semantic re-rank of
+Lore's results, or a memory-router proxy in the model's serving path, was
+rejected for the determinism cost (see the design's Alternatives). Revisit only
+as a fenced `lore-*` experiment, never in core, and only if Initiative 1's
+parallel-surface recall proves insufficient in practice.
+
+## Constraints
+
+- The integration is a `lore-*` companion, never engine code in `rac-core`
+  (ADR-068); RAC stays the deterministic, AI-optional core (ADR-002).
+- Data flows one way (RAC → Supermemory). RAC gains no dependency on, and no
+  read path from, the memory layer.
+- RAC is not a content store (ADR-024); the embedded copy lives in Supermemory,
+  and authoritative text is always re-fetched from Lore.
+
+## Non-Goals
+
+- Re-ranking or reordering Lore's served results with a semantic model — it
+  breaks determinism and desyncs from the grounding-eval (ADR-066).
+- A memory-router proxy that puts a fuzzy/AI component in the model's serving
+  path (contra ADR-002, ADR-067).
+- Serving or shadowing decision reads *from* Supermemory instead of Lore.
+- Embeddings, vector indexing, or an LLM judge inside `rac-core` (ADR-066).
+
+## Success Measures
+
+- An agent can recall a relevant recorded decision from a paraphrased,
+  zero-keyword-overlap query and then verify it verbatim in Lore.
+- Evidence (usage signal or user research) that agents miss decisions for lack
+  of semantic recall — the signal that would schedule Initiative 1 out of
+  `future/`.
+- The integration ships without any change to `rac-core`'s engine, contract, or
+  determinism guarantees.
+
+## Assumptions
+
+- `rac export --json` remains a stable, additive contract carrying `id`, `type`,
+  and `status` (ADR-007, ADR-063).
+- Supermemory (or an equivalent semantic-memory layer) stays self-hostable and
+  exposes an ingest API, so the integration imposes no cloud dependency on
+  adopters.
+- The paraphrase gap in Lore's keyword search is a real adoption friction worth
+  closing — to be confirmed before scheduling.
+
+## Risks
+
+- **Staleness / dual copy.** Supermemory holds a rewritten copy that can drift
+  from the corpus; mitigated by re-sync on change and by treating its copy as a
+  pointer, with verify-in-Lore as the authoritative step.
+- **Discipline drift.** The benefit depends on agents following the
+  fuzzy-find/deterministic-verify loop; if they cite Supermemory's rewritten
+  text directly, authority is lost. Mitigated by metadata carrying the canonical
+  `id` and by prompt/skill guidance.
+- **Positioning blur.** Marketing Lore alongside memory tools risks it being
+  mistaken for one; mitigated by holding the "authority, not memory" line
+  (ADR-024, ADR-017).
+
+## Related Decisions
+
+- ADR-002
+- ADR-017
+- ADR-024
+- ADR-036
+- ADR-039
+- ADR-066
+- ADR-068
+
+## Related Designs
+
+- lore-supermemory-interplay


### PR DESCRIPTION
# Summary

Records exploratory product direction for connecting Lore (the agent-facing
surface of RAC) to external semantic-memory and RAG systems. Per ADR-047, the
thinking lands as corpus artifacts rather than ephemeral chat.

Adds:
- `rac/designs/lore-supermemory-interplay.md` — the *how* for the Supermemory
  case: co-mount topology, the "fuzzy find, deterministic verify" loop, a one-way
  RAC → Supermemory ingest adapter, the guardrails, and the rejection of
  re-rank / memory-router coupling.
- `rac/roadmaps/future/lore-supermemory-grounding.md` — the *what / why* and
  positioning for Supermemory: Lore as the deterministic authority that fuzzy
  memory tools ground against.
- `rac/roadmaps/future/corpus-export-to-rag-backends.md` — the umbrella that
  generalizes the above into a one-way export to external memory, vector, and
  context-graph backends, with Supermemory as the first reference adapter.

All three are unscheduled future intent / proposed direction — no code change.

# Roadmap / ADR Trace

Artifacts:
- `rac/roadmaps/future/corpus-export-to-rag-backends.md` (Planned, unscheduled — umbrella)
- `rac/roadmaps/future/lore-supermemory-grounding.md` (Planned, unscheduled — first instance)
- `rac/designs/lore-supermemory-interplay.md` (Proposed)

Relevant ADRs (cited in the artifacts):
- ADR-002 (AI optional), ADR-066 (deterministic grounding eval), ADR-067
  (agent-integration boundary) — why a fuzzy component must stay out of Lore's
  serving path.
- ADR-037 / ADR-038 (token-boundary / body-text search) — the paraphrase gap the
  adapter addresses.
- ADR-007 / ADR-063 (stable additive contract / thin clients), ADR-055
  (relationship-type registry / Layer-3 graph) — the export seam and the typed
  graph the umbrella exports.
- ADR-024 / ADR-017 (not a content store / manages knowledge not work),
  ADR-036 / ADR-039 (Lore identity), ADR-068 (brand / `lore-*` companions) — the
  positioning and where any build lives.

# Scope

## Included
- A design recording the implementation approach for a one-way Supermemory
  ingest adapter (`rac export --json` → backend `add` with
  `metadata{id,type,status}`), realized as a `lore-*` companion, with no
  `rac-core` change required.
- A Supermemory future roadmap (intent, success measures gated on adoption
  signal, positioning).
- An umbrella future roadmap generalizing the pattern: ingestion-shaped export
  projections (documents; nodes + edges), reference `lore-*` adapters, and a
  documentation requirement to (1) name supported export targets explicitly and
  (2) document the post-recall verify-in-Lore loop.

## Excluded
- No code, dependency, or engine change — recorded direction only.
- No version scheduling — every item stays in `future/` until adoption signal
  warrants it.
- Re-ranking Lore's results, a memory-router proxy in the serving path, and
  computing embeddings inside RAC are recorded as **non-goals** (they break
  determinism and the grounding-eval guarantee); a fenced experiment is left as a
  narrow future door.
- The umbrella deliberately does **not** propose bespoke backend clients in
  `rac-core` (contrary to ADR-063 / ADR-024); the export contract is the product.

# Product / Architecture Decisions

- **One-way ingest over coupling.** RAC feeds the backend and never reads back,
  so Lore's determinism, AI-optional posture (ADR-002), and auditability are
  preserved. The adapter captures the recall benefit of a re-ranker without its
  cost, because the agent keeps authoritative (Lore) and associative (backend)
  results separate.
- **Graph-native differentiator.** RAC already owns a typed, validated
  relationship graph (ADR-055), so the umbrella exports a nodes + edges projection
  — handing GraphRAG/Neo4j/Graphiti/Cognee the real decision graph instead of one
  inferred from prose.
- **Companion, not core.** Any build is a `lore-*` repo (ADR-068); RAC does not
  become a content store (ADR-024). The design uses `Related Roadmaps` and the
  roadmaps use `Related Designs`, since the design spec does not permit
  `related_designs` — the three cross-reference legally.

# Verification

## Ran
- `rac validate rac/` — 252 valid, 0 invalid.
- `rac relationships rac/ --validate` — 1115 checked, 0 issues (the three
  artifacts cross-reference and every ADR target resolves).
- `rac review rac/` — exit 0, no priority 1-2 findings, health 92/100.
- `rac watchkeeper rac --base origin/main` — nothing requiring attention
  (+2 roadmap, +1 design).
- `python -m pytest tests/test_dogfood.py tests/test_golden.py` — 40 passed.

## Covered
- Each new artifact validates individually (0 errors, 0 warnings) and as part of
  the corpus; the review surfaces no findings against them; the umbrella's links
  to the Supermemory roadmap and design resolve within this branch, so the
  relationship gate stays green on merge.

# Review Path

1. `rac/roadmaps/future/corpus-export-to-rag-backends.md` — the umbrella: export
   projections, named targets, and the documentation requirements.
2. `rac/roadmaps/future/lore-supermemory-grounding.md` — the first instance:
   intent and positioning.
3. `rac/designs/lore-supermemory-interplay.md` — the implementation approach,
   guardrails, and the Alternatives section that rejects re-rank / router.

# Notes For Reviewer

Exploratory direction, not a committed build. The umbrella keeps Supermemory as
the first reference adapter and is deliberately bundled in this PR so its
`Related Roadmaps` / `Related Designs` edges resolve in one merge unit. The
companion repos, the export-shape contract, and the "verify-in-Lore" agent
discipline are listed as open questions / future design work.