### PR TITLE
feat(audit): add read-access audit recorder

### DIFF
--- a/.cursor/rules
+++ b/.cursor/rules
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: f8b25cc611194eab109e45eeca2b709dc9ec6473334e1dce76eab30963b6ed24) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: 7ff46bfd5bc5da127399bcf1416d9b1cdaf42a3414212529fb231ae01d8700ea) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -59,5 +59,6 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KVNM01QPBPXB** — ADR-075: The Pre-Merge Check Tier Is a Required Merge Gate on `main` _(Process)_
 - **RAC-KVPTVX3YZ87K** — ADR-076: Adopt CalVer (`YYYY.MM.N`) for RAC Releases _(Process)_
 - **RAC-KVTS86ZGVJV7** — ADR-077: The Two-Gate Capture Write Model _(Architecture)_
+- **RAC-KW2YW6XK593X** — ADR-084: Read-Access Audit Recorder _(Product)_
 - **RAC-KW47GFBHK31W** — ADR-086: Air-Gap Posture and Enterprise Telemetry Hard-Lock _(Product)_
 <!-- END RAC MANAGED BLOCK -->

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: f8b25cc611194eab109e45eeca2b709dc9ec6473334e1dce76eab30963b6ed24) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: 7ff46bfd5bc5da127399bcf1416d9b1cdaf42a3414212529fb231ae01d8700ea) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -59,5 +59,6 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KVNM01QPBPXB** — ADR-075: The Pre-Merge Check Tier Is a Required Merge Gate on `main` _(Process)_
 - **RAC-KVPTVX3YZ87K** — ADR-076: Adopt CalVer (`YYYY.MM.N`) for RAC Releases _(Process)_
 - **RAC-KVTS86ZGVJV7** — ADR-077: The Two-Gate Capture Write Model _(Architecture)_
+- **RAC-KW2YW6XK593X** — ADR-084: Read-Access Audit Recorder _(Product)_
 - **RAC-KW47GFBHK31W** — ADR-086: Air-Gap Posture and Enterprise Telemetry Hard-Lock _(Product)_
 <!-- END RAC MANAGED BLOCK -->

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,7 +92,7 @@ jobs:
           - name: explorer
             paths: "tests/test_explorer_adapter.py tests/test_explorer_app.py tests/test_explorer_cli.py tests/test_explorer_commands.py tests/test_explorer_editor.py tests/test_explorer_isolation.py tests/test_explorer_workspace.py"
           - name: mcp
-            paths: "tests/test_mcp_server.py tests/test_mcp_tools.py tests/test_mcp_isolation.py tests/test_mcp_telemetry.py tests/test_mcp_ping.py"
+            paths: "tests/test_mcp_server.py tests/test_mcp_tools.py tests/test_mcp_isolation.py tests/test_mcp_telemetry.py tests/test_mcp_ping.py tests/test_mcp_audit.py"
           - name: relationships
             paths: "tests/test_relationships.py tests/test_relationships_cmd.py tests/test_relationship_validation.py tests/test_relationship_graph.py tests/test_lifecycle_status.py tests/test_rename.py"
           - name: resolve

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: f8b25cc611194eab109e45eeca2b709dc9ec6473334e1dce76eab30963b6ed24) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: 7ff46bfd5bc5da127399bcf1416d9b1cdaf42a3414212529fb231ae01d8700ea) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -59,5 +59,6 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KVNM01QPBPXB** — ADR-075: The Pre-Merge Check Tier Is a Required Merge Gate on `main` _(Process)_
 - **RAC-KVPTVX3YZ87K** — ADR-076: Adopt CalVer (`YYYY.MM.N`) for RAC Releases _(Process)_
 - **RAC-KVTS86ZGVJV7** — ADR-077: The Two-Gate Capture Write Model _(Architecture)_
+- **RAC-KW2YW6XK593X** — ADR-084: Read-Access Audit Recorder _(Product)_
 - **RAC-KW47GFBHK31W** — ADR-086: Air-Gap Posture and Enterprise Telemetry Hard-Lock _(Product)_
 <!-- END RAC MANAGED BLOCK -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ to the corpus artifact and they load through the imports below.
 - Previous series: `rac/roadmaps/v0.21.x-editor/` (complete)
 - Decisions (ADRs): `rac/decisions/`
 
-<!-- BEGIN RAC MANAGED BLOCK (digest: f8b25cc611194eab109e45eeca2b709dc9ec6473334e1dce76eab30963b6ed24) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: 7ff46bfd5bc5da127399bcf1416d9b1cdaf42a3414212529fb231ae01d8700ea) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -84,5 +84,6 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KVNM01QPBPXB** — ADR-075: The Pre-Merge Check Tier Is a Required Merge Gate on `main` _(Process)_
 - **RAC-KVPTVX3YZ87K** — ADR-076: Adopt CalVer (`YYYY.MM.N`) for RAC Releases _(Process)_
 - **RAC-KVTS86ZGVJV7** — ADR-077: The Two-Gate Capture Write Model _(Architecture)_
+- **RAC-KW2YW6XK593X** — ADR-084: Read-Access Audit Recorder _(Product)_
 - **RAC-KW47GFBHK31W** — ADR-086: Air-Gap Posture and Enterprise Telemetry Hard-Lock _(Product)_
 <!-- END RAC MANAGED BLOCK -->

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -302,7 +302,46 @@ network code in RAC): failures are dropped without retries, the socket
 timeout is three seconds, and a build with no endpoint key configured sends
 nothing at all — `rac telemetry status` will say so.
 
-## 8. Troubleshooting
+## 8. Read-access audit log (enterprise, opt-in)
+
+For regulated installs that must record *who consulted which decision, when, and
+which artifact IDs came back* — the audit trail telemetry deliberately does not
+keep — the server can append one JSON line per read-tool call to a local file
+([ADR-084](https://github.com/itsthelore/rac-core/blob/main/rac/decisions/adr-084-read-access-audit-recorder.md)).
+
+It is **content-bearing by design and off by default**: with no `audit:` stanza
+nothing is written and responses are byte-identical to a server with no recorder.
+It is **local-only** — the engine never transmits it; shipping the log to a sink
+(Loki, S3, Elastic) is a separate collector's job. The log records the query and
+the returned artifact IDs, **never artifact bodies**.
+
+Enable it in `.rac/config.yaml` (committed and team-wide, so an auditor has one
+git-diffable artifact to point at):
+
+```yaml
+audit:
+  enabled: true
+  # path: /var/log/lore/audit.jsonl   # optional; default: $XDG_STATE_HOME/rac/audit.jsonl
+  # on_write_error: warn              # warn (default) | block
+```
+
+- **`path`** — where the JSONL is written. Default `$XDG_STATE_HOME/rac/audit.jsonl`;
+  override per machine with the `RAC_AUDIT_PATH` environment variable (for data
+  residency).
+- **`on_write_error`** — `warn` (the default) reports a write failure on stderr
+  and keeps serving; `block` refuses the call with an `audit-unavailable` error
+  rather than returning un-audited content.
+
+Each line records `ts`, a per-process `session`, the `principal`, the `tool`, the
+`query`, the `returned` artifact IDs, `outcome`, and `duration_ms`. The
+**principal is attributable, not authenticated** (ADR-084): it defaults to the git
+`user.name`/`user.email` in the served repository and can be overridden with the
+`RAC_AUDIT_PRINCIPAL` environment variable. The enforced access boundary stays the
+repository ACL plus human pull-request review — the log records who *claimed* to
+query, not a verified identity. When enabled, the server announces it on stderr at
+startup; it is never silent.
+
+## 9. Troubleshooting
 
 ### Server not listed in the client
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -30,6 +30,14 @@ a hosted service or a third-party certification (see [Scope](#scope-and-non-goal
   AI-assisted authoring is opt-in and bring-your-own-credentials
   ([ADR-035](https://github.com/itsthelore/rac-core/blob/main/rac/decisions/adr-035-byo-ai-credentials.md));
   nothing phones home on your behalf.
+- **Optional read-access audit, local-only.** Regulated installs can record who
+  consulted which decision over the MCP server — query and returned artifact IDs,
+  never bodies — by enabling an `audit:` stanza in `.rac/config.yaml`
+  ([ADR-084](https://github.com/itsthelore/rac-core/blob/main/rac/decisions/adr-084-read-access-audit-recorder.md)).
+  It is off by default (responses stay byte-identical without it) and the engine
+  never transmits it: the log is a local file, and shipping it to a sink is a
+  separate collector's job. It is a strict addition to the no-egress posture, not
+  an exception to it.
 - **Deterministic, local-only data flow.** The same corpus state yields
   byte-identical JSON and SARIF output, with no timestamps and stable ordering
   (ADR-002). Nothing leaves the machine: input is local Markdown, output is local
@@ -110,4 +118,5 @@ offline posture is out of scope for the project (v0.21.14 Non-Goals).
 - [ADR-002](https://github.com/itsthelore/rac-core/blob/main/rac/decisions/adr-002-ai-optional.md) — deterministic, AI-optional core.
 - [ADR-035](https://github.com/itsthelore/rac-core/blob/main/rac/decisions/adr-035-byo-ai-credentials.md) — bring-your-own AI credentials.
 - [ADR-041](https://github.com/itsthelore/rac-core/blob/main/rac/decisions/adr-041-anonymous-usage-ping.md) — the consent-gated, content-free anonymous ping.
+- [ADR-084](https://github.com/itsthelore/rac-core/blob/main/rac/decisions/adr-084-read-access-audit-recorder.md) — the local-only, default-off read-access audit log.
 - [ADR-086](https://github.com/itsthelore/rac-core/blob/main/rac/decisions/adr-086-air-gap-and-enterprise-telemetry-lock.md) — air-gap posture and the enterprise telemetry hard-lock.

--- a/rac/decisions/adr-084-read-access-audit-recorder.md
+++ b/rac/decisions/adr-084-read-access-audit-recorder.md
@@ -7,7 +7,7 @@ type: decision
 
 ## Status
 
-Proposed
+Accepted
 
 ## Category
 

--- a/src/rac/cli.py
+++ b/src/rac/cli.py
@@ -817,9 +817,14 @@ def cmd_mcp(args: argparse.Namespace) -> int:
     # Imported lazily: the MCP SDK is only needed when serving, and the base
     # CLI must not pay its import cost for every other command. stdout belongs
     # to the MCP protocol, so any diagnostics here go to stderr.
+    from rac.mcp.audit import MalformedAuditConfig
     from rac.mcp.server import run_server
 
-    return run_server(args.root, telemetry_enabled=args.telemetry)
+    try:
+        return run_server(args.root, telemetry_enabled=args.telemetry)
+    except MalformedAuditConfig as exc:  # bad `audit:` stanza (ADR-084)
+        print(f"rac: {exc}", file=sys.stderr)
+        raise SystemExit(EXIT_USAGE) from None
 
 
 def cmd_mcp_stats(args: argparse.Namespace) -> int:

--- a/src/rac/mcp/audit.py
+++ b/src/rac/mcp/audit.py
@@ -1,0 +1,323 @@
+"""Read-access audit recorder for the Guide MCP server (ADR-084).
+
+The deliberate inversion of telemetry (ADR-040): where telemetry is content-free
+and silently self-disabling, the audit recorder is content-BEARING by design and
+fail-LOUD. It answers the question telemetry cannot — who consulted which
+decision, when, and which artifact IDs came back — by appending one JSON line per
+MCP read-tool call.
+
+It is default-ABSENT: with no ``audit:`` stanza in ``.rac/config.yaml`` no
+recorder is built, no file is created, and the engine's content-free guarantee is
+byte-for-byte intact (ADR-084's strict-superset property). When enabled it is
+local-only — this module imports no network code (the isolation battery enforces
+it); shipping events to a sink is the ``lore-audit`` satellite's job, never the
+engine's (ADR-002, ADR-073).
+
+Recording is write-only observability outside the request/response contract
+(ADR-032): :func:`observe` returns the tool payload unchanged, so responses are
+byte-identical with and without the recorder — except, by design, under
+``on_write_error: block`` when a write fails, where the call is refused with a
+structured ``audit-unavailable`` error rather than serving un-audited content.
+
+The principal is attributable, not authenticated (ADR-065, ADR-077): it records
+who *claimed* to query (git identity by default, ``RAC_AUDIT_PRINCIPAL`` to
+override), never a verified identity — the enforced boundary stays repository ACL
+plus human pull-request review.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import secrets
+import subprocess
+import sys
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+import yaml
+
+from rac.errors import RACError
+
+# Pinned audit event schema version (ADR-084). Bumping it is a recorded decision.
+SCHEMA_VERSION = "1"
+
+# Repository config discovery (read-only half of the `.rac/config.yaml` contract).
+# Mirrored here rather than imported from ``rac.services.init`` because the MCP
+# layer must not import a write-capable service (ADR-031, the isolation battery).
+CONFIG_DIR = ".rac"
+CONFIG_FILE = "config.yaml"
+
+AUDIT_FILENAME = "audit.jsonl"
+PATH_ENV = "RAC_AUDIT_PATH"
+PRINCIPAL_ENV = "RAC_AUDIT_PRINCIPAL"
+UNATTRIBUTED = "unattributed"
+ON_WRITE_ERROR_VALUES = ("warn", "block")
+ERROR_AUDIT_UNAVAILABLE = "audit-unavailable"
+
+
+class MalformedAuditConfig(RACError):
+    """The ``audit:`` stanza in ``.rac/config.yaml`` is unreadable (ADR-084).
+
+    A misconfigured audit posture refuses the server start rather than silently
+    recording nothing — the compliance control is never quietly off.
+    """
+
+    def __init__(self, config_path: str, reason: str) -> None:
+        self.config_path = config_path
+        super().__init__(f"malformed audit config {config_path}: {reason}")
+
+
+@dataclass(frozen=True)
+class AuditConfig:
+    """The ``audit:`` stanza from ``.rac/config.yaml`` (ADR-084)."""
+
+    enabled: bool
+    path: str  # the configured path, or "" to use the default
+    on_write_error: str  # "warn" | "block"
+    config_path: str | None = None
+
+
+def _find_config_file(start_dir: str) -> Path | None:
+    """The nearest ``.rac/config.yaml`` at or above ``start_dir``, or None."""
+    current = Path(start_dir).resolve()
+    for directory in (current, *current.parents):
+        candidate = directory / CONFIG_DIR / CONFIG_FILE
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _state_dir() -> Path:
+    base = os.environ.get("XDG_STATE_HOME") or str(Path.home() / ".local" / "state")
+    return Path(base) / "rac"
+
+
+def audit_path(config: AuditConfig | None = None) -> Path:
+    """Resolve the audit log path: ``RAC_AUDIT_PATH`` > config ``path`` > XDG default."""
+    env_override = os.environ.get(PATH_ENV)
+    if env_override:
+        return Path(env_override)
+    if config is not None and config.path:
+        return Path(config.path)
+    return _state_dir() / AUDIT_FILENAME
+
+
+def load_audit_config(start_dir: str) -> AuditConfig:
+    """Read the ``audit`` stanza from the nearest ``.rac/config.yaml`` (ADR-084).
+
+    Returns a disabled config when there is no config file or no ``audit``
+    section. A malformed shape raises :class:`MalformedAuditConfig` — the audit
+    posture is never silently misconfigured.
+    """
+    disabled = AuditConfig(enabled=False, path="", on_write_error="warn")
+    config_path = _find_config_file(start_dir)
+    if config_path is None:
+        return disabled
+    try:
+        data = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise MalformedAuditConfig(str(config_path), f"invalid YAML: {exc}") from exc
+    section = data.get("audit") if isinstance(data, dict) else None
+    if section is None:
+        return disabled
+    if not isinstance(section, dict):
+        raise MalformedAuditConfig(str(config_path), "'audit' must be a mapping")
+    enabled = section.get("enabled", False)
+    if not isinstance(enabled, bool):
+        raise MalformedAuditConfig(str(config_path), "'audit.enabled' must be true or false")
+    path = section.get("path", "")
+    if not isinstance(path, str):
+        raise MalformedAuditConfig(str(config_path), "'audit.path' must be a string")
+    on_write_error = section.get("on_write_error", "warn")
+    if on_write_error not in ON_WRITE_ERROR_VALUES:
+        raise MalformedAuditConfig(
+            str(config_path),
+            f"'audit.on_write_error' must be one of {', '.join(ON_WRITE_ERROR_VALUES)}",
+        )
+    return AuditConfig(
+        enabled=enabled,
+        path=path,
+        on_write_error=on_write_error,
+        config_path=str(config_path),
+    )
+
+
+def _git_identity(root: str) -> str | None:
+    """``"Name <email>"`` from git config in ``root``, or None when unavailable."""
+
+    def _config(key: str) -> str | None:
+        try:
+            result = subprocess.run(
+                ["git", "config", key],
+                cwd=root,
+                capture_output=True,
+                check=False,
+                text=True,
+            )
+        except OSError:  # no git binary, or root is gone
+            return None
+        if result.returncode != 0:
+            return None
+        return result.stdout.strip() or None
+
+    name = _config("user.name")
+    email = _config("user.email")
+    if name and email:
+        return f"{name} <{email}>"
+    return email or name
+
+
+def resolve_principal(root: str) -> str:
+    """The audit principal: ``RAC_AUDIT_PRINCIPAL`` > git identity > ``unattributed``.
+
+    Attributable, not authenticated (ADR-084): records who *claimed* to query.
+    """
+    override = os.environ.get(PRINCIPAL_ENV)
+    if override and override.strip():
+        return override.strip()
+    return _git_identity(root) or UNATTRIBUTED
+
+
+class AuditRecorder:
+    """Append-only, content-bearing, fail-loud audit writer (ADR-084).
+
+    Unlike :class:`~rac.mcp.telemetry.TelemetryRecorder`, a write failure is
+    never silently swallowed: it is reported once on stderr (fail-loud), and the
+    recorder keeps trying, so ``on_write_error: block`` can refuse every
+    un-recordable call rather than disabling itself after the first.
+    """
+
+    def __init__(self, path: Path, principal: str, on_write_error: str = "warn") -> None:
+        self.path = path
+        self.principal = principal
+        self.on_write_error = on_write_error
+        self.session = secrets.token_hex(8)
+        self._warned = False
+
+    def record(self, event: dict) -> bool:
+        """Append one event line; return True on success, False on write failure."""
+        try:
+            with open(self.path, "a", encoding="utf-8") as handle:
+                handle.write(json.dumps(event, ensure_ascii=False) + "\n")
+            return True
+        except OSError as exc:
+            if not self._warned:
+                action = "refusing tool calls" if self.on_write_error == "block" else "continuing"
+                print(
+                    f"rac mcp: audit write failed ({exc}); {action} "
+                    f"(audit.on_write_error={self.on_write_error}, path={self.path}).",
+                    file=sys.stderr,
+                )
+                self._warned = True
+            return False
+
+
+def create_recorder(config: AuditConfig, root: str) -> AuditRecorder | None:
+    """Build an audit recorder when enabled, else ``None`` (the default-absent path)."""
+    if not config.enabled:
+        return None
+    path = audit_path(config)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        pass  # the recorder's first write will fail loud
+    return AuditRecorder(path, resolve_principal(root), config.on_write_error)
+
+
+def observe(recorder: AuditRecorder | None, tool: str, args: dict, call: Callable[[], str]) -> str:
+    """Run ``call``, record one audit event, and return the payload unchanged.
+
+    With no recorder this is exactly ``call()`` — audit off creates nothing and
+    leaves the response byte-identical (ADR-084's strict superset). A raised call
+    is recorded as ``outcome: "exception"`` and re-raised, never swallowed
+    (ADR-034). Under ``on_write_error: block`` a failed write refuses the call
+    with a structured ``audit-unavailable`` error rather than serving un-audited
+    content.
+    """
+    if recorder is None:
+        return call()
+    started = time.perf_counter()
+    try:
+        payload = call()
+    except BaseException:
+        recorder.record(_event(recorder, tool, args, [], "exception", started))
+        raise
+    event = _event(recorder, tool, args, _returned(payload), _outcome(payload), started)
+    if not recorder.record(event) and recorder.on_write_error == "block":
+        return json.dumps(
+            {"schema_version": SCHEMA_VERSION, "error": ERROR_AUDIT_UNAVAILABLE, "tool": tool},
+            ensure_ascii=False,
+        )
+    return payload
+
+
+def _event(
+    recorder: AuditRecorder,
+    tool: str,
+    args: dict,
+    returned: list[str],
+    outcome: str,
+    started: float,
+) -> dict:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "ts": datetime.now(UTC).isoformat(timespec="milliseconds").replace("+00:00", "Z"),
+        "session": recorder.session,
+        "principal": recorder.principal,
+        "tool": tool,
+        "query": dict(args),
+        "returned": returned,
+        "outcome": outcome,
+        "duration_ms": int((time.perf_counter() - started) * 1000),
+    }
+
+
+def _outcome(payload: str) -> str:
+    """``"error"`` when the payload is a structured error, else ``"ok"`` (ADR-034)."""
+    try:
+        data = json.loads(payload)
+    except ValueError:
+        return "ok"
+    if isinstance(data, dict) and isinstance(data.get("error"), str):
+        return "error"
+    return "ok"
+
+
+def _returned(payload: str) -> list[str]:
+    """The resolved artifact IDs a call surfaced, parsed from the serialized payload.
+
+    Records IDs only, never bodies (ADR-084): the primary artifact (get_artifact,
+    get_related), search/find matches, and get_related incoming + neighborhood
+    neighbours. The queried artifact's own outgoing references are raw declared
+    target text (``dict[str, list[str]]``), not resolved IDs, so they are not
+    recorded as returned access; get_summary surfaces no IDs.
+    """
+    try:
+        data = json.loads(payload)
+    except ValueError:
+        return []
+    if not isinstance(data, dict) or isinstance(data.get("error"), str):
+        return []
+    ids: list[str] = []
+    primary = data.get("id")
+    if isinstance(primary, str):
+        ids.append(primary)
+    for key in ("matches", "incoming", "neighborhood"):
+        value = data.get(key)
+        if isinstance(value, list):
+            ids.extend(
+                item["id"]
+                for item in value
+                if isinstance(item, dict) and isinstance(item.get("id"), str)
+            )
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for artifact_id in ids:
+        if artifact_id not in seen:
+            seen.add(artifact_id)
+            deduped.append(artifact_id)
+    return deduped

--- a/src/rac/mcp/server.py
+++ b/src/rac/mcp/server.py
@@ -44,6 +44,7 @@ stdout belongs to the MCP protocol; only stderr carries diagnostics.
 from __future__ import annotations
 
 import sys
+from collections.abc import Callable
 from pathlib import Path
 
 from mcp.server.fastmcp import FastMCP
@@ -52,7 +53,7 @@ from rac import consent as consent_record
 from rac.core.corpus import walk_corpus
 from rac.core.limits import MAX_TRAVERSAL_DEPTH
 from rac.core.markdown import parse
-from rac.mcp import errors, ping, telemetry
+from rac.mcp import audit, errors, ping, telemetry
 from rac.mcp.budget import (
     DEFAULT_BUDGET,
     HINT_RELATED,
@@ -297,44 +298,59 @@ def _get_summary(root: str, budget: int) -> str:
 
 
 def build_server(
-    root: str, budget: int = DEFAULT_BUDGET, recorder: TelemetryRecorder | None = None
+    root: str,
+    budget: int = DEFAULT_BUDGET,
+    recorder: TelemetryRecorder | None = None,
+    audit_recorder: audit.AuditRecorder | None = None,
 ) -> FastMCP:
     """Build the Guide MCP server bound to repository ``root``.
 
     ``budget`` is the per-response character cap (ADR-033), configurable here at
     startup; there is no per-call override. ``recorder`` enables opt-in usage
-    telemetry (ADR-040): with ``None`` — the default — nothing is recorded and
-    every call is exactly the bare tool body. The returned :class:`FastMCP`
-    instance has the five pinned tools registered and is ready to run over any
-    transport — the CLI runs it over stdio.
+    telemetry (ADR-040) and ``audit_recorder`` enables the read-access audit log
+    (ADR-084): with both ``None`` — the default — nothing is recorded and every
+    call is exactly the bare tool body. The returned :class:`FastMCP` instance
+    has the five pinned tools registered and is ready to run over any transport —
+    the CLI runs it over stdio.
     """
     server: FastMCP = FastMCP(SERVER_NAME)
 
+    def observed(tool: str, args: dict, call: Callable[[], str]) -> str:
+        # Audit (content-bearing, ADR-084) runs innermost so its duration is the
+        # pure call time; telemetry (content-free, ADR-040) wraps it and still
+        # sees the unchanged payload. Each is a no-op when its recorder is None,
+        # so the default response stays byte-identical.
+        return telemetry.observe(
+            recorder, tool, lambda: audit.observe(audit_recorder, tool, args, call)
+        )
+
     @server.tool(name="get_artifact", description=DESC_GET_ARTIFACT)
     def get_artifact(id: str) -> str:
-        return telemetry.observe(recorder, "get_artifact", lambda: _get_artifact(root, id, budget))
+        return observed("get_artifact", {"id": id}, lambda: _get_artifact(root, id, budget))
 
     @server.tool(name="search_artifacts", description=DESC_SEARCH_ARTIFACTS)
     def search_artifacts(query: str, type: str | None = None) -> str:
-        return telemetry.observe(
-            recorder, "search_artifacts", lambda: _search_artifacts(root, query, type, budget)
+        return observed(
+            "search_artifacts",
+            {"query": query, "type": type},
+            lambda: _search_artifacts(root, query, type, budget),
         )
 
     @server.tool(name="find_decisions", description=DESC_FIND_DECISIONS)
     def find_decisions_tool(topic: str) -> str:
-        return telemetry.observe(
-            recorder, "find_decisions", lambda: _find_decisions(root, topic, budget)
+        return observed(
+            "find_decisions", {"topic": topic}, lambda: _find_decisions(root, topic, budget)
         )
 
     @server.tool(name="get_related", description=DESC_GET_RELATED)
     def get_related(id: str, depth: int = 1) -> str:
-        return telemetry.observe(
-            recorder, "get_related", lambda: _get_related(root, id, budget, depth)
+        return observed(
+            "get_related", {"id": id, "depth": depth}, lambda: _get_related(root, id, budget, depth)
         )
 
     @server.tool(name="get_summary", description=DESC_GET_SUMMARY)
     def get_summary() -> str:
-        return telemetry.observe(recorder, "get_summary", lambda: _get_summary(root, budget))
+        return observed("get_summary", {}, lambda: _get_summary(root, budget))
 
     return server
 
@@ -411,6 +427,19 @@ def run_server(root: str, budget: int = DEFAULT_BUDGET, telemetry_enabled: bool 
             f"(no arguments, no content) to {recorder.path}",
             file=sys.stderr,
         )
+    # The read-access audit log is config-driven (ADR-084), not a flag: enabled
+    # by an ``audit:`` stanza in .rac/config.yaml. Default-absent — no stanza,
+    # no recorder, no file, and the response stays byte-identical.
+    audit_recorder = audit.create_recorder(audit.load_audit_config(root), root)
+    if audit_recorder is not None:
+        print(
+            "rac mcp: audit on — appending one line per read-tool call "
+            "(principal, query, returned artifact ids; never content) to "
+            f"{audit_recorder.path}",
+            file=sys.stderr,
+        )
     _maybe_start_sharing(root)
-    build_server(root, budget=budget, recorder=recorder).run(transport="stdio")
+    build_server(root, budget=budget, recorder=recorder, audit_recorder=audit_recorder).run(
+        transport="stdio"
+    )
     return 0

--- a/tests/test_mcp_audit.py
+++ b/tests/test_mcp_audit.py
@@ -1,0 +1,283 @@
+"""Read-access audit recorder contracts — content-bearing, local-only, fail-loud.
+
+The battery pins ADR-084's shape: default-ABSENT (no recorder, no file, and the
+response byte-identical to bare — the strict-superset guarantee); one pinned line
+per read-tool call carrying the principal, the query verbatim, and the returned
+artifact IDs but never a body; the principal is attributable (git identity / env /
+``unattributed``); the ``audit:`` config stanza parses or raises; and a write
+failure is fail-loud, refusing the call under ``on_write_error: block``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+from conftest import fixture_path
+
+from rac.mcp import audit
+from rac.mcp.audit import AuditConfig, AuditRecorder, MalformedAuditConfig
+from rac.mcp.budget import DEFAULT_BUDGET
+from rac.mcp.server import build_server
+
+CORPUS = fixture_path("mcp", "corpus")
+
+DEC = "RAC-MCPDEC000001"
+RDM = "RAC-MCPRDM000001"
+REQ = "RAC-MCPREQ000001"
+
+# The pinned audit event field set, in emission order (ADR-084).
+AUDIT_FIELDS = [
+    "schema_version",
+    "ts",
+    "session",
+    "principal",
+    "tool",
+    "query",
+    "returned",
+    "outcome",
+    "duration_ms",
+]
+
+TS_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$")
+
+
+def make_recorder(
+    tmp_path: Path, principal: str = "Tester <t@example.com>", on_write_error: str = "warn"
+) -> AuditRecorder:
+    return AuditRecorder(tmp_path / "audit.jsonl", principal, on_write_error)
+
+
+def call_text(
+    root: str,
+    tool: str,
+    args: dict,
+    budget: int = DEFAULT_BUDGET,
+    audit_recorder: AuditRecorder | None = None,
+) -> str:
+    server = build_server(root, budget=budget, audit_recorder=audit_recorder)
+    contents, _structured = asyncio.run(server.call_tool(tool, args))
+    assert len(contents) == 1
+    return contents[0].text
+
+
+def events_in(recorder: AuditRecorder) -> list[dict]:
+    return [json.loads(line) for line in recorder.path.read_text().splitlines() if line.strip()]
+
+
+# --- Default-absent: the strict-superset guarantee ------------------------------
+
+
+def test_default_absent_records_nothing(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+    for tool, args in [
+        ("get_artifact", {"id": DEC}),
+        ("search_artifacts", {"query": "event"}),
+        ("get_related", {"id": DEC}),
+        ("get_summary", {}),
+    ]:
+        call_text(CORPUS, tool, args)  # no audit_recorder
+    assert not audit.audit_path().exists()
+
+
+@pytest.mark.parametrize(
+    "tool,args,budget",
+    [
+        ("get_artifact", {"id": DEC}, DEFAULT_BUDGET),
+        ("get_artifact", {"id": "RAC-DOESNOTEXIST1"}, DEFAULT_BUDGET),  # error
+        ("get_artifact", {"id": DEC}, 200),  # truncated
+        ("search_artifacts", {"query": "event"}, DEFAULT_BUDGET),
+        ("find_decisions", {"topic": "event"}, DEFAULT_BUDGET),
+        ("get_related", {"id": DEC}, DEFAULT_BUDGET),
+        ("get_summary", {}, DEFAULT_BUDGET),
+    ],
+)
+def test_payload_byte_identical_with_and_without_recorder(tmp_path, tool, args, budget):
+    bare = call_text(CORPUS, tool, args, budget=budget)
+    recorded = call_text(CORPUS, tool, args, budget=budget, audit_recorder=make_recorder(tmp_path))
+    assert recorded == bare
+
+
+# --- The recorded contract ------------------------------------------------------
+
+
+def test_each_tool_records_one_pinned_event(tmp_path):
+    recorder = make_recorder(tmp_path)
+    tools = [
+        ("get_artifact", {"id": DEC}),
+        ("search_artifacts", {"query": "event"}),
+        ("get_summary", {}),
+    ]
+    for tool, args in tools:
+        call_text(CORPUS, tool, args, audit_recorder=recorder)
+    events = events_in(recorder)
+    assert [ev["tool"] for ev in events] == [tool for tool, _ in tools]
+    for ev in events:
+        assert list(ev) == AUDIT_FIELDS
+        assert ev["schema_version"] == "1"
+        assert TS_PATTERN.match(ev["ts"])
+        assert ev["session"] == recorder.session
+        assert ev["principal"] == "Tester <t@example.com>"
+        assert ev["outcome"] == "ok"
+        assert isinstance(ev["duration_ms"], int)
+
+
+def test_query_is_recorded_verbatim(tmp_path):
+    recorder = make_recorder(tmp_path)
+    call_text(CORPUS, "search_artifacts", {"query": "soft delete"}, audit_recorder=recorder)
+    event = events_in(recorder)[0]
+    assert event["query"] == {"query": "soft delete", "type": None}
+
+
+@pytest.mark.parametrize(
+    "tool,args,expected",
+    [
+        ("get_artifact", {"id": DEC}, [DEC]),
+        ("search_artifacts", {"query": "event"}, [DEC, RDM]),
+        ("find_decisions", {"topic": "event"}, [DEC]),
+        ("get_related", {"id": DEC}, [DEC, RDM, REQ]),
+        ("get_summary", {}, []),
+    ],
+)
+def test_returned_ids_per_tool(tmp_path, tool, args, expected):
+    recorder = make_recorder(tmp_path)
+    call_text(CORPUS, tool, args, audit_recorder=recorder)
+    assert events_in(recorder)[0]["returned"] == expected
+
+
+def test_no_artifact_body_is_recorded(tmp_path):
+    recorder = make_recorder(tmp_path)
+    payload = json.loads(call_text(CORPUS, "get_artifact", {"id": DEC}, audit_recorder=recorder))
+    body = payload["content"]
+    assert body  # the tool really did return the body...
+    raw = recorder.path.read_text()
+    assert body not in raw  # ...but the audit line records only the ID, never it
+
+
+def test_not_found_records_error_outcome_and_empty_returned(tmp_path):
+    recorder = make_recorder(tmp_path)
+    call_text(CORPUS, "get_artifact", {"id": "RAC-DOESNOTEXIST1"}, audit_recorder=recorder)
+    event = events_in(recorder)[0]
+    assert event["outcome"] == "error"
+    assert event["returned"] == []
+
+
+def test_exception_is_recorded_and_reraised(tmp_path):
+    recorder = make_recorder(tmp_path)
+
+    def boom() -> str:
+        raise RuntimeError("kaboom")
+
+    with pytest.raises(RuntimeError):
+        audit.observe(recorder, "get_artifact", {"id": "X"}, boom)
+    event = events_in(recorder)[0]
+    assert event["outcome"] == "exception"
+    assert event["returned"] == []
+
+
+# --- Principal: attributable, not authenticated ---------------------------------
+
+
+def test_principal_env_override_wins(tmp_path, monkeypatch):
+    monkeypatch.setenv("RAC_AUDIT_PRINCIPAL", "CI Bot <ci@example.com>")
+    assert audit.resolve_principal(str(tmp_path)) == "CI Bot <ci@example.com>"
+
+
+def test_principal_defaults_to_git_identity(tmp_path, monkeypatch):
+    monkeypatch.delenv("RAC_AUDIT_PRINCIPAL", raising=False)
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    subprocess.run(["git", "-C", str(tmp_path), "config", "user.name", "Ada Lovelace"], check=True)
+    subprocess.run(
+        ["git", "-C", str(tmp_path), "config", "user.email", "ada@example.com"], check=True
+    )
+    assert audit.resolve_principal(str(tmp_path)) == "Ada Lovelace <ada@example.com>"
+
+
+def test_principal_unattributed_without_git_or_env(tmp_path, monkeypatch):
+    monkeypatch.delenv("RAC_AUDIT_PRINCIPAL", raising=False)
+    monkeypatch.setattr(audit, "_git_identity", lambda root: None)
+    assert audit.resolve_principal(str(tmp_path)) == "unattributed"
+
+
+# --- Config + path resolution ---------------------------------------------------
+
+
+def _write_config(tmp_path: Path, body: str) -> None:
+    (tmp_path / ".rac").mkdir(parents=True, exist_ok=True)
+    (tmp_path / ".rac" / "config.yaml").write_text(body, encoding="utf-8")
+
+
+def test_load_audit_config_absent_is_disabled(tmp_path):
+    assert audit.load_audit_config(str(tmp_path)).enabled is False
+
+
+def test_load_audit_config_parses_the_stanza(tmp_path):
+    _write_config(
+        tmp_path,
+        "audit:\n  enabled: true\n  path: /var/log/lore/audit.jsonl\n  on_write_error: block\n",
+    )
+    config = audit.load_audit_config(str(tmp_path))
+    assert config.enabled is True
+    assert config.path == "/var/log/lore/audit.jsonl"
+    assert config.on_write_error == "block"
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "audit: not-a-mapping\n",
+        "audit:\n  enabled: yes-please\n",
+        "audit:\n  enabled: true\n  on_write_error: shout\n",
+        "audit:\n  enabled: true\n  path: 42\n",
+    ],
+)
+def test_load_audit_config_malformed_raises(tmp_path, body):
+    _write_config(tmp_path, body)
+    with pytest.raises(MalformedAuditConfig):
+        audit.load_audit_config(str(tmp_path))
+
+
+def test_audit_path_resolution_order(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
+    monkeypatch.delenv("RAC_AUDIT_PATH", raising=False)
+    # Default: XDG state dir.
+    assert audit.audit_path(None) == tmp_path / "state" / "rac" / "audit.jsonl"
+    # Config path beats the default.
+    configured = AuditConfig(enabled=True, path=str(tmp_path / "c.jsonl"), on_write_error="warn")
+    assert audit.audit_path(configured) == tmp_path / "c.jsonl"
+    # Env beats the config path.
+    monkeypatch.setenv("RAC_AUDIT_PATH", str(tmp_path / "env.jsonl"))
+    assert audit.audit_path(configured) == tmp_path / "env.jsonl"
+
+
+def test_create_recorder_disabled_returns_none(tmp_path):
+    config = AuditConfig(enabled=False, path="", on_write_error="warn")
+    assert audit.create_recorder(config, str(tmp_path)) is None
+
+
+# --- Fail-loud write handling ---------------------------------------------------
+
+
+def test_warn_mode_keeps_serving_and_warns_on_write_failure(tmp_path, capsys):
+    # Point the log at a directory so every append raises OSError.
+    blocked = tmp_path / "audit.jsonl"
+    blocked.mkdir()
+    recorder = AuditRecorder(blocked, "Tester <t@example.com>", "warn")
+    out = audit.observe(recorder, "get_summary", {}, lambda: '{"ok": true}')
+    assert out == '{"ok": true}'  # warn mode still serves the payload
+    assert "audit write failed" in capsys.readouterr().err
+
+
+def test_block_mode_refuses_the_call_on_write_failure(tmp_path, capsys):
+    blocked = tmp_path / "audit.jsonl"
+    blocked.mkdir()
+    recorder = AuditRecorder(blocked, "Tester <t@example.com>", "block")
+    out = audit.observe(recorder, "get_artifact", {"id": DEC}, lambda: '{"id": "X"}')
+    data = json.loads(out)
+    assert data["error"] == "audit-unavailable"
+    assert data["tool"] == "get_artifact"
+    assert "refusing tool calls" in capsys.readouterr().err


### PR DESCRIPTION
# Summary

Implements ADR-084 (Read-Access Audit Recorder), now marked Accepted. Adds a
content-bearing, default-absent, local-only recorder of MCP read-tool calls — the
audit trail telemetry deliberately does not keep (who consulted which decision,
when, and which artifact IDs came back). It is the deliberate inversion of
telemetry (ADR-040): same write-only, outside-the-contract posture, but content-
bearing and fail-loud.

Adds:
- `src/rac/mcp/audit.py` — `AuditConfig` + `load_audit_config` (the `audit:`
  stanza), `resolve_principal`, `AuditRecorder`, and `observe`.
- Server wiring in `build_server` / `run_server` (config-driven, no flag).
- ADR-084 flipped to Accepted; the agent-rules managed block regenerated.
- `docs/mcp.md` and `docs/security.md` coverage; `tests/test_mcp_audit.py`.

# ADR Trace

Implements `rac/decisions/adr-084-read-access-audit-recorder.md` (Accepted in this
PR). Related: ADR-040 (telemetry — the content-free sibling, untouched), ADR-032
(write-only, outside the request/response contract), ADR-002 / ADR-031 (offline;
the read-only consumer boundary), ADR-065 / ADR-077 (attributable-not-authenticated;
the trust boundary stays repo ACL + PR review), ADR-073 (the `lore-audit` sink is
a satellite), ADR-085 (the strict-superset property keeps enterprise a profile,
not a mode).

# Scope

## Included
- `audit.py`: config loading, path/principal resolution, the recorder, and
  per-tool returned-ID extraction.
- Server wiring: one `observed` helper wraps every tool; audit innermost of the
  telemetry wrap so responses stay byte-identical.
- ADR-084 Accepted + agent-rules block regenerated (scoped to `rac/`).
- Docs + the test battery (registered in the CI matrix, ADR-027).

## Excluded
- No transmission: the engine never ships the log. Shipping it to a sink (Loki,
  S3, Elastic) is the `lore-audit` satellite's job — out of scope here.
- No new network surface; the isolation battery stays green.
- The audit module imports no write-capable service (ADR-031): it carries its own
  `MalformedAuditConfig` and an inlined `.rac/config.yaml` discovery walk rather
  than importing `services.init`.
- CLI reads are out of scope; the recorder covers the MCP read tools only.

# Product / Architecture Decisions

- **Strict superset, not a second posture (ADR-085).** Default-absent: with no
  `audit:` stanza no recorder is built, no file is written, and every response is
  byte-identical to bare. This is the load-bearing property and is tested directly.
- **Content by design, but IDs only.** Records the query verbatim and the returned
  artifact IDs; never artifact bodies. `get_summary` surfaces no IDs; a queried
  artifact's own outgoing declarations (raw target text) are not recorded as
  returned access.
- **Fail-loud, not silent.** Unlike telemetry's silent self-disable, a write
  failure is reported on stderr; `on_write_error: block` refuses the call with a
  structured `audit-unavailable` error rather than serving un-audited content.
- **Attributable, not authenticated (ADR-084).** Principal defaults to git
  identity, overridable by `RAC_AUDIT_PRINCIPAL`; the enforced boundary stays repo
  ACL + PR review.
- **Config-driven, committed.** Enabled by an `audit:` stanza (the one
  git-diffable artifact an auditor points at), not a per-invocation flag.

# Proposed User-Facing Contract

- `.rac/config.yaml` `audit:` stanza — `enabled`, optional `path`,
  `on_write_error` (`warn` | `block`).
- Env: `RAC_AUDIT_PATH` (residency), `RAC_AUDIT_PRINCIPAL` (CI/service identity).
- The log: one JSONL line per read-tool call with `schema_version`, `ts`,
  `session`, `principal`, `tool`, `query`, `returned`, `outcome`, `duration_ms`.
- `rac mcp` announces audit on stderr when enabled; default is silent and absent.

# Verification

## Ran
- `pytest` (full suite) → `1661 passed, 1 skipped` (the new
  `tests/test_mcp_audit.py` plus everything else; the CI battery matrix is updated
  so the new file is enforced, ADR-027).
- `ruff check`, `ruff format --check`, `mypy src` → clean.
- `rac validate rac/` → `314 valid, 0 invalid`; `rac relationships rac/ --validate`
  → `0` issues; `rac review rac/` → exit `0`; `rac export rac/ --agent-rules
  --check` → in-sync.

## Covered
Default-absent (no file, byte-identical responses); payload byte-stability across
all tools/args/budgets; the pinned event schema; per-tool returned-ID extraction
(get_artifact, search, find_decisions, get_related, get_summary); no-body-recorded;
principal resolution (git / env / unattributed); config parse + malformed; path
resolution order; fail-loud warn and block modes; exception path re-raises.

# Review Path

`audit.py` (config + principal + recorder + observe + ID extraction) →
`server.py` (the `observed` wrap) / `cli.py` (clean failure) →
`tests/test_mcp_audit.py` → docs → ADR-084 status + agent-rules block.

# Notes For Reviewer

- The isolation boundary drove a small decoupling: `audit.py` does not import
  `services.init` (a write-capable service), so it defines its own config error
  and discovery walk — mirroring the read-only half of the `.rac/config.yaml`
  contract.
- The agent-rules diff is the single ADR-084 pointer + digest, scoped to `rac/`.

# Implementation Process

Implemented with AI assistance under the decision-contract workflow; final scope,
review, and acceptance decisions are the maintainer's.