### PR TITLE
docs(roadmap): scope v0.29.0 relevance ranking and v0.30.0 note-tool ingest

### DIFF
--- a/rac/decisions/adr-078-deterministic-relevance-ranking.md
+++ b/rac/decisions/adr-078-deterministic-relevance-ranking.md
@@ -1,0 +1,118 @@
+---
+schema_version: 1
+id: RAC-KVSQ24G2H2D6
+type: decision
+---
+# ADR-078: Deterministic Relevance Ranking — BM25, RRF, and a Graph Boost
+
+## Context
+
+Search ranks by a fixed tier ladder (id, title, path, heading, body; ties by
+sorted path) under ADR-037 and ADR-038. ADR-038 made two commitments that this
+decision must respect: the ladder's *matching* is token-boundary and body-aware,
+and — emphatically — there is "no embeddings, semantic scoring, stemming, or
+synonym expansion in Core, ever." ADR-066 reaffirms the same line for grounding:
+deterministic scoring, no embeddings, no LLM judge.
+
+The ladder's weakness is *ordering within a tier*: two body matches are ranked by
+path alphabetisation, not by how well each matches the query, so a weak hit can
+sort ahead of a strong one and, under the response budget, push the strong one
+out of the window. Two deterministic signals already present are unused for
+ranking — term frequency within a field, and the validated relationship graph (a
+much-referenced artifact is usually a better answer than an isolated one).
+
+The question is how to use them without crossing ADR-038/ADR-066. BM25 is a
+*lexical, statistical* relevance model (term frequency × inverse document
+frequency) — not semantic, no embeddings, no stemming required; Reciprocal Rank
+Fusion (RRF) combines ranked lists by `Σ 1/(k + rank)`, a pure arithmetic merge;
+graph centrality is a count over edges RAC already validates. All three are
+deterministic and explainable.
+
+## Decision
+
+Replace tier-precedence-then-path ordering with a deterministic **relevance
+score**, while reaffirming ADR-038/ADR-066's prohibition on embeddings, semantic
+scoring, stemming, and synonym expansion. This **refines ADR-038's ranking
+clause only**; its tier set, token-boundary matching, snippet fields, and the
+no-embeddings/no-semantic guardrail all stand unchanged.
+
+- **BM25-family lexical scoring.** Each matchable field is scored by term
+  frequency with inverse document frequency across the corpus — a statistical
+  lexical score, never a semantic one (ADR-038 holds).
+- **RRF fusion.** The per-field/tier ranked lists are fused with Reciprocal Rank
+  Fusion (`Σ 1/(k + rank)`), so a result strong on one signal ranks well without
+  hand-tuned tier weights. The tier *identity* still informs the inputs (an id
+  match is a strong list); RRF replaces the brittle "best tier, then path"
+  tiebreak.
+- **Bounded graph boost.** A deterministic boost derived from the validated
+  relationship graph (inbound-reference count, normalised/capped) is fused in as
+  one more signal, so connectedness breaks near-ties toward the artifact the
+  corpus already leans on. It is bounded so it cannot dominate lexical relevance.
+- **Explainable and additive.** Results keep their match evidence and gain the
+  contributing score components as additive JSON fields (ADR-007); the order is a
+  pure function of corpus bytes and the query, byte-stable across runs.
+
+The implementation stays in Core and serves `rac find` and `search_artifacts`
+identically (ADR-031). Quality is gated on the deterministic grounding benchmark
+(`rac eval --check`, ADR-066), so the new order is measured against the committed
+baseline rather than asserted.
+
+## Consequences
+
+Agents and humans get a candidate list ordered by relevance, so the right
+artifact lands inside the response budget more often — the ordering improvement
+the tier ladder could not make. Every component is deterministic and
+explainable, so the property that makes RAC's retrieval trustworthy and testable
+is preserved, and the change is provable on the eval benchmark.
+
+Trade-offs accepted: ranking gains moving parts ADR-038 deliberately avoided
+(BM25 statistics, an RRF merge, a graph term), which is more to test and explain
+than a path tiebreak — mitigated by golden tests, additive contracts, and the
+eval gate. The graph boost risks floating hubs onto unrelated queries; it is
+bounded and fused, never dominant, and tuned against the benchmark. This is a
+refinement of ADR-038, not a reversal: the moment a proposal here reached for an
+embedding or a semantic score, it would contradict ADR-038/ADR-066 and be out of
+scope.
+
+## Status
+
+Proposed
+
+## Category
+
+Technical
+
+## Alternatives Considered
+
+- **Keep the tier-precedence ladder.** The status quo (ADR-038). Rejected: it
+  leaves within-tier order to path alphabetisation, which is the defect — a weak
+  body hit can outrank a strong one and crowd it out of the budget.
+- **Add semantic / embedding ranking.** Rejected outright: it contradicts the
+  explicit "ever" prohibition of ADR-038 and ADR-066. Determinism, offline
+  operation, and explainability are non-negotiable here.
+- **Hand-tuned per-tier weights instead of RRF.** Rejected: weights are brittle
+  and corpus-specific; RRF is parameter-light (one constant `k`), deterministic,
+  and robust to combining heterogeneous signals.
+- **Graph boost as the primary sort key.** Rejected: it would answer queries with
+  whatever is most-referenced regardless of lexical fit. The boost is a bounded
+  tiebreak fused via RRF, not the lead signal.
+
+## Related Decisions
+
+- adr-038
+- adr-037
+- adr-066
+- adr-007
+- adr-031
+
+## Related Requirements
+
+- rac-deterministic-relevance-ranking
+
+## Related Designs
+
+- deterministic-relevance-ranking
+
+## Related Roadmaps
+
+- v0.29.0-relevance-ranking

--- a/rac/decisions/adr-079-note-tool-ingest-sources.md
+++ b/rac/decisions/adr-079-note-tool-ingest-sources.md
@@ -1,0 +1,110 @@
+---
+schema_version: 1
+id: RAC-KVSQ2A0BB9XF
+type: decision
+---
+# ADR-079: Note-Tool Exports Are Ingested by Normalisation, Not markitdown
+
+## Context
+
+ADR-072 settled that document ingestion parses through markitdown: a rich binary
+document (DOCX, PDF, PPTX, XLSX, HTML) is converted to Markdown, and new sources
+are "added by registering" converters. That is the right tool for office
+documents, where the job is extracting Markdown from a binary format.
+
+Note-tool / PKM exports — Obsidian, Logseq, Notion, Roam — are a different shape.
+They are *already* Markdown (or Markdown plus CSV/JSON), exported as a directory
+of interlinked notes, using wikilink syntax (`[[Note]]`, `[[Note|alias]]`) and
+tool-specific frontmatter. Feeding them through markitdown is wrong on two
+counts: there is no binary to parse, and markitdown would pass the wikilinks
+through as literal text, discarding the link graph — the very relationship signal
+RAC exists to preserve.
+
+So the question is not "which parser," but "how does a source that is already
+Markdown, and is a *graph* rather than a document, enter the pipeline."
+
+## Decision
+
+Note-tool exports are ingested by **normalisation**, added through ADR-072's
+converter registry as a distinct converter family — not by extending markitdown.
+
+- **Registry, not core.** Each tool (Obsidian, Logseq, Notion, Roam) is a
+  registered converter behind an optional extra, sitting beside the markitdown
+  converters in the ADR-072 registry. The engine core and the markitdown path for
+  binary documents are unchanged.
+- **Normalise, don't parse-from-binary.** A note-tool converter takes Markdown in
+  and emits RAC-shaped Markdown: it rewrites wikilink syntax into resolvable
+  references, maps known frontmatter, and preserves everything it cannot map
+  verbatim (lossless by default). markitdown is not in this path.
+- **A vault is a set, not a document.** Ingest accepts a directory export and
+  treats each note as a candidate artifact, so the unit of import is the graph,
+  not a single file.
+- **Wikilinks become candidate edges, never asserted ones.** A `[[Note]]` that
+  resolves to another imported note is surfaced as a candidate `## Related`
+  reference for human promotion — consistent with RAC's rule that edges are
+  declared and reviewed (ADR-074, ADR-065), not inferred and written by a tool.
+  Ambiguous links are reported, never guessed.
+- **Deterministic and offline (ADR-002).** Normalisation is pure text
+  transformation: identical export, identical drafts; no model, no network; never
+  overwrites an existing artifact.
+
+## Consequences
+
+A team's existing knowledge base in Obsidian, Logseq, Notion, or Roam becomes a
+single `rac ingest` away from a reviewable set of RAC drafts, with its link graph
+carried in as candidate relationships rather than flattened to plain text — a
+materially better first impression for adopters than "office documents only."
+The converter-registry boundary (ADR-072) keeps each tool's quirks and
+dependencies isolated and individually testable, and keeps them out of the core.
+
+Trade-offs accepted: this is per-tool work — each export format is its own
+converter with its own drift risk — rather than one universal importer; the
+registry contains that risk. Wikilink resolution can be ambiguous; the decision
+is to report ambiguity for human resolution, never to guess, which means some
+imported links land as candidates a human must still confirm — the correct cost
+under ADR-074/ADR-065. This refines ADR-072's "register new sources" extension
+point for a source class that is already Markdown; it does not change the
+markitdown decision for binary documents.
+
+## Status
+
+Proposed
+
+## Category
+
+Architecture
+
+## Alternatives Considered
+
+- **Run PKM exports through markitdown like any other source.** Rejected: there is
+  no binary to parse, and markitdown passes wikilinks through as literal text,
+  losing the link graph that is the point of importing a PKM tool.
+- **One universal "Markdown-with-wikilinks" importer.** Rejected: Obsidian,
+  Logseq, Notion, and Roam differ in link syntax, frontmatter, and export layout
+  enough that a single importer becomes a tangle of special cases; per-tool
+  converters behind the registry are cleaner and independently testable.
+- **Auto-create `## Related` edges from resolved wikilinks.** Rejected: an
+  imported edge nobody reviewed is not a validated edge (ADR-074, ADR-065).
+  Wikilinks enter as candidates for promotion, not as asserted edges.
+- **Keep ingest to office documents; tell PKM users to convert manually.**
+  Rejected: it leaves real, common knowledge bases outside the front door and
+  forgoes the link graph they already maintain.
+
+## Related Decisions
+
+- adr-072
+- adr-074
+- adr-065
+- adr-002
+
+## Related Requirements
+
+- rac-note-tool-ingest-sources
+
+## Related Designs
+
+- note-tool-ingest-sources
+
+## Related Roadmaps
+
+- v0.30.0-note-tool-ingest-sources

--- a/rac/designs/deterministic-relevance-ranking.md
+++ b/rac/designs/deterministic-relevance-ranking.md
@@ -1,0 +1,157 @@
+---
+schema_version: 1
+id: RAC-KVSQ25YPB5WT
+type: design
+---
+# Deterministic Relevance Ranking
+
+## Context
+
+This design is the *how* for the `rac-deterministic-relevance-ranking`
+requirement and the boundary ADR-078 draws: rank search by a deterministic
+relevance score — BM25-family lexical scoring, RRF fusion, and a bounded graph
+boost — without ever introducing embeddings or semantic scoring (ADR-038,
+ADR-066).
+
+The machinery to extend already exists. `services/resolve.py` runs the tiered
+matcher: for each artifact it finds the best (lowest) tier any query term hits
+across id, title, path, heading, and body (ADR-037 token-boundary matching,
+ADR-038 body tier), records match evidence `{field, terms, tier}` (v0.23
+explainable retrieval), and orders by tier then sorted path. This design keeps
+the matcher and the evidence; it replaces the *ordering* step.
+
+**Prior art.** Hybrid retrieval systems (for example GBrain) fuse a lexical
+(BM25/`tsvector`) ranking with a vector ranking using RRF, and boost by graph
+backlinks. RAC adopts the deterministic half — BM25 + RRF + a graph boost — and
+omits the vector half, which ADR-066 excludes.
+
+## User Need
+
+An agent grounding itself through `search_artifacts`, and a human running
+`rac find`, want the most relevant artifact at the top, not merely inside the
+correct tier. Under the response budget, order decides what the agent even sees.
+They also need the order to stay reproducible and explainable: the same query
+must give the same ranking, and a caller must be able to see why one hit
+outranks another, exactly as `--explain` shows today.
+
+## Design
+
+### Signals (all deterministic, all lexical or structural)
+
+For a query of one or more terms, each candidate artifact produces:
+
+- **Per-field BM25 scores.** For each matchable field (id, title, path, heading
+  text, body text) a BM25 score over the query terms: term frequency in the
+  field, damped by field length, weighted by inverse document frequency across
+  the corpus. Token-boundary tokenisation is ADR-037's, unchanged; no stemming,
+  no synonyms. Fields keep their relative importance through standard BM25 field
+  weighting (title and id heavier than body), replacing the hard tier cutoff with
+  a graded contribution.
+- **A graph score.** A bounded value from the validated relationship graph —
+  inbound reference count, normalised and capped (a log or min-cap so a few hubs
+  cannot dominate). Computed from the same relationship index `rac relationships`
+  and `rac doctor` already build.
+
+### Fusion (RRF)
+
+Each signal produces a ranked list of candidates. The lists are merged with
+**Reciprocal Rank Fusion**: an artifact's fused score is `Σ 1/(k + rank_s)` over
+each signal `s` it appears in, with a fixed constant `k` (the conventional 60,
+recorded as the one tunable). RRF is chosen over weighted-sum because it needs no
+per-field weight tuning, is robust to combining heterogeneous signals (a
+BM25 score and a graph count are not on the same scale), and is a pure arithmetic
+function — deterministic and trivially explainable.
+
+The matching contract from ADR-038 is unchanged: a multi-term query still
+requires every term to match somewhere; only artifacts that match at all enter
+the ranking. RRF reorders the matched set; it never widens it.
+
+### Tie-breaking
+
+Equal fused scores break by the existing rule — sorted path — so the order stays
+total and byte-stable. Tie-breaking is documented as part of the contract.
+
+### Surfaces and contract
+
+- **`rac find` / `search_artifacts`** consume the new order identically (ADR-031);
+  no new verb.
+- **Explainability (additive, ADR-007).** Each result keeps `{field, terms, tier}`
+  and gains optional score components: the per-signal contributions and the fused
+  score, so `--explain` and the JSON show *why* the order is what it is.
+  `schema_version` is unchanged; existing fields are untouched.
+- **Determinism.** The order is a pure function of corpus bytes and query, proven
+  by golden tests; no model, embedding, or network call is on the path.
+
+### Quality gate
+
+Ranking changes are measured, not asserted: the deterministic grounding benchmark
+(`rac eval --check`, ADR-066) must hold or improve Precision@k / Recall@k against
+the committed baseline before the change ships, so a ranking tweak that helps one
+query but hurts the corpus is caught.
+
+## Constraints
+
+- No embeddings, semantic scoring, stemming, or synonym expansion — ever
+  (ADR-038, ADR-066). BM25 is statistical lexical scoring; RRF and the graph
+  boost are arithmetic over existing data.
+- Deterministic and offline: identical bytes and query yield identical order.
+- Additive contract (ADR-007): existing search fields unchanged; score components
+  are new optional fields.
+- Reuse the existing matcher, tokeniser, relationship index, and eval harness; do
+  not fork a parallel search path. Core serves both surfaces (ADR-031).
+
+## Rationale
+
+BM25 is the standard deterministic answer to "which lexical match is stronger,"
+and it stays inside ADR-038's line because it is statistical, not semantic. RRF
+is the standard way to combine ranked lists without scale-matching or weight
+tuning, and it keeps the result explainable. The graph boost turns data RAC
+already validates into a relevance signal at near-zero cost. Gating on `rac eval`
+makes the whole thing falsifiable, which is the property ADR-066 exists to
+protect.
+
+## Alternatives
+
+- **Keep tier-then-path ordering.** Rejected (ADR-078): the within-tier order is
+  the defect.
+- **Vector / embedding ranking.** Rejected: contradicts ADR-038/ADR-066.
+- **Weighted-sum fusion with per-tier weights.** Rejected: brittle and
+  corpus-specific; RRF is parameter-light and robust.
+- **Unbounded backlink boost (as some hybrid systems use).** Rejected: it floats
+  hubs onto unrelated queries; the boost is capped and fused, not dominant.
+
+## Accessibility
+
+Output is plain text and diffable, the same shape as today's results, with the
+score components available in `--explain` and `--json`; nothing relies on colour
+or a graphical display.
+
+## Style Guidance
+
+Default human output is unchanged in shape — ranked list with snippets;
+`--explain` adds the score breakdown compactly, in the established `rac find`
+style. Copy frames the score as a deterministic relevance signal, never a
+semantic judgement of meaning.
+
+## Open Questions
+
+- The exact BM25 field weights and whether they are fixed or configurable.
+- The graph-score shape (raw inbound count vs a capped/log centrality) and its
+  cap, tuned against the benchmark.
+- Whether the RRF constant `k` is fixed at 60 or exposed in `.rac/config.yaml`.
+
+## Related Decisions
+
+- adr-078
+- adr-038
+- adr-037
+- adr-066
+- adr-007
+
+## Related Requirements
+
+- rac-deterministic-relevance-ranking
+
+## Related Roadmaps
+
+- v0.29.0-relevance-ranking

--- a/rac/designs/note-tool-ingest-sources.md
+++ b/rac/designs/note-tool-ingest-sources.md
@@ -1,0 +1,148 @@
+---
+schema_version: 1
+id: RAC-KVSQ2BANG6HS
+type: design
+---
+# Note-Tool Ingest Sources
+
+## Context
+
+This design is the *how* for the `rac-note-tool-ingest-sources` requirement and
+the boundary ADR-079 draws: ingest Obsidian, Logseq, Notion, and Roam exports by
+normalising their already-Markdown notes into RAC-shaped artifacts, through the
+ADR-072 converter registry, without touching markitdown or the core.
+
+`services/ingest.py` already defines a converter abstraction — a converter
+declares the sources it handles and turns a source into Markdown, and "new
+sources are added by registering" one. This design adds a converter *family* for
+note tools that normalises rather than parses-from-binary, and handles a
+directory of interlinked notes rather than a single file.
+
+## User Need
+
+A team adopting Lore has its decisions, specs, or product notes in Obsidian,
+Logseq, Notion, or Roam. They want one command that turns that export into a set
+of reviewable RAC drafts — with the links they already drew between notes carried
+in as candidate relationships, not flattened to plain text — so adoption is an
+import, not a rewrite. They need it deterministic and lossless, so the review
+step starts from a complete, faithful draft.
+
+## Design
+
+### Registration and selection
+
+Each tool is a registered converter behind an optional extra
+(`ingest-obsidian`, `ingest-logseq`, …), sitting in the ADR-072 registry beside
+the markitdown converters. Selection is by export shape (a detected vault
+layout / marker file) or an explicit `--from <tool>` flag, so a directory is
+routed to the right normaliser deterministically. The markitdown path for binary
+documents is untouched.
+
+### Directory in, artifact set out
+
+`rac ingest <export-dir>` walks the export and treats each note as a candidate
+artifact. Each note flows through the same normalisation steps and the existing
+artifact-draft path; nothing is written that would overwrite an existing
+artifact, and the output is a set of drafts for human review, not committed
+artifacts.
+
+### Normalisation steps (deterministic, per note)
+
+- **Wikilinks → resolvable references.** `[[Note]]`, `[[Note|alias]]`, and
+  heading/block references are parsed and resolved against the other notes in the
+  same export. A resolved target becomes a **candidate `## Related` reference**
+  (typed by the target's eventual artifact type where known); an unresolved or
+  ambiguous link is reported and left inline, never guessed and never written as
+  an asserted edge (ADR-079, ADR-074, ADR-065).
+- **Frontmatter mapping.** Known tool frontmatter keys map to RAC's shape where a
+  deterministic mapping exists; unmapped keys are preserved in the body so
+  nothing is lost (lossless by default).
+- **Body normalisation.** Tool-specific Markdown dialect (callouts, embeds,
+  block ids) is normalised to plain Markdown or preserved verbatim when there is
+  no faithful mapping — never dropped.
+
+### Per-tool specifics (the registry isolates these)
+
+- **Obsidian** — a vault of `.md` files; `[[wikilinks]]`, `![[embeds]]`, YAML
+  frontmatter.
+- **Logseq** — Markdown/outliner pages and journals; block references, page
+  links.
+- **Notion** — a Markdown + CSV export with hashed filenames; database CSVs and
+  the folder structure carry relationships.
+- **Roam** — a JSON or Markdown graph export; block-reference graph.
+
+Each is its own converter with its own tests, so one tool's export drift cannot
+break another or the core.
+
+### Boundary with the rest of the corpus
+
+The candidate `## Related` references this produces are exactly the kind of
+suggestion the relationship-completeness work surfaces — an imported wikilink is a
+mention the human promotes to a declared edge. Ingest stops at the draft and the
+candidate; promotion and validation stay human (ADR-074, ADR-065).
+
+## Constraints
+
+- Deterministic and offline (ADR-002): identical export yields byte-identical
+  drafts; no model, no network; never overwrites an existing artifact.
+- Lossless by default: unmapped content is preserved verbatim, never discarded.
+- Registry, not core (ADR-072): note-tool converters are registered extras; the
+  engine core and the markitdown path are unchanged.
+- Edges are candidates, never asserted (ADR-074, ADR-065): wikilinks become
+  suggested references for human promotion.
+
+## Rationale
+
+Normalisation, not markitdown, is correct because the input is already Markdown
+and the value is in the *links*, which markitdown would discard. Per-tool
+converters behind the existing registry isolate format drift and keep the core
+clean, exactly as ADR-072 intended for new sources. Carrying wikilinks in as
+candidate relationships — rather than dropping them or auto-asserting them — keeps
+the import inside RAC's declared-and-reviewed graph model while still delivering
+the connectivity the source already had.
+
+## Alternatives
+
+- **markitdown for everything.** Rejected (ADR-079): no binary to parse, and it
+  flattens the link graph.
+- **One universal wikilink importer.** Rejected: the tools differ enough that a
+  single importer becomes special-case soup; per-tool converters are cleaner.
+- **Auto-create edges from resolved wikilinks.** Rejected: unreviewed edges are
+  not validated edges (ADR-074, ADR-065).
+
+## Accessibility
+
+Ingest output is plain-text Markdown drafts, diffable and reviewable in any
+editor; the import summary (notes converted, links resolved, ambiguities to
+review) is plain text with a `--json` form, no reliance on colour or a GUI.
+
+## Style Guidance
+
+The import summary leads with what converted and what needs human attention
+(unresolved links, unmapped metadata), in the scannable style of existing
+`rac ingest` output. Copy frames imported links as *candidates to promote*, never
+as edges the tool has asserted.
+
+## Open Questions
+
+- Whether vault-internal link resolution should also propose the *inverse*
+  candidate edge on the target note, or only the forward one.
+- How Notion database CSVs map — as artifact metadata, as relationships, or as
+  separate artifacts.
+- Whether detection of export shape is automatic, flag-driven (`--from`), or both.
+
+## Related Decisions
+
+- adr-079
+- adr-072
+- adr-074
+- adr-065
+- adr-002
+
+## Related Requirements
+
+- rac-note-tool-ingest-sources
+
+## Related Roadmaps
+
+- v0.30.0-note-tool-ingest-sources

--- a/rac/requirements/rac-deterministic-relevance-ranking.md
+++ b/rac/requirements/rac-deterministic-relevance-ranking.md
@@ -1,0 +1,86 @@
+---
+schema_version: 1
+id: RAC-KVSQ232DWE6N
+type: requirement
+---
+# Deterministic Relevance Ranking
+
+## Problem
+
+RAC's search (`rac find` and `search_artifacts`) ranks by a fixed tier ladder —
+identifier, then title, then path, then heading, then body, with ties broken by
+sorted path (ADR-037, ADR-038). That is deterministic and explainable, but it is
+coarse: within a tier every hit is equal, so the order of two body-matched
+artifacts is decided by path alphabetisation, not by how well each actually
+matches the query. An agent grounding itself through `search_artifacts` gets a
+correctly-filtered but poorly-ordered candidate list, and the response budget
+means a weakly-relevant artifact sorted ahead of a strong one can crowd the
+strong one out of the window entirely.
+
+The signal to fix this is already in the corpus and unused for ranking: term
+frequency within a field, and the validated relationship graph (a
+heavily-referenced decision is usually a better answer than an isolated one).
+The constraint is that RAC's retrieval must stay deterministic, offline, and
+free of embeddings or semantic scoring (ADR-038, ADR-066) — so the fix has to be
+a *lexical and structural* relevance model, not a vector one.
+
+The affected users are every agent and human who searches: better ordering means
+the right artifact lands inside the response budget more often.
+
+## Requirements
+
+- [REQ-001] RAC SHALL rank search results by a deterministic relevance score, not by tier precedence alone, so that within and across tiers a more relevant artifact ranks higher.
+- [REQ-002] The score SHALL include a deterministic lexical component in the BM25 family (term frequency with inverse document frequency over the matchable fields), computed with no embeddings, semantic similarity, stemming, or synonym expansion (ADR-038, ADR-066).
+- [REQ-003] RAC SHALL fuse the per-field/tier signals into one ranking using Reciprocal Rank Fusion (RRF), so a result strong on one signal ranks sensibly without hand-tuned tier weights.
+- [REQ-004] RAC SHALL apply a deterministic graph-derived boost computed from the validated relationship graph (for example inbound-reference count or a bounded centrality measure), so a well-connected artifact ranks above an isolated one at equal lexical relevance.
+- [REQ-005] Ranking SHALL stay explainable: each result SHALL continue to carry its match evidence (winning field, matched terms, tier) and SHALL additionally expose the contributing score components, so a caller can see why one result outranks another (extending the explainable-retrieval contract).
+- [REQ-006] Ranking SHALL be deterministic and offline: identical corpus bytes and query yield a byte-identical ordering across runs, with stable, documented tie-breaking and no model or network call.
+- [REQ-007] The search JSON contract SHALL change additively (ADR-007): existing fields are unchanged and the score components are new optional fields, with `schema_version` unchanged.
+
+## Success Metrics
+
+- The grounding-eval benchmark (`rac eval --check`, ADR-066) holds or improves
+  Precision@k / Recall@k against the committed baseline after ranking changes —
+  the ordering is measured, not asserted.
+- Re-running a query on an unchanged corpus yields a byte-identical result order.
+- For a query with several body matches, the artifact a maintainer judges most
+  relevant ranks at or near the top, where tier-precedence alone left it ordered
+  by path.
+
+## Risks
+
+- **Complexity regression.** ADR-038 deliberately chose a simple ladder; a scorer
+  adds moving parts. Mitigation: keep every component deterministic and
+  explainable, pin behaviour with golden tests, and gate quality on `rac eval`.
+- **Hub over-boosting.** A graph boost could float highly-referenced artifacts to
+  the top of unrelated queries. Mitigation: bound the boost and fuse it via RRF
+  rather than letting it dominate lexical relevance; tune against the benchmark.
+
+## Assumptions
+
+- Lexical term-frequency relevance plus graph connectedness orders results closer
+  to what a searcher wants than tier-precedence-then-path does, and the
+  improvement is measurable via `rac eval`.
+- BM25, RRF, and graph centrality are deterministic and explainable, so they sit
+  inside ADR-038/ADR-066's prohibition on embeddings and semantic scoring.
+
+## Related Decisions
+
+- adr-078
+- adr-038
+- adr-037
+- adr-066
+- adr-007
+
+## Related Designs
+
+- deterministic-relevance-ranking
+
+## Related Roadmaps
+
+- v0.29.0-relevance-ranking
+
+## Related Requirements
+
+- rac-explainable-retrieval
+- rac-grounding-eval-benchmark

--- a/rac/requirements/rac-note-tool-ingest-sources.md
+++ b/rac/requirements/rac-note-tool-ingest-sources.md
@@ -1,0 +1,74 @@
+---
+schema_version: 1
+id: RAC-KVSQ28PK9A5P
+type: requirement
+---
+# Note-Tool Ingest Sources
+
+## Problem
+
+`rac ingest` turns rich documents into RAC artifacts through markitdown
+(ADR-072): DOCX, PDF, HTML, PPTX, XLSX, Markdown. But a large share of the
+product knowledge teams already hold lives in personal-knowledge-management (PKM)
+and note tools — Obsidian, Logseq, Notion, Roam — whose exports markitdown does
+not meaningfully handle. Those exports are *already* Markdown (or Markdown plus
+CSV/JSON), organised as a linked *graph of notes*, using wikilink syntax
+(`[[Note]]`, `[[Note|alias]]`) rather than standard Markdown links, with
+tool-specific frontmatter.
+
+The result is a gap on the front door of adoption: a team with a decision log in
+Obsidian or a Notion workspace cannot bring it into Lore without hand-rewriting
+every note. And the wikilink graph they already maintain — which is exactly the
+relationship signal RAC values — is lost on the way in. The affected users are
+new adopters with existing knowledge bases: ingest is their first impression, and
+right now it stops at office documents.
+
+## Requirements
+
+- [REQ-001] RAC SHALL ingest note-tool / PKM exports — at minimum Obsidian, Logseq, Notion, and Roam — converting each note into a RAC-shaped Markdown document for the existing artifact pipeline.
+- [REQ-002] Ingest SHALL accept a directory export (a vault or graph), not only a single file, and process each note in the export as a candidate artifact.
+- [REQ-003] Ingest SHALL normalise PKM wikilink syntax (`[[Note]]`, `[[Note|alias]]`, heading/block references) into resolvable references and surface the targets as candidate `## Related` links, never silently dropping them and never auto-asserting an edge.
+- [REQ-004] Ingest SHALL map tool-specific frontmatter and metadata to RAC's shape where a deterministic mapping exists, and preserve unmapped metadata in the body rather than discarding it.
+- [REQ-005] Note-tool sources SHALL be added through the existing converter registry (ADR-072) as registered converters / optional extras, without changing the engine core or the markitdown path for rich binary documents.
+- [REQ-006] Ingestion SHALL remain deterministic and offline (ADR-002): identical input yields identical output with no model or network call, and SHALL never overwrite an existing artifact.
+- [REQ-007] Conversion SHALL be lossless by default: content that cannot be mapped is preserved verbatim in the output so a human always reviews a complete draft.
+
+## Success Metrics
+
+- An Obsidian vault and a Notion export each convert to valid RAC Markdown drafts
+  (`rac validate` passes after the human review step) with no content silently
+  dropped.
+- Wikilinks in the source become candidate `## Related` references in the output,
+  so the imported graph's connectivity is offered for promotion rather than lost.
+- Re-running ingest on the same export produces byte-identical drafts.
+
+## Risks
+
+- **Format drift.** PKM export formats change and vary by version. Mitigation:
+  per-tool converters with their own tests, isolated behind the registry so one
+  tool's drift cannot break the others or the core.
+- **Wikilink ambiguity.** A `[[Name]]` may not resolve to a unique note.
+  Mitigation: deterministic resolution with reported ambiguity, surfaced as a
+  candidate for human resolution — never a guessed edge.
+
+## Assumptions
+
+- PKM exports are predominantly Markdown with predictable, parseable link and
+  frontmatter conventions, so deterministic normalisation is feasible without a
+  model.
+- Teams hold real product knowledge in these tools and will adopt Lore faster if
+  importing it is a command rather than a rewrite.
+
+## Related Decisions
+
+- adr-079
+- adr-072
+- adr-002
+
+## Related Designs
+
+- note-tool-ingest-sources
+
+## Related Roadmaps
+
+- v0.30.0-note-tool-ingest-sources

--- a/rac/roadmaps/v0.29.x-relevance-ranking/v0.29.0-relevance-ranking.md
+++ b/rac/roadmaps/v0.29.x-relevance-ranking/v0.29.0-relevance-ranking.md
@@ -1,0 +1,127 @@
+---
+schema_version: 1
+id: RAC-KVSQ27BCJ0TC
+type: roadmap
+---
+# RAC v0.29.0 — Deterministic Relevance Ranking
+
+## Status
+
+Planned
+
+## Context
+
+Search filters correctly but orders coarsely. The tier ladder (ADR-037, ADR-038)
+ranks by id, then title, then path, then heading, then body, breaking ties by
+sorted path — so within a tier, order is alphabetical, not relevant. Under the
+MCP response budget that ordering decides what an agent even sees: a weak body
+hit sorted ahead of a strong one can crowd the strong one out of the window.
+
+Two deterministic signals are already in the corpus and unused for ranking: term
+frequency within a field, and the validated relationship graph. This release uses
+them. ADR-078 refines ADR-038's ranking clause to a deterministic relevance score
+— BM25-family lexical scoring, RRF fusion, and a bounded graph boost — while
+reaffirming the hard line both ADR-038 and ADR-066 draw: no embeddings, no
+semantic scoring, no LLM, ever. The *how* is in the `deterministic-relevance-
+ranking` design. It is the deterministic half of what hybrid retrieval systems do;
+the vector half stays out by decision.
+
+## Outcomes
+
+- A search (CLI or MCP) returns its matches ordered by deterministic relevance, so
+  the most relevant artifact lands at or near the top — and inside the response
+  budget — instead of wherever path alphabetisation put it.
+- The order stays reproducible and explainable: same bytes and query give the same
+  ranking, and `--explain` / the JSON show the score components behind it.
+- The improvement is measured, not asserted: the grounding benchmark holds or
+  improves against its committed baseline.
+
+## Initiatives
+
+### Initiative 1 — BM25 lexical scoring (Core)
+
+Score each matchable field (id, title, path, heading, body) with a BM25-family
+term-frequency/IDF score over the query terms, reusing ADR-037's token-boundary
+tokeniser, with field weighting that preserves the tiers' relative importance as a
+graded contribution rather than a hard cutoff. No stemming, no synonyms, no
+embeddings.
+
+### Initiative 2 — RRF fusion (Core)
+
+Fuse the per-field ranked lists with Reciprocal Rank Fusion (`Σ 1/(k + rank)`,
+`k = 60`), replacing the "best tier then path" tiebreak with a parameter-light,
+deterministic merge. The matched set is unchanged; RRF only reorders it.
+
+### Initiative 3 — Bounded graph boost (Core)
+
+Add a deterministic boost from the validated relationship graph (normalised,
+capped inbound-reference signal from the existing relationship index) as one more
+fused signal, so connectedness breaks near-ties toward the artifact the corpus
+leans on — bounded so it cannot dominate lexical relevance.
+
+### Initiative 4 — Explainability and contract
+
+Extend the search result with additive score-component fields (per-signal
+contributions and the fused score) alongside the existing `{field, terms, tier}`
+evidence (ADR-007; `schema_version` unchanged), surfaced through `--explain` and
+`--json` on both `rac find` and `search_artifacts` (ADR-031).
+
+### Initiative 5 — Quality gate and determinism tests
+
+Golden tests pin byte-stable ordering and tie-breaking; the grounding benchmark
+(`rac eval --check`, ADR-066) must hold or improve Precision@k / Recall@k against
+the committed baseline before the ranking change ships.
+
+## Constraints
+
+- No embeddings, semantic scoring, stemming, or synonym expansion — ever
+  (ADR-038, ADR-066).
+- Deterministic and offline: identical bytes and query yield byte-identical order.
+- Additive contract (ADR-007): existing search fields unchanged.
+- Reuse the existing matcher, tokeniser, relationship index, and eval harness;
+  Core serves both surfaces (ADR-031).
+
+## Non-Goals
+
+- Any vector, embedding, or similarity-based ranking.
+- Query reformulation, stemming, or synonym expansion (the agent's job).
+- A new search verb or surface; this re-orders the existing ones.
+- Widening the matched set; ranking only reorders what already matches.
+
+## Success Measures
+
+- `rac eval --check` Precision@k / Recall@k hold or improve versus the committed
+  baseline after the ranking change.
+- Re-running a query on an unchanged corpus yields byte-identical ordering.
+- For a multi-body-match query, the maintainer-judged most relevant artifact ranks
+  at or near the top where tier-then-path left it ordered by path.
+
+## Assumptions
+
+- Lexical term-frequency relevance plus graph connectedness orders results closer
+  to intent than tier-precedence-then-path, and the gain is measurable on the
+  benchmark.
+- BM25, RRF, and graph centrality are deterministic and explainable, so they sit
+  inside ADR-038/ADR-066's prohibition.
+
+## Risks
+
+- **Complexity** beyond the simple ladder ADR-038 chose. Mitigation: determinism,
+  golden tests, explainable components, and the eval gate.
+- **Hub over-boosting** onto unrelated queries. Mitigation: bound the graph signal
+  and fuse via RRF rather than letting it lead; tune against the benchmark.
+
+## Related Requirements
+
+- rac-deterministic-relevance-ranking
+
+## Related Decisions
+
+- adr-078
+- adr-038
+- adr-037
+- adr-066
+
+## Related Designs
+
+- deterministic-relevance-ranking

--- a/rac/roadmaps/v0.30.x-ingest-sources/v0.30.0-note-tool-ingest-sources.md
+++ b/rac/roadmaps/v0.30.x-ingest-sources/v0.30.0-note-tool-ingest-sources.md
@@ -1,0 +1,119 @@
+---
+schema_version: 1
+id: RAC-KVSQ2CV0AM13
+type: roadmap
+---
+# RAC v0.30.0 — Note-Tool Ingest Sources
+
+## Status
+
+Planned
+
+## Context
+
+`rac ingest` converts rich documents through markitdown (ADR-072) — DOCX, PDF,
+PPTX, XLSX, HTML, Markdown — but stops at office documents. A large share of the
+product knowledge teams already hold lives in note / PKM tools (Obsidian, Logseq,
+Notion, Roam), whose exports are already Markdown, organised as a *graph* of
+notes with wikilink syntax. Today those teams cannot bring that knowledge into
+Lore without rewriting it, and the link graph they maintain — the relationship
+signal RAC values most — is lost on the way in.
+
+This release opens that door. ADR-079 adds note-tool exports as a normalising
+converter family in the ADR-072 registry: each note becomes a RAC-shaped draft,
+wikilinks become candidate `## Related` references (promoted by a human, never
+auto-asserted — ADR-074, ADR-065), and conversion stays deterministic, offline,
+and lossless (ADR-002). The *how* is in the `note-tool-ingest-sources` design.
+
+## Outcomes
+
+- A team can run `rac ingest` over an Obsidian, Logseq, Notion, or Roam export and
+  get a set of reviewable RAC drafts — adoption becomes an import, not a rewrite.
+- The source's wikilink graph is carried in as candidate relationships, so
+  connectivity is offered for promotion rather than flattened to plain text.
+- Conversion is deterministic and lossless: identical export, identical drafts,
+  nothing silently dropped, no existing artifact overwritten.
+
+## Initiatives
+
+### Initiative 1 — Note-tool converter family (registry)
+
+Add a converter family behind optional extras (`ingest-obsidian`,
+`ingest-logseq`, `ingest-notion`, `ingest-roam`) registered in the ADR-072
+converter registry, selected by detected export shape or an explicit `--from`
+flag. The engine core and the markitdown path for binary documents are unchanged.
+
+### Initiative 2 — Directory ingest (a vault is a set)
+
+Teach `rac ingest` to accept a directory export and process each note as a
+candidate artifact draft, never overwriting an existing artifact — the unit of
+import is the graph, not a single file.
+
+### Initiative 3 — Wikilink and frontmatter normalisation
+
+Parse and resolve wikilink syntax (`[[Note]]`, `[[Note|alias]]`, heading/block
+refs) against the export, emit resolved targets as candidate `## Related`
+references and report ambiguous ones, map known frontmatter to RAC's shape, and
+preserve everything unmapped verbatim (lossless by default).
+
+### Initiative 4 — Determinism, losslessness, and docs
+
+Golden tests pin byte-identical drafts for a fixed export and prove no content is
+dropped; `docs/cli.md` documents the supported note tools, the `--from` flag, and
+the candidate-link review step.
+
+## Constraints
+
+- Deterministic and offline (ADR-002): identical export yields byte-identical
+  drafts; no model or network; never overwrites an existing artifact.
+- Lossless by default: unmapped content is preserved verbatim.
+- Registry, not core (ADR-072): note-tool sources are registered extras; the core
+  and the markitdown binary-document path are untouched.
+- Candidates, not asserted edges (ADR-074, ADR-065): wikilinks become suggested
+  references a human promotes.
+
+## Non-Goals
+
+- Running PKM exports through markitdown (there is no binary to parse).
+- Auto-creating, writing, or asserting any `## Related` edge from a wikilink.
+- A single universal importer across all tools; each tool is its own converter.
+- Live, API-based sync with a hosted tool — this is export ingestion, offline.
+
+## Success Measures
+
+- An Obsidian vault and a Notion export each convert to RAC drafts that pass
+  `rac validate` after human review, with no content silently dropped.
+- Wikilinks in the source appear as candidate `## Related` references in the
+  drafts.
+- Re-running ingest on the same export produces byte-identical drafts.
+
+## Assumptions
+
+- PKM exports are predominantly Markdown with predictable link and frontmatter
+  conventions, so deterministic normalisation is feasible without a model.
+- Teams hold real product knowledge in these tools and adopt Lore faster when
+  importing it is a command rather than a rewrite.
+
+## Risks
+
+- **Export format drift** across tool versions. Mitigation: per-tool converters
+  with their own tests, isolated behind the registry.
+- **Wikilink ambiguity** where `[[Name]]` has no unique target. Mitigation:
+  deterministic resolution that reports ambiguity for human resolution, never a
+  guessed edge.
+
+## Related Requirements
+
+- rac-note-tool-ingest-sources
+
+## Related Decisions
+
+- adr-079
+- adr-072
+- adr-074
+- adr-065
+- adr-002
+
+## Related Designs
+
+- note-tool-ingest-sources


### PR DESCRIPTION
## What

Documents the remaining GBrain-inspired ideas as corpus artifacts — two coherent themes, each a full requirement + ADR + design + roadmap set. These are **plans** (Proposed ADRs, Planned roadmaps), not implementation.

### Theme 1 — Deterministic relevance ranking (v0.29.0)
The full **BM25 + RRF fusion** *and* the **graph-boost ranking** — they belong in one ranker.

- `requirements/rac-deterministic-relevance-ranking.md`
- **ADR-078** (Proposed) — BM25-family lexical scoring + RRF fusion + a bounded graph boost
- `designs/deterministic-relevance-ranking.md`
- `roadmaps/v0.29.x-relevance-ranking/v0.29.0-relevance-ranking.md`

### Theme 2 — Broader ingest sources (v0.30.0)
- `requirements/rac-note-tool-ingest-sources.md`
- **ADR-079** (Proposed) — Obsidian/Logseq/Notion/Roam via a normalising converter family in the ADR-072 registry
- `designs/note-tool-ingest-sources.md`
- `roadmaps/v0.30.x-ingest-sources/v0.30.0-note-tool-ingest-sources.md`

## The one nuance worth your eye

**ADR-078 refines ADR-038.** ADR-038 froze search ranking as a tier ladder and forbade "embeddings, semantic scoring, stemming, synonym expansion — *ever*." BM25/RRF/graph-boost are all deterministic **lexical/structural** (not semantic, not embeddings), so ADR-078 changes only the *ordering* model and **explicitly reaffirms** that prohibition — and gates the change on the `rac eval` benchmark so the new order is measured, not asserted. I kept it a *refinement* of ADR-038, not a supersession (its tier set, token-boundary matching, and snippets all stand).

The ingest theme stays inside the declared-graph model too: imported wikilinks become **candidate** `## Related` references a human promotes — never auto-asserted (ADR-074, ADR-065), tying back to the v0.28 link-suggestions work.

## Numbering
Reserved **adr-077 / v0.28** for the in-flight #190 (link suggestions); this uses **adr-078/079** and **v0.29/v0.30**. No cross-reference to #190's unmerged artifacts, so relationship validation stays clean.

## Gates
- `rac validate rac/` — pass (279 valid, 0 invalid)
- `rac relationships rac/ --validate` — pass (0 issues)
- `rac review rac/` — no priority 1–2 findings
- `rac export --agent-rules --check` — in sync (078/079 Proposed, correctly excluded)
- `rac coverage` — no new gaps

## Note
Plans only — both ADRs are `Proposed` pending your review. The ranking item is the higher-leverage one (it sharpens grounding retrieval); ingest is the adoption-front-door one. Approve/merge and I can implement either per its roadmap.