### PR TITLE
docs(prompt): require conventional commit-style PR titles

### DIFF
--- a/rac/prompts/rac-agent-pr-guidelines.md
+++ b/rac/prompts/rac-agent-pr-guidelines.md
@@ -36,6 +36,14 @@ Generate a pull request description for a RAC change. Use the implementation
 details, roadmap item, ADRs, commits, and code changes provided. Structure
 the PR as a release-contract record, using the format in Output.
 
+Title the pull request in the commit message format from
+`rac-agent-commit-guidelines.md` — `<type>(<area>): <imperative summary>` with an
+optional `[reference]`. The repository squash-merges pull requests, so the title
+becomes the squashed commit's subject line on `main`; a prose title (for example
+"Implement X" or "Add feature Y") breaks the `git log` readability the commit
+standard exists to preserve. Use the dominant change's type and area — usually
+the lead commit's.
+
 Be aggressive about documenting exclusions: prefer stating what RAC does now
 and what RAC deliberately does not do yet. Document accepted implementation
 decisions (naming, schema, JSON contract, validation behavior, exit-code
@@ -128,6 +136,10 @@ This section is the only sanctioned AI disclosure in a pull request.
 
 ## Constraints
 
+- Title the PR in commit-message form (`<type>(<area>): <imperative summary>`,
+  per `rac-agent-commit-guidelines.md`); it becomes the squash-merge commit
+  subject on `main`. Never use a prose title like "Implement X" or "Add
+  feature Y".
 - Do not create generic release notes.
 - Do not summarize only commits.
 - Do not omit intentional exclusions.


### PR DESCRIPTION
# Summary

Makes the PR-title convention explicit in the PR-authoring guidance. The repository
squash-merges pull requests, so the PR title becomes the squashed commit's subject
on `main` — it must therefore follow the commit message standard already defined in
`rac-agent-commit-guidelines.md`. The guidance previously specified the body format
but said nothing about the title.

Adds to `rac/prompts/rac-agent-pr-guidelines.md`:
- An Instructions paragraph requiring the title in `type(area): imperative summary`
  form, explaining the squash-merge rationale.
- A Constraints bullet forbidding prose titles like "Implement X" / "Add feature Y".

# ADR Trace

No ADR change. Aligns the PR-authoring prompt with the existing commit message
standard (`rac-agent-commit-guidelines.md`); both are agent operating-guidance
prompt artifacts under ADR-047.

# Scope

## Included
- Two additive edits to `rac/prompts/rac-agent-pr-guidelines.md` (Instructions
  rationale + Constraints rule).

## Excluded
- No change to the commit message standard itself, which already defines the
  format; this only states that PR titles follow it.
- No code change.

# Verification

## Ran
- `rac validate rac/prompts/rac-agent-pr-guidelines.md` → PASS, 0 errors/warnings.
- `rac validate rac/` → `314 valid, 0 invalid`.
- `rac relationships rac/ --validate` → `0` issues.
- `rac review rac/` → exit `0`.
- `rac export rac/ --agent-rules --check` → in-sync (a prompt edit leaves the
  decisions block untouched).

# Review Path

`rac/prompts/rac-agent-pr-guidelines.md` — the Instructions paragraph and the new
Constraints bullet.

# Notes For Reviewer

This PR's own title follows the new rule, as does the companion ADR-086 PR (#207),
which was retitled `feat(telemetry): add enterprise telemetry hard-lock`.

# Implementation Process

Authored with AI assistance under the decision-contract workflow; final review and
acceptance are the maintainer's.