### PR TITLE
docs(requirements): mark verified-shipped requirements Accepted

### DIFF
--- a/rac/requirements/rac-agent-context-guide.md
+++ b/rac/requirements/rac-agent-context-guide.md
@@ -7,7 +7,7 @@ type: requirement
 
 ## Status
 
-Proposed
+Accepted
 
 ## Problem
 

--- a/rac/requirements/rac-cross-artifact-enforcement.md
+++ b/rac/requirements/rac-cross-artifact-enforcement.md
@@ -11,7 +11,7 @@ type: requirement
 
 ## Status
 
-Proposed
+Accepted
 
 ## Problem
 

--- a/rac/requirements/rac-docs-site-landing-page.md
+++ b/rac/requirements/rac-docs-site-landing-page.md
@@ -7,7 +7,7 @@ type: requirement
 
 ## Status
 
-Proposed
+Accepted
 
 ## Problem
 

--- a/rac/requirements/rac-docs-site-platform.md
+++ b/rac/requirements/rac-docs-site-platform.md
@@ -7,7 +7,7 @@ type: requirement
 
 ## Status
 
-Proposed
+Accepted
 
 ## Problem
 

--- a/rac/requirements/rac-docs-site-publish-pipeline.md
+++ b/rac/requirements/rac-docs-site-publish-pipeline.md
@@ -7,7 +7,7 @@ type: requirement
 
 ## Status
 
-Proposed
+Accepted
 
 ## Problem
 

--- a/rac/requirements/rac-docs-site-readme-doorway.md
+++ b/rac/requirements/rac-docs-site-readme-doorway.md
@@ -7,7 +7,7 @@ type: requirement
 
 ## Status
 
-Proposed
+Accepted
 
 ## Problem
 

--- a/rac/requirements/rac-documentation-structure.md
+++ b/rac/requirements/rac-documentation-structure.md
@@ -7,7 +7,7 @@ type: requirement
 
 ## Status
 
-Proposed
+Accepted
 
 ## Problem
 

--- a/rac/requirements/rac-growth-agent-skill.md
+++ b/rac/requirements/rac-growth-agent-skill.md
@@ -7,7 +7,7 @@ type: requirement
 
 ## Status
 
-Proposed
+Accepted
 
 ## Problem
 

--- a/rac/requirements/rac-growth-ecosystem-list.md
+++ b/rac/requirements/rac-growth-ecosystem-list.md
@@ -7,7 +7,7 @@ type: requirement
 
 ## Status
 
-Proposed
+Accepted
 
 ## Problem
 

--- a/rac/requirements/rac-okf-carrier-profile.md
+++ b/rac/requirements/rac-okf-carrier-profile.md
@@ -11,7 +11,7 @@ type: requirement
 
 ## Status
 
-Proposed
+Accepted
 
 ## Problem
 

--- a/rac/requirements/rac-product-intent-ci-watchkeeper.md
+++ b/rac/requirements/rac-product-intent-ci-watchkeeper.md
@@ -7,7 +7,7 @@ type: requirement
 
 ## Status
 
-Proposed
+Accepted
 
 Previously deferred behind RAC Guide (the v0.10.x series), which has
 shipped through v0.10.6. The capability now proceeds as the v0.12.x

--- a/rac/requirements/rac-product-knowledge-navigator-explorer.md
+++ b/rac/requirements/rac-product-knowledge-navigator-explorer.md
@@ -7,7 +7,7 @@ type: requirement
 
 ## Status
 
-Proposed
+Accepted
 
 ## Problem
 

--- a/rac/requirements/rac-repository-review-mode.md
+++ b/rac/requirements/rac-repository-review-mode.md
@@ -7,7 +7,7 @@ type: requirement
 
 ## Status
 
-Proposed
+Accepted
 
 ## Problem
 

--- a/rac/requirements/rac-trust-transparency.md
+++ b/rac/requirements/rac-trust-transparency.md
@@ -7,7 +7,7 @@ type: requirement
 
 ## Status
 
-Proposed
+Accepted
 
 ## Problem
 


### PR DESCRIPTION
## Corpus-integrity: flip verified-shipped requirements to Accepted

A corpus-integrity review — prompted by finding the **v0.24 roadmap marked
`Achieved` before its scope had shipped** — checked the other still-`Proposed`
requirements against the actual code and tests. Several described functionality
that has **already shipped** in the `rac` package and were simply never flipped.

Each flip below was verified against an implementing module **and** a test, not
inferred from the name. This PR flips **14** requirements `Proposed → Accepted`:

| Requirement | Evidence |
| --- | --- |
| `cross-artifact-enforcement` | `ISSUE_TARGET_SUPERSEDED` / `ISSUE_EDGE_UNSUPPORTED` in `relationships.py`; `test_relationship_validation.py` |
| `product-knowledge-navigator-explorer` | `rac explorer` TUI (`src/rac/explorer/`); 7 explorer test files |
| `product-intent-ci-watchkeeper` | `rac watchkeeper` (`services/watchkeeper.py`); `test_watchkeeper.py` + goldens |
| `repository-review-mode` | `rac review` (`services/review.py`); `test_review.py` |
| `agent-context-guide` | `rac mcp` 5-tool surface (`mcp/server.py`); `test_mcp_*` |
| `trust-transparency` | tests/fixtures/goldens/CI/dogfood all present |
| `okf-carrier-profile` | `okf_conformance.py` + `rac export --okf`; `test_okf_conformance.py` |
| `documentation-structure` | README + `docs/` + dogfood `rac/` |
| `docs-site-landing-page` | `docs/index.md` |
| `docs-site-platform` | `mkdocs.yml` |
| `docs-site-publish-pipeline` | `.github/workflows/docs.yml` |
| `docs-site-readme-doorway` | README trimmed to the doorway |
| `growth-agent-skill` | `src/rac/skills/` + `rac skill install`; `test_skill.py` |
| `growth-ecosystem-list` | `docs/ecosystem.md` |

### Deliberately left `Proposed`

- `portal-citation-links` — **partial** (REQ-004 state-aware citation rendering
  not confirmed in the viewer).
- `growth-adoption`, `growth-contribution-policy`, `growth-essay-bridge`,
  `growth-extensibility`, `growth-positioning` — genuinely aspirational
  (no demo GIF / blocked on a gate / not operationalised / README lacks the
  sections).
- The three v0.24 requirements (`multi-hop-relationship-traversal`,
  `traceability-coverage-report`, `agent-usage-readback`) are flipped in **#181**,
  not here.

### Gates

Docs-only status change; `rac validate rac/`, `rac relationships rac/ --validate`,
and `rac review rac/` (92/100) all clean.