### PR TITLE
feat(release): adopt CalVer and add the fail-closed release gate [roadmap:v0.27.0]

### DIFF
--- a/.cursor/rules
+++ b/.cursor/rules
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: 4bad6cdd663e91b89aa7b39a27a3d25c33bec751ae167acff6f8eb911df1742d) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: b69411ed027089c1eda60e0497db694d5d092afaa85969a79d2202f3f38d9703) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -54,4 +54,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KVJY1KJEWZ87** — ADR-073: Backend Connectors Are Export-Contract Consumers, Not Per-Provider Repos _(Architecture)_
 - **RAC-KVK19NPWFYC9** — ADR-074: The Graph Export Surfaces Typed Relationship Edges _(Technical)_
 - **RAC-KVNM01QPBPXB** — ADR-075: The Pre-Merge Check Tier Is a Required Merge Gate on `main` _(Process)_
+- **RAC-KVPTVX3YZ87K** — ADR-076: Adopt CalVer (`YYYY.MM.N`) for RAC Releases _(Process)_
 <!-- END RAC MANAGED BLOCK -->

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: 4bad6cdd663e91b89aa7b39a27a3d25c33bec751ae167acff6f8eb911df1742d) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: b69411ed027089c1eda60e0497db694d5d092afaa85969a79d2202f3f38d9703) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -54,4 +54,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KVJY1KJEWZ87** — ADR-073: Backend Connectors Are Export-Contract Consumers, Not Per-Provider Repos _(Architecture)_
 - **RAC-KVK19NPWFYC9** — ADR-074: The Graph Export Surfaces Typed Relationship Edges _(Technical)_
 - **RAC-KVNM01QPBPXB** — ADR-075: The Pre-Merge Check Tier Is a Required Merge Gate on `main` _(Process)_
+- **RAC-KVPTVX3YZ87K** — ADR-076: Adopt CalVer (`YYYY.MM.N`) for RAC Releases _(Process)_
 <!-- END RAC MANAGED BLOCK -->

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -21,8 +21,27 @@ jobs:
     # pass before anything is built or published.
     uses: ./.github/workflows/tests.yml
 
+  verify-release:
+    # Fail-closed CalVer gate (REQ-Release-Versioning REQ-007, ADR-076): the
+    # release tag must be a well-formed YYYY.MM.N identifier and have a matching
+    # CHANGELOG.md entry, or nothing is built or published.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+      - name: Install package
+        run: python -m pip install -e .
+      - name: Verify release version and changelog
+        run: python -m rac.release "${{ github.event.release.tag_name }}"
+
   release-build:
-    needs: test
+    needs:
+      - test
+      - verify-release
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -119,6 +119,8 @@ jobs:
             paths: "tests/test_hook.py"
           - name: stats
             paths: "tests/test_stats.py"
+          - name: release
+            paths: "tests/test_release_version.py"
           - name: watchkeeper
             paths: "tests/test_watchkeeper.py tests/test_validate_action.py tests/test_pr_gate_action.py tests/test_gate.py tests/test_no_egress.py"
           # Trust gates (v0.7.9): dogfood validates RAC's own rac/ corpus,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: 4bad6cdd663e91b89aa7b39a27a3d25c33bec751ae167acff6f8eb911df1742d) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: b69411ed027089c1eda60e0497db694d5d092afaa85969a79d2202f3f38d9703) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -54,4 +54,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KVJY1KJEWZ87** — ADR-073: Backend Connectors Are Export-Contract Consumers, Not Per-Provider Repos _(Architecture)_
 - **RAC-KVK19NPWFYC9** — ADR-074: The Graph Export Surfaces Typed Relationship Edges _(Technical)_
 - **RAC-KVNM01QPBPXB** — ADR-075: The Pre-Merge Check Tier Is a Required Merge Gate on `main` _(Process)_
+- **RAC-KVPTVX3YZ87K** — ADR-076: Adopt CalVer (`YYYY.MM.N`) for RAC Releases _(Process)_
 <!-- END RAC MANAGED BLOCK -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,44 @@ User-visible changes to RAC, by release. Follows the spirit of
 [Keep a Changelog](https://keepachangelog.com/): user impact over implementation
 details, release history over commit history.
 
+## 2026.06.1
+
+The first release under **CalVer** (`YYYY.MM.N`, ADR-076): RAC's version now says
+*when* a build was cut, not a SemVer compatibility claim it never kept.
+Compatibility lives on `schema_version` (ADR-007); the roadmap `vX.Y.Z` numbers
+continue as internal planning scope-fences. This is a one-way cutover — every
+prior `vX.Y.Z` tag is retained, and `2026.06.1` supersedes `v0.19.0` as the
+latest release. It also ships the user-facing work accumulated across the
+v0.23–v0.26 scope-fences:
+
+- **A reimagined Explorer (TUI).** Three themes — `lantern` (dark default),
+  `parchment` (warm light), and `high-contrast` — switchable in `/settings` and
+  persisted, with theme-aware, accessible type tags. A portfolio list view
+  (`/list`) gives a dense, sortable table of the whole corpus with live fuzzy
+  search (`ctrl+f`), status filtering, and sort cycling. An optional split
+  master-detail layout pairs that list with a persistent reading pane so scanning
+  and reading happen together.
+
+- **Exportable corpus.** `rac export --documents` emits an ingestion-ready JSONL
+  projection (one Markdown-bodied record per artifact) that any RAG/memory backend
+  consumes directly, and `rac export --graph` hands a graph backend RAC's real,
+  validated relationship topology instead of one inferred from prose.
+
+- **Visible grounding and coverage.** Local, content-free telemetry shows how
+  agents actually consult Lore over time; a coverage view lists where the
+  knowledge graph is incomplete (requirements no roadmap schedules, decisions
+  nothing applies); and `get_related` can return a bounded multi-hop neighbourhood
+  within the response budget.
+
+- **Hardening (from the v0.23 line).** Explainable retrieval (search results show
+  *why* they matched), `rac doctor` for paste-ready corpus fixes, git-derived
+  provenance on `get_artifact`, a documented trust model (`SECURITY.md`), and a
+  gated, deterministic grounding benchmark (`rac eval --check`).
+
+- **Release tooling.** A fail-closed publish gate (`python -m rac.release`)
+  rejects any tag that is not a well-formed `YYYY.MM.N` identifier or that lacks a
+  changelog entry, so a malformed or undocumented release can never reach PyPI.
+
 ## v0.23.0 — Hardening
 
 The release that turns the grounding claim from "trust us" into something proven

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ to the corpus artifact and they load through the imports below.
 - Previous series: `rac/roadmaps/v0.21.x-editor/` (complete)
 - Decisions (ADRs): `rac/decisions/`
 
-<!-- BEGIN RAC MANAGED BLOCK (digest: 4bad6cdd663e91b89aa7b39a27a3d25c33bec751ae167acff6f8eb911df1742d) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: b69411ed027089c1eda60e0497db694d5d092afaa85969a79d2202f3f38d9703) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -79,4 +79,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KVJY1KJEWZ87** — ADR-073: Backend Connectors Are Export-Contract Consumers, Not Per-Provider Repos _(Architecture)_
 - **RAC-KVK19NPWFYC9** — ADR-074: The Graph Export Surfaces Typed Relationship Edges _(Technical)_
 - **RAC-KVNM01QPBPXB** — ADR-075: The Pre-Merge Check Tier Is a Required Merge Gate on `main` _(Process)_
+- **RAC-KVPTVX3YZ87K** — ADR-076: Adopt CalVer (`YYYY.MM.N`) for RAC Releases _(Process)_
 <!-- END RAC MANAGED BLOCK -->

--- a/rac/decisions/adr-076-calver-release-versioning.md
+++ b/rac/decisions/adr-076-calver-release-versioning.md
@@ -1,0 +1,153 @@
+---
+schema_version: 1
+id: RAC-KVPTVX3YZ87K
+type: decision
+---
+# ADR-076: Adopt CalVer (`YYYY.MM.N`) for RAC Releases
+
+## Context
+
+RAC published its package under SemVer (`vX.Y.Z`), with setuptools-scm deriving
+the build from the latest tag. Two numbering systems had quietly diverged: the
+roadmap series (`vX.Y.Z`) ran to v0.26 as planning **scope-fences**, while the
+published PyPI package sat at `v0.19.0` — nothing had been tagged in seven
+series. The SemVer minors were never used as release promises; they were scope
+fences, and a patch/minor bump asserted a compatibility contract RAC does not
+maintain on the version string and no consumer resolves.
+
+REQ-Release-Versioning (`RAC-KV3GGM1TFHY4`) captured the date-based alternative
+in detail and sat `Proposed`, deferred until cadence justified it. That point
+has arrived: a backlog of shipped work needs releasing, and the maintainer
+confirmed releases are cut monthly, not daily. A constraint also forces the
+shape of the answer — PyPI versions are one-way: `0.1.0`…`0.19.0` are already
+published and immutable, and pip resolves the highest version, so the next
+release must sort **above** `0.19.0`. A `YYYY.MM.N` identifier does (`2026.06.1`
+→ `(2026, 6, 1)` ≫ `(0, 19, 0)`), which both honours the constraint and answers
+the question a reader actually asks of the number: *how recent is this build*.
+
+## Decision
+
+RAC releases adopt CalVer of the form **`YYYY.MM.N`** — the UTC year and
+zero-padded month a release is cut, plus a within-month counter starting at `1`
+— as specified normatively by REQ-Release-Versioning (now `Accepted`).
+
+1. **The release identifier is `YYYY.MM.N`.** Month-granular with a within-month
+   counter (`2026.06.1`, `2026.06.2`, `2026.07.1`), matching a monthly cadence.
+   The first release under this scheme is `2026.06.1`.
+2. **The version carries no compatibility signal.** Stability and contract
+   compatibility live on `schema_version` (ADR-007), independent of the release
+   date. The CalVer number says only *when*.
+3. **Roadmap `vX.Y.Z` numbers stay as internal scope-fences**, decoupled from
+   release identifiers. They schedule and bound work; they are not releases.
+4. **The cutover is one-way (REQ-008).** Pre-cutover SemVer tags (`v0.1.0`…
+   `v0.19.0`) are retained immutably and never reinterpreted as dates; RAC's own
+   tooling does not co-order the two domains. Once a `2026.x` tag exists there is
+   no return to `0.x`/`1.x` — those sort lower and pip would ignore them.
+5. **Release is fail-closed (REQ-007).** The publish workflow verifies the tag is
+   a well-formed `YYYY.MM.N` identifier and that `CHANGELOG.md` has a matching
+   entry before anything is built or published (`python -m rac.release`).
+
+## Principles
+
+### Principle 1 — The release number answers the question it is actually asked
+
+Readers ask "how recent is this build", not "is it compatible with my pin". A
+date answers the former honestly; SemVer answered the latter falsely.
+
+### Principle 2 — Compatibility has its own home
+
+`schema_version` (ADR-007) versions RAC's contracts. Overloading that onto the
+release string is what made SemVer misleading; CalVer keeps the two separate.
+
+### Principle 3 — Scope-fences and releases are different things
+
+The roadmap `vX.Y.Z` numbers are planning boundaries and remain useful as such.
+Releases are date-stamped events. Conflating them is what let the two numbering
+systems drift seven versions apart.
+
+## Consequences
+
+### Positive
+
+- The next release sorts above `0.19.0`, so it cleanly becomes "latest" on PyPI;
+  the publish pipeline (setuptools-scm → tag) needs no change beyond the tag form.
+- No more debating whether a change is a "minor" or whether the product is "1.0":
+  the date is the version.
+- A fail-closed verifier prevents a malformed tag or a release with no changelog
+  entry from publishing.
+
+### Negative
+
+- The cutover is irreversible: CalVer is a permanent commitment, and SemVer
+  numbers can never be used again for this package.
+- A date carries no semantic-change signal; consumers wanting a compatibility
+  cue must read `schema_version` or the changelog, not the version.
+- The roadmap `vX.Y.Z` numbers no longer correspond to released versions, which
+  readers used to (loosely) assume; this ADR and the changelog record the split.
+
+## Alternatives Considered
+
+### Cut a `v1.0.0` (or continue `v0.20.0+`) under SemVer
+
+Stay on SemVer and release the backlog as `1.0.0` or `0.26.0`.
+
+#### Pros
+
+- Familiar; no tooling or convention change.
+
+#### Cons
+
+- Keeps asserting a compatibility contract RAC does not maintain, and re-opens
+  the "what does the minor mean / is it 1.0 yet" question every release — the
+  exact friction that left the package unreleased for seven series.
+
+Rejected in favour of separating recency (the date) from compatibility
+(`schema_version`).
+
+### Day-granular CalVer `YYYY.MM.DD` (REQ-Release-Versioning as first drafted)
+
+The originally-proposed scheme, with same-day `.2`/`.3` increments.
+
+#### Pros
+
+- Encodes the exact release day.
+
+#### Cons
+
+- Its motivation was many releases per day; the actual cadence is monthly, so a
+  full date is more precision than the cadence carries.
+
+Rejected; the requirement was revised to the month-granular `YYYY.MM.N`.
+
+## Status
+
+Accepted
+
+## Category
+
+Process
+
+## Relationship to Other ADRs
+
+### ADR-007 JSON Contract Stability
+
+`schema_version` is where compatibility is versioned. This ADR moves the release
+identifier off that job entirely, so the two signals stop being overloaded onto
+one string.
+
+### ADR-027 CI Test Topology — Merge-Gated, Per-Service Batteries
+
+The release gate (ADR-027 rule 2) already blocks publishing on a red suite; this
+ADR adds the fail-closed version/changelog check as a sibling release gate.
+
+## Success Measures
+
+- The first `2026.06.1` release publishes to PyPI and resolves as "latest".
+- No release publishes with a malformed version or a missing changelog entry.
+- The release identifier and `schema_version` move independently.
+- Historical `vX.Y.Z` tags remain present and unmodified.
+
+## Related Decisions
+
+- ADR-007
+- ADR-027

--- a/rac/requirements/rac-release-versioning.md
+++ b/rac/requirements/rac-release-versioning.md
@@ -11,17 +11,19 @@ type: requirement
 
 ## Status
 
-Proposed
+Accepted
 
 ## Problem
 
-RAC publishes its own releases under Semantic Versioning (`vX.Y.Z`), and
-setuptools-scm derives the package version from those tags. SemVer makes a
+RAC published its own releases under Semantic Versioning (`vX.Y.Z`), and
+setuptools-scm derived the package version from those tags. SemVer makes a
 promise RAC's release stream does not keep: a patch bump asserts a
 backward-compatible bug fix, a minor bump asserts backward-compatible new
 behaviour, yet RAC's user-visible changes — CLI output, validation strictness,
 artifact rules — do not map cleanly onto that contract, and no programmatic
-consumer resolves these version constraints. The number is read by humans
+consumer resolves these version constraints. In practice the SemVer minors were
+used as roadmap scope-fences, not releases: the planning numbers ran to v0.26
+while the published package sat at `v0.19.0`, and the number was read by humans
 scanning history, where the question is really *how recent is this build*, not
 *is it compatible with my pin*.
 
@@ -29,86 +31,82 @@ A date-based release identity answers the question that is actually asked. It
 states *when* a release was cut and stops encoding a compatibility claim RAC does
 not maintain on the version string. Compatibility, where RAC needs to signal it,
 already has an independent home in the schema/contract version (ADR-007), so the
-two concerns can be separated cleanly rather than overloaded onto one identifier.
+two concerns are separated cleanly rather than overloaded onto one identifier.
 
-This requirement captures the date-based scheme as a recorded option. It is
-filed `Proposed` and changes no tooling: the current SemVer release flow,
-setuptools-scm configuration, the existing `vX.Y.Z` tag history, and the
-versioned roadmap series all stand. Promotion to a decision, a roadmap, and an
-implementation is deferred until release cadence or consumer needs justify the
-apparatus.
+This requirement is `Accepted` and adopted by ADR-076. The release cadence is
+monthly rather than daily, so the identifier is month-granular with a
+within-month counter (`YYYY.MM.N`) rather than a full calendar date. The
+versioned roadmap series (`vX.Y.Z`) stand, now explicitly as **internal
+scope-fences** decoupled from release identifiers; the pre-cutover SemVer tags
+stand immutably.
 
 ## Requirements
 
-- [REQ-001] A release version MUST be a UTC calendar date of the form `YYYY.MM.DD`, where `YYYY` is a four-digit year, `MM` a zero-padded month `01`–`12`, and `DD` a zero-padded day valid for that month and year (including leap-year February); the date MUST be the UTC date on which the release is cut, so the identifier is deterministic and timezone-independent.
+- [REQ-001] A release version MUST be of the form `YYYY.MM.N`, where `YYYY` is a four-digit UTC year, `MM` a zero-padded month `01`–`12`, and `N` a within-month release counter; the year and month MUST be the UTC year and month in which the release is cut, so the identifier is deterministic and timezone-independent.
 
-- [REQ-002] When a single release is cut on a given UTC date, the version MUST omit the increment segment (`YYYY.MM.DD`); when more than one release is cut on the same UTC date, each release after the first MUST carry an increment segment starting at `.2` and rising by one (`YYYY.MM.DD.2`, `YYYY.MM.DD.3`, …), and an explicit `.1`, an increment of `.0`, and any leading-zero increment (`.02`) are invalid.
+- [REQ-002] The counter `N` MUST start at `1` for the first release of a given month and rise by one for each subsequent release that month (`2026.06.1`, `2026.06.2`, …); a counter of `0`, a leading-zero counter (`01`), and a bare `YYYY.MM` with no counter are invalid.
 
-- [REQ-003] Release precedence MUST be the lexicographic order of the tuple `(YYYY, MM, DD, increment)`, where an omitted increment is treated as `1`, so that `2026.06.14` precedes `2026.06.14.2`, which precedes `2026.06.15`.
+- [REQ-003] Release precedence MUST be the lexicographic order of the tuple `(YYYY, MM, N)`, so that `2026.06.1` precedes `2026.06.2`, which precedes `2026.07.1`.
 
-- [REQ-004] The release version MUST NOT encode any compatibility, stability, or severity signal; any such signal MUST live on the independent schema/contract version (ADR-007, `schema_version`), which versions and stabilises RAC's contracts separately from the release date.
+- [REQ-004] The release version MUST NOT encode any compatibility, stability, or severity signal; any such signal MUST live on the independent schema/contract version (ADR-007, `schema_version`), which versions and stabilises RAC's contracts separately from the release identifier.
 
-- [REQ-005] A release MUST be event-triggered, assigning a new release version only when released content has changed; each release MUST correspond to exactly one commit and exactly one immutable tag, and MUST have a changelog entry recording its compatibility-surface changes.
+- [REQ-005] A release MUST be event-triggered, assigning a new release version only when released content has changed; each release MUST correspond to exactly one commit and exactly one immutable tag, and MUST have a changelog entry recording its user-visible changes.
 
-- [REQ-006] A build that is not itself a release MUST carry a VCS-derived identifier (for example a development or local segment over the base release) that orders strictly after its base release and strictly before the next release or same-day increment, and a build identifier MUST NOT be mistaken for a release version.
+- [REQ-006] A build that is not itself a release MUST carry a VCS-derived identifier (for example a development or local segment over the base release) that orders strictly after its base release and strictly before the next release or same-month increment, and a build identifier MUST NOT be mistaken for a release version.
 
-- [REQ-007] Release verification MUST fail closed: a candidate version that is not a well-formed, calendar-valid date under REQ-001–REQ-003, or that lacks the changelog entry required by REQ-005, MUST NOT be published.
+- [REQ-007] Release verification MUST fail closed: a candidate version that is not a well-formed `YYYY.MM.N` identifier under REQ-001–REQ-003, or that lacks the changelog entry required by REQ-005, MUST NOT be published.
 
-- [REQ-008] Adoption MUST be a one-way cutover: pre-cutover SemVer tags (`vX.Y.Z`) MUST be retained immutably and MUST NOT be reinterpreted as dates or placed in a single precedence relation with date versions, so that date versions and SemVer versions remain distinct ordering domains separated at the cutover boundary.
+- [REQ-008] Adoption MUST be a one-way cutover: pre-cutover SemVer tags (`vX.Y.Z`) MUST be retained immutably and MUST NOT be reinterpreted as dates, and RAC's own tooling MUST NOT co-order date versions and SemVer versions in one precedence relation, so the two remain distinct ordering domains separated at the cutover boundary. (At the packaging layer a date version such as `2026.06.1` necessarily sorts above the final SemVer `0.19.0`, which is what lets it become "latest" on the index; this requirement constrains RAC's verifier, not the index's numeric ordering.)
 
-- [REQ-009] The canonical display form MUST be the zero-padded `YYYY.MM.DD[.increment]`, and a tool comparing versions MUST treat the PEP 440 normalised form (for example `2026.6.14`) as equal to its zero-padded canonical form, so packaging-layer normalisation does not create a spurious mismatch.
+- [REQ-009] The canonical display and tag form MUST be the zero-padded `YYYY.MM.N`, and a tool comparing versions MUST treat the PEP 440 normalised form (for example `2026.6.1`) as equal to its zero-padded canonical form (`2026.06.1`), so packaging-layer normalisation does not create a spurious mismatch.
 
 ## Acceptance Criteria
 
-- A verifier accepts `2026.06.14`, `2026.06.14.2`, `2026.12.31`, and
-  `2024.02.29`, and rejects `2026.13.01`, `2026.00.10`, `2026.02.30`,
-  `2025.02.29`, `2026.06.14.1`, `2026.06.14.0`, `2026.06.14.02`, and any
-  SemVer-form tag (`v0.13.7`) presented as a release version.
-- Sorting a set of valid release versions yields the REQ-003 order, with omitted
-  increments ordered as `1`.
+- A verifier accepts `2026.06.1`, `2026.06.2`, `2026.12.1`, and `2027.01.10`,
+  and rejects `2026.13.1`, `2026.00.1`, `2026.06.0`, `2026.06.01`, the bare
+  `2026.06`, and any SemVer-form tag (`v0.19.0`) presented as a release version.
+- The normalised spelling `2026.6.1` parses equal to the canonical `2026.06.1`.
+- Sorting a set of valid release versions yields the REQ-003 order.
 - A release lacking a changelog entry is rejected by the fail-closed check.
 - Pre-cutover SemVer tags remain present and unmodified after the cutover, and no
   comparison places a date version and a SemVer version in one ordered sequence.
 
 ## Success Metrics
 
-- Every published release version is a calendar-valid UTC date that round-trips
-  through parse → sort → display without ambiguity.
-- The release-date identifier and the schema/contract version (ADR-007) move
+- Every published release version is a well-formed `YYYY.MM.N` identifier that
+  round-trips through parse → sort → display without ambiguity.
+- The release identifier and the schema/contract version (ADR-007) move
   independently: a release can be cut without a contract change, and a contract
   change is recorded on its own version, neither overloading the other.
 - The cutover is documented once and requires no rewriting of historical tags.
 
 ## Risks
 
-- The motivating pressure (many releases per day, SemVer patch numbers read as
-  recency) may be weaker than the cost of replacing a working SemVer +
-  setuptools-scm pipeline. Mitigated by filing this `Proposed` and deferring
-  implementation until cadence justifies it.
 - A cutover that co-orders SemVer and date tags under one relation would corrupt
   "latest release" selection. Mitigated by REQ-008's distinct ordering domains and
   immutable retention.
 - Packaging-layer normalisation (PEP 440 dropping zero padding) could make a tool
   see two spellings of one version. Mitigated by REQ-009.
+- Month granularity cannot distinguish two releases in the same month on its own.
+  Mitigated by REQ-002's within-month counter.
 
 ## Assumptions
 
 - Compatibility signalling has, or can have, an independent home on the
   schema/contract version (ADR-007); this requirement concerns the *release*
   identifier, not that mechanism.
-- Release dates are assigned in UTC by the release process, so the identifier is
-  deterministic regardless of the releaser's local timezone.
-- The increment form is confirmed as omit-when-single: a sole daily release is
-  bare `YYYY.MM.DD`, and `.2` is the first explicit increment.
+- Release year and month are assigned in UTC by the release process, so the
+  identifier is deterministic regardless of the releaser's local timezone.
+- The release cadence is monthly or slower; a same-month second release is the
+  exception handled by the counter, not the norm.
 
 ## Priority
 
 Below RAC's core validation guarantees and additive to them: this changes only
 how RAC labels its own releases, not what `rac validate` or `rac relationships
---validate` accept. It is recorded now to preserve the reasoning; it is not
-scheduled. Promotion to an ADR, a roadmap item, and an implementation is a
-separate, later decision contingent on release cadence or consumer demand.
+--validate` accept.
 
 ## Related Decisions
 
 - ADR-007
+- ADR-076

--- a/rac/roadmaps/v0.27.x-calver/v0.27.0-calver-cutover.md
+++ b/rac/roadmaps/v0.27.x-calver/v0.27.0-calver-cutover.md
@@ -1,0 +1,93 @@
+---
+schema_version: 1
+id: RAC-KVPTXAGAPCWW
+type: roadmap
+---
+# RAC v0.27.0 — CalVer Release Cutover
+
+## Status
+
+Planned
+
+## Context
+
+RAC's published package sat at `v0.19.0` while the roadmap scope-fences ran to
+v0.26 — the SemVer minors were planning boundaries, never release promises, and
+the version asserted a compatibility contract RAC does not maintain. ADR-076
+adopts CalVer (`YYYY.MM.N`) for releases and ADR-007 keeps compatibility on
+`schema_version`; REQ-Release-Versioning is the normative spec. This item is the
+cutover itself: the tooling and documentation that make the first `2026.06.1`
+release well-formed, fail-closed, and reproducible.
+
+This is the scope-fence for the work; the release it ships in is `2026.06.1`
+(roadmap `vX.Y.Z` numbers stay internal scope-fences, decoupled from releases,
+per ADR-076).
+
+## Outcomes
+
+- **A fail-closed release gate** — the publish pipeline refuses any tag that is
+  not a well-formed `YYYY.MM.N` identifier or that lacks a matching changelog
+  entry, so a malformed or undocumented release can never reach PyPI (REQ-007).
+- **A clean cutover** — the first CalVer release (`2026.06.1`) publishes and
+  resolves as "latest", with every prior `vX.Y.Z` tag retained immutably and the
+  consolidated changelog covering the v0.23–v0.26 backlog.
+
+## Initiatives
+
+### Tier 1
+
+- **WS1 — Release verifier** `[internal]`. A `rac.release` module validating the
+  `YYYY.MM.N` grammar, PEP 440 normalised equivalence, precedence, and changelog
+  presence, invoked by the publish workflow as `python -m rac.release` before
+  build (REQ-001–REQ-003, REQ-005, REQ-007, REQ-009).
+- **WS2 — Consolidated changelog** `[user-facing]`. A single `2026.06.1`
+  changelog entry folding the unreleased v0.23–v0.26 user-facing work, plus the
+  CalVer cutover note.
+
+### Tier 2
+
+- **WS3 — setuptools-scm dev versions** `[internal]`. Confirm the dev/build
+  version derived after a `2026.06.1` tag orders sensibly (REQ-006); add a
+  `version_scheme` only if the default misbehaves.
+
+## Workstream Checklist
+
+Cross-session progress tracker. Status: `planned` → `in-progress` → `done` /
+`descoped`. This roadmap is the canonical tracker.
+
+Tier 1:
+
+- [x] WS1 release-verifier — `rac.release` + tests + publish-workflow gate — `done`
+- [x] WS2 consolidated-changelog — `2026.06.1` entry for v0.23–v0.26 — `done`
+
+Tier 2:
+
+- [x] WS3 scm-dev-versions — verified: the default scheme yields `2026.6.1` at the tag and `2026.6.2.devN` after, no `version_scheme` change needed — `done`
+
+## Success Measures
+
+- `python -m rac.release 2026.06.1` passes once the changelog entry exists, and
+  rejects `2026.06.0`, `2026.13.1`, a bare `2026.06`, and any `vX.Y.Z` tag.
+- The `2026.06.1` release publishes to PyPI and resolves as "latest"; the
+  pre-cutover SemVer tags remain present and unmodified.
+
+## Risks
+
+- A wrong setuptools-scm dev-version scheme could produce a confusing local
+  version after the cutover. Mitigation: WS3 verifies it before the first tag.
+- Month granularity cannot distinguish two same-month releases. Mitigation: the
+  within-month counter (REQ-002), exercised by the verifier tests.
+
+## Assumptions
+
+- ADR-076 and REQ-Release-Versioning are accepted, so this item implements an
+  already-decided scheme rather than re-opening it.
+
+## Related Decisions
+
+- adr-076
+- adr-007
+
+## Related Requirements
+
+- rac-release-versioning

--- a/src/rac/release.py
+++ b/src/rac/release.py
@@ -1,0 +1,106 @@
+"""Release-version verification — the fail-closed CalVer gate.
+
+RAC releases use a CalVer identifier ``YYYY.MM.N`` (REQ-Release-Versioning,
+ADR-076): the UTC year and zero-padded month a release is cut, plus a
+within-month counter starting at 1. The identifier carries no compatibility
+signal — that lives on ``schema_version`` (ADR-007). This module is the
+fail-closed verification REQ-007 requires: a release whose version is not a
+well-formed ``YYYY.MM.N`` identifier, or that has no matching ``CHANGELOG.md``
+entry, must not be published.
+
+This is internal release tooling, not part of RAC's public CLI or SDK surface
+(ADR-005, ADR-062): it is invoked by the publish workflow as ``python -m
+rac.release <version>``, never exported through ``rac.__all__``.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# Canonical identifier: four-digit year, zero-padded month 01-12, a counter
+# starting at 1 with no leading zero and no `.0`. This is the form a release
+# tag MUST use (REQ-001/002/009).
+_CANONICAL_RE = re.compile(r"^(?P<year>\d{4})\.(?P<month>0[1-9]|1[0-2])\.(?P<minor>[1-9]\d*)$")
+
+# Lenient parse: accepts the PEP 440 normalised spelling too (month without the
+# leading zero, e.g. `2026.6.1`), which packaging tools emit, so the two
+# spellings compare equal (REQ-009). The minor still rejects `.0` / leading zero.
+_PARSE_RE = re.compile(r"^(?P<year>\d{4})\.(?P<month>\d{1,2})\.(?P<minor>[1-9]\d*)$")
+
+
+def parse_release_version(version: str) -> tuple[int, int, int] | None:
+    """Return ``(year, month, minor)`` for a release version, else ``None``.
+
+    Accepts both the canonical zero-padded form (``2026.06.1``) and its PEP 440
+    normalised spelling (``2026.6.1``) so they map to the same tuple (REQ-009).
+    Rejects an out-of-range month and any non-``YYYY.MM.N`` string.
+    """
+    match = _PARSE_RE.match(version.strip())
+    if match is None:
+        return None
+    year = int(match["year"])
+    month = int(match["month"])
+    minor = int(match["minor"])
+    if not 1 <= month <= 12:
+        return None
+    return (year, month, minor)
+
+
+def is_canonical_release_version(version: str) -> bool:
+    """True when ``version`` is the canonical, zero-padded ``YYYY.MM.N`` tag form."""
+    return _CANONICAL_RE.match(version.strip()) is not None
+
+
+def changelog_has_entry(version: str, changelog: str) -> bool:
+    """True when ``CHANGELOG.md`` text has a ``## <version>`` heading (REQ-005)."""
+    pattern = rf"^##\s+{re.escape(version.strip())}(?:\s|—|-|$)"
+    return re.search(pattern, changelog, re.MULTILINE) is not None
+
+
+def verify_release(version: str, changelog_path: Path) -> list[str]:
+    """Return the reasons ``version`` must not publish; empty means it may.
+
+    Fail-closed (REQ-007): an ill-formed version or a missing changelog entry is
+    an error, and an unreadable changelog is treated as a missing entry rather
+    than passed over.
+    """
+    errors: list[str] = []
+    if not is_canonical_release_version(version):
+        errors.append(
+            f"version {version!r} is not a canonical CalVer release identifier "
+            "(expected YYYY.MM.N, zero-padded month, counter from 1)"
+        )
+        # A malformed version cannot have a meaningful changelog entry; stop here.
+        return errors
+    try:
+        changelog = changelog_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        errors.append(f"could not read changelog at {changelog_path}: {exc}")
+        return errors
+    if not changelog_has_entry(version, changelog):
+        errors.append(f"no '## {version}' entry found in {changelog_path.name} (REQ-005)")
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point: ``python -m rac.release <version> [changelog-path]``."""
+    args = sys.argv[1:] if argv is None else argv
+    if not args:
+        print("usage: python -m rac.release <version> [changelog-path]", file=sys.stderr)
+        return 2
+    version = args[0]
+    changelog_path = Path(args[1]) if len(args) > 1 else Path("CHANGELOG.md")
+    errors = verify_release(version, changelog_path)
+    if errors:
+        print(f"✗ release {version} rejected:", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 1
+    print(f"✓ release {version} is well-formed and has a changelog entry")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - module CLI shim
+    raise SystemExit(main())

--- a/tests/test_release_version.py
+++ b/tests/test_release_version.py
@@ -1,0 +1,93 @@
+"""Release-version verifier tests (REQ-Release-Versioning, ADR-076).
+
+Covers the CalVer identifier grammar (YYYY.MM.N), the PEP 440 normalised
+equivalence, precedence ordering, and the fail-closed publish gate.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from rac.release import (
+    changelog_has_entry,
+    is_canonical_release_version,
+    parse_release_version,
+    verify_release,
+)
+
+
+@pytest.mark.parametrize("version", ["2026.06.1", "2026.06.2", "2026.12.1", "2027.01.10"])
+def test_canonical_versions_accepted(version: str) -> None:
+    assert is_canonical_release_version(version)
+    assert parse_release_version(version) is not None
+
+
+@pytest.mark.parametrize(
+    "version",
+    [
+        "2026.13.1",  # month out of range
+        "2026.00.1",  # month zero
+        "2026.06.0",  # minor zero
+        "2026.06.01",  # leading-zero minor
+        "2026.06",  # bare month, no counter
+        "2026.6.1",  # not zero-padded — valid to parse, not canonical
+        "v0.19.0",  # SemVer tag
+        "0.19.0",  # SemVer version
+        "",
+    ],
+)
+def test_non_canonical_versions_rejected(version: str) -> None:
+    assert not is_canonical_release_version(version)
+
+
+def test_normalised_spelling_parses_equal_to_canonical() -> None:
+    # PEP 440 drops the leading zero on the published version; the two spellings
+    # MUST map to the same tuple (REQ-009).
+    assert parse_release_version("2026.6.1") == parse_release_version("2026.06.1") == (2026, 6, 1)
+
+
+@pytest.mark.parametrize("bad", ["2026.13.1", "2026.00.1", "2026.06.0", "2026.06.01", "nope"])
+def test_invalid_versions_do_not_parse(bad: str) -> None:
+    assert parse_release_version(bad) is None
+
+
+def test_precedence_is_year_month_minor() -> None:
+    # REQ-003: lexicographic over (YYYY, MM, N).
+    versions = ["2026.07.1", "2026.06.2", "2026.06.10", "2026.06.1", "2027.01.1"]
+    ordered = sorted(versions, key=parse_release_version)
+    assert ordered == ["2026.06.1", "2026.06.2", "2026.06.10", "2026.07.1", "2027.01.1"]
+
+
+def test_changelog_entry_detected_with_and_without_title() -> None:
+    assert changelog_has_entry("2026.06.1", "# Changelog\n\n## 2026.06.1 — CalVer cutover\n")
+    assert changelog_has_entry("2026.06.1", "## 2026.06.1\n")
+    assert not changelog_has_entry("2026.06.1", "## 2026.06.2 — later\n")
+    # A prefix must not match a longer version (word boundary).
+    assert not changelog_has_entry("2026.06.1", "## 2026.06.10 — other\n")
+
+
+def test_verify_release_passes_for_wellformed_with_entry(tmp_path: Path) -> None:
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text("# Changelog\n\n## 2026.06.1 — CalVer cutover\n", encoding="utf-8")
+    assert verify_release("2026.06.1", changelog) == []
+
+
+def test_verify_release_fails_closed_on_bad_version(tmp_path: Path) -> None:
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text("## 2026.06.1\n", encoding="utf-8")
+    errors = verify_release("v0.20.0", changelog)
+    assert errors and "canonical" in errors[0]
+
+
+def test_verify_release_fails_closed_on_missing_entry(tmp_path: Path) -> None:
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text("# Changelog\n\n## 2026.05.1 — earlier\n", encoding="utf-8")
+    errors = verify_release("2026.06.1", changelog)
+    assert errors and "no '## 2026.06.1' entry" in errors[0]
+
+
+def test_verify_release_fails_closed_on_unreadable_changelog(tmp_path: Path) -> None:
+    errors = verify_release("2026.06.1", tmp_path / "does-not-exist.md")
+    assert errors and "could not read changelog" in errors[0]


### PR DESCRIPTION
## Adopt CalVer (`YYYY.MM.N`) for RAC releases

Moves RAC's release identifier from SemVer to month-granular CalVer, and ships
the tooling + notes to cut the first `2026.06.1` release. Implements
`rac/roadmaps/v0.27.x-calver/v0.27.0-calver-cutover.md`.

**Why:** the package sat at `v0.19.0` while roadmap scope-fences ran to v0.26 —
the SemVer minors were planning boundaries, never release promises, and the
number asserted a compatibility contract RAC doesn't maintain. PyPI versions are
also one-way (`0.1.0`…`0.19.0` are immutable; pip resolves the highest), so the
next release must sort above `0.19.0`. A date does both: `2026.06.1` →
`(2026, 6, 1)` ≫ `(0, 19, 0)`, and it answers the question a reader actually asks
of the number — *how recent is this build*.

### Decisions & spec

- **ADR-076 — Adopt CalVer** (Process): the decision, the one-way cutover,
  compatibility staying on `schema_version` (ADR-007), roadmap `vX.Y.Z` numbers
  as explicit internal scope-fences.
- **REQ-Release-Versioning** revised from full-date `YYYY.MM.DD` → month-granular
  **`YYYY.MM.N`** (counter from 1) to match the monthly cadence, flipped
  `Proposed → Accepted`.
- **Roadmap v0.27.0** scoping WS1–WS3.

### Implementation

- **`src/rac/release.py`** — fail-closed verifier (REQ-007): validates the
  `YYYY.MM.N` grammar, PEP 440 normalised equivalence, precedence, and changelog
  presence. Internal tooling, not on the public CLI/SDK surface (ADR-005,
  ADR-062).
- **`python-publish.yml`** — a `verify-release` job runs `python -m rac.release
  "$TAG"` before build, so a malformed or undocumented tag can never publish.
- **`tests/test_release_version.py`** — grammar/precedence/gate coverage,
  registered as a new `release` CI battery.
- **setuptools-scm verified** (WS3): tag `2026.06.1` → published `2026.6.1`; next
  commit → `2026.6.2.dev1+g…`. Default scheme is correct, no change needed.

### Release notes

- **`CHANGELOG.md`** — a consolidated **`## 2026.06.1`** entry folding the
  v0.23–v0.26 user-facing work (Explorer TUI, corpus export, visibility/grounding,
  hardening) plus the cutover note.

### Cutting the release (after merge)

Create a GitHub Release tagged **`2026.06.1`** (no `v`). The publish workflow then
verifies the tag + changelog, runs the full suite gate, and publishes `2026.6.1`
to PyPI as the new latest. Pre-cutover `vX.Y.Z` tags are retained untouched.

### Gates

`ruff`, `mypy`, the release / battery-guard / SDK-surface / dogfood / golden /
corpus-shape tests, and `rac validate` + `relationships --validate` + `review`
(92/100) all pass; agent-rules drift in sync.

### Related decisions

ADR-076, ADR-007, ADR-027, ADR-005, ADR-062.