### PR TITLE
docs(decision): record competitive positioning (ADR-081)

### DIFF
--- a/rac/decisions/adr-081-competitive-positioning.md
+++ b/rac/decisions/adr-081-competitive-positioning.md
@@ -1,0 +1,118 @@
+---
+schema_version: 1
+id: RAC-KVTSP3P97GVE
+type: decision
+---
+# ADR-081: Competitive Positioning — The Source of Truth for Product Decisions
+
+## Context
+
+ADR-036 records Lore's product *identity*, and the `rac-growth-positioning`
+requirement records a narrow README relationship to spec-driven-development tools
+and OKF. Neither records where Lore sits against the broader competitive field, so
+evaluators have no recorded answer to "what is this versus the tools I already
+know," and the team has no shared positioning stance to derive a README, growth
+artifacts, or a pitch from.
+
+The team-scale (20+) market research (archived at
+`docs/research/team-scale-landscape.md`, a reference document, not an artifact —
+ADR-010/ADR-024) mapped four adjacent categories and produced the findings that
+shape positioning:
+
+- **Capture is solved and identical everywhere** (Markdown-in-git); survival at 20+
+  is decided by **staleness, discovery, and workflow-fit**, not capture.
+- **Every AI agent-context tool stores coding rules or indexed code — none governs
+  product decisions.** That is open whitespace. (Cursor, Amp, Cody, Augment, Glean,
+  Dust, Onyx.)
+- **Enterprise requirements management (Jama/DOORS/Polarion) has the governance but
+  crushing friction** — per-seat pricing that throttles collaboration, heavyweight
+  admin, scale bottlenecks, and lock-in.
+- **Sourcegraph publicly reversed out of embeddings** for enterprise context,
+  validating the no-embeddings stance (ADR-066); **DORA 2025 names "decision logs"**
+  as an AI-effectiveness lever; **staleness leading to trust collapse is the #1
+  abandonment driver**, and git + PR review alone is empirically insufficient to
+  prevent it.
+
+## Decision
+
+Position Lore as **the shared, git-native, deterministic source of truth for
+product *decisions*** — requirements, decisions, roadmaps, designs — served to
+coding agents. The stance has four pillars:
+
+- **The whitespace it owns.** Governed *product decisions* are the knowledge class
+  no agent-context tool manages (they hold coding rules or indexed code), and the
+  durable layer above spec-driven tools (which treat requirements as ephemeral
+  inputs). This extends `rac-growth-positioning`'s "layer above SDD" thesis to the
+  whole field.
+- **What it competes on.** The **freshness/drift problem** (a deterministic,
+  git-native equivalent of enterprise "suspect links" — the capability DOORS/Jama
+  charge six figures for) and **trust** ("verification you can't fake": PR review
+  plus immutable git history plus machine-checkable validation), at **zero per-seat
+  collaboration tax and zero lock-in** (it is just Markdown in the team's repo).
+- **What it deliberately does *not* compete on.** Embeddings / vector-RAG (ADR-066;
+  the lane a major incumbent reversed out of, and precision-poor for decisions);
+  agent runtime and code generation (ADR-069 split routing out; Lore is not an
+  SDD/codegen tool); and being a general content store (ADR-024).
+- **The wedge and the complement.** The wedge is the governance and traceability of
+  enterprise RM, git-native and friction-free, for teams priced out of or crushed by
+  it. The complement is that Lore *composes with* — does not compete against —
+  agent-context rules (`AGENTS.md`/`.cursor/rules`), SDD tools, and OKF, sitting at
+  the durable-decisions layer above them.
+
+All positioning claims must be verifiable and stated as complementary, never "better
+than," consistent with `rac-growth-positioning`'s constraints.
+
+## Consequences
+
+There is now a recorded positioning the README, growth artifacts, and any pitch can
+derive from, and a shared answer to "what is this versus X." The differentiators
+become claims the product must *back*: the freshness/drift capability (recorded as
+future intent), and the deterministic grounding benchmark (ADR-066) as the proof
+that curated decision context helps — the one number competitors cannot show.
+
+Trade-offs and honest limits, recorded so positioning does not outrun reality:
+
+- There is **no published proof that curated decision context lifts agent task
+  success**; the benchmark is how Lore earns the claim rather than asserts it.
+- The **freshness gap is real** until the drift-detection work ships — it is the
+  softest spot *and* the differentiator, so it is load-bearing.
+- Positioning **only wins if Lore replaces a silo, not adds one** beside
+  Confluence/Slack; "the source of truth" is the claim, "another store" is the
+  failure.
+
+## Status
+
+Proposed
+
+## Category
+
+Product
+
+## Alternatives Considered
+
+- **Position as a spec-driven-development / spec tool.** Rejected: SDD treats
+  requirements as ephemeral inputs and owns the spec→code path (with its openly
+  unsolved drift problem); Lore is the durable-decisions layer *above* it, not a
+  competitor (the existing `rac-growth-positioning` thesis).
+- **Position as an agent-memory / RAG tool.** Rejected: that is the embeddings /
+  vector lane ADR-066 excludes and a major incumbent (Sourcegraph) publicly reversed
+  out of — and it is precision-poor exactly where decisions live.
+- **Position as enterprise requirements management.** Rejected: matching DOORS/Jama
+  on governance by adopting their cost, lock-in, and heavyweight footprint reproduces
+  the friction that kills adoption; Lore's wedge is the opposite — friction-free and
+  git-native.
+- **Record no positioning (status quo).** Rejected: evaluators misfile Lore against
+  whichever category they arrived from, and the team has no shared stance to build
+  its README, growth work, or pitch on.
+
+## Related Decisions
+
+- adr-036
+- adr-066
+- adr-024
+- adr-069
+- adr-018
+
+## Related Requirements
+
+- rac-growth-positioning


### PR DESCRIPTION
## What

Records Lore's **competitive positioning** as a product decision — **ADR-081** (Proposed, Category: Product) — distilled from the team-scale market research.

A new artifact (as requested) rather than an edit, because:
- `rac-growth-positioning` is a *requirement* narrowly about README sections relating Lore to SDD/OKF.
- ADR-036 is product *identity*.
- Neither records the broader competitive **stance** — so this fills a real gap and extends both to the whole field.

## The recorded stance (four pillars)

1. **Whitespace it owns** — governed *product decisions*, the class no agent-context tool manages (they hold coding rules or indexed code); the durable layer above SDD tools.
2. **What it competes on** — the freshness/drift problem (git-native "suspect links" — what enterprise RM charges six figures for) and trust ("verification you can't fake"), at **zero per-seat tax, zero lock-in**.
3. **What it deliberately does *not* compete on** — embeddings/vector-RAG (ADR-066; the lane Sourcegraph reversed out of), agent runtime/codegen (ADR-069), general content storage (ADR-024).
4. **Wedge & complement** — the wedge against enterprise RM (governance, friction-free); composes with (doesn't compete against) agent-context rules, SDD, and OKF.

Honest limits are recorded in Consequences (no published proof curated context lifts task success → the grounding-eval is how it's earned; the freshness gap is load-bearing until the drift work ships; must replace a silo, not add one).

## Why ADR
Positioning is a deliberate product decision — sibling to ADR-036. References only decisions on `main` (036/066/024/069/018) + the `rac-growth-positioning` requirement; the full cited landscape lives in `docs/research/team-scale-landscape.md` (PR #195).

## Gates
- `rac validate rac/` — pass (280 valid, 0 invalid)
- `rac relationships rac/ --validate` — pass (0 issues)
- `rac review rac/` — no priority 1–2 findings
- `rac export --agent-rules --check` — in sync (ADR-081 Proposed, correctly excluded)