### PR TITLE
docs(roadmap): mark shipped historical roadmaps Achieved

### DIFF
--- a/rac/roadmaps/v0.10.x-guide/v0.10.0-guide-foundation.md
+++ b/rac/roadmaps/v0.10.x-guide/v0.10.0-guide-foundation.md
@@ -7,7 +7,7 @@ type: roadmap
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/rac/roadmaps/v0.10.x-guide/v0.10.1-guide-onboarding.md
+++ b/rac/roadmaps/v0.10.x-guide/v0.10.1-guide-onboarding.md
@@ -7,7 +7,7 @@ type: roadmap
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/rac/roadmaps/v0.10.x-guide/v0.10.2-guide-grounding-demo.md
+++ b/rac/roadmaps/v0.10.x-guide/v0.10.2-guide-grounding-demo.md
@@ -7,7 +7,7 @@ type: roadmap
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/rac/roadmaps/v0.10.x-guide/v0.10.3-search-quality.md
+++ b/rac/roadmaps/v0.10.x-guide/v0.10.3-search-quality.md
@@ -7,7 +7,7 @@ type: roadmap
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/rac/roadmaps/v0.10.x-guide/v0.10.4-guide-telemetry.md
+++ b/rac/roadmaps/v0.10.x-guide/v0.10.4-guide-telemetry.md
@@ -7,7 +7,7 @@ type: roadmap
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/rac/roadmaps/v0.10.x-guide/v0.10.5-bundled-agent-skill.md
+++ b/rac/roadmaps/v0.10.x-guide/v0.10.5-bundled-agent-skill.md
@@ -5,6 +5,10 @@ type: roadmap
 ---
 # v0.10.5 — Bundled Agent Skill
 
+## Status
+
+Achieved
+
 ## Outcomes
 
 - A host project can obtain the `rac-artifacts` Claude Code skill from

--- a/rac/roadmaps/v0.10.x-guide/v0.10.5-review-and-ingest-skills.md
+++ b/rac/roadmaps/v0.10.x-guide/v0.10.5-review-and-ingest-skills.md
@@ -5,6 +5,10 @@ type: roadmap
 ---
 # v0.10.5 — Review and Ingest Skills
 
+## Status
+
+Achieved
+
 ## Outcomes
 
 - An agent in a host project has bundled procedures for the two

--- a/rac/roadmaps/v0.10.x-guide/v0.10.6-anonymous-usage-sharing.md
+++ b/rac/roadmaps/v0.10.x-guide/v0.10.6-anonymous-usage-sharing.md
@@ -7,7 +7,7 @@ type: roadmap
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/rac/roadmaps/v0.11.x-portal/v0.11.0-portal-export.md
+++ b/rac/roadmaps/v0.11.x-portal/v0.11.0-portal-export.md
@@ -7,7 +7,7 @@ type: roadmap
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/rac/roadmaps/v0.11.x-portal/v0.11.1-docs-site.md
+++ b/rac/roadmaps/v0.11.x-portal/v0.11.1-docs-site.md
@@ -7,7 +7,7 @@ type: roadmap
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/rac/roadmaps/v0.12.x-watchkeeper/v0.12.0-repository-review.md
+++ b/rac/roadmaps/v0.12.x-watchkeeper/v0.12.0-repository-review.md
@@ -7,7 +7,7 @@ type: roadmap
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/rac/roadmaps/v0.12.x-watchkeeper/v0.12.1-intent-analysis.md
+++ b/rac/roadmaps/v0.12.x-watchkeeper/v0.12.1-intent-analysis.md
@@ -7,7 +7,7 @@ type: roadmap
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/rac/roadmaps/v0.12.x-watchkeeper/v0.12.2-watchkeeper.md
+++ b/rac/roadmaps/v0.12.x-watchkeeper/v0.12.2-watchkeeper.md
@@ -7,7 +7,7 @@ type: roadmap
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/rac/roadmaps/v0.12.x-watchkeeper/v0.12.3-watchkeeper-action.md
+++ b/rac/roadmaps/v0.12.x-watchkeeper/v0.12.3-watchkeeper-action.md
@@ -7,7 +7,7 @@ type: roadmap
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/rac/roadmaps/v0.13.x-welcome/v0.13.0-guided-first-run.md
+++ b/rac/roadmaps/v0.13.x-welcome/v0.13.0-guided-first-run.md
@@ -7,7 +7,7 @@ type: roadmap
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/rac/roadmaps/v0.13.x-welcome/v0.13.1-friendly-empty-corpus.md
+++ b/rac/roadmaps/v0.13.x-welcome/v0.13.1-friendly-empty-corpus.md
@@ -7,7 +7,7 @@ type: roadmap
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/rac/roadmaps/v0.13.x-welcome/v0.13.2-git-recency.md
+++ b/rac/roadmaps/v0.13.x-welcome/v0.13.2-git-recency.md
@@ -7,7 +7,7 @@ type: roadmap
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/rac/roadmaps/v0.13.x-welcome/v0.13.3-cadence-nudge.md
+++ b/rac/roadmaps/v0.13.x-welcome/v0.13.3-cadence-nudge.md
@@ -7,7 +7,7 @@ type: roadmap
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/rac/roadmaps/v0.13.x-welcome/v0.13.4-commit-nudge.md
+++ b/rac/roadmaps/v0.13.x-welcome/v0.13.4-commit-nudge.md
@@ -7,7 +7,7 @@ type: roadmap
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/rac/roadmaps/v0.13.x-welcome/v0.13.5-self-type-relationships.md
+++ b/rac/roadmaps/v0.13.x-welcome/v0.13.5-self-type-relationships.md
@@ -7,7 +7,7 @@ type: roadmap
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/rac/roadmaps/v0.13.x-welcome/v0.13.6-okf-bundle-export.md
+++ b/rac/roadmaps/v0.13.x-welcome/v0.13.6-okf-bundle-export.md
@@ -7,7 +7,7 @@ type: roadmap
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/rac/roadmaps/v0.14.x-enforcement/v0.14.0-enforcement-foundation.md
+++ b/rac/roadmaps/v0.14.x-enforcement/v0.14.0-enforcement-foundation.md
@@ -7,7 +7,7 @@ type: roadmap
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/rac/roadmaps/v0.14.x-enforcement/v0.14.1-status-consistency.md
+++ b/rac/roadmaps/v0.14.x-enforcement/v0.14.1-status-consistency.md
@@ -7,7 +7,7 @@ type: roadmap
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/rac/roadmaps/v0.15.x-interop/v0.15.0-okf-frontmatter-superset.md
+++ b/rac/roadmaps/v0.15.x-interop/v0.15.0-okf-frontmatter-superset.md
@@ -8,7 +8,7 @@ tags: [okf, interop]
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/rac/roadmaps/v0.15.x-interop/v0.15.1-okf-conformance-check.md
+++ b/rac/roadmaps/v0.15.x-interop/v0.15.1-okf-conformance-check.md
@@ -8,7 +8,7 @@ tags: [okf, interop, enforcement]
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/rac/roadmaps/v0.15.x-interop/v0.15.2-validation-overrides-and-sarif.md
+++ b/rac/roadmaps/v0.15.x-interop/v0.15.2-validation-overrides-and-sarif.md
@@ -8,7 +8,7 @@ tags: [validation, ci, onboarding, interop]
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/rac/roadmaps/v0.16.x-graph-integrity/v0.16.0-relationship-graph-integrity.md
+++ b/rac/roadmaps/v0.16.x-graph-integrity/v0.16.0-relationship-graph-integrity.md
@@ -8,7 +8,7 @@ tags: [relationships, enforcement, graph, lifecycle]
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/rac/roadmaps/v0.17.x-adoption/v0.17.0-single-document-import-skill.md
+++ b/rac/roadmaps/v0.17.x-adoption/v0.17.0-single-document-import-skill.md
@@ -8,7 +8,7 @@ tags: [skills, onboarding, adoption]
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/rac/roadmaps/v0.17.x-adoption/v0.17.1-per-type-standards-enforcement.md
+++ b/rac/roadmaps/v0.17.x-adoption/v0.17.1-per-type-standards-enforcement.md
@@ -8,7 +8,7 @@ tags: [standards, requirements, prompts, enforcement]
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/rac/roadmaps/v0.17.x-adoption/v0.17.2-ci-action-and-dx.md
+++ b/rac/roadmaps/v0.17.x-adoption/v0.17.2-ci-action-and-dx.md
@@ -8,7 +8,7 @@ tags: [ci, distribution, dx, sarif]
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/rac/roadmaps/v0.18.x-engine-health/v0.18.0-engine-simplification.md
+++ b/rac/roadmaps/v0.18.x-engine-health/v0.18.0-engine-simplification.md
@@ -7,7 +7,7 @@ type: roadmap
 
 ## Status
 
-Planned
+Achieved
 
 ## Outcomes
 

--- a/rac/roadmaps/v0.19.x-lifecycle/v0.19.0-roadmap-achieved-status.md
+++ b/rac/roadmaps/v0.19.x-lifecycle/v0.19.0-roadmap-achieved-status.md
@@ -7,7 +7,7 @@ type: roadmap
 
 ## Status
 
-Planned
+Achieved
 
 ## Outcomes
 

--- a/rac/roadmaps/v0.20.x-sdk/v0.20.0-python-sdk-foundation.md
+++ b/rac/roadmaps/v0.20.x-sdk/v0.20.0-python-sdk-foundation.md
@@ -8,7 +8,7 @@ tags: [sdk, api, packaging]
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/rac/roadmaps/v0.20.x-sdk/v0.20.1-python-sdk-docs.md
+++ b/rac/roadmaps/v0.20.x-sdk/v0.20.1-python-sdk-docs.md
@@ -8,7 +8,7 @@ tags: [sdk, docs]
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/rac/roadmaps/v0.7.x-trust/v0.7.10-artifact-templates.md
+++ b/rac/roadmaps/v0.7.x-trust/v0.7.10-artifact-templates.md
@@ -7,7 +7,7 @@ type: roadmap
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/rac/roadmaps/v0.7.x-trust/v0.7.13-metadata-migration.md
+++ b/rac/roadmaps/v0.7.x-trust/v0.7.13-metadata-migration.md
@@ -7,7 +7,7 @@ type: roadmap
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/rac/roadmaps/v0.7.x-trust/v0.7.14-audit-hardening.md
+++ b/rac/roadmaps/v0.7.x-trust/v0.7.14-audit-hardening.md
@@ -7,7 +7,7 @@ type: roadmap
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/rac/roadmaps/v0.7.x-trust/v0.7.5-repo-indexing.md
+++ b/rac/roadmaps/v0.7.x-trust/v0.7.5-repo-indexing.md
@@ -5,6 +5,10 @@ type: roadmap
 ---
 # RAC v0.7.5 — Repository Index
 
+## Status
+
+Achieved
+
 ## Context
 
 Previous v0.7 releases introduced repository-level intelligence:

--- a/rac/roadmaps/v0.7.x-trust/v0.7.9-repository-review.md
+++ b/rac/roadmaps/v0.7.x-trust/v0.7.9-repository-review.md
@@ -5,6 +5,10 @@ type: roadmap
 ---
 # RAC v0.7.9 — Repository Review
 
+## Status
+
+Achieved
+
 ## Problem
 
 RAC's repository intelligence exists as separate commands (`validate`, `relationships`,

--- a/rac/roadmaps/v0.8.x-explorer/v0.8.0-explorer-foundation.md
+++ b/rac/roadmaps/v0.8.x-explorer/v0.8.0-explorer-foundation.md
@@ -7,7 +7,7 @@ type: roadmap
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/rac/roadmaps/v0.8.x-explorer/v0.8.1-explorer-navigation.md
+++ b/rac/roadmaps/v0.8.x-explorer/v0.8.1-explorer-navigation.md
@@ -7,7 +7,7 @@ type: roadmap
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/rac/roadmaps/v0.8.x-explorer/v0.8.10-explorer-create-and-stats.md
+++ b/rac/roadmaps/v0.8.x-explorer/v0.8.10-explorer-create-and-stats.md
@@ -7,7 +7,7 @@ type: roadmap
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/rac/roadmaps/v0.8.x-explorer/v0.8.11-explorer-followups.md
+++ b/rac/roadmaps/v0.8.x-explorer/v0.8.11-explorer-followups.md
@@ -7,7 +7,7 @@ type: roadmap
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/rac/roadmaps/v0.8.x-explorer/v0.8.12-explorer-mascot-interaction.md
+++ b/rac/roadmaps/v0.8.x-explorer/v0.8.12-explorer-mascot-interaction.md
@@ -7,7 +7,7 @@ type: roadmap
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/rac/roadmaps/v0.8.x-explorer/v0.8.13-explorer-knowledge-graph-grammar.md
+++ b/rac/roadmaps/v0.8.x-explorer/v0.8.13-explorer-knowledge-graph-grammar.md
@@ -7,7 +7,7 @@ type: roadmap
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/rac/roadmaps/v0.8.x-explorer/v0.8.2-explorer-health.md
+++ b/rac/roadmaps/v0.8.x-explorer/v0.8.2-explorer-health.md
@@ -7,7 +7,7 @@ type: roadmap
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/rac/roadmaps/v0.8.x-explorer/v0.8.3-explorer-recommendations.md
+++ b/rac/roadmaps/v0.8.x-explorer/v0.8.3-explorer-recommendations.md
@@ -7,7 +7,7 @@ type: roadmap
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/rac/roadmaps/v0.8.x-explorer/v0.8.4-explorer-action-workflow.md
+++ b/rac/roadmaps/v0.8.x-explorer/v0.8.4-explorer-action-workflow.md
@@ -7,7 +7,7 @@ type: roadmap
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/rac/roadmaps/v0.8.x-explorer/v0.8.5-explorer-relationship-navigation.md
+++ b/rac/roadmaps/v0.8.x-explorer/v0.8.5-explorer-relationship-navigation.md
@@ -7,7 +7,7 @@ type: roadmap
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/rac/roadmaps/v0.8.x-explorer/v0.8.6-explorer-maturity.md
+++ b/rac/roadmaps/v0.8.x-explorer/v0.8.6-explorer-maturity.md
@@ -7,7 +7,7 @@ type: roadmap
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/rac/roadmaps/v0.8.x-explorer/v0.8.7-explorer-visual-overhaul.md
+++ b/rac/roadmaps/v0.8.x-explorer/v0.8.7-explorer-visual-overhaul.md
@@ -7,7 +7,7 @@ type: roadmap
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/rac/roadmaps/v0.8.x-explorer/v0.8.8-explorer-command-palette.md
+++ b/rac/roadmaps/v0.8.x-explorer/v0.8.8-explorer-command-palette.md
@@ -7,7 +7,7 @@ type: roadmap
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/rac/roadmaps/v0.8.x-explorer/v0.8.9-explorer-live-workspace.md
+++ b/rac/roadmaps/v0.8.x-explorer/v0.8.9-explorer-live-workspace.md
@@ -7,7 +7,7 @@ type: roadmap
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 


### PR DESCRIPTION
## What

Flip the lifecycle status of delivered roadmaps that predate the `Achieved` terminal state (ADR-061, introduced in v0.19.0) and were never retroactively updated, so the corpus stops reading shipped work as still `Planned`.

- **49** roadmaps moved `Planned → Achieved`
- **4** status-less roadmaps gained a `## Status: Achieved` section
- Covers the **v0.7.x–v0.20.x** series plus **v0.19.0** itself

Each item was verified delivered against the changelog and the shipped product before flipping — this is not a bulk sed.

## Result

| Status | Before | After |
| --- | --- | --- |
| Achieved | 32 | 85 |
| Planned | 52 | 3 |
| no status | 4 | 0 |
| Abandoned | 1 | 1 |

(versioned roadmaps; `future/` and `archive/` untouched)

## Deliberately left `Planned` — genuinely not delivered

- **`v0.21.10-marketplace-publish`** — the VS Code extension publish is a manual, human-owned step with no evidence it has run; every *other* v0.21.x item is already Achieved, and the changelog notes "only the actual publish step remains manual."
- **`v0.22.6-split-actions`** — explicitly deferred/parked in its own body ("this item is parked, not incomplete or abandoned").
- **`v0.27.0-calver-cutover`** — the `2026.6.1` release is not yet published.

These three are now the corpus's precise, honest backlog.

## Gates

- `rac validate rac/` — pass (271 valid, 0 invalid)
- `rac relationships rac/ --validate` — pass (0 issues)
- `rac review rac/` — no priority 1–2 findings (health 92/100, unchanged)

Per ADR-061, `Achieved` is a manual editorial knowledge-lifecycle marker set by a human at release — this PR is that catch-up edit for the releases that shipped before the status existed.