### PR TITLE
docs(roadmap): mark v0.23.0–v0.25.0 Achieved

### DIFF
--- a/rac/roadmaps/v0.23.x-hardening/v0.23.0-hardening.md
+++ b/rac/roadmaps/v0.23.x-hardening/v0.23.0-hardening.md
@@ -8,7 +8,7 @@ tags: [hardening, eval, doctor, trust, robustness, provenance]
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/rac/roadmaps/v0.24.x-visibility/v0.24.0-visibility.md
+++ b/rac/roadmaps/v0.24.x-visibility/v0.24.0-visibility.md
@@ -8,7 +8,7 @@ tags: [visibility, telemetry, read-back, traversal, coverage, relationships]
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/rac/roadmaps/v0.25.x-connect/v0.25.0-connect.md
+++ b/rac/roadmaps/v0.25.x-connect/v0.25.0-connect.md
@@ -7,12 +7,12 @@ type: roadmap
 
 ## Status
 
-Planned
+Achieved
 
-Planning artifacts only — no code. The workstreams land later as scoped PRs, as
-v0.23.0's and v0.24.0's did. This release schedules the engine half of the
-`corpus-export-to-rag-backends` umbrella; the connector itself is companion work
-in `lore-connectors` (ADR-073), out of this repo's scope.
+All three workstreams shipped as scoped PRs, as v0.23.0's and v0.24.0's did. This
+release delivered the engine half of the `corpus-export-to-rag-backends` umbrella;
+the connector itself is companion work in `lore-connectors` (ADR-073), out of this
+repo's scope.
 
 ## Context
 


### PR DESCRIPTION
# Summary

Brings the roadmap lifecycle states in line with what's shipped. Flips three
roadmaps from `Planned` to **Achieved**, ahead of the v0.25.0 publish:

- **v0.25.0 — Connect** — the export contract: WS1 (`rac export --documents`),
  WS2 (`rac export --graph` + ADR-074), WS3 (export docs). Status note under
  `## Status` also moved from future to past tense.
- **v0.24.0 — Visibility** — backfill; the work has landed on `main`.
- **v0.23.0 — Hardening** — backfill; already the top entry in `CHANGELOG.md`.

Both v0.23.0 and v0.24.0 were stranded at `Planned` despite shipping — the exact
stranding **ADR-061** exists to fix. Per ADR-061, `Achieved` is a human editorial
step set at release (never auto-flipped by a merge) and is *not* a retired status,
so inbound links to these roadmaps stay legal.

# Scope

- `rac/roadmaps/v0.25.x-connect/v0.25.0-connect.md` — `Planned → Achieved` + note tense.
- `rac/roadmaps/v0.24.x-visibility/v0.24.0-visibility.md` — `Planned → Achieved`.
- `rac/roadmaps/v0.23.x-hardening/v0.23.0-hardening.md` — `Planned → Achieved`.

No other change.

# Verification

- `rac validate rac/` → 263/263 valid, 0 invalid.
- `rac relationships rac/ --validate` → 0 issues (1231 checked).
- `rac review rac/` → no priority 1-2 findings.
- `Achieved` is a controlled roadmap-status value and not retired (ADR-061).