### PR TITLE
feat(telemetry): add enterprise telemetry hard-lock

### DIFF
--- a/.cursor/rules
+++ b/.cursor/rules
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: 3c53edfc4a0edf8ad94ad2fc8718733143fa3cf84add2a16f91338dc49363370) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: f8b25cc611194eab109e45eeca2b709dc9ec6473334e1dce76eab30963b6ed24) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -59,4 +59,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KVNM01QPBPXB** — ADR-075: The Pre-Merge Check Tier Is a Required Merge Gate on `main` _(Process)_
 - **RAC-KVPTVX3YZ87K** — ADR-076: Adopt CalVer (`YYYY.MM.N`) for RAC Releases _(Process)_
 - **RAC-KVTS86ZGVJV7** — ADR-077: The Two-Gate Capture Write Model _(Architecture)_
+- **RAC-KW47GFBHK31W** — ADR-086: Air-Gap Posture and Enterprise Telemetry Hard-Lock _(Product)_
 <!-- END RAC MANAGED BLOCK -->

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: 3c53edfc4a0edf8ad94ad2fc8718733143fa3cf84add2a16f91338dc49363370) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: f8b25cc611194eab109e45eeca2b709dc9ec6473334e1dce76eab30963b6ed24) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -59,4 +59,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KVNM01QPBPXB** — ADR-075: The Pre-Merge Check Tier Is a Required Merge Gate on `main` _(Process)_
 - **RAC-KVPTVX3YZ87K** — ADR-076: Adopt CalVer (`YYYY.MM.N`) for RAC Releases _(Process)_
 - **RAC-KVTS86ZGVJV7** — ADR-077: The Two-Gate Capture Write Model _(Architecture)_
+- **RAC-KW47GFBHK31W** — ADR-086: Air-Gap Posture and Enterprise Telemetry Hard-Lock _(Product)_
 <!-- END RAC MANAGED BLOCK -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: 3c53edfc4a0edf8ad94ad2fc8718733143fa3cf84add2a16f91338dc49363370) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: f8b25cc611194eab109e45eeca2b709dc9ec6473334e1dce76eab30963b6ed24) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -59,4 +59,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KVNM01QPBPXB** — ADR-075: The Pre-Merge Check Tier Is a Required Merge Gate on `main` _(Process)_
 - **RAC-KVPTVX3YZ87K** — ADR-076: Adopt CalVer (`YYYY.MM.N`) for RAC Releases _(Process)_
 - **RAC-KVTS86ZGVJV7** — ADR-077: The Two-Gate Capture Write Model _(Architecture)_
+- **RAC-KW47GFBHK31W** — ADR-086: Air-Gap Posture and Enterprise Telemetry Hard-Lock _(Product)_
 <!-- END RAC MANAGED BLOCK -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ to the corpus artifact and they load through the imports below.
 - Previous series: `rac/roadmaps/v0.21.x-editor/` (complete)
 - Decisions (ADRs): `rac/decisions/`
 
-<!-- BEGIN RAC MANAGED BLOCK (digest: 3c53edfc4a0edf8ad94ad2fc8718733143fa3cf84add2a16f91338dc49363370) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: f8b25cc611194eab109e45eeca2b709dc9ec6473334e1dce76eab30963b6ed24) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -84,4 +84,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KVNM01QPBPXB** — ADR-075: The Pre-Merge Check Tier Is a Required Merge Gate on `main` _(Process)_
 - **RAC-KVPTVX3YZ87K** — ADR-076: Adopt CalVer (`YYYY.MM.N`) for RAC Releases _(Process)_
 - **RAC-KVTS86ZGVJV7** — ADR-077: The Two-Gate Capture Write Model _(Architecture)_
+- **RAC-KW47GFBHK31W** — ADR-086: Air-Gap Posture and Enterprise Telemetry Hard-Lock _(Product)_
 <!-- END RAC MANAGED BLOCK -->

--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ Requires Python 3.11+. `uv tool install requirements-as-code` also works.
 - **Enforced at write time.** `rac validate` and `rac gate` reject malformed
   artifacts, broken or ambiguous links, and references to superseded decisions —
   in CI, before the knowledge lands.
+- **Air-gapped by design.** The engine makes no LLM calls and no network calls;
+  the only egress is a consent-gated, content-free usage ping that is off by
+  default, and regulated installs can prove it stays off with `rac telemetry off
+  --enterprise` ([security posture](docs/security.md), ADR-086).
 
 ## Connect your agent
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -944,16 +944,26 @@ version, and an active-repo count; never paths, queries, or repository
 content. Sharing is independent of the local `rac mcp --telemetry` flag.
 
 ```bash
-rac telemetry           # status (default): what is shared, and whether sending is possible
-rac telemetry on        # opt in; mints a random install id
-rac telemetry off       # opt out; nothing else changes
+rac telemetry                          # status (default): what is shared, and whether sending is possible
+rac telemetry on                       # opt in; mints a random install id
+rac telemetry off                      # opt out; nothing else changes
+rac telemetry off --enterprise         # hard-lock the ping off (forces the kill state, refuses 'on')
+rac telemetry off --enterprise --unlock  # remove the enterprise hard-lock
 ```
 
 `status` also reports when the build has no endpoint key configured — in
 that state nothing is sent even with consent. Consent lives at
 `~/.config/rac/telemetry.json`.
 
-- **Exit codes:** `0` consent shown or changed · `2` invalid action
+**Enterprise hard-lock (ADR-086).** For regulated installs that must *prove* the
+ping is off, `rac telemetry off --enterprise` forces the kill state at runtime
+(independent of the build's endpoint key), records a persistent lock, and refuses
+`rac telemetry on` until it is removed with `rac telemetry off --enterprise
+--unlock`. While locked, `status` reports `Sharing: locked (enterprise)`. The lock
+governs the anonymous ping only.
+
+- **Exit codes:** `0` consent shown or changed · `2` invalid action, or `on`
+  refused while enterprise-locked
 
 ---
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -18,9 +18,17 @@ a hosted service or a third-party certification (see [Scope](#scope-and-non-goal
   invariant ([ADR-002](https://github.com/itsthelore/rac-core/blob/main/rac/decisions/adr-002-ai-optional.md)):
   RAC is deterministic and AI-optional, so the core never depends on a remote
   call.
-- **No telemetry.** RAC collects no usage analytics in its default operation. The
-  optional MCP server and any AI-assisted authoring are explicitly opt-in and
-  bring-your-own-credentials ([ADR-035](https://github.com/itsthelore/rac-core/blob/main/rac/decisions/adr-035-byo-ai-credentials.md));
+- **No telemetry by default; provably off for regulated installs.** RAC collects
+  no usage analytics in its default operation. The one optional exception is a
+  consent-gated, content-free anonymous daily ping from the MCP server — a random
+  install id, the version, and an active-repo count, never paths, queries, or
+  content ([ADR-041](https://github.com/itsthelore/rac-core/blob/main/rac/decisions/adr-041-anonymous-usage-ping.md)) —
+  which stays off unless you opt in. A regulated install can prove it stays off at
+  runtime with `rac telemetry off --enterprise`: a tamper-evident hard-lock that
+  forces the ping off and refuses re-enabling until explicitly unlocked
+  ([ADR-086](https://github.com/itsthelore/rac-core/blob/main/rac/decisions/adr-086-air-gap-and-enterprise-telemetry-lock.md)).
+  AI-assisted authoring is opt-in and bring-your-own-credentials
+  ([ADR-035](https://github.com/itsthelore/rac-core/blob/main/rac/decisions/adr-035-byo-ai-credentials.md));
   nothing phones home on your behalf.
 - **Deterministic, local-only data flow.** The same corpus state yields
   byte-identical JSON and SARIF output, with no timestamps and stable ordering
@@ -101,3 +109,5 @@ offline posture is out of scope for the project (v0.21.14 Non-Goals).
 - [Validation](validation.md) — the write-time gate and SARIF output.
 - [ADR-002](https://github.com/itsthelore/rac-core/blob/main/rac/decisions/adr-002-ai-optional.md) — deterministic, AI-optional core.
 - [ADR-035](https://github.com/itsthelore/rac-core/blob/main/rac/decisions/adr-035-byo-ai-credentials.md) — bring-your-own AI credentials.
+- [ADR-041](https://github.com/itsthelore/rac-core/blob/main/rac/decisions/adr-041-anonymous-usage-ping.md) — the consent-gated, content-free anonymous ping.
+- [ADR-086](https://github.com/itsthelore/rac-core/blob/main/rac/decisions/adr-086-air-gap-and-enterprise-telemetry-lock.md) — air-gap posture and the enterprise telemetry hard-lock.

--- a/rac/decisions/adr-086-air-gap-and-enterprise-telemetry-lock.md
+++ b/rac/decisions/adr-086-air-gap-and-enterprise-telemetry-lock.md
@@ -7,7 +7,7 @@ type: decision
 
 ## Status
 
-Proposed
+Accepted
 
 ## Category
 

--- a/src/rac/cli.py
+++ b/src/rac/cli.py
@@ -1080,7 +1080,31 @@ def _maybe_ask_usage_sharing() -> None:
 
 
 def cmd_telemetry(args: argparse.Namespace) -> int:
+    enterprise = getattr(args, "enterprise", False)
+    unlock = getattr(args, "unlock", False)
+    # The enterprise flags are only meaningful with 'off' (ADR-086).
+    if (enterprise or unlock) and args.action != "off":
+        print(
+            "rac: --enterprise/--unlock are only valid with 'rac telemetry off'",
+            file=sys.stderr,
+        )
+        return EXIT_USAGE
+    if unlock and not enterprise:
+        print(
+            "rac: --unlock requires --enterprise (use 'rac telemetry off --enterprise --unlock')",
+            file=sys.stderr,
+        )
+        return EXIT_USAGE
+
     if args.action == "on":
+        if consent.load_consent().enterprise_locked:
+            print(
+                "rac: cannot opt in while the enterprise telemetry lock is set; "
+                "remove it with 'rac telemetry off --enterprise --unlock' first "
+                "(ADR-086).",
+                file=sys.stderr,
+            )
+            return EXIT_USAGE
         record = consent.opt_in()
         print(f"Sharing on. Install id: {record.install_id}")
         print(
@@ -1090,15 +1114,40 @@ def cmd_telemetry(args: argparse.Namespace) -> int:
         if not consent.POSTHOG_API_KEY:
             print("Note: this build has no PostHog key configured; nothing will be sent.")
     elif args.action == "off":
-        consent.opt_out()
-        print("Sharing off. Nothing will be sent.")
+        if enterprise and unlock:
+            consent.enterprise_unlock()
+            print(
+                "Enterprise lock removed. Sharing stays off; re-enable with "
+                "'rac telemetry on' (ADR-086)."
+            )
+        elif enterprise:
+            consent.enterprise_lock()
+            print(
+                "Sharing off and enterprise-locked. The daily ping is forced off "
+                "and cannot be re-enabled until unlocked with "
+                "'rac telemetry off --enterprise --unlock' (ADR-086)."
+            )
+        else:
+            consent.opt_out()
+            print("Sharing off. Nothing will be sent.")
     else:  # status
         status = consent.consent_status()
-        print(f"Sharing: {'on' if status.sharing else 'off'}")
+        if status.enterprise_locked:
+            sharing = "locked (enterprise)"
+        elif status.sharing:
+            sharing = "on"
+        else:
+            sharing = "off"
+        print(f"Sharing: {sharing}")
         print(f"Install id: {status.install_id or '(none)'}")
         print(f"Consented at: {status.consented_at or '(never)'}")
         print(f"Consent file: {status.path}")
-        if status.sharing:
+        if status.enterprise_locked:
+            print(
+                "Enterprise lock: on — the daily ping is forced off. Remove with "
+                "'rac telemetry off --enterprise --unlock' (ADR-086)."
+            )
+        elif status.sharing:
             print(
                 "Shared daily: install id, rac version, active-repo count. "
                 "Never paths, queries, or content (ADR-041)."
@@ -1779,6 +1828,16 @@ def build_parser() -> argparse.ArgumentParser:
         default="status",
         choices=["on", "off", "status"],
         help="on: opt in; off: opt out; status: show consent and what is shared (default).",
+    )
+    p_telemetry.add_argument(
+        "--enterprise",
+        action="store_true",
+        help="With 'off': hard-lock the ping off and refuse 'on' until unlocked (ADR-086).",
+    )
+    p_telemetry.add_argument(
+        "--unlock",
+        action="store_true",
+        help="With 'off --enterprise': remove the enterprise hard-lock (ADR-086).",
     )
     p_telemetry.set_defaults(func=cmd_telemetry)
 

--- a/src/rac/consent.py
+++ b/src/rac/consent.py
@@ -51,6 +51,10 @@ class Consent:
     install_id: str = ""
     salt: str = ""
     consented_at: str = ""
+    # The enterprise hard-lock (ADR-086). When true, the daily ping is forced
+    # off at runtime regardless of share_usage or the PostHog key, and opting
+    # in is refused until it is explicitly unlocked.
+    enterprise_locked: bool = False
 
 
 @dataclass(frozen=True)
@@ -62,6 +66,7 @@ class ConsentStatus:
     consented_at: str
     path: str
     endpoint_configured: bool
+    enterprise_locked: bool = False
 
 
 def consent_path() -> Path:
@@ -88,6 +93,7 @@ def load_consent() -> Consent:
         install_id=str(data.get("install_id", defaults.install_id)),
         salt=str(data.get("salt", defaults.salt)),
         consented_at=str(data.get("consented_at", defaults.consented_at)),
+        enterprise_locked=bool(data.get("enterprise_locked", defaults.enterprise_locked)),
     )
 
 
@@ -102,13 +108,20 @@ def save_consent(consent: Consent) -> None:
 
 
 def opt_in() -> Consent:
-    """Record consent, minting ids only where none exist yet."""
+    """Record consent, minting ids only where none exist yet.
+
+    The enterprise lock is preserved, never cleared here (ADR-086): turning
+    sharing on does not remove a hard-lock — only ``enterprise_unlock`` does.
+    Callers refuse opting in while locked; preserving the flag keeps the
+    runtime ping gate safe even if that guard is bypassed.
+    """
     existing = load_consent()
     consent = Consent(
         share_usage=True,
         install_id=existing.install_id or secrets.token_hex(16),
         salt=existing.salt or secrets.token_hex(16),
         consented_at=datetime.now(UTC).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        enterprise_locked=existing.enterprise_locked,
     )
     save_consent(consent)
     return consent
@@ -122,6 +135,40 @@ def opt_out() -> Consent:
         install_id=existing.install_id,
         salt=existing.salt,
         consented_at=existing.consented_at,
+        enterprise_locked=existing.enterprise_locked,
+    )
+    save_consent(consent)
+    return consent
+
+
+def enterprise_lock() -> Consent:
+    """Force the ping off and hard-lock it (ADR-086).
+
+    Sharing is turned off and the lock is recorded; the ids are kept so a later
+    unlock-and-opt-in stays continuous. While locked, the runtime ping gate
+    returns nothing and ``opt_in`` is refused by the CLI.
+    """
+    existing = load_consent()
+    consent = Consent(
+        share_usage=False,
+        install_id=existing.install_id,
+        salt=existing.salt,
+        consented_at=existing.consented_at,
+        enterprise_locked=True,
+    )
+    save_consent(consent)
+    return consent
+
+
+def enterprise_unlock() -> Consent:
+    """Remove the enterprise hard-lock (ADR-086); sharing stays off until opt-in."""
+    existing = load_consent()
+    consent = Consent(
+        share_usage=existing.share_usage,
+        install_id=existing.install_id,
+        salt=existing.salt,
+        consented_at=existing.consented_at,
+        enterprise_locked=False,
     )
     save_consent(consent)
     return consent
@@ -142,4 +189,5 @@ def consent_status() -> ConsentStatus:
         consented_at=consent.consented_at,
         path=str(consent_path()),
         endpoint_configured=bool(POSTHOG_API_KEY),
+        enterprise_locked=consent.enterprise_locked,
     )

--- a/src/rac/mcp/ping.py
+++ b/src/rac/mcp/ping.py
@@ -189,9 +189,13 @@ def start_ping_thread(consent: Consent) -> threading.Thread | None:
     """Start the daily-ping daemon thread, or return None when nothing may send.
 
     Requires recorded consent, a minted install id, and a configured key (the
-    empty-key kill switch, ADR-041). The thread dies with the process; there
-    is no shutdown choreography.
+    empty-key kill switch, ADR-041), and that the enterprise hard-lock is not
+    set (ADR-086) — the lock forces the ping off at runtime regardless of
+    consent or key. The thread dies with the process; there is no shutdown
+    choreography.
     """
+    if consent.enterprise_locked:
+        return None
     if not (consent.share_usage and consent.install_id and consent_record.POSTHOG_API_KEY):
         return None
 

--- a/src/rac/mcp/server.py
+++ b/src/rac/mcp/server.py
@@ -372,7 +372,7 @@ def _maybe_start_sharing(root: str) -> None:
     announced, never silent.
     """
     consent = consent_record.load_consent()
-    if not consent.share_usage:
+    if consent.enterprise_locked or not consent.share_usage:
         return
     ping.record_active_repo(root, consent.salt)
     thread = ping.start_ping_thread(consent)

--- a/tests/test_mcp_ping.py
+++ b/tests/test_mcp_ping.py
@@ -335,3 +335,100 @@ def test_sharing_on_without_key_says_nothing_will_be_sent(monkeypatch, capsys):
     captured = capsys.readouterr()
     assert "no PostHog key configured" in captured.err
     assert "nothing will be sent" in captured.err
+
+
+# --- Enterprise hard-lock (ADR-086) ---------------------------------------------
+
+
+def test_off_enterprise_records_lock_and_turns_sharing_off(capsys):
+    main(["telemetry", "on"])
+    capsys.readouterr()
+    assert main(["telemetry", "off", "--enterprise"]) == 0
+    assert "enterprise-locked" in capsys.readouterr().out
+    record = load_consent()
+    assert record.enterprise_locked is True
+    assert record.share_usage is False
+    # The install id survives so a later unlock-and-opt-in stays continuous.
+    assert record.install_id
+
+
+def test_on_is_refused_while_enterprise_locked(capsys):
+    main(["telemetry", "on"])
+    main(["telemetry", "off", "--enterprise"])
+    capsys.readouterr()
+    assert main(["telemetry", "on"]) == 2
+    assert "enterprise telemetry lock" in capsys.readouterr().err
+    # Refusal does not flip the record back on.
+    record = load_consent()
+    assert record.share_usage is False
+    assert record.enterprise_locked is True
+
+
+def test_ping_thread_suppressed_while_locked(monkeypatch):
+    # Even with consent, an install id, and a configured key, the lock wins.
+    monkeypatch.setattr(consent, "POSTHOG_API_KEY", "phc_test")
+    locked = Consent(share_usage=True, install_id="d" * 32, salt="e" * 32, enterprise_locked=True)
+    assert start_ping_thread(locked) is None
+
+
+def test_server_does_not_start_sharing_while_locked(monkeypatch, capsys, tmp_path):
+    monkeypatch.setattr(consent, "POSTHOG_API_KEY", "phc_test")
+    monkeypatch.setattr(ping, "_tick", lambda install_id: None)
+    # A hand-edited record with sharing on but locked: the lock still wins.
+    save_consent(
+        Consent(share_usage=True, install_id="d" * 32, salt="e" * 32, enterprise_locked=True)
+    )
+    server._maybe_start_sharing(str(tmp_path))
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""  # nothing announced, nothing started
+
+
+def test_unlock_removes_lock_and_allows_opt_in(capsys):
+    main(["telemetry", "off", "--enterprise"])
+    capsys.readouterr()
+    assert main(["telemetry", "off", "--enterprise", "--unlock"]) == 0
+    assert "lock removed" in capsys.readouterr().out.lower()
+    assert load_consent().enterprise_locked is False
+    assert main(["telemetry", "on"]) == 0
+    assert load_consent().share_usage is True
+
+
+def test_plain_off_preserves_enterprise_lock(capsys):
+    main(["telemetry", "off", "--enterprise"])
+    capsys.readouterr()
+    # A plain 'off' must never silently clear the lock.
+    assert main(["telemetry", "off"]) == 0
+    assert load_consent().enterprise_locked is True
+
+
+def test_status_reports_locked_enterprise(capsys):
+    main(["telemetry", "off", "--enterprise"])
+    capsys.readouterr()
+    assert main(["telemetry"]) == 0
+    out = capsys.readouterr().out
+    assert "Sharing: locked (enterprise)" in out
+    assert "Enterprise lock: on" in out
+
+
+def test_unlock_requires_enterprise(capsys):
+    assert main(["telemetry", "off", "--unlock"]) == 2
+    assert "--unlock requires --enterprise" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize("action", ["on", "status"])
+def test_enterprise_flags_rejected_outside_off(action, capsys):
+    assert main(["telemetry", action, "--enterprise"]) == 2
+    assert "only valid with 'rac telemetry off'" in capsys.readouterr().err
+
+
+def test_consent_round_trip_preserves_enterprise_lock():
+    saved = Consent(
+        share_usage=False,
+        install_id="a" * 32,
+        salt="b" * 32,
+        consented_at="t",
+        enterprise_locked=True,
+    )
+    save_consent(saved)
+    assert load_consent() == saved


### PR DESCRIPTION
# Summary

Implements ADR-086 (Air-Gap Posture and Enterprise Telemetry Hard-Lock), now
marked Accepted. Adds a provable, runtime enterprise lock for the anonymous usage
ping and consolidates the air-gap posture in the docs. The anonymous ping
(ADR-041) is the only behaviour touched.

Adds:
- `rac telemetry off --enterprise` / `--unlock` — a persistent, tamper-evident
  hard-lock that forces the ping off at runtime and refuses `rac telemetry on`
  until explicitly unlocked.
- `enterprise_locked` on the consent record, with a runtime gate in the ping
  thread and the MCP server's sharing hook.
- The air-gap posture consolidated and cited (README, `docs/security.md`,
  `docs/cli.md`).
- ADR-086 flipped to Accepted; the agent-rules managed block regenerated.

# ADR Trace

Implements `rac/decisions/adr-086-air-gap-and-enterprise-telemetry-lock.md`
(Accepted in this PR). Related: ADR-041 (the anonymous ping — the only egress,
now lockable), ADR-040 (content-free telemetry — untouched), ADR-002 / ADR-035 /
ADR-066 / ADR-067 (the posture this consolidates), ADR-084 (the audit recorder —
explicitly out of the lock's scope), ADR-085 (configuration-not-mode: the lock is
configuration, for everyone).

# Scope

## Included
- `enterprise_locked` consent field + `enterprise_lock` / `enterprise_unlock`
  (`consent.py`).
- Runtime ping gate (`ping.py`, `server.py`).
- CLI flags, locked status, and flag validation (`cli.py`).
- Docs consolidation (`README.md`, `docs/security.md`, `docs/cli.md`).
- ADR-086 Accepted + agent-rules block regenerated (scoped to `rac/`).
- 11 new tests.

## Excluded
- The lock governs the anonymous ping only; local usage logs (ADR-046) and the
  audit recorder (ADR-084) are untouched.
- No new network surface — the isolation battery is unchanged.
- The build-time PostHog key is not edited; the lock is a runtime force, not a
  key change.

# Product / Architecture Decisions

- The lock lives as a field on the existing consent record (one file, one
  concern), not a separate lock file.
- `off --enterprise` performs opt-out and sets the lock; a plain `off` preserves
  an existing lock and never silently clears it.
- Reversible only by an explicit `--unlock` (tamper-evident in `status`), not
  one-way — chosen so a machine leaving the regulated estate can be reconfigured.
- Scope is the ping; the audit recorder (ADR-084) is separate and unaffected.
- Refusing `on` while locked returns exit `2` (the usage-error convention).

# User-Facing Contract

## CLI
- `rac telemetry off --enterprise` — forces the ping off and records the lock.
- `rac telemetry off --enterprise --unlock` — removes the lock.
- `rac telemetry on` — refused while locked.
- `rac telemetry` (status) — reports `Sharing: locked (enterprise)` plus how to
  unlock.

## Exit codes
- `0` shown or changed · `2` invalid action, `on` refused while locked, or an
  invalid flag combination.

# Verification

## Ran
- `rac validate rac/` → `314 valid, 0 invalid`.
- `rac relationships rac/ --validate` → `0` issues.
- `rac review rac/` → exit `0`.
- `rac export rac/ --agent-rules --check` → in-sync.
- `pytest` over `test_mcp_ping` plus adjacent batteries (`test_no_egress`,
  `test_mcp_isolation`, `test_golden`, `test_dogfood`, `test_usage`,
  `test_mcp_telemetry`) → `128 passed`.
- `ruff check`, `ruff format --check`, `mypy` (changed files) → clean.

## Covered
Lock persistence; opt-in refusal while locked; runtime ping suppression (both
`start_ping_thread` and the server hook); unlock-and-re-enable; plain-`off`
preserving the lock; locked status output; flag-validation usage errors; consent
round-trip with the new field.

# Review Path

`consent.py` (model + lock) → `ping.py` / `server.py` (runtime gate) → `cli.py`
(flags, status, validation) → `tests/test_mcp_ping.py` → docs → ADR-086 status +
agent-rules block.

# Notes For Reviewer

- The agent-rules block diff is the single ADR-086 pointer + digest, scoped to
  `rac/`; an initial whole-repo regeneration wrongly pulled in
  `tests/fixtures`/`examples` decisions and was reverted.
- "Attributable, not authenticated" remains the model (no SSO/RBAC); the lock is
  about provable egress-off, not identity.

# Implementation Process

Implemented with AI assistance under the decision-contract workflow; final scope,
review, and acceptance decisions are the maintainer's.