### PR TITLE
docs(export): add export shape contract and backend-connector topology

### DIFF
--- a/.cursor/rules
+++ b/.cursor/rules
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: 17674c0a9cd84512168f93b80fb4a12925bf2b99c213024a1b9dcb820307073a) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: 6737a582a536703c7e0837489d18cf6c72eae0ecc985c85b5381018a2456bb33) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -51,4 +51,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KV80WX94GY8A** — ADR-067: Agent Integration is Context-Supply and Post-Edit Enforcement, Not Pre-Edit Interception _(Architecture)_
 - **RAC-KVA44MVMDXXX** — ADR-068: Extension, SDK, and Brand Architecture _(Architecture)_
 - **RAC-KVJK92SM2A1R** — ADR-072: Document Ingestion Parser Is markitdown _(Architecture)_
+- **RAC-KVJY1KJEWZ87** — ADR-073: Backend Connectors Are Export-Contract Consumers, Not Per-Provider Repos _(Architecture)_
 <!-- END RAC MANAGED BLOCK -->

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: 17674c0a9cd84512168f93b80fb4a12925bf2b99c213024a1b9dcb820307073a) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: 6737a582a536703c7e0837489d18cf6c72eae0ecc985c85b5381018a2456bb33) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -51,4 +51,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KV80WX94GY8A** — ADR-067: Agent Integration is Context-Supply and Post-Edit Enforcement, Not Pre-Edit Interception _(Architecture)_
 - **RAC-KVA44MVMDXXX** — ADR-068: Extension, SDK, and Brand Architecture _(Architecture)_
 - **RAC-KVJK92SM2A1R** — ADR-072: Document Ingestion Parser Is markitdown _(Architecture)_
+- **RAC-KVJY1KJEWZ87** — ADR-073: Backend Connectors Are Export-Contract Consumers, Not Per-Provider Repos _(Architecture)_
 <!-- END RAC MANAGED BLOCK -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: 17674c0a9cd84512168f93b80fb4a12925bf2b99c213024a1b9dcb820307073a) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: 6737a582a536703c7e0837489d18cf6c72eae0ecc985c85b5381018a2456bb33) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -51,4 +51,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KV80WX94GY8A** — ADR-067: Agent Integration is Context-Supply and Post-Edit Enforcement, Not Pre-Edit Interception _(Architecture)_
 - **RAC-KVA44MVMDXXX** — ADR-068: Extension, SDK, and Brand Architecture _(Architecture)_
 - **RAC-KVJK92SM2A1R** — ADR-072: Document Ingestion Parser Is markitdown _(Architecture)_
+- **RAC-KVJY1KJEWZ87** — ADR-073: Backend Connectors Are Export-Contract Consumers, Not Per-Provider Repos _(Architecture)_
 <!-- END RAC MANAGED BLOCK -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ to the corpus artifact and they load through the imports below.
 - Previous series: `rac/roadmaps/v0.21.x-editor/` (complete)
 - Decisions (ADRs): `rac/decisions/`
 
-<!-- BEGIN RAC MANAGED BLOCK (digest: 17674c0a9cd84512168f93b80fb4a12925bf2b99c213024a1b9dcb820307073a) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: 6737a582a536703c7e0837489d18cf6c72eae0ecc985c85b5381018a2456bb33) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -76,4 +76,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KV80WX94GY8A** — ADR-067: Agent Integration is Context-Supply and Post-Edit Enforcement, Not Pre-Edit Interception _(Architecture)_
 - **RAC-KVA44MVMDXXX** — ADR-068: Extension, SDK, and Brand Architecture _(Architecture)_
 - **RAC-KVJK92SM2A1R** — ADR-072: Document Ingestion Parser Is markitdown _(Architecture)_
+- **RAC-KVJY1KJEWZ87** — ADR-073: Backend Connectors Are Export-Contract Consumers, Not Per-Provider Repos _(Architecture)_
 <!-- END RAC MANAGED BLOCK -->

--- a/rac/decisions/adr-073-backend-connectors-consolidate.md
+++ b/rac/decisions/adr-073-backend-connectors-consolidate.md
@@ -1,0 +1,132 @@
+---
+schema_version: 1
+id: RAC-KVJY1KJEWZ87
+type: decision
+---
+# ADR-073: Backend Connectors Are Export-Contract Consumers, Not Per-Provider Repos
+
+## Context
+
+The export-to-RAG work (the umbrella roadmap `corpus-export-to-rag-backends`, the
+interplay design `lore-supermemory-interplay`, and the wire-shape design
+`corpus-export-shape-contract`) introduces *connectors* that push the corpus into
+external memory, vector, and graph backends — Supermemory, Mem0, Pinecone, Neo4j,
+Graphiti, Cognee, and so on. The early phrasing named a per-provider companion
+(`lore-supermemory`), which implies **one repository per provider** — a sprawl
+trap as the backend list grows.
+
+ADR-068 settles the topology for **client integrations**: each editor/agent
+integration is its own `lore-<client>` repository (`lore-vscode`, `lore-cursor`,
+`lore-claude`), and a single container repo is *rejected*, justified by
+"independent per-client cadence and ownership." But ADR-068 does not cover
+**backend connectors**, and the cadence/ownership rationale that warrants
+per-client repos does not hold for them:
+
+- A connector is a thin consumer of the published export contract (ADR-063), not
+  an independently-owned installable product.
+- Most backends need **no RAC-side code at all** — RAC emits a standard ingestion
+  shape (`rac export --documents` / `--graph`, per `corpus-export-shape-contract`)
+  that a provider's own ingestion consumes. The contract is the product.
+- ADR-064's "single `rac-actions` repo, one subdirectory per action" is the
+  closer precedent for thin, related wrappers maintained together.
+
+A connector also belongs outside `rac-core` regardless of repo count: it carries
+third-party SDK and network dependencies the engine must not (ADR-002, ADR-066),
+and pushing into an external store is not the engine's job (ADR-024).
+
+## Decision
+
+Treat memory, vector, and graph backend connectors as **export-contract
+consumers**, not per-provider installable products:
+
+- **The export contract is the product.** The long tail of backends is served by
+  the documented export shape (`rac export --documents` / `--graph`) plus the
+  provider's own ingestion — no RAC-side code per provider.
+- **Reference connectors consolidate into one companion repository,
+  `lore-connectors`**, with a module or recipe per provider — not one repo per
+  provider. This deliberately differs from ADR-068's per-client rule; the
+  discriminator is that connectors lack the independent cadence and ownership that
+  justify a repo per client.
+- **A dedicated `lore-<provider>` repo is created only if** a specific integration
+  grows into an installable product with its own surface — auth, a sync daemon,
+  an independent release cadence — the same test ADR-068 applies to clients. That
+  is the documented escape hatch, not the default.
+- **Connectors live outside `rac-core`** (ADR-002, ADR-024, ADR-063, ADR-066):
+  the engine stays pure-Python, AI-optional, deterministic, and offline.
+
+This does not reopen ADR-068; it extends the `lore-*` topology to a category
+ADR-068 did not address.
+
+## Consequences
+
+### Positive
+
+- No repo-per-provider sprawl; the export contract does the heavy lifting and most
+  providers need zero code.
+- One discoverable home for reference connectors (`lore-connectors`).
+- The engine stays clean — no third-party backend SDKs or network in `rac-core`.
+- The connector-vs-client distinction is now recorded, so it is not re-litigated.
+
+### Negative / trade-offs
+
+- `lore-connectors` mixes providers with different release needs in one repo.
+  Accepted: they are reference adapters, not independently-owned products; if one
+  outgrows that, it graduates to its own repo via the escape hatch.
+
+### Risks
+
+- The connector-vs-client line could blur over time. Mitigation: the test is
+  recorded — "an installable product with independent cadence and ownership earns
+  its own repo; a contract consumer does not."
+
+## Status
+
+Accepted
+
+## Category
+
+Architecture
+
+## Alternatives Considered
+
+### One `lore-<provider>` repo per backend
+
+Rejected: it is the sprawl this decision exists to prevent, and it misapplies
+ADR-068's per-client rule to a category whose cadence/ownership rationale does not
+fit.
+
+### Build connectors into `rac-core`
+
+Rejected: it drags third-party SDK and network dependencies into the engine,
+breaking its pure-Python, AI-optional, offline posture (ADR-002, ADR-066) and
+ADR-024 (not a content store).
+
+### Documentation recipes only, no connector repo
+
+Viable for the simplest `--documents` cases and encouraged where it suffices, but
+insufficient as the sole answer: a graph projection or a re-sync workflow wants
+real code. `lore-connectors` is the home for that; recipes cover the rest.
+
+## Related Decisions
+
+- adr-002
+- adr-024
+- adr-063
+- adr-064
+- adr-066
+- adr-068
+
+## Related Designs
+
+- lore-supermemory-interplay
+- corpus-export-shape-contract
+
+## Related Roadmaps
+
+- corpus-export-to-rag-backends
+
+## Review Date
+
+Revisit if a backend connector grows into an installable product with its own
+cadence (triggering the dedicated-repo escape hatch), or if the number of
+consolidated connectors makes `lore-connectors` unwieldy.

--- a/rac/designs/corpus-export-shape-contract.md
+++ b/rac/designs/corpus-export-shape-contract.md
@@ -89,9 +89,9 @@ JSONL (the de-facto ingestion shape), one object per artifact:
 #### Supermemory mapping (the first adapter)
 
 Each JSONL line maps to `add({ content: text, containerTag: source,
-metadata: { id, type, status, title, path } })`. The adapter is a `lore-*`
-companion (ADR-068), outbound-only; embeddings live in Supermemory, never in RAC
-(ADR-002, ADR-066).
+metadata: { id, type, status, title, path } })`. The connector is a module in the
+shared `lore-connectors` companion (ADR-073), outbound-only; embeddings live in
+Supermemory, never in RAC (ADR-002, ADR-066).
 
 ### `--graph` — later, for graph backends (not Supermemory)
 
@@ -117,8 +117,8 @@ companion (ADR-068), outbound-only; embeddings live in Supermemory, never in RAC
   names, a `schema_version` per projection; the viewer JSON contract is unchanged.
 - Deterministic and offline; no embeddings, vectors, or LLM in RAC
   (ADR-002, ADR-066).
-- One-way: the adapter is a `lore-*` companion (ADR-068); RAC does not store,
-  serve, or re-import the embedded copy (ADR-024).
+- One-way: the connector is a module in the `lore-connectors` companion
+  (ADR-073); RAC does not store, serve, or re-import the embedded copy (ADR-024).
 - Text only for the first phase; asset references (ADR-019) are out of scope.
 - Unknown-type files are skipped; invalid-but-recognizable artifacts export as
   classified — the same gate the existing export applies.
@@ -198,6 +198,7 @@ authoritative, current Lore artifact rather than to the backend's rewritten copy
 - ADR-063
 - ADR-066
 - ADR-068
+- ADR-073
 
 ## Related Roadmaps
 

--- a/rac/designs/corpus-export-shape-contract.md
+++ b/rac/designs/corpus-export-shape-contract.md
@@ -1,0 +1,205 @@
+---
+schema_version: 1
+id: RAC-KVJX3P88JSCA
+type: design
+---
+# Corpus Export Shape for External Memory and RAG
+
+## Status
+
+Proposed
+
+Exploratory — the implementation contract for the export *shape* under the
+unscheduled umbrella `corpus-export-to-rag-backends`. The first target is
+**Supermemory** (a documents/memory backend), so the `--documents` projection is
+the immediate deliverable and `--graph` is specified for later graph backends.
+Complements the interplay design `lore-supermemory-interplay` (the one-way,
+fuzzy-find/deterministic-verify shape this serializes for).
+
+## Context
+
+The umbrella roadmap commits to a one-way export of the corpus to external
+memory, vector, and context-graph backends. This design fixes the wire contract.
+
+Grounding in what `rac export` emits today matters, because the RAG shape is
+**not** just the existing JSON:
+
+- `build_corpus_export` (`src/rac/services/export.py`) produces a deterministic
+  `CorpusExport` (`schema_version "1"`), already offered in four modes — default
+  JSON, `--html` (Portal), `--okf` (one-Markdown-per-artifact bundle, ADR-050),
+  and `--agent-rules`. Adding a mode is the established, ADR-007-clean pattern.
+- Per artifact it carries `id`, `aliases`, `type`, `status`, `title`, `path`,
+  and **`body_html`** — the Markdown body rendered to HTML for the viewer.
+- Its `relationships` are flattened to a single untyped **`relates-to`** edge.
+  The code reserves richer typing as "a future decision, not an export
+  invention", even though the *typed* edges already exist via
+  `extract_relationships_full` + `relationship_types.REGISTRY`
+  (`supersedes`, `related_decisions`, … with direction and acyclicity).
+
+Two consequences shape this contract:
+
+1. A RAG/memory backend must embed **text, not HTML** — `body_html` is wrong for
+   ingestion, so the documents projection emits the **Markdown body** (a new
+   field; the raw body is already available via `split_frontmatter`).
+2. The graph projection **surfaces the typed edges** — it is exactly the "future
+   decision" the export code anticipated, and the differentiator behind "hand
+   GraphRAG the real decision graph instead of an inferred one".
+
+## User Need
+
+- **The Supermemory adapter (first target)** needs a stable, ingestion-shaped
+  export it can push without re-deriving anything from raw Markdown: one record
+  per artifact, clean text, and metadata carrying the canonical `id`, `type`, and
+  `status` — so the verify-in-Lore loop can re-fetch the authoritative artifact
+  and retired decisions stay filterable on read.
+- **A graph backend (later — Neo4j / Graphiti / Cognee)** needs typed nodes and
+  edges so it receives RAC's real, validated decision graph rather than one an
+  LLM infers from prose.
+
+## Design
+
+Two additive projection modes, beside `--okf` / `--html` / `--agent-rules`. The
+v1 viewer JSON (`CorpusExport.to_dict`) is left untouched (ADR-007); each new
+projection carries its own `schema_version` and grows only additively.
+
+### `--documents` — the immediate, Supermemory-first deliverable
+
+JSONL (the de-facto ingestion shape), one object per artifact:
+
+```json
+{"schema_version":"1","id":"RAC-KVJK92SM2A1R","type":"decision","status":"Accepted",
+ "title":"ADR-072: Document Ingestion Parser Is markitdown",
+ "text":"## Context\n…(Markdown body, frontmatter stripped)…",
+ "metadata":{"path":"rac/decisions/adr-072-…md","aliases":["ADR-072"],"tags":[],"source":"rac"}}
+```
+
+- `text` is the **Markdown body**, not `body_html`.
+- **One document per artifact — no chunking.** The artifact is the atomic
+  knowledge unit (ADR-004, ADR-010); chunking is the embedder's job and keeping
+  the unit whole stays deterministic.
+- `id` is the canonical opaque RAC identity (ADR-026) — the hook the
+  verify-in-Lore loop re-fetches by; `status` rides along so a retired or
+  superseded decision is filterable on read.
+- **All classified artifacts are included**, with `status` stamped — not dropped
+  — so the export stays complete; a stale hit is safe because the verify step
+  re-fetches and the status is present.
+- Determinism is preserved exactly as the existing export: sorted-path order, no
+  timestamps (ADR-002).
+
+#### Supermemory mapping (the first adapter)
+
+Each JSONL line maps to `add({ content: text, containerTag: source,
+metadata: { id, type, status, title, path } })`. The adapter is a `lore-*`
+companion (ADR-068), outbound-only; embeddings live in Supermemory, never in RAC
+(ADR-002, ADR-066).
+
+### `--graph` — later, for graph backends (not Supermemory)
+
+```json
+{"schema_version":"1","source":"rac",
+ "nodes":[{"id":"RAC-…","type":"decision","status":"Accepted","title":"ADR-072: …"}],
+ "edges":[{"source":"RAC-072","target":"RAC-059","type":"related_decisions","directed":false},
+          {"source":"RAC-new","target":"RAC-old","type":"supersedes","directed":true}]}
+```
+
+- Edge `type` comes straight from `relationship_types.REGISTRY`; `directed` from
+  `edge_spec.directional` (`supersedes` directed, `related_*` undirected).
+- Resolved targets become canonical-id edges; unresolved references keep their
+  literal target with `resolved:false` (no phantom nodes), mirroring how the
+  current export preserves unresolved targets verbatim.
+- Surfacing typed edges is the reserved "future decision", so this projection
+  carries **its own short ADR** when it is scheduled — it is out of scope for the
+  Supermemory-first phase.
+
+## Constraints
+
+- Additive only (ADR-007, ADR-063): new modes, stable lowercase-snake field
+  names, a `schema_version` per projection; the viewer JSON contract is unchanged.
+- Deterministic and offline; no embeddings, vectors, or LLM in RAC
+  (ADR-002, ADR-066).
+- One-way: the adapter is a `lore-*` companion (ADR-068); RAC does not store,
+  serve, or re-import the embedded copy (ADR-024).
+- Text only for the first phase; asset references (ADR-019) are out of scope.
+- Unknown-type files are skipped; invalid-but-recognizable artifacts export as
+  classified — the same gate the existing export applies.
+
+## Rationale
+
+- JSONL, one document per artifact, is the lingua franca of memory/vector/RAG
+  ingestion and keeps RAC's atomic unit and determinism intact.
+- Markdown over HTML: backends embed text; HTML tags are noise that pollutes
+  retrieval.
+- Include-all-with-status over a live-only default: completeness and determinism,
+  and the verify-in-Lore loop already makes a stale hit safe; the `status` field
+  lets the adapter or agent filter when it wants live-only.
+- Separate modes over extending the viewer JSON: mirrors `--okf` / `--html`, and
+  protects the locked viewer contract from churn.
+- Lead with `--documents` because the first target, Supermemory, consumes
+  documents, not a graph; the graph projection composes in later without
+  reworking the documents one.
+
+## Alternatives
+
+- **Reuse the existing `--json` payload directly** — rejected: its body is HTML
+  and its edges are untyped `relates-to`; both are wrong for ingestion.
+- **Chunk per section** — rejected for the first phase: non-atomic, less
+  deterministic, and the embedder's job; revisit only if whole-artifact
+  embedding proves too coarse for recall.
+- **Drop retired artifacts (live-only default)** — rejected as the default: loses
+  completeness; offered instead as an opt-in (`--live-only`, an open question).
+- **One combined mode emitting documents and graph together** — rejected:
+  different consumers (memory vs graph); separate modes compose better and
+  Supermemory needs only documents.
+
+## Accessibility
+
+This is primarily a machine contract, but the accessibility concern is
+*provenance legibility*: every record carries the canonical `id` and `status`, so
+a human auditing what an agent recalled can always trace a memory back to the
+authoritative, current Lore artifact rather than to the backend's rewritten copy.
+
+## Style Guidance
+
+- JSONL for `--documents` (one UTF-8 JSON object per line, stable key order);
+  `--graph` emits a single whole-graph JSON object.
+- Field names are lowercase snake_case and grow only additively (ADR-007).
+- Mode naming stays consistent with the existing flags
+  (`--documents`, `--graph` beside `--okf` / `--html` / `--agent-rules`).
+
+## Open Questions
+
+- A `--live-only` opt-in to drop retired/superseded artifacts for recall-focused
+  ingests.
+- Whether `--documents` metadata should also carry an artifact's outgoing typed
+  edges (its related ids), so a single memory knows its neighbours, or whether
+  that stays solely in `--graph`.
+- The `--graph` output format (single JSON vs JSONL with a `kind` discriminator)
+  and unresolved-edge handling — settle when that projection is scheduled.
+- The typed-edge ADR (surfacing `REGISTRY` edge types) — author when `--graph`
+  lands.
+- The `containerTag` / `source` scheme for multi-repo ingestion (per-repo vs
+  per-series).
+
+## Related Requirements
+
+- rac-agent-context-guide
+
+## Related Decisions
+
+- ADR-002
+- ADR-004
+- ADR-007
+- ADR-010
+- ADR-019
+- ADR-024
+- ADR-026
+- ADR-050
+- ADR-055
+- ADR-063
+- ADR-066
+- ADR-068
+
+## Related Roadmaps
+
+- corpus-export-to-rag-backends
+- lore-supermemory-grounding

--- a/rac/designs/lore-supermemory-interplay.md
+++ b/rac/designs/lore-supermemory-interplay.md
@@ -84,8 +84,8 @@ Lore*, never as a source of truth.
 
 ### The feed — a one-way ingest adapter
 
-A small companion, `lore-supermemory` (a `lore-*` repo per ADR-068, never inside
-`rac-core`):
+A Supermemory connector — a module (or recipe) in the shared `lore-connectors`
+companion, not a per-provider repo (ADR-073), and never inside `rac-core`:
 
 - runs `rac export --json` (the deterministic `CorpusExport`, a stable additive
   contract per ADR-007 / ADR-063) or reads the Markdown + frontmatter on disk;
@@ -117,9 +117,9 @@ already carries `id`, `type`, and `status`.
 - **Supermemory's copy is non-authoritative by construction.** Its ingest
   rewrites content with an LLM, so its text is an index, never a citation;
   authoritative text is always re-fetched from Lore.
-- **Companion, not core (ADR-068, ADR-024).** Any build is a `lore-*` repo. RAC
-  does not store, serve, or re-import the embedded copy; it is not becoming a
-  content store.
+- **Companion, not core (ADR-073, ADR-024).** Any build is a connector module in
+  the shared `lore-connectors` companion, not engine code. RAC does not store,
+  serve, or re-import the embedded copy; it is not becoming a content store.
 
 ## Rationale
 
@@ -175,8 +175,9 @@ Lore artifact, not the rewritten memory.
 
 ## Style Guidance
 
-- Name the companion `lore-supermemory` (the `lore-*` brand convention, ADR-068),
-  not `rac-*`; it is a Lore-brand integration, not an engine component.
+- The Supermemory connector is a module in the shared `lore-connectors` companion
+  (ADR-073), under the `lore-*` brand (ADR-068), not `rac-*`; it is a Lore-brand
+  integration, not an engine component, and not its own per-provider repo.
 - Vocabulary separates the layers: Lore *grounds* and is *authoritative*;
   Supermemory *recalls* and is *associative*. Never describe Supermemory output
   as a decision or a citation.
@@ -213,6 +214,7 @@ Lore artifact, not the rewritten memory.
 - ADR-066
 - ADR-067
 - ADR-068
+- ADR-073
 
 ## Related Roadmaps
 

--- a/rac/roadmaps/future/corpus-export-to-rag-backends.md
+++ b/rac/roadmaps/future/corpus-export-to-rag-backends.md
@@ -70,12 +70,15 @@ backends, and a *nodes + edges* projection for graph backends, both derived from
 the existing deterministic export (ADR-007). Embeddings are never computed in RAC
 — they live in the target (ADR-002, ADR-066).
 
-### Initiative 2 — Reference `lore-*` adapters
+### Initiative 2 — Reference connectors in one `lore-connectors` companion
 
-Ship a small, honest set of reference adapters as `lore-*` companions (ADR-068),
-not an exhaustive matrix: Supermemory first (per `lore-supermemory-grounding`),
-plus at least one graph-native target (e.g. Neo4j / Graphiti / Cognee) to prove
-the nodes+edges projection. Each is outbound-only; RAC never reads back.
+Ship a small, honest set of reference connectors as modules in a **single**
+`lore-connectors` companion (ADR-073), not one repo per provider and not an
+exhaustive matrix: Supermemory first (per `lore-supermemory-grounding`), plus at
+least one graph-native target (e.g. Neo4j / Graphiti / Cognee) to prove the
+nodes+edges projection. Each is outbound-only; RAC never reads back. A provider
+graduates to its own `lore-<provider>` repo only if it becomes an installable
+product with independent cadence (the ADR-073 escape hatch).
 
 ### Initiative 3 — Documentation that names targets and the validation loop
 
@@ -153,6 +156,7 @@ It must:
 - ADR-063
 - ADR-066
 - ADR-068
+- ADR-073
 
 ## Related Roadmaps
 


### PR DESCRIPTION
# Summary

Records the design and decision for exporting the RAC corpus to external memory,
RAG, and graph backends — the *how* (wire shape) and the *where* (connector
topology) under the `corpus-export-to-rag-backends` umbrella. Recorded direction
per ADR-047; no code change.

Adds:
- `rac/designs/corpus-export-shape-contract.md` — the export wire shape:
  a Supermemory-first `--documents` JSONL projection and a `--graph` projection
  for graph backends.
- `rac/decisions/adr-073-backend-connectors-consolidate.md` — ADR-073: backend
  connectors consolidate into one `lore-connectors` companion, not per-provider
  repos.

Updates:
- `rac/designs/lore-supermemory-interplay.md` and
  `rac/roadmaps/future/corpus-export-to-rag-backends.md` — repointed from a
  per-provider `lore-supermemory` companion to the shared `lore-connectors`,
  per ADR-073.

# Roadmap / ADR Trace

- Umbrella roadmap: `rac/roadmaps/future/corpus-export-to-rag-backends.md`
  (Planned, unscheduled).
- New decision: `rac/decisions/adr-073-backend-connectors-consolidate.md`.
- Relevant ADRs: ADR-007 / ADR-063 (additive contract, thin clients), ADR-055
  (typed relationship graph), ADR-004 / ADR-010 (atomic artifact unit), ADR-026
  (opaque id), ADR-050 (OKF projection), ADR-002 / ADR-066 (AI-optional, no
  embeddings in core), ADR-024 (not a content store), ADR-068 / ADR-064 (`lore-*`
  / multi-repo topology), ADR-019 (assets — out of scope).

# Scope

## Included
- **Export-shape design.** `--documents` JSONL — one Markdown-bodied record per
  artifact, carrying the canonical `id`/`type`/`status` for the verify-in-Lore
  loop, no chunking, all artifacts included with `status` stamped — as the
  Supermemory-first deliverable; `--graph` typed nodes+edges for graph backends
  as phase 2. Both are additive modes beside `--okf`/`--html`.
- **ADR-073.** Connector topology: one `lore-connectors` companion, the export
  contract is the product, a dedicated per-provider repo only when an integration
  earns it.
- **Repoints.** The interplay design, the umbrella roadmap, and the export-shape
  design now reference `lore-connectors` / ADR-073 instead of a per-provider repo.

## Excluded
- No code or engine change — `src/rac/services/export.py` is untouched.
- `--graph` implementation and its typed-edge ADR are deferred to phase 2;
  Supermemory (the first target) needs only `--documents`.
- No version scheduling — the umbrella stays in `future/` until scheduled.

# Product / Architecture Decisions

- **Two grounding findings shape the contract:** today's export emits HTML bodies
  (`body_html`) and flattens edges to untyped `relates-to`, so a RAG projection
  needs a Markdown `text` body, and surfacing the typed graph is the "future
  decision" the export code explicitly reserves.
- **Documents projection** is one record per artifact (atomic unit, ADR-004/010),
  no chunking; the canonical `id` is the verify-in-Lore hook; all artifacts are
  included with `status` stamped (completeness — the verify step makes a stale hit
  safe).
- **Additive modes** (`--documents`/`--graph`) leave the v1 viewer JSON untouched
  (ADR-007).
- **ADR-073** records that connectors are export-contract consumers, not
  per-provider installable products, and consolidate into `lore-connectors` —
  distinct from ADR-068's per-client rule, with "installable product with
  independent cadence" as the discriminator for earning a dedicated repo.

# Verification

## Ran
- `rac validate rac/` — 259 valid, 0 invalid.
- `rac relationships rac/ --validate` — 1189 checked, 0 issues.
- `rac review rac/` — exit 0, no priority 1-2 findings.
- `rac export rac/ --agent-rules --check` — in sync.
- `python -m pytest tests/test_dogfood.py tests/test_golden.py` — 40 passed.

## Covered
- ADR-073's references, and the new ADR-073 edges added to the three artifacts,
  all resolve within the branch — the ADR-073 to export-shape-design edge is why
  these are bundled in one PR (so the relationship gate stays green on merge).
- The agent-rules managed block was regenerated for ADR-073 (drift gate in sync).

# Review Path

1. `rac/decisions/adr-073-backend-connectors-consolidate.md` — the
   connector-vs-client topology decision and its escape hatch.
2. `rac/designs/corpus-export-shape-contract.md` — Context (the two findings),
   the `--documents` shape, the deferred `--graph` shape, Open Questions.
3. The three repoints to `lore-connectors`.

# Notes For Reviewer

- Bundled deliberately: the ADR references the export-shape design, so they share
  one merge unit to keep `rac relationships --validate` green.
- `--graph` and its typed-edge ADR are explicitly phase 2; this PR settles
  documents-first plus the connector topology.
- The agent-rules commit is mechanical (managed block gains the ADR-073 line).