### PR TITLE
docs(roadmap): open v0.25.0-connect

### DIFF
--- a/rac/decisions/adr-074-export-surfaces-typed-edges.md
+++ b/rac/decisions/adr-074-export-surfaces-typed-edges.md
@@ -1,0 +1,109 @@
+---
+schema_version: 1
+id: RAC-KVK19NPWFYC9
+type: decision
+---
+# ADR-074: The Graph Export Surfaces Typed Relationship Edges
+
+## Context
+
+`rac export` (`src/rac/services/export.py`) deliberately flattens every
+relationship to a single untyped `relates-to` edge. The code says so explicitly:
+"richer typing (supersedes/refines/implements) is reserved for a future decision,
+not an export invention." That flattening is correct for the Portal viewer, whose
+v1 contract (`CorpusExport.to_dict`) is reconciled with the vendored viewer and
+must stay stable (ADR-007).
+
+The typed graph nonetheless already exists inside the engine:
+`extract_relationships_full` plus the relationship-type registry (ADR-055) give
+`supersedes`, `related_decisions`, `related_requirements`, … each with declared
+direction and acyclicity, and that is what relationship validation runs on.
+
+The v0.25.0 graph export (`rac export --graph`, requirement
+`rac-corpus-graph-export`, design `corpus-export-shape-contract`) exists precisely
+to hand graph backends RAC's real decision topology rather than one inferred from
+prose. That requires surfacing the typed edges — the "future decision" the export
+code reserved. This ADR records that decision.
+
+## Decision
+
+The `rac export --graph` projection **surfaces typed relationship edges** taken
+from the relationship-type registry (ADR-055):
+
+- Each edge carries its registry `type` (`supersedes`, `related_decisions`,
+  `related_requirements`, `related_roadmaps`, `related_designs`,
+  `related_prompts`) and a `directed` flag derived from the registry
+  (`supersedes` is directed; the `related_*` edges are undirected).
+- This applies **only** to the new `--graph` projection. The default viewer JSON
+  (`CorpusExport.to_dict`) keeps its flattened, untyped `relates-to` edges
+  unchanged — the graph projection is separate and additive (ADR-007), so the
+  viewer contract is not touched.
+- Edge typing is derived from the registry and the same resolution validation
+  uses, never a hand-maintained table, so adding a relationship kind does not
+  leave the export stale.
+
+This lifts the export's self-imposed "untyped only" restriction for the graph
+projection alone, and leaves it in place for the viewer payload.
+
+## Consequences
+
+### Positive
+
+- Graph backends (Neo4j, Graphiti, Cognee) receive RAC's real, validated typed
+  graph instead of an LLM-inferred one — the differentiator behind the export-to-
+  graph work.
+- Typing comes from one declarative source (the registry), so it cannot drift from
+  what validation enforces.
+- The viewer's stable `relates-to` contract is untouched; the change is additive.
+
+### Negative / trade-offs
+
+- A second edge representation now exists (flattened `relates-to` for the viewer,
+  typed for `--graph`). Accepted: they serve different consumers, and both derive
+  from the same resolved graph, so they cannot disagree on *which* edges exist —
+  only on how much type detail is exposed.
+
+### Risks
+
+- The typed projection is mistaken for a change to the viewer contract.
+  Mitigation: the decision scopes typing to `--graph` only and states the viewer
+  payload is unchanged; a test asserts the viewer JSON is byte-stable.
+
+## Status
+
+Proposed
+
+Proposed until the v0.25.0 WS2 (graph export) workstream is accepted; the
+documents projection (WS1) does not depend on it.
+
+## Category
+
+Technical
+
+## Alternatives Considered
+
+### Keep all export edges untyped (`relates-to`)
+
+Rejected for the graph projection: it defeats the purpose of exporting to a graph
+backend, which is to convey the real typed topology rather than a flat
+adjacency the backend would then try to re-infer.
+
+### Add typing to the viewer JSON as well
+
+Rejected: the viewer's v1 contract is stable and reconciled with the vendored
+viewer (ADR-007); changing it is out of scope and unnecessary. Typing is added
+only where it is consumed — the `--graph` projection.
+
+## Related Decisions
+
+- adr-007
+- adr-055
+- adr-063
+
+## Related Designs
+
+- corpus-export-shape-contract
+
+## Related Roadmaps
+
+- v0.25.0-connect

--- a/rac/requirements/rac-corpus-documents-export.md
+++ b/rac/requirements/rac-corpus-documents-export.md
@@ -1,0 +1,88 @@
+---
+schema_version: 1
+id: RAC-KVK19KCJDCY6
+type: requirement
+tags: [user-facing, export, rag, ingestion, determinism]
+---
+# Requirement: Corpus Documents Export
+
+## Status
+
+Proposed
+
+Classification: `[user-facing]` — get the corpus into external memory/RAG
+backends. Scoped to v0.25.0 (WS1). A deterministic, ingestion-shaped JSONL
+projection derived from the existing export; no AI, additive output (ADR-007).
+
+## Problem
+
+`rac export` today produces a viewer-shaped payload: each artifact's body is
+rendered to HTML (`body_html`) and offered for the Portal. That is the wrong shape
+for an external memory or RAG backend, which ingests **text** plus metadata, not
+HTML. A team that wants its recorded decisions available to an agent's memory tool
+(Supermemory first, then any vector/RAG store) has no clean, stable way to feed
+them in — they would have to scrape raw Markdown and re-derive identity and status
+themselves. RAC should emit an ingestion-ready projection so the backend handles
+recall and Lore remains the authoritative source the agent verifies against.
+
+## Requirements
+
+- [REQ-001] RAC MUST provide an additive `rac export --documents` mode that emits one record per classified artifact as JSON Lines (one object per line), deterministically and offline, without altering the existing default export payload — the v1 viewer contract (ADR-007, ADR-002).
+- [REQ-002] Each record MUST carry the artifact's canonical opaque `id` (ADR-026), its `type`, its canonicalized `status`, its `title`, and a `text` field containing the artifact's Markdown body (frontmatter stripped) — not rendered HTML — so a backend embeds clean text.
+- [REQ-003] Each record MUST carry metadata sufficient for the verify-in-Lore loop and for namespacing: at least the canonical `id`, `type`, `status`, source `path`, `aliases`, `tags`, and a corpus `source` name, so an agent can re-fetch the authoritative artifact from Lore by `id` and a retired `status` is distinguishable on read.
+- [REQ-004] The export MUST emit one record per artifact as the atomic unit (ADR-004, ADR-010); it MUST NOT chunk artifacts into sub-records — chunking is the embedder's responsibility.
+- [REQ-005] All classified artifacts MUST be included with their `status` stamped — retired and superseded artifacts are not dropped — so the projection is complete and the agent or connector filters on read; unknown-type files are skipped, exactly as the existing export gate behaves.
+- [REQ-006] Output MUST be deterministic: identical corpus bytes produce a byte-identical projection across runs (sorted order, no timestamps), with no AI/LLM/embeddings and no network in the export path (ADR-002, ADR-066).
+- [REQ-007] The projection MUST NOT embed RAC-side embeddings or vectors; it carries text and metadata only, leaving embedding to the consuming backend (ADR-066).
+
+## Acceptance Criteria
+
+- `rac export --documents` over a fixture corpus emits valid JSONL, one line per
+  classified artifact, each line carrying `id`, `type`, `status`, `title`, `text`
+  (Markdown, not HTML), and the metadata block.
+- The default `rac export` (viewer JSON) output is unchanged byte-for-byte —
+  `--documents` is purely additive.
+- Two runs over an unchanged corpus produce byte-identical output; no network
+  access occurs.
+- A superseded decision appears in the output with `status` reflecting that, not
+  omitted.
+
+## Success Metrics
+
+- A maintainer pipes `rac export --documents` into a backend's ingestion
+  (Supermemory first) with no RAC-side per-provider code, and an agent completes
+  the verify-in-Lore loop from the resulting memories.
+
+## Risks
+
+- The projection drifts from the viewer contract or accidentally changes it.
+  Mitigation: REQ-001 makes it a separate additive mode; the viewer JSON is
+  asserted unchanged.
+- Output is non-deterministic (ordering, timestamps). Mitigation: REQ-006 and
+  byte-stable goldens.
+
+## Assumptions
+
+- The existing export already resolves `id`/`type`/`status` and the Markdown body
+  is recoverable (frontmatter split), so the projection needs no new schema.
+- The "documents + metadata + id" shape is the common ingestion denominator across
+  memory/vector/RAG backends.
+
+## Related Decisions
+
+- adr-002
+- adr-004
+- adr-007
+- adr-010
+- adr-026
+- adr-050
+- adr-063
+- adr-066
+
+## Related Designs
+
+- corpus-export-shape-contract
+
+## Related Roadmaps
+
+- v0.25.0-connect

--- a/rac/requirements/rac-corpus-graph-export.md
+++ b/rac/requirements/rac-corpus-graph-export.md
@@ -1,0 +1,83 @@
+---
+schema_version: 1
+id: RAC-KVK19MJNE7KX
+type: requirement
+tags: [internal, export, graph, relationships, determinism]
+---
+# Requirement: Corpus Graph Export
+
+## Status
+
+Proposed
+
+Classification: `[internal]` — give graph backends RAC's real decision graph.
+Scoped to v0.25.0 (WS2, Tier 2 / cut-first). A deterministic nodes+edges
+projection that surfaces the typed relationship graph; gated on ADR-074.
+
+## Problem
+
+GraphRAG-style backends (Neo4j, Graphiti, Cognee) build a knowledge graph from
+documents — typically by having an LLM *infer* entities and edges from prose,
+fuzzily and non-deterministically. RAC already owns a typed, validated
+relationship graph (ADR-055): artifacts are nodes, and `supersedes` / `related_*`
+are typed, directional-or-not edges that relationship validation already computes.
+But the current export flattens every edge to an untyped `relates-to` and exposes
+no node/edge projection, so a graph backend cannot consume the real graph and is
+forced to re-infer it. RAC should hand the graph over directly — deterministic and
+curated — so the backend reflects the team's actual decision topology.
+
+## Requirements
+
+- [REQ-001] RAC MUST provide an additive `rac export --graph` mode that emits a nodes+edges projection of the corpus, deterministically and offline, without altering the existing default export payload (ADR-007, ADR-002).
+- [REQ-002] Nodes MUST carry the canonical `id`, `type`, `status`, and `title`; edges MUST carry `source` and `target` canonical ids, the edge `type` taken from the relationship-type registry (`supersedes`, `related_decisions`, …), and a `directed` flag derived from the registry — `supersedes` directed, `related_*` undirected (ADR-055).
+- [REQ-003] Surfacing typed edge types rather than the viewer's flattened `relates-to` MUST follow ADR-074; the viewer JSON's `relates-to` contract MUST remain unchanged, the graph projection being separate and additive.
+- [REQ-004] Resolved references MUST become canonical-id edges; unresolved references MUST be preserved with the literal target and flagged unresolved, never silently dropped and never inventing a phantom node (matching how the existing export preserves unresolved targets).
+- [REQ-005] Output MUST be deterministic: identical corpus bytes produce a byte-identical graph across runs (sorted nodes and edges, no timestamps), with no AI/LLM/embeddings and no network (ADR-002, ADR-066).
+
+## Acceptance Criteria
+
+- `rac export --graph` over a fixture corpus with a supersession chain and several
+  `related_*` edges emits nodes for every classified artifact and edges whose types
+  and direction match `rac relationships`' resolved typed graph.
+- A `supersedes` edge is `directed: true`; a `related_decisions` edge is
+  `directed: false`.
+- An unresolved reference appears as an edge flagged unresolved with its literal
+  target, and creates no node.
+- The default `rac export` output is unchanged; two runs produce byte-identical
+  graph output.
+
+## Success Metrics
+
+- A graph backend ingests `rac export --graph` and reflects RAC's real
+  `supersedes`/`related_*` topology, with no LLM inference step.
+
+## Risks
+
+- The typed-edge surfacing leaks into or changes the viewer's `relates-to`
+  contract. Mitigation: REQ-003 and ADR-074 keep `--graph` a separate, additive
+  projection.
+- Edge typing drifts from the registry. Mitigation: REQ-002 derives types and
+  direction from the relationship-type registry, not a hand-maintained table.
+
+## Assumptions
+
+- The relationship-type registry and the resolution that validation performs are
+  sufficient to emit typed, directed edges without a new schema (ADR-055).
+- ADR-074 is accepted before this workstream ships (it is Proposed until then).
+
+## Related Decisions
+
+- adr-002
+- adr-007
+- adr-055
+- adr-063
+- adr-066
+- adr-074
+
+## Related Designs
+
+- corpus-export-shape-contract
+
+## Related Roadmaps
+
+- v0.25.0-connect

--- a/rac/roadmaps/v0.25.x-connect/v0.25.0-connect.md
+++ b/rac/roadmaps/v0.25.x-connect/v0.25.0-connect.md
@@ -1,0 +1,200 @@
+---
+schema_version: 1
+id: RAC-KVK1A9M20SYY
+type: roadmap
+---
+# RAC v0.25.0 — Connect
+
+## Status
+
+Planned
+
+Planning artifacts only — no code. The workstreams land later as scoped PRs, as
+v0.23.0's and v0.24.0's did. This release schedules the engine half of the
+`corpus-export-to-rag-backends` umbrella; the connector itself is companion work
+in `lore-connectors` (ADR-073), out of this repo's scope.
+
+## Context
+
+v0.24.0 made the corpus **visible**; v0.25.0 makes it **reachable**. Teams already
+run external memory, RAG, and graph tools (Supermemory, Mem0, vector stores,
+Neo4j / Graphiti / Cognee); today they cannot get RAC's recorded decisions into
+those tools without scraping raw Markdown. This release adds a stable,
+ingestion-shaped **export contract** so an agent can recall fuzzily from a backend
+and then *verify in Lore* — the fuzzy-find / deterministic-verify loop the
+interplay design works out.
+
+ADR-073 splits the work cleanly: the **engine** ships the export contract; the
+**connector** that pushes into a given backend is a module in the shared
+`lore-connectors` companion, on its own cadence, never in `rac-core`. So this
+release is scoped to the export *projections*, not to any backend integration.
+
+The wire shape is fixed by `corpus-export-shape-contract`, grounded in two facts
+about today's export (`src/rac/services/export.py`): it renders bodies to HTML
+(`body_html`) and flattens every edge to an untyped `relates-to`. A RAG projection
+therefore needs a Markdown text body, and surfacing the typed relationship graph
+is a reserved "future decision" — recorded here as ADR-074.
+
+## Outcomes
+
+User-felt outcomes (the release narrative leads only with these):
+
+- **Exportable corpus** — `rac export --documents` emits an ingestion-ready JSONL
+  projection (one Markdown-bodied record per artifact, carrying the canonical
+  `id`/`type`/`status`) that any memory/RAG backend consumes directly; this is the
+  Supermemory-first deliverable (WS1).
+- **Typed decision graph out** — `rac export --graph` hands a graph backend RAC's
+  real, validated `supersedes`/`related_*` topology instead of one an LLM infers
+  from prose (WS2, cut-first).
+- **Honest, named integration docs** — the export modes are documented with the
+  supported targets named explicitly and the verify-in-Lore loop spelled out
+  end to end (WS3).
+
+The `lore-connectors` companion and its Supermemory module are *not* built in this
+repo's release — they consume this contract on their own cadence (ADR-073).
+
+## Initiatives
+
+### Tier 1 — this is the release
+
+- **WS1 — Documents export** `[user-facing]`. `rac export --documents`: a JSONL
+  projection, one Markdown-bodied record per artifact, with
+  `metadata{id,type,status,title,path,aliases,tags,source}`, all classified
+  artifacts included with `status` stamped, one record per artifact (no chunking),
+  deterministic and offline. An additive mode beside `--okf`/`--html`/`--json`,
+  leaving the v1 viewer JSON untouched (ADR-007). Requirement
+  `rac-corpus-documents-export`.
+- **WS3 — Export documentation** `[user-facing]`. Document the export modes in
+  `docs/cli.md`, **name the supported targets** (memory layers, vector stores,
+  graph backends — which are shipped connectors vs generic-export targets), and
+  document the **verify-in-Lore loop** (backend recall → re-fetch the
+  authoritative artifact from Lore by `id` → retired-decision filtering). Makes
+  explicit that RAC provides the authoritative answer and does not validate the
+  backend's store.
+
+### Tier 2 — keep, scope down (cut first if the release runs short)
+
+- **WS2 — Typed graph export** `[internal]`. `rac export --graph`: a nodes+edges
+  projection whose edges carry their type from the relationship-type registry
+  (`supersedes`, `related_*`) with direction, resolved targets as canonical-id
+  edges and unresolved ones flagged. Surfacing typed edges is the reserved
+  decision, recorded as **ADR-074** (Proposed until this workstream is accepted).
+  Requirement `rac-corpus-graph-export`. Cut first: the Supermemory target needs
+  only WS1.
+
+### Tier 3 — deferred / documented (not built this release)
+
+- **The `lore-connectors` companion + Supermemory module** — companion work in a
+  separate repo on its own cadence (ADR-073); this release delivers the contract
+  it consumes, not the connector.
+- **Section-level chunking** — the artifact stays the atomic export unit
+  (ADR-004, ADR-010); chunking is the embedder's job. Revisit only if
+  whole-artifact embedding proves too coarse.
+- **A `--live-only` filter** to drop retired/superseded artifacts — an open
+  question in `corpus-export-shape-contract`; the documents projection includes
+  all artifacts with `status` stamped, and the verify step makes a stale hit safe.
+
+## Workstream Checklist
+
+Cross-session progress tracker. Status: `planned` → `in-progress` → `done` /
+`descoped`. This roadmap is the canonical tracker.
+
+Tier 1:
+
+- [ ] WS1 corpus-documents-export — JSONL documents projection — `planned`
+- [ ] WS3 export-documentation — named targets + verify-in-Lore loop — `planned`
+
+Tier 2 (cut first):
+
+- [ ] WS2 corpus-graph-export — typed nodes+edges + ADR-074 — `planned`
+
+## Success Measures
+
+- `rac export --documents` output piped into a backend's ingestion (Supermemory
+  first) lets an agent recall a candidate and complete the verify-in-Lore loop:
+  re-fetch the authoritative artifact by `id` and detect a retired decision.
+- The documents projection is byte-identical across repeated runs on an unchanged
+  corpus (deterministic), proven by goldens; bodies are Markdown, not HTML.
+- `rac export --graph` emits edges whose types match `rac relationships`'
+  resolved typed graph, with `supersedes` directed and `related_*` undirected.
+- The capability ships with no engine dependency on any backend and no
+  embeddings/AI/network in `rac-core`; the MCP surface is unchanged.
+
+## Constraints
+
+Non-negotiable guardrails, each a recorded decision:
+
+- The export contract grows only additively; new modes (`--documents`/`--graph`)
+  never change the v1 viewer JSON (ADR-007, ADR-063).
+- No AI/LLM, embeddings, vector search, or network in any export path (ADR-002,
+  ADR-066); everything runs offline and deterministically (ADR-002).
+- The documents projection emits a Markdown text body and one record per artifact
+  — the atomic knowledge unit (ADR-004, ADR-010).
+- Backend connectors live outside `rac-core` in `lore-connectors` (ADR-073); RAC
+  does not store, serve, or re-import the embedded copy (ADR-024).
+- Artifact content is untrusted input; the trust boundary is human PR review
+  (ADR-065). Roadmap lifecycle follows ADR-061.
+
+## Non-Goals
+
+- **No backend connector code in `rac-core`.** Connectors are export-contract
+  consumers in `lore-connectors`, not engine code (ADR-073, ADR-063).
+- **No re-rank, memory-router, or serving decisions *from* a backend** — carried
+  forward as non-goals from the umbrella; they break determinism and the
+  grounding-eval guarantee (ADR-066, ADR-067).
+- **No embeddings, vectors, or chunking in the engine** (ADR-066); the embedder
+  owns chunking.
+- **No new MCP tool or write capability**; this is an export surface, additive
+  output only (ADR-007).
+
+## Risks
+
+- **Scope creep into building the connector in-repo.** Mitigation: ADR-073 fixes
+  the connector as `lore-connectors` companion work; this release is the contract
+  only, restated as a Non-Goal.
+- **The typed-graph projection destabilises the viewer's `relates-to` contract.**
+  Mitigation: `--graph` is a separate, additive projection; the v1 viewer JSON is
+  untouched, and ADR-074 records the boundary.
+- **Export output bloat or non-determinism.** Mitigation: one record per artifact,
+  sorted order, no timestamps, byte-stable goldens (ADR-002).
+
+## Assumptions
+
+- The export already carries `id`/`type`/`status` and the resolved relationship
+  graph, so both projections derive from existing services without a new schema
+  (ADR-007, ADR-055).
+- The "documents + metadata + id" shape remains the common ingestion denominator,
+  so one documents projection serves most backends.
+- The export-shape design (`corpus-export-shape-contract`) and ADR-073 have landed
+  on `main` before this release's PR opens.
+
+## Related Decisions
+
+- adr-002
+- adr-004
+- adr-007
+- adr-010
+- adr-024
+- adr-026
+- adr-050
+- adr-055
+- adr-063
+- adr-066
+- adr-068
+- adr-073
+- adr-074
+
+## Related Requirements
+
+- rac-corpus-documents-export
+- rac-corpus-graph-export
+
+## Related Designs
+
+- corpus-export-shape-contract
+- lore-supermemory-interplay
+
+## Related Roadmaps
+
+- corpus-export-to-rag-backends
+- lore-supermemory-grounding


### PR DESCRIPTION
# Summary

Opens **v0.25.0 — Connect** as planning artifacts only (no code), scheduling the
*engine* half of the `corpus-export-to-rag-backends` umbrella. v0.24.0 made the
corpus visible; v0.25.0 makes it **reachable** — a stable, ingestion-shaped export
contract so an agent recalls fuzzily from external memory/RAG/graph backends and
then verifies in Lore. The connector itself is companion work in `lore-connectors`
(ADR-073), out of this repo's scope. Workstreams land later as scoped PRs, as
v0.23.0's and v0.24.0's did.

Adds:
- `rac/roadmaps/v0.25.x-connect/v0.25.0-connect.md` (Planned) — the implementation
  contract.
- `rac/requirements/rac-corpus-documents-export.md` (WS1) and
  `rac/requirements/rac-corpus-graph-export.md` (WS2).
- `rac/decisions/adr-074-export-surfaces-typed-edges.md` (Proposed) — typed edges
  in the `--graph` projection.

# Roadmap / ADR Trace

- Roadmap: `rac/roadmaps/v0.25.x-connect/v0.25.0-connect.md`.
- Builds on (all now on `main` via #164/#166): the umbrella
  `corpus-export-to-rag-backends`, the export-shape design
  `corpus-export-shape-contract`, and ADR-073 (connector topology).
- New decision: ADR-074 (Proposed).
- Relevant ADRs: ADR-007 / ADR-063 (additive contract, thin clients), ADR-055
  (typed graph), ADR-004 / ADR-010 (atomic unit), ADR-026 (opaque id), ADR-050
  (OKF), ADR-002 / ADR-066 (AI-optional, no embeddings), ADR-024 (not a content
  store), ADR-068 (`lore-*` topology).

# Scope

## Included
- **Tier 1:** WS1 documents export (`rac export --documents` JSONL, the
  Supermemory-first deliverable); WS3 export documentation (named targets + the
  verify-in-Lore loop).
- **Tier 2 (cut-first):** WS2 graph export (`rac export --graph` typed
  nodes+edges) plus ADR-074.
- Planning artifacts only: the roadmap, a requirement per workstream, and the
  gating ADR.

## Excluded
- No code or engine change.
- The `lore-connectors` companion and Supermemory module — companion work, own
  cadence (ADR-073).
- Chunking, a `--live-only` filter, and any embeddings/vectors in the engine —
  deferred (ADR-066).
- The umbrella roadmap stays **live** (a multi-release vision); v0.25.0 is its
  first engine increment, not a supersession.

# Product / Architecture Decisions

- **Version:** v0.24.0 is the merged Visibility release, so Connect is the next
  minor, `v0.25.0`, in a new `v0.25.x-connect` series.
- **Engine-vs-connector split (ADR-073):** the engine ships the export contract;
  connectors are export-contract consumers in `lore-connectors`, not engine code.
- **Two projections (from the export-shape design):** `--documents` for
  memory/RAG, `--graph` for graph backends; both additive modes beside
  `--okf`/`--html`/`--json`, leaving the v1 viewer JSON untouched (ADR-007).
- **ADR-074 (Proposed):** the `--graph` projection surfaces typed registry edges;
  the viewer's flattened `relates-to` contract is unchanged. Proposed keeps it out
  of the settled-decisions block until WS2 is accepted.
- **Tiering:** documents is Tier 1; graph is cut-first Tier 2 — the Supermemory
  target needs only documents.

# User-Facing Contract

N/A for this PR — no CLI, output, or exit-code change. The artifacts *describe*
the contracts the workstreams will deliver: WS1's `rac export --documents` JSONL
(one Markdown-bodied record per artifact, carrying canonical `id`/`type`/`status`);
WS2's `rac export --graph` nodes+edges. Those land with their implementation PRs.

# Verification

## Ran
- `rac validate rac/` — 263 valid, 0 invalid.
- `rac relationships rac/ --validate` — 1231 checked, 0 issues.
- `rac review rac/` — exit 0, no priority 1-2 findings.
- `rac export rac/ --agent-rules --check` — in sync (ADR-074 is Proposed, so the
  settled-decisions block is unchanged).
- `rac watchkeeper rac --base origin/main` — +1 roadmap, +2 requirements, +1
  decision; nothing requiring attention.
- `python -m pytest tests/test_dogfood.py tests/test_golden.py` — 40 passed.

## Covered
- Every reference resolves against `main` (the umbrella, the export-shape design,
  and ADR-073 landed via #166); the roadmap links its requirements, ADR-074, and
  the supporting designs; requirement `REQ-NNN` ids are well-formed.

# Review Path

1. `rac/roadmaps/v0.25.x-connect/v0.25.0-connect.md` — Status/Context (the
   engine-vs-connector split), Initiatives (the tiers), Non-Goals.
2. `rac/requirements/rac-corpus-documents-export.md` — WS1, the Supermemory-first
   deliverable.
3. `rac/decisions/adr-074-export-surfaces-typed-edges.md` and
   `rac/requirements/rac-corpus-graph-export.md` — WS2, cut-first.

# Notes For Reviewer

- Two calls are yours: the theme name (**Connect**) and the version (**v0.25.0**)
  are proposed — rename freely. ADR-074 is **Proposed**; WS2 (graph) is gated on
  accepting it, and WS1 (documents) does not depend on it.
- Planning artifacts only — Status `Planned`; no release, tag, or implementation
  is implied.
- The umbrella roadmap is intentionally left live rather than superseded: it is a
  multi-release vision and v0.25.0 is its first engine increment.