### PR TITLE
docs(ecosystem): add client integration examples (Amp, Claude Code, Codex, Cursor, Copilot)

### DIFF
--- a/docs/ecosystem.md
+++ b/docs/ecosystem.md
@@ -11,6 +11,8 @@ planned or placeholder entries.
 | `rac-artifacts` Claude Code skill | A project-level agent skill that teaches Claude Code to create, validate, and update RAC artifacts using the `rac` CLI | [`.claude/skills/rac-artifacts/`](https://github.com/itsthelore/rac-core/blob/main/.claude/skills/rac-artifacts/SKILL.md) |
 | MCP grounding example | A runnable demo showing an agent connected to RAC Guide over MCP respecting a recorded decision that an unconnected agent violates | [`examples/guide/`](https://github.com/itsthelore/rac-core/blob/main/examples/guide/demo.md) |
 | Amp setup | A worked setup connecting Sourcegraph's Amp to RAC — it reads the generated `AGENTS.md` natively and queries the `lore` MCP server | [`examples/amp/`](https://github.com/itsthelore/rac-core/blob/main/examples/amp/README.md) |
+| Claude Code setup | A worked setup connecting Claude Code to RAC — the generated `CLAUDE.md`, the `lore` MCP server, the `rac-artifacts` skill, and the optional pre-edit veto hook | [`examples/claude-code/`](https://github.com/itsthelore/rac-core/blob/main/examples/claude-code/README.md) |
+| Codex setup | A worked setup connecting OpenAI Codex to RAC — it reads the generated `AGENTS.md` and queries the `lore` MCP server via `config.toml` | [`examples/codex/`](https://github.com/itsthelore/rac-core/blob/main/examples/codex/README.md) |
 
 ## Adding an entry
 

--- a/docs/ecosystem.md
+++ b/docs/ecosystem.md
@@ -10,6 +10,7 @@ planned or placeholder entries.
 | RAC dogfood corpus | This repository's own product knowledge — requirements, decisions, roadmaps, prompts, designs — validated in CI by the engine it specifies | [`rac/`](https://github.com/itsthelore/rac-core/tree/main/rac/) |
 | `rac-artifacts` Claude Code skill | A project-level agent skill that teaches Claude Code to create, validate, and update RAC artifacts using the `rac` CLI | [`.claude/skills/rac-artifacts/`](https://github.com/itsthelore/rac-core/blob/main/.claude/skills/rac-artifacts/SKILL.md) |
 | MCP grounding example | A runnable demo showing an agent connected to RAC Guide over MCP respecting a recorded decision that an unconnected agent violates | [`examples/guide/`](https://github.com/itsthelore/rac-core/blob/main/examples/guide/demo.md) |
+| Amp setup | A worked setup connecting Sourcegraph's Amp to RAC — it reads the generated `AGENTS.md` natively and queries the `lore` MCP server | [`examples/amp/`](https://github.com/itsthelore/rac-core/blob/main/examples/amp/README.md) |
 
 ## Adding an entry
 

--- a/docs/ecosystem.md
+++ b/docs/ecosystem.md
@@ -13,6 +13,8 @@ planned or placeholder entries.
 | Amp setup | A worked setup connecting Sourcegraph's Amp to RAC — it reads the generated `AGENTS.md` natively and queries the `lore` MCP server | [`examples/amp/`](https://github.com/itsthelore/rac-core/blob/main/examples/amp/README.md) |
 | Claude Code setup | A worked setup connecting Claude Code to RAC — the generated `CLAUDE.md`, the `lore` MCP server, the `rac-artifacts` skill, and the optional pre-edit veto hook | [`examples/claude-code/`](https://github.com/itsthelore/rac-core/blob/main/examples/claude-code/README.md) |
 | Codex setup | A worked setup connecting OpenAI Codex to RAC — it reads the generated `AGENTS.md` and queries the `lore` MCP server via `config.toml` | [`examples/codex/`](https://github.com/itsthelore/rac-core/blob/main/examples/codex/README.md) |
+| Cursor setup | A worked setup connecting Cursor to RAC — it reads the generated `AGENTS.md` and queries the `lore` MCP server via `.cursor/mcp.json` | [`examples/cursor/`](https://github.com/itsthelore/rac-core/blob/main/examples/cursor/README.md) |
+| GitHub Copilot setup | A worked setup connecting Copilot in VS Code to RAC — the generated `.github/copilot-instructions.md` plus the `lore` MCP server in agent mode | [`examples/copilot/`](https://github.com/itsthelore/rac-core/blob/main/examples/copilot/README.md) |
 
 ## Adding an entry
 

--- a/examples/amp/README.md
+++ b/examples/amp/README.md
@@ -1,0 +1,95 @@
+# RAC with Amp
+
+This shows how to connect [Amp](https://ampcode.com) — Sourcegraph's coding agent
+— to RAC, so Amp respects the decisions your team has already recorded. A
+stranger can reproduce the setup from this file alone.
+
+RAC meets Amp on two surfaces Amp already supports natively, so there is no
+Amp-specific RAC code: a generated **`AGENTS.md`** (context Amp reads every
+session) and the **`lore` MCP server** (tools Amp queries on demand). They are
+complementary — one pushes the decisions into context, the other lets Amp pull
+the full text and relationships when it needs them.
+
+## Prerequisites
+
+```bash
+pip install requirements-as-code   # the `rac` CLI and the `lore` MCP server
+```
+
+You also need a repository with a RAC corpus under `rac/` (run `rac quickstart`
+in a fresh project, or point at this repository's own `rac/`).
+
+## 1. Generate `AGENTS.md` (the push)
+
+Amp reads `AGENTS.md` for project conventions and guidance. RAC generates one
+from your recorded decisions:
+
+```bash
+rac export rac/ --agent-rules
+```
+
+This writes (or updates) `AGENTS.md` at the repository root, inside a managed
+block — anything you keep outside the block is preserved. Amp discovers it
+automatically: it reads `AGENTS.md` from the working directory up through the
+parent directories, and from subtrees as it opens files there. Re-run the export
+whenever decisions change (a pre-commit hook or CI step keeps it current); the
+`agent-rules` drift check (`rac export rac/ --agent-rules --check`) fails if it
+falls out of sync.
+
+> Amp falls back to `CLAUDE.md` when no `AGENTS.md` is present — RAC generates
+> that target too, so either way Amp sees the decisions.
+
+## 2. Add the `lore` MCP server (the pull)
+
+Amp configures MCP servers under the `amp.mcpServers` key. Add a project-level
+`.amp/settings.json` at the repository root (a sample is in
+[`settings.example.json`](settings.example.json)):
+
+```json
+{
+  "amp.mcpServers": {
+    "lore": {
+      "command": "rac",
+      "args": ["mcp", "--root", "."]
+    }
+  }
+}
+```
+
+- **Project config:** `.amp/settings.json` in the repo root (commit it so the
+  team shares it). Use `"."` for `--root` so it resolves to the repository.
+- **User config:** `~/.config/amp/settings.json` — use an absolute `--root`
+  path there.
+
+This exposes RAC's five read-only `lore` tools to Amp: `get_summary`,
+`search_artifacts`, `get_artifact`, `get_related`, and `find_decisions`. The
+server re-reads the corpus from disk on every call, returns structured JSON
+errors rather than exceptions, and never writes to the repository.
+
+## 3. Verify it
+
+Use the bundled grounding demo to see the difference a connection makes. The
+[`examples/guide/`](../guide/demo.md) demo runs the same coding task twice —
+once with no MCP server and once with `lore` connected — and shows the
+unconnected agent violating a recorded decision that the connected one respects.
+Point Amp at it the same way (its prompt and corpus are client-agnostic), or run
+`rac mcp --root examples/guide` and ask Amp to implement the task in
+`examples/guide/task/`.
+
+## Enforcement is separate, and Amp-agnostic
+
+RAC supplies context and enforces *after* the edit — it does not intercept Amp's
+edit loop (ADR-067). Whatever Amp writes is checked by `rac validate` and
+`rac relationships --validate` (and the GitHub Action / pre-merge gate) the same
+as any other contributor; the trust boundary is human PR review and CI, not the
+agent. The per-edit `rac hook` is specific to Claude Code, so with Amp you rely
+on the CI gate rather than a live pre-edit block — Amp's loop stays untouched and
+adds no latency.
+
+## Summary
+
+| Surface | Command | What Amp does with it |
+| --- | --- | --- |
+| `AGENTS.md` | `rac export rac/ --agent-rules` | Reads it every session — decisions are always in context |
+| `lore` MCP | `.amp/settings.json` → `rac mcp --root .` | Calls `find_decisions` / `get_related` to consult the full corpus on demand |
+| CI gate | `rac validate` · `rac relationships --validate` | Enforces the corpus on every PR, regardless of which agent edited |

--- a/examples/amp/settings.example.json
+++ b/examples/amp/settings.example.json
@@ -1,0 +1,8 @@
+{
+  "amp.mcpServers": {
+    "lore": {
+      "command": "rac",
+      "args": ["mcp", "--root", "."]
+    }
+  }
+}

--- a/examples/claude-code/README.md
+++ b/examples/claude-code/README.md
@@ -1,0 +1,94 @@
+# RAC with Claude Code
+
+[Claude Code](https://docs.anthropic.com/en/docs/claude-code) is RAC's most
+integrated client — it gets the two surfaces every client gets (a generated
+context file + the `lore` MCP server), plus two Claude-Code-specific extras: a
+bundled authoring **skill** and the only platform seam that allows a real
+**pre-edit veto**. A stranger can reproduce this from the file alone.
+
+## Prerequisites
+
+```bash
+pip install requirements-as-code   # the `rac` CLI and the `lore` MCP server
+```
+
+A repository with a RAC corpus under `rac/` (run `rac quickstart`, or use this
+repository's own `rac/`).
+
+## 1. `CLAUDE.md` — context every session (the push)
+
+```bash
+rac export rac/ --agent-rules
+```
+
+Writes the settled decisions into a managed block in `CLAUDE.md` at the repo
+root (your own content outside the block is preserved). Claude Code reads
+`CLAUDE.md` automatically. Re-run on change; `rac export rac/ --agent-rules
+--check` fails CI if it drifts.
+
+## 2. The `lore` MCP server — query on demand (the pull)
+
+```bash
+claude mcp add lore -- rac mcp --root .
+```
+
+…or commit a project-level `.mcp.json` so the team shares it:
+
+```json
+{
+  "mcpServers": {
+    "lore": { "command": "rac", "args": ["mcp", "--root", "."] }
+  }
+}
+```
+
+Exposes the five read-only tools `get_summary`, `search_artifacts`,
+`get_artifact`, `get_related`, `find_decisions`. The server re-reads the corpus
+on every call and never writes to the repo.
+
+## 3. The authoring skill (Claude-Code-specific)
+
+```bash
+rac skill install rac-artifacts
+```
+
+Installs a project skill that teaches Claude Code to create, validate, and
+update RAC artifacts with the `rac` CLI (it only touches the `rac/` subtree).
+`rac skill list` shows the bundled skills (`rac-artifacts`, `rac-import`,
+`rac-ingest`, `rac-review`).
+
+## 4. Enforcement — two seams
+
+RAC supplies context and enforces *after* the edit (ADR-067); it does not rewrite
+Claude Code's loop. Two optional guards:
+
+- **Git hook (any client).** `rac hook install --style pre-commit` validates
+  staged artifacts on commit (`--style post-commit` is an advisory cadence
+  nudge that never blocks). This is a *git* hook, not a Claude Code hook.
+- **Pre-edit veto (Claude-Code-only).** Claude Code's `PreToolUse` hook is the
+  one platform seam that can block an edit *before* it lands. The RAC VS Code /
+  Cursor extension generates it ("RAC: Enable Claude Code pre-edit hook"), or you
+  can register it by hand in `.claude/settings.json` under `hooks.PreToolUse`:
+  it pipes the proposed content to `rac validate - --corpus rac/` and **blocks
+  (exit 2)** only on a structural finding — a reference to a retired or missing
+  decision, or a malformed artifact — and **fails open** on any internal error.
+  All validation stays in `rac`; the hook computes nothing (ADR-063, ADR-067).
+
+Either way, the CI / PR gate (`rac validate`, `rac relationships --validate`)
+remains the backstop, regardless of which agent edited.
+
+## Verify it
+
+Run the bundled grounding demo — same task twice, once unconnected and once with
+`lore` connected — and watch the connected run respect a recorded decision the
+unconnected run violates: [`examples/guide/`](../guide/demo.md).
+
+## Summary
+
+| Surface | Command | What Claude Code does with it |
+| --- | --- | --- |
+| `CLAUDE.md` | `rac export rac/ --agent-rules` | Reads it every session |
+| `lore` MCP | `claude mcp add lore -- rac mcp --root .` | Calls `find_decisions` / `get_related` on demand |
+| Skill | `rac skill install rac-artifacts` | Authors artifacts with the `rac` CLI |
+| Pre-edit veto | `.claude/settings.json` → `PreToolUse` → `rac validate - --corpus rac/` | Blocks an edit that contradicts a decision |
+| CI gate | `rac validate` · `rac relationships --validate` | Enforces on every PR |

--- a/examples/codex/README.md
+++ b/examples/codex/README.md
@@ -1,0 +1,79 @@
+# RAC with Codex
+
+[OpenAI Codex](https://developers.openai.com/codex) (the Codex CLI) consumes RAC
+on the same two surfaces it already supports natively — an `AGENTS.md` it reads
+for project instructions, and MCP servers it connects to — so there is no
+Codex-specific RAC code. A stranger can reproduce this from the file alone.
+
+## Prerequisites
+
+```bash
+pip install requirements-as-code   # the `rac` CLI and the `lore` MCP server
+```
+
+A repository with a RAC corpus under `rac/` (run `rac quickstart`, or use this
+repository's own `rac/`).
+
+## 1. Generate `AGENTS.md` (the push)
+
+Codex reads `AGENTS.md` for project instructions. RAC generates one from your
+recorded decisions:
+
+```bash
+rac export rac/ --agent-rules
+```
+
+Writes `AGENTS.md` at the repo root, in a managed block (your own content is
+preserved). Codex discovers it from the project root; re-run the export when
+decisions change (`rac export rac/ --agent-rules --check` fails CI on drift).
+
+## 2. Add the `lore` MCP server (the pull)
+
+Either use the CLI:
+
+```bash
+codex mcp add lore -- rac mcp --root .
+```
+
+…or add a `[mcp_servers.lore]` table to Codex's `config.toml` (a sample is in
+[`config.example.toml`](config.example.toml)):
+
+```toml
+[mcp_servers.lore]
+command = "rac"
+args = ["mcp", "--root", "."]
+```
+
+- **Global config** (most reliable): `~/.codex/config.toml` — use an absolute
+  `--root` path there.
+- **Project config:** `.codex/config.toml` in the repo root is honoured for
+  *trusted* projects; some Codex surfaces only load the global file, so if the
+  server does not appear, fall back to `~/.codex/config.toml`.
+
+This exposes the five read-only `lore` tools (`get_summary`, `search_artifacts`,
+`get_artifact`, `get_related`, `find_decisions`). The server re-reads the corpus
+on every call and never writes to the repo.
+
+## 3. Enforcement is separate, and Codex-agnostic
+
+RAC supplies context and enforces *after* the edit (ADR-067) — it does not
+intercept Codex's loop. Whatever Codex writes is checked by `rac validate` and
+`rac relationships --validate` (and the GitHub Action / pre-merge gate) the same
+as any other contributor; the trust boundary is human PR review and CI. The
+per-edit pre-edit veto is Claude-Code-specific (see
+[`examples/claude-code/`](../claude-code/README.md)); with Codex you rely on the
+CI gate, which keeps Codex's loop untouched and adds no latency.
+
+## Verify it
+
+Run the bundled grounding demo — same task twice, once unconnected and once with
+`lore` connected — and watch the connected run respect a recorded decision the
+unconnected run violates: [`examples/guide/`](../guide/demo.md).
+
+## Summary
+
+| Surface | Command | What Codex does with it |
+| --- | --- | --- |
+| `AGENTS.md` | `rac export rac/ --agent-rules` | Reads it as project instructions |
+| `lore` MCP | `codex mcp add lore -- rac mcp --root .` | Calls `find_decisions` / `get_related` on demand |
+| CI gate | `rac validate` · `rac relationships --validate` | Enforces on every PR |

--- a/examples/codex/config.example.toml
+++ b/examples/codex/config.example.toml
@@ -1,0 +1,6 @@
+# The `lore` MCP server for OpenAI Codex.
+# Add this to ~/.codex/config.toml (global) or .codex/config.toml (trusted
+# project). Use an absolute path for --root in the global file.
+[mcp_servers.lore]
+command = "rac"
+args = ["mcp", "--root", "."]

--- a/examples/copilot/README.md
+++ b/examples/copilot/README.md
@@ -1,0 +1,74 @@
+# RAC with GitHub Copilot
+
+[GitHub Copilot](https://github.com/features/copilot) in VS Code consumes RAC on
+two surfaces — a generated custom-instructions file Copilot reads, and the `lore`
+MCP server its agent mode connects to. A stranger can reproduce this from the
+file alone.
+
+## Prerequisites
+
+```bash
+pip install requirements-as-code   # the `rac` CLI and the `lore` MCP server
+```
+
+A repository with a RAC corpus under `rac/` (run `rac quickstart`, or use this
+repository's own `rac/`).
+
+## 1. Custom instructions (the push)
+
+```bash
+rac export rac/ --agent-rules
+```
+
+Among the agent-context files this writes is **`.github/copilot-instructions.md`**
+— Copilot's repository custom-instructions file — into a managed block (your own
+content is preserved). Copilot Chat applies it automatically (ensure
+*"Use Instruction Files"* / `github.copilot.chat.codeGeneration.useInstructionFiles`
+is enabled — on by default in recent VS Code). Re-run on change;
+`rac export rac/ --agent-rules --check` fails CI on drift.
+
+## 2. The `lore` MCP server (the pull)
+
+Copilot's **agent mode** uses MCP servers. Add `.vscode/mcp.json` in the repo
+root — note VS Code uses the **`servers`** key (not `mcpServers`); a sample is in
+[`mcp.example.json`](mcp.example.json):
+
+```json
+{
+  "servers": {
+    "lore": {
+      "type": "stdio",
+      "command": "rac",
+      "args": ["mcp", "--root", "."]
+    }
+  }
+}
+```
+
+(Or run **MCP: Open User Configuration** for a user-level server.) Start it from
+the MCP view, then use Copilot Chat in **Agent** mode. It exposes the five
+read-only `lore` tools (`get_summary`, `search_artifacts`, `get_artifact`,
+`get_related`, `find_decisions`); the server re-reads the corpus on every call
+and never writes to the repo.
+
+## 3. Enforcement is separate, and Copilot-agnostic
+
+RAC supplies context and enforces *after* the edit (ADR-067). No platform API
+vetoes a Copilot suggestion before it lands, so Copilot relies on the post-edit
+guard: `rac validate` / `rac relationships --validate` and the GitHub Action /
+pre-merge gate. (The pre-edit veto is Claude-Code-specific — see
+[`examples/claude-code/`](../claude-code/README.md).)
+
+## Verify it
+
+Run the bundled grounding demo — same task twice, once unconnected and once with
+`lore` connected — and watch the connected run respect a recorded decision the
+unconnected run violates: [`examples/guide/`](../guide/demo.md).
+
+## Summary
+
+| Surface | Command | What Copilot does with it |
+| --- | --- | --- |
+| `.github/copilot-instructions.md` | `rac export rac/ --agent-rules` | Applies it as repo custom instructions |
+| `lore` MCP | `.vscode/mcp.json` (`servers`) → `rac mcp --root .` | Agent mode calls `find_decisions` / `get_related` on demand |
+| CI gate | `rac validate` · `rac relationships --validate` | Enforces on every PR |

--- a/examples/copilot/mcp.example.json
+++ b/examples/copilot/mcp.example.json
@@ -1,0 +1,9 @@
+{
+  "servers": {
+    "lore": {
+      "type": "stdio",
+      "command": "rac",
+      "args": ["mcp", "--root", "."]
+    }
+  }
+}

--- a/examples/cursor/README.md
+++ b/examples/cursor/README.md
@@ -1,0 +1,76 @@
+# RAC with Cursor
+
+[Cursor](https://cursor.com) consumes RAC on two surfaces — a generated context
+file Cursor reads, and the `lore` MCP server it connects to. A stranger can
+reproduce this from the file alone.
+
+## Prerequisites
+
+```bash
+pip install requirements-as-code   # the `rac` CLI and the `lore` MCP server
+```
+
+A repository with a RAC corpus under `rac/` (run `rac quickstart`, or use this
+repository's own `rac/`).
+
+## 1. Context file (the push)
+
+```bash
+rac export rac/ --agent-rules
+```
+
+This writes several agent-context files, two of which Cursor reads:
+
+- **`AGENTS.md` (recommended).** Cursor reads `AGENTS.md` at the project root as
+  plain instructions — the simplest, glob-free path, and the one to rely on here.
+- **`.cursor/rules`.** RAC also writes this legacy single rules file. Modern
+  Cursor's rules system is a `.cursor/rules/*.mdc` *directory* with metadata
+  (`description`/`globs`/`alwaysApply`), so the single-file form may be ignored by
+  current Cursor — prefer `AGENTS.md` above until RAC emits an `.mdc` rule. Either
+  way the decisions reach Cursor through `AGENTS.md`.
+
+The managed block keeps your own content intact; re-run on change
+(`rac export rac/ --agent-rules --check` fails CI on drift).
+
+## 2. The `lore` MCP server (the pull)
+
+Add `.cursor/mcp.json` in the repo root (project-scoped; a sample is in
+[`mcp.example.json`](mcp.example.json)):
+
+```json
+{
+  "mcpServers": {
+    "lore": { "command": "rac", "args": ["mcp", "--root", "."] }
+  }
+}
+```
+
+- **Project:** `.cursor/mcp.json` (commit it to share with the team).
+- **Global:** `~/.cursor/mcp.json` — use an absolute `--root` path.
+
+Enable the server in Cursor's MCP settings if prompted. It exposes the five
+read-only `lore` tools (`get_summary`, `search_artifacts`, `get_artifact`,
+`get_related`, `find_decisions`); the server re-reads the corpus on every call
+and never writes to the repo.
+
+## 3. Enforcement is separate, and Cursor-agnostic
+
+RAC supplies context and enforces *after* the edit (ADR-067). There is no
+platform API to veto a Cursor agent edit before it lands, so Cursor relies on the
+post-edit guard: `rac validate` / `rac relationships --validate` and the GitHub
+Action / pre-merge gate, the same as any contributor. (The pre-edit veto is
+Claude-Code-specific — see [`examples/claude-code/`](../claude-code/README.md).)
+
+## Verify it
+
+Run the bundled grounding demo — same task twice, once unconnected and once with
+`lore` connected — and watch the connected run respect a recorded decision the
+unconnected run violates: [`examples/guide/`](../guide/demo.md).
+
+## Summary
+
+| Surface | Command | What Cursor does with it |
+| --- | --- | --- |
+| `AGENTS.md` | `rac export rac/ --agent-rules` | Reads it as project instructions |
+| `lore` MCP | `.cursor/mcp.json` → `rac mcp --root .` | Calls `find_decisions` / `get_related` on demand |
+| CI gate | `rac validate` · `rac relationships --validate` | Enforces on every PR |

--- a/examples/cursor/mcp.example.json
+++ b/examples/cursor/mcp.example.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "lore": {
+      "command": "rac",
+      "args": ["mcp", "--root", "."]
+    }
+  }
+}


### PR DESCRIPTION
## Client integration examples + ecosystem entries

Worked, reproducible setups for connecting RAC to the major coding agents, each
listed in `docs/ecosystem.md` pointing at a concrete `examples/` directory (so
the entries meet the list's "exists and is inspectable" criterion). The same
two-surface story underlies all five — a generated context file (push) and the
`lore` MCP server (pull) — with no client-specific RAC code. These five cover
every agent-context target RAC already generates (`AGENTS.md`, `CLAUDE.md`,
`.cursor/rules`, `.github/copilot-instructions.md`).

| Example | Context file (push) | MCP (pull) | Notes |
| --- | --- | --- | --- |
| `examples/amp/` | `AGENTS.md` | `amp.mcpServers` in `.amp/settings.json` | + `settings.example.json` |
| `examples/claude-code/` | `CLAUDE.md` | `claude mcp add` / `.mcp.json` | + `rac-artifacts` skill + the `PreToolUse` **pre-edit veto** (`rac validate - --corpus`) — the only client with a real pre-edit block |
| `examples/codex/` | `AGENTS.md` | `[mcp_servers.lore]` in `config.toml` / `codex mcp add` | + `config.example.toml`; global-vs-trusted-project note |
| `examples/cursor/` | `AGENTS.md` (recommended) | `mcpServers` in `.cursor/mcp.json` | Cursor's rules moved to `.cursor/rules/*.mdc`, so the legacy `.cursor/rules` file is a fallback — `AGENTS.md` is the lead |
| `examples/copilot/` | `.github/copilot-instructions.md` | **`servers`** in `.vscode/mcp.json` (not `mcpServers`) | agent mode |

### Accuracy notes
- Each config was checked against the vendor's current docs (Amp manual, Codex
  config reference, Cursor docs, VS Code MCP docs). VS Code uses `servers`;
  Cursor's rules format changed; Codex config is global-vs-project-scoped.
- Enforcement is consistently framed as context-supply + post-edit CI gate
  (ADR-067); the pre-edit veto is called out as Claude-Code-specific, and
  `rac hook` is clarified as a *git* hook (distinct from that veto).

### Scope
Docs/examples only — nothing under `rac/` or `src/`, so the corpus gates and the
package are untouched. Ecosystem links are absolute URLs, so the strict docs
build is unaffected.