### PR TITLE
docs(decision): record git-main as the single source of truth, not a database

### DIFF
--- a/rac/decisions/adr-080-single-source-of-truth-git-not-database.md
+++ b/rac/decisions/adr-080-single-source-of-truth-git-not-database.md
@@ -1,0 +1,102 @@
+---
+schema_version: 1
+id: RAC-KVSTYDARXKYW
+type: decision
+---
+# ADR-080: The Single Source of Truth Is Git `main`, Not a Database
+
+## Context
+
+A recurring question as Lore targets teams of 50+ developers: if every developer
+runs Lore against their own clone, won't those copies drift out of sync, and
+shouldn't there be a central database everyone queries instead?
+
+Lore's architecture answers the first half already. The corpus is Markdown in a
+git repository (ADR-001, ADR-018), served read-only and re-read per call
+(ADR-032), deterministically and offline (ADR-002), with no embeddings (ADR-066).
+It is governed exactly as code is: a change becomes authoritative only when it
+lands on `main` through human PR review (ADR-065) behind the merge gate
+(ADR-075). The question is whether "everyone runs their own copy" is a
+consistency problem a database would solve — and it is the opposite.
+
+## Decision
+
+Lore's single source of truth is the corpus on the git host's `main` branch.
+RAC does not adopt a database as a system of record, and a developer's local
+clone is a working copy that converges on `main`, never a competing truth.
+
+- **`main` is the one canonical state**, exactly as a codebase has one. A local
+  checkout is either current with `main` or a `git pull` behind it. Only PR
+  review writes to `main` (ADR-065), so a local copy can be *stale* but never
+  *authoritative-and-divergent*. Git already keeps a 50-developer team consistent
+  on a shared codebase with no database to synchronise it; the corpus is governed
+  identically.
+- **A database would add drift, not remove it.** It is a second representation of
+  the knowledge that must be continuously reconciled with `main` — two stores
+  that can disagree, where files-in-git is one. The forces that justify a
+  database for agent-memory tools do not apply here: Lore is read-only (no write
+  contention), has no embeddings (ADR-066), and stores text git versions natively.
+- **Determinism makes "in sync" precise.** Identical corpus bytes yield identical
+  answers (ADR-032), so two agents reading the same commit hold the same knowledge
+  by construction; consistency reduces to "same commit," which git manages.
+- **A hard central guarantee is a server, not a database.** A team that wants every
+  agent to call one always-current endpoint — rather than its own checkout — runs
+  a single shared `rac mcp` server fronting an auto-updated `main` checkout. The
+  corpus stays the source of truth; the shared server is one reader of it. That
+  topology is recorded as future intent (`lore-at-team-scale`) and needs HTTP
+  serving, which is a transport feature, not a datastore.
+- **Database-grade querying lives downstream.** If a team wants graph or vector
+  queries over the knowledge, `rac export --graph` / `--documents` feed a database
+  the team runs (ADR-073). The engine stays pure; the corpus stays canonical.
+
+## Consequences
+
+Zero infrastructure: no database to run, migrate, back up, or secure — git
+provides durability, history, access control, and audit, and "your knowledge is
+Markdown in git" is both the architecture and a differentiator against tools that
+make you stand up a datastore. Trust and freshness come from git + PR review +
+determinism, not from a server holding mutable state.
+
+Trade-off accepted: in the default local-clone topology a developer on a stale
+checkout queries stale knowledge until they pull — the same staleness as an
+un-pulled codebase, resolved the same way. Teams that find this unacceptable
+adopt the shared-server topology (still a server, still no database). The cost of
+*not* adding a database is that there is no single live process all reads pass
+through by default; the benefit is that there is exactly one representation of the
+truth, and it is the one the team already reviews and versions.
+
+## Status
+
+Proposed
+
+## Category
+
+Architecture
+
+## Alternatives Considered
+
+- **A central database as the system of record.** Rejected: it is a second
+  representation to reconcile with `main`, loses git's diffability, history, and
+  offline operation, and re-introduces the drift it claims to cure; none of the
+  forces that justify a database (concurrent writes, vectors, embedding-scale
+  storage) apply to a read-only, no-embedding, text corpus.
+- **A central database as a shared cache (not the source of truth).** Deferred,
+  not adopted: a *persistent derived index* may be warranted at scale, but it is a
+  rebuildable cache behind ADR-032's snapshot seam (recorded in
+  `lore-at-team-scale`), not a database and not authoritative.
+- **Local-clone only, with no shared option.** Rejected: teams that want a single
+  live endpoint have a legitimate need; a shared `rac mcp` server meets it without
+  a database, so the topology is recorded as intent rather than refused.
+
+## Related Decisions
+
+- adr-001
+- adr-018
+- adr-032
+- adr-065
+- adr-066
+- adr-073
+
+## Related Roadmaps
+
+- lore-at-team-scale

--- a/rac/roadmaps/future/lore-at-team-scale.md
+++ b/rac/roadmaps/future/lore-at-team-scale.md
@@ -1,0 +1,118 @@
+---
+schema_version: 1
+id: RAC-KVSTYENH8X0S
+type: roadmap
+---
+# RAC — Lore at Team Scale (Future)
+
+## Status
+
+Planned
+
+Unscheduled — captured as future intent for teams of 50+ developers, not yet on
+a release. Nothing here has hit its trigger; it graduates out of `future/` into a
+versioned series when one does.
+
+## Context
+
+Lore is built as files-in-git: one canonical corpus on `main`, served read-only
+and re-read per call (ADR-032), with no database (ADR-080). That model is correct
+and keeps consistency where git already provides it. Two questions appear only at
+team scale, and both have answers that are *servers and caches, never a database*:
+
+- **Consistency.** In the default topology each developer runs a local `rac mcp`
+  against their own checkout, so two developers can be on different commits until
+  they pull. A team may want every agent to call one always-current source of
+  truth instead of individual copies.
+- **Performance.** As a corpus grows into the thousands of artifacts — plausible
+  once large note-tool vaults are imported — re-reading and re-indexing on every
+  call starts to cost real latency, which ADR-032 explicitly defers optimising
+  "behind the corpus-snapshot seam" until a real user reports it.
+
+This item records the intent for both, on the no-database terms ADR-080 sets.
+
+## Outcomes
+
+- A team can point every developer's agent at one always-current endpoint that
+  reflects `main`, so reads come from a single source of truth rather than
+  individual checkouts that lag.
+- Per-call latency stays acceptable as the corpus grows large, without changing
+  the determinism or freshness contract.
+- No database is introduced: git stays the system of record (ADR-080).
+
+## Initiatives
+
+### Initiative 1 — Centralised shared MCP server (HTTP transport)
+
+`rac mcp` gains an HTTP / streamable transport so a single instance, fronting an
+auto-updated `main` checkout, serves the whole team from one endpoint. It stays
+read-only and stateless per call (ADR-032); a merge webhook (or periodic pull)
+keeps the checkout current, so every agent reads `main`. This is the single
+source of truth everyone calls — a server, not a database (ADR-080). Today
+`rac mcp` is stdio-only, so this is the load-bearing build.
+
+### Initiative 2 — Derived-index persistence (behind the ADR-032 seam)
+
+A content-addressed, rebuild-on-change index cache so per-call work stops scaling
+with corpus size: the relationship graph and search index are derived once and
+reused while the corpus content-hash is unchanged, and invalidated on any change
+so freshness and determinism hold (ADR-032). It is a rebuildable cache, not a
+store — "files are truth, the index is disposable." Likely triggers: corpus-wide
+BM25 document-frequency statistics from the relevance-ranking work, and large
+note-tool vault imports.
+
+### Initiative 3 — Operate-it documentation
+
+A deployment recipe for the shared server (container, the keep-current webhook,
+read-only posture, no secrets) and guidance on when a team needs it versus the
+local-clone default — so the central-source-of-truth option is reproducible.
+
+## Constraints
+
+- No database as a system of record; files-in-git stay canonical (ADR-080).
+- Read-only and stateless per call; the determinism and freshness contract of
+  ADR-032 holds for both the shared server and the cache.
+- The cache is a rebuildable derived index, never authoritative; any corpus change
+  invalidates it.
+
+## Non-Goals
+
+- A database, vector store, or any persistent system of record other than git.
+- Write-through the server: knowledge still changes only by PR to `main`
+  (ADR-065).
+- Embeddings or semantic indexing (ADR-066).
+
+## Success Measures
+
+- With the shared server, every team agent returns the same answer for the same
+  query at a given moment, because all read one `main`-backed checkout.
+- With the cache, repeated reads of an unchanged large corpus avoid re-indexing,
+  and a single change invalidates and rebuilds it; answers stay byte-identical to
+  the uncached path.
+- No new datastore appears in the deployment: the only moving parts are a git
+  checkout and a stateless reader.
+
+## Assumptions
+
+- Teams that want a single live endpoint are a real segment; the local-clone
+  default remains correct for everyone else.
+- Per-call recompute is fine at current scale and becomes a latency concern only
+  for large corpora — so persistence is a deferred optimisation, not a day-one
+  need (ADR-032).
+
+## Risks
+
+- A shared server drifts from `main` if the keep-current step fails. Mitigation:
+  the server re-reads per call (ADR-032) and the pull is driven by merge events,
+  so staleness is bounded and observable.
+- A persistent cache serves stale results if invalidation is wrong. Mitigation:
+  content-addressed keying — any byte change to the corpus changes the key and
+  forces a rebuild — keeping the determinism contract intact.
+
+## Related Decisions
+
+- adr-080
+- adr-032
+- adr-001
+- adr-066
+- adr-073


### PR DESCRIPTION
## What

Captures the team-scale (50+ developers) consistency question — "won't individual copies drift; shouldn't there be a central database?" — as recorded knowledge.

- **ADR-080** (Proposed) — *The Single Source of Truth Is Git `main`, Not a Database.* Records why the files-in-git model is the *more* consistent design at scale, not the less.
- **`future/lore-at-team-scale.md`** — the deferred intent that delivers the hard central guarantee and the performance headroom, on no-database terms.

## The argument (for the PR record)

- **The single source of truth already exists and is centralised: `main`.** A local clone is a working copy that converges on `main` — stale at worst, never authoritative-and-divergent (only PR review writes to `main`, ADR-065). Git keeps 50 devs consistent on a shared codebase with no database; the corpus is governed identically.
- **A database would *add* drift** — a second representation to reconcile with `main`. The forces that push agent-memory tools onto Postgres (concurrent writes, vectors, embedding-scale storage) don't apply: Lore is read-only, has no embeddings (ADR-066), and stores text git versions natively.
- **The hard guarantee you want — everyone calling one always-current endpoint — is a *server, not a database*:** a single shared `rac mcp` over HTTP fronting an auto-updated `main` checkout. That's recorded as `lore-at-team-scale` Initiative 1, because `rac mcp` is stdio-only today and that's the real build.
- **Database-grade querying lives downstream** via `rac export --graph`/`--documents` → a DB the team runs (ADR-073). Engine stays pure; corpus stays canonical.

`lore-at-team-scale` also folds in the **derived-index persistence** you asked me to capture (Initiative 2) — a content-addressed, rebuild-on-change cache behind ADR-032's snapshot seam, triggered by BM25 IDF (v0.29) and large vault imports (v0.30). Files are truth; the index is disposable.

## Gates
- `rac validate rac/` — pass (273 valid, 0 invalid)
- `rac relationships rac/ --validate` — pass (0 issues)
- `rac review rac/` — no priority 1–2 findings
- `rac export --agent-rules --check` — in sync (ADR-080 Proposed, excluded)

## Note
Plan/decision only — ADR-080 is `Proposed` for your review. The one product fork it implies: **do you want the centralised shared-server topology (HTTP serving) to become a built, supported capability?** I've recorded it as future intent reflecting your stated preference; say the word and it graduates to a versioned roadmap.