### PR TITLE
feat(visabilit): delive multi-hop, coverage, usage read-back [roadmap:v0.24.0]

### DIFF
--- a/.cursor/rules
+++ b/.cursor/rules
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: b69411ed027089c1eda60e0497db694d5d092afaa85969a79d2202f3f38d9703) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: b95a2921a2b52da24fb1e3632f8d78893f2f7d314c589e2b93f8b16e54c8cac0) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -39,6 +39,7 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KTYZVKZQWD98** — ADR-043: Watchkeeper Revision Materialization _(Technical)_
 - **RAC-KV2E5A5E1F1H** — ADR-044: Onboarding Scaffold Writes One Starter Artifact _(Product)_
 - **RAC-KV2E5B1122YN** — ADR-045: Recency Is Derived From Git, Not Stored In Frontmatter _(Technical)_
+- **RAC-KV2E9HYHVV8G** — ADR-046: CLI Usage Telemetry _(Product)_
 - **RAC-KV2J0GYNCAJF** — ADR-047: Agent Operating-Guidance Documents Are Prompt Artifacts _(Process)_
 - **RAC-KV4ZAGWPAA6X** — ADR-059: Reuse a Single Markdown Parser Instance _(Architecture)_
 - **RAC-KV4ZAHVNGH2J** — ADR-060: Share Structural Validation Across Per-Type Validators _(Architecture)_

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: b69411ed027089c1eda60e0497db694d5d092afaa85969a79d2202f3f38d9703) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: b95a2921a2b52da24fb1e3632f8d78893f2f7d314c589e2b93f8b16e54c8cac0) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -39,6 +39,7 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KTYZVKZQWD98** — ADR-043: Watchkeeper Revision Materialization _(Technical)_
 - **RAC-KV2E5A5E1F1H** — ADR-044: Onboarding Scaffold Writes One Starter Artifact _(Product)_
 - **RAC-KV2E5B1122YN** — ADR-045: Recency Is Derived From Git, Not Stored In Frontmatter _(Technical)_
+- **RAC-KV2E9HYHVV8G** — ADR-046: CLI Usage Telemetry _(Product)_
 - **RAC-KV2J0GYNCAJF** — ADR-047: Agent Operating-Guidance Documents Are Prompt Artifacts _(Process)_
 - **RAC-KV4ZAGWPAA6X** — ADR-059: Reuse a Single Markdown Parser Instance _(Architecture)_
 - **RAC-KV4ZAHVNGH2J** — ADR-060: Share Structural Validation Across Per-Type Validators _(Architecture)_

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -103,6 +103,8 @@ jobs:
             paths: "tests/test_review.py tests/test_cadence.py"
           - name: doctor
             paths: "tests/test_doctor.py"
+          - name: coverage-report
+            paths: "tests/test_coverage.py"
           - name: robustness
             paths: "tests/test_robustness.py"
           - name: idempotent

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -105,6 +105,8 @@ jobs:
             paths: "tests/test_doctor.py"
           - name: coverage-report
             paths: "tests/test_coverage.py"
+          - name: usage
+            paths: "tests/test_usage.py"
           - name: robustness
             paths: "tests/test_robustness.py"
           - name: idempotent

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: b69411ed027089c1eda60e0497db694d5d092afaa85969a79d2202f3f38d9703) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: b95a2921a2b52da24fb1e3632f8d78893f2f7d314c589e2b93f8b16e54c8cac0) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -39,6 +39,7 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KTYZVKZQWD98** — ADR-043: Watchkeeper Revision Materialization _(Technical)_
 - **RAC-KV2E5A5E1F1H** — ADR-044: Onboarding Scaffold Writes One Starter Artifact _(Product)_
 - **RAC-KV2E5B1122YN** — ADR-045: Recency Is Derived From Git, Not Stored In Frontmatter _(Technical)_
+- **RAC-KV2E9HYHVV8G** — ADR-046: CLI Usage Telemetry _(Product)_
 - **RAC-KV2J0GYNCAJF** — ADR-047: Agent Operating-Guidance Documents Are Prompt Artifacts _(Process)_
 - **RAC-KV4ZAGWPAA6X** — ADR-059: Reuse a Single Markdown Parser Instance _(Architecture)_
 - **RAC-KV4ZAHVNGH2J** — ADR-060: Share Structural Validation Across Per-Type Validators _(Architecture)_

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ to the corpus artifact and they load through the imports below.
 - Previous series: `rac/roadmaps/v0.21.x-editor/` (complete)
 - Decisions (ADRs): `rac/decisions/`
 
-<!-- BEGIN RAC MANAGED BLOCK (digest: b69411ed027089c1eda60e0497db694d5d092afaa85969a79d2202f3f38d9703) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: b95a2921a2b52da24fb1e3632f8d78893f2f7d314c589e2b93f8b16e54c8cac0) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -64,6 +64,7 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KTYZVKZQWD98** — ADR-043: Watchkeeper Revision Materialization _(Technical)_
 - **RAC-KV2E5A5E1F1H** — ADR-044: Onboarding Scaffold Writes One Starter Artifact _(Product)_
 - **RAC-KV2E5B1122YN** — ADR-045: Recency Is Derived From Git, Not Stored In Frontmatter _(Technical)_
+- **RAC-KV2E9HYHVV8G** — ADR-046: CLI Usage Telemetry _(Product)_
 - **RAC-KV2J0GYNCAJF** — ADR-047: Agent Operating-Guidance Documents Are Prompt Artifacts _(Process)_
 - **RAC-KV4ZAGWPAA6X** — ADR-059: Reuse a Single Markdown Parser Instance _(Architecture)_
 - **RAC-KV4ZAHVNGH2J** — ADR-060: Share Structural Validation Across Per-Type Validators _(Architecture)_

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -913,6 +913,29 @@ RAC sends nothing itself. `--json` and `--share` are mutually exclusive.
 
 ---
 
+## usage
+
+Summarize recorded **CLI usage** alongside the Guide MCP tools — per-command and
+per-tool call counts, errors, session count, and a recent-activity trend. When
+sharing consent is recorded (`rac telemetry on`), each completed `rac` command
+appends one **content-free** event (subcommand name, outcome, duration — never
+argv, paths, or artifact ids) to a local log; `rac usage` reads it back.
+`rac mcp-stats` stays Guide-only for back-compat; `rac usage` covers both logs
+(ADR-046).
+
+```bash
+rac usage           # human summary of CLI + Guide usage
+rac usage --json    # the same summary as JSON
+rac usage --share   # prefilled GitHub usage-report issue URL (counts only)
+```
+
+An empty or missing log is a valid answer — telemetry is opt-in and off by
+default. `--json` and `--share` are mutually exclusive.
+
+- **Exit code:** always `0` — a read-back of local counts, never a failure.
+
+---
+
 ## telemetry
 
 Show or change anonymous usage-sharing consent (ADR-041). With consent on,

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -378,6 +378,26 @@ so it is safe in CI; it needs git history and is silent outside a git repository
 or on an empty corpus. The framing is capture cadence, not work tracking
 (ADR-017).
 
+## coverage
+
+Report typed **traceability coverage gaps** over the corpus relationship graph —
+where the knowledge graph is incomplete, distinct from `rac doctor`'s integrity
+checks. Three deterministic gap classes: **unscheduled** requirements (no roadmap
+references them), **unapplied** decisions (no requirement or roadmap references
+them), and **unscoped** roadmaps (referencing no requirement).
+
+- **Input:** `rac coverage <directory>` — scanned recursively for `*.md`.
+- **Options:** `--json`
+- **Exit code:** always `0` — coverage is **advisory**, a completeness signal for
+  human judgement, never a build failure (a roadmap may precede its requirements,
+  a decision may be recorded before anything applies it). It stays out of the
+  `rac gate` enforcement path (ADR-049).
+
+```bash
+rac coverage rac/
+rac coverage rac/ --json
+```
+
 ```text
 Repository Review
 =================

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -127,6 +127,13 @@ a decision covers.
 | `get_artifact` | When an artifact ID appears, or before changing anything a decision covers |
 | `get_related` | After retrieving an artifact — finds what else the change could affect |
 
+`get_related` takes an optional `depth` (default `1`, capped at `5`): the default
+returns immediate neighbours only, while `depth>1` additionally returns a
+`neighborhood` array of artifacts two or more hops away, each tagged with its
+`hops` distance — for transitive context such as a decision a requirement's
+roadmap depends on. The walk is bounded (depth, frontier, visited-set, and a work
+budget) and deterministic; a truncation marker is set if any cap stops it.
+
 The tool descriptions contain the trigger language; well-tuned agents call them
 without being told to.
 

--- a/rac/decisions/adr-046-cli-usage-telemetry.md
+++ b/rac/decisions/adr-046-cli-usage-telemetry.md
@@ -7,7 +7,7 @@ type: decision
 
 ## Status
 
-Proposed
+Accepted
 
 ## Category
 

--- a/rac/requirements/rac-agent-usage-readback.md
+++ b/rac/requirements/rac-agent-usage-readback.md
@@ -8,7 +8,7 @@ tags: [user-facing, telemetry, read-back, local-first, privacy]
 
 ## Status
 
-Proposed
+Accepted
 
 Classification: `[user-facing]` — the team can see how agents consult Lore. Scoped to the
 v0.24.0 visibility release (WS-E). Promotes the future placeholder

--- a/rac/requirements/rac-multi-hop-relationship-traversal.md
+++ b/rac/requirements/rac-multi-hop-relationship-traversal.md
@@ -8,7 +8,7 @@ tags: [internal, relationships, traversal, mcp, determinism]
 
 ## Status
 
-Proposed
+Accepted
 
 Classification: `[internal]` — richer relationship answers. Scoped to the v0.24.0
 visibility release (WS-D, Tier 2, cut-first). Extends the existing 1-hop

--- a/rac/requirements/rac-traceability-coverage-report.md
+++ b/rac/requirements/rac-traceability-coverage-report.md
@@ -8,7 +8,7 @@ tags: [user-facing, traceability, coverage, relationships, determinism]
 
 ## Status
 
-Proposed
+Accepted
 
 Classification: `[user-facing]` — see where the knowledge graph is incomplete. Scoped to the v0.24.0 visibility release (WS-F). A deterministic report of typed traceability gaps over the existing relationship graph; no new schema, no AI, additive output (ADR-007).
 

--- a/rac/roadmaps/v0.24.x-visibility/v0.24.0-visibility.md
+++ b/rac/roadmaps/v0.24.x-visibility/v0.24.0-visibility.md
@@ -96,12 +96,12 @@ Cross-session progress tracker. Status: `planned` → `in-progress` → `done` /
 
 Tier 1:
 
-- [ ] WS-E agent-usage-readback — content-free local read-back surface — `planned`
-- [ ] WS-F traceability-coverage-report — typed, advisory coverage gaps — `planned`
+- [x] WS-E agent-usage-readback — `rac usage` over a content-free, consent-gated CLI log (ADR-046) — `done`
+- [x] WS-F traceability-coverage-report — `rac coverage`, typed advisory gaps — `done`
 
 Tier 2 (cut first):
 
-- [ ] WS-D multi-hop-relationship-traversal — bounded N-hop, four caps — `planned`
+- [x] WS-D multi-hop-relationship-traversal — `get_related(depth)`, four caps — `done`
 
 ## Success Measures
 

--- a/src/rac/cli.py
+++ b/src/rac/cli.py
@@ -106,6 +106,7 @@ from rac.core.templates import (
 )
 from rac.core.validation import has_errors
 from rac.output.portal import PortalSeamMissing, PortalShellMissing
+from rac.services import coverage as coverage_service
 from rac.services import doctor
 from rac.services import eval as eval_service
 from rac.services.agent_rules import (
@@ -554,6 +555,24 @@ def cmd_doctor(args: argparse.Namespace) -> int:
     else:
         print(doctor.render_doctor_human(report))
     return EXIT_OK if report.ok else EXIT_VALIDATION_FAILED
+
+
+def cmd_coverage(args: argparse.Namespace) -> int:
+    """Report typed traceability coverage gaps — advisory, never a build failure.
+
+    Unscheduled requirements, unapplied decisions, and unscoped roadmaps derived
+    from the relationship graph (rac-traceability-coverage-report, WS-F). Coverage
+    is a completeness signal for human judgement, so it always exits 0 (REQ-005).
+    """
+    if not Path(args.directory).is_dir():
+        print(f"rac: not a directory: {args.directory}", file=sys.stderr)
+        raise SystemExit(EXIT_USAGE)
+    report = coverage_service.analyze_coverage(args.directory)
+    if args.json:
+        print(coverage_service.render_coverage_json(report))
+    else:
+        print(coverage_service.render_coverage_human(report))
+    return EXIT_OK
 
 
 def cmd_gate(args: argparse.Namespace) -> int:
@@ -1446,6 +1465,22 @@ def build_parser() -> argparse.ArgumentParser:
         help="Recurse into subdirectories (the default; accepted for clarity).",
     )
     p_doctor.set_defaults(func=cmd_doctor)
+
+    p_coverage = sub.add_parser(
+        "coverage",
+        help="Report typed traceability coverage gaps (advisory, never blocking).",
+        parents=[version_parent],
+    )
+    p_coverage.add_argument(
+        "directory",
+        nargs="?",
+        default=".",
+        help="Directory to analyse recursively for *.md (default: current directory).",
+    )
+    p_coverage.add_argument(
+        "--json", action="store_true", help="Emit JSON instead of human-readable text."
+    )
+    p_coverage.set_defaults(func=cmd_coverage)
 
     p_gate = sub.add_parser(
         "gate",

--- a/src/rac/cli.py
+++ b/src/rac/cli.py
@@ -86,9 +86,8 @@ import sys
 import time
 from pathlib import Path
 
-from rac import consent
+from rac import consent, usage
 from rac import output as outputs
-from rac import usage
 from rac.core.classification import score_artifacts
 from rac.core.hooks import (
     DEFAULT_STYLE,

--- a/src/rac/cli.py
+++ b/src/rac/cli.py
@@ -83,10 +83,12 @@ from __future__ import annotations
 
 import argparse
 import sys
+import time
 from pathlib import Path
 
 from rac import consent
 from rac import output as outputs
+from rac import usage
 from rac.core.classification import score_artifacts
 from rac.core.hooks import (
     DEFAULT_STYLE,
@@ -835,6 +837,25 @@ def cmd_mcp_stats(args: argparse.Namespace) -> int:
         print(outputs.render_mcp_stats_human(summary))
     # An empty or missing log is a valid answer (telemetry is off by default),
     # like `rac find` with no matches.
+    return EXIT_OK
+
+
+def cmd_usage(args: argparse.Namespace) -> int:
+    """Unified read-back over the CLI-usage log and the Guide log (ADR-046, WS-E).
+
+    `rac mcp-stats` stays Guide-only for back-compat; this command summarises
+    both. An empty or missing log is a valid answer (telemetry is off by default).
+    """
+    from rac.mcp.telemetry import summarize as guide_summarize
+
+    summary = usage.summarize_usage()
+    guide = guide_summarize().to_dict()
+    if args.share:
+        print(usage.share_url(summary, guide))
+    elif args.json:
+        print(usage.render_json(summary, guide))
+    else:
+        print(usage.render_human(summary, guide))
     return EXIT_OK
 
 
@@ -1762,6 +1783,25 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p_telemetry.set_defaults(func=cmd_telemetry)
 
+    p_usage = sub.add_parser(
+        "usage",
+        help="Summarize recorded CLI and Guide usage (content-free, local).",
+        parents=[version_parent],
+    )
+    usage_mode = p_usage.add_mutually_exclusive_group()
+    usage_mode.add_argument(
+        "--json", action="store_true", help="Emit JSON instead of human-readable text."
+    )
+    usage_mode.add_argument(
+        "--share",
+        action="store_true",
+        help=(
+            "Print a prefilled GitHub usage-report issue URL to review and "
+            "submit in your browser; RAC sends nothing itself."
+        ),
+    )
+    p_usage.set_defaults(func=cmd_usage)
+
     p_new = sub.add_parser(
         "new",
         help="Create a new artifact from its canonical template.",
@@ -2060,7 +2100,21 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
-    return args.func(args)
+    # CLI usage telemetry (ADR-046, WS-E): record one content-free event per
+    # completed command, after dispatch, gated by recorded consent. Write-only
+    # and silent-fail, so it never alters output or exit codes (ADR-032).
+    command = getattr(args, "command", "") or ""
+    start = time.monotonic()
+    outcome = usage.OUTCOME_EXCEPTION
+    try:
+        result = args.func(args)
+        outcome = usage.OUTCOME_OK if result == 0 else usage.OUTCOME_ERROR
+        return result
+    except SystemExit as exc:
+        outcome = usage.OUTCOME_OK if exc.code in (0, None) else usage.OUTCOME_ERROR
+        raise
+    finally:
+        usage.record_command(command, outcome, int((time.monotonic() - start) * 1000))
 
 
 if __name__ == "__main__":

--- a/src/rac/core/limits.py
+++ b/src/rac/core/limits.py
@@ -40,6 +40,18 @@ MAX_CAPTURED_LINES = 50_000  # total non-blank body lines captured per document
 # force an unbounded in-memory list before the response budget trims it.
 MAX_RELATED_EDGES = 1000
 
+# Bounded multi-hop traversal caps for get_related (v0.24, WS-D;
+# rac-multi-hop-relationship-traversal REQ-002). A depth parameter widens
+# get_related beyond immediate neighbours, but every traversal stays bounded by
+# four caps so a deep or high-fan-out graph cannot hang or exhaust memory:
+#   - a maximum depth (the requested N is clamped to this ceiling),
+#   - a maximum frontier size per BFS level,
+#   - a visited set that prevents revisiting a node (cycle-safe), and
+#   - a total work budget on edges examined across the whole walk.
+MAX_TRAVERSAL_DEPTH = 5  # ceiling on the requested hop depth
+MAX_TRAVERSAL_FRONTIER = 1000  # nodes admitted per level before the level truncates
+MAX_TRAVERSAL_WORK = 10_000  # edges examined across the whole walk before it stops
+
 
 def max_file_bytes() -> int:
     """The per-file byte cap, honoring ``RAC_MAX_FILE_BYTES`` (REQ-001)."""

--- a/src/rac/mcp/server.py
+++ b/src/rac/mcp/server.py
@@ -50,6 +50,7 @@ from mcp.server.fastmcp import FastMCP
 
 from rac import consent as consent_record
 from rac.core.corpus import walk_corpus
+from rac.core.limits import MAX_TRAVERSAL_DEPTH
 from rac.core.markdown import parse
 from rac.mcp import errors, ping, telemetry
 from rac.mcp.budget import (
@@ -67,6 +68,7 @@ from rac.services.portfolio import build_portfolio_summary
 from rac.services.recency import artifact_provenance
 from rac.services.relationships import (
     incoming_references,
+    neighborhood,
     outgoing_references,
     relationships_from_corpus,
 )
@@ -110,7 +112,9 @@ DESC_GET_RELATED = (
     "knowledge: the references it declares and the artifacts that reference "
     "it. Call this after retrieving an artifact, and before changing anything "
     "it covers, to find the decisions, requirements, designs, and roadmaps the "
-    "change could affect."
+    "change could affect. Pass depth>1 (up to 5) to also return a `neighborhood` "
+    "of artifacts two or more hops out, each tagged with its hop distance, when "
+    "you need transitive context rather than immediate neighbours."
 )
 
 DESC_FIND_DECISIONS = (
@@ -207,7 +211,7 @@ def _find_decisions(root: str, topic: str, budget: int) -> str:
     return serialize(payload, budget)
 
 
-def _get_related(root: str, artifact_id: str, budget: int) -> str:
+def _get_related(root: str, artifact_id: str, budget: int, depth: int = 1) -> str:
     # One corpus walk feeds resolution, outgoing, and incoming, so the whole
     # response reflects a single atomic snapshot of the repository (ADR-032):
     # there is no window in which the relationship view drifts mid-call.
@@ -248,6 +252,19 @@ def _get_related(root: str, artifact_id: str, budget: int) -> str:
         "outgoing": outgoing.by_section,
         "incoming": incoming,
     }
+    # Bounded multi-hop (v0.24, WS-D): depth>1 adds an additive `neighborhood`
+    # field listing artifacts two-or-more hops out, each tagged with its hop
+    # distance (ADR-007). depth=1 leaves the payload byte-identical to before.
+    neighborhood_truncated = False
+    if depth > 1:
+        hood = neighborhood(relationships, identity_by_path, artifact.path, depth=depth)
+        payload["neighborhood"] = [
+            {"id": n.id, "type": n.type, "title": n.title, "path": n.path, "hops": n.hops}
+            for n in hood.nodes
+            if n.hops > 1
+        ]
+        payload["depth"] = min(depth, MAX_TRAVERSAL_DEPTH)
+        neighborhood_truncated = hood.truncated
     # Per-call edge cap overflow (WS4, REQ-007): when collection hit the cap, mark
     # the response truncated up front. The ADR-033 response budget then enforces
     # the character cap on top; if it must drop further incoming entries it
@@ -256,7 +273,7 @@ def _get_related(root: str, artifact_id: str, budget: int) -> str:
     edge_overflow = (incoming_result.total - len(incoming_result.items)) + (
         outgoing.total - outgoing.kept
     )
-    if edge_overflow > 0:
+    if edge_overflow > 0 or neighborhood_truncated:
         payload[MARKER_TRUNCATED] = True
         payload[MARKER_OMITTED] = edge_overflow
         payload[MARKER_HINT] = HINT_RELATED
@@ -310,8 +327,10 @@ def build_server(
         )
 
     @server.tool(name="get_related", description=DESC_GET_RELATED)
-    def get_related(id: str) -> str:
-        return telemetry.observe(recorder, "get_related", lambda: _get_related(root, id, budget))
+    def get_related(id: str, depth: int = 1) -> str:
+        return telemetry.observe(
+            recorder, "get_related", lambda: _get_related(root, id, budget, depth)
+        )
 
     @server.tool(name="get_summary", description=DESC_GET_SUMMARY)
     def get_summary() -> str:

--- a/src/rac/services/coverage.py
+++ b/src/rac/services/coverage.py
@@ -1,0 +1,169 @@
+"""Traceability coverage report — typed completeness gaps (v0.24, WS-F).
+
+Coverage answers a different question from `rac doctor`'s integrity checks: not
+"is this artifact reachable or well-formed" but "does it have the *specific*
+traceability edge its type expects". Three deterministic, advisory gap classes
+are derived from the corpus relationship graph (rac-traceability-coverage-report):
+
+  - **unscheduled** — a requirement that no roadmap references (nothing schedules
+    the capability),
+  - **unapplied** — a decision that no requirement or roadmap references (the
+    decision is recorded but nothing applies it),
+  - **unscoped** — a roadmap that references no requirement (the plan scopes no
+    capability).
+
+Gaps are completeness signals for human judgement, never validation errors: a
+roadmap may legitimately precede its requirements, a decision may be recorded
+before anything applies it. The report stays out of the `rac gate` enforcement
+path (ADR-049) and never fails a build. Deterministic and offline (ADR-002).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+from rac.core.corpus import walk_corpus
+from rac.services.index import index_from_corpus
+from rac.services.relationships import relationships_from_corpus
+
+# Gap class -> (artifact type it applies to, the missing-coverage description).
+# Derived from the relationship semantics rather than a per-artifact table, so a
+# new type does not silently inherit a coverage rule (rac-traceability-coverage
+# REQ-006): each rule is one type and one expected traceability direction.
+GAP_UNSCHEDULED = "unscheduled"
+GAP_UNAPPLIED = "unapplied"
+GAP_UNSCOPED = "unscoped"
+
+_MISSING = {
+    GAP_UNSCHEDULED: "no roadmap schedules this requirement",
+    GAP_UNAPPLIED: "no requirement or roadmap applies this decision",
+    GAP_UNSCOPED: "this roadmap references no requirement",
+}
+
+
+@dataclass(frozen=True)
+class CoverageGap:
+    """One typed traceability gap."""
+
+    path: str
+    id: str
+    type: str
+    gap: str  # GAP_* class
+    missing: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "path": self.path,
+            "id": self.id,
+            "type": self.type,
+            "gap": self.gap,
+            "missing": self.missing,
+        }
+
+
+@dataclass(frozen=True)
+class CoverageReport:
+    """The coverage report for a directory (advisory; never a build failure)."""
+
+    directory: str
+    gaps: list[CoverageGap]
+
+    @property
+    def counts(self) -> dict[str, int]:
+        out = {GAP_UNSCHEDULED: 0, GAP_UNAPPLIED: 0, GAP_UNSCOPED: 0}
+        for gap in self.gaps:
+            out[gap.gap] += 1
+        return out
+
+    def to_dict(self) -> dict[str, Any]:
+        counts = self.counts
+        return {
+            "schema_version": "1",
+            "directory": self.directory,
+            "gaps": [g.to_dict() for g in self.gaps],
+            "summary": {**counts, "total": len(self.gaps)},
+        }
+
+
+def analyze_coverage(directory: str) -> CoverageReport:
+    """Derive the typed coverage gaps for ``directory`` from its relationship graph."""
+    entries = list(walk_corpus(directory, recursive=True))
+    index = index_from_corpus(directory, entries, recursive=True).artifacts
+    type_by_path = {a.path: a.type for a in index}
+    identity = {a.path: (a.id, a.type) for a in index}
+    relationships = relationships_from_corpus(entries)
+
+    # Resolved incoming source types and resolved outgoing target types per path.
+    incoming_types: dict[str, set[str]] = {a.path: set() for a in index}
+    outgoing_types: dict[str, set[str]] = {a.path: set() for a in index}
+    for rel in relationships:
+        if rel.resolved_path is None or rel.resolved_path == rel.source_path:
+            continue
+        source_type = type_by_path.get(rel.source_path)
+        target_type = type_by_path.get(rel.resolved_path)
+        if rel.resolved_path in incoming_types and source_type is not None:
+            incoming_types[rel.resolved_path].add(source_type)
+        if rel.source_path in outgoing_types and target_type is not None:
+            outgoing_types[rel.source_path].add(target_type)
+
+    gaps: list[CoverageGap] = []
+    for artifact in index:
+        artifact_id, artifact_type = identity[artifact.path]
+        gap: str | None = None
+        if artifact_type == "requirement" and "roadmap" not in incoming_types[artifact.path]:
+            gap = GAP_UNSCHEDULED
+        elif artifact_type == "decision" and not (
+            {"requirement", "roadmap"} & incoming_types[artifact.path]
+        ):
+            gap = GAP_UNAPPLIED
+        elif artifact_type == "roadmap" and "requirement" not in outgoing_types[artifact.path]:
+            gap = GAP_UNSCOPED
+        if gap is not None:
+            gaps.append(
+                CoverageGap(
+                    path=artifact.path,
+                    id=artifact_id,
+                    type=artifact_type,
+                    gap=gap,
+                    missing=_MISSING[gap],
+                )
+            )
+
+    # Deterministic order: gap class, then ascending path (REQ-003).
+    order = {GAP_UNSCHEDULED: 0, GAP_UNAPPLIED: 1, GAP_UNSCOPED: 2}
+    gaps.sort(key=lambda g: (order[g.gap], g.path))
+    return CoverageReport(directory=directory, gaps=gaps)
+
+
+def render_coverage_json(report: CoverageReport) -> str:
+    return json.dumps(report.to_dict(), indent=2, ensure_ascii=False)
+
+
+def render_coverage_human(report: CoverageReport) -> str:
+    counts = report.counts
+    lines = [f"Traceability coverage — {report.directory}", ""]
+    if not report.gaps:
+        lines.append("✓ No coverage gaps — every artifact has its expected traceability edge.")
+        return "\n".join(lines)
+    headings = {
+        GAP_UNSCHEDULED: "Unscheduled requirements (no roadmap schedules them)",
+        GAP_UNAPPLIED: "Unapplied decisions (no requirement or roadmap applies them)",
+        GAP_UNSCOPED: "Unscoped roadmaps (reference no requirement)",
+    }
+    for gap_class, heading in headings.items():
+        members = [g for g in report.gaps if g.gap == gap_class]
+        if not members:
+            continue
+        lines.append(f"{heading}: {len(members)}")
+        for gap in members:
+            lines.append(f"  {gap.id}  {gap.path}")
+        lines.append("")
+    total = len(report.gaps)
+    lines.append(
+        f"{total} coverage gap{'s' if total != 1 else ''} "
+        f"({counts[GAP_UNSCHEDULED]} unscheduled, {counts[GAP_UNAPPLIED]} unapplied, "
+        f"{counts[GAP_UNSCOPED]} unscoped) — advisory, not a build failure."
+    )
+    return "\n".join(lines)

--- a/src/rac/services/relationships.py
+++ b/src/rac/services/relationships.py
@@ -23,7 +23,12 @@ from rac.core.artifacts import ArtifactSpec, spec_for
 from rac.core.classification import classify
 from rac.core.corpus import CorpusCache, CorpusEntry, walk_corpus
 from rac.core.identity import artifact_identifier, artifact_identifiers
-from rac.core.limits import MAX_RELATED_EDGES
+from rac.core.limits import (
+    MAX_RELATED_EDGES,
+    MAX_TRAVERSAL_DEPTH,
+    MAX_TRAVERSAL_FRONTIER,
+    MAX_TRAVERSAL_WORK,
+)
 from rac.core.markdown import parse_file
 from rac.core.models import Product
 from rac.core.relationship_types import REGISTRY, edge_spec
@@ -1102,3 +1107,105 @@ def incoming_references(
             )
     incoming.sort(key=lambda e: (_relationship_order(e.section), e.id, e.path))
     return IncomingReferences(items=incoming, total=total)
+
+
+@dataclass(frozen=True)
+class NeighborhoodNode:
+    """One artifact reachable from the origin, with its hop distance (v0.24, WS-D)."""
+
+    id: str
+    type: str
+    title: str | None
+    path: str
+    hops: int
+
+
+@dataclass(frozen=True)
+class Neighborhood:
+    """The bounded multi-hop neighbourhood of an origin artifact.
+
+    ``nodes`` excludes the origin and is ordered deterministically by
+    ``(hops, type, id)`` so response-budget truncation drops the farthest,
+    lowest-priority artifacts first. ``truncated`` is True when any traversal
+    cap stopped the walk early.
+    """
+
+    nodes: list[NeighborhoodNode]
+    truncated: bool
+
+
+def neighborhood(
+    relationships: list[Relationship],
+    identity_by_path: dict[str, tuple[str, str, str | None]],
+    origin_path: str,
+    *,
+    depth: int,
+    max_frontier: int = MAX_TRAVERSAL_FRONTIER,
+    work_budget: int = MAX_TRAVERSAL_WORK,
+) -> Neighborhood:
+    """Artifacts within ``depth`` hops of ``origin_path`` (v0.24, WS-D).
+
+    A breadth-first walk over resolved relationship edges in both directions,
+    bounded by the four caps from ``rac-parser-traversal-robustness`` REQ-010:
+    the requested ``depth`` is clamped to :data:`MAX_TRAVERSAL_DEPTH`, each level
+    admits at most ``max_frontier`` nodes, a visited set makes the walk
+    cycle-safe, and ``work_budget`` caps the edges examined across the whole
+    walk. The origin is never included. Deterministic and offline (ADR-002):
+    identical corpus bytes yield a byte-identical, ordered result.
+    """
+    depth = max(0, min(depth, MAX_TRAVERSAL_DEPTH))
+
+    # Undirected adjacency over resolved edges; each entry carries the relationship
+    # rank of the edge so discovery order is deterministic (REQ-004).
+    adjacency: dict[str, list[tuple[str, int]]] = {}
+    for rel in relationships:
+        if rel.resolved_path is None or rel.source_path == rel.resolved_path:
+            continue
+        rank = _relationship_order(rel.relationship)
+        adjacency.setdefault(rel.source_path, []).append((rel.resolved_path, rank))
+        adjacency.setdefault(rel.resolved_path, []).append((rel.source_path, rank))
+
+    visited: set[str] = {origin_path}
+    discovered: list[tuple[int, int, str, str]] = []  # (hops, rank, id, path)
+    frontier = [origin_path]
+    work = 0
+    truncated = False
+
+    for current_depth in range(1, depth + 1):
+        next_frontier: list[str] = []
+        for path in sorted(frontier):
+            for neighbor_path, rank in sorted(set(adjacency.get(path, []))):
+                work += 1
+                if work > work_budget:
+                    truncated = True
+                    break
+                if neighbor_path in visited:
+                    continue
+                visited.add(neighbor_path)
+                identity = identity_by_path.get(neighbor_path)
+                if identity is None:  # pragma: no cover — every edge target is indexed
+                    continue
+                discovered.append((current_depth, rank, identity[0], neighbor_path))
+                if len(next_frontier) >= max_frontier:
+                    truncated = True
+                else:
+                    next_frontier.append(neighbor_path)
+            if truncated and work > work_budget:
+                break
+        frontier = next_frontier
+        if not frontier:
+            break
+
+    discovered.sort()  # (hops, rank, id, path) — deterministic, stable truncation
+    nodes = [
+        NeighborhoodNode(
+            id=identity_by_path[path][0],
+            type=identity_by_path[path][1],
+            title=identity_by_path[path][2],
+            path=path,
+            hops=hops,
+        )
+        for hops, _rank, _id, path in discovered
+    ]
+    nodes.sort(key=lambda n: (n.hops, n.type, n.id))
+    return Neighborhood(nodes=nodes, truncated=truncated)

--- a/src/rac/usage.py
+++ b/src/rac/usage.py
@@ -1,0 +1,197 @@
+"""CLI usage telemetry — content-free, consent-gated, local-only (v0.24, WS-E).
+
+ADR-046: when — and only when — sharing consent is recorded (ADR-041,
+`rac telemetry on`), each completed `rac` command appends one content-free event
+to a separate local log, `$XDG_STATE_HOME/rac/rac-usage.jsonl`. The event schema
+is pinned: ``schema_version``, ``ts`` (ISO 8601 UTC), ``session`` (random
+per-process hex), ``command`` (the subcommand name only), ``outcome``
+(``ok`` | ``error`` | ``exception``), and ``duration_ms``. Argv, flag values,
+positional arguments, file paths, artifact IDs, and repository content are never
+recorded — the named absent fields are a test, not a comment (ADR-040).
+
+Recording is write-only observability outside the command's output (ADR-032):
+the recorder runs after dispatch, never feeds back into a command, leaves exit
+codes unchanged, and disables itself silently when it cannot write — telemetry
+failure never breaks a command.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import secrets
+from collections import Counter
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from rac.consent import load_consent
+
+SCHEMA_VERSION = "1"
+USAGE_FILENAME = "rac-usage.jsonl"
+OUTCOME_OK = "ok"
+OUTCOME_ERROR = "error"
+OUTCOME_EXCEPTION = "exception"
+
+# One random session id per process, so the read-back can count sessions without
+# anything identifying. Generated at import, never persisted to config.
+_SESSION = secrets.token_hex(8)
+
+
+def usage_path() -> Path:
+    """Location of the CLI-usage log (separate from the Guide log, ADR-046)."""
+    base = os.environ.get("XDG_STATE_HOME") or str(Path.home() / ".local" / "state")
+    return Path(base) / "rac" / USAGE_FILENAME
+
+
+def _event(command: str, outcome: str, duration_ms: int) -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "ts": datetime.now(UTC).isoformat(),
+        "session": _SESSION,
+        "command": command,
+        "outcome": outcome,
+        "duration_ms": duration_ms,
+    }
+
+
+def record_command(command: str, outcome: str, duration_ms: int) -> None:
+    """Append one content-free usage event, if consent is recorded (ADR-046).
+
+    Silent on every failure path — no consent, no command name, or an
+    unwritable log all mean "record nothing", never an exception.
+    """
+    if not command:
+        return
+    try:
+        if not load_consent().share_usage:
+            return
+        path = usage_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        line = json.dumps(_event(command, outcome, duration_ms), ensure_ascii=False)
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(line + "\n")
+    except OSError:
+        return
+
+
+def read_usage(path: Path | None = None) -> list[dict[str, Any]]:
+    """Read usage events; a missing or malformed log yields what is parseable."""
+    log = path if path is not None else usage_path()
+    events: list[dict[str, Any]] = []
+    try:
+        text = log.read_text(encoding="utf-8")
+    except OSError:
+        return events
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            row = json.loads(line)
+        except ValueError:
+            continue
+        if isinstance(row, dict):
+            events.append(row)
+    return events
+
+
+@dataclass(frozen=True)
+class CommandUsage:
+    command: str
+    calls: int
+    errors: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"command": self.command, "calls": self.calls, "errors": self.errors}
+
+
+@dataclass(frozen=True)
+class UsageSummary:
+    total: int
+    sessions: int
+    commands: list[CommandUsage]
+    recent: dict[str, int]  # date (YYYY-MM-DD, UTC) -> event count, last N days
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "total": self.total,
+            "sessions": self.sessions,
+            "commands": [c.to_dict() for c in self.commands],
+            "recent": self.recent,
+        }
+
+
+def summarize_usage(path: Path | None = None, *, days: int = 7) -> UsageSummary:
+    """Per-command counts, session count, and a recent-activity trend (REQ-001)."""
+    events = read_usage(path)
+    sessions = {ev["session"] for ev in events if isinstance(ev.get("session"), str)}
+    by_command: dict[str, list[dict]] = {}
+    for ev in events:
+        command = ev.get("command")
+        if isinstance(command, str):
+            by_command.setdefault(command, []).append(ev)
+    commands = [
+        CommandUsage(
+            command=command,
+            calls=len(rows),
+            errors=sum(1 for ev in rows if ev.get("outcome") in (OUTCOME_ERROR, OUTCOME_EXCEPTION)),
+        )
+        for command, rows in sorted(by_command.items())
+    ]
+    day_counts: Counter[str] = Counter()
+    for ev in events:
+        ts = ev.get("ts")
+        if isinstance(ts, str) and len(ts) >= 10:
+            day_counts[ts[:10]] += 1
+    recent = dict(sorted(day_counts.items())[-days:])
+    return UsageSummary(total=len(events), sessions=len(sessions), commands=commands, recent=recent)
+
+
+# Read-back rendering (ADR-046): one surface summarises both the CLI-usage log
+# and the Guide log. The Guide summary is passed as a plain dict so this module
+# never imports the MCP SDK. Sharing reuses the local-first, user-submitted flow.
+
+SHARE_ISSUE_URL = "https://github.com/itsthelore/rac-core/issues/new"
+SHARE_TEMPLATE = "guide-usage-report.yml"
+SHARE_FIELD = "report"
+
+
+def _combined(summary: UsageSummary, guide: dict[str, Any] | None) -> dict[str, Any]:
+    return {"schema_version": SCHEMA_VERSION, "cli": summary.to_dict(), "guide": guide or {}}
+
+
+def render_json(summary: UsageSummary, guide: dict[str, Any] | None) -> str:
+    return json.dumps(_combined(summary, guide), ensure_ascii=False, indent=2)
+
+
+def render_human(summary: UsageSummary, guide: dict[str, Any] | None) -> str:
+    lines = ["RAC usage", ""]
+    if summary.total == 0:
+        lines.append("No CLI usage recorded — telemetry is off (enable with `rac telemetry on`).")
+    else:
+        lines.append(f"CLI commands: {summary.total} calls across {summary.sessions} session(s)")
+        for c in summary.commands:
+            errs = f"  ({c.errors} error{'s' if c.errors != 1 else ''})" if c.errors else ""
+            lines.append(f"  {c.command:<16} {c.calls}{errs}")
+        if summary.recent:
+            trend = ", ".join(f"{day}: {n}" for day, n in summary.recent.items())
+            lines.append(f"  recent: {trend}")
+    tools = (guide or {}).get("tools") or []
+    if tools:
+        lines.extend(["", "Guide MCP tools:"])
+        for tool in tools:
+            errs = f"  ({tool['errors']} error(s))" if tool.get("errors") else ""
+            lines.append(f"  {tool['tool']:<16} {tool['calls']}{errs}")
+    return "\n".join(lines)
+
+
+def share_url(summary: UsageSummary, guide: dict[str, Any] | None) -> str:
+    """A prefilled GitHub issue URL — counts only, no local path (ADR-046, ADR-035)."""
+    import urllib.parse
+
+    report = json.dumps(_combined(summary, guide), ensure_ascii=False, indent=2)
+    query = urllib.parse.urlencode({"template": SHARE_TEMPLATE, SHARE_FIELD: report})
+    return f"{SHARE_ISSUE_URL}?{query}"

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -1,0 +1,148 @@
+"""Traceability coverage report tests (v0.24, WS-F).
+
+Each typed gap class is exercised on a built corpus, plus the clean case, the
+JSON contract, and the advisory exit code (coverage never fails a build).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from rac.cli import main
+from rac.services.coverage import (
+    GAP_UNAPPLIED,
+    GAP_UNSCHEDULED,
+    GAP_UNSCOPED,
+    analyze_coverage,
+)
+
+REQ_BODY = "## Problem\n\nNeeded.\n\n## Requirements\n\n- [REQ-001] The system MUST do X.\n"
+DEC_BODY = (
+    "## Status\n\nAccepted\n\n## Category\n\nArchitecture\n\n## Context\n\nC.\n\n"
+    "## Decision\n\nD.\n\n## Consequences\n\nX.\n"
+)
+RDM_BODY = "## Outcomes\n\n- An outcome.\n\n## Initiatives\n\n- An initiative.\n"
+
+
+def _write(base: Path, name: str, ident: str, atype: str, body: str, related: str = "") -> None:
+    (base / name).write_text(
+        f"---\nschema_version: 1\nid: {ident}\ntype: {atype}\n---\n# {ident}\n\n{body}{related}",
+        encoding="utf-8",
+    )
+
+
+def _related(section: str, *ids: str) -> str:
+    return f"\n## {section}\n\n" + "".join(f"- {i}\n" for i in ids)
+
+
+def test_unscheduled_requirement_flagged(tmp_path):
+    # A requirement no roadmap references is unscheduled.
+    _write(tmp_path, "req.md", "RAC-TCVREQ000001", "requirement", REQ_BODY)
+    report = analyze_coverage(str(tmp_path))
+    assert [(g.type, g.gap) for g in report.gaps] == [("requirement", GAP_UNSCHEDULED)]
+
+
+def test_scheduled_requirement_not_flagged(tmp_path):
+    # A roadmap that references the requirement clears the unscheduled gap...
+    _write(tmp_path, "req.md", "RAC-TCVREQ000001", "requirement", REQ_BODY)
+    _write(
+        tmp_path,
+        "rdm.md",
+        "RAC-TCVRDM000001",
+        "roadmap",
+        RDM_BODY,
+        _related("Related Requirements", "RAC-TCVREQ000001"),
+    )
+    report = analyze_coverage(str(tmp_path))
+    # ...and that roadmap is itself scoped (it references a requirement), so no gaps.
+    assert report.gaps == []
+
+
+def test_unapplied_decision_flagged(tmp_path):
+    _write(tmp_path, "dec.md", "RAC-TCVDEC000001", "decision", DEC_BODY)
+    report = analyze_coverage(str(tmp_path))
+    assert [(g.type, g.gap) for g in report.gaps] == [("decision", GAP_UNAPPLIED)]
+
+
+def test_decision_applied_by_requirement_not_flagged(tmp_path):
+    _write(tmp_path, "dec.md", "RAC-TCVDEC000001", "decision", DEC_BODY)
+    _write(
+        tmp_path,
+        "req.md",
+        "RAC-TCVREQ000001",
+        "requirement",
+        REQ_BODY,
+        _related("Related Decisions", "RAC-TCVDEC000001"),
+    )
+    report = analyze_coverage(str(tmp_path))
+    # The decision is applied; the requirement is still unscheduled.
+    assert [(g.type, g.gap) for g in report.gaps] == [("requirement", GAP_UNSCHEDULED)]
+
+
+def test_unscoped_roadmap_flagged(tmp_path):
+    _write(tmp_path, "rdm.md", "RAC-TCVRDM000001", "roadmap", RDM_BODY)
+    report = analyze_coverage(str(tmp_path))
+    assert [(g.type, g.gap) for g in report.gaps] == [("roadmap", GAP_UNSCOPED)]
+
+
+def test_gaps_ordered_by_class_then_path(tmp_path):
+    _write(tmp_path, "rdm.md", "RAC-TCVRDM000001", "roadmap", RDM_BODY)
+    _write(tmp_path, "dec.md", "RAC-TCVDEC000001", "decision", DEC_BODY)
+    _write(tmp_path, "req.md", "RAC-TCVREQ000001", "requirement", REQ_BODY)
+    report = analyze_coverage(str(tmp_path))
+    # unscheduled, then unapplied, then unscoped (REQ-003).
+    assert [g.gap for g in report.gaps] == [GAP_UNSCHEDULED, GAP_UNAPPLIED, GAP_UNSCOPED]
+
+
+def test_json_contract_and_summary(tmp_path):
+    _write(tmp_path, "req.md", "RAC-TCVREQ000001", "requirement", REQ_BODY)
+    report = analyze_coverage(str(tmp_path))
+    data = report.to_dict()
+    assert data["schema_version"] == "1"
+    assert data["summary"] == {
+        GAP_UNSCHEDULED: 1,
+        GAP_UNAPPLIED: 0,
+        GAP_UNSCOPED: 0,
+        "total": 1,
+    }
+    gap = data["gaps"][0]
+    assert set(gap) == {"path", "id", "type", "gap", "missing"}
+
+
+def test_cli_coverage_is_advisory_exit_zero(tmp_path, capsys):
+    _write(tmp_path, "req.md", "RAC-TCVREQ000001", "requirement", REQ_BODY)
+    rc = main(["coverage", str(tmp_path)])
+    assert rc == 0  # advisory, never a build failure (REQ-005)
+    assert "Unscheduled requirements" in capsys.readouterr().out
+
+
+def test_cli_coverage_json(tmp_path, capsys):
+    _write(tmp_path, "req.md", "RAC-TCVREQ000001", "requirement", REQ_BODY)
+    rc = main(["coverage", str(tmp_path), "--json"])
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    assert data["summary"]["total"] == 1
+
+
+def test_clean_corpus_has_no_gaps(tmp_path, capsys):
+    # A roadmap scoping a requirement, the requirement scheduled, a decision applied.
+    _write(
+        tmp_path,
+        "rdm.md",
+        "RAC-TCVRDM000001",
+        "roadmap",
+        RDM_BODY,
+        _related("Related Requirements", "RAC-TCVREQ000001"),
+    )
+    _write(
+        tmp_path,
+        "req.md",
+        "RAC-TCVREQ000001",
+        "requirement",
+        REQ_BODY,
+        _related("Related Decisions", "RAC-TCVDEC000001"),
+    )
+    _write(tmp_path, "dec.md", "RAC-TCVDEC000001", "decision", DEC_BODY)
+    report = analyze_coverage(str(tmp_path))
+    assert report.gaps == []

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -740,3 +740,37 @@ def test_get_related_performs_exactly_one_corpus_walk(monkeypatch):
     server_obj = build_server(CORPUS)
     asyncio.run(server_obj.call_tool("get_related", {"id": DEC}))
     assert calls["count"] == 1
+
+
+# --- get_related bounded multi-hop (v0.24, WS-D) -----------------------------
+
+
+def _chain_corpus(root) -> None:
+    """Three decisions linked head->tail: dec1 -> dec2 -> dec3."""
+    from pathlib import Path
+
+    base = Path(root)
+    ids = ["RAC-MCPCHN000001", "RAC-MCPCHN000002", "RAC-MCPCHN000003"]
+    for i, ident in enumerate(ids):
+        link = f"\n## Related Decisions\n\n- {ids[i + 1]}\n" if i + 1 < len(ids) else ""
+        (base / f"dec{i + 1}.md").write_text(
+            f"---\nschema_version: 1\nid: {ident}\ntype: decision\n---\n"
+            f"# Chain {i + 1}\n\n## Status\n\nAccepted\n\n## Category\n\nArchitecture\n\n"
+            f"## Context\n\nC.\n\n## Decision\n\nD.\n\n## Consequences\n\nX.\n{link}",
+            encoding="utf-8",
+        )
+
+
+def test_get_related_depth_one_has_no_neighborhood_field(tmp_path):
+    _chain_corpus(tmp_path)
+    payload = call(str(tmp_path), "get_related", {"id": "RAC-MCPCHN000001"})
+    assert "neighborhood" not in payload and "depth" not in payload
+
+
+def test_get_related_depth_two_surfaces_two_hop_neighbour(tmp_path):
+    _chain_corpus(tmp_path)
+    payload = call(str(tmp_path), "get_related", {"id": "RAC-MCPCHN000001", "depth": 2})
+    assert payload["depth"] == 2
+    # dec1 -> dec2 (1 hop, already in outgoing) -> dec3 (2 hops, in neighborhood).
+    hood = {(n["id"], n["hops"]) for n in payload["neighborhood"]}
+    assert ("RAC-MCPCHN000003", 2) in hood

--- a/tests/test_relationships.py
+++ b/tests/test_relationships.py
@@ -279,3 +279,86 @@ def test_linked_fixtures_validate(artifact, info):
     filename, _ = info
     issues = validate(parse(open(fixture_path("relationships", filename)).read()))
     assert not has_errors(issues), f"{filename} should validate without errors"
+
+
+# --- bounded multi-hop neighbourhood (v0.24, WS-D) ---------------------------
+
+from rac.core.limits import MAX_TRAVERSAL_DEPTH  # noqa: E402
+from rac.services.relationships import (  # noqa: E402
+    Relationship,
+    neighborhood,
+)
+
+
+def _chain(*paths: str) -> tuple[list[Relationship], dict[str, tuple[str, str, str | None]]]:
+    """A directed chain p0 -> p1 -> ... as resolved relationships, plus identities."""
+    rels = [
+        Relationship(
+            source_path=paths[i],
+            relationship="related_decisions",
+            target=paths[i + 1],
+            resolved_path=paths[i + 1],
+            issue=None,
+        )
+        for i in range(len(paths) - 1)
+    ]
+    identity = {p: (f"ID-{p}", "decision", f"Title {p}") for p in paths}
+    return rels, identity
+
+
+def test_neighborhood_walks_both_directions_with_hop_distance():
+    rels, identity = _chain("a", "b", "c", "d")
+    hood = neighborhood(rels, identity, "b", depth=2)
+    # From b: a and c are 1 hop, d is 2 hops; b (origin) is excluded.
+    assert {(n.path, n.hops) for n in hood.nodes} == {("a", 1), ("c", 1), ("d", 2)}
+    assert not hood.truncated
+
+
+def test_neighborhood_depth_one_returns_only_immediate_neighbours():
+    rels, identity = _chain("a", "b", "c", "d")
+    hood = neighborhood(rels, identity, "a", depth=1)
+    assert {n.path for n in hood.nodes} == {"b"}
+
+
+def test_neighborhood_ordered_by_hops_then_type_then_id():
+    rels, identity = _chain("a", "b", "c")
+    hood = neighborhood(rels, identity, "a", depth=2)
+    assert [(n.hops, n.id) for n in hood.nodes] == [(1, "ID-b"), (2, "ID-c")]
+
+
+def test_neighborhood_is_cycle_safe():
+    # a -> b -> c -> a : a visited as origin, so the walk terminates.
+    rels, identity = _chain("a", "b", "c")
+    rels.append(
+        Relationship(
+            source_path="c",
+            relationship="related_decisions",
+            target="a",
+            resolved_path="a",
+            issue=None,
+        )
+    )
+    hood = neighborhood(rels, identity, "a", depth=10)
+    assert {n.path for n in hood.nodes} == {"b", "c"}
+    assert not hood.truncated
+
+
+def test_neighborhood_clamps_depth_to_the_ceiling():
+    paths = [f"p{i}" for i in range(MAX_TRAVERSAL_DEPTH + 5)]
+    rels, identity = _chain(*paths)
+    hood = neighborhood(rels, identity, paths[0], depth=999)
+    # Nothing beyond the clamped ceiling is reached from the origin.
+    assert max(n.hops for n in hood.nodes) == MAX_TRAVERSAL_DEPTH
+
+
+def test_neighborhood_work_budget_truncates_and_flags():
+    rels, identity = _chain("a", "b", "c", "d", "e")
+    hood = neighborhood(rels, identity, "a", depth=5, work_budget=1)
+    assert hood.truncated
+
+
+def test_neighborhood_deterministic_across_runs():
+    rels, identity = _chain("a", "b", "c", "d")
+    first = neighborhood(rels, identity, "b", depth=3)
+    second = neighborhood(rels, identity, "b", depth=3)
+    assert [n.path for n in first.nodes] == [n.path for n in second.nodes]

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -1,0 +1,113 @@
+"""CLI usage telemetry tests (v0.24, WS-E; ADR-046).
+
+Recording is consent-gated, content-free, and write-only: the named absent
+fields (argv, paths, ids) are a test, not a comment.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from rac import consent, usage
+from rac.cli import main
+
+EVENT_KEYS = {"schema_version", "ts", "session", "command", "outcome", "duration_ms"}
+
+
+@pytest.fixture
+def isolated(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "cfg"))
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
+    return tmp_path
+
+
+def _enable(consent_dir: Path) -> None:
+    consent.opt_in()  # records share_usage=True at $XDG_CONFIG_HOME/rac/telemetry.json
+
+
+def test_no_recording_without_consent(isolated):
+    usage.record_command("validate", usage.OUTCOME_OK, 5)
+    assert not usage.usage_path().exists()
+
+
+def test_records_one_event_with_consent(isolated):
+    _enable(isolated)
+    usage.record_command("validate", usage.OUTCOME_OK, 5)
+    events = usage.read_usage()
+    assert len(events) == 1
+    assert set(events[0]) == EVENT_KEYS
+    assert events[0]["command"] == "validate"
+    assert events[0]["outcome"] == "ok"
+
+
+def test_event_is_content_free_through_real_dispatch(isolated, capsys):
+    # Run a real command whose args carry a path; the recorded event must not
+    # leak the path, argv, or any id — only the pinned fields (ADR-046).
+    _enable(isolated)
+    secret_path = str(Path(__file__))  # a real path passed as the positional
+    main(["validate", secret_path])
+    raw = usage.usage_path().read_text(encoding="utf-8")
+    assert secret_path not in raw
+    event = json.loads(raw.splitlines()[-1])
+    assert set(event) == EVENT_KEYS
+    assert event["command"] == "validate"
+
+
+def test_recording_does_not_change_exit_code(isolated):
+    _enable(isolated)
+    # A non-existent file makes validate exit non-zero (SystemExit); recording in
+    # the finally clause must still happen and must not swallow or alter the exit.
+    with pytest.raises(SystemExit) as exc:
+        main(["validate", str(isolated / "nope.md")])
+    assert exc.value.code != 0
+    event = json.loads(usage.usage_path().read_text(encoding="utf-8").splitlines()[-1])
+    assert event["command"] == "validate"
+    assert event["outcome"] in ("error", "exception")
+
+
+def test_empty_log_summarizes_without_error(isolated):
+    summary = usage.summarize_usage()
+    assert summary.total == 0 and summary.sessions == 0 and summary.commands == []
+
+
+def test_summary_counts_per_command_and_sessions(isolated):
+    _enable(isolated)
+    for _ in range(3):
+        usage.record_command("validate", usage.OUTCOME_OK, 1)
+    usage.record_command("review", usage.OUTCOME_ERROR, 1)
+    summary = usage.summarize_usage()
+    assert summary.total == 4
+    assert summary.sessions == 1  # one process == one session
+    by_command = {c.command: (c.calls, c.errors) for c in summary.commands}
+    assert by_command == {"validate": (3, 0), "review": (1, 1)}
+    assert sum(summary.recent.values()) == 4  # the recent-activity trend
+
+
+def test_usage_command_renders_and_is_advisory(isolated, capsys):
+    _enable(isolated)
+    usage.record_command("validate", usage.OUTCOME_OK, 1)
+    rc = main(["usage"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "CLI commands" in out and "validate" in out
+
+
+def test_usage_command_json(isolated, capsys):
+    _enable(isolated)
+    usage.record_command("validate", usage.OUTCOME_OK, 1)
+    main(["usage", "--json"])
+    data = json.loads(capsys.readouterr().out)
+    assert data["cli"]["total"] == 1
+    assert "guide" in data  # unified read-back covers both logs
+
+
+def test_usage_share_url_is_local_only(isolated, capsys):
+    _enable(isolated)
+    usage.record_command("validate", usage.OUTCOME_OK, 1)
+    main(["usage", "--share"])
+    url = capsys.readouterr().out.strip()
+    assert url.startswith("https://github.com/itsthelore/rac-core/issues/new")
+    assert str(isolated) not in url  # no local path in the shared payload


### PR DESCRIPTION
## Deliver v0.24 Visibility

The v0.24 roadmap was marked `Achieved` but its scope had never shipped — a code
review confirmed `get_related` was 1-hop, there was no coverage surface, and all
three underlying requirements were still `Proposed`. This PR actually delivers
the three workstreams, making the `Achieved` status honest. Implements
`rac/roadmaps/v0.24.x-visibility/v0.24.0-visibility.md`.

### WS-D — Bounded multi-hop `get_related`

`get_related` gains an additive `depth` parameter (default `1`, byte-identical;
capped at `5`). `depth>1` returns a `neighborhood` of artifacts two-or-more hops
out, each tagged with its `hops` distance — a breadth-first walk over resolved
edges in both directions, bounded by the four caps from
`rac-parser-traversal-robustness` REQ-010 (depth, frontier, visited-set, work
budget), deterministic and cycle-safe.

### WS-F — Traceability coverage report

A new `rac coverage` command reports typed completeness gaps over the
relationship graph — **unscheduled** requirements (no roadmap), **unapplied**
decisions (nothing applies them), **unscoped** roadmaps (no requirement) — with
human and JSON output. Advisory: always exits `0`, stays out of the `rac gate`
path (ADR-049), distinct from `doctor`'s integrity checks.

### WS-E — Agent usage read-back (with ADR-046)

Accepts **ADR-046** (Proposed → Accepted) so RAC records one **content-free**
event per completed `rac` command — `command`, `outcome`, `duration_ms`, never
argv / paths / artifact ids — to a separate local log, gated by the existing
ADR-041 consent. Recording is write-only and silent-fail, leaving exit codes
unchanged. A new `rac usage` read-back summarises both the CLI-usage and Guide
logs (`mcp-stats` stays Guide-only for back-compat), with `--json` / `--share`.

### Decisions & requirements

- ADR-046 → Accepted; agent-rules blocks regenerated.
- `rac-multi-hop-relationship-traversal`, `rac-traceability-coverage-report`,
  `rac-agent-usage-readback` → all flipped `Proposed → Accepted`.
- v0.24 roadmap workstream checklist marked done.

### Gates

New batteries (`coverage-report`, `usage`) plus the existing suite pass; `ruff`,
`mypy`, the agent-rules drift check, and `rac validate` +
`relationships --validate` + `review` (92/100) all clean. The content-free
guarantee is enforced by a test asserting the recorded event leaks no path even
through real `rac validate <path>` dispatch.

### Related decisions

ADR-046, ADR-040, ADR-041, ADR-032, ADR-033, ADR-049, ADR-055, ADR-007.