### PR TITLE
docs(ingest): record markitdown as the ingestion parser (reject liteparse)

### DIFF
--- a/.cursor/rules
+++ b/.cursor/rules
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: b3f1ad9cb7d425608c113cea71b5e77c4497cbe4f85d73888f540fec03bc37fa) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: 17674c0a9cd84512168f93b80fb4a12925bf2b99c213024a1b9dcb820307073a) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -50,4 +50,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KV6KFCC8MHTM** — ADR-066: Grounding Eval Scoring Is Deterministic — No Embeddings, No LLM Judge _(Technical)_
 - **RAC-KV80WX94GY8A** — ADR-067: Agent Integration is Context-Supply and Post-Edit Enforcement, Not Pre-Edit Interception _(Architecture)_
 - **RAC-KVA44MVMDXXX** — ADR-068: Extension, SDK, and Brand Architecture _(Architecture)_
+- **RAC-KVJK92SM2A1R** — ADR-072: Document Ingestion Parser Is markitdown _(Architecture)_
 <!-- END RAC MANAGED BLOCK -->

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: b3f1ad9cb7d425608c113cea71b5e77c4497cbe4f85d73888f540fec03bc37fa) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: 17674c0a9cd84512168f93b80fb4a12925bf2b99c213024a1b9dcb820307073a) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -50,4 +50,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KV6KFCC8MHTM** — ADR-066: Grounding Eval Scoring Is Deterministic — No Embeddings, No LLM Judge _(Technical)_
 - **RAC-KV80WX94GY8A** — ADR-067: Agent Integration is Context-Supply and Post-Edit Enforcement, Not Pre-Edit Interception _(Architecture)_
 - **RAC-KVA44MVMDXXX** — ADR-068: Extension, SDK, and Brand Architecture _(Architecture)_
+- **RAC-KVJK92SM2A1R** — ADR-072: Document Ingestion Parser Is markitdown _(Architecture)_
 <!-- END RAC MANAGED BLOCK -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: b3f1ad9cb7d425608c113cea71b5e77c4497cbe4f85d73888f540fec03bc37fa) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: 17674c0a9cd84512168f93b80fb4a12925bf2b99c213024a1b9dcb820307073a) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -50,4 +50,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KV6KFCC8MHTM** — ADR-066: Grounding Eval Scoring Is Deterministic — No Embeddings, No LLM Judge _(Technical)_
 - **RAC-KV80WX94GY8A** — ADR-067: Agent Integration is Context-Supply and Post-Edit Enforcement, Not Pre-Edit Interception _(Architecture)_
 - **RAC-KVA44MVMDXXX** — ADR-068: Extension, SDK, and Brand Architecture _(Architecture)_
+- **RAC-KVJK92SM2A1R** — ADR-072: Document Ingestion Parser Is markitdown _(Architecture)_
 <!-- END RAC MANAGED BLOCK -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ to the corpus artifact and they load through the imports below.
 - Previous series: `rac/roadmaps/v0.21.x-editor/` (complete)
 - Decisions (ADRs): `rac/decisions/`
 
-<!-- BEGIN RAC MANAGED BLOCK (digest: b3f1ad9cb7d425608c113cea71b5e77c4497cbe4f85d73888f540fec03bc37fa) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: 17674c0a9cd84512168f93b80fb4a12925bf2b99c213024a1b9dcb820307073a) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -75,4 +75,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KV6KFCC8MHTM** — ADR-066: Grounding Eval Scoring Is Deterministic — No Embeddings, No LLM Judge _(Technical)_
 - **RAC-KV80WX94GY8A** — ADR-067: Agent Integration is Context-Supply and Post-Edit Enforcement, Not Pre-Edit Interception _(Architecture)_
 - **RAC-KVA44MVMDXXX** — ADR-068: Extension, SDK, and Brand Architecture _(Architecture)_
+- **RAC-KVJK92SM2A1R** — ADR-072: Document Ingestion Parser Is markitdown _(Architecture)_
 <!-- END RAC MANAGED BLOCK -->

--- a/rac/decisions/adr-072-ingest-parser-markitdown.md
+++ b/rac/decisions/adr-072-ingest-parser-markitdown.md
@@ -1,0 +1,137 @@
+---
+schema_version: 1
+id: RAC-KVJK92SM2A1R
+type: decision
+---
+# ADR-072: Document Ingestion Parser Is markitdown
+
+## Context
+
+RAC's `rac ingest` converts a rich source document (DOCX, PDF, HTML, PPTX,
+XLSX) into Markdown so it can be classified and restructured into artifacts.
+Per ADR-010, ingestion is *conversion only* — its job is to turn a document
+into Markdown text that preserves structure (headings, lists, tables), and
+nothing more. It does not judge artifact type or extract semantics.
+
+Today that conversion uses **markitdown** (Microsoft, MIT). It is wired as an
+*optional, pure-Python* dependency: the core install pulls none of it, and the
+format support ships as granular extras (`ingest`, `ingest-pdf`,
+`ingest-office`, `ingest-all`). It is isolated behind the `DocumentConverter`
+Protocol in `src/rac/services/ingest.py` — a single `MarkItDownConverter`
+registered in `_CONVERTERS`, returning `IngestResult.markdown: str`. DOCX, HTML,
+PPTX, and XLSX are converted natively in Python. No prior ADR pins the parser,
+so the choice is open.
+
+The maintainer asked whether to swap markitdown for **liteparse**
+(run-llama/liteparse, Apache-2.0). On inspection liteparse is a different class
+of tool:
+
+- It is a **TypeScript/Node.js** project. Its PyPI package shells out to a Node
+  CLI, so using it from Python **requires a Node.js runtime** on the host.
+- For the office and HTML formats RAC relies on most, it requires
+  **LibreOffice** and **ImageMagick** as external system binaries; PDF is native
+  (bundled PDFium) with OCR via bundled Tesseract.
+- Its strengths are **layout-aware/spatial PDF extraction** (bounding boxes),
+  **OCR of scanned documents**, and page screenshots for agents. Its own
+  documentation steers complex documents toward the cloud LlamaParse service and
+  notes that "Markdown reconstruction quality varies with document complexity."
+
+Those strengths target a problem RAC's ingest does not have. RAC ingests
+born-digital product documents (PRDs, decision records) where the need is clean
+document→Markdown text, not OCR or spatial reconstruction.
+
+## Decision
+
+Keep **markitdown** as RAC's document-ingestion converter. Do not adopt
+liteparse as the default parser.
+
+Preserve the `DocumentConverter` Protocol seam (`src/rac/services/ingest.py`) so
+that, *if* PDF extraction quality ever becomes a real need, a liteparse-backed
+converter can be added as an **optional, PDF-only** converter behind its own
+extra — registered ahead of markitdown for `.pdf` only — without replacing
+markitdown or disturbing the native-Python office/HTML path. That is a future
+option, explicitly not taken now.
+
+This decision records the parser choice; it changes no code, dependency, or
+packaging. `src/rac/services/ingest.py` and `pyproject.toml` are unchanged.
+
+This is distinct from ADR-059, which governs reuse of a single *internal*
+markdown-it-py parser instance for parsing RAC's own artifacts. ADR-059 is about
+reading RAC Markdown; this ADR is about the *ingest* converter that turns
+foreign documents into Markdown. The two parser decisions should not be
+conflated.
+
+## Consequences
+
+### Positive
+
+- Keeps RAC a **pure-Python `pip install`** (ADR-005): no Node.js runtime and no
+  LibreOffice/ImageMagick system binaries are introduced.
+- DOCX, HTML, PPTX, and XLSX continue to convert **natively in Python**; the
+  common DOCX path does not regress to requiring LibreOffice.
+- Conversion stays **deterministic** — no OCR variability enters the pipeline.
+- markitdown remains *optional* and granular per format, so the core tool and
+  Markdown pass-through work with no ingest extra installed.
+- The decision and its evaluation are now durable corpus knowledge, so the
+  liteparse question does not have to be re-litigated from memory.
+
+### Negative / trade-offs
+
+- markitdown's PDF extraction is plainer than a layout-aware parser; RAC accepts
+  simpler PDF fidelity in exchange for the lighter, all-Python footprint.
+- RAC forgoes liteparse's OCR and spatial-extraction features — acceptable,
+  since ADR-010 scopes ingest to structure-preserving text only.
+
+### Risks
+
+- markitdown could become unmaintained or fall behind on a format. Mitigation:
+  the `DocumentConverter` Protocol makes the parser swappable at one seam, and a
+  per-format converter (including an opt-in liteparse PDF converter) can be added
+  without touching the rest of the pipeline.
+
+## Status
+
+Accepted
+
+## Category
+
+Architecture
+
+## Alternatives Considered
+
+### Swap markitdown for liteparse
+
+Rejected. It would add a Node.js runtime plus LibreOffice and ImageMagick system
+binaries to a pure-Python CLI, and would regress the common DOCX/Office path from
+native Python to a LibreOffice shell-out — all to gain OCR and layout-aware
+extraction that RAC's ingest (ADR-010) does not use. The footprint cost is real
+and the benefit does not apply to RAC's inputs.
+
+### Add liteparse now as an optional PDF-only converter
+
+Deferred. The `DocumentConverter` Protocol makes this clean, and it would keep
+markitdown as the default while offering stronger PDF parsing on opt-in. But it
+still drags in the Node.js + Tesseract footprint for that extra, and there is no
+evidence yet that markitdown's PDF output is a practical limitation. Revisit only
+if PDF quality becomes a recurring complaint.
+
+### Drop rich-document ingest entirely
+
+Rejected. Removing document conversion would contradict ADR-006 (Ingestion Over
+Rewrite): RAC must meet users where their knowledge already lives rather than ask
+them to rewrite documents by hand.
+
+## Related Decisions
+
+- adr-005
+- adr-006
+- adr-008
+- adr-010
+- adr-011
+- adr-059
+
+## Review Date
+
+Revisit if PDF or scanned-document extraction quality becomes a recurring
+complaint from users, or if markitdown becomes unmaintained or drops a format
+RAC depends on.


### PR DESCRIPTION
# Summary

Records the decision to keep `markitdown` as RAC's document-ingestion converter,
after evaluating `liteparse` (run-llama/liteparse) as a replacement. Captured as
an ADR so the evaluation is durable corpus knowledge (ADR-047) rather than a
chat that disappears.

Adds:
- `rac/decisions/adr-072-ingest-parser-markitdown.md` (ADR-072, Accepted,
  Architecture).

# Roadmap / ADR Trace

This ADR:
- `rac/decisions/adr-072-ingest-parser-markitdown.md`

Related decisions cited:
- ADR-005 (CLI first / pure-Python install), ADR-006 (ingestion over rewrite),
  ADR-008 (agent-ready service layers), ADR-010 (documents are not artifacts —
  ingest is structure-preserving conversion only), ADR-011 (file-first
  pipelines), ADR-059 (the *internal* markdown-it-py parser — distinct concern).

# Scope

## Included
- An Architecture ADR recording: keep markitdown; do not adopt liteparse as the
  default; preserve the `DocumentConverter` Protocol seam so an optional,
  PDF-only liteparse converter remains a clean future option.

## Excluded
- No code, dependency, or `pyproject.toml` change. `src/rac/services/ingest.py`
  is untouched — this records the decision, it does not alter the implementation.
- Adding liteparse as an opt-in PDF converter now is **deferred**, not adopted.

# Product / Architecture Decisions

- **markitdown stays.** It is already an optional, pure-Python dependency behind
  the `DocumentConverter` Protocol, converting DOCX/HTML/PPTX/XLSX natively in
  Python. Keeping it preserves the `pip install` story (ADR-005) and a
  deterministic conversion path.
- **liteparse rejected as default.** It is a TypeScript/Node.js tool whose Python
  package shells out to a Node CLI and needs LibreOffice + ImageMagick for the
  office/HTML formats RAC relies on most. Its OCR / layout-aware strengths target
  a problem RAC's ingest (ADR-010) does not have, and a swap would regress the
  common DOCX path to a LibreOffice shell-out.
- **Seam preserved.** The Protocol keeps a future opt-in, PDF-only liteparse
  converter a one-seam change, distinct from ADR-059 (which governs reuse of the
  internal markdown parser, not the ingest converter).

# Verification

## Ran
- `rac validate rac/decisions/adr-072-ingest-parser-markitdown.md` — 0 errors,
  0 warnings.
- `rac validate rac/` — 252 valid, 0 invalid.
- `rac relationships rac/ --validate` — 1112 checked, 0 issues (all six related
  decisions resolve).
- `rac review rac/` — exit 0, no priority 1-2 findings, health 92/100.
- `rac watchkeeper rac --base origin/main` — nothing requiring attention (+1
  decision).
- `python -m pytest tests/test_dogfood.py tests/test_golden.py` — 40 passed.

## Covered
- The ADR validates standalone and within the corpus; the review raises no
  findings against it; the status (Accepted) and category (Architecture) are
  spec-valid; every relationship target resolves.

# Review Path

1. `rac/decisions/adr-072-ingest-parser-markitdown.md` — Context (the liteparse
   evaluation), Decision, and Alternatives Considered.

# Notes For Reviewer

ADR-072 ratifies the status quo; it deliberately makes no code change. The
liteparse evaluation rests on liteparse being a Node-core tool with a Python
shell-out and system-binary requirements (LibreOffice / ImageMagick / Tesseract).