### PR TITLE
docs(roadmap): capture team-scale research findings as future intent

### DIFF
--- a/docs/research/team-scale-landscape.md
+++ b/docs/research/team-scale-landscape.md
@@ -1,0 +1,287 @@
+# Team-Scale Knowledge Tooling — Competitive Landscape & Lessons for Lore
+
+> **Status: research document, not a RAC artifact.** Per ADR-010 ("Documents Are
+> Not Artifacts") and ADR-024 ("RAC Is Not a Content Store"), this is reference /
+> working material, not part of the validated `rac/` corpus. Its *actionable*
+> conclusions are captured as corpus artifacts — see "What this produced" below.
+>
+> **Scope:** how software teams of 20+ engineers (not indie hackers) adopt, govern,
+> and sustain knowledge tools, and what Lore (RAC) should learn.
+> **Method:** multi-angle web research across four adjacent product categories plus
+> a cross-cutting failure-mode pass, with adversarial verification and
+> evidence-vs-marketing tagging. Confidence and primary sources cited inline.
+> **Date:** 2026-06.
+
+---
+
+## Executive summary
+
+Across every category the finding is the same: **capture is solved and identical
+everywhere (Markdown-in-git, immutable records, status + supersession). What decides
+survival at 20+ is (a) fighting staleness/trust-collapse, (b) discovery, and (c)
+riding the existing workflow.** Lore's no-database / files-in-git / PR-review / MCP
+design is *structurally aligned with nearly every sustaining mechanism the evidence
+supports* — its single biggest exposure is the **freshness-signal gap**, which is
+both the best-documented cause of abandonment *and* the gap no agent-context
+competitor has solved.
+
+One-sentence positioning that the research supports:
+
+> **Lore is the shared, git-native, deterministic source of truth for product
+> *decisions* — the knowledge class no agent-context tool governs and no team can
+> afford from enterprise requirements management — winning on the freshness/drift
+> problem (now empirically the #1 adoption determinant) and the no-embeddings bet
+> that a major incumbent (Sourcegraph) publicly reversed into.**
+
+---
+
+## Category findings
+
+### 1. AI agent context / memory for teams
+
+*Cursor, Continue, Sourcegraph Cody & Amp, Augment, Glean, Dust, Onyx.*
+
+- **Files-in-git + PR review is now an industry pattern, not a compromise.** Cursor
+  (`.cursor/rules/*.mdc`) and Amp (`AGENTS.md`) are git-committed Markdown reviewed
+  through the normal PR flow — Lore's exact substrate. [high]
+  ([Cursor rules](https://cursor.com/docs/context/rules), [Amp](https://ampcode.com/news/AGENT.md))
+- **Sourcegraph publicly abandoned embeddings** for enterprise context (third-party
+  code transmission, vector-DB maintenance, poor scaling) and replaced them with
+  deterministic search — strong external validation of Lore's no-embeddings stance
+  (ADR-066). [high] ([Sourcegraph](https://sourcegraph.com/blog/how-cody-understands-your-codebase))
+- **"Shared team memory" is oversold.** Cursor Memories and Augment's base index are
+  **per-user**; real org memory (Augment Cosmos) is preview-only — a genuinely
+  shared, governed team source is unmet demand. [high]
+- **Hosted RAG has under-disclosed staleness windows everywhere** (Glean up to a
+  ~30-day full-crawl gap; Dust 1–2 days; Onyx 30-min default). "Real-time" is
+  marketing; ACLs gate *retrieval*, not LLM-synthesis oversharing. [high/medium]
+- **The dominant adoption-killer is context being silently ignored** by the model —
+  "Cursor is a predictive engine, not a policy enforcer." Shared context buys
+  consistency-by-default, never compliance-by-guarantee — exactly the boundary
+  ADR-067 already encodes (context-supply + post-edit enforcement). [high]
+- **None of them ship freshness, expiry, or ownership metadata on the rules
+  themselves** — the gap Lore can own. [high]
+
+### 2. Decision & spec tooling
+
+*ADR tools (adr-tools, MADR, Log4brains, Backstage ADR plugin); spec-driven dev
+(GitHub Spec Kit, AWS Kiro, Tessl); enterprise RM (Jama, IBM DOORS, Siemens
+Polarion).*
+
+**ADRs.** Convergent design since Nygard (2011): Markdown-in-repo, immutable,
+status + supersession. Tools differ on **discovery**, not capture (Log4brains adds a
+static searchable site; Backstage couples ADRs to the catalog entity via
+`backstage.io/adr-location`). The documented death pattern is the **"abandonment
+curve"** (5 ADRs in month one, then nothing) and **stale "Accepted" records eroding
+trust**; the antidote is an *operating model* (ownership + cadence + a "Gardener"
+role + bounded review windows + CODEOWNERS), not tooling. ThoughtWorks put
+lightweight ADRs in **Adopt** and the rule is "store in source control… in sync with
+the code." [high on mechanics, medium on failure-mode blogs]
+([Nygard](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions),
+[MADR](https://adr.github.io/madr/),
+[Log4brains](https://github.com/thomvaill/log4brains),
+[Backstage](https://backstage.io/docs/architecture-decisions/),
+[ThoughtWorks](https://www.thoughtworks.com/radar/techniques/lightweight-architecture-decision-records))
+
+> Note for Lore: Log4brains deliberately avoids fixed numbered filenames to prevent
+> multi-dev merge collisions — Lore's minted opaque IDs (`RAC-…`) already solve this.
+> And `rac review`/`doctor`/`coverage` *automate the "Gardener" role* that the
+> evidence says is the manual antidote to the abandonment curve.
+
+**Spec-driven dev.** Spec Kit / Kiro / Tessl invert the source of truth ("intent is
+the source of truth, code is generated") via a Markdown phase pipeline. Enforcement
+is **AI-mediated and human-gated, not deterministic** (Spec Kit has no blocking
+gates; Kiro's "neuro-symbolic" analysis uses LLM + SMT). **Their central, openly
+unsolved problem is spec↔code drift** — there is an "Ask HN: specs go stale" thread
+and no vendor documents a deterministic anti-drift mechanism; the recurring critique
+is "SDD is waterfall." Kiro independently uses **EARS** (which Lore validates
+deterministically). [high]
+([Spec Kit](https://github.com/github/spec-kit),
+[Kiro](https://kiro.dev/docs/specs/), [Kiro deep analysis](https://kiro.dev/blog/deep-spec-analysis/),
+[Tessl](https://tessl.io/blog/tessl-launches-spec-driven-framework-and-registry/),
+["waterfall" critique](https://news.ycombinator.com/item?id=45935763))
+
+> Note for Lore: **Lore sidesteps SDD's core unsolved problem** — it doesn't generate
+> code from artifacts, it records *decisions an agent consults*, so there's no
+> spec→code sync to rot. And it does deterministically the structural slice Kiro
+> needs an LLM+SMT solver for.
+
+**Enterprise RM (Jama / DOORS / Polarion).** Full formal governance — e-signatures,
+FDA 21 CFR Part 11, baselines, workflow states, and **"suspect links"** (downstream
+items flagged the moment an upstream item changes; DOORS: valid/invalid/suspect).
+The gap is **not capability — it's friction**: opaque seat pricing
+(~$400–600/user/yr DOORS; ~$1,788/user/yr Polarion; Jama quote-only), steep admin,
+performance that degrades at scale (DOORS Next is *vendor-acknowledged* poor;
+Polarion is bottlenecked by SVN single-writer commits), brutal export/migration
+lock-in, and — most telling — **license cost literally throttles collaboration**
+("only a limited number of people" get authoring licenses). [high on friction,
+medium on third-party pricing]
+([Jama](https://www.jamasoftware.com/platform/jama-connect/features/),
+[DOORS link validity](https://jazz.net/help-dev/clm/topic/com.ibm.jazz.vvc.doc/topics/c_linkval.html),
+[DOORS Next perf](https://www.ibm.com/support/pages/ibm-doors-next-7x-performance-considerations),
+[Polarion](https://www.siemens.com/en-us/products/polarion/requirements/))
+
+> Note for Lore: **"suspect links" is the proven enterprise drift mechanism** — Lore
+> can deliver a deterministic, git-native version (commit diffs + the validated
+> graph) without the per-seat tax, SVN bottleneck, or lock-in. Their fatal flaw
+> (friction/cost/lock-in, not capability) is Lore's wedge.
+
+### 3. Internal developer portals
+
+*Backstage, Port, Cortex, OpsLevel.*
+
+- **Ownership is a committed field for routing, not enforcement** (`catalog-info.yaml`
+  `spec.owner`); Backstage's own docs say it is explicitly *not* for runtime auth.
+  [high] ([Backstage descriptor](https://backstage.io/docs/features/software-catalog/descriptor-format/))
+- **Scorecards = deterministic checks** grouped into maturity levels (OpsLevel
+  bronze/silver/gold; a baseline check flags orphaned/ownerless services) — Lore's
+  `rac validate`/`review` analog. [high] ([OpsLevel](https://docs.opslevel.com/docs/scorecards))
+- **Drift is the real enemy**; portals fight it with auto-discovery + orphan/drift
+  detection (Backstage `backstage.io/orphan` + `orphanStrategy`). Lore can't
+  auto-discover (no crawler/DB) but counters with **git-derived staleness** (ADR-045).
+  [high] ([Backstage life-of-an-entity](https://backstage.io/docs/features/software-catalog/life-of-an-entity/))
+- **TechDocs = Markdown in the same repo as code, updated in the same PR** — Lore's
+  exact model, proven at Spotify scale (280+ teams, 2,000+ services). [high]
+- Adoption: **"usage can be mandated, but adoption must be earned"** — top-down
+  mandates correlate with *lower* developer satisfaction; portals become shelfware
+  when devs revert to Slack. [medium, analyst/vendor]
+
+### 4. Team knowledge bases / wikis
+
+*Notion, Confluence, Stack Overflow for Teams, Slab, Slite.*
+
+- **The decay problem is real and vendor-acknowledged.** Failure modes: content
+  decay ("the gap between documented truth and operational reality widens silently"),
+  ownership vacuum ("everyone is responsible = nobody"), and misaligned incentives
+  ("nobody gets recognized for updating a Confluence page"). [high on mechanisms]
+- **Every tool ships the same anti-staleness primitive: owner + expiry clock +
+  freshness signal that biases retrieval** (Notion page verification, Slab/Confluence
+  verified status with auto-un-verify, SO for Teams Content Health, Slite
+  verification). But it's a **self-clicked "verify" button** — human attestation, not
+  proof. [high] ([Notion](https://www.notion.com/help/guides/verify-knowledge-your-teammates-can-trust-with-page-verification),
+  [SO for Teams](https://stackoverflow.co/internal/features/))
+- **Findability decays independently** (recycled but directional stats: ~1.8 hrs/day
+  searching; ~½ of searches end in "not found"); knowledge fragments across
+  Slack/docs and the single source of truth splinters. [medium]
+- All five are bolting LLM Q&A over the corpus; Slite explicitly positions verified
+  docs as "the source of truth for Claude, ChatGPT, Cursor." AI *surfaces* gaps but
+  doesn't fix decay. [high]
+
+> Note for Lore: its freshness primitive is *structurally stronger* — **git history
+> is deterministic recency (ADR-045) and PR review is enforced attestation —
+> "verification you can't fake"** — plus `rac validate`/`relationships` as
+> machine-checkable rot detection no wiki has. The inherited risk: **PR review raises
+> contribution cost — the exact friction that kills wikis at 20+** (mitigate with
+> agent-assisted authoring + fast gates).
+
+---
+
+## Cross-cutting evidence (the empirical backbone)
+
+- **Docs measurably drift.** A study of 27,772 PRs across 714 repos: only ~0.8% of
+  PRs update the README; ~21.5% of changes that should have updated it didn't; doc
+  updates are ~1% of PR activity and routinely overlooked. [high]
+  ([arXiv 2603.00489](https://arxiv.org/abs/2603.00489))
+- **Documentation quality has a measured payoff.** DORA: high-quality docs make teams
+  "more than twice as likely" to hit performance targets, and amplify every technical
+  practice. **DORA 2025 explicitly endorses "connecting AI tools to internal
+  documentation, codebases, and *decision logs*"** — Lore's exact use case, named.
+  AI is an "amplifier" that magnifies good docs and exposes bad. [high / medium-high]
+  ([DORA docs](https://dora.dev/capabilities/documentation-quality/),
+  [DORA 2025](https://dora.dev/dora-report-2025/))
+- **The load-bearing adversarial finding: git + PR review alone does *not* keep docs
+  fresh.** The docs-as-code literature itself concedes "no empirical data validates
+  whether drift actually decreases at scale," and the 0.8% data shows reviewers
+  routinely miss doc drift. Co-locating in git is **necessary but proven-insufficient**
+  — which is why the deterministic freshness/drift signal matters. [high]
+- **Context rot is established.** Chroma Research tested 18 frontier models; every one
+  degrades as input length grows, well before window overflow — favoring *curated,
+  minimal, on-demand* context over corpus dumps. [high]
+  ([Chroma](https://research.trychroma.com/context-rot))
+- **The MCP "context tax."** Simon Willison stopped using MCP for coding agents
+  because tool descriptions eat context (GitHub's MCP ≈23k tokens) and CLIs are
+  lower-tax — but he endorses the underlying "context engineering" discipline. A
+  knowledge server justifies itself only if it stays lean. [high]
+  ([Willison](https://simonwillison.net/tags/model-context-protocol/))
+- **Honest gap:** there is **no published proof that curated decision context lifts
+  coding-agent task success.** The strongest defensible claim is that context-rot +
+  context-engineering evidence supports *selective* delivery. Lore's grounding-eval
+  (ADR-066) is the way to *be* the one who proves it. [high confidence in the gap]
+
+---
+
+## What determines whether a 20-person team adopts vs abandons Lore (impact-ordered)
+
+| # | Lesson | Tag | Action |
+|---|---|---|---|
+| 1 | Lives in the PR/git workflow, not a separate destination | **FITS** (strongest) | This *is* docs-as-code — the #1 sustaining mechanism. Lead with it. |
+| 2 | Staleness → trust collapse is the top killer; git+PR review is proven-insufficient | **RISK** (no DB; recency from git, ADR-045) | Surface git-derived staleness loudly + a deterministic "suspect" drift gate. Highest-leverage build. → `future/freshness-and-drift-detection` |
+| 3 | Automate the "Gardener" (the manual health-review that's the documented ADR antidote) | **POSITIONING** | `rac review`/`doctor`/`coverage` = machine-checkable health no wiki/portal has. Make it a scheduled CI report. |
+| 4 | "Verification you can't fake" | **POSITIONING** | Enforced PR review + immutable git history vs competitors' self-clicked verify buttons. |
+| 5 | Effortless consumption — context comes to the agent | **FITS** | The read-only MCP server pushes context in-flow; counters the "go to the wiki" abandonment driver. |
+| 6 | …but keep the surface LEAN (context tax + context rot) | **POSITIONING / RISK** | Few tools, small descriptions, retrieve-on-demand (ADR-033). CLI-first (ADR-005) may out-adopt MCP. → `future/lean-context-delivery` |
+| 7 | Discovery/proximity is the survival differentiator, not capture | **FITS** | Attach decisions to the code/services they affect + the typed graph (ADR-074). → `future/decision-to-code-proximity` |
+| 8 | Contribution friction from the PR gate (the friction that kills wikis) | **CONFLICT** (ADR-065) | Mitigate with agent-assisted authoring (`rac-artifacts` skill) + fast gates. |
+| 9 | AI changes the ROI of curation | **POSITIONING** | The timing tailwind. Lead GTM with "your agents improve on day one from artifacts you already have." |
+| 10 | Only wins if it REPLACES a silo, not adds one | **POSITIONING** | Position as *the* source of truth, not "another store" beside Confluence/Slack. |
+| 11 | Low ceremony | **FITS** | ADR evidence: heavy templates get abandoned. Guard against template bloat. |
+| 12 | Prove it | **HONEST** | Grounding-eval (ADR-066) — no public proof curated context lifts task success yet; be the one with the number. |
+
+---
+
+## Competitive landscape & positioning
+
+- **Closest single competitor concept:** `mcp-adr-analysis-server` — an MCP server that
+  serves/analyzes ADRs to agents. Lore differentiates by being full artifact families
+  + deterministic validation + a validated graph, not ADR analysis alone.
+  ([repo](https://github.com/tosin2013/mcp-adr-analysis-server))
+- **Patterns to borrow:** Spec Kit's `constitution` (governed project principles),
+  Backstage's catalog-coupled ADR discovery (`adr-location`).
+- **The whitespace:** every agent-context tool stores **coding rules** or **indexed
+  code**; none governs **product decisions / requirements / roadmaps**. That is Lore's
+  uncontested niche.
+- **The wedge against enterprise RM:** the traceability + governance value of
+  DOORS/Jama/Polarion (suspect links, baselines, review), git-native — no per-seat
+  collaboration tax, zero lock-in (it's just Markdown), no SVN bottleneck,
+  deterministic — for teams priced out of or crushed by enterprise RM.
+- **Lore's defensible middle** sits between lightweight MCP file/notes servers
+  (deterministic but unstructured) and enterprise RAG-over-docs (embeddings,
+  precision-poor for decisions): deterministic + *structured artifacts* + a *validated
+  graph*.
+
+---
+
+## Honest caveats & open questions
+
+1. **No published proof curated decision context lifts agent task success.** Evidence
+   supports *selective* delivery (context rot), not "decisions demonstrably make
+   agents better." Grounding-eval (ADR-066) is the answer and a moat.
+2. **The freshness gap is real and is Lore's softest spot** — but also the gap nobody
+   else has solved, so it is a differentiator to win, not just a risk to cover.
+3. **Decision rationale cannot be auto-generated**, so Lore can *detect and surface*
+   staleness, not make it "structurally impossible" the way generated API docs can.
+4. **MCP resources are under-adopted** (clients favor tools); agent-context conventions
+   (AGENTS.md / CLAUDE.md / Cursor rules) are unsettled — don't over-commit to one
+   surface.
+5. **Contribution friction** at 20+ is inherited from the PR gate.
+6. **Sourcing limits:** many adoption/ROI and pricing figures are vendor or
+   third-party estimates (medium confidence); the durable facts are the mechanism
+   docs, the arXiv drift study, DORA, the Sourcegraph embeddings reversal, and the
+   enterprise "suspect link" semantics.
+
+---
+
+## What this produced (captured as corpus)
+
+The *actionable* findings were distilled into unscheduled `future/` roadmap items
+(this document is the reference behind them):
+
+- `rac/roadmaps/future/freshness-and-drift-detection.md` — loud git-derived staleness
+  + a deterministic git-native "suspect links" drift gate (lesson #2/#3/#4).
+- `rac/roadmaps/future/decision-to-code-proximity.md` — declared code-scope references
+  so the governing decision surfaces at the point of work (lesson #7).
+- `rac/roadmaps/future/lean-context-delivery.md` — measure/bound the agent-facing
+  footprint and keep a first-class CLI path (lesson #6).
+
+The competitive *positioning* conclusions belong with the `rac-growth-positioning`
+requirement or a dedicated `design` (not yet captured at the time of writing).

--- a/rac/roadmaps/future/decision-to-code-proximity.md
+++ b/rac/roadmaps/future/decision-to-code-proximity.md
@@ -1,0 +1,107 @@
+---
+schema_version: 1
+id: RAC-KVTRP9G4CN2N
+type: roadmap
+---
+# RAC — Decision-to-Code Proximity (Future)
+
+## Status
+
+Planned
+
+Unscheduled — captured for future consideration from the team-scale (20+) market
+research. It graduates out of `future/` into a versioned series when prioritised.
+
+## Context
+
+A consistent finding across the research: at 20+ engineers, **discovery and
+proximity-to-code — not capture — decide whether a decision corpus survives.**
+Capture is solved and identical everywhere (Markdown-in-git). What separates the
+tools that get read from the ones that rot is whether the record surfaces *where
+the work happens*. ADRs "rot when stored away from the code, where engineers do
+not look"; ThoughtWorks' rule is to keep decisions "in source control… in sync
+with the code"; Backstage's ADR plugin attaches records to the service they affect
+via a `backstage.io/adr-location` annotation so they "sit next to the services
+they affect."
+
+Lore's artifacts live in `rac/`, validated and linked to *each other*, but they
+are not linked to the **code or components they govern**. So an agent (or a human)
+working in `src/auth/` has no deterministic way to ask "which recorded decisions
+govern this code?" This item closes that gap — the discovery differentiator — and
+it is also the precondition for the drift gate in
+`freshness-and-drift-detection` (you cannot flag a decision "suspect" when its code
+changes until the decision knows which code it governs).
+
+## Outcomes
+
+- An artifact can declare the code paths or components it governs, validated like
+  any other reference.
+- Given a file or directory, a deterministic lookup returns the artifacts that
+  govern it — so the right decision surfaces at the point of work, for an agent or
+  a developer.
+
+## Initiatives
+
+### Initiative 1 — Code-scope references on artifacts
+
+An optional, declared reference on an artifact naming the code it governs — path
+globs or a component identifier — validated deterministically in the
+asset-reference style (ADR-019). Declared and human-reviewed, never inferred from
+code content.
+
+### Initiative 2 — "Decisions affecting this path" lookup
+
+A deterministic CLI and MCP lookup: given a file or directory, return the
+governing artifacts (and their status), so an agent editing code is grounded in
+the decisions that constrain it without searching. Read-only, additive (ADR-007).
+
+### Initiative 3 — Feeds proximity-aware surfacing and drift
+
+The code-scope reference becomes the join that lets the Explorer show "decisions
+for this area" and lets the drift gate flag an artifact when its governed code
+changes (the `freshness-and-drift-detection` tie-in).
+
+## Constraints
+
+- Declared and validated, never inferred (ADR-074, ADR-065): code scope is an
+  authored reference a human reviews, not a guess from parsing code.
+- Deterministic and offline (ADR-066): the path↔artifact lookup is a pure function
+  of declared references and the file tree.
+- No database: associations are declared references resolved at read time.
+
+## Non-Goals
+
+- Parsing or understanding code semantics; this maps declared paths, not meaning.
+- Auto-associating decisions to code by similarity or embeddings.
+
+## Success Measures
+
+- An artifact can name the code it governs and the reference validates.
+- Querying a path returns its governing artifacts deterministically and
+  reproducibly.
+- The association is reusable by both discovery (Explorer/CLI/MCP) and the drift
+  gate.
+
+## Assumptions
+
+- Proximity-to-code is the discovery mechanism that most affects whether a 20+
+  team's decision corpus is actually consulted, per the research.
+- Declared path scopes are precise enough to be useful without code analysis, the
+  same way `## Related` references are useful without semantic linking.
+
+## Risks
+
+- Path globs drift as the codebase is refactored, leaving stale scopes. Mitigation:
+  this is exactly the drift the freshness gate is meant to surface — a moved path
+  becomes a "suspect" signal, not a silent rot.
+
+## Related Decisions
+
+- adr-019
+- adr-074
+- adr-028
+- adr-065
+
+## Related Roadmaps
+
+- freshness-and-drift-detection

--- a/rac/roadmaps/future/freshness-and-drift-detection.md
+++ b/rac/roadmaps/future/freshness-and-drift-detection.md
@@ -1,0 +1,126 @@
+---
+schema_version: 1
+id: RAC-KVTRP81ZWA57
+type: roadmap
+---
+# RAC — Freshness Signals and Drift Detection (Future)
+
+## Status
+
+Planned
+
+Unscheduled — captured for future consideration from the team-scale (20+) market
+research. It is the highest-leverage finding of that research and graduates out of
+`future/` into a versioned series when prioritised.
+
+## Context
+
+The strongest, best-evidenced finding from researching knowledge tools at team
+scale: **staleness leading to trust collapse is the number-one cause of
+abandonment** — once a reader hits one wrong page, they distrust the whole corpus
+and revert to Slack or reading source. And the evidence is empirical, not
+folklore: a study of 27,772 pull requests across 714 repositories found only
+~0.8% of PRs update the README and ~21.5% of changes that should have updated it
+did not; DORA finds high-quality documentation more than doubles the odds of
+hitting performance targets.
+
+The sharp, uncomfortable corollary: **git + PR review is necessary but
+proven-insufficient to keep knowledge fresh** — the docs-as-code literature itself
+concedes there is no evidence drift decreases at scale, and the PR data shows
+reviewers routinely miss documentation updates. So Lore's PR-review trust boundary
+(ADR-065) alone will not keep the corpus trustworthy.
+
+What every serious tool at the high end *does* ship is a freshness mechanism:
+enterprise requirements tools (Jama, IBM DOORS, Siemens Polarion) all flag
+downstream items as **"suspect"** when an upstream item changes; team wikis bolt on
+owner + expiry-clock verification. By contrast, the AI agent-context tools
+(Cursor, Amp, Continue, Augment) ship *no* freshness tooling at all — a gap Lore
+can own. Lore already holds the raw material to do a deterministic, git-native
+version: recency derived from git (ADR-045) and a validated relationship graph
+(ADR-074). This item is that capability.
+
+## Outcomes
+
+- Git-derived staleness is surfaced **loudly** wherever the corpus is read — the
+  CLI, the MCP responses, the TUI — so decay is visible, not silent.
+- A deterministic **drift gate** flags an artifact as "suspect" when something it
+  governs or references changes but the artifact itself did not — the git-native
+  equivalent of enterprise "suspect links," with no database and no AI.
+
+## Initiatives
+
+### Initiative 1 — Loud freshness signals
+
+Surface git-derived recency on reads — last-touched date, the commit/PR that last
+changed an artifact, and a staleness indicator — across `rac` CLI output, the MCP
+`get_artifact`/search responses (additively, ADR-007), and the Explorer. Recency
+stays derived from git, never stored in frontmatter (ADR-045).
+
+### Initiative 2 — Deterministic drift gate ("suspect" detection)
+
+When an artifact references a target — another artifact, or (with the
+decision-to-code-proximity work) a code path it governs — and that target changes
+in a commit while the artifact does not, flag the artifact "suspect" for review.
+Pure git-diff over the validated relationship graph; no model, no embeddings. It
+can run advisory in `rac doctor`/`review` or as a CI gate (ADR-075), the team's
+choice.
+
+### Initiative 3 — Freshness biases surfacing
+
+A stale-flagged artifact is surfaced for review (in `review`/`doctor`/coverage) and
+can be de-prioritised in retrieval until refreshed — so the freshness signal
+actually changes what readers and agents see.
+
+## Constraints
+
+- Deterministic and git-derived (ADR-045): staleness is computed from commit
+  history, never a stored "verified" flag that would duplicate git state.
+- No database, no AI/embeddings (ADR-066): drift detection is git-diff plus the
+  declared relationship graph.
+- PR review remains the human attestation (ADR-065); this *augments* it with the
+  machine-checkable signal the evidence says review alone lacks.
+
+## Non-Goals
+
+- Auto-fixing staleness: decision rationale cannot be regenerated, so Lore detects
+  and surfaces drift, it does not silently rewrite an artifact.
+- A frontmatter "last verified" checkbox: that duplicates state git already holds
+  and invites the self-clicked-verify theatre wikis rely on.
+
+## Success Measures
+
+- A reader or agent can see, at the point of use, when an artifact was last
+  touched and whether it is suspect.
+- Changing a target without updating an artifact that references it produces a
+  deterministic "suspect" finding, reproducibly.
+- No new datastore is introduced; the signal is a pure function of git history and
+  the relationship graph.
+
+## Assumptions
+
+- Trust collapse from staleness is the dominant abandonment driver at 20+, so a
+  visible, automated freshness signal is the single highest-leverage adoption
+  lever — and one no agent-context competitor ships.
+- A git-native "suspect links" mechanism delivers the value enterprises pay
+  six-figure sums for, without their cost or lock-in.
+
+## Risks
+
+- Over-flagging (every upstream edit marks everything suspect) trains people to
+  ignore it. Mitigation: scope "suspect" to declared references and meaningful
+  target changes; make it advisory before it is ever a gate.
+- A freshness signal could imply a freshness *guarantee*. Mitigation: frame it as
+  "review recommended," an input to human judgement (ADR-065), never proof of
+  correctness.
+
+## Related Decisions
+
+- adr-045
+- adr-065
+- adr-074
+- adr-066
+
+## Related Requirements
+
+- rac-traceability-coverage-report
+- rac-doctor-diagnostic-validator

--- a/rac/roadmaps/future/lean-context-delivery.md
+++ b/rac/roadmaps/future/lean-context-delivery.md
@@ -1,0 +1,104 @@
+---
+schema_version: 1
+id: RAC-KVTRPAX62TWJ
+type: roadmap
+---
+# RAC — Lean Context Delivery (Future)
+
+## Status
+
+Planned
+
+Unscheduled — captured for future consideration from the team-scale (20+) market
+research. It graduates out of `future/` into a versioned series when prioritised.
+
+## Context
+
+The research surfaced a real risk to how Lore *delivers* knowledge to agents. Two
+independent findings converge: **"context rot"** is empirically established —
+Chroma Research tested 18 frontier models and found every one degrades as input
+length grows, well before the context window fills — so dumping a corpus actively
+*worsens* output; and the **MCP "context tax"** is a live critique — Simon Willison
+stopped using MCP for coding agents because tool descriptions "take up a lot of
+valuable real estate" (GitHub's MCP server cited at ~23k tokens) and found CLI
+utilities a lower-tax path. The practitioner guidance to keep instruction files
+under ~200 lines is the same lesson from the other side.
+
+The implication for Lore is sharp: **a knowledge server justifies itself only if it
+stays lean — otherwise it becomes the noise it was meant to cure.** Lore already
+has the right instincts recorded — a response budget (ADR-033), a minimal
+tools-only surface, and a CLI-first posture (ADR-005) — but nothing yet *measures
+and bounds* the agent-facing footprint, and the CLI-as-delivery path is
+under-documented relative to MCP. This item makes leanness a measured property and
+keeps the low-tax delivery option first-class.
+
+## Outcomes
+
+- The agent-facing footprint — tool descriptions, schemas, and response payloads —
+  is measured and held within a stated token budget, so Lore does not become the
+  context tax it warns against.
+- Retrieval is selective and on-demand by default (pull the relevant artifact, not
+  the corpus), the documented antidote to context rot.
+- The CLI delivery path (`find` / `resolve` / `relationships`) is a documented,
+  supported, low-context-tax alternative to the MCP server, not an afterthought.
+
+## Initiatives
+
+### Initiative 1 — Measure and bound the MCP surface
+
+Audit the token cost of the MCP tool surface (descriptions + schemas) and the
+typical response, and hold it to a budget — the leanness that ADR-033 asserts,
+made measurable and regression-checkable.
+
+### Initiative 2 — Selective, on-demand retrieval by default
+
+Confirm and document that the default path retrieves the *relevant* artifacts, not
+the whole corpus, so context rot is avoided by construction — small, scoped,
+relevant payloads over bulk inclusion.
+
+### Initiative 3 — CLI-first delivery as a first-class option
+
+Document and, where needed, sharpen the CLI delivery path (`find`/`resolve`/
+`relationships`) as the lowest-context-tax way to ground an agent — the path the
+MCP critique favours (ADR-005), offered alongside the MCP server, not instead of
+it.
+
+## Constraints
+
+- Deterministic and offline (ADR-066): no semantic compression or summarisation to
+  shrink payloads.
+- Selective delivery respects the response budget (ADR-033); both the MCP server
+  and the CLI remain supported surfaces.
+
+## Non-Goals
+
+- Removing or deprecating the MCP server; this keeps both surfaces and makes the
+  trade-off explicit.
+- AI-based summarisation or compression of artifacts to fit a budget.
+
+## Success Measures
+
+- The agent-facing token footprint is measured and stays within its budget across
+  releases.
+- A team can ground an agent through the CLI path with materially lower context
+  cost than a heavyweight tool surface, with documented guidance on when to use
+  which.
+
+## Assumptions
+
+- Context rot and the MCP context tax are real and persistent enough that leanness
+  is a durable design constraint, not a passing concern.
+- A measured budget plus a documented CLI path is enough; no semantic compression
+  is needed for a small, structured corpus.
+
+## Risks
+
+- Optimising for leanness could under-serve an agent that genuinely needs more
+  context. Mitigation: selective on-demand retrieval lets the agent pull more when
+  it asks, rather than front-loading everything.
+
+## Related Decisions
+
+- adr-033
+- adr-005
+- adr-066


### PR DESCRIPTION
## What

Captures the team-scale (20+) market research, in two forms:

**1. The actionable findings → unscheduled `future/` roadmap items** (validated corpus):
- **`future/freshness-and-drift-detection.md`** (the lead) — loud git-derived staleness signals + a deterministic, git-native **"suspect links"** drift gate. Staleness→trust-collapse is the #1 abandonment driver (empirical: ~0.8% of PRs update the README; ~21.5% of needed updates missed), git+PR review is **proven-insufficient** for freshness, and it's the gap enterprise RM charges six figures for while agent-context tools ship nothing.
- **`future/decision-to-code-proximity.md`** — declared code-scope references so "which decisions govern this file?" is a deterministic lookup (the discovery differentiator + precondition for the drift gate).
- **`future/lean-context-delivery.md`** — measure/bound the agent-facing footprint + keep a first-class CLI path (context rot + the MCP context tax).

**2. The full report → `docs/research/team-scale-landscape.md`** — a plain document, **not** a RAC artifact (ADR-010 / ADR-024), confirmed outside the corpus (`rac validate rac/` still counts 279 artifacts). The cited synthesis behind the future items: all four categories (AI agent context, decision/spec + enterprise RM, developer portals, knowledge bases), the empirical backbone (the arXiv drift study, DORA, Sourcegraph's embeddings reversal, "suspect links"), the prioritized adopt-vs-abandon verdict, and the competitive positioning.

## Why this shape
The `future/` items are unscheduled (no new ADRs — intent records the *what*; decisions come when scheduled) and reference only settled decisions on `main`. The report stays a document because RAC is not a content store. The competitive *positioning* conclusions still belong with `rac-growth-positioning` or a `design` — not in this PR.

## Gates
- `rac validate rac/` — pass (279 valid, 0 invalid; the docs/ report is correctly *not* an artifact)
- `rac relationships rac/ --validate` — pass (0 issues)
- `rac review rac/` — no priority 1–2 findings
- `rac export --agent-rules --check` — in sync