### PR TITLE
docs(release): close the v0.26.x series and record the merge-gate ADR [roadmap:v0.26.3]

### DIFF
--- a/.cursor/rules
+++ b/.cursor/rules
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: bd2a3eb266502357e10d8a8d9a0dc79cf317ae95f2874b2f3e2d0b1d4811026c) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: 4bad6cdd663e91b89aa7b39a27a3d25c33bec751ae167acff6f8eb911df1742d) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -53,4 +53,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KVJK92SM2A1R** — ADR-072: Document Ingestion Parser Is markitdown _(Architecture)_
 - **RAC-KVJY1KJEWZ87** — ADR-073: Backend Connectors Are Export-Contract Consumers, Not Per-Provider Repos _(Architecture)_
 - **RAC-KVK19NPWFYC9** — ADR-074: The Graph Export Surfaces Typed Relationship Edges _(Technical)_
+- **RAC-KVNM01QPBPXB** — ADR-075: The Pre-Merge Check Tier Is a Required Merge Gate on `main` _(Process)_
 <!-- END RAC MANAGED BLOCK -->

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: bd2a3eb266502357e10d8a8d9a0dc79cf317ae95f2874b2f3e2d0b1d4811026c) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: 4bad6cdd663e91b89aa7b39a27a3d25c33bec751ae167acff6f8eb911df1742d) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -53,4 +53,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KVJK92SM2A1R** — ADR-072: Document Ingestion Parser Is markitdown _(Architecture)_
 - **RAC-KVJY1KJEWZ87** — ADR-073: Backend Connectors Are Export-Contract Consumers, Not Per-Provider Repos _(Architecture)_
 - **RAC-KVK19NPWFYC9** — ADR-074: The Graph Export Surfaces Typed Relationship Edges _(Technical)_
+- **RAC-KVNM01QPBPXB** — ADR-075: The Pre-Merge Check Tier Is a Required Merge Gate on `main` _(Process)_
 <!-- END RAC MANAGED BLOCK -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: bd2a3eb266502357e10d8a8d9a0dc79cf317ae95f2874b2f3e2d0b1d4811026c) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: 4bad6cdd663e91b89aa7b39a27a3d25c33bec751ae167acff6f8eb911df1742d) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -53,4 +53,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KVJK92SM2A1R** — ADR-072: Document Ingestion Parser Is markitdown _(Architecture)_
 - **RAC-KVJY1KJEWZ87** — ADR-073: Backend Connectors Are Export-Contract Consumers, Not Per-Provider Repos _(Architecture)_
 - **RAC-KVK19NPWFYC9** — ADR-074: The Graph Export Surfaces Typed Relationship Edges _(Technical)_
+- **RAC-KVNM01QPBPXB** — ADR-075: The Pre-Merge Check Tier Is a Required Merge Gate on `main` _(Process)_
 <!-- END RAC MANAGED BLOCK -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ to the corpus artifact and they load through the imports below.
 - Previous series: `rac/roadmaps/v0.21.x-editor/` (complete)
 - Decisions (ADRs): `rac/decisions/`
 
-<!-- BEGIN RAC MANAGED BLOCK (digest: bd2a3eb266502357e10d8a8d9a0dc79cf317ae95f2874b2f3e2d0b1d4811026c) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: 4bad6cdd663e91b89aa7b39a27a3d25c33bec751ae167acff6f8eb911df1742d) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -78,4 +78,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KVJK92SM2A1R** — ADR-072: Document Ingestion Parser Is markitdown _(Architecture)_
 - **RAC-KVJY1KJEWZ87** — ADR-073: Backend Connectors Are Export-Contract Consumers, Not Per-Provider Repos _(Architecture)_
 - **RAC-KVK19NPWFYC9** — ADR-074: The Graph Export Surfaces Typed Relationship Edges _(Technical)_
+- **RAC-KVNM01QPBPXB** — ADR-075: The Pre-Merge Check Tier Is a Required Merge Gate on `main` _(Process)_
 <!-- END RAC MANAGED BLOCK -->

--- a/rac/decisions/adr-075-required-merge-gate.md
+++ b/rac/decisions/adr-075-required-merge-gate.md
@@ -1,0 +1,180 @@
+---
+schema_version: 1
+id: RAC-KVNM01QPBPXB
+type: decision
+---
+# ADR-075: The Pre-Merge Check Tier Is a Required Merge Gate on `main`
+
+## Context
+
+ADR-027 fixed RAC's CI test topology: the full battery × version grid is
+merge-gated on `main`, and pull requests instead run a deliberately small
+pre-merge tier in `.github/workflows/pr-checks.yml` — the static quality gates
+(`ruff check`, `ruff format --check`, `mypy src/`) plus a smoke battery and the
+dogfood gates (`validate`, `pr-gate`, `doctor`, `watchkeeper`, `agent-rules`,
+`grounding-eval`). ADR-027 describes *what runs* on a pull request, and why.
+
+What it never states is whether those checks **block the merge**. That is a
+separate, GitHub-side control: a branch-protection rule on `main` listing the
+required status checks. The two are independent — a workflow can run and report
+red on a pull request while the merge button stays green, because the check is
+advisory unless branch protection marks it *required*.
+
+That gap is not hypothetical. PR #178 (the v0.26.3 split layout) merged to
+`main` with the `lint (ruff + mypy)` job failing: `mypy` had flagged a
+`str | None` value passed where `str` was expected. The pre-merge tier did its
+job and reported the failure, but nothing stopped the merge, so the regression
+landed on `main` and turned the post-merge run red. The follow-up PR had to
+carry the fix.
+
+`main` is already a protected branch, so some protection exists — but the
+pre-merge tier's checks are evidently not in its required set, which is exactly
+how a red `lint` job reached `main`. Absent a recorded decision, *which* checks
+gate a merge is an invisible repository setting that no one reviews and that
+drifts silently. ADR-027 made the trigger policy deliberate; this ADR does the
+same for the enforcement policy it implies.
+
+## Decision
+
+The `pr-checks.yml` pre-merge tier is a **required merge gate** on `main`.
+
+1. **Branch protection on `main` requires the pre-merge checks to pass before
+   merging.** Every job `pr-checks.yml` runs on `pull_request` is a required
+   status check: at minimum `lint (ruff + mypy)`, and the smoke and dogfood
+   jobs that constitute the tier (`smoke (core + golden + dogfood, py3.11)`,
+   `validate`, `pr-gate`, `doctor`, `watchkeeper`, `agent-rules`,
+   `grounding-eval`). A pull request cannot merge while any of them is red or
+   pending.
+
+2. **The gate is not bypassable by routine merges.** Branch protection applies
+   to everyone using the merge button, maintainers included; a red pre-merge
+   tier is fixed, not merged through. (An explicit administrator override
+   remains available for genuine emergencies, used knowingly, not as the
+   default path.)
+
+3. **Pull requests must be up to date with `main` before merging.** "Require
+   branches to be up to date" is enabled, so a check that went green against a
+   stale base cannot merge over newer changes it never ran against.
+
+This is the GitHub-side complement to ADR-027: ADR-027 says the tier *runs* on
+pull requests; this ADR says a failing tier *blocks* the merge.
+
+## Principles
+
+### Principle 1 — Running a check and enforcing it are distinct decisions
+
+A workflow that reports red is worth nothing to `main`'s health unless the
+merge is blocked on it. Enforcement is its own choice and is recorded as one.
+
+### Principle 2 — The merge gate is recorded knowledge, not an invisible setting
+
+Which checks gate a merge lives here, where it is reviewable, rather than only
+in a repository settings page that drifts unseen. A change to the required set
+is a deliberate edit to this decision.
+
+### Principle 3 — `main` stays green by construction
+
+The cheapest place to catch lint, type, contract, and corpus breakage is before
+it lands. Requiring the pre-merge tier keeps `main` releasable, which protects
+the release gate ADR-027 rule 2 depends on.
+
+## Consequences
+
+### Positive
+
+- A red pre-merge tier blocks the merge, so regressions like #178's `mypy`
+  failure cannot reach `main` through the normal flow.
+- The post-merge full grid (ADR-027 rule 1) starts from a `main` that already
+  passed lint, types, and the smoke/dogfood gates, so it fails far less often.
+- The required set is auditable in this ADR; widening or narrowing it is a
+  reviewed change.
+
+### Negative
+
+- Merges wait for the pre-merge tier to finish, adding the tier's runtime
+  (~2 minutes) to the merge path. This is the intended cost.
+- The required-check **names** in branch protection must track the job names in
+  `pr-checks.yml`; renaming a job without updating the rule silently drops it
+  from the gate. Mitigation: treat a `pr-checks.yml` job rename as also editing
+  the branch-protection required set, and keep both in step with this ADR.
+- Branch protection is a GitHub repository setting, not a file in the repo, so
+  this decision states the policy but cannot itself apply it; the setting is
+  maintained by hand to match.
+
+## Alternatives Considered
+
+### Leave the tier advisory (the prior state)
+
+Run `pr-checks.yml` on pull requests but require none of its checks to merge.
+
+#### Pros
+
+- Maximum flexibility; a maintainer can merge over a red check at will.
+
+#### Cons
+
+- Exactly the state that let #178 merge red. The signal exists but does not
+  protect `main`.
+
+Rejected — the signal is only worth the runtime if it gates.
+
+### Require the full battery grid on pull requests
+
+Make the merge gate the whole per-service × version grid rather than the smoke
+tier.
+
+#### Pros
+
+- Strongest possible pre-merge guarantee.
+
+#### Cons
+
+- Reverses ADR-027 rule 1, which deliberately keeps the full grid merge-gated
+  on `main` and pull requests light, to bound Actions usage on in-flight
+  branches.
+
+Rejected — the smoke tier plus the post-merge grid is the balance ADR-027
+already chose; this ADR enforces that tier, it does not enlarge it.
+
+## Status
+
+Accepted
+
+## Category
+
+Process
+
+## Relationship to Other ADRs
+
+### ADR-027 CI Test Topology — Merge-Gated, Per-Service Batteries
+
+ADR-027 defines the pre-merge tier and *when* it runs. This ADR adds the
+enforcement ADR-027 left implicit: the tier is a required, non-bypassable merge
+gate on `main`. The two are read together.
+
+### ADR-005 CLI First and ADR-007 JSON Contract Stability
+
+The smoke and dogfood gates in the tier exercise the CLI surface and the JSON
+output. Requiring them before merge keeps RAC's public contracts green on
+`main`, upstream of the release gate that ultimately protects them.
+
+## Success Measures
+
+- No change reaches `main` through the merge button while any `pr-checks.yml`
+  job is red — a regression like #178 is blocked at the PR, not fixed afterward.
+- The post-merge full grid on `main` is green on the merge commit far more often
+  than before, because `main` only receives changes that already passed the
+  tier.
+- The required-check set changes only by a deliberate edit to this decision and
+  the matching branch-protection setting.
+
+## Review Date
+
+Review before v1.0.0, or sooner if `pr-checks.yml`'s job set changes materially
+or RAC accepts outside contributors who need a different gate.
+
+## Related Decisions
+
+- adr-027
+- adr-005
+- adr-007

--- a/rac/roadmaps/v0.26.x-tui-revamp/v0.26.3-split-layout.md
+++ b/rac/roadmaps/v0.26.x-tui-revamp/v0.26.3-split-layout.md
@@ -7,7 +7,7 @@ type: roadmap
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/rac/roadmaps/v0.26.x-tui-revamp/v0.26.4-editor-flow.md
+++ b/rac/roadmaps/v0.26.x-tui-revamp/v0.26.4-editor-flow.md
@@ -7,19 +7,26 @@ type: roadmap
 
 ## Status
 
-Planned
+Abandoned
 
 ## Context
 
-`rac explorer` opens an artifact's source in an external editor — resolving the
-command from the `editor` preference, then `$VISUAL` / `$EDITOR`, and launching
-it fire-and-forget (`Popen`), which suits GUI editors (VS Code, Cursor). Two
-pieces from the Explorer follow-ups (`explorer-followups`) remain: a first-run
-prompt to set the editor, and support for terminal editors (vim, neovim,
-`emacs -nw`) that need the TUI suspended while they own the terminal. This
-release closes that loop so terminal-first users get a native edit experience.
-The Explorer still authors nothing itself; editing belongs to the external tool
-(ADR-024).
+This item is retired without separate work: when the tui-revamp series was
+sketched it was scoped from a stale reading of the Explorer follow-ups, but both
+pieces it planned had already shipped in the v0.8.x series and are covered by
+passing tests. `rac explorer` already opens an artifact's source in an external
+editor — resolving the command from the `editor` preference, then `$VISUAL` /
+`$EDITOR`. Terminal editors (vim, neovim, `emacs -nw`) already suspend the
+Explorer through `App.suspend()`, pause the live watcher, and rescan on resume
+(`launch_editor`, `is_terminal_editor`); GUI editors keep the fire-and-forget
+`Popen` path. The first-run editor prompt already runs between the welcome and
+the summary (`#firstrun-editor`): Enter accepts the `$VISUAL` / `$EDITOR`
+fallback, typing sets the preference, Esc skips. The Explorer still authors
+nothing itself; editing belongs to the external tool (ADR-024).
+
+The tui-revamp series therefore closes at v0.26.3. The outcomes and initiatives
+below are preserved as the original record of what was planned; they describe
+behaviour that already exists rather than work still to do.
 
 ## Outcomes
 

--- a/src/rac/explorer/widgets/views.py
+++ b/src/rac/explorer/widgets/views.py
@@ -1047,7 +1047,8 @@ class PortfolioView(Vertical):
         table = self.query_one(DataTable)
         if self._follow and table.row_count:
             first = next(iter(table.rows))
-            self.post_message(self.Followed(first.value))
+            if first.value is not None:
+                self.post_message(self.Followed(first.value))
             table.move_cursor(row=0)
 
     def refresh_tags(self) -> None:


### PR DESCRIPTION
## Close the v0.26.x series, fix the CI regression, record the gate

Three related changes, all stemming from the v0.26.x tui-revamp wrap-up:

### 1. Roadmap status

- **v0.26.3 split-layout → Achieved.** The split master-detail layout (#178)
  is merged and shipped; flip Planned → Achieved (ADR-061).
- **v0.26.4 editor-flow → Abandoned.** Sketched from a stale reading of the
  Explorer follow-ups — terminal-editor suspend/resume and the first-run
  editor prompt both already shipped in v0.8.x and are covered by passing
  tests. Retired as Abandoned with the rationale recorded in-file; its
  Outcomes/Initiatives are preserved as the record of what was planned.

### 2. CI fix

- **`reveal_first` null-key guard.** mypy on `main` flagged the split layout's
  `reveal_first` passing a `DataTable` row-key value (`str | None`) to the
  `Followed` message, which expects `str`. The highlighted-row handler already
  guards for `None`; mirror it in `reveal_first`. This is the regression that
  turned `main` red after #178 merged.

### 3. ADR-075 — required merge gate

- **`rac/decisions/adr-075-required-merge-gate.md`.** #178 merged with a red
  `lint (ruff + mypy)` job because the `pr-checks.yml` pre-merge tier was
  advisory, not a required status check. ADR-027 defined the tier but never
  stated it must block merge. ADR-075 records that the pre-merge tier is a
  required, non-bypassable merge gate on `main`, extending ADR-027. The
  derived agent-rules blocks (`AGENTS.md`, `CLAUDE.md`,
  `.github/copilot-instructions.md`, `.cursor/rules`) are regenerated to list
  it.
  - **Note:** the ADR records the policy; applying it is a GitHub
    branch-protection change (add the `pr-checks.yml` jobs — at minimum
    `lint (ruff + mypy)` — to `main`'s required status checks). That setting
    is maintained by hand and is not part of this PR.

### Resulting series

| Roadmap | Status |
| --- | --- |
| v0.26.0 appearance | Achieved |
| v0.26.1 legibility | Achieved |
| v0.26.2 portfolio-list | Achieved |
| v0.26.3 split-layout | Achieved |
| v0.26.4 editor-flow | Abandoned (already shipped in v0.8.x) |

### Gates

`ruff`, `mypy`, the split-layout tests, and the agent-rules drift check pass
locally; `rac validate rac/`, `rac relationships rac/ --validate`, and
`rac review rac/` all clean (review 92/100, no priority 1–2 findings).

### Related decisions

ADR-061, ADR-027, ADR-017, ADR-024, ADR-005, ADR-007.