### PR TITLE
docs(design): scope the Lore capture overlay and Slack bot host builds

### DIFF
--- a/rac/designs/lore-capture-overlay.md
+++ b/rac/designs/lore-capture-overlay.md
@@ -1,0 +1,176 @@
+---
+schema_version: 1
+id: RAC-KVW465584DP3
+type: design
+---
+# Lore Capture Overlay
+
+## Status
+
+Proposed
+
+Exploratory — records the architecture for a possible build so the reasoning
+lives in the corpus, not a tool's scratch space (ADR-047). It is not an accepted
+build; the unscheduled umbrella is the future roadmap `lore-overlay`. It deepens
+**Host B** of `lore-capture-surfaces` into a worked *how*, reusing the write and
+approval pipeline already designed in `lore-slack-capture-flow`.
+
+## Context
+
+`lore-capture-surfaces` named the desktop overlay (Host B) as one of the favoured
+ways to reach an author "alongside any screen", but sketched it in a paragraph.
+This design works it out. The job is narrow: a person presses a global hotkey, a
+small modal appears over whatever they are doing, they talk a decision through,
+and it becomes a proposed artifact — without the author leaving their current app,
+learning Markdown, or touching git.
+
+The overlay is a `lore-*` product (ADR-068) that will live in its own repository;
+it consumes Lore's published contract rather than reimplementing the engine
+(ADR-063), and the language model that runs the interview lives in the app, never
+in `rac-core` (ADR-002, ADR-067). Its write-and-approve path is **not new** — it
+is the same one `lore-slack-capture-flow` already worked out, so this design
+focuses on the desktop-specific shell and points at that pipeline for the rest.
+
+## User Need
+
+A macOS user (a PM, an engineer, anyone) has just decided something and wants it
+recorded *now*, mid-task, without context-switching into an IDE or a browser.
+They need a capture surface that is always one keystroke away, fast to dismiss,
+and that never lands anything in the team's record without review.
+
+## Design
+
+### Shell — summon a modal, do not watch the screen
+
+The overlay is built on **Tauri v2** as a single codebase, **macOS-first** with
+Windows a fast-follow and Linux/Wayland deferred (per `lore-capture-surfaces`:
+Wayland breaks global hotkeys, always-on-top, and tray). A global hotkey summons a
+**non-activating floating panel** (macOS `NSPanel`; Windows `RegisterHotKey` +
+`WS_EX_TOPMOST`) from a tray/menu-bar item. The decisive scoping choice from the
+capture design holds: the overlay **summons a modal, it does not watch the
+screen** — a plain hotkey-plus-panel needs none of the macOS TCC permissions
+(Accessibility, Screen Recording) that reading on-screen context would require,
+and so carries none of that privacy liability. Reading the active document or
+clipboard is a later, explicitly permission-gated enhancement, never the MVP.
+
+### Brain — the `rac-capture` loop, model in the app
+
+Inside the modal the app runs the **`rac-capture`** loop (the skill is the brain;
+the host is the interface): capture raw intent first, ask two-to-four pre-filled
+questions, draft against the real schema, let the author ratify, and validate. The
+model call goes through a **bring-your-own-gateway** seam — a configurable
+OpenAI-compatible `base_url` + key + model, sourced from an OS secret store, with
+**no prompt-content telemetry** (ADR-035). The app reaches the engine as a thin
+client (ADR-063): it shells to a bundled/located `rac` (`rac schema`, `rac new`,
+`rac validate`, `rac resolve`/`rac find`) rather than reimplementing
+classification or validation.
+
+### Write and approve — reuse the Slack pipeline's two gates
+
+The overlay writes exactly as `lore-slack-capture-flow` specifies, because the
+desktop origin changes nothing downstream. It opens a **draft pull request** via a
+GitHub App (least privilege: `contents:write` + `pull_requests:write` +
+`metadata:read`; branch → file → `draft: true`), credits the human author, and the
+app's GitHub identity holds **no approval or merge power**. The **two-gate write
+model (ADR-077)** governs: the author's in-app confirmation is *fidelity*, not a
+trust boundary; an **independent** maintainer's PR merge is the trust boundary
+(ADR-065). The app's own confirmation never lands anything in the trusted corpus.
+
+### Settings
+
+A small settings surface holds the three things the app needs: the **gateway**
+(endpoint, key, model), the **target repository + GitHub App** install, and the
+**global hotkey**. Nothing else is stored; the app is not a content store
+(ADR-024) — it emits artifacts to git and keeps no canonical copy.
+
+### Distribution
+
+macOS: Developer ID signing + notarization. Windows (fast-follow): Authenticode —
+practically a cloud signing service such as Azure Trusted Signing — plus the
+SmartScreen-reputation ramp and a bundled/bootstrapped WebView2 runtime (Tauri
+renders in the OS webview).
+
+## Constraints
+
+- **No AI in the engine (ADR-002, ADR-067); credentials are user-managed
+  (ADR-035).** The interview model runs in the app behind a configurable gateway.
+- **Thin client over the contract (ADR-063).** The app drives the `rac` CLI; it
+  reimplements no engine behaviour.
+- **Two gates; the writer only proposes (ADR-065, ADR-077).** In-app confirm is
+  fidelity; an independent PR merge is the trust boundary; the app's GitHub
+  identity never approves or merges.
+- **Not a content store (ADR-024).** Emit to git; store only configuration.
+- **A `lore-*` product in its own repo (ADR-068).** Not engine code in `rac-core`.
+- **Summon-a-modal, not watch-the-screen.** No Accessibility/Screen-Recording
+  permissions in the MVP; on-screen context is a later, permission-gated option.
+
+## Rationale
+
+Tauri v2 over native AppKit keeps Windows a cheap fast-follow on one codebase
+without stranding the favoured B+C pair (Slack already covers Windows users), for
+a modest polish cost versus native. Summon-a-modal is the highest-leverage scoping
+call: it delivers the "alongside any screen" feel while sidestepping the entire
+macOS permission gauntlet and its standing privacy liability. Reusing the Slack
+pipeline's GitHub-App + two-gate write path means the overlay is genuinely a
+*shell* over shared machinery — the capture core, the gateway seam, and the
+approval model are identical, so the net-new surface is small and the trust
+properties are inherited rather than re-argued.
+
+## Alternatives
+
+- **Native Swift/AppKit — rejected.** Locks the surface to macOS; Tauri keeps
+  Windows a cheap fast-follow for a modest polish cost.
+- **Electron — rejected.** Heavier than Tauri for the same OS-webview UI, with no
+  offsetting benefit for a small capture modal.
+- **Watch-the-screen / Accessibility capture (Cluely-shaped) — rejected for the
+  MVP.** Buys context the capture job does not need at the price of the full TCC
+  permission surface and a standing privacy liability; deferred as a
+  permission-gated option.
+- **Reimplement the engine in the app — rejected.** Violates thin-client (ADR-063);
+  the app shells to `rac` instead.
+
+## Accessibility
+
+- **Keyboard-first by construction.** Summoned by a hotkey; the modal takes
+  keyboard focus on open and is fully operable and dismissible from the keyboard.
+- **Provenance legibility.** A captured draft is clearly marked *proposed* until
+  an independent maintainer merges it; the app never presents its own confirmation
+  as ratification.
+- **Plain-language interview.** Essential, pre-filled questions only; no schema
+  jargon or empty required fields shown to the author.
+
+## Style Guidance
+
+- `lore-*` brand (ADR-068); the app is a Lore product, the engine stays `rac-*`.
+- Vocabulary stays honest: the app *captures* and *proposes*; the author
+  *confirms* (fidelity); an independent maintainer *merges* (trust boundary).
+- Flag the fast-moving externals (macOS permission cadence, Windows cloud-signing,
+  WebView2) rather than asserting frozen behaviour.
+
+## Open Questions
+
+- **Engine access**: bundle the `rac` CLI with the app, require it on PATH, or
+  consume the published TypeScript SDK once it ships? (Thin-client either way.)
+- **GitHub App auth for a desktop app**: the OAuth **device flow** for install /
+  token, and where the installation token is cached on-device.
+- **Offline behaviour**: capture-and-queue when there is no network, draft PR on
+  reconnect.
+- **Live-viewer tie-in**: should the overlay also host the repo-watching
+  `rac export` viewer (Thread A of `lore-frontend-optionality`), or stay
+  capture-only?
+
+## Related Decisions
+
+- ADR-002
+- ADR-024
+- ADR-035
+- ADR-063
+- ADR-065
+- ADR-067
+- ADR-068
+- ADR-077
+
+## Related Roadmaps
+
+- lore-overlay
+- rac-capture-skill

--- a/rac/roadmaps/future/lore-overlay.md
+++ b/rac/roadmaps/future/lore-overlay.md
@@ -1,0 +1,122 @@
+---
+schema_version: 1
+id: RAC-KVW466JX9931
+type: roadmap
+---
+# Lore Overlay (Future)
+
+## Status
+
+Planned
+
+Unscheduled — recorded as future intent, not yet on a release. It is gated on the
+decision to start a `lore-*` desktop product and must not displace nearer-term
+work. The implementation contract (the *how*) lives in the design `lore-overlay`.
+
+## Context
+
+`lore-capture-surfaces` names a desktop overlay (Host B) as one of the favoured
+ways to reach a non-technical author "alongside any screen", and
+`lore-capture-overlay` (design) works out its architecture: a Tauri v2 app,
+macOS-first, that summons a
+modal from a global hotkey, runs the `rac-capture` loop behind a bring-your-own
+gateway, and opens a draft pull request through the same GitHub-App + two-gate
+path as `lore-slack-capture-flow`. This roadmap records the *what and why* and the
+build's acceptance bar, kept as intent rather than a scheduled release. It is the
+desktop sibling of `lore-slack-bot`; both wrap the shared capture core
+(`rac-capture-skill`).
+
+## Outcomes
+
+- A macOS user captures a decision from a global hotkey, mid-task, without leaving
+  their current app, learning Markdown, or touching git — and nothing enters the
+  reviewed corpus except through an independent maintainer's pull-request merge
+  (ADR-065, ADR-077).
+- Lore proves a **desktop host** over the shared capture core, so a second
+  installable surface exists alongside the harness skill and (eventually) the
+  Slack bot.
+
+## Initiatives
+
+### Initiative 1 — macOS MVP
+
+A Tauri v2 menu-bar app: global hotkey → non-activating modal → the `rac-capture`
+interview → a draft pull request via the GitHub App → the two-gate model. Includes
+the settings surface (gateway endpoint/key/model; target repo + GitHub App;
+hotkey). Signed with Developer ID and notarized. This is the smallest end-to-end
+slice that captures a real decision.
+
+### Initiative 2 — Windows fast-follow
+
+Bring the same codebase to Windows (tray via `Shell_NotifyIcon`, hotkey via
+`RegisterHotKey`, always-on-top via `WS_EX_TOPMOST`), with Authenticode / Azure
+Trusted Signing, the SmartScreen-reputation ramp, and a bundled/bootstrapped
+WebView2 runtime.
+
+### Initiative 3 — Polish and the optional live viewer
+
+Quality-of-life (capture-and-queue when offline; richer pre-fill), and a decision
+on whether the overlay also hosts the repo-watching `rac export` viewer (Thread A
+of `lore-frontend-optionality`) or stays capture-only.
+
+## Constraints
+
+- AI runs in the app behind a user-managed gateway, never in `rac-core` (ADR-002,
+  ADR-035, ADR-067); the app is a thin client over the `rac` contract (ADR-063).
+- Two gates; the app's GitHub identity only proposes and never approves/merges
+  (ADR-065, ADR-077).
+- A `lore-*` product in its own repository, not engine code (ADR-068); it emits to
+  git and stores no content (ADR-024).
+
+## Non-Goals
+
+- Screen-watching / Accessibility-based on-screen capture — out of the MVP; a
+  later, permission-gated option at most.
+- Linux/Wayland support — deferred (portal-gated, compositor-uneven).
+- Bundling or hosting a model — the app calls a user-configured endpoint.
+
+## Success Measures
+
+- A macOS user produces a schema-valid artifact (`rac validate` exits 0) from a
+  hotkey-summoned interview, choosing no id and writing no Markdown, landing it as
+  a draft PR promoted only by an independent merge.
+- The app reuses `lore-slack-capture-flow`'s write/approve path and the
+  `rac-capture` core with no `rac-core` change.
+- Evidence that authors use a desktop hotkey surface (the signal that would
+  schedule this out of `future/`).
+
+## Assumptions
+
+- The `rac` contract the app depends on (`schema`, `new`, `validate`, `resolve`/
+  `find`) stays stable and additive (ADR-007, ADR-063).
+- A GitHub App with least-privilege scopes can be installed against the target
+  repo and authenticated from a desktop app (device flow).
+- The summon-a-modal scope is sufficient for capture; on-screen context is not
+  needed for the MVP.
+
+## Risks
+
+- **Distribution tax.** Signing/notarization (macOS) and Authenticode +
+  SmartScreen reputation + WebView2 (Windows) are real, ongoing costs; mitigated
+  by macOS-first and a cloud signing service.
+- **Desktop GitHub-App auth.** The device-flow install and on-device token caching
+  are the least-charted part; mitigated by treating it as Initiative 1's spike.
+- **Scope creep into screen-watching.** The temptation to read on-screen context;
+  mitigated by the summon-a-modal Non-Goal.
+
+## Related Decisions
+
+- ADR-035
+- ADR-063
+- ADR-065
+- ADR-067
+- ADR-068
+- ADR-077
+
+## Related Designs
+
+- lore-capture-overlay
+
+## Related Roadmaps
+
+- rac-capture-skill

--- a/rac/roadmaps/future/lore-slack-bot.md
+++ b/rac/roadmaps/future/lore-slack-bot.md
@@ -1,0 +1,125 @@
+---
+schema_version: 1
+id: RAC-KVW467ZRW4EH
+type: roadmap
+---
+# Lore Slack Bot (Future)
+
+## Status
+
+Planned
+
+Unscheduled — recorded as future intent, not yet on a release. It is gated on the
+decision to start a `lore-*` Slack product and must not displace nearer-term work.
+The implementation contract (the *how*) already exists: the design
+`lore-slack-capture-flow`.
+
+## Context
+
+`lore-capture-surfaces` names the Slack bot (Host C) as the favoured way to reach
+a whole team — product managers included — with zero per-user install, capturing
+decisions where they are actually made. Unlike the overlay, its architecture is
+already fully worked out in `lore-slack-capture-flow`: a message-shortcut/slash
+trigger, an assistant-thread interview, ack-in-3s + async + idempotent writes, a
+draft pull request through a least-privilege GitHub App, the two-gate approval
+model (ADR-077), provenance via `chat.getPermalink`, and the governance posture
+for routing thread content to a user-managed gateway (ADR-035). This roadmap
+records the *what and why* and the build's acceptance bar — the schedule, not the
+design. It is the team-native sibling of `lore-overlay`; both wrap the shared
+capture core (`rac-capture-skill`).
+
+## Outcomes
+
+- A team captures a decision from a Slack thread without leaving Slack and with no
+  per-user install, and it enters the reviewed corpus only through an independent
+  maintainer's pull-request merge (ADR-065, ADR-077).
+- Lore reaches the audience the harness skill cannot — non-technical authors who
+  live in Slack — proving the team-native host over the shared capture core.
+
+## Initiatives
+
+### Initiative 1 — Capture MVP
+
+A message shortcut ("Save as decision") / slash command → an assistant-thread
+interview running the `rac-capture` loop → a draft pull request via the GitHub App
+→ the two-gate model. Implements the ack-in-3s + async worker with `event_id`
+dedup and an idempotent write keyed on `(channel, ts)`, and stores the
+`chat.getPermalink` as provenance. The smallest slice that turns a thread into a
+reviewable artifact.
+
+### Initiative 2 — Governance, gateway, and hosting
+
+Route inference through a user-managed OpenAI-compatible gateway (retention/
+telemetry off, region-pinned; ADR-035); store metadata/permalink, not transcripts.
+Stand up the service (Socket Mode vs a public request URL), OAuth install with
+per-workspace token storage, and Slack request-signature verification.
+
+### Initiative 3 — Marketplace / Enterprise-Grid readiness
+
+The disclosure, least-privilege scopes, TLS, and admin-approval posture an app
+needs when it exports message content to an external model, so a governed org can
+adopt it.
+
+## Constraints
+
+- AI runs in the service behind a user-managed gateway, never in `rac-core`
+  (ADR-002, ADR-035, ADR-067); the bot is a thin client over the `rac` contract
+  (ADR-063).
+- Two gates; the bot's GitHub identity only proposes and never approves/merges,
+  and is never on a review-bypass list (ADR-065, ADR-077).
+- Capture knowledge, not work (ADR-017): record the durable decision, never
+  mirror tickets/owners/sprints. Emit to git; store no transcripts (ADR-024).
+- A `lore-*` product in its own repository, not engine code (ADR-068).
+
+## Non-Goals
+
+- Storing raw Slack transcripts (store the permalink + the artifact).
+- Giving the bot approval or merge power (it only opens draft PRs).
+- Inheriting Slack's first-party privacy guarantees for the external model call —
+  the app must provide its own.
+
+## Success Measures
+
+- A teammate turns a Slack thread into a schema-valid artifact (`rac validate`
+  exits 0) via the interview, landed as a draft PR promoted only by an independent
+  merge, with a working permalink back to the source thread.
+- Reprocessing a Slack retry (`event_id` replay) updates in place rather than
+  creating a duplicate artifact.
+- An Enterprise-Grid admin can approve the app from its disclosed data-flow and
+  least-privilege scopes.
+
+## Assumptions
+
+- Slack's assistant/interaction APIs the design relies on stay available (flagged
+  fast-moving in `lore-slack-capture-flow`).
+- A GitHub App with least-privilege scopes can be installed against the target
+  repo from the service.
+- The `rac` contract stays stable and additive (ADR-007, ADR-063).
+
+## Risks
+
+- **Fast-moving Slack AI surfaces.** The assistant-thread and streaming APIs change
+  often; mitigated by isolating the Slack adapter and re-verifying before build.
+- **Governance boundary crossing.** Exporting thread content to an external model
+  invites admin scrutiny; mitigated by the gateway, metadata-only storage, and
+  disclosure (Initiatives 2–3).
+- **Operational surface.** A hosted, multi-tenant service with secrets and OAuth
+  tokens is a real attack surface; mitigated by least-privilege scopes and the
+  inbound-bot security review parked in `lore-capture-followups`.
+
+## Related Decisions
+
+- ADR-017
+- ADR-035
+- ADR-065
+- ADR-067
+- ADR-068
+- ADR-077
+
+## Related Designs
+
+- lore-slack-capture-flow
+
+## Related Roadmaps
+
+- rac-capture-skill


### PR DESCRIPTION
# Summary

Scopes the first two capture **host surfaces** from `lore-capture-surfaces` (the
favoured B + C pair) as recorded intent. Adds an architecture design for the
desktop overlay (which had none) and a build roadmap for each surface. No engine
or product code — these are `lore-*` products (ADR-068) destined for their own
repos; this is the scoping that precedes those builds.

Adds:
- `rac/designs/lore-capture-overlay.md` — the overlay architecture (the *how*).
- `rac/roadmaps/future/lore-overlay.md` — the overlay build plan.
- `rac/roadmaps/future/lore-slack-bot.md` — the Slack-bot build plan (the *how*
  already lives in `lore-slack-capture-flow`).

# Roadmap / ADR Trace

New artifacts:
- Design: `rac/designs/lore-capture-overlay.md`
- Roadmaps: `rac/roadmaps/future/lore-overlay.md`, `rac/roadmaps/future/lore-slack-bot.md`

Grounded in:
- `rac/designs/lore-capture-surfaces.md` (Hosts B and C), `rac/designs/lore-slack-capture-flow.md` (the Slack pipeline)
- `rac/decisions/adr-077-two-gate-capture-write-model.md`, `adr-065`, `adr-035`, `adr-068`, `adr-063`, `adr-002`/`adr-067`, `adr-017`
- `rac/roadmaps/future/rac-capture-skill.md` (the shared capture core both wrap)

# Scope

## Included
- Overlay design: Tauri v2, macOS-first; **summon-a-modal not watch-the-screen**;
  the `rac-capture` loop behind a BYO gateway; write/approve via the *same*
  GitHub-App + two-gate path as the Slack flow.
- Two `future/` build roadmaps (MVP boundary, initiatives, non-goals, success
  measures, risks) for the overlay and the Slack bot.

## Excluded
- No host code is built; these are scoping artifacts only.
- No engine, CLI, schema, or test change — corpus-only.
- Linux/Wayland (overlay) and screen-watching capture remain explicit non-goals.

# Product / Architecture Decisions
- The overlay is a *shell* over shared machinery: it reuses the capture core, the
  BYO-gateway seam, and the two-gate write model (ADR-077), so the net-new surface
  is the desktop shell, not the write/approve path.
- Design/roadmap slugs are kept distinct (`lore-capture-overlay` design vs
  `lore-overlay` roadmap), mirroring the `lore-slack-capture-flow` / `lore-slack-bot`
  pair, to avoid ambiguous alias resolution.
- Both roadmaps stay `Planned`/Unscheduled; they wrap `rac-capture-skill`.

# User-Facing Contract
- None. No CLI, JSON, or exit-code change; corpus artifacts only.

# Verification

## Ran
- `rac validate rac/`
- `rac relationships rac/ --validate`
- `rac review rac/`
- `rac export rac/ --agent-rules --check`

## Covered
- 303 artifacts valid, 0 invalid; 1506 relationships checked, 0 issues; `rac
  review` health 93/100 with no priority 1-2 findings.
- The three artifacts classify correctly (one `design`, two `roadmap`) and resolve
  by id; their cross-links resolve.
- agent-rules drift check is **in-sync** — designs/roadmaps don't change the
  distilled (accepted-decision) block, so no regeneration is needed (unlike the
  ADR in #196).

# Review Path
1. `rac/designs/lore-capture-overlay.md` — the overlay architecture.
2. `rac/roadmaps/future/lore-overlay.md` — the overlay build plan.
3. `rac/roadmaps/future/lore-slack-bot.md` — the Slack-bot build plan.

# Notes For Reviewer
- The overlay design records real open questions (desktop GitHub-App auth via
  device flow; embed-vs-shell the `rac` CLI; offline capture) rather than
  resolving them — appropriate for scoping, not building.

# Implementation Process
Implemented with AI assistance under the corpus's exploration/roadmap conventions;
final scope, review, and acceptance decisions were made by the maintainer.