### PR TITLE
docs(readme): align with wayfinder and unblock the Docs deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,13 @@
   <img alt="Lore — agents that know why. Deterministic. Read-only. No RAG, no guessing." src="https://raw.githubusercontent.com/itsthelore/rac-core/main/rac/assets/images/lore-header-light.png">
 </picture>
 
+<p align="center">
 <a href="#install">Install</a> ·
 <a href="#connect-your-agent">Connect your agent</a> ·
 <a href="https://itsthelore.github.io/rac-core/">Docs</a> ·
 <a href="https://itsthelore.github.io/rac-core/cli/">CLI</a> ·
 <a href="https://github.com/itsthelore/rac-core/blob/main/CHANGELOG.md">Changelog</a>
+</p>
 
 [![CI](https://github.com/itsthelore/rac-core/actions/workflows/ci.yml/badge.svg)](https://github.com/itsthelore/rac-core/actions/workflows/ci.yml) [![PyPI](https://img.shields.io/pypi/v/requirements-as-code)](https://pypi.org/project/requirements-as-code/) [![Python](https://img.shields.io/pypi/pyversions/requirements-as-code)](https://pypi.org/project/requirements-as-code/) [![Types: Mypy](https://img.shields.io/badge/types-Mypy-blue.svg)](https://mypy-lang.org/) [![License: Apache 2.0](https://img.shields.io/pypi/l/requirements-as-code)](https://github.com/itsthelore/rac-core/blob/main/LICENSE)
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,13 @@
   <img alt="Lore — agents that know why. Deterministic. Read-only. No RAG, no guessing." src="https://raw.githubusercontent.com/itsthelore/rac-core/main/rac/assets/images/lore-header-light.png">
 </picture>
 
-[![CI](https://github.com/itsthelore/rac-core/actions/workflows/ci.yml/badge.svg)](https://github.com/itsthelore/rac-core/actions/workflows/ci.yml) [![PyPI](https://img.shields.io/pypi/v/requirements-as-code)](https://pypi.org/project/requirements-as-code/) [![Python](https://img.shields.io/pypi/pyversions/requirements-as-code)](https://pypi.org/project/requirements-as-code/) [![License: Apache 2.0](https://img.shields.io/pypi/l/requirements-as-code)](https://github.com/itsthelore/rac-core/blob/main/LICENSE)
+<a href="#install">Install</a> ·
+<a href="#connect-your-agent">Connect your agent</a> ·
+<a href="https://itsthelore.github.io/rac-core/">Docs</a> ·
+<a href="https://itsthelore.github.io/rac-core/cli/">CLI</a> ·
+<a href="https://github.com/itsthelore/rac-core/blob/main/CHANGELOG.md">Changelog</a>
+
+[![CI](https://github.com/itsthelore/rac-core/actions/workflows/ci.yml/badge.svg)](https://github.com/itsthelore/rac-core/actions/workflows/ci.yml) [![PyPI](https://img.shields.io/pypi/v/requirements-as-code)](https://pypi.org/project/requirements-as-code/) [![Python](https://img.shields.io/pypi/pyversions/requirements-as-code)](https://pypi.org/project/requirements-as-code/) [![Types: Mypy](https://img.shields.io/badge/types-Mypy-blue.svg)](https://mypy-lang.org/) [![License: Apache 2.0](https://img.shields.io/pypi/l/requirements-as-code)](https://github.com/itsthelore/rac-core/blob/main/LICENSE)
 
 > **Give your coding agent the decisions your team already made — so it stops re-doing things you ruled out.**
 
@@ -86,6 +92,39 @@ Google's Open Knowledge Format (OKF) standardises the *carrier* — a Git tree o
 - [Quickstart](https://itsthelore.github.io/rac-core/quickstart/) — install and author your first artifact
 - [MCP server](https://itsthelore.github.io/rac-core/mcp/) — tools, client configuration, examples
 - [CLI reference](https://itsthelore.github.io/rac-core/cli/) — every command, flag, and exit code
+
+## Origin
+
+Lore is the product surface of **RAC — Requirements as Code**, the open-source
+engine underneath; the package, CLI, and MCP server ship under the `rac` name,
+and `lore` is the server identity and brand.
+[Wayfinder](https://github.com/itsthelore/wayfinder-router), the deterministic
+prompt-complexity router, began as a `route` experiment inside RAC and was split
+into its own tool — routing is a runtime concern, not a knowledge one.
+
+## Repository layout
+
+```text
+rac-core/
+  src/rac/        the engine: CLI, core, services, output, the in-process MCP
+                  server (rac mcp), and bundled skills, templates, and git hooks
+  rac/            the dogfood corpus — requirements, decisions, designs, roadmaps,
+                  and prompts that govern the project itself
+  tests/          per-service batteries plus core / cli / artifacts coverage (ADR-027)
+  docs/           the documentation site (MkDocs)
+  examples/       the grounding demo, woven into the corpus and the test fixtures
+  rac-localview/  the Portal / graph viewer, vendored into the engine
+```
+
+## Test
+
+```bash
+pip install -e .[dev]
+python -m pytest
+```
+
+`ruff check`, `ruff format --check`, and `mypy src/` run in CI alongside the
+per-service batteries (ADR-027).
 
 ## Project status
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -62,7 +62,7 @@ the tier that matches the change at hand.
 
 ### 1. Inner loop (smoke) — fastest signal
 
-The `smoke` job in [`.github/workflows/pr-checks.yml`](../.github/workflows/pr-checks.yml)
+The `smoke` job in [`.github/workflows/pr-checks.yml`](https://github.com/itsthelore/rac-core/blob/main/.github/workflows/pr-checks.yml)
 (`core` subset + `golden` + `dogfood`, py3.11). Catches output-contract drift and
 corpus damage in seconds:
 
@@ -96,7 +96,7 @@ lint trio, the smoke set, plus the dogfood gates:
 ### 3. Full local CI (merge grid) — the complete suite
 
 The per-service battery × Python-version grid from the reusable
-[`.github/workflows/tests.yml`](../.github/workflows/tests.yml). Every
+[`.github/workflows/tests.yml`](https://github.com/itsthelore/rac-core/blob/main/.github/workflows/tests.yml). Every
 `tests/test_*.py` belongs to exactly one battery (enforced by
 `tests/test_ci_batteries.py`). This is the grid that gates `main` (`ci.yml`) and
 releases (`python-publish.yml`, `needs: test`). Locally it is just the whole


### PR DESCRIPTION
# Summary

Two docs changes on the same branch:

1. **Unblock the Docs deploy** (the reported failure) — repair two strict-mode
   links in `docs/testing.md`.
2. **Align the README** with the `itsthelore/wayfinder-router` conventions
   (requested).

## 1. Docs deploy fix

`docs.yml` runs `mkdocs build --strict`, which turns a broken internal link into
a build failure (and blocks the Pages deploy). `docs/testing.md` linked two
workflow files via relative paths pointing *outside* the docs tree
(`../.github/workflows/pr-checks.yml`, `…/tests.yml`); mkdocs can't resolve those
as docs, so strict mode aborted. Both now use absolute GitHub blob URLs, which
strict mode allows.

Root cause: these links landed with the v0.23.0 test-tier docs (`ab664e8`), so
the Docs deploy has been red since then — not related to the v0.25.0 export
documentation.

## 2. README alignment

Brings rac-core's README to the same family conventions as the sibling
`wayfinder-router` README, **keeping rac-core's own content** (convention parity,
not a content rewrite):

- **Nav links** under the banner (Install · Connect your agent · Docs · CLI ·
  Changelog).
- A **Mypy types badge** in the badge row.
- New **Origin**, **Repository layout**, and **Test** sections.
- The **Origin** section cross-links Wayfinder — which split out of RAC — matching
  its reciprocal note, so the two repos read as one org.

No existing sections were removed. `README.md` is not part of the MkDocs nav, so
it has no effect on the strict build.

# Verification

- `mkdocs build --strict` (mkdocs 1.6.1 + mkdocs-material 9.7.6, matching
  `docs.yml`) — **exit 0**, "Documentation built" (previously: "Aborted with 2
  warnings in strict mode!").
- Standard pr-checks are green (docs-only; no corpus or code change).

# Notes For Reviewer

- The Docs workflow runs only on push to `main`, so it won't appear in this PR's
  checks — the local strict build confirms the fix, and it goes green on merge.
- README nav: if you'd rather the links point elsewhere (or want it centered to
  match wayfinder's banner more closely), say so and I'll adjust.
- A harmless pre-existing INFO remains (`v0.22-housekeeping-runbook.md` not in
  `nav`) — INFO, not a warning; happy to add it to the nav if you want it tidied.