### PR TITLE
docs(decision): record ADR-083 third-party artifact types

### DIFF
--- a/rac/decisions/adr-077-third-party-artifact-types.md
+++ b/rac/decisions/adr-077-third-party-artifact-types.md
@@ -1,0 +1,166 @@
+---
+schema_version: 1
+id: RAC-KVTSPK4CJHWK
+type: decision
+tags: [extensibility, plugins, schema, sdk, architecture]
+---
+# ADR-077: Third-Party Artifact Types via Entry-Point Plugins (Schema Composition Over the Code-Defined Core)
+
+## Status
+
+Proposed
+
+## Category
+
+Architecture
+
+## Context
+
+RAC recognises five artifact types, defined once in a closed in-package registry
+(`ARTIFACT_SPECS` in `core/artifacts.py`) and consumed in roughly eight places —
+classification, validation, templates, schema, identity, relationships, and the
+`inspect`/`portfolio` services. A team needing a sixth, domain-specific type has
+no supported path but to fork the engine. The `rac-growth-extensibility`
+requirement records the demand and a five-part contract (REQ-001..REQ-005):
+discover third-party specs through a Python entry-point group, isolate their
+failures, ship their templates as package resources, and let them participate in
+every command through the same deterministic, section-heading mechanisms as
+built-ins.
+
+ADR-052 §5 deferred custom types post-PMF and named the intended path: "schema
+composition over this code-defined core … recorded as its own ADR — never a
+silent edit to an accepted decision." This ADR is that record. It does not ship
+the engine change; it fixes the design so the decision is gate-validated corpus
+knowledge before any code is written, and so the post-PMF / GATE-2 (CLA, ADR-071)
+boundary stays intact. The companion Design
+(`third-party-artifact-extensibility`) holds the implementation *how*.
+
+Two recorded decisions constrain the shape. ADR-055 deferred custom *relationship*
+types on the same boundary, so a custom artifact type must not smuggle in new
+edge kinds. ADR-062 fixed the SDK surface as `rac.__all__` and keeps `ArtifactSpec`
+internal, so publishing an extension point that hands plugin authors an
+`ArtifactSpec` forces an explicit, recorded surface change rather than an implicit
+one.
+
+## Decision
+
+1. **Discovery is entry-point based and absent-safe.** RAC discovers third-party
+   specs through a declared entry-point group (`rac.artifact_specs`), resolved via
+   `importlib.metadata`, loaded once and cached per process. Built-ins are always
+   present; with no plugin installed every command's behaviour and output is
+   byte-for-byte unchanged (REQ-001). The mechanism adds no mandatory dependency
+   and imports nothing from a contributing package beyond its registered entry
+   point (REQ-005), mirroring the `explorer` extra's lazy-import boundary.
+
+2. **Built-ins always win; bad specs warn and skip.** A discovered object that is
+   not a structurally valid `ArtifactSpec`, whose name collides with a built-in,
+   or that duplicates an already-loaded third-party name, is reported as a warning
+   and skipped — never crashing a command, never altering built-in behaviour
+   (REQ-002). Warnings are emitted through Python's `warnings` machinery (a
+   dedicated `ArtifactSpecWarning`), not the pinned stdout/stderr streams, so the
+   golden CLI output contract holds when no plugin is installed.
+
+3. **Templates load from the contributing package, deterministically.** A
+   third-party type carries an optional reference to its own template resource
+   (a `(package, resource)` pair); built-ins leave it unset and keep loading from
+   `rac.templates` (ADR-021), unchanged. Loading stays inside RAC's
+   `importlib.resources` path so RAC owns error mapping and offline determinism
+   (ADR-002). A plugin-supplied loader callable is rejected — it would let
+   arbitrary, possibly networked code run at template time and break that
+   determinism.
+
+4. **Custom types are first-class for knowledge, not for the graph (v1).** A
+   loaded type participates in classification, validation, `rac schema`, and
+   template listing through the existing section-heading mechanisms, with no
+   artifact-specific branch in core (REQ-004): a registered type with no bespoke
+   validator gets generic structural validation (title, required sections,
+   status metadata) rather than the requirement fallback. A custom artifact may
+   *reference* built-in types, but custom types are **not yet valid relationship
+   targets and introduce no new edge kinds**. Auto-derived `related_<type>` edges
+   stay deferred under ADR-055's lineage, liftable only by a future ADR if demand
+   is proven. The known sharp edge — a built-in `## Related Decisions` reference
+   that resolves to a custom-type artifact still flags a target-type mismatch — is
+   accepted and tested as deliberate v1 behaviour.
+
+5. **`ArtifactSpec` becomes a published, append-only contract.** Because the entry
+   point hands plugin authors `ArtifactSpec`, it must be public: it is added to
+   `rac.__all__` and re-exported from the top-level package, with an append-only
+   field discipline (new fields are optional and appended; existing fields keep
+   their meaning). This **extends ADR-062's surface explicitly** — recorded here
+   rather than as a silent edit — and inherits ADR-062's pre-1.0 semantics.
+
+6. **Determinism is preserved, not absolute.** The classifier stays deterministic
+   and unchanged; installing a plugin whose section vocabulary overlaps a built-in
+   can shift the best-fit type of a genuinely ambiguous document. This is inherent,
+   bounded by the built-in-wins collision rules in decision 2, and stays
+   explainable through `rac inspect`'s scored breakdown (ADR-002).
+
+This decision is scope and shape only; nothing in `src/rac/` changes until the
+work is scheduled, which remains gated post-PMF and behind GATE-2 (CLA) for any
+public invitation.
+
+## Consequences
+
+### Positive
+
+- The path ADR-052 promised exists as validated corpus knowledge: the five-part
+  requirement now has a recorded mechanism, so the eventual implementation is a
+  scoped build, not a fresh design.
+- Open-core success measures in ADR-012 (community schemas, third-party tooling)
+  gain a concrete, distribution-native mechanism without RAC hosting anything
+  (ADR-024).
+- The constant-to-registry seam and generic-validation routing are additive and
+  reuse existing helpers, so built-in behaviour and the golden output contract are
+  provably untouched when no plugin is present.
+
+### Negative
+
+- Publishing the entry-point group and `ArtifactSpec` creates two compatibility
+  surfaces that constrain future refactors; the append-only discipline in
+  decision 5 is the cost of that commitment.
+- Entry-point loading runs third-party code at CLI start-up; failure isolation
+  (decision 2) bounds correctness failures but not latency, so a slow plugin still
+  taxes every invocation until a future opt-out is considered.
+
+### Neutral
+
+- Per-type JSON that enumerates counts becomes additive: a custom type's key
+  appears only when its plugin is installed, consistent with ADR-007.
+- Custom relationship types remain deferred (ADR-055); this ADR deliberately does
+  not widen the graph layer.
+
+## Alternatives Considered
+
+- **A repo-local config file of custom types (`.rac/types.yaml`).** Rejected:
+  duplicates the entry-point discovery the `explorer`/`ingest` extras already model,
+  and turns the type set into per-checkout configuration rather than installed,
+  versioned capability (ADR-024).
+- **An authoritative JSON Schema dialect with `allOf` composition (the original
+  hardening brief).** Rejected by ADR-052 already; this ADR keeps the code-defined
+  envelope and composes over it.
+- **Plugin-supplied template loader callables.** Rejected (decision 3): breaks
+  offline determinism and RAC's deterministic error mapping.
+- **Auto-deriving a `related_<type>` edge for every registered custom type.**
+  Rejected for v1: it would introduce new edge kinds at runtime, make
+  graph-integrity checks depend on installed plugins, and contradict ADR-055's
+  code-defined relationship registry.
+
+## Related Decisions
+
+- adr-052
+- adr-055
+- adr-062
+- adr-021
+- adr-007
+- adr-002
+- adr-012
+- adr-024
+- adr-068
+
+## Related Requirements
+
+- rac-growth-extensibility
+
+## Related Designs
+
+- third-party-artifact-extensibility

--- a/rac/decisions/adr-083-third-party-artifact-types.md
+++ b/rac/decisions/adr-083-third-party-artifact-types.md
@@ -4,7 +4,7 @@ id: RAC-KVTSPK4CJHWK
 type: decision
 tags: [extensibility, plugins, schema, sdk, architecture]
 ---
-# ADR-077: Third-Party Artifact Types via Entry-Point Plugins (Schema Composition Over the Code-Defined Core)
+# ADR-083: Third-Party Artifact Types via Entry-Point Plugins (Schema Composition Over the Code-Defined Core)
 
 ## Status
 

--- a/rac/designs/third-party-artifact-extensibility.md
+++ b/rac/designs/third-party-artifact-extensibility.md
@@ -1,0 +1,246 @@
+---
+schema_version: 1
+id: RAC-KVTSPM9V9VDQ
+type: design
+tags: [extensibility, plugins, registry, validation, architecture]
+---
+# Design: Third-Party Artifact Type Extensibility
+
+## Context
+
+ADR-077 decides *that* RAC will discover third-party artifact types through an
+entry-point group, isolate their failures, load their templates from the
+contributing package, and route them through generic structural validation, while
+keeping custom relationship types deferred (ADR-055) and making `ArtifactSpec` a
+published contract (extending ADR-062). This design is the *how*: the concrete
+seam that turns the closed `ARTIFACT_SPECS` tuple into a discoverable registry,
+the exact dispatch insertion point in validation, the template-resolution branch,
+and the test shape that proves the change is inert when no plugin is installed.
+
+It is recorded now, with no engine change, because the implementation is deferred
+post-PMF and (for any public invitation) behind GATE-2. Writing the mechanism down
+while it is fresh keeps the eventual build a scoped exercise rather than a
+re-derivation, and lets the gates validate the plan as corpus knowledge.
+
+## User Need
+
+Two audiences, one mechanism:
+
+- A **team** whose corpus needs a sixth, domain-specific type (a `runbook`, a
+  `policy`) wants `rac new`, `rac validate`, `rac inspect`, and `rac schema` to
+  handle it the same way they handle a requirement — by installing a package, not
+  forking the engine.
+- A **plugin author** wants to declare one `ArtifactSpec` and one template in a
+  small `rac-<bundle>` package, register them under a documented entry-point group,
+  and trust that a malformed bundle degrades to a warning rather than breaking
+  every RAC command for their users.
+
+Neither needs new analysis behaviour. The need is that the existing deterministic,
+section-heading machinery becomes reachable by installed types it did not ship
+with.
+
+## Design
+
+### 1. The registry seam (load-bearing)
+
+Every consumer today binds the constant directly (`from .artifacts import
+ARTIFACT_SPECS`). A `from x import CONST` binding is captured at import time, so
+the set cannot be made dynamic by mutating the tuple — and a frozen module global
+must not be mutated anyway. The whole design rests on converting **constant access
+into function access**.
+
+A new module `core/artifact_registry.py` owns discovery, caching, failure
+isolation, and the merged view:
+
+- `artifact_specs() -> tuple[ArtifactSpec, ...]` — built-ins first, then
+  discovered third-party specs; cached for the process.
+- `spec_for(name) -> ArtifactSpec | None` — linear scan over `artifact_specs()`
+  (moves here from `artifacts.py`).
+- `is_builtin(name) -> bool` — membership in the frozen set of built-in names.
+- `_reset_cache()` — test seam only.
+
+`artifacts.py` keeps owning the built-in spec *data* (the five `ArtifactSpec`
+definitions); the registry imports that data, never the reverse, so there is no
+import cycle. Consumers repoint from the constant to `artifact_specs()`. The edits
+are mechanical and already enumerated by exploration: `classification.py`
+(`score_artifacts`), `templates.py` (`available_templates` and the membership
+check), `schema.py` (`available_schemas`, `schema_reference`), `services/inspect.py`
+and `services/portfolio.py` (the `{spec.name: 0 ...}` count seeds),
+`services/relationships.py` and `core/identity.py` (which already take a `spec`
+or call `spec_for`), and `validation.py`. Callers that pass a literal built-in
+name (`spec_for("requirement")`, etc.) keep working because built-ins are always
+present.
+
+### 2. Discovery and failure isolation
+
+`artifact_specs()` appends discovered specs by mirroring the `explorer` launcher's
+lazy-import, fail-soft precedent. Discovery iterates the entry points of group
+`rac.artifact_specs`, loads each, and admits its spec(s) through one guard:
+
+1. **Contract check** — the loaded object is an `ArtifactSpec` with a non-empty
+   string `name`/`display` and a non-empty `required` tuple.
+2. **Built-in collision** — a name already owned by a built-in is skipped
+   (built-ins always win).
+3. **Duplicate third-party** — a name already loaded is skipped (first wins,
+   deterministic given a stable iteration order).
+4. **Normalisation** — the name must already be its normalised
+   (stripped, case-folded) form, so classification and section matching stay
+   deterministic.
+
+Each rejection is a `warnings.warn(..., ArtifactSpecWarning)` plus a skip — never a
+raise. Routing through `warnings` rather than `print(..., file=sys.stderr)` is
+deliberate: the golden CLI tests pin stdout/stderr byte-for-byte, so a warnings
+channel keeps the "no plugin → output unchanged" guarantee structurally true and
+lets a malformed-plugin test assert with `pytest.warns` without touching golden
+fixtures. Caching makes discovery run once per process.
+
+### 3. Validation routing
+
+`validation.py::validate` classifies the product, then dispatches. The change
+inserts **one type-agnostic branch** after the five built-in arms and **before**
+the Unknown/legacy requirement fallback:
+
+> if `spec_for(type)` returns a spec and `not is_builtin(type)` → route to a new
+> `_validate_generic(product, spec)`.
+
+`_validate_generic` is pure composition of the existing ADR-060 shared helpers —
+`_validate_title`, `_validate_required_sections` (iterates `spec.required`), and
+`_validate_status_metadata` (iterates `spec.metadata`) — and adds no new logic. It
+is the same shape the `decision`/`prompt`/`design` validators already have. Those
+named validators are deliberately *not* collapsed into it in this change, to
+preserve their REQ-traceable docstrings and avoid golden churn.
+
+The branch keys on a predicate, never a type name, so REQ-004 ("no
+artifact-specific branches in core") holds. The four invariants are preserved:
+the five built-ins keep their explicit arms; `requirement` still reaches its
+bespoke arm because `is_builtin("requirement")` is true; an Unknown document has
+no spec (`spec_for` returns `None`) and falls through unchanged; only a
+registered third-party type reaches the generic validator.
+
+### 4. Template resolution
+
+`ArtifactSpec` gains one appended optional field, a `(package, resource)` reference
+to a template; built-ins leave it unset. `load_template` branches on the spec
+rather than the type name: unset → the `rac.templates` path (unchanged); set →
+`resources.files(package).joinpath(resource)`. The caught-exception set widens to
+include `ModuleNotFoundError` alongside `FileNotFoundError`, so a plugin naming a
+missing package degrades to `TemplateResourceMissing` (an operational error,
+exit 1), never a traceback. `available_templates()` follows the registry from the
+seam in section 1, so a custom type appears in `rac new` and `rac templates`
+automatically. `rac schema` needs no change — it is already fully spec-driven, and
+its starter-body defaults degrade to a generic "describe this section" for an
+unknown section name.
+
+### 5. Relationships scope (v1)
+
+Per ADR-077 decision 4 and ADR-055, v1 introduces no new edge kinds. A custom
+artifact may declare the built-in relationship sections (`## Related Decisions`,
+etc.) and reference built-in types — `services/relationships.py::_collect` already
+handles that by iterating `spec.optional`. A custom type is **not** added to any
+built-in edge's `range`, so a built-in `related_*` reference resolving to a
+custom-type artifact still flags `relationship-target-type-mismatch`. That sharp
+edge is recorded and pinned by a test, so the deferral is a deliberate, observable
+decision rather than an accident. Auto-derived `related_<type>` edges are left for
+a future relationships ADR.
+
+### 6. `ArtifactSpec` stability boundary
+
+Publishing the entry point makes `ArtifactSpec` a compatibility surface, so it
+joins `rac.__all__` and is re-exported from the top-level package (ADR-062's
+mechanism: the surface *is* `__all__`). The dataclass is already frozen with
+all-defaulted optional fields; the stated rule is append-only (new fields optional
+and appended last, existing fields unchanged). An `from rac import ArtifactSpec`
+surface test guards it.
+
+### 7. Sequencing and the smallest reversible step
+
+The implementation order is: registry seam → discovery + isolation → validation
+routing → templates → relationships scope → schema/CLI fall-out → `ArtifactSpec`
+surface → tests. The **smallest reversible first step** is the registry seam alone
+(section 1) returning only the built-in tuple: a pure, mechanical refactor that is
+provably inert (the whole suite plus golden output pass unchanged) and trivially
+revertible, isolating the one invasive change — constant access becoming function
+access across ~8 modules — from all plugin semantics, which then layer on
+additively behind the seam.
+
+## Constraints
+
+- **Inert when absent (REQ-001).** With no plugin installed, `artifact_specs()`
+  equals the built-in tuple and every command's output is byte-for-byte unchanged;
+  this is the acceptance gate for the seam and the regression net for every later
+  step.
+- **Determinism (ADR-002).** No semantic or LLM scoring; classification stays the
+  existing deterministic scorer. Collision rules are fixed before any plugin can
+  affect a corpus.
+- **Additive contracts (ADR-007).** Result `to_dict()` shapes and per-type count
+  maps gain keys, never lose or repurpose them; no `schema_version` bump.
+- **No mandatory dependency (REQ-005).** `importlib.metadata` and
+  `importlib.resources` are stdlib; nothing from a contributing package is
+  imported beyond its entry point.
+- **Deferred boundaries.** Custom relationship types stay deferred (ADR-055); any
+  public invitation stays behind GATE-2 (CLA, ADR-071). This design enables the
+  engine; it does not announce the ecosystem.
+
+## Rationale
+
+The constant-to-function seam is the one genuinely invasive move, and isolating it
+as the first, inert step de-risks everything else, which becomes additive. Reusing
+the ADR-060 helpers for generic validation means a custom type inherits correct
+structural checks with no new code and no per-type branch, honouring REQ-004
+literally. Carrying the template location as data on the spec — rather than a
+callable — keeps loading inside RAC's deterministic `importlib.resources` path so
+RAC owns error mapping and offline behaviour. Keeping the graph layer code-defined
+holds the line ADR-055 drew and keeps graph-integrity checks independent of which
+plugins happen to be installed.
+
+## Alternatives
+
+- **Collapse the four spec-driven validators into `_validate_generic` now.**
+  Deferred: correct eventually, but it churns golden output and erases
+  REQ-traceable docstrings; do it as a later cleanup, not inside this change.
+- **A loader callable on the entry point for templates.** Rejected (ADR-077
+  decision 3): arbitrary code at template time breaks offline determinism.
+- **Exempt custom-type targets from the built-in range check in v1.** Rejected for
+  v1: it is a behaviour change to the built-in graph contract; left for the future
+  relationships ADR so the change is deliberate.
+
+## Accessibility
+
+Not applicable — this is a code-level extension mechanism with no user-facing UI.
+Plugin-authoring documentation, when GATE-2 clears, follows the repository's
+existing readable-prose conventions.
+
+## Style Guidance
+
+- The new module is `core/artifact_registry.py`; the public accessor is
+  `artifact_specs()` (verb-free noun accessor, matching `available_schemas()` /
+  `available_templates()`).
+- The warning type is `ArtifactSpecWarning(UserWarning)`; the new optional field
+  name reads as data (`template_resource`), not behaviour.
+- The validation branch stays type-agnostic — keyed on `is_builtin`, never on a
+  named custom type.
+
+## Open Questions
+
+- Whether a future opt-out (an env var or config flag) is needed if a slow plugin
+  taxes start-up; deferred until a real plugin proves the latency risk.
+- Whether `ArtifactSpec` warrants a narrower public construction factory rather
+  than direct export; the dataclass is stable, so direct export is preferred until
+  field churn appears.
+- The trigger that schedules implementation (PMF signal and/or a design partner),
+  and the separate GATE-2 trigger for any public ecosystem invitation.
+
+## Related Decisions
+
+- adr-077
+- adr-052
+- adr-055
+- adr-062
+- adr-021
+- adr-060
+- adr-002
+- adr-007
+
+## Related Requirements
+
+- rac-growth-extensibility

--- a/rac/designs/third-party-artifact-extensibility.md
+++ b/rac/designs/third-party-artifact-extensibility.md
@@ -8,7 +8,7 @@ tags: [extensibility, plugins, registry, validation, architecture]
 
 ## Context
 
-ADR-077 decides *that* RAC will discover third-party artifact types through an
+ADR-083 decides *that* RAC will discover third-party artifact types through an
 entry-point group, isolate their failures, load their templates from the
 contributing package, and route them through generic structural validation, while
 keeping custom relationship types deferred (ADR-055) and making `ArtifactSpec` a
@@ -133,7 +133,7 @@ unknown section name.
 
 ### 5. Relationships scope (v1)
 
-Per ADR-077 decision 4 and ADR-055, v1 introduces no new edge kinds. A custom
+Per ADR-083 decision 4 and ADR-055, v1 introduces no new edge kinds. A custom
 artifact may declare the built-in relationship sections (`## Related Decisions`,
 etc.) and reference built-in types — `services/relationships.py::_collect` already
 handles that by iterating `spec.optional`. A custom type is **not** added to any
@@ -198,7 +198,7 @@ plugins happen to be installed.
 - **Collapse the four spec-driven validators into `_validate_generic` now.**
   Deferred: correct eventually, but it churns golden output and erases
   REQ-traceable docstrings; do it as a later cleanup, not inside this change.
-- **A loader callable on the entry point for templates.** Rejected (ADR-077
+- **A loader callable on the entry point for templates.** Rejected (ADR-083
   decision 3): arbitrary code at template time breaks offline determinism.
 - **Exempt custom-type targets from the built-in range check in v1.** Rejected for
   v1: it is a behaviour change to the built-in graph contract; left for the future
@@ -232,7 +232,7 @@ existing readable-prose conventions.
 
 ## Related Decisions
 
-- adr-077
+- adr-083
 - adr-052
 - adr-055
 - adr-062

--- a/rac/requirements/rac-growth-extensibility.md
+++ b/rac/requirements/rac-growth-extensibility.md
@@ -99,6 +99,11 @@ standalone repository, not a directory in this one:
 - adr-015
 - adr-021
 - adr-024
+- adr-077
+
+## Related Designs
+
+- third-party-artifact-extensibility
 
 ## Related Requirements
 

--- a/rac/requirements/rac-growth-extensibility.md
+++ b/rac/requirements/rac-growth-extensibility.md
@@ -99,7 +99,7 @@ standalone repository, not a directory in this one:
 - adr-015
 - adr-021
 - adr-024
-- adr-077
+- adr-083
 
 ## Related Designs
 


### PR DESCRIPTION
# Summary

Records the deferred design for **user-extensible artifact types** as durable
corpus knowledge. This is the ADR that ADR-052 §5 requires ("recorded as its own
ADR — never a silent edit to an accepted decision") plus its companion Design.
**Design-only — no engine change.**

Adds:
- **ADR-083** (Proposed): the entry-point plugin mechanism (`rac.artifact_specs`),
  warn-and-skip failure isolation, generic-validation routing, template
  resolution, the v1 relationship-scope deferral, and the `ArtifactSpec`
  stability boundary.
- A **Design** artifact with the implementation *how* (the `ARTIFACT_SPECS`
  constant→`artifact_specs()` registry seam, the validation dispatch insertion
  point, template resolution, and the smallest reversible first step).
- **Linkage** from the `rac-growth-extensibility` requirement to both.

> Note: this branch was refreshed against `main` and the ADR was renumbered
> 077 → **083** (the next free number); `main` had since claimed `adr-077`.

# Roadmap / ADR Trace

Requirement (what/why):
- `rac/requirements/rac-growth-extensibility.md` (REQ-001..REQ-005)

Future roadmap:
- `rac/roadmaps/future/growth-programme.md` ("Ecosystem seed")

Relevant ADRs:
- `rac/decisions/adr-083-third-party-artifact-types.md` (this PR, Proposed)
- `rac/decisions/adr-052-rac-core-okf-superset-conformance.md` — the deferral this discharges
- `rac/decisions/adr-055-relationship-type-registry-and-graph-integrity.md` — custom relationship types deferred
- `rac/decisions/adr-062-python-sdk-public-surface.md` — SDK surface extended
- `rac/decisions/adr-060-shared-structural-validation-helpers.md` — helpers reused by generic validation
- `rac/decisions/adr-021-templates-product-contracts.md` — templates ship as package resources

# Scope

## Included
- ADR-083 (Proposed) recording six decisions: discovery, failure isolation/collision rules, template resolution, v1 relationship scope, `ArtifactSpec` stability boundary, determinism note.
- The Design artifact (the *how*).
- Requirement linkage (`Related Decisions: adr-083`, `Related Designs: third-party-artifact-extensibility`).

## Excluded
- **No engine code** under `src/rac/` — the registry, validation, and template modules are unchanged; the Design only *describes* them.
- **No new edge kinds**; custom types are not yet valid relationship targets (deferred, ADR-055).
- **No `docs/ecosystem.md` invitation** — any public contribution surface stays gated behind GATE-2 (CLA; ADR-071 chose DCO-for-now).
- **No new versioned roadmap item** — scheduling the build stays post-PMF.

# Product / Architecture Decisions

- `ArtifactSpec` becomes public (added to `rac.__all__`), **extending ADR-062 explicitly** rather than via a silent edit, because publishing the entry point makes the dataclass a compatibility contract. Append-only field discipline.
- Third-party validation reuses the ADR-060 helpers (`_validate_title`, `_validate_required_sections`, `_validate_status_metadata`) via a single **type-agnostic** branch keyed on `is_builtin`, not per-type code (honours REQ-004 literally).
- Template location is carried as **data** (`template_resource = (package, resource)`) on the spec, not a loader callable, to preserve offline determinism and RAC's error mapping (ADR-002).

# User-Facing Contract

N/A for this PR — design-only corpus change. No CLI, human-output, JSON, or
exit-code behaviour changes. The contract these artifacts describe ships when the
work is scheduled.

# Verification

## Ran (on the branch merged with `main`)
- `rac validate rac/` → PASS, 305 valid / 0 invalid, OKF v0.1 conformant, exit 0
- `rac relationships rac/ --validate` → 1528 checked, 0 issues, exit 0
- `rac review rac/` → 0 broken relationships, no Priority 1–2 findings
- `rac inspect` on both new files → Decision 100% / Design 100% confidence

## Covered
- Positive: both artifacts classify correctly and validate clean.
- Relationships: every new reference resolves uniquely; no ambiguous or missing targets across the merged corpus (the prior `adr-077` ambiguity is resolved by the renumber).
- Boundary: only pre-existing findings remain; the new files are not flagged.

# Review Path

1. `rac/decisions/adr-083-third-party-artifact-types.md` — the decision/contract.
2. `rac/designs/third-party-artifact-extensibility.md` — the implementation *how*.
3. `rac/requirements/rac-growth-extensibility.md` — linkage (+5 lines).

# Notes For Reviewer

- ADR-083 decision 5 extends the **accepted** ADR-062 surface by adding
  `ArtifactSpec` to `rac.__all__`. It is recorded in-ADR per ADR-052's "its own
  ADR" instruction; if you'd prefer a standalone ADR amending ADR-062 instead,
  that's a one-artifact change.
- Design-only by deliberate choice — the post-PMF / GATE-2 boundary is left
  intact, so nothing in `src/rac/` moves in this PR.