### PR TITLE
docs(roadmap): mark v0.27.0 CalVer cutover Achieved

### DIFF
--- a/rac/roadmaps/v0.27.x-calver/v0.27.0-calver-cutover.md
+++ b/rac/roadmaps/v0.27.x-calver/v0.27.0-calver-cutover.md
@@ -7,7 +7,7 @@ type: roadmap
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 


### PR DESCRIPTION
## What

Flip `v0.27.0-calver-cutover` from `Planned` to the `Achieved` terminal state (ADR-061).

The cutover is now genuinely delivered: **`2026.06.4` is published to PyPI** — `requirements_as_code-2026.6.4` (wheel + sdist, uploaded 2026-06-23T06:34:33Z), license **Apache-2.0**, and it supersedes `v0.19.0` as the latest release.

This was the last open item from the active roadmap. The only versioned roadmaps still `Planned` are the two deliberately-deferred ones (`v0.21.10-marketplace-publish`, `v0.22.6-split-actions`).

## Gates

- `rac validate rac/` — pass (271 valid, 0 invalid)
- `rac relationships rac/ --validate` — pass (0 issues)