### PR TITLE
docs(decision): record ADR-077 two-gate capture write model

### DIFF
--- a/.cursor/rules
+++ b/.cursor/rules
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: 5a1211eb5abaa73c98a2cdb4351feadf1e6cdadf26d5f21b4ce2d3c394a74485) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: 3c53edfc4a0edf8ad94ad2fc8718733143fa3cf84add2a16f91338dc49363370) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -58,4 +58,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KVK19NPWFYC9** — ADR-074: The Graph Export Surfaces Typed Relationship Edges _(Technical)_
 - **RAC-KVNM01QPBPXB** — ADR-075: The Pre-Merge Check Tier Is a Required Merge Gate on `main` _(Process)_
 - **RAC-KVPTVX3YZ87K** — ADR-076: Adopt CalVer (`YYYY.MM.N`) for RAC Releases _(Process)_
+- **RAC-KVTS86ZGVJV7** — ADR-077: The Two-Gate Capture Write Model _(Architecture)_
 <!-- END RAC MANAGED BLOCK -->

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: 5a1211eb5abaa73c98a2cdb4351feadf1e6cdadf26d5f21b4ce2d3c394a74485) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: 3c53edfc4a0edf8ad94ad2fc8718733143fa3cf84add2a16f91338dc49363370) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -58,4 +58,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KVK19NPWFYC9** — ADR-074: The Graph Export Surfaces Typed Relationship Edges _(Technical)_
 - **RAC-KVNM01QPBPXB** — ADR-075: The Pre-Merge Check Tier Is a Required Merge Gate on `main` _(Process)_
 - **RAC-KVPTVX3YZ87K** — ADR-076: Adopt CalVer (`YYYY.MM.N`) for RAC Releases _(Process)_
+- **RAC-KVTS86ZGVJV7** — ADR-077: The Two-Gate Capture Write Model _(Architecture)_
 <!-- END RAC MANAGED BLOCK -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: 5a1211eb5abaa73c98a2cdb4351feadf1e6cdadf26d5f21b4ce2d3c394a74485) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: 3c53edfc4a0edf8ad94ad2fc8718733143fa3cf84add2a16f91338dc49363370) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -58,4 +58,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KVK19NPWFYC9** — ADR-074: The Graph Export Surfaces Typed Relationship Edges _(Technical)_
 - **RAC-KVNM01QPBPXB** — ADR-075: The Pre-Merge Check Tier Is a Required Merge Gate on `main` _(Process)_
 - **RAC-KVPTVX3YZ87K** — ADR-076: Adopt CalVer (`YYYY.MM.N`) for RAC Releases _(Process)_
+- **RAC-KVTS86ZGVJV7** — ADR-077: The Two-Gate Capture Write Model _(Architecture)_
 <!-- END RAC MANAGED BLOCK -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ to the corpus artifact and they load through the imports below.
 - Previous series: `rac/roadmaps/v0.21.x-editor/` (complete)
 - Decisions (ADRs): `rac/decisions/`
 
-<!-- BEGIN RAC MANAGED BLOCK (digest: 5a1211eb5abaa73c98a2cdb4351feadf1e6cdadf26d5f21b4ce2d3c394a74485) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: 3c53edfc4a0edf8ad94ad2fc8718733143fa3cf84add2a16f91338dc49363370) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -83,4 +83,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KVK19NPWFYC9** — ADR-074: The Graph Export Surfaces Typed Relationship Edges _(Technical)_
 - **RAC-KVNM01QPBPXB** — ADR-075: The Pre-Merge Check Tier Is a Required Merge Gate on `main` _(Process)_
 - **RAC-KVPTVX3YZ87K** — ADR-076: Adopt CalVer (`YYYY.MM.N`) for RAC Releases _(Process)_
+- **RAC-KVTS86ZGVJV7** — ADR-077: The Two-Gate Capture Write Model _(Architecture)_
 <!-- END RAC MANAGED BLOCK -->

--- a/rac/decisions/adr-077-two-gate-capture-write-model.md
+++ b/rac/decisions/adr-077-two-gate-capture-write-model.md
@@ -1,0 +1,100 @@
+---
+schema_version: 1
+id: RAC-KVTS86ZGVJV7
+type: decision
+---
+# ADR-077: The Two-Gate Capture Write Model
+
+## Status
+
+Accepted
+
+## Category
+
+Architecture
+
+## Context
+
+Lore's capture surfaces turn a person's input into an artifact and write it to
+the repository. The first of these — the `rac-capture` skill — has shipped, and
+the `lore-capture-surfaces` design names more to come (a desktop overlay, a Slack
+bot, a web modal). Each crosses the same threshold: a surface takes knowledge
+from an author and proposes it for the corpus.
+
+ADR-065 already names the corpus-wide trust boundary — artifact content is
+untrusted until a human accepts it through pull-request review — but it does not
+say *who* performs that review relative to *who authored the change*, which is the
+question a capture flow makes acute. A capture surface has a natural temptation to
+treat the author's own confirmation ("yes, that is what I meant") as enough to
+land the artifact. Security and change-management practice is unambiguous that an
+actor who originates a change cannot also be the control that authorizes it:
+separation of duties (NIST SP 800-53 AC-5), the four-eyes / two-person rule, OWASP
+secure-SDLC guidance that changes be "reviewed by individuals other than the
+originating author," and SLSA's source track, which requires that "the uploader
+and reviewer are two different trusted persons." The platforms a capture host runs
+on do not enforce this for us — Slack, for instance, surfaces who clicked but does
+nothing to stop an author approving their own request.
+
+## Decision
+
+A capture surface uses **two distinct gates, on two different actors**:
+
+- **Gate 1 — fidelity.** The author confirms, in the host, that the surface
+  captured what they meant. This is a data-quality check; it is **not** a trust
+  boundary and confers no authority to enter the record. A host must not rely on
+  the host platform to enforce independence at this gate.
+- **Gate 2 — the trust boundary.** An **independent** maintainer reviews and
+  merges the pull request. This is the trust boundary, extending ADR-065 to the
+  capture path, and it is enforced by the platform's required-review controls
+  together with a "someone other than the author/last pusher" rule.
+
+**Corollary:** a capture host or bot only *proposes* — it opens a draft pull
+request — and never holds approval or merge power, and is never placed on a
+review-bypass list.
+
+## Consequences
+
+Capture stays low-friction (a draft can be committed freely) while the record
+stays trustworthy (an independent merge admits it), and the model is uniform
+across every capture host, composing with existing branch-protection machinery
+rather than inventing an approval system.
+
+The trade-offs accepted: capture can never simply *land* an artifact — there is
+always a human merge step by someone other than the author. The guarantee is
+procedural, so a project that does not actually require independent review
+inherits no protection. And the "someone other than the author" rule must be set
+explicitly: required reviews plus the not-the-author setting, because CODEOWNERS
+alone is self-satisfiable when the author is themselves a listed owner, and a
+GitHub App's own review can satisfy a required review if the app holds
+write/admin — so the writer must never be granted that standing.
+
+## Alternatives Considered
+
+### Single gate — the author confirms and it lands
+
+Treat the in-host confirmation as sufficient to write to the record. Rejected:
+this is self-approval, which the separation-of-duties literature classifies as the
+*absence* of a control, not a weak one.
+
+### The writer writes straight to the trusted branch
+
+Skip the pull request and commit directly. Rejected: it bypasses every
+required-review control. The draft PR is precisely the mechanism that turns a
+capture into a *reviewable proposal*.
+
+### Give the writer bot approval or merge power
+
+Let the capture bot approve or merge its own proposal. Rejected: a bot review can
+satisfy a required review when the app has write/admin, silently defeating Gate 2;
+the writer must only ever open the PR.
+
+## Related Decisions
+
+- ADR-017
+- ADR-065
+- ADR-067
+
+## Related Designs
+
+- lore-capture-surfaces
+- lore-slack-capture-flow

--- a/rac/roadmaps/future/rac-capture-skill.md
+++ b/rac/roadmaps/future/rac-capture-skill.md
@@ -14,6 +14,11 @@ concrete build proposed by the `lore-capture-surfaces` design (Host A); it is a
 near-zero-build item gated only on the decision to start, and it must not
 displace nearer-term committed work.
 
+**Update — Initiative 1 (the `rac-capture` skill) shipped** (merged in PR #193).
+The roadmap stays `Planned` rather than `Achieved` because Initiatives 2–3 (the
+host surfaces) remain deferred; this records that the shared capture core now
+exists.
+
 ## Context
 
 `lore-frontend-optionality` established that Lore's binding constraint is
@@ -56,7 +61,7 @@ of scope here — they wrap this same skill later.
 
 ## Initiatives
 
-### Initiative 1 — The `rac-capture` skill
+### Initiative 1 — The `rac-capture` skill *(delivered, PR #193)*
 
 Author `src/rac/skills/rac-capture/SKILL.md` as the interview variant of
 `rac-import`, reusing the same CLI seams (`rac schema`, `rac inspect`, `rac new`,


### PR DESCRIPTION
# Summary

Post-merge follow-up to #193. Records the **two-gate capture write model** as an
accepted decision (ADR-077) — captured by exercising the new `rac-capture` skill
end to end — and reconciles the capture roadmap to note the skill shipped.

Adds:
- `rac/decisions/adr-077-two-gate-capture-write-model.md` — elevates the two-gate
  principle from a design note to an Accepted Architecture decision.
- A status update on `rac/roadmaps/future/rac-capture-skill.md` marking Initiative
  1 (the skill) delivered, while the roadmap stays `Planned` (host surfaces remain).

# Roadmap / ADR Trace

New decision:
- `rac/decisions/adr-077-two-gate-capture-write-model.md`

Roadmap:
- `rac/roadmaps/future/rac-capture-skill.md` (Initiative 1 marked delivered)

Grounded in / related:
- `rac/decisions/adr-065-artifact-content-untrusted.md` (ADR-077 extends its trust boundary to the capture path)
- `rac/decisions/adr-017-rac-managed-knowledge-not-work.md`, `adr-067` (no AI in core / post-edit enforcement)
- Designs: `rac/designs/lore-capture-surfaces.md`, `rac/designs/lore-slack-capture-flow.md`

# Scope

## Included
- ADR-077: two gates, two actors — Gate 1 (author confirms fidelity, *not* a trust
  boundary) and Gate 2 (an independent maintainer's PR merge is the trust boundary);
  the writer host/bot only proposes (opens a draft PR) and never holds approval power.
- The roadmap status reconcile.

## Excluded
- No engine, CLI, schema, or test change — this is corpus-only.
- No host build; the host surfaces remain deferred in the roadmap.

# Product / Architecture Decisions
- ADR-077 is recorded `Accepted` because the model is already the operative
  practice (it is how #193 itself landed), and `Category: Architecture`.
- It extends ADR-065 rather than restating it: ADR-065 sets the corpus trust
  boundary; ADR-077 fixes *who reviews relative to who authored* for capture writes
  (separation of duties / four-eyes / SLSA two-party review), and records the
  CODEOWNERS-alone and bot-self-approval footguns.
- The ADR was authored by exercising the `rac-capture` skill (interview → real
  schema → human ratification of type/title/relationships → `rac new` → `rac validate`).

# User-Facing Contract
- None. No CLI, JSON, or exit-code change; corpus artifacts only.

# Verification

## Ran
- `rac validate rac/`
- `rac relationships rac/ --validate`
- `rac review rac/`
- `rac resolve` on the new decision

## Covered
- 277 artifacts valid, 0 invalid; 1318 relationships checked, 0 issues; `rac
  review` health 93/100 with no priority 1-2 findings.
- ADR-077 classifies as `decision`, resolves by id, and its Related Decisions
  (ADR-017/065/067) and Related Designs (`lore-capture-surfaces`,
  `lore-slack-capture-flow`) all resolve.

# Review Path
1. `rac/decisions/adr-077-two-gate-capture-write-model.md` — the decision itself.
2. `rac/roadmaps/future/rac-capture-skill.md` — the status reconcile.

# Notes For Reviewer
- This PR is itself a worked instance of ADR-077: it was opened by the author and
  is intended to be merged by an independent maintainer (Gate 2).

# Implementation Process
Implemented with AI assistance under the corpus's exploration/roadmap conventions;
final scope, review, and acceptance decisions were made by the maintainer.