### PR TITLE
docs(changelog): retitle the first CalVer entry 2026.06.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,13 @@ User-visible changes to RAC, by release. Follows the spirit of
 [Keep a Changelog](https://keepachangelog.com/): user impact over implementation
 details, release history over commit history.
 
-## 2026.06.1
+## 2026.06.4 — the "unlock" release
 
 The first release under **CalVer** (`YYYY.MM.N`, ADR-076): RAC's version now says
 *when* a build was cut, not a SemVer compatibility claim it never kept.
 Compatibility lives on `schema_version` (ADR-007); the roadmap `vX.Y.Z` numbers
 continue as internal planning scope-fences. This is a one-way cutover — every
-prior `vX.Y.Z` tag is retained, and `2026.06.1` supersedes `v0.19.0` as the
+prior `vX.Y.Z` tag is retained, and `2026.06.4` supersedes `v0.19.0` as the
 latest release. It also ships the user-facing work accumulated across the
 v0.23–v0.26 scope-fences:
 


### PR DESCRIPTION
## Why

The `2026.6.4` release publish failed at the `verify-release` gate:

```
✗ release 2026.6.4 rejected:
  - version '2026.6.4' is not a canonical CalVer release identifier
    (expected YYYY.MM.N, zero-padded month, counter from 1)
```

Two things were off, and this PR fixes the one in the repo:

1. **Tag form** — the tag was `2026.6.4`; the gate requires the zero-padded `2026.06.4` (ADR-076). *Fixed by re-tagging — see below, not in this PR.*
2. **Changelog heading** — `CHANGELOG.md` carried `## 2026.06.1`, so even a correctly-padded tag would then fail `changelog_has_entry` (REQ-005). **This PR retitles the consolidated first-CalVer entry to `## 2026.06.4`** (heading + one prose reference). The earlier `.1`–`.3` counters were consumed by unpublished tag attempts; `.4` is the first that publishes.

## Verification

```
$ python -m rac.release "2026.06.4" CHANGELOG.md
✓ release 2026.06.4 is well-formed and has a changelog entry
$ python -m rac.release "2026.6.4" CHANGELOG.md
✗ release 2026.6.4 rejected: ... (gate still strict — by design)
```

## To finish the release (after this merges)

Re-cut the tag in canonical form on the new `main` HEAD:

```bash
git tag -d 2026.6.4 && git push origin :refs/tags/2026.6.4   # remove the bad tag
# delete the GitHub Release for 2026.6.4 in the UI, then create a new
# Release with tag  2026.06.4  on the latest main commit
```

setuptools-scm normalizes the build to `2026.6.4` for PyPI regardless, so the published package version is unchanged — only the git tag carries the canonical zero-padded form the gate enforces.