### PR TITLE
docs(footprint): Omnigent recipe + integration and artifact-family factory roadmaps

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -80,6 +80,27 @@ Create or edit `.cursor/mcp.json` in your project root:
 
 <!-- TODO: verify against Cursor <version> before release -->
 
+### Omnigent
+
+[Omnigent](https://omnigent.ai) is a meta-harness: its custom agents are defined
+in a `config.yaml`, and an MCP server is a first-class tool type. Add a `lore`
+entry under the agent's `tools:` section:
+
+```yaml
+tools:
+  lore:
+    type: mcp
+    command: rac
+    args: ["mcp", "--root", "/path/to/your/repo"]
+```
+
+The tool travels with the agent definition, so it stays attached whichever
+harness Omnigent routes to. A worked setup — including pointing the agent's
+`instructions` at the generated `AGENTS.md` — is in
+[`examples/omnigent/`](https://github.com/itsthelore/rac-core/blob/main/examples/omnigent/README.md).
+
+<!-- TODO: verify against Omnigent <version> before release -->
+
 ## 3. Point Guide at a repository
 
 `--root` accepts any directory. It does not have to be the top of a Git

--- a/examples/omnigent/README.md
+++ b/examples/omnigent/README.md
@@ -1,0 +1,97 @@
+# RAC with Omnigent
+
+[Omnigent](https://omnigent.ai) is an open-source meta-harness: a layer that
+sits above agent harnesses (Claude Code, Codex, Cursor, Pi, and custom agents)
+so you can swap or combine them without rewriting, govern them with policies,
+and collaborate on live sessions. Because an Omnigent custom agent is just a
+`config.yaml`, it consumes RAC on the same two surfaces every other client
+does — an `AGENTS.md` it reads for instructions, and MCP servers it connects to
+as tools — so there is no Omnigent-specific RAC code.
+
+This recipe is written against Omnigent's documented custom-agent schema. Smoke-
+test it against your Omnigent version before relying on it in production.
+
+## Prerequisites
+
+```bash
+pip install requirements-as-code   # the `rac` CLI and the `lore` MCP server
+```
+
+A repository with a RAC corpus under `rac/` (run `rac quickstart`, or use this
+repository's own `rac/`). A working Omnigent install with at least one harness
+configured.
+
+## 1. Generate `AGENTS.md` (the push)
+
+Omnigent's custom agents take a system prompt inline or from a file. Point the
+agent's `instructions` at the `AGENTS.md` RAC generates from your recorded
+decisions:
+
+```bash
+rac export rac/ --agent-rules
+```
+
+This writes `AGENTS.md` at the repo root, in a managed block (your own content
+is preserved). Reference it from the agent's `config.yaml`:
+
+```yaml
+instructions: AGENTS.md
+```
+
+Re-run the export when decisions change (`rac export rac/ --agent-rules --check`
+fails CI on drift). The same file is read verbatim whichever harness the agent
+is bound to, so the grounding survives a one-line harness swap.
+
+## 2. Add the `lore` MCP tool (the pull)
+
+Omnigent declares tools in the agent's `config.yaml`. An MCP server is a
+first-class tool type, so add a `lore` entry under `tools:` (a sample is in
+[`config.example.yaml`](config.example.yaml)):
+
+```yaml
+tools:
+  lore:
+    type: mcp
+    command: rac
+    args: ["mcp", "--root", "."]
+```
+
+This exposes the read-only `lore` tools (`get_summary`, `search_artifacts`,
+`get_artifact`, `get_related`, `find_decisions`). Because the tool travels with
+the agent definition, it stays attached across every harness the agent runs on —
+that is the whole point of the meta-harness layer. The server re-reads the
+corpus on every call and never writes to the repo.
+
+Use an absolute `--root` if the agent runs from a working directory other than
+the corpus root.
+
+## 3. Enforcement is separate, and harness-agnostic
+
+RAC supplies context and enforces *after* the edit (ADR-067) — it does not
+intercept the agent's loop. Whatever the agent writes is checked by
+`rac validate` and `rac relationships --validate` (and the GitHub Action /
+pre-merge gate) the same as any other contributor; the trust boundary is human
+PR review and CI (ADR-065). That holds no matter which harness Omnigent routes
+to, and adds no latency to the loop.
+
+Omnigent's distinctive layer is its stateful **policies** — cost budgets,
+permissions, and guardrails evaluated server-, agent-, and session-wide. Today
+RAC's role stops at supplying grounding through the `lore` tools; a
+decisions-aware Omnigent policy (one that consults the corpus to gate an action
+at the harness layer) would be *pre-action* interception and so sits outside the
+ADR-067 boundary. It is not part of this recipe and would need a recorded
+decision before it is built.
+
+## Verify it
+
+Run the bundled grounding demo — same task twice, once unconnected and once with
+`lore` connected — and watch the connected run respect a recorded decision the
+unconnected run violates: [`examples/guide/`](../guide/demo.md).
+
+## Summary
+
+| Surface | Where it goes | What Omnigent does with it |
+| --- | --- | --- |
+| `AGENTS.md` | `instructions: AGENTS.md` in `config.yaml` | Reads it as the agent's instructions |
+| `lore` MCP | `tools.lore` (`type: mcp`) in `config.yaml` | Calls `find_decisions` / `get_related` on demand |
+| CI gate | `rac validate` · `rac relationships --validate` | Enforces on every PR |

--- a/examples/omnigent/config.example.yaml
+++ b/examples/omnigent/config.example.yaml
@@ -1,0 +1,10 @@
+# The `lore` MCP server as an Omnigent tool.
+# Add this `lore` entry under the `tools:` section of your Omnigent custom
+# agent's config.yaml. Omnigent runs the command as an MCP server and exposes
+# its read-only tools to whichever harness the agent is bound to. Use an
+# absolute path for --root if the agent runs from a different working directory.
+tools:
+  lore:
+    type: mcp
+    command: rac
+    args: ["mcp", "--root", "."]

--- a/rac/roadmaps/future/artifact-family-factory.md
+++ b/rac/roadmaps/future/artifact-family-factory.md
@@ -1,0 +1,159 @@
+---
+schema_version: 1
+id: RAC-KVV611BA0CB0
+type: roadmap
+---
+# Artifact Family Factory (Future)
+
+## Status
+
+Planned
+
+Unscheduled — captured as future intent, not yet on a release. This is the
+mechanism for growing RAC's *artifact* footprint on-thesis: more typed,
+deterministic, human-ratified families, never more stored content (ADR-024) and
+never work-tracking (ADR-017). It is scoped by proving the mechanism with one
+pilot family, not by adding an open-ended set at once.
+
+## Context
+
+RAC's families have grown deliberately — Requirements, Decisions, Roadmaps,
+Prompts, Designs — and ADR-010 names the next candidates directly: a PRD "may
+contain Requirements, Decisions, Risks, Success metrics, Roadmap information",
+i.e. Risk and Metric are knowledge types already understood to be extractable but
+not yet modelled. The engine is built for this: classification is separate from
+validation, structural validation is shared across per-type validators (ADR-060)
+over a single parser instance (ADR-059), and a template is the creation contract
+for each type (ADR-021). Adding a family should therefore be a *repeatable
+contract*, not a bespoke effort each time.
+
+The footprint argument is the inverse of becoming a content store. RAC grows by
+being the narrow, typed, ratified layer in *more knowledge dimensions* — Risk,
+Metric, Glossary — each one deterministic and diffable, each one improving agent
+grounding. That strengthens the moat (ADR-024, ADR-017) instead of diluting it
+into a general-purpose store.
+
+A "factory" must stay scoped. This item establishes the family-creation contract
+and proves it by landing exactly one pilot family end to end (model → schema →
+template → classifier → validator → CLI → negative boundary tests → docs). Each
+subsequent family is then its own scoped roadmap item that instantiates the same
+contract — the factory makes them cheap and consistent; it does not pre-commit
+to all of them.
+
+## Outcomes
+
+- Adding a new artifact family is a **repeatable, documented contract**: a fixed
+  sequence (model, schema, `rac new` template per ADR-021, deterministic
+  classifier, structural validator reusing the shared core per ADR-060, CLI
+  surface, tests, docs) that any new family follows identically.
+- **One pilot family ships end to end** to prove the contract — Risk is the
+  recommended pilot (named in ADR-010, pure knowledge, pairs with Decisions),
+  with Metric/OKR and Glossary/Term as the next named candidates, each its own
+  future scoped item.
+- Each new family is **deterministic and ratified, never work or content**: it
+  carries knowledge and a lifecycle status (ADR-061-style terminal states where
+  meaningful), but no ownership, assignment, scheduling, or workflow (ADR-017),
+  and stores no external content (ADR-024).
+- The family-creation contract enforces RAC's standing test rules: **negative
+  boundary tests** for the new type and **adjacent-type non-misclassification**
+  (the new type and existing types do not classify as each other).
+
+## Initiatives
+
+### Initiative 1 — The family-creation contract
+
+Document the canonical sequence for adding a family and the artifacts each step
+produces: the type's data model, its schema, its `rac new` template (the creation
+contract, ADR-021), its deterministic classifier rule, its validator built on the
+shared structural core (ADR-060) over the single parser (ADR-059), its CLI
+exposure, and its required tests and docs. Classification stays separate from
+validation, so a recognisable-but-invalid instance still classifies as the type
+and then fails validation.
+
+### Initiative 2 — Pilot family: Risk (end to end)
+
+Instantiate the contract once, fully, with Risk: model the fields a risk needs
+(statement, likelihood/impact as descriptive knowledge — not a work score),
+classify it deterministically, validate it structurally, expose it through the
+CLI, and link it to the Decisions and Requirements it bears on. Risk must read as
+recorded knowledge, not a risk *register* with work semantics (ADR-017).
+
+### Initiative 3 — Boundary and non-misclassification coverage
+
+Ship the negative tests the session-start rules require: malformed-but-recognised
+Risk instances fail validation as Risk (not silently reclassified), and Risk does
+not misclassify as Decision/Requirement/Design nor they as Risk. This coverage is
+part of the contract every future family repeats.
+
+## Constraints
+
+- New families are knowledge artifacts only — no ownership, assignment,
+  prioritisation, workflow state, scheduling, or delivery tracking (ADR-017).
+- New families store no external content and treat their Markdown as externally
+  owned source files (ADR-024, ADR-010: documents are containers, artifacts are
+  extracted knowledge types).
+- Each family is schema/spec-driven: behaviour comes from the type's schema,
+  template, and shared structural validation (ADR-021, ADR-059, ADR-060), not
+  artifact-specific branches.
+- Knowledge is ratified, not synthesised: a family instance enters the trusted
+  corpus by human PR review (ADR-065), not by automated inference.
+
+## Non-Goals
+
+- Adding many families at once. The factory proves itself on one pilot; each
+  further family is a separate scoped roadmap item.
+- Supporting more *content/data formats* or becoming a store (that would
+  supersede ADR-024 and is explicitly out of scope here).
+- Any work-management concept entering through a new family (ADR-017).
+- Embeddings, scoring, or LLM-judged classification; families classify
+  deterministically (ADR-066).
+
+## Success Measures
+
+- A contributor can add a new family by following the documented contract alone,
+  producing model, schema, template, classifier, validator, CLI surface, tests,
+  and docs in the same shape as the pilot.
+- The Risk pilot passes `rac validate` and `rac relationships --validate`, and its
+  negative boundary and adjacent-type tests pass.
+- No new family introduces a work-management field or a content-storage surface;
+  review rejects any that does.
+- Each family's behaviour derives from its schema and the shared validator, with
+  no new artifact-specific branching in the engine.
+
+## Assumptions
+
+- ADR-010, ADR-017, and ADR-024 remain the governing boundary: more knowledge
+  *types* are in scope; more stored *content* and any work-tracking are not.
+- The shared structural validator (ADR-060) and single parser (ADR-059) remain
+  the basis for per-type validation, so a new family reuses them.
+- `rac new <type>` remains the template-driven creation path (ADR-021).
+- Adoption signal and corpus need justify which families graduate out of
+  `future/` and in what order.
+
+## Risks
+
+- **Family sprawl / scope creep.** An unbounded "add every type" reading dilutes
+  focus. Mitigation: the factory ships one pilot; each further family is its own
+  scoped item gated on need.
+- **Work-management leakage.** A Risk or Metric family quietly grows ownership or
+  status-workflow fields. Mitigation: the constraint above and review against
+  ADR-017; families carry knowledge and lifecycle, never assignment or scheduling.
+- **Content-store drift.** A family becomes a place to park documents. Mitigation:
+  ADR-010/ADR-024 framing — the artifact is extracted knowledge, the document is
+  an externally owned container.
+
+## Related Decisions
+
+- ADR-004
+- ADR-010
+- ADR-017
+- ADR-021
+- ADR-024
+- ADR-059
+- ADR-060
+- ADR-061
+- ADR-065
+
+## Related Roadmaps
+
+- growth-programme

--- a/rac/roadmaps/future/integration-recipe-factory.md
+++ b/rac/roadmaps/future/integration-recipe-factory.md
@@ -1,0 +1,127 @@
+---
+schema_version: 1
+id: RAC-KVV60ZNYKXQT
+type: roadmap
+---
+# Integration Recipe Factory (Future)
+
+## Status
+
+Planned
+
+Unscheduled — captured as future intent, not yet on a release. This is the
+*harness* half of the integration story; the *backend/RAG* half lives in
+`corpus-export-to-rag-backends`, and the positioning/ecosystem framing in
+`growth-programme`. It must not displace nearer-term committed work, and it
+adds no engine code.
+
+## Context
+
+RAC already meets coding agents on two surfaces it does not own: a generated
+`AGENTS.md` / `CLAUDE.md` an agent reads for instructions (the "push"), and the
+`lore` MCP server an agent connects to for live retrieval (the "pull"). Because
+both are standard surfaces, connecting a new harness is documentation, not
+engine work — a worked `examples/<client>/` setup (README plus a sample config)
+and a subsection in `docs/mcp.md`. The repository already carries this pattern
+for Amp, Claude Code, Codex, Copilot, Cursor, and Omnigent.
+
+Today each new harness is added ad hoc. The same shapes recur — the same
+`command: rac, args: [mcp, --root, .]` block in three config dialects (JSON,
+TOML, YAML), the same push/pull/enforcement structure in each README, the same
+"verify with the grounding demo" close — so the work is a factory waiting to be
+named. The agent-tool landscape is wide and moving (Windsurf, Cline, Zed,
+Gemini CLI, Goose, Continue, JetBrains AI, and more), so footprint here grows by
+*repeating a cheap, on-thesis recipe*, not by building per-harness code.
+
+This is the highest-leverage footprint lever precisely because it changes
+nothing about RAC's boundary: every recipe is context-supply and post-edit
+enforcement (ADR-067), the agent-ready surface RAC already committed to
+(ADR-008), with non-Python clients staying thin consumers of the contract
+(ADR-063). RAC stores nothing new and serves nothing new (ADR-024).
+
+## Outcomes
+
+- Adding a new harness integration is a **repeatable, contract-shaped task**: a
+  documented recipe template plus a checklist produce a consistent
+  `examples/<client>/` setup and `docs/mcp.md` subsection, with no engine change.
+- **The set of supported harnesses grows and is named explicitly.** A reader can
+  see, in `docs/ecosystem.md`, exactly which harnesses have a verified recipe —
+  never a vague "works with any MCP client".
+- Every recipe carries the same three surfaces — push (`AGENTS.md`), pull (`lore`
+  MCP), and enforcement (CI gate, ADR-067 / ADR-065) — so the boundary is
+  restated identically everywhere and never drifts into pre-edit interception.
+- A recipe is listed in `docs/ecosystem.md` **only after it is verified against a
+  released engine version**, honouring that file's existing real-and-verified
+  rule; unverified recipes ship with the `verify against <client> <version>`
+  marker in `docs/mcp.md` and stay off the ecosystem table until smoke-tested.
+
+## Initiatives
+
+### Initiative 1 — A recipe template and authoring contract
+
+Extract the recurring shape into a reusable contract: the push/pull/enforcement
+README skeleton, the three config dialects (JSON / TOML / YAML) for the same
+`lore` server invocation, and the standard "verify with `examples/guide/`" close.
+Authoring a new recipe becomes filling the template, the same way `rac new` makes
+an artifact from a template (ADR-021).
+
+### Initiative 2 — A prioritised harness backlog
+
+Maintain a named, prioritised list of candidate harnesses (e.g. Windsurf, Cline,
+Zed, Gemini CLI, Goose, Continue, JetBrains AI), each a single
+`examples/<client>/` unit of work. Priority follows real adoption signal, not
+completeness; the list is honest about what is shipped versus candidate.
+
+### Initiative 3 — A verification gate before ecosystem listing
+
+Each recipe is smoke-tested against the released engine before its
+`docs/ecosystem.md` row is added. Until then it lives as documentation with the
+`verify against <client> <version>` marker (the convention already in
+`docs/mcp.md`). This keeps the ecosystem table trustworthy and the boundary
+between "documented" and "verified" explicit.
+
+## Success Measures
+
+- A contributor can produce a new, structurally consistent `examples/<client>/`
+  recipe from the template and checklist alone, without reading another recipe.
+- `docs/ecosystem.md` names every harness with a verified recipe; each row is
+  real and verified, and no row is added before smoke-test.
+- The grounding demo (`examples/guide/`) is the verification close for every
+  recipe, so each is proven against the same engine behaviour.
+- New recipes land with zero `rac-core` engine diff.
+
+## Assumptions
+
+- `rac export rac/ --agent-rules` and the `lore` MCP server remain the two stable
+  integration surfaces (ADR-008, ADR-030, ADR-031), with the export a stable
+  additive contract (ADR-007, ADR-063).
+- The "MCP server + agent-instructions file" pattern remains the de-facto way
+  harnesses consume external context, so one recipe shape serves most targets.
+- Adoption signal justifies which harnesses are worth a verified recipe.
+
+## Risks
+
+- **Harness sprawl.** Chasing every MCP client is unbounded. Mitigation: ship
+  verified recipes by adoption signal; the template is the product, the backlog
+  is explicitly prioritised, not exhaustive.
+- **Stale config dialects.** A harness changes its config format and a recipe
+  rots. Mitigation: the `verify against <client> <version>` marker and the
+  ecosystem-listing gate keep claims dated and verified.
+- **Boundary drift.** A harness offers a pre-edit hook and a recipe is tempted to
+  use it as enforcement. Mitigation: the enforcement section is fixed by ADR-067
+  — context-supply and post-edit CI, restated identically in every recipe.
+
+## Related Decisions
+
+- ADR-007
+- ADR-008
+- ADR-024
+- ADR-030
+- ADR-031
+- ADR-063
+- ADR-067
+
+## Related Roadmaps
+
+- corpus-export-to-rag-backends
+- growth-programme


### PR DESCRIPTION
# Summary

Documentation and future-intent only — no engine code, no released-scope change.

Adds:
- A worked Omnigent meta-harness setup recipe (`examples/omnigent/` + a `docs/mcp.md` subsection), connecting the `lore` MCP server and the generated `AGENTS.md` to Omnigent custom agents.
- Two unscheduled `future/` roadmap items capturing on-thesis footprint programmes: an Integration Recipe Factory and an Artifact Family Factory.

# Roadmap / ADR Trace

New future roadmap artifacts:
- `rac/roadmaps/future/integration-recipe-factory.md` (RAC-KVV60ZNYKXQT)
- `rac/roadmaps/future/artifact-family-factory.md` (RAC-KVV611BA0CB0)

Relevant ADRs (cited, not modified):
- `rac/decisions/adr-008-agent-ready-architecture.md` — agent-ready surface
- `rac/decisions/adr-067-agent-integration-context-supply.md` — context-supply and post-edit enforcement, not pre-edit interception
- `rac/decisions/adr-063-non-python-thin-clients.md` — non-Python clients are thin clients over the contract
- `rac/decisions/adr-024-rac-not-content-store.md` — not a content store
- `rac/decisions/adr-017-rac-managed-knowledge-not-work.md` — manages knowledge, not work
- `rac/decisions/adr-010-documents-are-not-artifacts.md` — families are extracted knowledge types
- `rac/decisions/adr-021-templates-as-artifact-creation-contracts.md` — templates as creation contracts
- `rac/decisions/adr-060-shared-structural-validation.md`, `rac/decisions/adr-059-reuse-markdown-parser.md` — shared validation over a single parser

# Scope

## Included
- `examples/omnigent/README.md` and `examples/omnigent/config.example.yaml`: the `lore` MCP server as an Omnigent `tools:` entry (`type: mcp`), and `AGENTS.md` via the agent's `instructions:`, mirroring the existing Codex/Cursor recipes (push / pull / enforcement).
- `docs/mcp.md`: an Omnigent subsection alongside Claude Code / Desktop / Cursor, carrying the standard `verify against CLIENT VERSION` marker.
- Integration Recipe Factory roadmap: makes the harness MCP-recipe pattern a repeatable, contract-shaped task; scoped to the harness half only.
- Artifact Family Factory roadmap: documents the repeatable family-creation contract and scopes it to one pilot family (Risk).

## Excluded
- The `docs/ecosystem.md` row for Omnigent is deliberately not added: that file's rule is real-and-verified-against-a-released-engine, and the Omnigent YAML is written against the published schema but not runtime-verified here. The row is held until smoke-tested — exactly the gate the integration-factory item formalizes.
- The backend / RAG / vector / graph connector side of integrations: out of scope here, owned by the existing `corpus-export-to-rag-backends` item. The integration factory cross-references it rather than duplicating it.
- Any engine code, new artifact type, or content-storage / work-tracking surface. Both roadmaps are unscheduled intent; building a family or a recipe is a later scoped item with its own approval.

# Product / Architecture Decisions

- Integration footprint grows by repeating a cheap documentation recipe (an `examples/CLIENT/` directory plus a `docs/mcp.md` subsection), not by adding per-harness engine code — keeps non-Python clients thin (ADR-063) and the integration surface to the existing `AGENTS.md` export and `lore` MCP server (ADR-008).
- Every recipe's enforcement section is fixed to post-edit CI (ADR-067 / ADR-065); recipes do not adopt a harness pre-edit hook as enforcement, so the boundary is restated identically everywhere.
- Artifact-family growth is fenced to knowledge types only: a new family carries knowledge and a lifecycle, never ownership/assignment/workflow (ADR-017) and never stored content (ADR-024). The factory proves itself on one pilot rather than adding an open-ended set.

# User-Facing Contract

## CLI
None. No commands added or changed.

## Human / JSON Output
None. No output shape changes.

## Exit Codes
Unchanged.

# Verification

## Ran
- `rac validate rac/` — clean (282 valid, 0 invalid).
- `rac relationships rac/ --validate` — 0 issues across 1352 relationships; every cross-reference in both new roadmaps resolves.
- `rac review rac/` — health 93/100; neither new file appears in any priority 1–2 finding.

## Covered
- Both new roadmap artifacts parse, classify as `roadmap`, and validate structurally.
- All `Related Decisions` / `Related Roadmaps` references in both files resolve against the corpus (relationship validation reports zero broken).
- Corpus-wide validation and relationship checks remain clean after the additions.

# Review Path

1. `rac/roadmaps/future/integration-recipe-factory.md` — scope boundary against `corpus-export-to-rag-backends`.
2. `rac/roadmaps/future/artifact-family-factory.md` — the family-creation contract and the ADR-017 / ADR-024 fences.
3. `examples/omnigent/README.md` and `config.example.yaml` — the worked recipe.
4. `docs/mcp.md` — the Omnigent subsection.

# Notes For Reviewer

- The Omnigent recipe is written against Omnigent's published custom-agent schema and has not been runtime-verified in this environment; the `docs/ecosystem.md` listing is intentionally deferred until a smoke-test confirms it.
- Both roadmaps are unscheduled `future/` intent. They define contracts; they do not pull anything onto a release. Scheduling either is a separate decision.

# Implementation Process

Drafted with AI assistance under the roadmap-contract workflow; final scope, review, and acceptance decisions are the maintainer's.