### PR TITLE
docs(roadmap): scope v0.28.0 relationship link suggestions

### DIFF
--- a/rac/decisions/adr-077-suggested-relationship-edges-advisory.md
+++ b/rac/decisions/adr-077-suggested-relationship-edges-advisory.md
@@ -1,0 +1,116 @@
+---
+schema_version: 1
+id: RAC-KVSNP0M66V2V
+type: decision
+---
+# ADR-077: Suggested Relationship Edges Are Advisory and Never Auto-Applied
+
+## Context
+
+RAC's relationship graph is authoritative because every edge is *declared* in a
+`## Related <Type>` section and *validated* — the export surfaces "RAC's
+validated decision graph rather than one inferred from prose" (ADR-074). That
+property is the product: agents and backends trust the graph precisely because a
+human wrote and reviewed each edge (ADR-065 — artifact content is untrusted
+until human PR review makes it authoritative).
+
+But the same property leaves a gap. Artifacts constantly name each other in
+prose — an ADR id, a requirement, a design slug — without a matching declared
+edge. The link is real and intended; the graph just doesn't carry it. `rac
+doctor` already finds orphans (nothing links *to* an artifact) but cannot find a
+link the author plainly meant and merely forgot to promote.
+
+A tempting fix is to do what general agent-memory tools (e.g. GBrain) do:
+deterministically scan text and *auto-wire* the edges. RAC must not — auto-wired
+edges are exactly the "inferred from prose" graph ADR-074 rejects, and they
+would bypass the human-review trust boundary (ADR-065). Equally, RAC must not
+reach for an LLM to judge whether two artifacts are related: the core is
+AI-optional and offline (ADR-002), and grounding stays deterministic with no
+embeddings or LLM judge (ADR-066). The open question is how to close the gap
+*without* crossing either line.
+
+## Decision
+
+RAC adds a deterministic detector that surfaces **mentioned-but-unlinked
+references** — body references to other artifacts that are not present in the
+source artifact's declared `## Related` sections — as **advisory suggestions**,
+under three firm boundaries:
+
+- **Suggest, never apply.** The detector reports a candidate edge and the
+  `## Related <Type>` line that would capture it. It never creates, writes, or
+  modifies an edge. A human promotes a suggestion through normal review. The
+  declared `## Related` sections remain the single source of truth for the graph
+  (ADR-074); what is inferred is a *suggestion*, never an *edge*.
+- **Deterministic, no AI.** Matching reuses the existing reference resolver and
+  token-boundary matching (ADR-037): canonical ids, declared aliases, and
+  filename-style references only. No model, embedding, or network call enters
+  the path (ADR-002, ADR-066). Identical corpora produce byte-identical
+  findings.
+- **Advisory, never a gate.** Findings are warnings that exit zero. A
+  mentioned-but-unlinked reference does not fail `rac validate` or
+  `rac relationships --validate` and cannot block a merge on its own, so an
+  intentional prose mention is never *forced* to become a declared edge.
+
+## Consequences
+
+The validated graph gains a completeness signal — a worklist of links the text
+already implies — without losing the property that makes it trustworthy: every
+edge that exists is still human-declared and validated. The detector is the
+deterministic, in-domain half of what auto-wiring tools do, kept on RAC's side
+of the inference line.
+
+Trade-offs accepted: the detector can produce false positives (a body may name
+an artifact it is not "related" to in the graph sense); this is mitigated by
+high-precision id/alias/filename matching and by advisory-only severity, so a
+false positive costs a glance, never a bad edge. Title-based matching is
+deliberately out of scope at first because titles are prose-like and noisy (a
+deferred question, not a hard exclusion). Because suggestions are not applied,
+the graph never improves on its own — closing a suggestion is always a human
+edit, which is the point.
+
+## Status
+
+Proposed
+
+## Category
+
+Architecture
+
+## Alternatives Considered
+
+- **Auto-create the edges from prose.** Rejected: this is the "inferred from
+  prose" graph ADR-074 rejects, and it bypasses the human-review trust boundary
+  (ADR-065). An edge nobody reviewed is not a validated edge.
+- **Use an LLM to suggest related artifacts.** Rejected: non-deterministic and
+  contrary to the AI-optional, offline core (ADR-002) and the no-embeddings,
+  no-LLM-judge grounding stance (ADR-066). Deterministic id/alias matching is
+  the reusable, testable piece RAC is uniquely placed to own.
+- **Make a mentioned-but-unlinked reference a validation error.** Rejected: it
+  would force every prose mention to become a declared edge, erasing the
+  author's intent (a body may legitimately name an artifact without a graph
+  relationship) and turning a helpful nudge into a merge blocker (against the
+  gate discipline of ADR-075).
+- **Do nothing; rely on manual review.** Rejected: the orphan check already
+  shows the value of surfacing graph gaps, and this gap — a link the author
+  already wrote in prose — is the most recoverable of all. Leaving it manual
+  forgoes a deterministic, low-cost win.
+
+## Related Decisions
+
+- adr-074
+- adr-065
+- adr-066
+- adr-002
+- adr-037
+
+## Related Requirements
+
+- rac-unlinked-reference-detection
+
+## Related Designs
+
+- mentioned-but-unlinked-detection
+
+## Related Roadmaps
+
+- v0.28.0-link-suggestions

--- a/rac/decisions/adr-082-suggested-relationship-edges-advisory.md
+++ b/rac/decisions/adr-082-suggested-relationship-edges-advisory.md
@@ -3,7 +3,7 @@ schema_version: 1
 id: RAC-KVSNP0M66V2V
 type: decision
 ---
-# ADR-077: Suggested Relationship Edges Are Advisory and Never Auto-Applied
+# ADR-082: Suggested Relationship Edges Are Advisory and Never Auto-Applied
 
 ## Context
 

--- a/rac/designs/mentioned-but-unlinked-detection.md
+++ b/rac/designs/mentioned-but-unlinked-detection.md
@@ -1,0 +1,177 @@
+---
+schema_version: 1
+id: RAC-KVSNP20PPZ15
+type: design
+---
+# Mentioned-but-Unlinked Reference Detection
+
+## Context
+
+This design is the *how* for the `rac-unlinked-reference-detection` requirement
+and the boundary ADR-077 draws: surface body references to other artifacts that
+are not declared as `## Related` edges, as advisory suggestions, deterministically,
+without ever auto-applying an edge.
+
+The machinery already exists in spirit. `services/relationships.py` builds the
+declared graph — it parses each `## Related <Type>` section into resolved
+`Relationship` edges and already powers orphan detection in `rac doctor`. The
+reference resolver (`rac resolve`) and token-boundary matching (ADR-037) already
+turn a token like `adr-074` into a known artifact without substring false
+positives. This design reuses both for a new axis: instead of "which declared
+edges exist," it asks "which artifacts does the *body* name that the declared
+edges miss."
+
+**Prior art.** Zero-LLM, deterministic edge extraction from Markdown text is the
+mechanism behind general agent-memory tools such as GBrain. RAC adopts the
+*detection* (pure string/id matching, no model) but not the *auto-wiring*: the
+output is a suggestion a human promotes, never an edge the tool writes (ADR-077).
+
+## User Need
+
+A corpus maintainer wants the declared graph to be as complete as the prose
+already implies — without hand-scanning every artifact for links they forgot to
+promote. They need a check that says, in plain terms, "this artifact's body
+mentions ADR-074 but has no `## Related Decisions` link to it — add one?" and
+gives them a paste-ready line to do it. The agents and backends that consume the
+graph need the same thing indirectly: a denser, still-validated graph.
+
+The check must never act on its own (the maintainer decides), never block CI,
+and never depend on a model or network — it has to run in the same offline,
+deterministic pass as the rest of `rac doctor`.
+
+## Design
+
+### What counts as a mention
+
+For a source artifact `A`, a *mention* is a token in `A`'s body that resolves —
+via the same resolver `rac relationships --validate` uses — to a corpus artifact
+`B`, where `B != A` and `B` is not already a declared `## Related` target of `A`.
+
+Matched reference forms (high precision, deterministic):
+
+- **Canonical ids** — `RAC-XXXXXXXX`.
+- **Filename-style references** — `<letters>-<digits>` prefixes such as
+  `adr-074`, and artifact filename stems used as refs.
+- **Declared aliases** — any alias an artifact registers for resolution.
+
+Title text is **not** matched in this design (titles are prose-like and noisy);
+that is an Open Question, not part of the shipped matcher.
+
+### What is scanned, and what is excluded
+
+The body is taken from the parsed Markdown AST (`core/markdown.py`), reusing the
+single shared parser. Excluded from matching, so they cannot produce a finding:
+
+- the YAML frontmatter block (identity, not prose);
+- the `## Related <Type>` sections themselves (their references are the declared
+  edges, not mentions);
+- fenced code blocks (a code sample's contents must not masquerade as a
+  reference — the same exclusion the parser already applies for structural
+  scanning);
+- the artifact's own id/aliases (no self-references).
+
+### The finding
+
+One finding per `(A, B)` pair, regardless of how many times `A`'s body names
+`B`. Each finding carries:
+
+- the source artifact (`A`),
+- the matched target (`B`) and the token that matched,
+- the `## Related <Type>` section that would capture the edge, derived from
+  `B`'s type via the relationship-type registry (ADR-055) — a decision target
+  maps to `## Related Decisions`, a requirement to `## Related Requirements`,
+  and so on,
+- a paste-ready suggested line (for example `- adr-074` under
+  `## Related Decisions`).
+
+Findings are **advisory**: a new `rac doctor` finding code
+(`unlinked-reference`) alongside the existing `orphaned-artifact` /
+`high-fan-out-hub` warnings, all of which exit zero. The detection logic lives in
+a service function that returns the finding set; `rac doctor` is the first
+surface. `rac coverage` is a candidate second surface (a mentioned-but-unlinked
+reference is also a graph-completeness gap) and is left as an Open Question so
+the first release ships one clear home.
+
+### Determinism
+
+The function is pure over corpus bytes: same corpus, byte-identical findings,
+proven by golden tests. Output is sorted (by source path, then target id) so
+diffs are stable. No model, embedding, or network call is on the path
+(ADR-002, ADR-066).
+
+## Constraints
+
+- Offline, AI-optional (ADR-002) and deterministic with no embeddings or LLM
+  judge (ADR-066): pure function of corpus bytes.
+- Suggest, never apply (ADR-077): the detector emits findings only; it never
+  writes an edge. The declared `## Related` sections stay the source of truth
+  (ADR-074), and promotion stays a human review act (ADR-065).
+- Advisory severity (ADR-075 gate discipline): findings exit zero and never
+  change the `rac validate` / `rac relationships --validate` contract.
+- Reuse, don't reinvent: the resolver, token-boundary matcher, relationship
+  index, and Markdown parser are shared with the existing relationship and
+  doctor code, not duplicated.
+
+## Rationale
+
+Matching on ids, aliases, and filename refs — not titles or free text — is what
+keeps the detector trustworthy without a model: these forms resolve
+unambiguously through the same machinery validation already trusts, so a match
+is a real reference, not a guess. Routing the output through `rac doctor` as an
+advisory reuses the paste-ready-fix UX users already know and keeps the feature
+on the correct side of every recorded boundary: it makes the *validated* graph
+more complete instead of replacing it with an inferred one.
+
+## Alternatives
+
+- **Auto-promote matches to declared edges.** Rejected by ADR-077: an
+  unreviewed edge is not a validated edge (ADR-074, ADR-065).
+- **Embed artifacts and suggest by similarity.** Rejected: non-deterministic and
+  contrary to ADR-002/ADR-066; also lower precision than exact id/ref matching
+  for this specific job.
+- **Match titles and arbitrary noun phrases too.** Deferred, not adopted: title
+  matching trades precision for recall and risks a noisy channel maintainers
+  learn to ignore (see Open Questions).
+- **Make it a hard validation error.** Rejected by ADR-077: it would force every
+  prose mention into a declared edge and turn a nudge into a merge blocker.
+
+## Accessibility
+
+Output is plain text, readable and diffable, in the same shape as existing
+`rac doctor` findings: the suggestion is stated in words with the paste-ready
+line, no reliance on colour or a graphical display. `--json` carries the same
+fields for automation.
+
+## Style Guidance
+
+Each finding leads with the relationship it suggests ("body references B; no
+Related <Type> link"), then the paste-ready fix — scannable, matching the tone of
+the existing orphan and hub findings. Copy frames the result as a *suggestion to
+review*, never as an assertion that an edge exists.
+
+## Open Questions
+
+- **Title matching.** Whether to add exact, whole-token title matching as an
+  opt-in second tier, and how to bound its false-positive rate before it ships.
+- **Second surface.** Whether `rac coverage` should also report
+  mentioned-but-unlinked references as a completeness gap, or whether keeping it
+  to `rac doctor` is clearer.
+- **Directionality.** Whether a suggestion should also be offered on the *target*
+  side (B could declare the inverse edge), or only on the mentioning side.
+
+## Related Decisions
+
+- adr-077
+- adr-074
+- adr-065
+- adr-066
+- adr-002
+- adr-037
+
+## Related Requirements
+
+- rac-unlinked-reference-detection
+
+## Related Roadmaps
+
+- v0.28.0-link-suggestions

--- a/rac/designs/mentioned-but-unlinked-detection.md
+++ b/rac/designs/mentioned-but-unlinked-detection.md
@@ -8,7 +8,7 @@ type: design
 ## Context
 
 This design is the *how* for the `rac-unlinked-reference-detection` requirement
-and the boundary ADR-077 draws: surface body references to other artifacts that
+and the boundary ADR-082 draws: surface body references to other artifacts that
 are not declared as `## Related` edges, as advisory suggestions, deterministically,
 without ever auto-applying an edge.
 
@@ -24,7 +24,7 @@ edges miss."
 **Prior art.** Zero-LLM, deterministic edge extraction from Markdown text is the
 mechanism behind general agent-memory tools such as GBrain. RAC adopts the
 *detection* (pure string/id matching, no model) but not the *auto-wiring*: the
-output is a suggestion a human promotes, never an edge the tool writes (ADR-077).
+output is a suggestion a human promotes, never an edge the tool writes (ADR-082).
 
 ## User Need
 
@@ -103,7 +103,7 @@ diffs are stable. No model, embedding, or network call is on the path
 
 - Offline, AI-optional (ADR-002) and deterministic with no embeddings or LLM
   judge (ADR-066): pure function of corpus bytes.
-- Suggest, never apply (ADR-077): the detector emits findings only; it never
+- Suggest, never apply (ADR-082): the detector emits findings only; it never
   writes an edge. The declared `## Related` sections stay the source of truth
   (ADR-074), and promotion stays a human review act (ADR-065).
 - Advisory severity (ADR-075 gate discipline): findings exit zero and never
@@ -124,7 +124,7 @@ more complete instead of replacing it with an inferred one.
 
 ## Alternatives
 
-- **Auto-promote matches to declared edges.** Rejected by ADR-077: an
+- **Auto-promote matches to declared edges.** Rejected by ADR-082: an
   unreviewed edge is not a validated edge (ADR-074, ADR-065).
 - **Embed artifacts and suggest by similarity.** Rejected: non-deterministic and
   contrary to ADR-002/ADR-066; also lower precision than exact id/ref matching
@@ -132,7 +132,7 @@ more complete instead of replacing it with an inferred one.
 - **Match titles and arbitrary noun phrases too.** Deferred, not adopted: title
   matching trades precision for recall and risks a noisy channel maintainers
   learn to ignore (see Open Questions).
-- **Make it a hard validation error.** Rejected by ADR-077: it would force every
+- **Make it a hard validation error.** Rejected by ADR-082: it would force every
   prose mention into a declared edge and turn a nudge into a merge blocker.
 
 ## Accessibility
@@ -161,7 +161,7 @@ review*, never as an assertion that an edge exists.
 
 ## Related Decisions
 
-- adr-077
+- adr-082
 - adr-074
 - adr-065
 - adr-066

--- a/rac/requirements/rac-unlinked-reference-detection.md
+++ b/rac/requirements/rac-unlinked-reference-detection.md
@@ -1,0 +1,80 @@
+---
+schema_version: 1
+id: RAC-KVSNNZ7YRMEZ
+type: requirement
+---
+# Unlinked Reference Detection
+
+## Problem
+
+RAC's relationship graph is built only from edges an author declares in
+`## Related <Type>` sections. That is deliberate — the graph is *validated*,
+not inferred from prose (ADR-074) — but it leaves a real gap: an artifact's
+body routinely names another artifact (an ADR id, a requirement, a design)
+without a matching `## Related` edge. The reference is true and intentional,
+yet the graph does not carry it, so traversal, coverage, and the export
+contract all under-report the corpus's actual connectedness.
+
+Today `rac doctor` finds *orphans* (artifacts nothing links to) but has no way
+to find a link the author clearly meant — one they already wrote in prose and
+simply did not promote to a declared edge. Authors are left to notice missing
+links by eye. The affected users are corpus maintainers and the agents that
+consume the graph: both see a sparser graph than the text supports.
+
+## Requirements
+
+- [REQ-001] RAC SHALL detect, for each artifact, references in that artifact's body to other corpus artifacts — matched by canonical id, declared alias, or filename-style reference (for example `adr-074`) — that are absent from the artifact's declared `## Related <Type>` sections.
+- [REQ-002] RAC SHALL report each mentioned-but-unlinked reference as an advisory finding that names the source artifact, the matched target, the token that matched, and the `## Related <Type>` section that would capture the edge.
+- [REQ-003] Detection SHALL be deterministic and offline: a pure function of corpus bytes with no model, embedding, or network call, such that identical corpora produce byte-identical findings (ADR-002, ADR-066).
+- [REQ-004] RAC SHALL NOT create, write, or modify any relationship edge automatically; a finding is a suggestion a human promotes through review (ADR-065, ADR-077).
+- [REQ-005] The advisory SHALL NOT change the exit code of `rac validate` or `rac relationships --validate`; a mentioned-but-unlinked reference never blocks a merge on its own.
+- [REQ-006] Detection SHALL exclude self-references, targets already declared as edges, fenced code blocks, and the `## Related` sections themselves, and SHALL emit at most one finding per (source artifact, target artifact) pair.
+
+## Success Metrics
+
+- On the dogfood corpus, the detector surfaces only references a maintainer
+  agrees should be promoted (high precision); spot-checked false positives are
+  near zero because matching is limited to ids, aliases, and filename refs.
+- The check adds no new failing exit code: `rac validate` and
+  `rac relationships --validate` exit codes are unchanged with the detector
+  present.
+- Re-running the detector on an unchanged corpus yields byte-identical output.
+
+## Risks
+
+- **Noise.** Loose matching (especially on titles) would flood maintainers with
+  spurious suggestions and train them to ignore the channel. Mitigation: ship
+  id/alias/filename matching only; treat title matching as a separate, deferred
+  question (the design's Open Questions).
+- **Edge-meaning drift.** A suggestion could be read as an assertion that an
+  edge exists. Mitigation: findings are advisory and never auto-applied
+  (REQ-004); the declared `## Related` sections remain the single source of
+  truth (ADR-074).
+
+## Assumptions
+
+- A body reference to another artifact, by id or filename ref, is usually a link
+  the author intended and would promote if reminded.
+- Deterministic matching on ids, aliases, and filename references is
+  high-precision enough to be trusted without a model (ADR-002, ADR-066).
+
+## Related Decisions
+
+- adr-077
+- adr-074
+- adr-065
+- adr-066
+- adr-002
+
+## Related Designs
+
+- mentioned-but-unlinked-detection
+
+## Related Roadmaps
+
+- v0.28.0-link-suggestions
+
+## Related Requirements
+
+- rac-traceability-coverage-report
+- rac-doctor-diagnostic-validator

--- a/rac/requirements/rac-unlinked-reference-detection.md
+++ b/rac/requirements/rac-unlinked-reference-detection.md
@@ -26,7 +26,7 @@ consume the graph: both see a sparser graph than the text supports.
 - [REQ-001] RAC SHALL detect, for each artifact, references in that artifact's body to other corpus artifacts — matched by canonical id, declared alias, or filename-style reference (for example `adr-074`) — that are absent from the artifact's declared `## Related <Type>` sections.
 - [REQ-002] RAC SHALL report each mentioned-but-unlinked reference as an advisory finding that names the source artifact, the matched target, the token that matched, and the `## Related <Type>` section that would capture the edge.
 - [REQ-003] Detection SHALL be deterministic and offline: a pure function of corpus bytes with no model, embedding, or network call, such that identical corpora produce byte-identical findings (ADR-002, ADR-066).
-- [REQ-004] RAC SHALL NOT create, write, or modify any relationship edge automatically; a finding is a suggestion a human promotes through review (ADR-065, ADR-077).
+- [REQ-004] RAC SHALL NOT create, write, or modify any relationship edge automatically; a finding is a suggestion a human promotes through review (ADR-065, ADR-082).
 - [REQ-005] The advisory SHALL NOT change the exit code of `rac validate` or `rac relationships --validate`; a mentioned-but-unlinked reference never blocks a merge on its own.
 - [REQ-006] Detection SHALL exclude self-references, targets already declared as edges, fenced code blocks, and the `## Related` sections themselves, and SHALL emit at most one finding per (source artifact, target artifact) pair.
 
@@ -60,7 +60,7 @@ consume the graph: both see a sparser graph than the text supports.
 
 ## Related Decisions
 
-- adr-077
+- adr-082
 - adr-074
 - adr-065
 - adr-066

--- a/rac/roadmaps/v0.28.x-link-suggestions/v0.28.0-link-suggestions.md
+++ b/rac/roadmaps/v0.28.x-link-suggestions/v0.28.0-link-suggestions.md
@@ -1,0 +1,128 @@
+---
+schema_version: 1
+id: RAC-KVSNP3C2T4WA
+type: roadmap
+---
+# RAC v0.28.0 — Relationship Link Suggestions
+
+## Status
+
+Planned
+
+## Context
+
+RAC's relationship graph is only as complete as the edges authors remember to
+declare in `## Related <Type>` sections. The text is usually ahead of the graph:
+artifacts name each other in prose — an ADR id, a requirement, a design slug —
+without a matching declared edge. The link is real and intended; the graph just
+does not carry it, so traversal, coverage, and the export contract under-report
+how connected the corpus actually is. `rac doctor` finds orphans but cannot find
+a link the author already wrote in prose and simply did not promote.
+
+This release closes that gap on RAC's own terms. ADR-077 sets the boundary —
+detect mentioned-but-unlinked references and **suggest** them, deterministically,
+but never auto-create an edge — so the graph stays *validated*, not inferred from
+prose (ADR-074), and promotion stays a human review act (ADR-065). The *how* is
+in the `mentioned-but-unlinked-detection` design; this item schedules it.
+
+It is the in-domain, deterministic half of what general agent-memory tools do by
+auto-wiring — kept on RAC's side of the inference line (ADR-002, ADR-066).
+
+## Outcomes
+
+- A maintainer running `rac doctor` sees, as advisory findings, the references
+  an artifact's body makes to other artifacts that are missing from its declared
+  `## Related` sections — each with a paste-ready line to promote it.
+- The declared graph gets measurably denser over time without any edge ever
+  being written by the tool: every promotion is a reviewed human edit.
+- The behaviour is deterministic and offline end to end: same corpus,
+  byte-identical findings; no model, embedding, or network call.
+
+## Initiatives
+
+### Initiative 1 — Detection service (Core)
+
+A pure function over the parsed corpus and the existing relationship index that
+returns, per artifact, the set of body references (canonical id, alias, or
+filename-style ref) that resolve to another artifact not already declared as a
+`## Related` edge. Reuses the resolver, token-boundary matching (ADR-037), the
+relationship index, and the shared Markdown parser; excludes frontmatter, the
+`## Related` sections, fenced code blocks, and self-references. The *how* is in
+the `mentioned-but-unlinked-detection` design.
+
+### Initiative 2 — `rac doctor` surface
+
+Expose the findings as a new advisory `rac doctor` code (`unlinked-reference`)
+alongside the existing orphan and hub warnings. Each finding names the source,
+the matched target and token, the `## Related <Type>` section that would capture
+it (derived from the target's type via the registry), and a paste-ready
+suggested line. Human output plus `--json`, exit zero — advisory, never a gate.
+
+### Initiative 3 — Boundary and contract coverage
+
+Golden and boundary tests pin the determinism (byte-identical findings on an
+unchanged corpus), the exclusions (code fences, declared edges, self-refs), the
+one-finding-per-pair rule, and the advisory exit code — proving the detector
+never changes the `rac validate` / `rac relationships --validate` contract.
+
+### Initiative 4 — Documentation
+
+Document the new `rac doctor` finding in `docs/cli.md`: what it detects, why it
+is advisory, and how to promote a suggestion to a declared edge.
+
+## Constraints
+
+- AI-optional, offline (ADR-002) and deterministic with no embeddings or LLM
+  judge (ADR-066).
+- Suggest, never apply (ADR-077): findings only; the tool writes no edge.
+- Advisory severity: exit zero; the `rac validate` / `rac relationships
+  --validate` contract is unchanged (ADR-075 gate discipline).
+- Reuse the shared resolver, matcher, relationship index, and parser; no
+  parallel mechanism.
+
+## Non-Goals
+
+- Auto-creating, writing, or modifying any relationship edge.
+- Any model, embedding, or similarity-based suggestion.
+- Title or free-text matching in this release (a deferred design question).
+- Making a mentioned-but-unlinked reference a validation error or a merge gate.
+
+## Success Measures
+
+- On the dogfood corpus, `rac doctor` surfaces only references a maintainer
+  agrees should be promoted (high precision; near-zero spot-checked false
+  positives).
+- `rac validate` and `rac relationships --validate` exit codes are identical
+  with and without the detector present.
+- Re-running `rac doctor` on an unchanged corpus yields byte-identical findings.
+
+## Assumptions
+
+- A body reference by id or filename ref is usually a link the author intended
+  and would promote if reminded.
+- Deterministic id/alias/filename matching is high-precision enough to be
+  trusted without a model.
+
+## Risks
+
+- **Noise** from over-broad matching trains maintainers to ignore the channel.
+  Mitigation: id/alias/filename matching only; title matching deferred.
+- **Misreading a suggestion as an asserted edge.** Mitigation: advisory framing
+  and copy that names it a suggestion to review (ADR-077); the tool never
+  applies it.
+
+## Related Requirements
+
+- rac-unlinked-reference-detection
+
+## Related Decisions
+
+- adr-077
+- adr-074
+- adr-065
+- adr-066
+- adr-002
+
+## Related Designs
+
+- mentioned-but-unlinked-detection

--- a/rac/roadmaps/v0.28.x-link-suggestions/v0.28.0-link-suggestions.md
+++ b/rac/roadmaps/v0.28.x-link-suggestions/v0.28.0-link-suggestions.md
@@ -19,7 +19,7 @@ does not carry it, so traversal, coverage, and the export contract under-report
 how connected the corpus actually is. `rac doctor` finds orphans but cannot find
 a link the author already wrote in prose and simply did not promote.
 
-This release closes that gap on RAC's own terms. ADR-077 sets the boundary —
+This release closes that gap on RAC's own terms. ADR-082 sets the boundary —
 detect mentioned-but-unlinked references and **suggest** them, deterministically,
 but never auto-create an edge — so the graph stays *validated*, not inferred from
 prose (ADR-074), and promotion stays a human review act (ADR-065). The *how* is
@@ -74,7 +74,7 @@ is advisory, and how to promote a suggestion to a declared edge.
 
 - AI-optional, offline (ADR-002) and deterministic with no embeddings or LLM
   judge (ADR-066).
-- Suggest, never apply (ADR-077): findings only; the tool writes no edge.
+- Suggest, never apply (ADR-082): findings only; the tool writes no edge.
 - Advisory severity: exit zero; the `rac validate` / `rac relationships
   --validate` contract is unchanged (ADR-075 gate discipline).
 - Reuse the shared resolver, matcher, relationship index, and parser; no
@@ -108,7 +108,7 @@ is advisory, and how to promote a suggestion to a declared edge.
 - **Noise** from over-broad matching trains maintainers to ignore the channel.
   Mitigation: id/alias/filename matching only; title matching deferred.
 - **Misreading a suggestion as an asserted edge.** Mitigation: advisory framing
-  and copy that names it a suggestion to review (ADR-077); the tool never
+  and copy that names it a suggestion to review (ADR-082); the tool never
   applies it.
 
 ## Related Requirements
@@ -117,7 +117,7 @@ is advisory, and how to promote a suggestion to a declared edge.
 
 ## Related Decisions
 
-- adr-077
+- adr-082
 - adr-074
 - adr-065
 - adr-066


### PR DESCRIPTION
## What

A deterministic **mentioned-but-unlinked reference detector**: a `rac doctor` advisory that finds artifact ids/aliases/filename-refs cited in an artifact's *body* but missing from its declared `## Related` sections, and suggests promoting them — **never auto-creating an edge** (detect → suggest → human promotes; ADR-074/ADR-065).

## Artifacts
- `requirements/rac-unlinked-reference-detection.md`
- `decisions/adr-082-suggested-relationship-edges-advisory.md` — **ADR-082** (Proposed)
- `designs/mentioned-but-unlinked-detection.md`
- `roadmaps/v0.28.x-link-suggestions/v0.28.0-link-suggestions.md`

> **Numbering:** renumbered **ADR-077 → ADR-082** to resolve a collision with #196 (Accepted ADR-077, the two-gate capture model). File renamed, title + all cross-references updated; artifact id unchanged.

## Gates
- `rac validate` — 275 valid, 0 invalid · `rac relationships --validate` — 0 issues · `rac review` — no priority 1–2 · `agent-rules --check` — in sync.

Plan only — ADR-082 is `Proposed` pending review.