### PR TITLE
Propose enterprise-adoption decision set (ADR-084–091)

### DIFF
--- a/rac/decisions/adr-084-read-access-audit-recorder.md
+++ b/rac/decisions/adr-084-read-access-audit-recorder.md
@@ -1,0 +1,207 @@
+---
+schema_version: 1
+id: RAC-KW2YW6XK593X
+type: decision
+---
+# ADR-084: Read-Access Audit Recorder
+
+## Status
+
+Proposed
+
+## Category
+
+Product
+
+## Context
+
+The corpus records *what was decided*; nothing records *who consulted which
+decision, and when*. Regulators ask exactly that — "did X have access to
+decision D at the time of change Y" — and the MCP query log is the missing half
+of the audit trail. ADR-040 telemetry answers none of it by design: it is
+content-free, recording no query text and no artifact IDs.
+
+The recorded constraints pull against each other. ADR-040 and ADR-041 pin
+telemetry to record no content and fence the only network import to
+`mcp/ping.py`. ADR-032 makes tool output a pure function of repository bytes and
+tool input. ADR-002 keeps the engine offline and deterministic. ADR-065 and
+ADR-077 locate the trust boundary at repository ACL plus human pull-request
+review, not tool-level authentication — which is also the position an enterprise
+adopter arrives at independently ("no SSO or RBAC on the MCP; ACL the repo,
+audit is the answer").
+
+An audit trail must record precisely the content — queries and returned IDs —
+that telemetry is pinned never to touch. The decision is the shape of a
+content-bearing recorder that can sit beside a content-free engine without
+becoming a second operating posture.
+
+## Decision
+
+A read-access audit recorder ships as a sibling to `mcp/telemetry.py`:
+content-bearing by design, default-absent, local-only, and persistently enabled.
+
+- **Default-absent.** With no `audit:` stanza (the default), no audit file is
+  created and the default engine's content-free guarantee is byte-for-byte
+  intact. This strict-superset property is the load-bearing clause: it is what
+  keeps an enterprise deployment a configuration of the same engine, not a
+  second posture.
+- **Scope: the MCP read tools only** — `get_artifact`, `search_artifacts`,
+  `find_decisions`, `get_related`, `get_summary`. CLI reads are out of scope:
+  they are local, repository-ACL-bounded, and already covered by shell history.
+- **Record: one JSON line per call**, with a pinned schema — `schema_version`,
+  `ts` (ISO 8601 UTC), `session` (per-process hex), `principal`, `tool`,
+  `query` (the read's arguments verbatim: id, query string, topic, or depth),
+  `returned` (the list of artifact IDs, each with a `resolved` flag and a
+  provenance reference), `outcome`, and `duration_ms`. Artifact bodies and any
+  repository content beyond the returned IDs are never recorded. Adding a field
+  is a recorded decision, not a patch.
+- **Enablement: an `audit:` stanza in `.rac/config.yaml`** — `enabled: true`, an
+  optional `path` (default `$XDG_STATE_HOME/rac/audit.jsonl`, redirectable via
+  `RAC_AUDIT_PATH` for residency), and `on_write_error` (`warn` | `block`,
+  default `warn`). The stanza is committed, team-wide, deterministic, and
+  git-diffable: the single artifact an auditor points at. Unlike ADR-040's
+  per-invocation flag, audit is persistent by design — an audit log that can be
+  silently turned off per call is not an audit log. When enabled, `rac mcp`
+  announces on stderr what is recorded and where.
+- **Identity: attributable, not authenticated.** The principal defaults to the
+  git `user.email` and `user.name`, and is overridable via `RAC_AUDIT_PRINCIPAL`
+  for CI or service contexts. The log records who *claimed* to query; the
+  enforced boundary remains repository ACL plus pull-request review (ADR-065,
+  ADR-077). This is recorded as attribution, never sold as authentication.
+- **Local-only, no network.** The audit module imports no network code; the
+  isolation battery is extended to forbid `urllib` and `socket` imports outside
+  `mcp/ping.py` and within the audit module specifically. Shipping events to a
+  sink (Loki, S3, Elastic) is a `lore-audit` satellite that tails the JSONL,
+  never the engine.
+- **Write-only, outside the request/response contract** (ADR-032): the log
+  never feeds a response, and payload-stability tests compare responses
+  byte-for-byte with and without the recorder. Unlike telemetry, a write failure
+  is fail-loud rather than silently swallowed — an audit gap is a compliance
+  event; a strict install may set `on_write_error: block` to refuse serving when
+  it cannot record.
+- **Never folded into the ping or consent payload.** It is a separate,
+  separately governed artifact; the content-free telemetry schema (ADR-040,
+  ADR-041) is untouched.
+
+## Consequences
+
+### Positive
+
+- The missing half of the audit trail exists: "did X have access to decision D
+  at the time of change Y" becomes answerable from local JSONL.
+- The strict-superset property is provable. Default-absent means an auditor
+  reading the source still gets the one-file answer to "is exfiltration
+  possible", because the default path is unchanged.
+- An enterprise adopter clears its compliance gate without SSO or RBAC on the
+  MCP — "ACL the repo, audit is the answer" becomes literally true.
+
+### Negative
+
+- A content-bearing local artifact now exists; the deployment that enables it
+  inherits retention, residency, and access obligations the engine never had.
+  Those attach to the deployment, not the engine, but they are real and the docs
+  must say so.
+- "Attributable, not authenticated" is a weaker claim than an SSO-backed audit
+  trail; an auditor expecting verified principals must be told the boundary is
+  the repository ACL.
+- Persistent, config-based enablement diverges from ADR-040's deliberate
+  anti-persistence; the precedent must be defended (silently-off is acceptable
+  for telemetry, disqualifying for audit).
+
+### Risks
+
+- Creep toward recording bodies or content under "richer audit" pressure.
+  Mitigation: the schema is pinned here and in a contract battery; `returned` is
+  IDs only, and the absent body field is a test, not a comment.
+- A network import creeps into the audit module to "just ship it". Mitigation:
+  the isolation battery forbids it; transmission is satellite-only.
+- The log is mistaken for authentication. Mitigation: the identity clause, the
+  stderr announcement, and the docs all state attributable-not-authenticated.
+- An audit gap is silently tolerated. Mitigation: writes are fail-loud, and the
+  `block` option lets strict installs refuse to serve without recording.
+
+## Alternatives Considered
+
+### Fold audit fields into the telemetry log
+
+One log, less code.
+
+#### Disadvantages
+
+- It makes the named-absent fields (query, returned IDs) present, destroying the
+  content-free guarantee of ADR-040 and ADR-041 and the strict-superset property
+  the whole posture rests on. Rejected.
+
+### SSO or authenticated audit on a shared MCP
+
+Verified principals, in a form regulators recognise.
+
+#### Disadvantages
+
+- Requires the hosted, shared MCP that the architecture (and the adopter)
+  reject; repository ACL already bounds access. Rejected.
+
+### Transmit audit events directly from the engine to a sink
+
+Turnkey aggregation with no satellite.
+
+#### Disadvantages
+
+- A second engine network surface, contradicting ADR-002 and the
+  single-fenced-ping isolation rule. The sink belongs in the `lore-audit`
+  satellite. Rejected.
+
+### No audit log; rely on the corpus and git history
+
+Zero new surface.
+
+#### Disadvantages
+
+- Git shows what *changed*, never who *read* a decision before changing it; the
+  regulator question stays unanswerable. Rejected.
+
+A default-absent, local-only, content-bearing-by-design recorder under a
+committed config stanza, with transmission delegated to a satellite, is
+selected.
+
+## Relationship to Other Decisions
+
+- ADR-040 (local telemetry) and ADR-041 (anonymous ping): this recorder is their
+  deliberate inversion — the same write-only, outside-the-contract posture, but
+  content-bearing and persistent. It does not modify the telemetry or ping
+  schema, and the content-free guarantee holds whenever audit is absent (the
+  default). It shares the one-fenced-network-module rule.
+- ADR-032 (stateless reads): the recorder is write-only observability outside
+  the request/response contract; responses stay byte-identical with it attached.
+- ADR-002 (AI-optional, offline): the engine stays offline; transmission is a
+  satellite concern.
+- ADR-065 (artifact content untrusted) and ADR-077 (two-gate capture write
+  model): the log records attributable-not-authenticated access; it complements,
+  never replaces, the repository-ACL plus pull-request-review boundary.
+- ADR-064 (multi-repo extraction) and ADR-073 (backend connectors consolidate):
+  the `lore-audit` collector consumes the published JSONL contract; no engine
+  network code.
+- ADR-013 (leverage existing source control): the audit log is machine state
+  under XDG directories, never repository state; it never enters the corpus.
+
+## Success Measures
+
+- With no `audit:` stanza, no audit file is created and MCP responses are
+  byte-identical to today; the content-free guarantee battery passes unchanged.
+- With audit enabled, each MCP read-tool call appends exactly one line matching
+  the pinned schema, carrying the query and the returned IDs and no artifact
+  body.
+- The isolation battery rejects any network or socket import in the audit
+  module.
+- `rac mcp` announces audit recording on stderr when it is enabled.
+- A `lore-audit` satellite can tail the JSONL to a sink with zero engine
+  changes.
+
+## Review Date
+
+Review when a design partner needs a field the pinned schema lacks, when
+`on_write_error: block` sees real use, or when the `lore-audit` satellite ships.
+
+## Related Requirements
+
+- rac-trust-transparency

--- a/rac/decisions/adr-085-enterprise-configuration-not-mode.md
+++ b/rac/decisions/adr-085-enterprise-configuration-not-mode.md
@@ -1,0 +1,137 @@
+---
+schema_version: 1
+id: RAC-KW47GDXPQSQ2
+type: decision
+---
+# ADR-085: Enterprise Adoption Is Configuration and Distribution, Not a Mode
+
+## Status
+
+Proposed
+
+## Category
+
+Architecture
+
+## Context
+
+Enterprise interest pushes for an "enterprise mode" that reconfigures Lore for a
+multi-repo, federated, Atlassian-and-pipeline world — a posture distinct from the
+standards the project has imposed: a single canonical corpus (ADR-018, ADR-080),
+not a content store (ADR-024), local-per-developer with no hosted service,
+content-free telemetry (ADR-040, ADR-041), and a one-artifact onboarding scaffold
+(ADR-044).
+
+A semantic mode is the expensive answer. It forks the product: a permanently
+doubled test matrix, a "does this still hold under enterprise mode?" tax on every
+future decision, and two trust stories for one tool. The recorded invariants are
+not obstacles to enterprise adoption; they are the product an enterprise is
+buying. The question is the shape of "enterprise" that delivers the asks without
+forking the engine.
+
+## Decision
+
+Enterprise adoption is delivered as **configuration plus distribution, never a
+semantic operating mode**.
+
+- A named profile (`rac init --profile enterprise`, ADR-088) is pure sugar over
+  knobs that already exist — enforcement policy (ADR-049), validation severity
+  overrides (ADR-053), `.mcp.json`, the telemetry kill-state (ADR-086). It adds
+  no code path a solo developer cannot also reach.
+- Network, SDK, and write-back capabilities live in satellites that consume only
+  published contracts (ADR-064, ADR-073, ADR-090), never engine internals.
+- Each genuinely-new capability is decided by its own ADR, for **everyone**,
+  never gated behind an "enterprise" label.
+
+This yields a reusable rule for classifying any future "should this be a mode?"
+question:
+
+- **Invariant test** — changes a recorded invariant (ADR-024, ADR-018/080,
+  ADR-002, ADR-040/041, ADR-065/077)? Its own ADR, decided for everyone, never
+  gated.
+- **Preset test** — only sets values for knobs that already exist and are
+  committed and versioned? A profile (config-only, no runtime branch).
+- **Network test** — makes a network, SDK, or third-party call? A satellite; the
+  engine never gains a second network import outside the fenced `mcp/ping.py`.
+- **Content test** — records artifact content (queries, returned IDs, paths)? A
+  separate, local-only, opt-in, default-off artifact under its own ADR
+  (ADR-084).
+- **Write-back test** — any write into a document platform is propose-only via
+  human pull-request review (ADR-077), satellite-resident, or it is not built.
+- **Cultural backstop** — does the bundle add any code path the solo developer
+  cannot also reach? If yes, it is a mode; refuse. A profile must emit exactly
+  the files a careful admin would hand-write.
+
+Bright lines that no flag may ever cross: the content-store rule (ADR-024); the
+single canonical root and git-main-as-truth (ADR-018, ADR-080); deterministic,
+offline, Git-native resolution — external state never enters `rac validate`
+(ADR-002, ADR-016, ADR-055); content-free telemetry and the single fenced ping
+(ADR-040, ADR-041); the human-PR-review trust boundary (ADR-065, ADR-077); the
+one-artifact scaffold bound (ADR-044); and the standing red lines (no SSO on a
+shared MCP, no RBAC on MCP tools, no web editing UI, no hosted multi-tenant
+service).
+
+## Consequences
+
+### Positive
+
+- One product, one trust story: the OSS solo developer and the regulated
+  enterprise run the same engine, configured differently.
+- A durable decision rule governs the whole enterprise programme (ADR-084,
+  ADR-086 through ADR-091) and future asks, so each is scoped consistently.
+- Zero behavioural fork means no doubled test matrix and no per-ADR "enterprise
+  mode" tax.
+
+### Negative
+
+- "Just turn on these flags" demands discipline: a named profile (ADR-088) and
+  good docs do the work a mode would otherwise centralise.
+- Carry shifts to satellites and to export-contract conformance (ADR-073), which
+  must be invested in rather than assumed free.
+
+### Risks
+
+- A profile slips into a mode by accumulating behaviour. Mitigation: the cultural
+  backstop above is the test — a profile may add no code path the solo developer
+  cannot reach.
+- A capability is gated behind "enterprise" for commercial reasons. Mitigation:
+  the invariant test routes any rules-change to its own ADR for everyone.
+
+## Alternatives Considered
+
+### A real semantic enterprise mode
+
+A distinct operating mode that changes invariants (repo structure, content-store
+rules, trust model).
+
+#### Disadvantages
+
+- Forks the product: doubled test matrix, a per-ADR tax, and two trust stories.
+  Rejected unanimously by the design council.
+
+### Additive flags only, no named profile
+
+Ship every capability as an independent flag and rely on documentation.
+
+#### Disadvantages
+
+- At scale, a doc you must apply has materially worse adherence than a command
+  you run, and an auditor wants one committed artifact, not nine toggles per
+  machine. The profile (ADR-088) earns its place on adherence, not capability.
+
+Configuration plus distribution, never a mode, is selected.
+
+## Relationship to Other Decisions
+
+- Governs the enterprise programme: ADR-084 (audit recorder), ADR-086 (air-gap
+  and telemetry lock), ADR-087 (external-reference relationships), ADR-088
+  (profile scaffold), ADR-089 (federation), ADR-090 (satellite topology),
+  ADR-091 (observability boundary).
+- ADR-024, ADR-018, ADR-080, ADR-002, ADR-040, ADR-041, ADR-065, ADR-077: the
+  invariants the bright lines protect.
+- ADR-036, ADR-039, ADR-068: the product and brand identity a single,
+  unforked product preserves.
+
+## Related Requirements
+
+- rac-trust-transparency

--- a/rac/decisions/adr-086-air-gap-and-enterprise-telemetry-lock.md
+++ b/rac/decisions/adr-086-air-gap-and-enterprise-telemetry-lock.md
@@ -1,0 +1,118 @@
+---
+schema_version: 1
+id: RAC-KW47GFBHK31W
+type: decision
+---
+# ADR-086: Air-Gap Posture and Enterprise Telemetry Hard-Lock
+
+## Status
+
+Proposed
+
+## Category
+
+Product
+
+## Context
+
+The first item on a regulated firm's checklist for any AI-adjacent tool is "does
+this exfiltrate our source to a public API?" Lore's answer is "no, by design" —
+but only if the docs say so prominently and the telemetry path can be provably
+switched off.
+
+The stance already exists; it is just scattered. ADR-002 makes AI optional and
+the engine offline; ADR-035 keeps inference on user-managed credentials with no
+RAC cloud dependency; ADR-066 keeps the grounding eval embedding-free and
+LLM-judge-free; ADR-067 makes the agent surface the only integration boundary;
+ADR-040 and ADR-041 keep telemetry content-free and fence the only network import
+to `mcp/ping.py`. What is missing is a single citable statement and a provable
+runtime off-switch: the ping kill switch today is a build-time constant
+(`POSTHOG_API_KEY`) that is currently populated, so "it is empty" is not a
+runtime guarantee an operator can assert.
+
+## Decision
+
+Record the consolidated air-gap posture as a citable decision, and add a runtime
+enterprise lock.
+
+- **The posture, stated once:** the engine makes no LLM calls and no network
+  calls except the single, consent-gated, content-free daily ping (ADR-041);
+  retrieval and validation are deterministic and offline (ADR-002, ADR-066);
+  inference, when used at all, runs on the operator's own credentials (ADR-035);
+  the agent surface is the only thing infosec must gate (ADR-067). This ADR is
+  the canonical reference the docs (README, SECURITY) point to.
+- **`rac telemetry off --enterprise`** forces the kill state at runtime. Because
+  `POSTHOG_API_KEY` is populated, this is a runtime force, not an assertion over
+  an empty constant: it unconditionally disables the ping, writes a persistent
+  enterprise-lock to the telemetry config, and `rac telemetry status` reports
+  "locked (enterprise)". While locked, `rac telemetry on` refuses.
+- **Reversibility is explicit and tamper-evident.** The lock is removed only by a
+  documented action (`rac telemetry off --enterprise --unlock`, or deleting the
+  lock file), and `status` always shows the current lock state. It is never a
+  silent toggle.
+- The lock governs the anonymous ping only; the local audit recorder (ADR-084)
+  is a separate, separately-governed capability and is unaffected.
+
+## Consequences
+
+### Positive
+
+- The procurement question has a one-line, citable answer backed by an ADR id
+  and a provable runtime switch.
+- The lock decouples the operator's guarantee from a build-time constant: an
+  enterprise can prove the ping is off on their machines regardless of how the
+  package was built.
+
+### Negative
+
+- A new flag and a persistent lock file add a small surface to the telemetry
+  command and its tests.
+- "Locked unless explicitly unlocked" is slightly more to explain than a single
+  empty constant.
+
+### Risks
+
+- The lock is mistaken for the whole air-gap story. Mitigation: the posture
+  statement is the citable core; the lock is one provable control within it.
+- An operator expects the lock to also gag the audit recorder. Mitigation: the
+  decision states the scope explicitly; the recorder is default-absent anyway
+  (ADR-084).
+
+## Alternatives Considered
+
+### Leave the stance scattered across ADRs and READMEs
+
+Do nothing new; rely on the existing decisions.
+
+#### Disadvantages
+
+- An infosec reviewer cannot cite "no exfiltration by design" from one place, and
+  cannot prove the ping is off at runtime. The checklist stalls.
+
+### A fully one-way, irreversible lock
+
+Once enterprise-locked, never reversible by the CLI.
+
+#### Disadvantages
+
+- Too brittle for legitimate configuration changes (a machine repurposed out of
+  the regulated estate); an explicit, documented, tamper-evident unlock is
+  honest without being a foot-gun.
+
+The consolidated posture plus a reversible-by-explicit-action runtime lock is
+selected.
+
+## Relationship to Other Decisions
+
+- ADR-040, ADR-041: the lock forces the kill state the ping's design already
+  allows; the content-free guarantee is unchanged.
+- ADR-002, ADR-035, ADR-066, ADR-067: the posture this ADR consolidates and makes
+  citable.
+- ADR-084: the audit recorder is out of scope of the lock; named here to prevent
+  confusion.
+- ADR-085: an instance of the rule — a provable control delivered as
+  configuration, for everyone, not a mode.
+
+## Related Requirements
+
+- rac-trust-transparency

--- a/rac/decisions/adr-087-external-reference-relationships.md
+++ b/rac/decisions/adr-087-external-reference-relationships.md
@@ -1,0 +1,122 @@
+---
+schema_version: 1
+id: RAC-KW47GGS85CKG
+type: decision
+---
+# ADR-087: External-Reference Relationships (Jira and Beyond)
+
+## Status
+
+Proposed
+
+## Category
+
+Technical
+
+## Context
+
+Change traceability in many organisations runs through Jira. Without a typed way
+to link an artifact to its ticket, teams jam ticket IDs into prose and the link
+goes stale; with one, the corpus gains regulator-grade traceability — "this ADR
+implements this Jira" becomes a typed edge.
+
+The relationship registry (ADR-055) is code-defined and enforces each edge's
+range to in-corpus artifact types; resolution is deterministic and Git-native
+(ADR-016). A Jira ticket is not an artifact, so it cannot be a normal edge
+target. ADR-052 defers fully custom, repo-declared edge kinds. ADR-010 already
+recognises that untyped targets exist and are legitimate. The need is a typed,
+lintable link to an *external* system that deliberately does not resolve to a
+local artifact.
+
+## Decision
+
+Introduce an **external-reference relationship family**: code-defined edges whose
+target is an external identifier rather than an in-corpus artifact, explicitly
+exempt from artifact-range resolution (the ADR-010 untyped-target shape,
+generalised).
+
+- The first instance is `related_jira`, declared via a `## Related Jira` section.
+  The mechanism is general so future external edges (for example GitHub issues or
+  ServiceNow records) reuse the same exemption rather than each re-litigating it.
+- **Syntax:** one item per line — a Jira key (`PROJ-1234`) or a full Jira URL.
+- **Engine scope is format-lint only.** `rac validate` checks the syntax
+  deterministically and offline and flags malformed entries; it never contacts
+  Jira and an external reference never affects whether the corpus is valid beyond
+  its format.
+- **Existence and state checks** (does the ticket exist; is it in an allowed
+  state) require a token and a network call and therefore live in the
+  `lore-atlassian` satellite (ADR-090), never in the engine (ADR-002, ADR-073).
+  Enforcement is at write time, not agent time (ADR-067).
+- **Graph export** surfaces the external edge as a typed edge marked unresolved
+  or external (ADR-074), so graph backends see the relationship without the
+  engine pretending to resolve it.
+
+## Consequences
+
+### Positive
+
+- Typed, lintable change traceability the corpus can carry and the graph export
+  can surface, without a database and without a network dependency in the engine.
+- A reusable external-reference shape means the next external system is additive,
+  not another exemption debate.
+
+### Negative
+
+- An external edge is only as fresh as the satellite's optional state check; the
+  engine alone cannot tell a stale ticket from a live one.
+- A second class of edge (external-target) adds nuance to the registry and the
+  graph export contract.
+
+### Risks
+
+- Pressure to make the engine call Jira "just to validate the ticket".
+  Mitigation: the engine is format-lint only by decision; state checks are
+  satellite-only (ADR-002).
+- The exemption is read as the door to arbitrary custom edge kinds (ADR-052).
+  Mitigation: the family is code-defined here, not repo-declared; new external
+  kinds are added by ADR, like any registry change.
+
+## Alternatives Considered
+
+### Keep Jira IDs in prose
+
+No typed edge; mention the ticket in the body.
+
+#### Disadvantages
+
+- Untyped, unlinted, and invisible to the graph export; the link rots and
+  traceability is unverifiable.
+
+### Force a Jira edge into the existing artifact-range registry
+
+Add `related_jira` with a normal range.
+
+#### Disadvantages
+
+- A Jira ticket is not an artifact; range resolution would always fail. The
+  external-target exemption is the correct mechanism, not a workaround.
+
+### A full custom-relationship-type system
+
+Let repos declare arbitrary edge kinds in config.
+
+#### Disadvantages
+
+- Deferred by ADR-052; far more surface than the need. A code-defined external
+  family covers the real requirement now.
+
+The external-reference family with `related_jira` as its first instance is
+selected.
+
+## Relationship to Other Decisions
+
+- ADR-055, ADR-016: extends the code-defined registry with an external-target
+  edge class; resolution stays deterministic and Git-native for in-corpus edges.
+- ADR-010: generalises the untyped-target exemption to typed external references.
+- ADR-052: custom repo-declared kinds remain deferred; this family is
+  code-defined.
+- ADR-074: external edges surface in the typed graph export, marked unresolved.
+- ADR-067, ADR-073, ADR-090: write-time format-lint in the engine; token-gated
+  state checks in `lore-atlassian`.
+- ADR-085: an instance of the rule — the network half is a satellite, the
+  deterministic half is the engine, decided for everyone.

--- a/rac/decisions/adr-088-enterprise-profile-scaffold.md
+++ b/rac/decisions/adr-088-enterprise-profile-scaffold.md
@@ -1,0 +1,109 @@
+---
+schema_version: 1
+id: RAC-KW47GJ749PKC
+type: decision
+---
+# ADR-088: Enterprise Profile Scaffold (`rac init --profile`)
+
+## Status
+
+Proposed
+
+## Category
+
+Product
+
+## Context
+
+Adoption follows the path of least resistance. A team that must think for an hour
+about which ADR fields to use, how to wire `.mcp.json`, and how to gate CI will
+fall back to a Confluence page. A one-command, firm-shaped start removes that
+friction.
+
+Two recorded decisions bound how far a scaffold may go. ADR-044 binds onboarding
+to writing exactly one starter artifact into an empty corpus, as the unmodified
+canonical template. ADR-024 forbids content-store behaviour. ADR-085 settles that
+"enterprise" is configuration, not a mode, and that a profile must emit only what
+a careful admin would hand-write.
+
+## Decision
+
+`rac init --profile <name>` writes **configuration only, never authored prose**.
+
+- What a profile emits:
+  - `.rac/config.yaml` enforcement policy (ADR-049) and validation severity
+    (ADR-053) stanzas;
+  - `.mcp.json` wired for Claude Code and Cursor;
+  - optionally a CI gate stanza (for example a Bitbucket Pipelines block) as
+    configuration;
+  - when federation exists (ADR-089), a parent-corpus declaration line.
+- Profiles are built-in, named bundles shipped with the package (`default`,
+  `enterprise`). A profile must emit exactly the files a careful admin would
+  hand-write (the ADR-085 cultural backstop): it adds no code path a solo
+  developer cannot reach.
+- It writes no ADR or prompt prose. Firm ADR templates and standards prompts
+  live in the firm's standards corpus and are *referenced* (via federation,
+  ADR-089), not generated — preserving ADR-044 and ADR-024.
+- The one-starter-artifact scaffold (ADR-044, `rac quickstart`) is unchanged;
+  `--profile` is configuration layering, composable with it.
+- **Hollow-on-parent:** until ADR-089 ships, `--profile enterprise` emits no
+  parent-corpus line. A preset cannot configure a mechanism that does not exist.
+
+## Consequences
+
+### Positive
+
+- A firm-shaped start is one command, lowering the activation energy that
+  otherwise sends teams back to Confluence.
+- The auditor and the new team get one committed, git-diffable configuration
+  artifact rather than a checklist to apply per machine.
+
+### Negative
+
+- Built-in named profiles must be maintained as the config surface evolves.
+- "Profiles write config, not content" is a line that must be held against
+  requests to also scaffold starter ADR prose.
+
+### Risks
+
+- A profile grows into a content generator. Mitigation: ADR-044 and ADR-024 bound
+  it; the profile emits configuration and references, never authored prose.
+- A profile smuggles in behaviour. Mitigation: the ADR-085 backstop — no code
+  path the solo developer cannot reach.
+
+## Alternatives Considered
+
+### A richer scaffold that writes starter ADRs and prompts
+
+Generate firm-styled content files on init.
+
+#### Disadvantages
+
+- Reopens ADR-024 and exceeds ADR-044's one-artifact bound; the firm's standards
+  belong in a referenced corpus, not in generated prose.
+
+### Documentation only ("do these nine steps")
+
+Ship a setup guide instead of a command.
+
+#### Disadvantages
+
+- At scale, adherence to a doc you must apply is materially worse than to a
+  command you run; the profile is the discoverable, repeatable artifact.
+
+A config-only, built-in named profile, composable with the existing scaffold, is
+selected.
+
+## Relationship to Other Decisions
+
+- ADR-044, ADR-024: the bounds the profile respects; it writes config, not
+  content, and leaves the one-artifact scaffold unchanged.
+- ADR-049, ADR-053: the existing config knobs a profile presets.
+- ADR-085: the profile is the concrete mechanism of "enterprise is
+  configuration, not a mode".
+- ADR-089: supplies the parent-corpus declaration the profile is hollow on until
+  it ships.
+
+## Related Requirements
+
+- rac-trust-transparency

--- a/rac/decisions/adr-089-corpus-federation.md
+++ b/rac/decisions/adr-089-corpus-federation.md
@@ -28,11 +28,14 @@ once.
 
 ## Decision
 
-Federation is **accepted in principle but deferred in mechanism, and
-design-partner-gated**. The engine will gain a parent-corpus resolver under a
-future design and its own implementing ADR, written when a design partner commits
-to it — not speculatively. This decision records the bar that any such design must
-clear.
+Federation is **accepted in principle but deferred in mechanism and sequenced
+last** among the enterprise items. A design partner is available, so the work is
+unblocked; it is nonetheless scheduled after the lower-risk, additive enterprise
+decisions (ADR-084, ADR-086 through ADR-088, ADR-090, ADR-091), so the engine's
+deepest change is taken on deliberately rather than first. The engine will gain a
+parent-corpus resolver under a future design and its own implementing ADR, built
+with the design partner against a real shared-standards corpus. This decision
+records the bar that any such design must clear.
 
 Non-negotiable constraints on any future federation design:
 
@@ -61,8 +64,8 @@ profile scaffold (ADR-088) emits no parent declaration.
 
 - The bar is recorded now, so the eventual design cannot quietly become an
   enterprise-only fork or a network dependency.
-- Firms get a credible answer ("yes, under these constraints, when we build it
-  with you") without the project paying for a speculative, partner-less design.
+- Firms get a credible answer ("yes, under these constraints, built with our
+  design partner") while the cheaper, additive enterprise wins land first.
 
 ### Negative
 
@@ -78,14 +81,16 @@ profile scaffold (ADR-088) emits no parent declaration.
 
 ## Alternatives Considered
 
-### Build federation now, speculatively
+### Build federation first, ahead of the additive items
 
-Design and ship the resolver ahead of a design partner.
+Take on the resolver before the lower-risk enterprise decisions.
 
 #### Disadvantages
 
-- The deepest change on the roadmap, built without a real corpus to test the
-  override and provenance semantics against; high risk of rework.
+- Front-loads the deepest, highest-risk change and delays the cheaper enterprise
+  value (audit, air-gap, Jira, profile, observability). Even with a partner,
+  sequencing it first maximises risk exposure before the additive wins are
+  banked.
 
 ### Enterprise-only federation
 
@@ -105,8 +110,8 @@ Keep every corpus single-tree forever.
 - Leaves a real, repeated enterprise need (firm-wide standards) permanently
   unmet.
 
-Accept in principle, defer the mechanism, bind the constraints, gate on a design
-partner.
+Accept in principle, defer the mechanism, bind the constraints, and sequence it
+last — built with the design partner once the additive items have landed.
 
 ## Relationship to Other Decisions
 

--- a/rac/decisions/adr-089-corpus-federation.md
+++ b/rac/decisions/adr-089-corpus-federation.md
@@ -1,0 +1,118 @@
+---
+schema_version: 1
+id: RAC-KW47GKNGVVBT
+type: decision
+---
+# ADR-089: Corpus Federation — Parent Corpus and `## inherits`
+
+## Status
+
+Proposed
+
+## Category
+
+Architecture
+
+## Context
+
+Many repositories share one firm-wide set of standards. Without inheritance,
+every repository reinvents the firm's ADRs, and there is no single place to hold
+rules that should apply across an organisation.
+
+Federation is the single genuine semantic change among the enterprise asks, and
+the deepest. Today the corpus is single-tree: one canonical root per repository
+(ADR-018) with git `main` as the only source of truth (ADR-080); cross-repository
+references do not resolve; relationships are local and Git-native (ADR-016,
+ADR-055). A parent-corpus mechanism touches resolution, validation, and export at
+once.
+
+## Decision
+
+Federation is **accepted in principle but deferred in mechanism, and
+design-partner-gated**. The engine will gain a parent-corpus resolver under a
+future design and its own implementing ADR, written when a design partner commits
+to it — not speculatively. This decision records the bar that any such design must
+clear.
+
+Non-negotiable constraints on any future federation design:
+
+- **Never gated behind "enterprise."** If federation is sound it is sound for the
+  solo developer; it changes resolution for everyone or not at all (ADR-085).
+  Gating a truth-model change behind a commercial label is precisely the mode
+  failure this programme refuses.
+- **Deterministic and offline** (ADR-002): parent resolution reads materialised
+  bytes — a pinned submodule, a vendored bundle, or a path — never a live network
+  fetch inside the validate path.
+- **Single canonical state preserved per repo** (ADR-018, ADR-080): a parent is
+  an inherited, read-only layer; the child's `main` remains its own truth;
+  overrides are explicit, not implicit precedence.
+- **Git-native and human-readable** (ADR-016, ADR-055): inheritance is declared
+  in Markdown (a `## inherits` section) plus a pinned source reference; no
+  database and no hidden index becomes the source of truth.
+- **Provenance preserved:** an inherited artifact is always attributable to its
+  source corpus, never silently absorbed.
+
+Until the implementing design lands, `## inherits` is unrecognised, and the
+profile scaffold (ADR-088) emits no parent declaration.
+
+## Consequences
+
+### Positive
+
+- The bar is recorded now, so the eventual design cannot quietly become an
+  enterprise-only fork or a network dependency.
+- Firms get a credible answer ("yes, under these constraints, when we build it
+  with you") without the project paying for a speculative, partner-less design.
+
+### Negative
+
+- The highest-value enterprise lever stays unbuilt in the near term; shared
+  standards remain a manual or satellite concern until then.
+
+### Risks
+
+- Pressure to ship federation quickly and gated behind "enterprise". Mitigation:
+  this ADR forbids enterprise-gating and binds the constraints in advance.
+- Scope creep toward a live cross-repo index. Mitigation: materialised-bytes,
+  offline, Git-native are recorded constraints, not preferences.
+
+## Alternatives Considered
+
+### Build federation now, speculatively
+
+Design and ship the resolver ahead of a design partner.
+
+#### Disadvantages
+
+- The deepest change on the roadmap, built without a real corpus to test the
+  override and provenance semantics against; high risk of rework.
+
+### Enterprise-only federation
+
+Offer inheritance as a paid/enterprise capability.
+
+#### Disadvantages
+
+- Gates a resolution-model change behind a label — the forbidden mode (ADR-085).
+  Rejected.
+
+### Never federate
+
+Keep every corpus single-tree forever.
+
+#### Disadvantages
+
+- Leaves a real, repeated enterprise need (firm-wide standards) permanently
+  unmet.
+
+Accept in principle, defer the mechanism, bind the constraints, gate on a design
+partner.
+
+## Relationship to Other Decisions
+
+- ADR-018, ADR-080: federation must preserve the single canonical state per repo;
+  a parent is read-only and inherited.
+- ADR-016, ADR-055: inheritance stays Git-native and human-readable; no database.
+- ADR-002: parent resolution is offline over materialised bytes.
+- ADR-085: federation is decided for everyone, never an enterprise gate.
+- ADR-088: the profile scaffold stays hollow on the parent line until this ships.

--- a/rac/decisions/adr-090-enterprise-satellite-topology.md
+++ b/rac/decisions/adr-090-enterprise-satellite-topology.md
@@ -1,0 +1,119 @@
+---
+schema_version: 1
+id: RAC-KW47GN4SB403
+type: decision
+---
+# ADR-090: Enterprise Satellite Topology
+
+## Status
+
+Proposed
+
+## Category
+
+Architecture
+
+## Context
+
+Beyond configuration, the enterprise asks are network, SDK, and write-back work:
+ingest from and publish to Confluence, resolve and comment on Jira, gate CI on
+Bitbucket and Jenkins, aggregate audit logs to a sink, and package the whole for
+Kubernetes. ADR-064, ADR-068, and ADR-073 already establish that such work lives
+in satellite repositories that depend only on the published package, CLI, and
+export contracts — never engine internals. This decision names the enterprise
+satellites and the boundaries they honour, so the engine-side contracts they
+imply are visible in one place.
+
+## Decision
+
+Enterprise integrations are delivered as a small constellation of satellites, kept
+deliberately few rather than one-per-integration.
+
+- **`lore-atlassian`** — one satellite for the Atlassian suite (shared Cloud
+  auth):
+  - inbound Confluence ingest, feeding `rac ingest` and the existing human-review
+    loop (ADR-072, ADR-006);
+  - outbound Confluence publish as a managed block, reusing the `agent_rules`
+    managed-block pattern;
+  - Jira external-edge resolution and state checks (ADR-087);
+  - gatekeeper comment-mode, posting a blocking decision to the linked Jira
+    ticket and Confluence page.
+- **`lore-pipelines`** — a Bitbucket Pipelines pipe and a Jenkins shared-library
+  wrapper over the already-CI-neutral `rac gate` (ADR-049, ADR-054).
+- **`lore-audit`** — a collector that tails the ADR-084 audit JSONL to a sink
+  (Loki, S3, Elastic), shipped as a GitHub Action and a Bitbucket pipe.
+- Optional Helm/ArgoCD packaging lays down `lore-watchkeeper`, `lore-audit`, and
+  the Confluence sync cron as deployable applications.
+
+Boundaries every enterprise satellite honours:
+
+- Consumes only published contracts — the CLI, the `--documents` and `--graph`
+  exports, and the audit JSONL — never engine internals (ADR-063, ADR-073).
+- All write-back is propose-only through human pull-request review (ADR-065,
+  ADR-077); RAC never becomes a write-through path into a document platform.
+- Adds no network code to the engine; satellites own all network and SDK
+  dependencies (ADR-002).
+
+Engine-side contracts this topology implies (recorded here, each built under its
+own ADR): the audit JSONL (ADR-084), the external-edge graph marker (ADR-087,
+ADR-074), and a Bitbucket Code-Insights output format alongside SARIF
+(an ADR-054 extension).
+
+## Consequences
+
+### Positive
+
+- One place names the enterprise satellites and the rules they obey, so the
+  engine stays the engine and the contracts they need are explicit.
+- Consolidating Atlassian into one satellite matches the single shared auth and
+  the cross-product comment-mode, avoiding two repos that share one auth layer.
+
+### Negative
+
+- Several satellites pinned to the export contract mean continuous
+  conformance-test carry against each engine release (ADR-073); the cost is real
+  and must be invested in, not assumed free.
+- A cross-satellite bug has no single owning repo; coordination falls to the
+  contracts and the reference configuration (ADR-091, the paved-path example).
+
+### Risks
+
+- An integration grows a network dependency back into the engine. Mitigation:
+  the boundary rules are recorded here; the engine gains no network import
+  (ADR-002).
+- Write-back becomes a bypass of PR review. Mitigation: propose-only via PR is a
+  named boundary (ADR-065, ADR-077).
+
+## Alternatives Considered
+
+### One repository per provider/integration
+
+Separate `lore-confluence`, `lore-jira`, `lore-bitbucket`, and so on.
+
+#### Disadvantages
+
+- Fragments shared auth and the cross-product comment-mode; more repos to keep
+  green against the contract (ADR-073). Consolidation is the cheaper carry.
+
+### In-engine connectors
+
+Build the network/SDK work into `rac-core`.
+
+#### Disadvantages
+
+- Contradicts ADR-002 and the single-fenced-ping rule; the engine stops being
+  offline and deterministic. Rejected.
+
+A small consolidated constellation of contract-consuming satellites is selected.
+
+## Relationship to Other Decisions
+
+- ADR-064, ADR-068, ADR-073, ADR-063: the satellite model and the
+  contract-consumer boundary this decision applies.
+- ADR-084: the audit JSONL the `lore-audit` collector consumes.
+- ADR-087, ADR-074: the external-edge graph marker `lore-atlassian` resolves.
+- ADR-049, ADR-054: the CI-neutral gate and SARIF output `lore-pipelines` wraps.
+- ADR-065, ADR-077: write-back is propose-only via PR.
+- ADR-072, ADR-006: inbound ingest reuses the conversion and human-review loop.
+- ADR-085: the distribution half of "configuration plus distribution, not a
+  mode".

--- a/rac/decisions/adr-091-engine-observability-boundary.md
+++ b/rac/decisions/adr-091-engine-observability-boundary.md
@@ -1,0 +1,106 @@
+---
+schema_version: 1
+id: RAC-KW47GPJVWDZ1
+type: decision
+---
+# ADR-091: Engine Observability Boundary
+
+## Status
+
+Proposed
+
+## Category
+
+Technical
+
+## Context
+
+"Metrics on every route" is an operations default, and a tool with no Prometheus
+endpoint can read as "did not think about ops." But the MCP server is stdio-only,
+stateless, and runs as one process per developer (ADR-031, ADR-032), and a hosted
+or shared server is a non-goal. A Prometheus `/metrics` endpoint presumes a
+long-running server to scrape — exactly what the local-per-developer model does
+not provide and the no-hosted-service stance rejects. The need is real
+(operators want signal); the question is the shape of observability that fits a
+local, stateless, offline process.
+
+## Decision
+
+The engine's observability is bounded to what fits a local, stateless, offline
+process, all off by default with one flag to enable.
+
+- **Opt-in structured JSON logs** to stderr (off by default; one flag turns them
+  on), carrying operational events — startup, and per-call tool, outcome, and
+  duration — with no artifact content beyond what the audit recorder (ADR-084)
+  separately governs.
+- **Sentry-compatible error-reporting hooks**: an optional DSN the operator
+  supplies (bring-your-own, ADR-035); off by default; no RAC-hosted sink. It
+  honours the air-gap lock (ADR-086) — disabled while telemetry is
+  enterprise-locked unless the operator has explicitly set their own DSN.
+- **No Prometheus `/metrics` HTTP endpoint in the engine.** There is no shared,
+  long-running server to scrape in the local-per-developer model, and adding an
+  HTTP surface to a stdio process is out of scope. A scrape endpoint, if ever
+  justified, belongs to a shared-deployment satellite (for example the
+  Helm-packaged watchkeeper, ADR-090) and is decided there.
+
+## Consequences
+
+### Positive
+
+- Operators get real signal (structured logs, error reporting) without the engine
+  growing a hosted or scraped surface.
+- The `/metrics` gap is deliberate and documented, not an oversight; the decision
+  explains where a scrape endpoint would live if a shared deployment ever needs
+  one.
+
+### Negative
+
+- A checkbox-driven review that expects a `/metrics` endpoint will not find one;
+  the rationale must be pointed to.
+- Error reporting requires the operator to supply and manage a DSN; there is no
+  turnkey sink.
+
+### Risks
+
+- A `/metrics` endpoint is added under ops pressure, dragging an HTTP server into
+  a stdio process. Mitigation: this ADR scopes it out and routes it to a
+  shared-deployment satellite.
+- Error reporting leaks content. Mitigation: the structured-log and error payload
+  carry no artifact content beyond ADR-084's governed fields.
+
+## Alternatives Considered
+
+### Ship a Prometheus `/metrics` endpoint now
+
+Add an HTTP metrics surface to the MCP server.
+
+#### Disadvantages
+
+- Presumes a long-running, scrapable server that the local-per-developer model
+  does not provide and the no-hosted-service stance rejects. Belongs to a
+  shared-deployment satellite if anywhere.
+
+### No observability at all
+
+Keep stderr diagnostics only.
+
+#### Disadvantages
+
+- Reads as ops-blind and gives operators no structured signal or error
+  reporting; the need is real even if the hosted shape is wrong.
+
+Opt-in structured logs plus bring-your-own error reporting, no engine scrape
+endpoint, is selected.
+
+## Relationship to Other Decisions
+
+- ADR-031, ADR-032: the stdio, stateless, one-process-per-developer model that
+  rules out a scrape endpoint in the engine.
+- ADR-035: error reporting is bring-your-own DSN, no RAC-hosted sink.
+- ADR-084: structured logs carry no content beyond the audit recorder's governed
+  fields.
+- ADR-086: error reporting honours the enterprise telemetry lock.
+- ADR-090: a scrape endpoint, if ever needed, lives in a shared-deployment
+  satellite.
+- ADR-085: observability delivered as opt-in configuration, for everyone, not a
+  mode.


### PR DESCRIPTION
# Summary

Proposes the enterprise-adoption decision contract as eight `Proposed` ADRs. No
engine code yet: decisions land first, then implementation builds on the ratified
contract (the two-gate model, ADR-077). The set answers one framing question —
"does Lore need an enterprise *mode*?" — and records the boundaries for every
enterprise ask that follows.

Adds:
- `rac/decisions/adr-084-read-access-audit-recorder.md` — a content-bearing,
  default-absent, local-only MCP query audit recorder.
- `rac/decisions/adr-085-enterprise-configuration-not-mode.md` — the umbrella:
  enterprise is configuration + distribution, never a semantic mode; plus a
  reusable decision rule and the bright lines.
- `rac/decisions/adr-086-air-gap-and-enterprise-telemetry-lock.md` — consolidates
  the LLM-call-free posture; adds `rac telemetry off --enterprise`.
- `rac/decisions/adr-087-external-reference-relationships.md` — a typed
  external-target edge family; first instance `## Related Jira`.
- `rac/decisions/adr-088-enterprise-profile-scaffold.md` — `rac init --profile`,
  config-only.
- `rac/decisions/adr-089-corpus-federation.md` — accepted in principle, mechanism
  deferred and sequenced last.
- `rac/decisions/adr-090-enterprise-satellite-topology.md` — names the
  `lore-atlassian` / `lore-pipelines` / `lore-audit` constellation and its
  boundaries.
- `rac/decisions/adr-091-engine-observability-boundary.md` — opt-in logs +
  BYO-DSN error reporting; no `/metrics` endpoint in the engine.

# ADR Trace

No roadmap item yet — the enterprise roadmap series (name/CalVer per ADR-076) is a
follow-up. These are the decisions that series will implement.

New ADRs: 084, 085, 086, 087, 088, 089, 090, 091.

Most-cited existing decisions: ADR-024 (not a content store), ADR-018 / ADR-080
(single canonical root), ADR-002 (offline/deterministic), ADR-040 / ADR-041
(content-free telemetry, single fenced ping), ADR-065 / ADR-077 (PR-review trust),
ADR-064 / ADR-073 (satellite/contract-consumer model), ADR-052 (custom edge kinds
deferred), ADR-010 (untyped targets), ADR-074 (typed graph export).

# Scope

## Included
- Eight `Proposed` decision artifacts; corpus validates 314/314 with 0
  relationship issues and no priority 1–2 review findings.

## Excluded
- All engine/CLI implementation — this PR is decisions only.
- Satellite code (`lore-atlassian`, `lore-pipelines`, `lore-audit`) — separate
  repos, out of scope for rac-core.
- The federation *mechanism* (the `## inherits` resolver) — accepted in principle,
  deferred and sequenced last (ADR-089).
- A Prometheus `/metrics` endpoint in the engine — deliberately out of scope
  (ADR-091).
- Authored-prose scaffolding in profiles — config only (ADR-088, preserving
  ADR-044 / ADR-024).

# Product / Architecture Decisions

- **Profile, not mode** (ADR-085). All five council seats, from five different
  incentive structures, rejected a semantic mode. Enterprise = config preset +
  satellites; the cultural backstop is that a profile may add no code path a solo
  developer cannot reach.
- **Audit is a strict superset, not a second posture** (ADR-084). The recorder is
  default-*absent*, so the engine's content-free guarantee is byte-for-byte intact
  by default; it records the query + returned IDs (never bodies), local-only, no
  engine network, transmission delegated to a satellite. This is the load-bearing
  decision the whole "profile not mode" verdict rests on.
- **External edges are a family, not Jira-specific** (ADR-087). Code-defined,
  exempt from artifact-range resolution (generalising ADR-010); engine does
  format-lint only; token-gated state checks live in the satellite.
- **Telemetry lock is a runtime force, reversible-by-explicit-action** (ADR-086).
  `POSTHOG_API_KEY` is populated, so `--enterprise` forces the kill state at
  runtime and reports it; unlock is documented and tamper-evident, not silent.
- **Identity is attributable, not authenticated** (ADR-084). The enforced boundary
  stays repo ACL + PR review; the log records who *claimed* to query and does not
  pretend to authenticate.
- **Federation is sequenced, not partner-gated** (ADR-089). A design partner is
  available; it is nonetheless scheduled after the additive items, with its
  constraints (never enterprise-gated, offline/materialized-bytes, single-root
  preserved, Git-native, provenance) bound now.
- **One Atlassian satellite** (ADR-090). Shared Cloud auth and cross-product
  comment-mode make one repo correct; all write-back is propose-only via PR.

# Proposed User-Facing Contract (not yet implemented)

These ADRs propose, for later implementation under their own changes:
- `rac telemetry off --enterprise` (+ `--unlock`); `rac telemetry status` reports
  the lock (ADR-086).
- A `## Related Jira` section accepting a Jira key or URL, format-linted by
  `rac validate` (ADR-087).
- `rac init --profile NAME` writing `.rac/config.yaml` / `.mcp.json` / gate
  config (ADR-088).
- An `audit:` stanza in `.rac/config.yaml` (`enabled`, `path`, `on_write_error`)
  and `RAC_AUDIT_PATH` / `RAC_AUDIT_PRINCIPAL` (ADR-084).

# Verification

## Ran
- `rac validate rac/` → exit 0: `314 artifact(s) checked: 314 valid, 0 invalid`.
- `rac relationships rac/ --validate` → exit 0: `Relationships Checked: 1536`,
  `Validation Issues: 0`.
- `rac review rac/` → exit 0 (no priority 1–2 findings).
- `rac validate` on each new ADR file → PASS, 0 errors / 0 warnings.

## Covered
- Structural validation of all eight new decision artifacts (frontmatter, required
  sections, category, status).
- Relationship resolution of the typed `Related Requirements` edges
  (`rac-trust-transparency`) added by 084–086, 088.
- System-assigned opaque IDs (ADR-026); statuses are all `Proposed`.

# Review Path

Suggested order: 085 (umbrella + decision rule) → 084 (audit recorder, the
load-bearing one) → 086 (air-gap/lock) → 087 (external edges) → 088 (profile) →
089 (federation, deferred) → 090 (satellite topology) → 091 (observability).

# Notes For Reviewer

- Everything is `Proposed`; this review is the ratification gate (ADR-077 —
  reviewed by someone other than the author).
- Decisions worth a maintainer call: the audit "attributable-not-authenticated"
  boundary (ADR-084), the persistent-config audit enablement that diverges from
  ADR-040's anti-persistence (ADR-084), the lock reversibility model (ADR-086),
  and "one topology ADR vs split per integration" (ADR-090).
- Federation (ADR-089) is intentionally a *defer* decision; if you'd prefer it not
  hold an ADR number until implementation starts, it can become a
  `rac/roadmaps/future/` stub instead — but then its constraints are not binding.
- Two facts corrected against the tree during drafting: `POSTHOG_API_KEY` is
  populated (`src/rac/consent.py`), and `EdgeSpec.range` is artifact-only
  (`src/rac/core/relationship_types.py`), which is why ADR-087 needs the explicit
  external-target exemption.

# Implementation Process

Drafted with AI assistance under the decision-contract workflow; final scope,
review, and acceptance decisions are the maintainer's via this review.