### PR TITLE
docs(skill): recognize the Lore brand in skill triggers

### DIFF
--- a/.claude/skills/rac-artifacts/SKILL.md
+++ b/.claude/skills/rac-artifacts/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rac-artifacts
-description: Author and maintain RAC (requirements-as-code) Markdown artifacts — requirements, decisions, roadmaps, prompts, designs — using the rac CLI. Use when asked to create, read, validate, update, or link RAC artifacts in a project's rac/ directory.
+description: Author and maintain RAC (requirements-as-code) Markdown artifacts — requirements, decisions, roadmaps, prompts, designs — using the rac CLI. Use when asked to create, read, validate, update, or link Lore (RAC) artifacts in a project's rac/ directory.
 ---
 
 # RAC artifacts

--- a/.claude/skills/rac-import/SKILL.md
+++ b/.claude/skills/rac-import/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rac-import
-description: Reformat ONE existing document (a decision, requirement, design, roadmap, or prompt) into ONE valid RAC (requirements-as-code) artifact, with a mandatory human-review step before any file is written and `rac validate` as the deterministic close. Use when a user wants to import a single existing decision or document into a project's rac/ directory. Single-document only — for multi-format or bulk conversion use the rac-ingest skill.
+description: Reformat ONE existing document (a decision, requirement, design, roadmap, or prompt) into ONE valid RAC (requirements-as-code) artifact, with a mandatory human-review step before any file is written and `rac validate` as the deterministic close. Use when a user wants to add or import a single existing decision or document into Lore (a project's rac/ directory). Single-document only — for multi-format or bulk conversion use the rac-ingest skill.
 ---
 
 # RAC single-document import

--- a/.claude/skills/rac-ingest/SKILL.md
+++ b/.claude/skills/rac-ingest/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rac-ingest
-description: Convert legacy documents (DOCX, PDF, HTML, PPTX, XLSX, Markdown) into valid, linked RAC (requirements-as-code) artifacts using the rac CLI. Use when asked to import, convert, or migrate existing documents into a project's rac/ directory.
+description: Convert legacy documents (DOCX, PDF, HTML, PPTX, XLSX, Markdown) into valid, linked RAC (requirements-as-code) artifacts using the rac CLI. Use when asked to add, import, convert, or migrate existing documents into Lore (a project's rac/ directory).
 ---
 
 # RAC legacy document conversion

--- a/.claude/skills/rac-review/SKILL.md
+++ b/.claude/skills/rac-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rac-review
-description: Review and triage a RAC (requirements-as-code) corpus using the rac CLI — work prioritised findings worst-first until validation and relationship checks pass. Use when asked to review, triage, or fix findings across a project's rac/ directory.
+description: Review and triage a RAC (requirements-as-code) corpus using the rac CLI — work prioritised findings worst-first until validation and relationship checks pass. Use when asked to review, triage, or fix findings across a project's Lore corpus (the rac/ directory).
 ---
 
 # RAC corpus review

--- a/src/rac/core/skills.py
+++ b/src/rac/core/skills.py
@@ -35,19 +35,19 @@ class SkillSpec:
 BUNDLED_SKILLS = (
     SkillSpec(
         name="rac-artifacts",
-        description="Author and maintain RAC Markdown artifacts with the rac CLI.",
+        description="Author and maintain Lore (RAC) Markdown artifacts with the rac CLI.",
     ),
     SkillSpec(
         name="rac-review",
-        description="Review a RAC corpus and work findings worst-first.",
+        description="Review a Lore (RAC) corpus and work findings worst-first.",
     ),
     SkillSpec(
         name="rac-ingest",
-        description="Convert legacy documents into valid, linked RAC artifacts.",
+        description="Convert legacy documents into valid, linked Lore (RAC) artifacts.",
     ),
     SkillSpec(
         name="rac-import",
-        description="Reformat one document into one valid RAC artifact, with human review.",
+        description="Reformat one document into one valid Lore (RAC) artifact, with human review.",
     ),
 )
 

--- a/src/rac/skills/rac-artifacts/SKILL.md
+++ b/src/rac/skills/rac-artifacts/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rac-artifacts
-description: Author and maintain RAC (requirements-as-code) Markdown artifacts — requirements, decisions, roadmaps, prompts, designs — using the rac CLI. Use when asked to create, read, validate, update, or link RAC artifacts in a project's rac/ directory.
+description: Author and maintain RAC (requirements-as-code) Markdown artifacts — requirements, decisions, roadmaps, prompts, designs — using the rac CLI. Use when asked to create, read, validate, update, or link Lore (RAC) artifacts in a project's rac/ directory.
 ---
 
 # RAC artifacts

--- a/src/rac/skills/rac-import/SKILL.md
+++ b/src/rac/skills/rac-import/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rac-import
-description: Reformat ONE existing document (a decision, requirement, design, roadmap, or prompt) into ONE valid RAC (requirements-as-code) artifact, with a mandatory human-review step before any file is written and `rac validate` as the deterministic close. Use when a user wants to import a single existing decision or document into a project's rac/ directory. Single-document only — for multi-format or bulk conversion use the rac-ingest skill.
+description: Reformat ONE existing document (a decision, requirement, design, roadmap, or prompt) into ONE valid RAC (requirements-as-code) artifact, with a mandatory human-review step before any file is written and `rac validate` as the deterministic close. Use when a user wants to add or import a single existing decision or document into Lore (a project's rac/ directory). Single-document only — for multi-format or bulk conversion use the rac-ingest skill.
 ---
 
 # RAC single-document import

--- a/src/rac/skills/rac-ingest/SKILL.md
+++ b/src/rac/skills/rac-ingest/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rac-ingest
-description: Convert legacy documents (DOCX, PDF, HTML, PPTX, XLSX, Markdown) into valid, linked RAC (requirements-as-code) artifacts using the rac CLI. Use when asked to import, convert, or migrate existing documents into a project's rac/ directory.
+description: Convert legacy documents (DOCX, PDF, HTML, PPTX, XLSX, Markdown) into valid, linked RAC (requirements-as-code) artifacts using the rac CLI. Use when asked to add, import, convert, or migrate existing documents into Lore (a project's rac/ directory).
 ---
 
 # RAC legacy document conversion

--- a/src/rac/skills/rac-review/SKILL.md
+++ b/src/rac/skills/rac-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rac-review
-description: Review and triage a RAC (requirements-as-code) corpus using the rac CLI — work prioritised findings worst-first until validation and relationship checks pass. Use when asked to review, triage, or fix findings across a project's rac/ directory.
+description: Review and triage a RAC (requirements-as-code) corpus using the rac CLI — work prioritised findings worst-first until validation and relationship checks pass. Use when asked to review, triage, or fix findings across a project's Lore corpus (the rac/ directory).
 ---
 
 # RAC corpus review

--- a/tests/golden/skill_list_human.txt
+++ b/tests/golden/skill_list_human.txt
@@ -1,6 +1,6 @@
 Bundled agent skills:
 
-- rac-artifacts  Author and maintain RAC Markdown artifacts with the rac CLI.
-- rac-review     Review a RAC corpus and work findings worst-first.
-- rac-ingest     Convert legacy documents into valid, linked RAC artifacts.
-- rac-import     Reformat one document into one valid RAC artifact, with human review.
+- rac-artifacts  Author and maintain Lore (RAC) Markdown artifacts with the rac CLI.
+- rac-review     Review a Lore (RAC) corpus and work findings worst-first.
+- rac-ingest     Convert legacy documents into valid, linked Lore (RAC) artifacts.
+- rac-import     Reformat one document into one valid Lore (RAC) artifact, with human review.

--- a/tests/golden/skill_list_json.txt
+++ b/tests/golden/skill_list_json.txt
@@ -3,19 +3,19 @@
   "skills": [
     {
       "skill": "rac-artifacts",
-      "description": "Author and maintain RAC Markdown artifacts with the rac CLI."
+      "description": "Author and maintain Lore (RAC) Markdown artifacts with the rac CLI."
     },
     {
       "skill": "rac-review",
-      "description": "Review a RAC corpus and work findings worst-first."
+      "description": "Review a Lore (RAC) corpus and work findings worst-first."
     },
     {
       "skill": "rac-ingest",
-      "description": "Convert legacy documents into valid, linked RAC artifacts."
+      "description": "Convert legacy documents into valid, linked Lore (RAC) artifacts."
     },
     {
       "skill": "rac-import",
-      "description": "Reformat one document into one valid RAC artifact, with human review."
+      "description": "Reformat one document into one valid Lore (RAC) artifact, with human review."
     }
   ]
 }


### PR DESCRIPTION
# Summary

Users meet the product as **Lore** (ADR-036, ADR-039), but the four bundled
agent skills described themselves only as **RAC** — so a natural request like
*"add this into Lore"* had nothing in the skill descriptions to match on. This
names the product in each skill's trigger language so both *"into Lore"* and
*"into RAC"* route to the right skill.

Touches the two places a skill's description lives:
- The **`SKILL.md` frontmatter** descriptions (what the coding agent matches on
  to auto-invoke a skill), for all four skills, in `src/rac/skills/` and the
  in-sync dogfood copies in `.claude/skills/`.
- The **`rac skill list` one-liners** in `src/rac/core/skills.py` (the registry).

# Scope

## Included
- `rac-import`, `rac-ingest`, `rac-artifacts`, `rac-review` — each "Use when…"
  trigger now names **Lore** (e.g. *"…add or import a single existing decision or
  document into Lore (a project's `rac/` directory)"*).
- Registry one-liners gain `Lore (RAC)`.
- `.claude/skills/` mirror kept identical (the `test_packaged_skill_matches_dogfood_copy`
  drift gate); `skill_list` goldens regenerated.

## Excluded / unchanged
- **Skill names stay `rac-*`** — frozen technical identifiers used by
  `rac skill install <name>` (ADR-068's engine-prefix convention). Only the human
  trigger copy changed.
- The artifact/format vocabulary stays accurate: descriptions still lead with
  "RAC (requirements-as-code)" for the *artifact* type; "Lore" is added to the
  *trigger* sentence (and `Lore (RAC)` in the registry).
- No new ADR — this is brand-consistent UX copy, aligned with ADR-036/039.

# Verification

## Ran
- `python -m pytest tests/test_skill.py` — 42 passed (drift gate, single-line
  description check, frontmatter↔registry name match, regenerated goldens).
- `ruff check` / `ruff format --check` / `mypy src` — clean.
- `python -m pytest tests/test_cli.py tests/test_dogfood.py tests/test_golden.py`
  — passed; `rac validate rac/` — 263 valid, 0 invalid.

## Covered
- `.claude/skills/*/SKILL.md` byte-identical to `src/rac/skills/*` (no drift);
  the `skill_list` golden diff is *only* the `RAC` → `Lore (RAC)` additions;
  every description stays a single line.

# Notes For Reviewer

- The README's import line (*"import this decision doc into RAC"* → *"…into
  Lore"*) is intentionally **not** here — it rides with the README work on the
  docs PR (#170) to avoid two PRs touching `README.md`.