### PR TITLE
docs(readme): say "into Lore" in the import example

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ a human-review step before anything is written.
 rac skill install rac-import   # installs into .claude/skills/ (Claude Code / Cursor auto-discover)
 ```
 
-Then ask your agent, in plain language: *"import this decision doc into RAC"*
+Then ask your agent, in plain language: *"import this decision doc into Lore"*
 (paste the text or give a path). The skill reads the real schema with
 `rac schema`, drafts the artifact from **only** what your document says, and
 shows you the proposed **type, title, and any relationships to confirm or


### PR DESCRIPTION
# Summary

One-line follow-up: the README's natural-language import example now says
*"import this decision doc into **Lore**"* instead of *"into RAC"*, matching the
Lore-aware skill triggers shipped in #171.

This is the copy line I'd flagged to fold into the README work on #170, but #170
merged before it landed — so it's its own small PR.

# Scope

- `README.md`, the "Importing an existing decision" example phrase only.
- The artifact-format vocabulary is deliberately unchanged — the skill still
  produces *"one valid RAC artifact"* (RAC is the engine/format; Lore is the
  product the user addresses). Same Lore-in-the-trigger / RAC-for-the-format split
  used in the skill descriptions.

# Verification

- One-word copy change; no code, corpus, or build impact. `README.md` is not in
  the MkDocs nav, so the Docs build is unaffected (and is green on `main`).