### PR TITLE
docs(readme): adopt the full structural mirror with branded diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,26 +9,96 @@
 </picture>
 
 <p align="center">
-<a href="#install">Install</a> ·
-<a href="#connect-your-agent">Connect your agent</a> ·
+<a href="#quickstart">Quickstart</a> ·
+<a href="#how-it-compares">How it compares</a> ·
+<a href="#how-it-works">How it works</a> ·
 <a href="https://itsthelore.github.io/rac-core/">Docs</a> ·
 <a href="https://itsthelore.github.io/rac-core/cli/">CLI</a> ·
 <a href="https://github.com/itsthelore/rac-core/blob/main/CHANGELOG.md">Changelog</a>
 </p>
 
-[![CI](https://github.com/itsthelore/rac-core/actions/workflows/ci.yml/badge.svg)](https://github.com/itsthelore/rac-core/actions/workflows/ci.yml) [![PyPI](https://img.shields.io/pypi/v/requirements-as-code)](https://pypi.org/project/requirements-as-code/) [![Python](https://img.shields.io/pypi/pyversions/requirements-as-code)](https://pypi.org/project/requirements-as-code/) [![Types: Mypy](https://img.shields.io/badge/types-Mypy-blue.svg)](https://mypy-lang.org/) [![License: Apache 2.0](https://img.shields.io/pypi/l/requirements-as-code)](https://github.com/itsthelore/rac-core/blob/main/LICENSE)
+<p align="center">
+<a href="https://github.com/itsthelore/rac-core/actions/workflows/ci.yml"><img src="https://github.com/itsthelore/rac-core/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+<a href="https://pypi.org/project/requirements-as-code/"><img src="https://img.shields.io/pypi/v/requirements-as-code" alt="PyPI"></a>
+<a href="https://pypi.org/project/requirements-as-code/"><img src="https://img.shields.io/pypi/pyversions/requirements-as-code" alt="Python"></a>
+<a href="https://mypy-lang.org/"><img src="https://img.shields.io/badge/types-Mypy-blue.svg" alt="Typed"></a>
+<a href="https://github.com/itsthelore/rac-core/blob/main/LICENSE"><img src="https://img.shields.io/pypi/l/requirements-as-code" alt="License: Apache 2.0"></a>
+</p>
 
 > **Give your coding agent the decisions your team already made — so it stops re-doing things you ruled out.**
 
-Lore keeps your team's recorded knowledge — requirements, decisions, designs, roadmaps, and prompts — as typed Markdown in your repo and serves it read-only to Claude Code, Cursor, and Claude Desktop over MCP, so the agent cites your decisions instead of violating them. It is built on **RAC — Requirements as Code**, the open-source engine underneath; the package, CLI, and MCP server ship under the `rac` name.
+Lore keeps your team's recorded knowledge — requirements, decisions, designs, roadmaps, and prompts — as typed Markdown in your repo and serves it **read-only** to Claude Code, Cursor, and Claude Desktop over MCP, so the agent cites your decisions instead of violating them. No RAG, no embeddings, no model call to decide what's relevant — retrieval is deterministic and reproducible. It is built on **RAC — Requirements as Code**, the open-source engine underneath; the package, CLI, and MCP server ship under the `rac` name.
+
+## How it compares
+
+Lore isn't a search index or a memory tool — it's the **deterministic system of
+record** an agent grounds against. Fuzzy retrieval (RAG, agent memory) is good at
+finding *what's near* a loose question; Lore is good at returning the *exact,
+current* decision and declining the ones you've superseded. They compose well —
+recall fuzzily, then verify in Lore.
+
+| | Lore | Fuzzy retrieval (RAG / agent memory) |
+|---|---|---|
+| Good at | the exact, current decision | finding what's *near* a question |
+| Retrieval | deterministic, reproducible | similarity-ranked, varies by run |
+| Role | source of truth, read-only | a fast index or working copy |
+| In CI | enforced (`rac validate` / `rac gate`) | not its job |
+
+## Quickstart
+
+1. **Install** the engine:
+
+   ```bash
+   pip install requirements-as-code
+   ```
+
+2. **Scaffold** identity and your first artifact:
+
+   ```bash
+   rac quickstart
+   ```
+
+3. **Connect your agent** (Claude Code, from your repo root):
+
+   ```bash
+   claude mcp add lore -- rac mcp
+   ```
+
+4. **Enforce** in CI so bad knowledge never lands:
+
+   ```bash
+   rac validate rac/ && rac gate rac/
+   ```
 
 ## Install
 
-```bash
-pip install requirements-as-code
-```
+| Command | Gets you |
+|---|---|
+| `pip install requirements-as-code` | the `rac` CLI + the `lore` MCP server |
+| `pip install 'requirements-as-code[ingest]'` | + DOCX / HTML import |
+| `pip install 'requirements-as-code[ingest-all]'` | + PDF / PPTX / XLSX import |
+| `pip install 'requirements-as-code[explorer]'` | + the terminal Explorer (`rac explorer`) |
 
 Requires Python 3.11+. `uv tool install requirements-as-code` also works.
+
+## How it works
+
+<p align="center">
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="rac/assets/images/lore-how-it-works-dark.svg">
+  <source media="(prefers-color-scheme: light)" srcset="rac/assets/images/lore-how-it-works-light.svg">
+  <img alt="How Lore works: typed Markdown in your repo flows through the deterministic rac engine into the read-only lore MCP server, which serves your agent." src="rac/assets/images/lore-how-it-works-light.svg" width="900">
+</picture>
+</p>
+
+- **Typed Markdown, in your repo.** Every artifact is plain Markdown with a tiny
+  frontmatter envelope; the engine classifies it deterministically and validates
+  it against a per-type schema.
+- **Read-only at serve time.** The MCP server only ever reads; the trust boundary
+  is human PR review, and the agent cannot mutate the store.
+- **Enforced at write time.** `rac validate` and `rac gate` reject malformed
+  artifacts, broken or ambiguous links, and references to superseded decisions —
+  in CI, before the knowledge lands.
 
 ## Connect your agent
 
@@ -51,41 +121,73 @@ Claude Desktop / Cursor (`mcpServers` in the client config):
 ## Author and enforce artifacts
 
 ```bash
-rac quickstart             # one command: set up identity + scaffold your first artifact
+rac quickstart             # set up identity + scaffold your first artifact
+rac new decision adr.md    # scaffold a typed artifact (mints the id)
 rac validate rac/          # check every artifact in a directory
 rac inspect requirement.md # see its type and completeness
 rac review rac/            # full repository review, worst problems first
-rac export rac/ --html --out lore-export.html    # the Portal, one file
+rac gate rac/              # the merge gate: validate + relationships + review
 ```
 
-## Importing an existing decision
+## Import an existing decision
 
 Already have decisions in Confluence, Notion, or loose Markdown? The `rac-import`
-agent skill turns **one** existing document into **one** valid RAC artifact, with
-a human-review step before anything is written.
+agent skill turns **one** existing document into **one** valid artifact, with a
+human-review step before anything is written:
 
 ```bash
-rac skill install rac-import   # installs into .claude/skills/ (Claude Code / Cursor auto-discover)
+rac skill install rac-import
 ```
 
-Then ask your agent, in plain language: *"import this decision doc into RAC"*
-(paste the text or give a path). The skill reads the real schema with
-`rac schema`, drafts the artifact from **only** what your document says, and
-shows you the proposed **type, title, and any relationships to confirm or
-correct** before it writes a file. It scaffolds with `rac new` (which mints the
-id), then closes on `rac validate` — and offers fixes if validation fails, so it
-never leaves an invalid artifact behind. It is single-document by design; for
-multi-format or bulk conversion use the `rac-ingest` skill.
+Then ask your agent, in plain language: *"import this decision doc into Lore."* It
+drafts from **only** what your document says, shows you the proposed type, title,
+and relationships to confirm, scaffolds with `rac new`, and closes on
+`rac validate`. For multi-format or bulk conversion, use the `rac-ingest` skill.
 
-## Who it's for
+## Export the corpus
 
-- **Teams running coding agents heavily** (Claude Code, Cursor) who are tired of the agent ignoring decisions the team already made.
-- **Teams who already write ADRs** and want those decisions to actually shape what the agent does.
-- **Anyone who wants the *why* behind their software versioned alongside the code.**
+```bash
+rac export rac/ --html --out lore.html   # the Portal: the whole graph, one file
+rac export rac/ --okf                    # a conformant Open Knowledge Format bundle
+rac export rac/ --documents              # JSONL for memory/RAG backends
+rac export rac/ --graph                  # the typed decision graph for graph backends
+```
+
+The `--documents` and `--graph` modes feed external memory, RAG, and graph tools
+so an agent can recall fuzzily there and then **verify in Lore** — see the
+[CLI reference](https://itsthelore.github.io/rac-core/cli/#export). The connectors
+themselves live in the separate `lore-connectors` companion.
+
+## Python API
+
+The engine is a library too; its public surface is `rac.__all__`.
+
+```python
+from rac import parse_file, classify, find_artifacts
+
+art = parse_file("rac/decisions/adr-001-markdown-first.md")
+print(classify(art).type)                  # -> "decision"
+
+result = find_artifacts("rac/", "caching")  # returns a SearchResult
+for hit in result.matches:
+    print(hit.id, hit.title)
+```
 
 ## How it relates to OKF
 
-Google's Open Knowledge Format (OKF) standardises the *carrier* — a Git tree of Markdown with YAML front matter — and is deliberately permissive: an OKF consumer must not reject a bundle for missing fields, unknown types, or broken links. RAC writes that same carrier and adds what OKF leaves to the consumer: **write-time enforcement** in CI. `rac validate` and `rac relationships --validate` reject malformed artifacts, broken or ambiguous links, references to superseded decisions, and relationship edges a type does not support — deterministically, before the knowledge lands. OKF is read-optimised interchange; RAC is write-time enforcement, and `rac export --okf` turns any RAC repo into a conformant OKF bundle — so the two compose rather than compete.
+Google's Open Knowledge Format (OKF) standardises the *carrier* — a Git tree of
+Markdown with YAML front matter — and is deliberately permissive. RAC writes that
+same carrier and adds what OKF leaves to the consumer: **write-time enforcement**
+in CI. `rac validate` and `rac relationships --validate` reject malformed
+artifacts, broken links, and references to superseded decisions, deterministically,
+before the knowledge lands. `rac export --okf` turns any RAC repo into a conformant
+OKF bundle — so the two compose rather than compete.
+
+## Who it's for
+
+- **Teams running coding agents heavily** (Claude Code, Cursor) tired of the agent ignoring decisions the team already made.
+- **Teams who already write ADRs** and want those decisions to actually shape what the agent does.
+- **Anyone who wants the *why* behind their software versioned alongside the code.**
 
 ## Documentation
 
@@ -98,8 +200,8 @@ Google's Open Knowledge Format (OKF) standardises the *carrier* — a Git tree o
 ## Origin
 
 Lore is the product surface of **RAC — Requirements as Code**, the open-source
-engine underneath; the package, CLI, and MCP server ship under the `rac` name,
-and `lore` is the server identity and brand.
+engine underneath; the package, CLI, and MCP server ship under the `rac` name, and
+`lore` is the server identity and brand.
 [Wayfinder](https://github.com/itsthelore/wayfinder-router), the deterministic
 prompt-complexity router, began as a `route` experiment inside RAC and was split
 into its own tool — routing is a runtime concern, not a knowledge one.
@@ -130,7 +232,8 @@ per-service batteries (ADR-027).
 
 ## Project status
 
-Lore is early and evolving quickly. The MCP server ships today. Contributions, ideas, and experiments welcome — see [CONTRIBUTING.md](https://github.com/itsthelore/rac-core/blob/main/CONTRIBUTING.md).
+Lore is early and evolving quickly. The MCP server ships today. Contributions,
+ideas, and experiments welcome — see [CONTRIBUTING.md](https://github.com/itsthelore/rac-core/blob/main/CONTRIBUTING.md).
 
 ## License
 

--- a/rac/assets/images/lore-how-it-works-dark.svg
+++ b/rac/assets/images/lore-how-it-works-dark.svg
@@ -1,0 +1,54 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 232" width="900" height="232" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" fill="#f5a623"/>
+    </marker>
+  </defs>
+
+  <!-- panel -->
+  <rect x="0.5" y="0.5" width="899" height="231" rx="16" fill="#121212" stroke="#2a2a26"/>
+
+  <!-- box 1: your repo -->
+  <rect x="14" y="26" width="188" height="150" rx="10" fill="#1b1a15" stroke="#3d3b34"/>
+  <text x="108" y="54" text-anchor="middle" fill="#f5a623" font-size="13" font-weight="700">your repo</text>
+  <line x1="64" y1="62" x2="152" y2="62" stroke="#a8762a" stroke-width="1"/>
+  <text x="108" y="86" text-anchor="middle" fill="#8f8d84" font-size="10.5">typed Markdown</text>
+  <text x="108" y="106" text-anchor="middle" fill="#d6d4cc" font-size="10.5">decisions · requirements</text>
+  <text x="108" y="124" text-anchor="middle" fill="#d6d4cc" font-size="10.5">designs · roadmaps</text>
+  <text x="108" y="142" text-anchor="middle" fill="#d6d4cc" font-size="10.5">prompts</text>
+
+  <!-- box 2: rac engine -->
+  <rect x="242" y="26" width="188" height="150" rx="10" fill="#1b1a15" stroke="#3d3b34"/>
+  <text x="336" y="54" text-anchor="middle" fill="#f5a623" font-size="13" font-weight="700">rac engine</text>
+  <line x1="292" y1="62" x2="380" y2="62" stroke="#a8762a" stroke-width="1"/>
+  <text x="336" y="86" text-anchor="middle" fill="#57c97a" font-size="10.5">deterministic</text>
+  <text x="336" y="106" text-anchor="middle" fill="#d6d4cc" font-size="10.5">classify · validate</text>
+  <text x="336" y="124" text-anchor="middle" fill="#d6d4cc" font-size="10.5">resolve · relationships</text>
+  <text x="336" y="142" text-anchor="middle" fill="#d6d4cc" font-size="10.5">review · gate</text>
+
+  <!-- box 3: lore MCP server -->
+  <rect x="470" y="26" width="188" height="150" rx="10" fill="#1b1a15" stroke="#3d3b34"/>
+  <text x="564" y="54" text-anchor="middle" fill="#f5a623" font-size="13" font-weight="700">lore MCP server</text>
+  <line x1="510" y1="62" x2="618" y2="62" stroke="#a8762a" stroke-width="1"/>
+  <text x="564" y="84" text-anchor="middle" fill="#4ec9b0" font-size="10.5">read-only</text>
+  <text x="564" y="102" text-anchor="middle" fill="#d6d4cc" font-size="10">get_artifact · get_related</text>
+  <text x="564" y="118" text-anchor="middle" fill="#d6d4cc" font-size="10">search_artifacts</text>
+  <text x="564" y="134" text-anchor="middle" fill="#d6d4cc" font-size="10">find_decisions</text>
+  <text x="564" y="150" text-anchor="middle" fill="#d6d4cc" font-size="10">get_summary</text>
+
+  <!-- box 4: your agent -->
+  <rect x="698" y="26" width="188" height="150" rx="10" fill="#1b1a15" stroke="#3d3b34"/>
+  <text x="792" y="54" text-anchor="middle" fill="#f5a623" font-size="13" font-weight="700">your agent</text>
+  <line x1="748" y1="62" x2="836" y2="62" stroke="#a8762a" stroke-width="1"/>
+  <text x="792" y="92" text-anchor="middle" fill="#d6d4cc" font-size="10.5">Claude Code · Cursor</text>
+  <text x="792" y="112" text-anchor="middle" fill="#d6d4cc" font-size="10.5">Claude Desktop</text>
+  <text x="792" y="134" text-anchor="middle" fill="#8f8d84" font-size="10.5">cites your decisions</text>
+
+  <!-- arrows -->
+  <line x1="206" y1="101" x2="240" y2="101" stroke="#f5a623" stroke-width="2" marker-end="url(#arrow)"/>
+  <line x1="434" y1="101" x2="468" y2="101" stroke="#f5a623" stroke-width="2" marker-end="url(#arrow)"/>
+  <line x1="662" y1="101" x2="696" y2="101" stroke="#f5a623" stroke-width="2" marker-end="url(#arrow)"/>
+
+  <!-- caption -->
+  <text x="450" y="206" text-anchor="middle" fill="#8f8d84" font-size="11">Markdown in your repo  ·  deterministic engine  ·  read-only MCP  ·  agents that know why</text>
+</svg>

--- a/rac/assets/images/lore-how-it-works-light.svg
+++ b/rac/assets/images/lore-how-it-works-light.svg
@@ -1,0 +1,54 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 232" width="900" height="232" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">
+  <defs>
+    <marker id="arrowL" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" fill="#c47f12"/>
+    </marker>
+  </defs>
+
+  <!-- panel -->
+  <rect x="0.5" y="0.5" width="899" height="231" rx="16" fill="#f6f4ee" stroke="#e4e0d4"/>
+
+  <!-- box 1: your repo -->
+  <rect x="14" y="26" width="188" height="150" rx="10" fill="#fbfaf5" stroke="#ddd8c9"/>
+  <text x="108" y="54" text-anchor="middle" fill="#b5710c" font-size="13" font-weight="700">your repo</text>
+  <line x1="64" y1="62" x2="152" y2="62" stroke="#c9912f" stroke-width="1"/>
+  <text x="108" y="86" text-anchor="middle" fill="#76746b" font-size="10.5">typed Markdown</text>
+  <text x="108" y="106" text-anchor="middle" fill="#2f2d28" font-size="10.5">decisions · requirements</text>
+  <text x="108" y="124" text-anchor="middle" fill="#2f2d28" font-size="10.5">designs · roadmaps</text>
+  <text x="108" y="142" text-anchor="middle" fill="#2f2d28" font-size="10.5">prompts</text>
+
+  <!-- box 2: rac engine -->
+  <rect x="242" y="26" width="188" height="150" rx="10" fill="#fbfaf5" stroke="#ddd8c9"/>
+  <text x="336" y="54" text-anchor="middle" fill="#b5710c" font-size="13" font-weight="700">rac engine</text>
+  <line x1="292" y1="62" x2="380" y2="62" stroke="#c9912f" stroke-width="1"/>
+  <text x="336" y="86" text-anchor="middle" fill="#2f8f55" font-size="10.5">deterministic</text>
+  <text x="336" y="106" text-anchor="middle" fill="#2f2d28" font-size="10.5">classify · validate</text>
+  <text x="336" y="124" text-anchor="middle" fill="#2f2d28" font-size="10.5">resolve · relationships</text>
+  <text x="336" y="142" text-anchor="middle" fill="#2f2d28" font-size="10.5">review · gate</text>
+
+  <!-- box 3: lore MCP server -->
+  <rect x="470" y="26" width="188" height="150" rx="10" fill="#fbfaf5" stroke="#ddd8c9"/>
+  <text x="564" y="54" text-anchor="middle" fill="#b5710c" font-size="13" font-weight="700">lore MCP server</text>
+  <line x1="510" y1="62" x2="618" y2="62" stroke="#c9912f" stroke-width="1"/>
+  <text x="564" y="84" text-anchor="middle" fill="#1f9685" font-size="10.5">read-only</text>
+  <text x="564" y="102" text-anchor="middle" fill="#2f2d28" font-size="10">get_artifact · get_related</text>
+  <text x="564" y="118" text-anchor="middle" fill="#2f2d28" font-size="10">search_artifacts</text>
+  <text x="564" y="134" text-anchor="middle" fill="#2f2d28" font-size="10">find_decisions</text>
+  <text x="564" y="150" text-anchor="middle" fill="#2f2d28" font-size="10">get_summary</text>
+
+  <!-- box 4: your agent -->
+  <rect x="698" y="26" width="188" height="150" rx="10" fill="#fbfaf5" stroke="#ddd8c9"/>
+  <text x="792" y="54" text-anchor="middle" fill="#b5710c" font-size="13" font-weight="700">your agent</text>
+  <line x1="748" y1="62" x2="836" y2="62" stroke="#c9912f" stroke-width="1"/>
+  <text x="792" y="92" text-anchor="middle" fill="#2f2d28" font-size="10.5">Claude Code · Cursor</text>
+  <text x="792" y="112" text-anchor="middle" fill="#2f2d28" font-size="10.5">Claude Desktop</text>
+  <text x="792" y="134" text-anchor="middle" fill="#76746b" font-size="10.5">cites your decisions</text>
+
+  <!-- arrows -->
+  <line x1="206" y1="101" x2="240" y2="101" stroke="#c47f12" stroke-width="2" marker-end="url(#arrowL)"/>
+  <line x1="434" y1="101" x2="468" y2="101" stroke="#c47f12" stroke-width="2" marker-end="url(#arrowL)"/>
+  <line x1="662" y1="101" x2="696" y2="101" stroke="#c47f12" stroke-width="2" marker-end="url(#arrowL)"/>
+
+  <!-- caption -->
+  <text x="450" y="206" text-anchor="middle" fill="#76746b" font-size="11">Markdown in your repo  ·  deterministic engine  ·  read-only MCP  ·  agents that know why</text>
+</svg>


### PR DESCRIPTION
# Summary

Adopts the full structural mirror of the
[wayfinder-router README](https://github.com/itsthelore/wayfinder-router/blob/main/README.md)
for rac-core, so the two projects read as a family.

The README now leads with a centered header, nav, and badge rows (adding a
Mypy/typed badge), a **How it compares** table that frames Lore as the
deterministic system of record next to fuzzy retrieval, a Quickstart, an
**Install** matrix of the extras, and a **branded How-it-works diagram** —
hand-authored dark + light SVGs in the Lore palette, served via `<picture>` so
each color scheme gets its own variant. It then walks Connect, Author, Import,
Export, the Python API, the OKF relationship, audience, Docs, Origin, repository
layout, Test, and project status.

# Scope

- `README.md` — full restructure to mirror wayfinder-router's conventions.
- `rac/assets/images/lore-how-it-works-dark.svg` and
  `lore-how-it-works-light.svg` — new branded diagrams (repo → engine → MCP →
  agent), referenced by relative path from the README.

# Supersedes #172

This carries #172's intent: the natural-language import example now reads
*"import this decision doc into **Lore**."*, matching the Lore-aware skill
triggers from #171. #172 will be closed as superseded once this lands.

# Verification

- `README.md` is not in the MkDocs nav, so the Docs build is unaffected (green
  on `main`). The diagram paths resolve relative to the repo root, and GitHub
  renders the `<picture>` source set with the light SVG as the fallback `img`.