### PR TITLE
docs(roadmap): capture deep-dive deferred adoptions for future consideration

### DIFF
--- a/rac/roadmaps/future/retrieval-diagnostics.md
+++ b/rac/roadmaps/future/retrieval-diagnostics.md
@@ -1,0 +1,112 @@
+---
+schema_version: 1
+id: RAC-KVTP8MN27M64
+type: roadmap
+---
+# RAC — Retrieval Diagnostics (Future)
+
+## Status
+
+Planned
+
+Unscheduled — captured for future consideration from the agent-runtime deep dive
+(GBrain, Hermes). These are deterministic retrieval-tooling refinements that
+complement the planned relevance-ranking work (the v0.29 `deterministic-relevance-
+ranking` design and ADR-078); they graduate out of `future/` alongside or after it.
+
+## Context
+
+The deep dive into hybrid-retrieval systems surfaced two deterministic ideas Lore
+does not yet have, both inside its no-embeddings, no-LLM line (ADR-066, ADR-002):
+
+- **Explain-miss.** GBrain ships `search diagnose` — "trace which retrieval layer
+  surfaces or misses a page." Lore has explain-*hit* (the v0.23 explainable-
+  retrieval evidence: winning field, matched terms, tier) but no way to ask "why
+  did my query *not* surface artifact X." For an author maintaining a corpus, the
+  absence is often the more useful question.
+- **Floor-ratio gate.** GBrain bounds its boosts with a "floor-ratio gate" that
+  "prevents weak candidates from exceeding primary results via boosting." Lore's
+  planned graph/relevance boost (ADR-078) is specified as *bounded*; the floor-ratio
+  gate is a concrete, deterministic mechanism that guarantees a boosted weak result
+  can never outrank a strong lexical match.
+
+Hermes adds a framing note worth recording: it cleanly separates *bounded always-
+in-context facts* from *on-demand deterministic full-text recall* — a two-tier
+recall model Lore can articulate (skills/summaries always surfaced vs. deep
+`search_artifacts` on demand) without new code.
+
+## Outcomes
+
+- An author can ask "why did my query not surface artifact X?" and get a
+  deterministic trace (which tier or term excluded it), complementing explain-hit.
+- The relevance/graph boost is provably bounded: a floor-ratio gate makes "the
+  boost cannot float a weak result above a strong match" a tested guarantee, not a
+  hope.
+
+## Initiatives
+
+### Initiative 1 — Explain-miss (`diagnose`)
+
+Extend the explainable-retrieval surface (`rac find --explain` / the search
+evidence) to explain *absences*: given a query and a target artifact, report
+deterministically why the target did not rank or did not match (no term hit a
+tier, a term matched nothing, the budget truncated it). No model; pure trace over
+the existing matcher.
+
+### Initiative 2 — Floor-ratio bounded-boost gate
+
+Fold a floor-ratio gate into the relevance-ranking boost so a boosted candidate
+cannot exceed a primary lexical match beyond a bounded ratio — the concrete
+realisation of ADR-078's "bounded graph boost." Pinned by golden tests.
+
+### Initiative 3 — Two-tier recall framing
+
+Document the recall model explicitly — always-surfaced context vs. on-demand
+search — so the split is stated for agents and authors. Documentation/UX, not new
+behaviour.
+
+## Constraints
+
+- Deterministic and offline (ADR-002, ADR-066): diagnostics and the gate are pure
+  functions of corpus bytes and the query; no embeddings, no model.
+- Additive contract (ADR-007): explain-miss output and any score detail are new
+  optional fields; existing search responses are unchanged.
+- Reuse the existing matcher, tokeniser (ADR-037), and tiers (ADR-038); no parallel
+  search path.
+
+## Non-Goals
+
+- Vector or semantic diagnosis of why a result was or was not relevant.
+- Any change to which artifacts match; diagnostics explain the existing behaviour,
+  and the gate only re-orders within already-matched results.
+
+## Success Measures
+
+- For a query that fails to surface a known artifact, `diagnose` names the
+  deterministic reason, reproducibly.
+- With the floor-ratio gate, no boosted result outranks a stronger lexical match
+  beyond the bounded ratio, proven by golden tests.
+
+## Assumptions
+
+- "Why didn't it find X" is a common authoring question once a corpus is large
+  enough that relevance ranking matters (the v0.29 trigger).
+- A bounded-boost guarantee is more valuable expressed as a tested gate than as
+  prose in the ranking design.
+
+## Risks
+
+- Explain-miss could over-report trivial non-matches. Mitigation: scope it to a
+  named target artifact (why did *this* not surface), not "everything that didn't
+  match."
+
+## Related Decisions
+
+- adr-037
+- adr-038
+- adr-066
+- adr-007
+
+## Related Requirements
+
+- rac-explainable-retrieval

--- a/rac/roadmaps/future/skill-trust-and-surfacing.md
+++ b/rac/roadmaps/future/skill-trust-and-surfacing.md
@@ -1,0 +1,126 @@
+---
+schema_version: 1
+id: RAC-KVTP8K78NM4E
+type: roadmap
+---
+# RAC — Skill Trust and Surfacing (Future)
+
+## Status
+
+Planned
+
+Unscheduled — captured for future consideration from the agent-runtime deep dive
+(OpenClaw, Hermes, GBrain). Nothing here is committed; it graduates out of
+`future/` into a versioned series if a concrete need (notably third-party skills)
+appears.
+
+## Context
+
+Lore ships agent skills (`rac skill install` / `list`), bundled first-party and
+kept byte-identical to the dogfood copies. The deep dive into agent runtimes
+surfaced a cluster of *skill-surface* patterns Lore does not have, all
+deterministic and AI-free:
+
+- **OpenClaw** has mature skill packaging — `openclaw skills verify` (a trust
+  envelope + security scan), a fail-closed `security.installPolicy`, declarative
+  static gating (`requires.bins/anyBins/env/config`, `os`, `always`), and a public
+  registry with `install @owner/slug` resolution.
+- **Hermes** retrieves skills by *progressive disclosure* (`skills_list` →
+  `skill_view`) and has an open issue to replace a ~4.5k-token skill broadcast with
+  ranked/pinned retrieval — a token-budget lesson.
+- **GBrain** validates its skill tree for reachability and non-overlap
+  (`check-resolvable`, MECE/DRY).
+
+These matter most if Lore ever distributes or accepts **third-party** skills,
+where "is this skill safe and supported here?" becomes a real question. They sit
+naturally on Lore's existing boundaries: skill/artifact content is untrusted until
+human review (ADR-065), the engine stays deterministic and offline (ADR-002), and
+tool/skill surfaces respect a response budget (ADR-033).
+
+## Outcomes
+
+- A distributed skill can be **verified before install** — a deterministic trust
+  envelope and security scan, with a fail-closed install policy — so a stranger's
+  skill is checked, not trusted (ADR-065).
+- A skill declares its **environment requirements statically** (binaries, env,
+  config, OS), so an unsupported skill is gated deterministically rather than
+  failing at run time.
+- Skill metadata is **surfaced to clients within a token budget** (ranked/limited),
+  not broadcast wholesale (ADR-033).
+
+## Initiatives
+
+### Initiative 1 — Skill verification and fail-closed install policy
+
+A `rac skill verify` that statically inspects a skill package (structure, declared
+capabilities, injection-style content) and a configurable fail-closed install
+policy, mirroring OpenClaw's `verify` + `installPolicy`. This is the
+untrusted-content boundary of ADR-065 applied to skills; when scheduled it needs a
+skill-trust-boundary ADR.
+
+### Initiative 2 — Declarative static gating manifest
+
+A skill manifest gains optional deterministic gating — `requires` (binaries, env
+vars, config keys) and `os` — evaluated statically so `rac skill install`/`list`
+can mark a skill supported or unsupported on this machine without running it.
+
+### Initiative 3 — Optional skills registry and slug install
+
+A content-addressed skill index with `install <owner>/<slug>` resolution. Gated on
+a product decision to support third-party skills at all — today Lore bundles
+first-party skills only, so this is the most speculative initiative and is recorded
+as a fork, not a commitment.
+
+### Initiative 4 — Token-budgeted skill surfacing
+
+When skill metadata is surfaced to a client, rank and limit it to a budget rather
+than broadcasting the full set (Hermes' progressive-disclosure lesson; ADR-033).
+
+### Initiative 5 — Skill-tree resolvability check
+
+A deterministic validation that the installed skill set is reachable and
+non-overlapping (GBrain's `check-resolvable`), so skills do not silently shadow one
+another.
+
+## Constraints
+
+- Deterministic and offline (ADR-002): verification, gating, and surfacing are
+  static checks; no model, no network, no execution of the skill.
+- Untrusted by default (ADR-065): verification informs a human; nothing is trusted
+  because it passed a scan.
+- The read-only knowledge engine and its MCP surface are unaffected; this concerns
+  the skill-distribution surface only.
+
+## Non-Goals
+
+- Executing or sandboxing skills at runtime (that is the agent client's job).
+- Any AI-judged skill quality or auto-generated skills.
+- Committing to third-party skill distribution before the product decision is made.
+
+## Success Measures
+
+- A skill from outside the package can be inspected and either cleared or rejected
+  by a deterministic policy before anything is installed.
+- An unsupported skill (missing a required binary) is reported as unsupported by a
+  static check, not by a runtime failure.
+- Surfacing a large skill set to a client stays within a stated token budget.
+
+## Assumptions
+
+- Third-party or distributed skills are a plausible future direction; until then
+  these patterns are dormant intent, correctly unscheduled.
+- Static verification and gating are high-value precisely because they need no AI
+  and no execution.
+
+## Risks
+
+- Building verification before any third-party skills exist would be speculative.
+  Mitigation: this stays in `future/` until a concrete distribution need appears.
+- A trust envelope could imply safety it cannot guarantee. Mitigation: framed as an
+  input to human review (ADR-065), never an automatic trust grant.
+
+## Related Decisions
+
+- adr-065
+- adr-002
+- adr-033


### PR DESCRIPTION
## What

Records the genuinely-new, in-domain findings from the agent-runtime deep dive (OpenClaw, Hermes, GBrain) as **unscheduled `future/` intent** — captured so they're not lost, committed to nothing.

Two items, grouped by the surface they touch:

### `future/skill-trust-and-surfacing.md`
The one substantive *new area* (mostly from OpenClaw). Lore ships skills (`rac skill`) but has no trust story:
- Skill **`verify` + fail-closed install policy** — ADR-065-native (skill content is untrusted).
- **Declarative static gating** (`requires.bins/env/config`, `os`) — deterministic "is this supported here?"
- **Optional third-party registry** + slug install — explicitly recorded as a *product fork*, not a commitment (Lore is first-party-only today).
- **Token-budgeted skill surfacing** (Hermes progressive disclosure; ADR-033).
- **Skill-tree resolvability** check (GBrain `check-resolvable`).

### `future/retrieval-diagnostics.md`
Deterministic retrieval refinements that complement the planned v0.29 ranking (inside ADR-066's no-embeddings line):
- **Explain-miss (`diagnose`)** — "why did my query *not* surface artifact X?" (Lore has explain-*hit* only).
- **Floor-ratio bounded-boost gate** — makes ADR-078's "bounded boost" a tested guarantee.
- **Two-tier recall framing** (Hermes) — docs/UX, not code.

## Why this shape
Both are `future/` (unscheduled, "for future consideration") — they graduate to a versioned series when a concrete need appears (third-party skills; large-corpus ranking). No new ADRs yet: future intent records the *what*, decisions come when scheduled. No cross-references to the unmerged v0.28/v0.29/v0.30 plans, so the graph stays clean.

The deep dive's headline finding isn't in this PR because it isn't a feature: **Hermes and GBrain independently converged on Lore's exact knowledge-layer architecture** (Markdown-in-git + deterministic BM25/FTS5 + zero-LLM edges, *rejecting* vectors/graphs) — strong external validation of ADR-002/066, ADR-080, and the v0.28/v0.29 plans.

## Gates
- `rac validate rac/` — pass (273 valid, 0 invalid)
- `rac relationships rac/ --validate` — pass (0 issues)
- `rac review rac/` — no priority 1–2 findings
- `rac export --agent-rules --check` — in sync