### PR TITLE
feat(skill): add rac-capture interview authoring skill

### DIFF
--- a/.claude/skills/rac-capture/SKILL.md
+++ b/.claude/skills/rac-capture/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: rac-capture
+description: Capture a NEW decision or requirement from a conversation (an interview) into ONE valid RAC (requirements-as-code) artifact — you interview and propose, the human ratifies, `rac validate` closes, and promotion into the trusted corpus is by pull request reviewed by someone other than the author. Use when a user wants to record a fresh decision or requirement into Lore (a project's rac/ directory) by talking it through rather than importing a document. For an existing document use rac-import; for bulk conversion use rac-ingest.
+---
+
+# RAC interview capture
+
+Turn a conversation into one valid RAC artifact. You interview the author and
+propose; the human ratifies; `rac validate` is the deterministic check; an
+independent reviewer promotes it by pull request. This skill never adds AI to the
+RAC core — it runs in the coding agent and uses the `rac` CLI.
+
+## Hard constraints
+
+- **Capture knowledge, not work.** Record a decision or a long-lived requirement
+  and its rationale — never owners, assignees, sprints, priorities, or due dates.
+  If the conversation is about *who does what by when*, that belongs in the team's
+  work tracker, not in RAC; say so and stop.
+- **The schema is not yours to invent.** Read the real shape with
+  `rac schema <type>` (and `rac schema` for the recognised types). Use the real
+  section names, the real artifact types, and the real `## Related <Type>`
+  relationship sections. Never guess or hard-code a field, type, or relationship
+  kind. If you cannot run `rac schema`, stop and say so.
+- **No invention.** Capture only what the author actually tells you. Where a
+  required section has no material, **ask a question** — do not fill it with
+  plausible-sounding text. The interview gathers facts; it does not author them.
+- **Human ratification is mandatory and explicit (before any file is written).**
+  Present the draft and require the user to confirm or correct **(a) the artifact
+  type, (b) the title, and (c) each relationship** before you write anything.
+  Relationships are *suggestions to confirm*, never silently asserted. The `id` is
+  minted by `rac new` (opaque, system-assigned) — never hand-write or choose it.
+- **Close on deterministic validation.** After writing, run `rac validate`. If it
+  fails, show the errors, offer to fix them, and re-validate. Never leave an
+  invalid artifact behind.
+- **Save is a draft commit; promotion is a pull request.** A fresh capture is
+  *untrusted* until a human reviews it. Write the artifact, optionally commit it as
+  a draft on a branch when the user confirms, but **never write straight to the
+  trusted corpus, never auto-commit without confirmation, and never self-merge.**
+  The trust boundary is review and merge by **someone other than the author**.
+
+## 1. Capture the raw intent first
+
+Let the author say it their way before you ask anything — paste or dictate the
+decision in plain language. Do not gate capture behind your questions; collect the
+brain-dump, then structure it. If they describe several distinct decisions, capture
+one artifact at a time and offer to repeat for the rest.
+
+## 2. Choose the type and read its real schema
+
+Decide *with the author* whether this is a decision, requirement, design, roadmap,
+or prompt (most captures are a decision or a requirement). Then read the actual
+contract:
+
+```bash
+rac schema                     # the recognised artifact types
+rac schema decision            # required / recommended / optional sections, and
+                               # any controlled values (e.g. Status, Category)
+rac schema decision --json     # the same, machine-readable
+```
+
+Map the captured intent onto *these* section names. Do not introduce sections the
+schema does not define.
+
+## 3. Interview to fill the template
+
+Ask only the **two to four** things you cannot infer from the brain-dump or safely
+default — and ask them as **confirmations, pre-filled with your best reading**, not
+as blank prompts. Keep each question short and let the author skip or accept. Good
+targets: the precise decision/requirement statement, the context that forced it,
+the consequences or rationale, and a `## Status` value (use one of the controlled
+values `rac schema` lists). Requirements are testable `- [REQ-001] ...` lines under
+`## Requirements`; prefer normative wording (MUST / SHOULD / MAY), and avoid vague
+verbs (support, handle, allow, enable) that `rac validate` warns on.
+
+## 4. Dedupe, then draft
+
+Before drafting, check whether the team already recorded this, so capture does not
+create a duplicate:
+
+```bash
+rac find "<key words from the decision>" rac/
+```
+
+If a close match exists, surface it and ask whether to update that artifact
+(via `rac-import` / a normal edit) instead of creating a new one. Otherwise, draft
+the content under the type's real headings, keeping the author's own wording where
+it fits. For each **required** section with no captured material, leave a clearly
+marked gap to raise with the user — do not invent.
+
+## 5. Review gate — confirm before writing
+
+Present, in the conversation (not as a file yet):
+
+- the **draft** artifact;
+- a short summary: the **chosen type**, the **proposed title**, and any
+  **relationships the author named** (never relationships inferred by scanning the
+  repository — that is out of scope);
+- every **gap** where a required section had no material.
+
+Ask the user to confirm or correct the type, the title, and each relationship.
+Verify any relationship target actually resolves before proposing it:
+
+```bash
+rac resolve <id> rac/
+rac find "<text>" rac/
+```
+
+Do not write a file until the user has confirmed.
+
+## 6. Write, then validate
+
+On confirmation, scaffold the file (this mints the id and writes the canonical
+template — it never overwrites an existing file), then replace the template body
+with the confirmed content:
+
+```bash
+rac new decision rac/decisions/<slug>.md
+```
+
+Write artifacts only inside the host project's RAC directory (`rac/` by default;
+confirm the path if the project keeps them elsewhere) under the matching subfolder
+(`rac/decisions/`, `rac/requirements/`, `rac/roadmaps/`, `rac/prompts/`,
+`rac/designs/`). If the project has no `.rac/config.yaml`, run `rac init` once at
+the project root first. Keep the `##` headings and the frontmatter block intact;
+never edit the minted `id`.
+
+Then close on validation:
+
+```bash
+rac validate rac/decisions/<slug>.md
+```
+
+Treat errors as blocking — show them, offer fixes, and re-run until it exits 0.
+`rac improve <file> --template` prints section stubs when the content exists to
+fill a missing recommended section. If the artifact links to others, finish with
+`rac relationships rac/ --validate`.
+
+## 7. Hand off — draft commit, promote by pull request
+
+A validated capture is a **draft**, not yet trusted knowledge. With the user's
+go-ahead, commit it on a branch (a draft), but leave the promotion to the team's
+normal pull-request flow:
+
+- the author's confirmation in this conversation is a *fidelity* check — "we
+  captured what you meant" — **not** ratification into the record;
+- the **trust boundary** is a pull request reviewed and merged by **someone other
+  than the author** (the project's required-review gate), which is also where
+  `rac validate` / `rac relationships --validate` run as checks.
+
+Never open-and-self-approve, and never merge the author's own capture for them.
+
+## Out of scope
+
+- Reformatting an **existing document** into an artifact — use `rac-import`.
+- Bulk or batch conversion, directory crawling, or "migrate my whole wiki" — use
+  `rac-ingest`.
+- Inferring relationships by scanning the repository — only the links the author
+  names, each confirmed.
+- Inventing context, consequences, rationale, or requirements the author did not
+  provide.
+- Auto-committing without the human-review step, or merging a capture into the
+  trusted corpus without independent review.
+- Recording ownership, assignment, scheduling, or any work-tracking field.

--- a/rac/designs/lore-capture-surfaces.md
+++ b/rac/designs/lore-capture-surfaces.md
@@ -104,6 +104,21 @@ ADR-065's own words, a legitimate *untrusted* state), and the **pull request is
 reserved for promoting** that draft into the reviewed corpus an agent grounds
 against. Capture stays low-friction without weakening the trust boundary.
 
+### The two-gate write model (every host)
+
+"Approval" in a capture flow is **two distinct gates, on two different actors** —
+a distinction that holds for *every* writing host, not just Slack. **Gate 1** is
+the author confirming, in the host, *"you captured what I meant"* — a
+**data-quality / fidelity** check that is **not a trust boundary** (it is
+self-approval, which separation-of-duties and four-eyes guidance — NIST AC-5,
+OWASP, SLSA two-party review — classify as the absence of a control). **Gate 2**
+is an **independent** maintainer reviewing and merging the pull request — the
+actual trust boundary (ADR-065), enforced by required reviews + a "someone other
+than the author" rule. The corollary binds every host: a writer host or bot only
+ever **proposes** (opens the draft PR) and **never holds approval or merge power**
+— otherwise the second gate collapses back into self-approval. The Slack host
+works this out end to end in `lore-slack-capture-flow`.
+
 ### Four hosts over the one core
 
 Each host is a thin adapter that runs the capture agent and drives the `rac` CLI;
@@ -216,6 +231,10 @@ direction, not a closed decision.
 - **Save is a commit; promotion into the trusted corpus is a PR (ADR-065).** A
   host commits drafts freely but never lets unreviewed content enter the
   agent-grounding corpus except through human PR review.
+- **Two gates, and the writer only proposes.** The author's in-host confirmation
+  is a fidelity gate, not a trust boundary; an *independent* maintainer's PR merge
+  is the trust boundary (ADR-065). A writer host or bot opens the draft PR and
+  must never hold approval or merge power.
 - **Not a content store (ADR-024).** A host emits artifacts to git and stores no
   canonical content of its own.
 - **Installed surfaces are `lore-*` products (ADR-068).** The overlay, the bot,

--- a/rac/designs/lore-capture-surfaces.md
+++ b/rac/designs/lore-capture-surfaces.md
@@ -130,14 +130,19 @@ Stack: **Tauri v2**, not native Swift/AppKit. The MVP can ship **macOS-first**
 `collectionBehavior` to cross Spaces), but Tauri keeps **Windows** a cheap
 fast-follow (tray via `Shell_NotifyIcon`, global hotkey via `RegisterHotKey`,
 always-on-top via `WS_EX_TOPMOST`) on one codebase, where native AppKit would
-lock the surface to macOS forever. **Linux is deferred**: on Wayland, global
-hotkeys, always-on-top, and tray icons are all portal-mediated with uneven
-compositor support (KDE better, GNOME gaps), so "always-available" there is a
-per-compositor gamble rather than a guarantee. The distribution tax is real on
-both shipping platforms — Developer ID signing + notarization on macOS,
-Authenticode (increasingly EV / cloud) signing + SmartScreen reputation on
-Windows. The overlay is **where bring-your-own-gateway config lives**, because
-the app itself makes the model call.
+lock the surface to macOS forever. Because Tauri renders in the OS webview
+(`WKWebView` on macOS, **WebView2 / Edge Chromium on Windows**), a Windows build
+carries a **WebView2 runtime dependency** — evergreen on current Windows 11, but
+the installer should bootstrap it for older targets. **Linux is deferred**: on
+Wayland, global hotkeys, always-on-top, and tray icons are all portal-mediated
+with uneven compositor support (KDE better, GNOME gaps), so "always-available"
+there is a per-compositor gamble rather than a guarantee. The distribution tax is
+real on both shipping platforms — Developer ID signing + notarization on macOS,
+and **Authenticode** signing on Windows, where unsigned or low-reputation
+binaries trip **SmartScreen** warnings; the current low-friction path is a cloud
+signing service such as **Azure Trusted Signing**, the modern alternative to
+buying a traditional EV certificate. The overlay is **where bring-your-own-gateway
+config lives**, because the app itself makes the model call.
 
 **Host C — a Slack bot.** Reaches the **whole team, including PMs, with no
 per-user install**, and captures decisions *where they are actually made* — the

--- a/rac/designs/lore-capture-surfaces.md
+++ b/rac/designs/lore-capture-surfaces.md
@@ -1,0 +1,340 @@
+---
+schema_version: 1
+id: RAC-KVSM9E6BNWNH
+type: design
+---
+# Lore Capture Surfaces
+
+## Status
+
+Proposed
+
+Exploratory — this records the reasoning from a capture-interface exploration so
+it lives in the corpus, not a tool's scratch space (ADR-047). It is not an
+accepted build. It develops Thread E (authoring / capture) of
+`lore-frontend-optionality` into its own design: how a non-technical author gets
+recorded knowledge *into* the corpus, and which host surfaces are worth building.
+
+## Context
+
+`lore-frontend-optionality` established that Lore's biggest gap is **authoring**:
+grounding (serving recorded knowledge to agents) is leverage on an asset that has
+to be authored first, and the people who own the source knowledge — product
+managers — live in Word, Docs, Confluence, and Jira, not in an IDE or an agent
+harness. That design reframed the barrier as **capture-and-structure**, not
+*editing*, and sketched four capture options. This design takes the first of
+them — an agent-interview capture flow — and works out the interface.
+
+The organizing insight comes from grounding the question against the code rather
+than the tool landscape: **the skill is the brain; the host is the interface.**
+A capture skill modelled on `rac-import` (`src/rac/skills/rac-import/SKILL.md`)
+is host-agnostic. Its loop is already most of what is needed:
+
+> interview the author → draft against the real schema (`rac schema <type>`) →
+> the human ratifies type, title, and each relationship → `rac new` mints the
+> opaque id and scaffolds the file → `rac validate` is the deterministic close.
+
+`rac-import` does exactly this for an existing *document*; capture does it for a
+*conversation*. Crucially, the MCP server exposes five read-only tools and the
+engine contains **no LLM client at all** (there is no model call anywhere under
+`src/rac/`). So the language model that runs the interview never lives in the
+engine — it lives in whatever **host** runs the agent. "What interface should
+capture take?" therefore resolves to: **what hosts run the capture agent for
+people who do not live in a coding harness?** Each host is a thin client
+(ADR-063) over one shared capture core, and each emits to git; none stores
+content (ADR-024) and none is an editor.
+
+This design was prompted by a survey of how always-available capture tools work —
+the macOS menu-bar "click the icon → modal" pattern (ChatGPT desktop, Raycast),
+Slack's assistant and modal surfaces, the bring-your-own-LLM gateway model
+(LiteLLM, OpenRouter), and quick-capture UX (Drafts, Linear, Todoist, Obsidian
+QuickAdd). A seven-angle research pass (primary sources, contested claims flagged
+inline) backs the trade-offs below.
+
+## User Need
+
+The author this design serves is the one Lore currently locks out: a **product
+manager or domain owner who has a decision or requirement in their head** (or in
+a Word doc, or a Slack thread) and **no way to get it into the corpus without
+learning git, Markdown, or an IDE.** They need to:
+
+- record the durable knowledge — a decision and its rationale, a long-lived
+  requirement (ADR-020) — not a work item (ADR-017);
+- do it in a surface they already have open, with the fewest possible steps;
+- trust that nothing lands in the team's record without review.
+
+A second audience is the **larger engineering team** that will host any such
+surface: they need it to route through their own model gateway for cost, audit,
+and data-residency control, and to respect the existing git/PR trust boundary.
+
+## Design
+
+### The capture core (the `rac-capture` skill)
+
+A new skill — `rac-capture` — is the interview variant of `rac-import`: same
+hard constraints (the schema is not the agent's to invent; human review of type,
+title, and relationships is mandatory before any write; close on `rac validate`;
+no invention), with the *source* being a short interview instead of a supplied
+document. The research on quick-capture converges on a clear shape the interview
+should follow:
+
+- **Capture the raw intent first, ask questions second.** Every leading tool
+  lets the user dump unstructured text instantly (Drafts' "where text starts";
+  Linear/Todoist/Things default to an inbox) before any structuring. The
+  interview must never gate capture behind its questions.
+- **Pre-fill answers from the dump; ask only what cannot be inferred or safely
+  defaulted.** Linear requires only a title and status and defaults everything
+  else; the interview's two-to-four questions should be confirmations, not blank
+  prompts. *(The specific "2–4" count and the circulated conversational-form
+  completion-lift figures are weakly-sourced heuristics, not research constants —
+  treat the direction as sound and the numbers as advisory.)*
+- **Defer structure, then draft it.** Capture now, ask a few questions, produce
+  the structured artifact, leave it editable — mirroring progressive disclosure
+  and Linear's grace window.
+
+The single biggest failure mode is the interview re-introducing the up-front
+decisions that capture is supposed to defer; the mitigation is to capture free
+text first, pre-fill proposed answers, and allow skip/Enter-through.
+
+### Save is a commit; promotion is a PR
+
+Following `lore-frontend-optionality`'s refinement of ADR-065: a capture surface
+**commits a draft freely** (an unreviewed branch or a `drafts/` area is, in
+ADR-065's own words, a legitimate *untrusted* state), and the **pull request is
+reserved for promoting** that draft into the reviewed corpus an agent grounds
+against. Capture stays low-friction without weakening the trust boundary.
+
+### Four hosts over the one core
+
+Each host is a thin adapter that runs the capture agent and drives the `rac` CLI;
+they differ only in reach, friction, build cost, and where the model call lives.
+
+**Host A — existing agent harnesses (Claude Desktop / Claude Code / Cursor).**
+Near-zero build: the skill plus the existing MCP server already work here. It
+reaches engineers, *not* PMs, and the harness owns the model (bring-your-own-key
+is the harness's concern). This is the cheapest test of the whole loop and is the
+shared core every other host wraps, so it ships first.
+
+**Host B — a cross-platform desktop overlay** (the "little app alongside any
+screen"). A global hotkey summons a small modal that runs the interview and then
+commits a file / opens a PR. The decisive scoping insight: **capture needs
+*summon-a-modal*, not *watch-the-screen*.** A plain global-hotkey-plus-modal
+avoids the entire macOS permission gauntlet the research surfaced — Accessibility
+reads (which can capture passwords with *no* on-screen recording indicator) and
+Screen Recording (which on macOS Sequoia re-prompts roughly monthly). Reading
+on-screen context, à la ChatGPT "Work with Apps" or Cluely, is a *later,
+permission-gated* enhancement, never the MVP.
+
+Stack: **Tauri v2**, not native Swift/AppKit. The MVP can ship **macOS-first**
+(`NSStatusItem` menu-bar item, `NSPanel` non-activating floating panel,
+`collectionBehavior` to cross Spaces), but Tauri keeps **Windows** a cheap
+fast-follow (tray via `Shell_NotifyIcon`, global hotkey via `RegisterHotKey`,
+always-on-top via `WS_EX_TOPMOST`) on one codebase, where native AppKit would
+lock the surface to macOS forever. **Linux is deferred**: on Wayland, global
+hotkeys, always-on-top, and tray icons are all portal-mediated with uneven
+compositor support (KDE better, GNOME gaps), so "always-available" there is a
+per-compositor gamble rather than a guarantee. The distribution tax is real on
+both shipping platforms — Developer ID signing + notarization on macOS,
+Authenticode (increasingly EV / cloud) signing + SmartScreen reputation on
+Windows. The overlay is **where bring-your-own-gateway config lives**, because
+the app itself makes the model call.
+
+**Host C — a Slack bot.** Reaches the **whole team, including PMs, with no
+per-user install**, and captures decisions *where they are actually made* — the
+direct answer to "decisions happen in Slack and never get recorded." A message
+shortcut ("Save as decision") or slash command starts the flow. Two Slack
+constraints shape it: Block Kit **modals cap at 100 blocks and a three-view
+stack**, so a genuine multi-turn interview belongs in the **assistant-thread
+surface** (`assistant.threads.*`, with native streaming), not a modal; and the
+**three-second acknowledgement rule** forces a quick-ack-then-async-follow-up
+architecture for any model call. It commits through a **GitHub App → PR**, which
+suits the async, review-first flow. The costs are a hosted, multi-tenant network
+service (a public endpoint or Socket Mode, per-workspace OAuth token storage,
+request-signature verification) and a **governance boundary crossing**: piping
+Slack thread content to an external model triggers app-approval, data-residency,
+and (on Enterprise Grid) admin-policy review. That crossing is precisely why
+bring-your-own-gateway is *mandatory* here, not optional. *(Slack's AI/assistant
+APIs are fast-moving — the assistant surface, native streaming, and a scope
+change for `assistant.threads.setStatus` all shipped or shifted across 2025–2026
+— so this host carries the most version risk.)*
+
+**Host D — a web modal** (extending `rac-localview`). Reuses the existing React
+app: pick a type, fill a template-driven form *or* paste prose for an
+AI-assisted draft, preview, and open a PR via the GitHub API — the GitBook middle
+path, git staying the source of truth. It reaches anyone with a link and no
+install (good for PMs), but it is "another tab": it lacks the overlay's
+always-available friction win and Slack's team-native reach.
+
+### The bring-your-own-gateway seam (the LiteLLM answer)
+
+For every host that itself calls the model (B, C, D), "support the team's LiteLLM
+key" costs almost nothing: expose a configurable **OpenAI-compatible `base_url` +
+API key + model name (+ optional headers)**, source the key from an environment
+variable or OS secret store, and emit **no prompt-content telemetry**. That one
+seam is the de-facto industry convention — LiteLLM, OpenRouter, Azure OpenAI,
+Vertex, Ollama, and vLLM all expose it, and Cursor, Continue, Aider, Cline, and
+Zed all consume it. For an engineering team it unlocks data-residency, cost
+control, and audit; for the Slack host it is what makes the model boundary
+crossing acceptable to admins. In Host A it is free (the harness owns the model).
+This is baked in from the first version of any host, not retrofitted.
+
+### Recommended sequencing
+
+1. **Host A — the `rac-capture` skill — now.** Near-zero build, validates the
+   loop in today's harnesses, seeds the corpus, and is the shared core B/C/D
+   wrap.
+2. **The favoured pair, B + C, which are complementary across platforms.** The
+   macOS-first overlay serves desktop users where they work; the Slack bot serves
+   everyone else — including Windows users — with no install. They are not
+   either/or so much as two reach surfaces over the same core.
+3. **Host D (web modal)** as the broad-but-shallow fallback, reusing
+   `rac-localview`, if a no-install browser surface is wanted.
+
+All three reach surfaces are recorded as open options; B + C are the favoured
+direction, not a closed decision.
+
+## Constraints
+
+- **AI lives in the host, never the engine (ADR-002, ADR-067).** The interview
+  model, like every other model in Lore's orbit, runs in the harness, the
+  overlay, or the bot — never in `rac-core`. The engine stays deterministic and
+  AI-optional.
+- **Thin clients over the contract (ADR-063).** Every host drives the published
+  `rac` CLI and consumes the stable contract; none reimplements classification or
+  validation.
+- **Capture knowledge, not work (ADR-017).** A capture flow records decisions and
+  long-lived requirements (ADR-020); it must not mirror tickets, owners, sprints,
+  or workflow state, even when the source is a Jira-shaped conversation.
+- **Templates are the creation contract (ADR-021).** Drafts are shaped by the
+  real schema read at runtime (`rac schema`), never by fields the host invents;
+  ingestion-over-rewrite (ADR-006) still applies when the source is a document.
+- **Save is a commit; promotion into the trusted corpus is a PR (ADR-065).** A
+  host commits drafts freely but never lets unreviewed content enter the
+  agent-grounding corpus except through human PR review.
+- **Not a content store (ADR-024).** A host emits artifacts to git and stores no
+  canonical content of its own.
+- **Installed surfaces are `lore-*` products (ADR-068).** The overlay, the bot,
+  and the web capture surface are `lore-*` brand, not `rac-*` engine code.
+- **Bring-your-own-gateway carries no prompt telemetry.** Any host making a model
+  call exposes a configurable OpenAI-compatible endpoint and must not exfiltrate
+  prompt content, consistent with the local/opt-in telemetry posture (ADR-040,
+  ADR-041).
+
+## Rationale
+
+The skill-is-brain / host-is-interface split is what makes the whole space
+tractable: it concentrates all the durable value (classification against the real
+schema, validation, the human-ratify gate, the commit/PR discipline) in one
+host-agnostic core, and reduces each surface to a thin adapter. That is why
+building three reach surfaces is not three times the work — they share the core
+and differ only in how they collect the interview and where they post the result.
+
+The summon-a-modal-not-watch-the-screen decision is the highest-leverage scoping
+call. The instinct to build a Cluely-style always-watching overlay would saddle
+the product with the macOS TCC permission gauntlet, a standing privacy liability
+(Accessibility reads have no recording indicator and can capture secrets visible
+on screen), and a recurring-reprompt UX tax — all for context a knowledge-capture
+tool does not need. A global hotkey and a focused modal deliver the "alongside
+any screen" feel with none of that.
+
+Choosing Tauri v2 over native AppKit trades a small amount of per-platform polish
+for keeping Windows a cheap fast-follow on one codebase. Since the favoured B + C
+pair already covers Windows users through Slack, the overlay can ship macOS-first
+without stranding anyone — but the stack choice keeps the door open rather than
+nailing it shut.
+
+The bring-your-own-gateway seam is near-free and does double duty: it is the
+engineering-team governance story *and* the mitigation for Slack's model boundary
+crossing. Exposing one configurable endpoint is cheaper than any bespoke
+integration and is what every comparable dev tool already does.
+
+The trade-off accepted: capture surfaces are real `lore-*` products with real
+build and (for the bot) operational cost, which Lore takes on because the
+alternative — leaving authoring to a handful of technical maintainers — caps the
+corpus and, with it, the value of everything downstream (grounding included).
+
+## Alternatives
+
+- **Build an editor instead of a capture flow — rejected.** This repeats the
+  framing `lore-frontend-optionality` already rejected: the barrier is
+  capture-and-structure, not text entry, and a homegrown editor is a perpetual
+  maintenance sink that fights "file over app" portability. A capture surface
+  produces a draft and a PR; it never becomes the editor the author lives in.
+- **An always-watching, screen-reading overlay (Cluely-shaped) — rejected for
+  the MVP.** It buys context the capture use case does not need at the price of
+  the full TCC permission surface and a standing privacy liability. On-screen
+  context is a later, explicitly permission-gated option, not the core.
+- **Native Swift/AppKit overlay — rejected.** It locks the surface to macOS,
+  whereas Tauri keeps Windows a cheap fast-follow on a single codebase for a
+  modest polish cost.
+- **MCP write tools for direct authoring — rejected.** The read-only, tools-only
+  surface (ADR-030) and the no-pre-edit-interception stance (ADR-067) keep
+  authoring on the file/PR path; a write tool in the MCP would cross the trust
+  boundary in the wrong place.
+- **Do nothing — the honest baseline.** Engineers can already author through Host
+  A today. Acceptable only if the corpus is being authored; the whole point of
+  Thread E is that the non-technical author is locked out, so "do nothing"
+  silently bets the record stays the domain of a few maintainers.
+
+## Accessibility
+
+- **Keyboard-first capture.** The capture modal should take keyboard focus on
+  open and be fully operable and dismissible from the keyboard, matching the
+  Explorer's keyboard-first conventions (ADR-028) and the universal quick-capture
+  pattern (a global hotkey into a focused modal).
+- **Provenance legibility.** As elsewhere in Lore, a draft produced by an
+  AI-assisted interview must be clearly marked as a *proposed* artifact awaiting
+  human ratification, never presented as already-authoritative recorded
+  knowledge.
+- **Plain-language first.** The interview asks essential questions in plain
+  language and pre-fills proposed answers, so a non-technical author is never
+  confronted with schema jargon or empty required fields.
+
+## Style Guidance
+
+- Name the capture surfaces under the `lore-*` brand (ADR-068); the skill is
+  `rac-capture` (an engine-adjacent skill, like `rac-import`), while the overlay,
+  bot, and web surface are Lore-brand products.
+- Keep the vocabulary honest: a host *captures* and *proposes*; the human
+  *ratifies*; git/PR *records*. A draft is never described as a decision until it
+  is merged.
+- Where a claim is load-bearing, cite the source in prose and carry its caveat;
+  flag the fast-moving areas (Slack AI surfaces, Windows cloud-signing, macOS
+  permission cadence) rather than asserting a frozen certainty.
+
+## Open Questions
+
+- Where do drafts live before promotion — a `drafts/` path, an `/intake` branch,
+  or a fork — and what is the lightest review that still satisfies ADR-065 for a
+  solo maintainer versus a team?
+- How good must the freeform→typed classification be before a non-technical
+  author can self-serve, and how are its mistakes surfaced for human review
+  rather than hidden?
+- For Host C, does the interview live in the assistant-thread surface (richer,
+  more version-risk) or a capped modal (simpler, shallower), and which model
+  boundary-crossing posture clears a typical Enterprise-Grid admin review?
+- Should the first build (Host A `rac-capture`) be scheduled as a non-versioned
+  `rac/roadmaps/future/` item now, or after the skill is prototyped?
+- Does the overlay (Host B) earn its build cost once the Slack bot (Host C)
+  already covers the same authors on every platform?
+
+## Related Decisions
+
+- ADR-002
+- ADR-006
+- ADR-017
+- ADR-020
+- ADR-021
+- ADR-024
+- ADR-028
+- ADR-030
+- ADR-040
+- ADR-041
+- ADR-063
+- ADR-065
+- ADR-067
+- ADR-068
+
+## Related Roadmaps
+
+- lore-supermemory-grounding

--- a/rac/designs/lore-frontend-optionality.md
+++ b/rac/designs/lore-frontend-optionality.md
@@ -15,6 +15,11 @@ accepted build. It surveys the option space, recommends a priority order, and
 leaves the editor question recorded as a weighed conclusion rather than a closed
 decision.
 
+It was subsequently extended after a red-team with **Thread E — authoring /
+capture**, which reframes the editor question as a *capture-and-structure*
+problem for non-technical authors and reorders the priorities so capture ranks
+at the top, ahead of grounding.
+
 ## Context
 
 "What should Lore's frontend be?" is the wrong question, because Lore is not
@@ -68,14 +73,21 @@ Three audiences sit behind "frontend," and they want different things:
   Explorer and `rac-localview` already serve.
 - **Maintainers** authoring artifacts need a *low-friction edit→validate→commit
   loop* — without Lore having to become the editor they live in.
+- **Non-technical authors** — the product managers who *own the source
+  knowledge* but work in Word, Google Docs, Confluence, and Jira — need a way to
+  get knowledge into the corpus *at all*, without learning git, markdown, or an
+  IDE. The original draft under-served this audience; it is the subject of
+  Thread E.
 
 The need this design weighs is **where the next unit of frontend effort buys the
 most**, given those three audiences and Lore's recorded identity.
 
 ## Design
 
-The six tools cluster into four threads. Each maps onto Lore differently; the
-recommended priority order follows.
+The six tools cluster into four threads (A–D). A red-team of this design then
+surfaced a fifth — **Thread E, authoring / capture** — that the tool survey had
+hidden behind Thread B; it is recorded after the four and ranks *first* in the
+revised priority order. Each thread maps onto Lore differently.
 
 ### Thread D — Grounding inside agent IDEs *(the recommendation)*
 
@@ -167,15 +179,86 @@ one the maintainer already loves.
   of *meaning* — is real, but Lore's entities are artifacts and its review
   surface is the pull request.
 
+### Thread E — Authoring / capture *(the cold-start precondition — added on red-team)*
+
+Threads A–D were drafted as if the corpus already exists; a red-team exposed
+that assumption. **Grounding (D) is leverage on an asset that has to be authored
+first** — an agent cannot ground against a decision nobody captured — and the
+people who own the source knowledge (product managers) live in Word, Docs,
+Confluence, and Jira, not in an IDE or an agent harness. The original draft
+under-weighted this by collapsing authoring into Thread B and then correctly
+dismissing the *wrong* UI: the barrier is **not** *editing markdown* (an editor
+question, answered "don't build one"), it is **capture-and-structure** — getting
+unstructured knowledge out of a PM's head and tools into a typed, validated
+artifact. Capture is therefore reframed as a first-class thread and ranked above
+grounding, because **grounding's authority-of-record moat is hostage to how
+complete and current the corpus is**: a thin or stale record grounds agents on
+confidently-wrong guidance, which is worse than no record.
+
+The shape that stays inside the recorded decisions:
+
+> **Capture** (where the author already is) → **Structure** (a template-driven
+> form or an agent interview, with any AI *outside* the deterministic core) →
+> **Save** (a commit) → **Promote** (the PR review boundary into the trusted
+> corpus).
+
+- **The interpretation step lives outside core (ADR-002, ADR-067).** Format
+  conversion is deterministic (markitdown, ADR-072); turning *freeform prose*
+  into a *typed, sectioned, linked* artifact requires classification, which the
+  deterministic core must not perform. The AI-assisted draft is a companion —
+  the same one-way pattern as `lore-supermemory-interplay`, never engine code.
+- **Save is a commit; only promotion to the trusted corpus is a PR (refines
+  ADR-065).** ADR-065 places the trust boundary at human PR review *into the
+  agent-grounding corpus*, and explicitly treats "unreviewed branches" and
+  "machine-ingested documents not yet merged" as legitimate — merely *untrusted*
+  — states. So a capture surface may **commit drafts freely** to a working branch
+  or a `drafts/` area with no PR ceremony; the PR gate is reserved for the moment
+  a draft is *promoted* into the reviewed corpus an agent grounds against. This
+  keeps authoring low-friction without weakening the boundary.
+- **Capture knowledge, not work (ADR-017).** A connector extracts the durable
+  decision or long-lived requirement (ADR-020) from a ticket or doc; it never
+  mirrors owners, sprints, or workflow state.
+
+Four implementation options, cheapest first:
+
+1. **Agent-interview authoring** *(ship first; near-zero build)* — a skill/prompt
+   ("record a decision") that interviews the author in plain language, dedupes
+   via `search_artifacts`, drafts against the template (ADR-021), and commits the
+   draft or opens the promotion PR. Reuses `rac-artifacts` / `rac-import`,
+   templates, and the `lore` MCP. The author talks, reviews, and approves —
+   never touching markdown or git. Compounds with Thread D (the same surface now
+   also *seeds* the corpus).
+2. **Self-serve ingestion** *(meet them in Word)* — make `rac ingest`
+   self-service via an `/intake` GitHub Action (drop a `.docx` / `.pdf` →
+   markitdown → an AI classify-and-structure companion → a draft commit /
+   proposal). Reuses the `rac-ingest` skill and the already-designed
+   `explorer-import-workflow` (detect → review → confirm).
+3. **Guided web capture** *(the real non-technical front door; bigger build)* —
+   extend `rac-localview` from viewer to viewer + capture: pick a type, fill a
+   **template-driven form** (the form *is* the template, ADR-021 — not a freeform
+   editor, which sidesteps the person-years cost), preview, and commit / propose
+   via the GitHub API. The GitBook middle path the research endorsed; git stays
+   the source of truth (ADR-024).
+4. **Tracker connectors** *(defer; ADR-gated)* — one-way knowledge extraction
+   from Jira / Linear / Confluence in `lore-connectors`, extracting durable
+   knowledge only. This is the easiest place to breach ADR-017, so it requires an
+   explicit new ADR reaffirming the knowledge-not-work boundary before it is
+   built.
+
 ### Recommended priority order
 
-1. **Grounding distribution (D)** — highest leverage, near-zero build, reinforces
-   identity. The recommendation.
-2. **Authoring-flow enrichment, not an editor (B)** — stay BYO-editor; if
-   anything, invest in templates + validate-on-save + diff-at-commit.
-3. **Live desktop wrapper (A)** — optional; Tauri v2 directly, repo-watching
+1. **Authoring / capture (E)** — the cold-start precondition. Start with the
+   near-zero-build agent-interview skill and the `/intake` action. Without it the
+   corpus stays thin and there is little for Thread D to serve.
+2. **Grounding distribution (D)** — highest leverage *once there is a corpus to
+   ground against*; near-zero build, reinforces identity. E and D compound — the
+   same surface that grounds can also capture.
+3. **Authoring-flow enrichment, not an editor (B)** — for IDE-resident
+   maintainers, stay BYO-editor; if anything, templates + validate-on-save +
+   diff-at-commit.
+4. **Live desktop wrapper (A)** — optional; Tauri v2 directly, repo-watching
    variant only, Linux as the risk surface.
-4. **lix (C)** — inspiration / watch only; do not adopt.
+5. **lix (C)** — inspiration / watch only; do not adopt.
 
 ## Constraints
 
@@ -185,9 +268,13 @@ one the maintainer already loves.
 - **RAC is not a content store (ADR-024).** Frontends view, navigate, ground, and
   link back to artifacts on disk; they do not become the canonical home of
   content.
-- **The trust boundary is human PR review (ADR-065).** The "review the diff
-  before it lands" ritual belongs to the git PR, not to an in-app editor's own
-  approval flow.
+- **The trust boundary is human PR review *into the corpus* (ADR-065) — but a
+  save is a commit, not a PR.** ADR-065 names "unreviewed branches" and
+  not-yet-merged drafts as legitimate, untrusted states, so a capture surface may
+  commit drafts freely; the PR gate applies only to *promoting* a draft into the
+  reviewed corpus an agent grounds against. The "review the diff before it lands"
+  ritual belongs to that promotion PR, not to an in-app editor's own approval
+  flow.
 - **Recency and history come from git (ADR-045), pipelines are file-first
   (ADR-011).** A second change-control engine (lix) is redundant for markdown and
   conflicts with these.
@@ -247,10 +334,16 @@ contract, the validation, and the grounding that actually differentiate it.
 - **A static-only desktop shell — rejected.** It adds little over
   `rac export --html` opening in a browser. Only a *live*, repo-watching variant
   would justify the surface.
+- **Treat authoring as an editor problem (the original draft's framing) —
+  rejected on red-team.** Asking "should Lore build an editor?" answers the wrong
+  question and dismisses the wrong UI; the non-technical author's barrier is
+  capture-and-structure, not text entry. Thread E replaces this framing.
 - **Do nothing (the honest baseline).** Lore's five surfaces already cover the
-  three audiences. Acceptable until the grounding-distribution story (Thread D)
-  is worth scheduling — which is the signal that would open a future roadmap
-  item, not this design.
+  agent, human-reader, and IDE-maintainer audiences. Acceptable *only* if the
+  corpus is already being authored — but the red-team's point is that the
+  non-technical author is locked out today, so for a cold-start corpus "do
+  nothing" silently bets the corpus stays the domain of a few technical
+  maintainers.
 
 ## Accessibility
 
@@ -295,21 +388,38 @@ contract, the validation, and the grounding that actually differentiate it.
 - Should Thread D's distribution work be promoted to a non-versioned
   `rac/roadmaps/future/` item once there is evidence agents are under-grounded for
   lack of easy registration?
+- For **capture (Thread E)**, where do drafts live before promotion — a
+  `drafts/` path, an `/intake` branch, or a fork — and what is the lightest
+  review that still satisfies ADR-065's boundary for a solo maintainer versus a
+  team?
+- How good must the freeform→typed **classify pass** be before self-serve
+  ingestion (Options 2–3) is trustworthy enough to expose to a non-technical
+  author, and how are its mistakes surfaced for human review rather than hidden?
+- Does Thread E warrant its own dedicated design and a future roadmap item, or
+  does recording it here as the top-priority thread suffice until a build is
+  scheduled?
 
 ## Related Decisions
 
+- ADR-002
 - ADR-005
+- ADR-006
 - ADR-007
 - ADR-011
+- ADR-017
+- ADR-020
+- ADR-021
 - ADR-024
 - ADR-028
 - ADR-029
 - ADR-030
+- ADR-044
 - ADR-045
 - ADR-063
 - ADR-065
 - ADR-067
 - ADR-068
+- ADR-072
 
 ## Related Roadmaps
 

--- a/rac/designs/lore-frontend-optionality.md
+++ b/rac/designs/lore-frontend-optionality.md
@@ -1,0 +1,317 @@
+---
+schema_version: 1
+id: RAC-KVSF2ZC1BFC5
+type: design
+---
+# Lore Frontend Optionality
+
+## Status
+
+Proposed
+
+Exploratory — this records the reasoning from a frontend-optionality exploration
+so it lives in the corpus, not a tool's scratch space (ADR-047). It is not an
+accepted build. It surveys the option space, recommends a priority order, and
+leaves the editor question recorded as a weighed conclusion rather than a closed
+decision.
+
+## Context
+
+"What should Lore's frontend be?" is the wrong question, because Lore is not
+greenfield. It already ships five human- and agent-facing surfaces:
+
+- the `rac` CLI — the canonical surface (ADR-005);
+- the read-only stdio MCP server `lore` — five deterministic tools for agents
+  (ADR-029, ADR-030);
+- a Textual TUI Explorer — keyboard-first terminal browsing (ADR-028);
+- `rac-localview` — a single-file React Portal (`rac export --html`) with a
+  force-directed graph view; and
+- the `lore-vscode` extension — in-editor validation, navigation, and an
+  embedded graph webview (the v0.21.x editor series).
+
+So the real question is **optionality**: which *thin shell over the stable
+contract* earns further investment, and what — if anything — Lore should borrow
+from the current crop of local-first and agentic tools. This design was prompted
+by six such projects:
+
+- **Pake** (github.com/tw93/pake) — a Tauri/Rust wrapper that turns a webpage
+  into a small native desktop app.
+- **Flashtype** (github.com/opral/flashtype.ai) — an Electron markdown editor
+  for Claude/Codex whose thesis is "Agents edit. You review the diff. Nothing
+  lands without you," built on lix.
+- **ZenNotes** (github.com/ZenNotes/zennotes) — a local-first markdown vault
+  (Electron + CodeMirror 6, optional Go backend) that ships its own MCP server.
+- **lix** (github.com/opral/lix) — an embeddable, in-process change-control
+  engine for any file format, with entity-level semantic diffs and a SQL query
+  layer.
+- **Orca** (github.com/stablyai/orca) and **Fusion** (github.com/Runfusion/Fusion)
+  — agent-orchestration environments (ADEs) that run many coding agents in
+  isolated worktrees.
+
+A five-angle research pass (with sources, contested claims flagged inline) backs
+the synthesis below. The unifying finding: **Lore's frontend strategy is "thin
+shells over a stable contract, meet users where they already are" — not owning
+an app surface.** Every thread lands back on the same recorded decisions —
+non-Python clients are thin clients over the published contract (ADR-063), RAC is
+not a content store (ADR-024), and the trust boundary is human PR review
+(ADR-065).
+
+## User Need
+
+Three audiences sit behind "frontend," and they want different things:
+
+- **Agents** grounding a task need *authority* — the exact, current wording of
+  what the team has decided, addressable by ID and auditable. This is what the
+  `lore` MCP server already serves.
+- **Humans** reading recorded knowledge need *navigation* — to browse, search,
+  and follow relationships without a build step or a server. This is what the
+  Explorer and `rac-localview` already serve.
+- **Maintainers** authoring artifacts need a *low-friction edit→validate→commit
+  loop* — without Lore having to become the editor they live in.
+
+The need this design weighs is **where the next unit of frontend effort buys the
+most**, given those three audiences and Lore's recorded identity.
+
+## Design
+
+The six tools cluster into four threads. Each maps onto Lore differently; the
+recommended priority order follows.
+
+### Thread D — Grounding inside agent IDEs *(the recommendation)*
+
+The highest-leverage "frontend" for Lore is not a UI at all — it is being the
+**cited authority of record inside the agent IDEs people already use**.
+
+- MCP reached production scale in 2026 (on the order of 10k+ public servers; a
+  cross-vendor standard across Claude Code, Cursor, Codex, Copilot, Zed,
+  Windsurf). A single stdio server registers once and plugs into all of them at
+  ~child-process latency — which is exactly the shape `rac mcp` already has.
+- Claude Code's project-scoped `.mcp.json` makes "commit a knowledge MCP server
+  to the repo, shared across the team" a *first-class, already-supported*
+  pattern. Orca (stablyai/orca) exposes MCP config as a first-class extension
+  surface with per-project/session scoped leases — a natural host. Fusion's MCP
+  support is undocumented in its README (plausible but unverified).
+- The "fuzzy find → deterministic verify" loop Lore already designed for
+  (`lore-supermemory-interplay`) is now a *named, published* architecture
+  pattern (e.g. REGAL's non-interference: "interpretation may depend on computed
+  artifacts, but computation must not depend on interpretation").
+- The defensibility argument: citation hallucination runs roughly 14–95% across
+  models; grounding measurably cuts errors but never to zero, so an
+  ID-addressable, validated authority an agent must resolve against is a genuine
+  trust differentiator. *(Caveat: "authority of record = durable moat" is a
+  forward-looking bet, not a market-proven position.)*
+
+This thread is distribution and positioning of a surface Lore already ships, not
+a new build. That is precisely why it ranks first.
+
+### Thread B — Authoring / editing surface *(stay bring-your-own-editor)*
+
+The editor question was held open going in; the evidence resolves it to a clear
+**weighed recommendation: do not build a homegrown editor.**
+
+- A production text/rich-text editor is a perpetual sink — mature editors
+  represent tens to hundreds of person-years, and maintenance cost meets or
+  exceeds build cost indefinitely. The decisive cost is opportunity cost:
+  engineering spent on text entry is not spent on Lore's differentiator
+  (classification, validation, relationships, grounding).
+- The instructive counterexample reinforces the same point. GitHub — whose
+  identity *is* the git repo — added in-browser editing by **embedding VS Code**
+  (`github.dev`), not by building an editor. Owning the authoring loop can be
+  right; building the editor yourself is not.
+- The convergent low-regret pattern is **delegate-and-validate**: edit in the
+  user's own tool (`$EDITOR`/VS Code), validate on save via a file-watcher, make
+  commit easy. Lore already does this — the extension validates in-editor and the
+  Explorer opens `$EDITOR` ("Explorer is not an editor",
+  `explorer-editor-integrations`).
+- The genuinely transferable idea from Flashtype is *not* "an editor" but the
+  **review-the-diff-before-it-lands ritual** — which Lore already gets for free
+  from git PRs (ADR-065). Plain-markdown portability ("file over app") is a
+  load-bearing trust argument that an in-app editor monopoly would *undercut*.
+
+If Lore ever invests in authoring, it should be *flow enrichment* —
+richer templates (`rac new`), validate-on-save, and surfacing the
+diff/validation at commit time — never a homegrown editor competing with the
+one the maintainer already loves.
+
+### Thread A — Desktop wrapper (Pake / Tauri) *(optional, low priority)*
+
+- Tauri v2 wraps an existing React SPA close to drop-in (point `frontendDist` at
+  the build output; a static viewer needs no React changes), and ships far
+  smaller than Electron. The headline "≈20× smaller" is trivial-wrapper
+  marketing, though — the only first-party *production*-migration figure found was
+  roughly 3×.
+- The real risk is the Linux webview: **WebKitGTK is maintainer-acknowledged
+  unstable** ("getting worse each release"), and macOS WebKit is pinned to the OS
+  version. For a viewer expected to run across arbitrary distros this is the
+  exposure. Pake itself is a quick-wrapper, not a product framework — a
+  first-party product should use **Tauri v2 directly**.
+- The marginal value of a desktop shell over `rac export --html` (which already
+  opens in any browser) is modest. The one *compelling* variant is a **live**
+  local app — watch the repo, re-export on change — turning a static export into
+  a living viewer. Only that variant earns a release slot.
+
+### Thread C — lix change-control model *(inspiration, not dependency)*
+
+- lix is genuinely interesting: in-process change control for *any* format with
+  entity-level semantic diffs and a SQL history layer. But it is pre-1.0 (v0.7),
+  its **markdown plugin is beta**, its shipping SDK is JavaScript (the Rust core
+  is still landing), and visible production usage is essentially Opral's own apps
+  (Flashtype, inlang) — no clear third-party shipper.
+- For an **already git-native, markdown-only, PR-reviewed** corpus, lix largely
+  *duplicates* git. Its net-new value appears only for non-line-diffable formats
+  (DOCX/XLSX/PDF), sub-file semantic diff/merge, or embedded in-app review where
+  shelling out to git + GitHub is not viable. Adopting it would cut against
+  recency-from-git (ADR-045), file-first pipelines (ADR-011), and PR-as-trust-
+  boundary (ADR-065).
+- Record it as a **watch** item. The transferable concept — review at the level
+  of *meaning* — is real, but Lore's entities are artifacts and its review
+  surface is the pull request.
+
+### Recommended priority order
+
+1. **Grounding distribution (D)** — highest leverage, near-zero build, reinforces
+   identity. The recommendation.
+2. **Authoring-flow enrichment, not an editor (B)** — stay BYO-editor; if
+   anything, invest in templates + validate-on-save + diff-at-commit.
+3. **Live desktop wrapper (A)** — optional; Tauri v2 directly, repo-watching
+   variant only, Linux as the risk surface.
+4. **lix (C)** — inspiration / watch only; do not adopt.
+
+## Constraints
+
+- **Thin clients over the contract (ADR-063).** Any frontend consumes the
+  published CLI/JSON/MCP surfaces; none reimplements the engine. This is why
+  `rac-localview` and the extension are viable and why a homegrown editor is not.
+- **RAC is not a content store (ADR-024).** Frontends view, navigate, ground, and
+  link back to artifacts on disk; they do not become the canonical home of
+  content.
+- **The trust boundary is human PR review (ADR-065).** The "review the diff
+  before it lands" ritual belongs to the git PR, not to an in-app editor's own
+  approval flow.
+- **Recency and history come from git (ADR-045), pipelines are file-first
+  (ADR-011).** A second change-control engine (lix) is redundant for markdown and
+  conflicts with these.
+- **The MCP surface is read-only and tools-only (ADR-029, ADR-030).** The
+  grounding thread is distribution of that surface, not new write capability.
+- **Brand and topology (ADR-068).** Installed surfaces are `lore-*`; the engine
+  and build-coupled internals are `rac-*`. A desktop wrapper or distribution
+  bundle is a `lore-*` product, not engine code.
+- **The export contract grows only additively (ADR-007).** Wrappers and grounding
+  bundles depend on the stable export shape, never on private internals.
+- **No homegrown editor.** Treated here as a strong recommendation (see Status),
+  grounded in build/maintenance cost and the git-source-of-truth identity — not
+  an absolute prohibition.
+
+## Rationale
+
+Three independent lines of reasoning point the same way.
+
+First, **leverage-per-build**. Thread D reuses a surface Lore already ships and
+only needs distribution and positioning; it is the cheapest path to the largest
+strategic payoff. Threads A and C are net-new builds whose value is conditional;
+Thread B's most valuable form is *not building* the obvious thing.
+
+Second, **identity coherence**. Lore's whole differentiator is a deterministic,
+auditable, git-backed system of record. A surface that strengthens that — being
+the cited authority an agent verifies against — compounds the identity. A surface
+that competes with it — owning the editor, or running a second change-control
+engine — dilutes it. For a tool whose source of truth lives in the user's git
+repo, owning the editor is strategically incoherent unless the editor strictly
+improves the git round-trip, which delegate-and-validate already achieves.
+
+Third, **cost honesty**. The editor question feels like a product gap, but the
+evidence is lopsided: editors are among the most expensive surfaces to build and
+maintain, and even GitHub chose to embed rather than build. The friction the
+editor question is really about — the edit→validate round-trip — is better solved
+at the access layer (validate where the user already works) than by adding a new
+surface the user has to move into.
+
+The trade-off accepted: Lore declines to own the most visible, demo-friendly
+surface (a polished standalone app) in exchange for keeping its effort on the
+contract, the validation, and the grounding that actually differentiate it.
+
+## Alternatives
+
+- **Build a homegrown markdown editor (Flashtype/ZenNotes shape) — rejected.**
+  Perpetual maintenance cost, opportunity cost against the real differentiator,
+  and a direct tension with "file over app" portability and ADR-024. The
+  delegate-and-validate pattern captures the benefit (low edit→validate friction)
+  without the cost.
+- **Adopt lix as a change-control layer — rejected.** For markdown in a git repo
+  reviewed by PR, lix duplicates git while adding a pre-1.0 dependency with a beta
+  markdown plugin; it conflicts with ADR-045, ADR-011, and ADR-065. Kept as a
+  watch item for a future, non-markdown, in-app-review need.
+- **Pake quick-wrap of the Portal — rejected as a product path.** Fine as a
+  personal convenience, but for a first-party surface use Tauri v2 directly; Pake
+  is a wrapper, not a maintainable product framework.
+- **A static-only desktop shell — rejected.** It adds little over
+  `rac export --html` opening in a browser. Only a *live*, repo-watching variant
+  would justify the surface.
+- **Do nothing (the honest baseline).** Lore's five surfaces already cover the
+  three audiences. Acceptable until the grounding-distribution story (Thread D)
+  is worth scheduling — which is the signal that would open a future roadmap
+  item, not this design.
+
+## Accessibility
+
+- **Provenance legibility (grounding surface).** As with
+  `lore-supermemory-interplay`, results an agent or operator consumes must never
+  blur authority: Lore's verbatim, ID-addressed, lifecycle-stamped text stays
+  distinct from any associative or model-rewritten copy.
+- **Local-graph-first framing (viewer).** Research on full force-directed graphs
+  is consistent: past roughly 200 nodes a global graph becomes a "hairball" that
+  is pleasant but navigationally weak. *(Contested — defenders value it for small
+  vaults and cluster-spotting.)* The defensible, accessible value is the **local
+  graph** (a node's neighborhood) plus orphan / unresolved-target detection.
+  `rac-localview` should lead with local views, not the global hairball.
+- **Keyboard-first parity.** Any new surface should match the Explorer's
+  keyboard-first conventions (ADR-028) rather than assume a pointer.
+
+## Style Guidance
+
+- Name installed surfaces under the `lore-*` brand and keep engine/build-coupled
+  internals `rac-*` (ADR-068); a distribution bundle or desktop wrapper is a
+  Lore-brand product, not engine code.
+- Vocabulary keeps the layers honest: Lore *grounds* and is *authoritative*;
+  fuzzy or semantic companions *recall* and are *associative*. A viewer *displays*
+  artifacts; it does not own them.
+- Wrappers and grounding bundles depend only on the published, additively-growing
+  contract (ADR-007) — `id`, `type`, `status`, and the documented export shape
+  (`corpus-export-shape-contract`) — never on private internals.
+- Where a claim is load-bearing, cite the source in prose (as here) and carry its
+  caveat; prefer an honest "contested / forward-looking" flag over a promotional
+  certainty.
+
+## Open Questions
+
+- Does the **live desktop wrapper** (Thread A) earn a release slot at all, or is
+  "open the HTML export in a browser" the right permanent answer?
+- What is the **minimal `.mcp.json` distribution story** per host — Claude Code
+  (committed project scope), Cursor, Codex, Orca — and should Lore ship a
+  documented snippet (or a `rac mcp init` helper) for each?
+- If authoring-flow enrichment is ever pursued, what is its exact scope —
+  templates only, or validate-on-save plus a commit-time diff/validation surface —
+  and where does it live (`lore-*` surface vs engine affordance)?
+- Should Thread D's distribution work be promoted to a non-versioned
+  `rac/roadmaps/future/` item once there is evidence agents are under-grounded for
+  lack of easy registration?
+
+## Related Decisions
+
+- ADR-005
+- ADR-007
+- ADR-011
+- ADR-024
+- ADR-028
+- ADR-029
+- ADR-030
+- ADR-045
+- ADR-063
+- ADR-065
+- ADR-067
+- ADR-068
+
+## Related Roadmaps
+
+- lore-supermemory-grounding
+- repo-extraction-programme

--- a/rac/designs/lore-slack-capture-flow.md
+++ b/rac/designs/lore-slack-capture-flow.md
@@ -1,0 +1,256 @@
+---
+schema_version: 1
+id: RAC-KVSV66Z4X71Z
+type: design
+---
+# Lore Slack Capture Flow
+
+## Status
+
+Proposed
+
+Exploratory — this records the reasoning from a research pass into the Slack
+ingest path so it lives in the corpus, not a tool's scratch space (ADR-047). It
+is not an accepted build. It deepens **Host C** of `lore-capture-surfaces` into a
+worked, end-to-end pipeline, and answers one question precisely: when Slack is the
+ingest point, how does captured knowledge get *written* and *approved by a human*.
+
+## Context
+
+`lore-capture-surfaces` named four hosts for the capture core and flagged the
+Slack bot (Host C) as the most operationally complex — a hosted, multi-tenant
+service that crosses a data-governance boundary. This design works that host out
+in detail. The motivating question is the one a reviewer asks first: *who approves
+what gets recorded, and where does that approval actually happen?*
+
+The research lands on a single load-bearing finding: **"approval" is two distinct
+gates, on two different actors, in two different systems.** Conflating them is the
+classic mistake, because the author confirming their own capture is not, in any
+governance sense, a control. The corpus already encodes the right boundary —
+ADR-065 makes human pull-request review the trust boundary — so this design mostly
+shows how a Slack flow *respects* recorded decisions rather than inventing new
+ones: ADR-065 (PR review is the trust boundary), ADR-017 (attribution is history,
+not work), ADR-035 (user-managed AI credentials), and ADR-002 / ADR-067 (no AI in
+the engine).
+
+A claim convention note: load-bearing operational facts below are drawn from
+primary Slack and GitHub documentation and from established security guidance
+(separation of duties / four-eyes — NIST AC-5, OWASP, SLSA two-party review).
+Fast-moving areas (Slack's AI/assistant and Workflow Builder surfaces) are flagged
+where they appear.
+
+## User Need
+
+Three roles meet in this flow:
+
+- **The author** — someone in a Slack thread who has just made or recorded a
+  decision and wants it captured, without leaving Slack, learning Markdown, or
+  touching git.
+- **The maintainer** — who must be able to judge whether the proposed artifact
+  faithfully reflects what was decided, and ratify it into the trusted record.
+- **The admin** — who governs whether thread content may cross to an external
+  model at all, and needs the data flow disclosed.
+
+The need is to get a faithful, reviewable artifact out of a conversation **without
+letting the person who said it be the one who admits it to the record.**
+
+## Design
+
+### The pipeline, end to end
+
+1. **Trigger (capture).** A **message shortcut** ("Save as decision") or a slash
+   command starts the flow. Slack hands the app a `trigger_id` (usable for ~3
+   seconds to open a modal) plus the message's `channel` and `ts`.
+
+2. **Interview (structure).** Because Block Kit **modals cap at 100 blocks and a
+   three-view stack**, a genuine multi-turn interview belongs in the
+   **assistant-thread** surface (`assistant.threads.*`), not a single modal; a
+   light capture can use a modal form. Either way: capture the raw text first,
+   then ask two-to-four pre-filled confirmation questions. The model runs in the
+   **host**, never the engine (ADR-002, ADR-067), through a user-configured
+   gateway (ADR-035). *(Slack's assistant APIs are fast-moving — treat that
+   surface as version-sensitive.)*
+
+3. **Acknowledge in 3 s, then work async — and stay idempotent.** Slack requires
+   an HTTP 200 within **3 seconds**, but an LLM call plus a git write will not
+   finish that fast, so the endpoint **acks immediately and processes on a
+   worker**. The Events API is **at-least-once** with a **three-retry storm**
+   (immediate, ~1 min, ~5 min) carrying `X-Slack-Retry-Num`, so the worker must
+   **dedup on the event's `event_id`** (a store with a TTL longer than the retry
+   window). Dedup alone does not make the *write* idempotent: derive a
+   deterministic artifact id/filename from `(channel, ts)` so reprocessing
+   updates in place, and rely on the GitHub Contents API's `sha` precondition to
+   return a 409 conflict rather than silently creating a divergent second
+   artifact.
+
+4. **Gate 1 — the author confirms (fidelity, *not* a trust boundary).** In Slack,
+   a `primary` **Approve** and a `danger` **Reject** button (optionally a
+   `confirm` dialog), or a modal submit. The interaction payload's `user`
+   identifies who clicked. This gate answers *"did we capture what you meant"* —
+   a **data-quality** check. It is **not** a trust boundary, and crucially
+   **Slack does not enforce four-eyes**: the app sees `user.id` but nothing stops
+   the author approving their own capture, so this gate must never be treated as
+   ratification.
+
+5. **Write — a draft pull request.** The app writes through a **GitHub App**: it
+   mints a short-lived (≈1 hour) **installation access token** scoped to the repo,
+   acting as its own bot identity, with **least privilege — only `contents:write`
+   + `pull_requests:write` + `metadata:read`** (avoiding `.github/workflows` so no
+   `workflows` permission is needed). The sequence is *get base ref → create a
+   branch → write the artifact file → open a `draft: true` pull request*. The PR
+   body links the **`chat.getPermalink`** back to the originating thread as
+   provenance, and credits the human author with a `Co-authored-by:` trailer. Two
+   hard rules from the research: the bot **must not hold approval power**, and it
+   **must not be on a ruleset bypass list** — because a GitHub App's own review
+   *can* satisfy required reviews if it has write/admin, which would silently
+   defeat the gate (the self-approval footgun).
+
+6. **Gate 2 — an independent maintainer reviews and merges (the trust boundary).**
+   This is where ADR-065 actually lives. Branch protection requires an approving
+   review **from someone other than the author/last pusher**, with **CODEOWNERS**
+   *combined with* that not-the-author rule (CODEOWNERS alone is self-satisfiable
+   if the author is an owner), **dismiss-stale-approvals** on new commits, and a
+   **required status check running `rac validate` / `rac relationships
+   --validate`** so nothing invalid can merge. The reviewer follows the Slack
+   permalink to judge fidelity, then merges — and only then does the artifact
+   enter the trusted, agent-grounding corpus.
+
+7. **Audit.** Traceability assembles from **four independent records across two
+   systems**: the Slack permalink (source), the Slack click log (who captured /
+   confirmed), the GitHub PR review (who ratified), and the signed commit history
+   (the merge). Because they live in different systems, forging the chain requires
+   cross-system collusion.
+
+8. **Governance.** Slack's strong privacy guarantees are **first-party only** —
+   the moment thread content is sent to an external model it leaves Slack's trust
+   boundary, and that assurance becomes the operator's to provide. The mitigations
+   are the BYO-gateway posture ADR-035 already mandates: route inference through a
+   user-controlled OpenAI-compatible endpoint (a self-hosted LiteLLM proxy or a
+   local model), retention/telemetry off (a config choice, not a default),
+   region-pinned; **store metadata and the permalink, not the raw transcript**;
+   and treat thread content as untrusted input (prompt injection), which is the
+   same posture ADR-065 already takes. Slack Marketplace / Enterprise-Grid add
+   disclosure, least-privilege scopes, TLS 1.2+, and request-signature
+   verification, and admins can gate the app.
+
+### The spine
+
+The whole pipeline reduces to one rule: **the bot proposes, an independent human
+disposes.** Gate 1 makes the capture faithful; Gate 2 makes it trusted; the two
+are deliberately different people, checks, and systems.
+
+## Constraints
+
+- **The trust boundary is human PR review (ADR-065).** Admission to the corpus
+  happens only at an independent maintainer's merge — never at the author's Slack
+  confirmation, and never by the writer bot.
+- **No AI in the engine (ADR-002, ADR-067); credentials are user-managed
+  (ADR-035).** The interview model and any classification run in the host, behind
+  a configurable OpenAI-compatible gateway with retention off.
+- **Attribution is history, not work (ADR-017).** Record who captured and who
+  approved (identity + timestamp + permalink) as provenance; never add owner,
+  assignee, sprint, or due-date fields.
+- **Not a content store (ADR-024).** Persist the permalink and the resulting
+  artifact in git; do not store raw Slack transcripts.
+- **Thin client over the contract (ADR-063).** The bot drives the `rac` CLI / Git
+  + GitHub APIs; it adds nothing to `rac-core`.
+- **Installed surface is a `lore-*` product (ADR-068).** The Slack app is
+  Lore-brand, hosted separately from the engine.
+- **Operational invariants.** Ack < 3 s then process async; dedup on `event_id`;
+  idempotent write keyed on `(channel, ts)` with the Contents API `sha` guard; the
+  writer bot has least-privilege scopes, no approval power, and no ruleset bypass.
+
+## Rationale
+
+The two-gate model is forced by security first principles, not preference.
+Separation of duties (NIST SP 800-53 AC-5), the four-eyes / two-person rule, OWASP
+secure-SDLC ("reviewed by individuals other than the originating author"), and
+SLSA's source track ("the uploader and reviewer are two different trusted
+persons") all say the same thing: an actor who originates a change cannot also be
+the control that authorizes it. The author's Slack confirmation can only attest
+*intent* ("you transcribed me correctly"); it provides no independent assurance of
+*validity* ("this should enter the record"). Treating it as the trust boundary is
+functionally self-approval, which the literature classifies as the *absence* of a
+control rather than a weak one.
+
+Opening the capture as a **draft PR** is precisely what lets GitHub's platform
+machinery — required reviews, not-the-author, CODEOWNERS, dismiss-stale, required
+status checks — apply; writing straight to the trusted branch would bypass all of
+it. Least-privilege GitHub-App tokens (short-lived, own identity, repo-scoped) make
+the writer auditable and revocable, and withholding approval power from the bot is
+what stops the self-approval footgun. The permalink is not decoration: per the
+provenance principle, the independent reviewer cannot judge fidelity without access
+to the source the artifact claims to capture.
+
+The trade-off accepted: this host carries real operational and governance weight
+(a hosted service, a GitHub App, a model boundary crossing) — justified because
+Slack is where many decisions are actually made and never recorded, and this is
+the path that captures them without weakening the trust boundary.
+
+## Alternatives
+
+- **Single gate — the author confirms in Slack and it lands — rejected.** That is
+  self-approval; it satisfies no separation-of-duties requirement and admits
+  unreviewed content to the record.
+- **Bot writes straight to the trusted branch — rejected.** It bypasses every
+  required-review control; the draft PR is the mechanism that makes capture a
+  *reviewable proposal*.
+- **Give the writer bot approval / merge power (or a ruleset bypass) — rejected.**
+  A GitHub App review can satisfy required reviews if it has write/admin, silently
+  defeating Gate 2; the writer must only ever *open* the PR.
+- **Store the raw Slack transcript in the artifact — rejected.** It violates "not
+  a content store" (ADR-024) and Slack's "store metadata, not data" guidance;
+  persist the permalink and the structured artifact instead.
+- **Inherit Slack's privacy guarantees for the external model call — rejected as
+  unsound.** Those guarantees are first-party; a third-party export must provide
+  its own (BYO-gateway, retention off, disclosure).
+
+## Accessibility
+
+- **Provenance legibility.** Every artifact carries a working link back to the
+  Slack thread it came from, so a reviewer (or a later reader) can always reach
+  the source; a draft is clearly marked *proposed* until merged.
+- **Keyboard-first by construction.** The Slack surfaces (buttons, modals, threads)
+  are natively keyboard- and screen-reader-operable; confirmations should state who
+  approved and what happened in text, not colour alone.
+- **Plain-language interview.** Questions are essential-only and pre-filled, so a
+  non-technical author is never shown schema jargon or empty required fields.
+
+## Style Guidance
+
+- The Slack app is a `lore-*` product (ADR-068); the engine stays `rac-*`.
+- Keep the two gates verbally distinct: the author *confirms* (fidelity); an
+  independent maintainer *approves/ratifies* (trust boundary). Never call the
+  Slack confirmation an approval of the record.
+- Cite load-bearing operational facts in prose with their source and carry the
+  caveat; flag the fast-moving Slack AI/Workflow-Builder surfaces rather than
+  asserting frozen behaviour.
+
+## Open Questions
+
+- Interview surface: the richer **assistant-thread** (more capability, more
+  version risk) versus a **capped modal** (simpler, shallower) — which clears a
+  typical Enterprise-Grid admin review?
+- **Permalink durability**: a permalink breaks if the source message is deleted or
+  expires under a retention policy; what is recorded so provenance survives the
+  source?
+- The exact **idempotency key** and dedup TTL, and how a same-thread re-capture
+  updates rather than duplicates.
+- The **Enterprise-Grid admin posture**: what disclosures and scopes clear app
+  approval for an app that exports message content to a model.
+
+## Related Decisions
+
+- ADR-002
+- ADR-017
+- ADR-024
+- ADR-035
+- ADR-063
+- ADR-065
+- ADR-067
+- ADR-068
+
+## Related Roadmaps
+
+- rac-capture-skill
+- lore-capture-followups

--- a/rac/roadmaps/future/lore-capture-followups.md
+++ b/rac/roadmaps/future/lore-capture-followups.md
@@ -1,0 +1,118 @@
+---
+schema_version: 1
+id: RAC-KVSV68H019N9
+type: roadmap
+---
+# Lore Capture — Further Exploration (Future)
+
+## Status
+
+Planned
+
+Unscheduled — recorded as a backlog of *exploration and documentation* that the
+capture work surfaced but did not resolve. It is intent, not a committed release,
+and must not displace nearer-term work. Each initiative is a candidate for its own
+design or roadmap once picked up.
+
+## Context
+
+Two designs worked out the capture story so far: `lore-capture-surfaces` (the
+skill-is-brain / host-is-interface model and the four host surfaces) and
+`lore-slack-capture-flow` (the end-to-end Slack write-and-approve pipeline). The
+research behind them repeatedly turned up adjacent questions that are real but out
+of scope for those artifacts. This roadmap parks them in the corpus so they are
+not lost, with enough framing that a future session can pick one up and scope it
+properly. Following ADR-047, durable thinking lives here rather than in a tool's
+scratch space.
+
+## Outcomes
+
+- The open threads from the capture work are recorded as trackable intent, so the
+  next builder starts from "what's already known and still open" rather than
+  re-deriving it.
+- Lore has a clear-eyed view of the capture surface area beyond Slack — other
+  ingest points, the quality of the structuring step, and how to know any of it is
+  working — without committing to build them prematurely.
+
+## Initiatives
+
+### Initiative 1 — Other ingest points
+
+Explore capture surfaces beyond Slack and the harness: email→artifact (forward a
+decision to an address), the `/intake` GitHub Action drop-zone for documents
+(`rac ingest` self-service), and extraction from trackers/wikis
+(Jira / Linear / Confluence). The tracker case is **ADR-017-gated**: it must
+extract the durable decision or long-lived requirement, never mirror tickets,
+owners, or sprints, and likely needs an explicit ADR before it is built.
+
+### Initiative 2 — Classification-quality evaluation
+
+The freeform→typed structuring step is where capture can quietly go wrong (wrong
+type, mis-mapped sections). Define how its quality is measured and how its mistakes
+are surfaced for the human-ratify gate rather than hidden — consistent with the
+deterministic, no-LLM-judge discipline RAC already holds for grounding (ADR-066).
+
+### Initiative 3 — Corpus-lift measurement
+
+Decide how to tell whether capture actually *works*: does it raise corpus
+completeness and recency, and are knowledge owners (not just maintainers) authoring
+through it? This is the success signal `rac-capture-skill` names as the trigger to
+schedule a host surface out of `future/`.
+
+### Initiative 4 — Inbound-bot security review
+
+A capture bot is an internet-exposed, multi-tenant service that crosses a model
+boundary. Scope a security review covering the boundary crossing, prompt injection
+(thread content is untrusted, ADR-065), least-privilege scopes (Slack and the
+GitHub App), secret handling, and the data-governance disclosures admins expect.
+
+## Constraints
+
+- Each initiative respects the recorded boundaries: knowledge not work (ADR-017),
+  human PR review as the trust boundary (ADR-065), user-managed AI credentials and
+  no AI in core (ADR-035, ADR-002).
+- Nothing here is scheduled; picking up an initiative means scoping it as its own
+  design/roadmap first, not expanding an existing release.
+
+## Non-Goals
+
+- Committing to build any ingest point, evaluation harness, or security programme
+  in this artifact — it records intent, not a release.
+- Re-opening settled decisions; tracker import in particular stays gated behind an
+  explicit future ADR.
+
+## Success Measures
+
+- A future session picking up any initiative finds the open questions and
+  constraints already framed here, and turns one into a scoped design/roadmap
+  without re-deriving the research.
+- The corpus-lift initiative yields a concrete, deterministic signal that could
+  justify scheduling a capture host out of `future/`.
+
+## Assumptions
+
+- The capture core (`rac-capture-skill`) is the prerequisite; these followups
+  presuppose it exists or is in progress.
+- The published CLI/export contract stays stable and additive (ADR-007, ADR-063),
+  so connectors and evaluators can build on it without engine changes.
+
+## Risks
+
+- **Scope sprawl.** A backlog can invite premature building; mitigated by keeping
+  every item explicitly unscheduled and ADR-gated where it touches the work/
+  knowledge boundary.
+- **Staleness.** Fast-moving externals (Slack AI surfaces, tracker APIs) may date
+  the framing; mitigated by treating each item as a starting point to re-verify,
+  not a spec.
+
+## Related Decisions
+
+- ADR-002
+- ADR-017
+- ADR-035
+- ADR-065
+- ADR-066
+
+## Related Roadmaps
+
+- rac-capture-skill

--- a/rac/roadmaps/future/rac-capture-skill.md
+++ b/rac/roadmaps/future/rac-capture-skill.md
@@ -1,0 +1,177 @@
+---
+schema_version: 1
+id: RAC-KVSPDB82WFK0
+type: roadmap
+---
+# RAC Capture Skill (Future)
+
+## Status
+
+Planned
+
+Unscheduled — captured as future intent, not yet on a release. This is the first
+concrete build proposed by the `lore-capture-surfaces` design (Host A); it is a
+near-zero-build item gated only on the decision to start, and it must not
+displace nearer-term committed work.
+
+## Context
+
+`lore-frontend-optionality` established that Lore's binding constraint is
+**authoring**: the corpus has to be written before grounding it has any value,
+and the people who own the source knowledge — product managers — cannot get a
+decision or requirement into the corpus without git, Markdown, and an IDE.
+`lore-capture-surfaces` answered the *how* with one organizing idea — **the
+skill is the brain, the host is the interface** — and named the cheapest first
+move: an agent-interview capture skill that runs in the harnesses people already
+have.
+
+That skill is `rac-capture`. It is the interview twin of the existing
+`rac-import` skill (`src/rac/skills/rac-import/SKILL.md`): same deterministic
+spine, but the *source* is a short interview with the author instead of a
+supplied document. It interviews the author in plain language, drafts an artifact
+against the **real schema** (`rac schema <type>`, never invented fields), has the
+human ratify type, title, and each relationship, scaffolds the file with
+`rac new` (which mints the opaque id), and closes on `rac validate`. The model
+that runs the interview lives in the harness, never in `rac-core` (there is no
+LLM client in the engine), so the skill adds no AI to the core (ADR-002,
+ADR-067).
+
+This roadmap records the *what and why* and the acceptance bar for that build,
+kept as recorded intent rather than a scheduled release. The host surfaces the
+design also describes (desktop overlay, Slack bot, web modal) are explicitly out
+of scope here — they wrap this same skill later.
+
+## Outcomes
+
+- A non-technical author can record a decision or a long-lived requirement
+  (ADR-020) through a guided interview in a harness they already run (Claude
+  Desktop / Code / Cursor), **without** writing Markdown, choosing an id, or
+  knowing the schema — and nothing lands in the reviewed corpus except through a
+  human-reviewed pull request (ADR-065).
+- The corpus starts getting authored by the people who own the knowledge, not
+  only by a handful of technical maintainers — lifting the ceiling on everything
+  downstream, grounding included.
+- The shared **capture core** exists and is proven, so the later host surfaces
+  (overlay / Slack / web) are thin adapters over it rather than re-implementations.
+
+## Initiatives
+
+### Initiative 1 — The `rac-capture` skill
+
+Author `src/rac/skills/rac-capture/SKILL.md` as the interview variant of
+`rac-import`, reusing the same CLI seams (`rac schema`, `rac inspect`, `rac new`,
+`rac validate`, `rac resolve` / `rac find` for relationship targets). The loop:
+
+1. **Capture raw intent first.** Let the author brain-dump the decision in plain
+   language before any structuring question — never gate capture behind the
+   interview.
+2. **Interview to fill the template, pre-filling from the dump.** Ask only the
+   two-to-four essential things that cannot be inferred or safely defaulted, as
+   confirmations rather than blank prompts; allow skip / Enter-through.
+3. **Ratify, then write.** Present the draft with its proposed type, title, and
+   any relationships the author named (never repo-scanned), require explicit
+   confirmation, then `rac new` to scaffold and mint the id.
+4. **Close on validation.** Run `rac validate`; treat errors as blocking; finish
+   with `rac relationships --validate` if the artifact links to others.
+
+### Initiative 2 — The save/promote boundary
+
+Define how the skill lands its output so it respects ADR-065: a draft is a
+**commit** (an unreviewed branch or `drafts/` area — a legitimate *untrusted*
+state in ADR-065's own words), and a **pull request** is what promotes it into
+the reviewed corpus an agent grounds against. The skill never writes straight to
+the trusted corpus.
+
+### Initiative 3 — Deferred: the host surfaces
+
+Recorded as the sequel, **not** in scope here. The desktop overlay (Host B),
+Slack bot (Host C), and web modal (Host D) from `lore-capture-surfaces` each wrap
+this skill once it is proven; they carry their own build, distribution, and
+bring-your-own-gateway concerns and should be scheduled separately.
+
+## Constraints
+
+- **No AI in the engine (ADR-002, ADR-067).** The interview model runs in the
+  harness; `rac-core` stays deterministic and AI-optional. The skill, like
+  `rac-import`, explicitly adds no model call to core.
+- **The schema is not the skill's to invent (ADR-021).** Sections, types, and
+  relationship kinds come from `rac schema` at runtime; ingestion-over-rewrite
+  (ADR-006) applies when the source includes a document.
+- **Knowledge, not work (ADR-017).** The skill captures decisions and long-lived
+  requirements; it must not record owners, sprints, or workflow state.
+- **Human ratification is mandatory before any write, and no auto-commit without
+  it.** Relationships are suggestions to confirm, never silently asserted; the id
+  is system-minted, never hand-chosen.
+- **Not a content store (ADR-024).** The skill emits Markdown to git and stores
+  nothing of its own.
+
+## Non-Goals
+
+- Building any host surface (overlay, Slack bot, web modal) — those are deferred
+  to the design's later phases.
+- Bulk or multi-document conversion — that remains `rac-ingest`'s job; this is a
+  single interview → single artifact.
+- Inferring relationships by scanning the repository — only links the author
+  names, each confirmed.
+- Inventing context, rationale, or requirements the author did not provide — gaps
+  in required sections are surfaced as questions, never filled with plausible text.
+- Any engine, MCP-surface, or contract change — the skill rides the existing CLI.
+
+## Success Measures
+
+- A non-technical author, starting from a plain-language description, produces a
+  schema-valid artifact (`rac validate` exits 0) through the interview, having
+  chosen no id and written no Markdown by hand.
+- The artifact lands as a draft commit and is promoted only via a human-reviewed
+  PR — never written straight into the trusted corpus.
+- The skill reuses the `rac-import` patterns and adds **no** code to `rac-core`
+  (no engine, MCP, or contract change).
+- Evidence (usage or user research) that authors who would not touch an IDE will
+  use the interview — the signal that would schedule a host surface out of
+  `future/`.
+
+## Assumptions
+
+- The `rac` CLI surfaces the skill depends on — `rac schema`, `rac inspect`,
+  `rac new`, `rac validate`, `rac resolve` / `rac find` — stay stable and
+  additive (ADR-007, ADR-063).
+- The author is working in a harness that can run a skill and reach a model;
+  bring-your-own-key is the harness's concern at this stage (Host A), not the
+  skill's.
+- The friction the skill removes (git / Markdown / schema knowledge) is the real
+  barrier for non-technical authors — to be confirmed by use.
+
+## Risks
+
+- **The interview re-introduces up-front friction.** If it asks blank,
+  schema-shaped questions it just relocates the burden it was meant to remove;
+  mitigated by capturing raw text first, pre-filling answers, and keeping the
+  question count low and skippable.
+- **Quality of freeform → typed structuring.** A loose description may map poorly
+  onto a type's sections; mitigated by the mandatory human-ratify gate and by
+  surfacing gaps as questions rather than inventing content.
+- **Scope creep into a host build.** The temptation to jump to the overlay or
+  Slack bot before the core skill is proven; mitigated by holding Initiative 3 as
+  deferred and shipping the harness skill first.
+- **Misclassification as work.** Interviews about "what we decided" can drift
+  toward tickets/owners; mitigated by the ADR-017 boundary baked into the skill's
+  constraints.
+
+## Related Decisions
+
+- ADR-002
+- ADR-006
+- ADR-017
+- ADR-020
+- ADR-021
+- ADR-024
+- ADR-065
+- ADR-067
+
+## Related Designs
+
+- lore-capture-surfaces
+
+## Related Roadmaps
+
+- lore-supermemory-grounding

--- a/src/rac/core/skills.py
+++ b/src/rac/core/skills.py
@@ -51,7 +51,7 @@ BUNDLED_SKILLS = (
     ),
     SkillSpec(
         name="rac-capture",
-        description="Capture a new decision or requirement from a conversation into one valid Lore (RAC) artifact, with human review.",
+        description="Capture a new decision or requirement into a valid Lore (RAC) artifact.",
     ),
 )
 

--- a/src/rac/core/skills.py
+++ b/src/rac/core/skills.py
@@ -49,6 +49,10 @@ BUNDLED_SKILLS = (
         name="rac-import",
         description="Reformat one document into one valid Lore (RAC) artifact, with human review.",
     ),
+    SkillSpec(
+        name="rac-capture",
+        description="Capture a new decision or requirement from a conversation into one valid Lore (RAC) artifact, with human review.",
+    ),
 )
 
 

--- a/src/rac/skills/rac-capture/SKILL.md
+++ b/src/rac/skills/rac-capture/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: rac-capture
+description: Capture a NEW decision or requirement from a conversation (an interview) into ONE valid RAC (requirements-as-code) artifact — you interview and propose, the human ratifies, `rac validate` closes, and promotion into the trusted corpus is by pull request reviewed by someone other than the author. Use when a user wants to record a fresh decision or requirement into Lore (a project's rac/ directory) by talking it through rather than importing a document. For an existing document use rac-import; for bulk conversion use rac-ingest.
+---
+
+# RAC interview capture
+
+Turn a conversation into one valid RAC artifact. You interview the author and
+propose; the human ratifies; `rac validate` is the deterministic check; an
+independent reviewer promotes it by pull request. This skill never adds AI to the
+RAC core — it runs in the coding agent and uses the `rac` CLI.
+
+## Hard constraints
+
+- **Capture knowledge, not work.** Record a decision or a long-lived requirement
+  and its rationale — never owners, assignees, sprints, priorities, or due dates.
+  If the conversation is about *who does what by when*, that belongs in the team's
+  work tracker, not in RAC; say so and stop.
+- **The schema is not yours to invent.** Read the real shape with
+  `rac schema <type>` (and `rac schema` for the recognised types). Use the real
+  section names, the real artifact types, and the real `## Related <Type>`
+  relationship sections. Never guess or hard-code a field, type, or relationship
+  kind. If you cannot run `rac schema`, stop and say so.
+- **No invention.** Capture only what the author actually tells you. Where a
+  required section has no material, **ask a question** — do not fill it with
+  plausible-sounding text. The interview gathers facts; it does not author them.
+- **Human ratification is mandatory and explicit (before any file is written).**
+  Present the draft and require the user to confirm or correct **(a) the artifact
+  type, (b) the title, and (c) each relationship** before you write anything.
+  Relationships are *suggestions to confirm*, never silently asserted. The `id` is
+  minted by `rac new` (opaque, system-assigned) — never hand-write or choose it.
+- **Close on deterministic validation.** After writing, run `rac validate`. If it
+  fails, show the errors, offer to fix them, and re-validate. Never leave an
+  invalid artifact behind.
+- **Save is a draft commit; promotion is a pull request.** A fresh capture is
+  *untrusted* until a human reviews it. Write the artifact, optionally commit it as
+  a draft on a branch when the user confirms, but **never write straight to the
+  trusted corpus, never auto-commit without confirmation, and never self-merge.**
+  The trust boundary is review and merge by **someone other than the author**.
+
+## 1. Capture the raw intent first
+
+Let the author say it their way before you ask anything — paste or dictate the
+decision in plain language. Do not gate capture behind your questions; collect the
+brain-dump, then structure it. If they describe several distinct decisions, capture
+one artifact at a time and offer to repeat for the rest.
+
+## 2. Choose the type and read its real schema
+
+Decide *with the author* whether this is a decision, requirement, design, roadmap,
+or prompt (most captures are a decision or a requirement). Then read the actual
+contract:
+
+```bash
+rac schema                     # the recognised artifact types
+rac schema decision            # required / recommended / optional sections, and
+                               # any controlled values (e.g. Status, Category)
+rac schema decision --json     # the same, machine-readable
+```
+
+Map the captured intent onto *these* section names. Do not introduce sections the
+schema does not define.
+
+## 3. Interview to fill the template
+
+Ask only the **two to four** things you cannot infer from the brain-dump or safely
+default — and ask them as **confirmations, pre-filled with your best reading**, not
+as blank prompts. Keep each question short and let the author skip or accept. Good
+targets: the precise decision/requirement statement, the context that forced it,
+the consequences or rationale, and a `## Status` value (use one of the controlled
+values `rac schema` lists). Requirements are testable `- [REQ-001] ...` lines under
+`## Requirements`; prefer normative wording (MUST / SHOULD / MAY), and avoid vague
+verbs (support, handle, allow, enable) that `rac validate` warns on.
+
+## 4. Dedupe, then draft
+
+Before drafting, check whether the team already recorded this, so capture does not
+create a duplicate:
+
+```bash
+rac find "<key words from the decision>" rac/
+```
+
+If a close match exists, surface it and ask whether to update that artifact
+(via `rac-import` / a normal edit) instead of creating a new one. Otherwise, draft
+the content under the type's real headings, keeping the author's own wording where
+it fits. For each **required** section with no captured material, leave a clearly
+marked gap to raise with the user — do not invent.
+
+## 5. Review gate — confirm before writing
+
+Present, in the conversation (not as a file yet):
+
+- the **draft** artifact;
+- a short summary: the **chosen type**, the **proposed title**, and any
+  **relationships the author named** (never relationships inferred by scanning the
+  repository — that is out of scope);
+- every **gap** where a required section had no material.
+
+Ask the user to confirm or correct the type, the title, and each relationship.
+Verify any relationship target actually resolves before proposing it:
+
+```bash
+rac resolve <id> rac/
+rac find "<text>" rac/
+```
+
+Do not write a file until the user has confirmed.
+
+## 6. Write, then validate
+
+On confirmation, scaffold the file (this mints the id and writes the canonical
+template — it never overwrites an existing file), then replace the template body
+with the confirmed content:
+
+```bash
+rac new decision rac/decisions/<slug>.md
+```
+
+Write artifacts only inside the host project's RAC directory (`rac/` by default;
+confirm the path if the project keeps them elsewhere) under the matching subfolder
+(`rac/decisions/`, `rac/requirements/`, `rac/roadmaps/`, `rac/prompts/`,
+`rac/designs/`). If the project has no `.rac/config.yaml`, run `rac init` once at
+the project root first. Keep the `##` headings and the frontmatter block intact;
+never edit the minted `id`.
+
+Then close on validation:
+
+```bash
+rac validate rac/decisions/<slug>.md
+```
+
+Treat errors as blocking — show them, offer fixes, and re-run until it exits 0.
+`rac improve <file> --template` prints section stubs when the content exists to
+fill a missing recommended section. If the artifact links to others, finish with
+`rac relationships rac/ --validate`.
+
+## 7. Hand off — draft commit, promote by pull request
+
+A validated capture is a **draft**, not yet trusted knowledge. With the user's
+go-ahead, commit it on a branch (a draft), but leave the promotion to the team's
+normal pull-request flow:
+
+- the author's confirmation in this conversation is a *fidelity* check — "we
+  captured what you meant" — **not** ratification into the record;
+- the **trust boundary** is a pull request reviewed and merged by **someone other
+  than the author** (the project's required-review gate), which is also where
+  `rac validate` / `rac relationships --validate` run as checks.
+
+Never open-and-self-approve, and never merge the author's own capture for them.
+
+## Out of scope
+
+- Reformatting an **existing document** into an artifact — use `rac-import`.
+- Bulk or batch conversion, directory crawling, or "migrate my whole wiki" — use
+  `rac-ingest`.
+- Inferring relationships by scanning the repository — only the links the author
+  names, each confirmed.
+- Inventing context, consequences, rationale, or requirements the author did not
+  provide.
+- Auto-committing without the human-review step, or merging a capture into the
+  trusted corpus without independent review.
+- Recording ownership, assignment, scheduling, or any work-tracking field.

--- a/tests/golden/skill_install_human.txt
+++ b/tests/golden/skill_install_human.txt
@@ -2,5 +2,6 @@ Installed rac-artifacts skill: .claude/skills/rac-artifacts/SKILL.md
 Installed rac-review skill: .claude/skills/rac-review/SKILL.md
 Installed rac-ingest skill: .claude/skills/rac-ingest/SKILL.md
 Installed rac-import skill: .claude/skills/rac-import/SKILL.md
+Installed rac-capture skill: .claude/skills/rac-capture/SKILL.md
 
 Claude Code discovers skills automatically from .claude/skills/ in the project.

--- a/tests/golden/skill_install_json.txt
+++ b/tests/golden/skill_install_json.txt
@@ -17,6 +17,10 @@
     {
       "skill": "rac-import",
       "path": ".claude/skills/rac-import/SKILL.md"
+    },
+    {
+      "skill": "rac-capture",
+      "path": ".claude/skills/rac-capture/SKILL.md"
     }
   ]
 }

--- a/tests/golden/skill_list_human.txt
+++ b/tests/golden/skill_list_human.txt
@@ -4,3 +4,4 @@ Bundled agent skills:
 - rac-review     Review a Lore (RAC) corpus and work findings worst-first.
 - rac-ingest     Convert legacy documents into valid, linked Lore (RAC) artifacts.
 - rac-import     Reformat one document into one valid Lore (RAC) artifact, with human review.
+- rac-capture    Capture a new decision or requirement from a conversation into one valid Lore (RAC) artifact, with human review.

--- a/tests/golden/skill_list_human.txt
+++ b/tests/golden/skill_list_human.txt
@@ -4,4 +4,4 @@ Bundled agent skills:
 - rac-review     Review a Lore (RAC) corpus and work findings worst-first.
 - rac-ingest     Convert legacy documents into valid, linked Lore (RAC) artifacts.
 - rac-import     Reformat one document into one valid Lore (RAC) artifact, with human review.
-- rac-capture    Capture a new decision or requirement from a conversation into one valid Lore (RAC) artifact, with human review.
+- rac-capture    Capture a new decision or requirement into a valid Lore (RAC) artifact.

--- a/tests/golden/skill_list_json.txt
+++ b/tests/golden/skill_list_json.txt
@@ -16,6 +16,10 @@
     {
       "skill": "rac-import",
       "description": "Reformat one document into one valid Lore (RAC) artifact, with human review."
+    },
+    {
+      "skill": "rac-capture",
+      "description": "Capture a new decision or requirement from a conversation into one valid Lore (RAC) artifact, with human review."
     }
   ]
 }

--- a/tests/golden/skill_list_json.txt
+++ b/tests/golden/skill_list_json.txt
@@ -19,7 +19,7 @@
     },
     {
       "skill": "rac-capture",
-      "description": "Capture a new decision or requirement from a conversation into one valid Lore (RAC) artifact, with human review."
+      "description": "Capture a new decision or requirement into a valid Lore (RAC) artifact."
     }
   ]
 }

--- a/tests/test_skill.py
+++ b/tests/test_skill.py
@@ -32,7 +32,7 @@ from rac.services.skill import SkillFileExists, install_skills
 REPO_ROOT = Path(__file__).parent.parent
 GOLDEN_DIR = Path(__file__).parent / "golden"
 
-SKILL_NAMES = ["rac-artifacts", "rac-review", "rac-ingest", "rac-import"]
+SKILL_NAMES = ["rac-artifacts", "rac-review", "rac-ingest", "rac-import", "rac-capture"]
 
 
 def dogfood_path(name: str) -> Path:


### PR DESCRIPTION
# Summary

Records a frontend-optionality exploration for Lore as corpus artifacts, develops
its authoring/capture thread into worked designs, and ships the first concrete
build — the `rac-capture` agent skill.

Adds:
- Four design/roadmap artifacts capturing the exploration (frontend optionality →
  capture surfaces → Slack write-and-approve flow), plus two `future/` roadmaps
  (the scoped skill build and a further-exploration backlog).
- One user-visible capability: the `rac-capture` bundled skill, registered and
  installable via `rac skill`, with its byte-identical `.claude/skills/` dogfood copy.

# Roadmap / ADR Trace

Roadmaps:
- `rac/roadmaps/future/rac-capture-skill.md` (the skill; Initiative 1 is built here)
- `rac/roadmaps/future/lore-capture-followups.md` (deferred backlog)

Designs:
- `rac/designs/lore-frontend-optionality.md`
- `rac/designs/lore-capture-surfaces.md`
- `rac/designs/lore-slack-capture-flow.md`

Relevant decisions the work is grounded in:
- `rac/decisions/adr-065-artifact-content-untrusted.md` (human PR review is the trust boundary)
- `rac/decisions/adr-017-rac-managed-knowledge-not-work.md` (capture knowledge, not work)
- `rac/decisions/adr-035-byo-ai-credentials.md` (user-managed AI credentials)
- `rac/decisions/adr-002-ai-optional.md`, `adr-021-templates-product-contracts.md`, `adr-063` (thin clients), `adr-068` (brand/topology)

# Scope

## Included
- The reasoning of the exploration as validated RAC artifacts (designs + future roadmaps).
- The `rac-capture` skill: the interview twin of `rac-import` — capture a new
  decision/requirement from a conversation, draft against the real schema, human
  ratifies type/title/relationships, `rac validate` closes; registry entry,
  dogfood copy, and refreshed skill goldens.
- The two-gate write model recorded as a cross-cutting principle in
  `lore-capture-surfaces` and worked end-to-end in `lore-slack-capture-flow`.

## Excluded (deliberately, recorded as future intent)
- No host surface is built: the desktop overlay, the Slack bot, and the web modal
  are designed only, not implemented.
- No engine, MCP-surface, or export-contract change; the skill rides the existing CLI.
- Tracker import (Jira/Linear/Confluence) stays gated behind a future ADR (ADR-017).
- The classification-quality eval, corpus-lift metric, and inbound-bot security
  review are parked in `lore-capture-followups`, not built.

# Product / Architecture Decisions
- The skill is the brain; the host is the interface. The capture loop is
  host-agnostic and lives in a skill that runs in the harness, so no LLM enters
  `rac-core` (ADR-002, ADR-067).
- Two gates, two actors: an author's in-host confirmation is a fidelity check, not
  a trust boundary; the trust boundary is an independent maintainer's PR merge
  (ADR-065). A writer host/bot only proposes and never holds approval power.
- `rac-capture` is registered after `rac-import` in `BUNDLED_SKILLS`; the packaged
  resource and the `.claude/skills/` copy are byte-identical (the drift test,
  REQ-007), and the skill frontmatter `name` matches the registry name.
- Designs carry related-artifact links only to types the schema supports;
  design-to-design references are prose (validated relationship rule).

# User-Facing Contract

## CLI
- `rac skill list` and `rac skill list --json` now enumerate five skills,
  including `rac-capture`.
- `rac skill install` (all) and `rac skill install rac-capture` write
  `.claude/skills/rac-capture/SKILL.md`; existing no-overwrite/all-or-nothing
  behavior is unchanged.

## JSON Output
- The `skill list` / `skill install` JSON payloads gain a `rac-capture` entry; the
  schema shape (`schema_version` "1", `skills[]`) is unchanged.

## Exit Codes
- Unchanged: `0` listed/installed, `1` refused/operational error, `2` unknown skill
  name or bad path.

# Verification

## Ran
- `rac validate rac/`
- `rac relationships rac/ --validate`
- `rac review rac/`
- `python -m pytest tests/test_skill.py`

## Covered
- Corpus: 276 artifacts valid, 0 invalid; 1317 relationships checked, 0 issues;
  `rac review` health 93/100 with no priority 1-2 findings.
- Skill: 45 tests pass — registry order and one-line descriptions, the packaged
  resource byte-identical to the dogfood copy, frontmatter `name` matches the
  registry, install (all / named / no-overwrite / all-or-nothing) and list
  contracts, and the refreshed human + JSON goldens.
- Environment caveat (not introduced by this change): the full suite has
  pre-existing failures where optional deps are absent in the container (`mcp`,
  `textual` modules) and where `rac` is not on PATH for the post-commit hook test.

# Review Path
1. `rac/designs/lore-frontend-optionality.md` — the landscape and the authoring/capture thread.
2. `rac/designs/lore-capture-surfaces.md` — the four hosts and the two-gate principle.
3. `rac/designs/lore-slack-capture-flow.md` — the Slack write-and-approve pipeline.
4. `rac/roadmaps/future/rac-capture-skill.md` and `lore-capture-followups.md` — scoped build and backlog.
5. `src/rac/core/skills.py`, `src/rac/skills/rac-capture/SKILL.md` (+ dogfood copy) — the skill and its registration.
6. `tests/test_skill.py` and `tests/golden/skill_*` — coverage and goldens.

# Notes For Reviewer
- The skill build slightly precedes its roadmap's "unscheduled" status by intent
  (the maintainer asked to draft it); the roadmap remains the recorded what/why.
- The Slack-flow design records a build that is not in this PR; it is documentation
  to gate a future implementation, not code.

# Implementation Process
Implemented with AI assistance under the corpus's exploration/roadmap conventions;
final scope, review, and acceptance decisions were made by the maintainer.