### PR TITLE
feat(relationships): add external-reference (Jira) relationship edges

### DIFF
--- a/.cursor/rules
+++ b/.cursor/rules
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: 7ff46bfd5bc5da127399bcf1416d9b1cdaf42a3414212529fb231ae01d8700ea) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: b133cd2ff821db8329714794bebe19ca1fef61436f54f237f4f02fe38c835efe) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -61,4 +61,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KVTS86ZGVJV7** — ADR-077: The Two-Gate Capture Write Model _(Architecture)_
 - **RAC-KW2YW6XK593X** — ADR-084: Read-Access Audit Recorder _(Product)_
 - **RAC-KW47GFBHK31W** — ADR-086: Air-Gap Posture and Enterprise Telemetry Hard-Lock _(Product)_
+- **RAC-KW47GGS85CKG** — ADR-087: External-Reference Relationships (Jira and Beyond) _(Technical)_
 <!-- END RAC MANAGED BLOCK -->

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: 7ff46bfd5bc5da127399bcf1416d9b1cdaf42a3414212529fb231ae01d8700ea) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: b133cd2ff821db8329714794bebe19ca1fef61436f54f237f4f02fe38c835efe) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -61,4 +61,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KVTS86ZGVJV7** — ADR-077: The Two-Gate Capture Write Model _(Architecture)_
 - **RAC-KW2YW6XK593X** — ADR-084: Read-Access Audit Recorder _(Product)_
 - **RAC-KW47GFBHK31W** — ADR-086: Air-Gap Posture and Enterprise Telemetry Hard-Lock _(Product)_
+- **RAC-KW47GGS85CKG** — ADR-087: External-Reference Relationships (Jira and Beyond) _(Technical)_
 <!-- END RAC MANAGED BLOCK -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: 7ff46bfd5bc5da127399bcf1416d9b1cdaf42a3414212529fb231ae01d8700ea) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: b133cd2ff821db8329714794bebe19ca1fef61436f54f237f4f02fe38c835efe) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -61,4 +61,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KVTS86ZGVJV7** — ADR-077: The Two-Gate Capture Write Model _(Architecture)_
 - **RAC-KW2YW6XK593X** — ADR-084: Read-Access Audit Recorder _(Product)_
 - **RAC-KW47GFBHK31W** — ADR-086: Air-Gap Posture and Enterprise Telemetry Hard-Lock _(Product)_
+- **RAC-KW47GGS85CKG** — ADR-087: External-Reference Relationships (Jira and Beyond) _(Technical)_
 <!-- END RAC MANAGED BLOCK -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ to the corpus artifact and they load through the imports below.
 - Previous series: `rac/roadmaps/v0.21.x-editor/` (complete)
 - Decisions (ADRs): `rac/decisions/`
 
-<!-- BEGIN RAC MANAGED BLOCK (digest: 7ff46bfd5bc5da127399bcf1416d9b1cdaf42a3414212529fb231ae01d8700ea) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: b133cd2ff821db8329714794bebe19ca1fef61436f54f237f4f02fe38c835efe) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -86,4 +86,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KVTS86ZGVJV7** — ADR-077: The Two-Gate Capture Write Model _(Architecture)_
 - **RAC-KW2YW6XK593X** — ADR-084: Read-Access Audit Recorder _(Product)_
 - **RAC-KW47GFBHK31W** — ADR-086: Air-Gap Posture and Enterprise Telemetry Hard-Lock _(Product)_
+- **RAC-KW47GGS85CKG** — ADR-087: External-Reference Relationships (Jira and Beyond) _(Technical)_
 <!-- END RAC MANAGED BLOCK -->

--- a/docs/relationships.md
+++ b/docs/relationships.md
@@ -34,6 +34,32 @@ is stripped; the rest of the line is the id, matched case-insensitively against 
 relationship section is only recognized on a type that declares it (so an unknown
 document contributes no relationships).
 
+## External references (Jira)
+
+`## Related Jira` links an artifact to a Jira ticket — an *external* reference
+that deliberately does not resolve to an in-corpus artifact (ADR-087). It turns
+change traceability ("this ADR implements PROJ-1234") into corpus data instead of
+prose:
+
+```markdown
+## Related Jira
+- PROJ-1234
+- https://acme.atlassian.net/browse/PROJ-5678
+```
+
+Each entry is a Jira key (`PROJ-1234`) or a full URL. The engine does **format-lint
+only, offline**: `rac validate` flags an entry that is neither a well-formed key
+nor a URL (`malformed-external-reference`, overridable per
+[ADR-053](https://github.com/itsthelore/rac-core/blob/main/rac/decisions/adr-053-validation-severity-overrides.md)),
+and `rac relationships --validate` never reports a Jira entry as a broken reference.
+The engine **never contacts Jira** — checking that a ticket exists or is in an
+allowed state needs a token and lives in the `lore-atlassian` satellite (ADR-090),
+not the engine (ADR-002).
+
+In `rac export --graph` an external edge carries `"external": true` and
+`"resolved": false`, so a graph backend can tell a deliberate Jira link from a
+dangling in-corpus reference (both are unresolved, only the external one is marked).
+
 ## Viewing relationships
 
 ```bash

--- a/rac/decisions/adr-087-external-reference-relationships.md
+++ b/rac/decisions/adr-087-external-reference-relationships.md
@@ -7,7 +7,7 @@ type: decision
 
 ## Status
 
-Proposed
+Accepted
 
 ## Category
 

--- a/src/rac/core/artifacts.py
+++ b/src/rac/core/artifacts.py
@@ -95,6 +95,7 @@ RELATIONSHIP_DESCRIPTIONS: dict[str, str] = {
     "related prompts": "Prompt artifacts this artifact references",
     "related designs": "Design artifacts this artifact references",
     "supersedes": "The artifact this one supersedes",
+    "related jira": "Jira tickets this artifact traces to (external reference, ADR-087)",
 }
 
 
@@ -119,6 +120,7 @@ ARTIFACT_SPECS: tuple[ArtifactSpec, ...] = (
             "related prompts",
             "related designs",
             "related requirements",
+            "related jira",
         ),
         # Lifecycle status (ADR-051): optional, validated-if-present. Status stays
         # a knowledge lifecycle (current vs replaced), never work/delivery state.
@@ -136,6 +138,7 @@ ARTIFACT_SPECS: tuple[ArtifactSpec, ...] = (
                 "related prompts",
                 "related designs",
                 "related requirements",
+                "related jira",
             ),
         },
         guidance={
@@ -180,6 +183,7 @@ ARTIFACT_SPECS: tuple[ArtifactSpec, ...] = (
             "related roadmaps",
             "related designs",
             "related decisions",
+            "related jira",
         ),
         metadata={
             "status": ("Proposed", "Accepted", "Superseded", "Deprecated"),
@@ -192,6 +196,7 @@ ARTIFACT_SPECS: tuple[ArtifactSpec, ...] = (
             "related roadmaps",
             "related designs",
             "related decisions",
+            "related jira",
         ),
         guidance={
             "context": (
@@ -233,6 +238,7 @@ ARTIFACT_SPECS: tuple[ArtifactSpec, ...] = (
             "related prompts",
             "related designs",
             "related roadmaps",
+            "related jira",
         ),
         # Lifecycle status (ADR-051, ADR-061): Planned is the live state and
         # Achieved is the live terminal state (the intent was delivered, so the
@@ -255,6 +261,7 @@ ARTIFACT_SPECS: tuple[ArtifactSpec, ...] = (
                 "related prompts",
                 "related designs",
                 "related roadmaps",
+                "related jira",
             ),
         },
         guidance={
@@ -293,6 +300,7 @@ ARTIFACT_SPECS: tuple[ArtifactSpec, ...] = (
             "related decisions",
             "related roadmaps",
             "related designs",
+            "related jira",
         ),
         # Lifecycle status (ADR-051): Active is the live state, Deprecated retired.
         metadata={"status": ("Active", "Deprecated")},
@@ -311,6 +319,7 @@ ARTIFACT_SPECS: tuple[ArtifactSpec, ...] = (
                 "related decisions",
                 "related roadmaps",
                 "related designs",
+                "related jira",
             ),
         },
         guidance={
@@ -369,6 +378,7 @@ ARTIFACT_SPECS: tuple[ArtifactSpec, ...] = (
             "related decisions",
             "related roadmaps",
             "related prompts",
+            "related jira",
         ),
         # Lifecycle status (ADR-051): same spine as decisions/requirements.
         metadata={"status": ("Proposed", "Accepted", "Superseded", "Deprecated")},
@@ -389,6 +399,7 @@ ARTIFACT_SPECS: tuple[ArtifactSpec, ...] = (
                 "related decisions",
                 "related roadmaps",
                 "related prompts",
+                "related jira",
             ),
         },
         guidance={

--- a/src/rac/core/relationship_types.py
+++ b/src/rac/core/relationship_types.py
@@ -38,6 +38,11 @@ class EdgeSpec:
     # decision legitimately points at the one it retires.
     forbids_target_status: bool = True
     cardinality: str = "many"  # declared; not yet enforced
+    # External-reference family (ADR-087): the target is an external identifier
+    # (e.g. a Jira key or URL), not an in-corpus artifact. External edges are
+    # exempt from range and referential-integrity resolution and are
+    # format-linted instead; the graph export marks them external and unresolved.
+    external: bool = False
 
 
 def _related(target_type: str) -> EdgeSpec:
@@ -67,6 +72,11 @@ REGISTRY: dict[str, EdgeSpec] = {
             inverse="superseded-by",
             forbids_target_status=False,
         ),
+        # External-reference family (ADR-087): a code-defined edge whose target is
+        # a Jira ticket (key or URL), not an in-corpus artifact. No artifact range;
+        # format-linted, not resolved. Future external systems add sibling edges
+        # here rather than re-litigating the exemption.
+        EdgeSpec(name="related_jira", range=(), external=True),
     )
 }
 

--- a/src/rac/core/validation.py
+++ b/src/rac/core/validation.py
@@ -34,6 +34,28 @@ _THEN_RE = re.compile(r"\bthen\b", re.IGNORECASE)
 _HORIZON_VALUES = ("now", "next", "later")
 _QUARTER_RE = re.compile(r"^Q[1-4]\s+\d{4}$")
 
+# External-reference format-lint (ADR-087). A relationship section the registry
+# marks external (## Related Jira) carries external identifiers, not artifact
+# references; each entry must be a well-formed key or URL. Pure and offline — the
+# engine never contacts the external system; ticket existence/state checks are the
+# lore-atlassian satellite's job (ADR-090). New external kinds register a
+# validator here, keyed by the snake_case edge name.
+MALFORMED_EXTERNAL_REFERENCE = "malformed-external-reference"
+_JIRA_KEY_RE = re.compile(r"^[A-Z][A-Z0-9]+-\d+$")
+_URL_RE = re.compile(r"^https?://\S+$")
+_EXTERNAL_LIST_MARKER_RE = re.compile(r"^(?:[-*+]|\d+\.)\s+")
+
+
+def _is_valid_jira_ref(ref: str) -> bool:
+    """A Jira key (``PROJ-1234``) or an http(s) URL — format only, no lookup."""
+    return bool(_JIRA_KEY_RE.match(ref) or _URL_RE.match(ref))
+
+
+# Per external edge kind: (entry validator, human label for the diagnostic).
+_EXTERNAL_REF_RULES: dict[str, tuple[Callable[[str], bool], str]] = {
+    "related_jira": (_is_valid_jira_ref, "Jira key (e.g. PROJ-1234) or URL"),
+}
+
 
 def has_errors(issues: list[Issue]) -> bool:
     """True if any issue is error-severity."""
@@ -50,6 +72,7 @@ def validate(product: Product) -> list[Issue]:
     must be routed explicitly above it.
     """
     issues = _validate_metadata(product)
+    issues += _validate_external_references(product)
     artifact_type = classify(product).type
     if artifact_type == "decision":
         return issues + _validate_decision(product)
@@ -182,6 +205,37 @@ def _validate_metadata(product: Product) -> list[Issue]:
                 "choose one",
             )
         )
+    return issues
+
+
+def _validate_external_references(product: Product) -> list[Issue]:
+    """Format-lint external-reference relationship sections (ADR-087).
+
+    For any relationship section the registry marks external (``## Related
+    Jira``), each entry must be a well-formed external identifier. A pure, offline
+    syntax check — the engine never contacts the external system; existence and
+    state checks live in the lore-atlassian satellite (ADR-090). Runs for every
+    artifact type and is overridable per ADR-053 like any validation rule.
+    """
+    spec = spec_for(classify(product).type)
+    if spec is None:
+        return []
+    issues: list[Issue] = []
+    for section in spec.optional:
+        rule = _EXTERNAL_REF_RULES.get(section.replace(" ", "_"))
+        if rule is None:
+            continue
+        is_valid, label = rule
+        for line in product.sections.get(section, "").splitlines():
+            entry = _EXTERNAL_LIST_MARKER_RE.sub("", line.strip(), count=1).strip()
+            if entry and not is_valid(entry):
+                issues.append(
+                    Issue(
+                        "error",
+                        MALFORMED_EXTERNAL_REFERENCE,
+                        f"## {section.title()} entry {entry!r} is not a valid {label}.",
+                    )
+                )
     return issues
 
 

--- a/src/rac/services/export.py
+++ b/src/rac/services/export.py
@@ -222,7 +222,10 @@ class GraphEdge:
     …) and ``directed`` follows the registry (``supersedes`` is directed; the
     ``related_*`` edges are not). ``resolved`` is False when the reference does
     not resolve uniquely, in which case ``target`` is the literal reference text
-    (no phantom node is invented).
+    (no phantom node is invented). ``external`` is True for an external-reference
+    edge (``related_jira``, ADR-087) whose target is a Jira ticket rather than an
+    in-corpus artifact — always unresolved by design, and distinguished from a
+    dangling in-corpus link, which is unresolved but not external.
     """
 
     source: str
@@ -230,6 +233,7 @@ class GraphEdge:
     type: str
     directed: bool
     resolved: bool
+    external: bool = False
 
     def to_dict(self) -> dict:
         return {
@@ -238,6 +242,7 @@ class GraphEdge:
             "type": self.type,
             "directed": self.directed,
             "resolved": self.resolved,
+            "external": self.external,
         }
 
 
@@ -422,6 +427,7 @@ def build_graph_export(directory: str, recursive: bool = True) -> GraphExport:
                 type=rel.relationship,
                 directed=kind.directional if kind else False,
                 resolved=rel.resolved_path is not None,
+                external=kind.external if kind else False,
             )
         )
     edges.sort(key=lambda edge: (edge.source, edge.type, edge.target))

--- a/src/rac/services/relationships.py
+++ b/src/rac/services/relationships.py
@@ -44,12 +44,20 @@ RELATED_SECTIONS: tuple[str, ...] = (
     "related designs",
 )
 
-# The full relationship-section vocabulary and its canonical ordering, including
-# ``supersedes``. This module owns the ordering; ``stats`` and the
-# ``relationships`` command both render by-type output in this order. ``supersedes``
-# is the one section that does *not* appear in the inspect ``relationships`` dict:
-# there it stays a top-level scalar for backwards compatibility (ADR-007).
-RELATIONSHIP_SECTIONS: tuple[str, ...] = RELATED_SECTIONS + ("supersedes",)
+# External-reference relationship sections (ADR-087): recognized sections whose
+# target is an external identifier (a Jira ticket), not a peer artifact. They are
+# extracted and graphed like the others but format-linted, not resolved. Kept
+# separate from RELATED_SECTIONS, which is exactly the per-artifact-type vocabulary
+# (one ``related <type>s`` per type).
+EXTERNAL_SECTIONS: tuple[str, ...] = ("related jira",)
+
+# The full relationship-section vocabulary and its canonical ordering: the per-type
+# ``related *`` sections, then ``supersedes``, then the external-reference sections.
+# This module owns the ordering; ``stats`` and the ``relationships`` command both
+# render by-type output in this order. ``supersedes`` is the one section that does
+# *not* appear in the inspect ``relationships`` dict: there it stays a top-level
+# scalar for backwards compatibility (ADR-007).
+RELATIONSHIP_SECTIONS: tuple[str, ...] = RELATED_SECTIONS + ("supersedes",) + EXTERNAL_SECTIONS
 
 # A *well-formed* leading Markdown list marker: ``-``, ``*``, ``+``, or ``N.``
 # followed by whitespace. Only these are stripped; any other leading text is
@@ -104,9 +112,10 @@ def extract_relationships(product: Product, spec: ArtifactSpec) -> dict[str, lis
     """Cross-artifact references for ``rac inspect``.
 
     Excludes ``supersedes`` — that stays a top-level scalar in inspect output
-    (ADR-007). Order follows ``spec.optional`` (the artifact's own schema order).
+    (ADR-007). External-reference sections (``related jira``) are included. Order
+    follows ``spec.optional`` (the artifact's own schema order).
     """
-    return _collect(product, spec, RELATED_SECTIONS)
+    return _collect(product, spec, RELATED_SECTIONS + EXTERNAL_SECTIONS)
 
 
 def extract_relationships_full(product: Product, spec: ArtifactSpec) -> dict[str, list[str]]:
@@ -512,6 +521,9 @@ def _resolve_references(
         if spec is None:
             continue
         for section, refs in extract_relationships_full(product, spec).items():
+            edge = edge_spec(section)
+            if edge is not None and edge.external:
+                continue  # external refs (ADR-087) are format-linted, not resolved
             for ref in refs:
                 checked += 1
                 targets = [p for p, _ in index.get(ref.casefold(), [])]
@@ -944,10 +956,25 @@ def relationships_from_corpus(entries: list[CorpusEntry]) -> list[Relationship]:
         if spec is None:
             continue
         for section, refs in extract_relationships_full(product, spec).items():
+            edge = edge_spec(section)
+            external = edge is not None and edge.external
             for ref in refs:
-                targets = [p for p, _ in index.get(ref.casefold(), [])]
                 resolved: str | None = None
                 issue: str | None = None
+                if external:
+                    # External references (ADR-087) resolve to no in-corpus
+                    # artifact by design — an edge for the graph, never "broken".
+                    relationships.append(
+                        Relationship(
+                            source_path=path,
+                            relationship=section,
+                            target=ref,
+                            resolved_path=None,
+                            issue=None,
+                        )
+                    )
+                    continue
+                targets = [p for p, _ in index.get(ref.casefold(), [])]
                 if not targets:
                     issue = ISSUE_TARGET_NOT_FOUND
                 elif len(targets) > 1:

--- a/tests/golden/schema_requirement_human.txt
+++ b/tests/golden/schema_requirement_human.txt
@@ -40,6 +40,8 @@ Optional Sections:
       Description: Design artifacts this artifact references
   - Related Requirements
       Description: Requirement artifacts this artifact references
+  - Related Jira
+      Description: Jira tickets this artifact traces to (external reference, ADR-087)
 
 Metadata Fields:
   - Status: Proposed | Accepted | Superseded | Deprecated

--- a/tests/test_design.py
+++ b/tests/test_design.py
@@ -142,6 +142,7 @@ def test_schema_reference_shape():
         "related decisions",
         "related roadmaps",
         "related prompts",
+        "related jira",
     ]
 
 
@@ -163,6 +164,7 @@ def test_schema_json_includes_optional_relationship_sections(capsys):
         "related_decisions",
         "related_roadmaps",
         "related_prompts",
+        "related_jira",
     ]
 
 

--- a/tests/test_graph_export.py
+++ b/tests/test_graph_export.py
@@ -42,6 +42,21 @@ def test_edges_are_typed_and_sorted():
     assert keys == sorted(keys)
 
 
+def test_related_jira_edge_is_external_and_unresolved(tmp_path):
+    (tmp_path / "adr-001.md").write_text(
+        "# D\n\n## Status\n\nAccepted\n\n## Context\n\nc\n\n## Decision\n\nd\n\n"
+        "## Consequences\n\nq\n\n## Related Jira\n\n- PROJ-1234\n",
+        encoding="utf-8",
+    )
+    graph = build_graph_export(str(tmp_path))
+    jira = [e for e in graph.edges if e.type == "related_jira"]
+    assert len(jira) == 1
+    assert jira[0].target == "PROJ-1234"
+    assert jira[0].resolved is False
+    assert jira[0].external is True  # distinct from a dangling in-corpus link
+    assert "PROJ-1234" not in {n.id for n in graph.nodes}  # no phantom node
+
+
 def test_unresolved_reference_kept_and_flagged():
     graph = build_graph_export(fixture_path("export"))
     by_target = {e.target: e for e in graph.edges}

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -165,6 +165,7 @@ def test_schema_reference_shape():
         "related decisions",
         "related roadmaps",
         "related designs",
+        "related jira",
     ]
 
 
@@ -179,6 +180,7 @@ def test_schema_json_includes_optional_relationship_sections(capsys):
         "related_decisions",
         "related_roadmaps",
         "related_designs",
+        "related_jira",
     ]
 
 

--- a/tests/test_relationship_graph.py
+++ b/tests/test_relationship_graph.py
@@ -48,6 +48,7 @@ def test_registry_declares_built_in_edges():
         "related_prompts",
         "related_designs",
         "supersedes",
+        "related_jira",
     }
     supersedes = edge_spec("supersedes")
     assert supersedes is not None
@@ -55,6 +56,12 @@ def test_registry_declares_built_in_edges():
     assert supersedes.forbids_target_status is False  # the exemption is data-driven
     assert edge_spec("related_decisions").range == ("decision",)
     assert edge_spec("related_decisions").forbids_target_status is True
+    # External-reference family (ADR-087): no artifact range, format-linted not
+    # resolved, surfaced in the graph as external.
+    jira = edge_spec("related_jira")
+    assert jira is not None
+    assert jira.external is True
+    assert jira.range == ()
 
 
 # --- range -------------------------------------------------------------------

--- a/tests/test_relationship_validation.py
+++ b/tests/test_relationship_validation.py
@@ -64,6 +64,19 @@ def test_self_type_relationships_resolve(tmp_path):
     assert report.ok
 
 
+def test_related_jira_is_not_a_broken_reference(tmp_path):
+    # External references (ADR-087) resolve to no in-corpus artifact by design;
+    # they are format-linted by `rac validate`, never reported as not-found here.
+    (tmp_path / "adr-001.md").write_text(
+        _DECISION.format(t="A1")
+        + "\n## Related Jira\n\n- PROJ-1234\n- https://acme.atlassian.net/browse/AB-9\n",
+        encoding="utf-8",
+    )
+    report = validate_relationships(str(tmp_path))
+    assert report.ok
+    assert all(i.code != ISSUE_TARGET_NOT_FOUND for i in report.issues)
+
+
 def test_self_type_broken_reference_is_reported(tmp_path):
     (tmp_path / "v2.md").write_text(
         _ROADMAP.format(t="Two") + "\n## Related Roadmaps\n\n- v-missing\n", encoding="utf-8"

--- a/tests/test_relationships.py
+++ b/tests/test_relationships.py
@@ -59,6 +59,17 @@ def test_parse_references_strips_well_formed_markers():
     assert parse_references(body) == ["ADR-004", "ADR-012", "ADR-020", "ADR-030"]
 
 
+def test_inspect_extracts_related_jira():
+    # External-reference family (ADR-087): a recognized relationship section whose
+    # entries are kept verbatim (Jira keys / URLs), like any other Related section.
+    body = (
+        "# D\n\n## Context\n\nc\n\n## Decision\n\nd\n\n## Consequences\n\nq\n"
+        "\n## Related Jira\n\n- PROJ-1234\n- PROJ-5678\n"
+    )
+    result = inspect_text(body)
+    assert result.relationships["related_jira"] == ["PROJ-1234", "PROJ-5678"]
+
+
 def test_parse_references_preserves_non_marker_text():
     # A hyphen mid-token and a leading dash without a following space are NOT
     # list markers, so the text is preserved verbatim.

--- a/tests/test_roadmap.py
+++ b/tests/test_roadmap.py
@@ -106,6 +106,7 @@ def test_schema_reference_shape():
         "related prompts",
         "related designs",
         "related roadmaps",
+        "related jira",
     ]
 
 
@@ -121,6 +122,7 @@ def test_schema_json_includes_optional_relationship_sections(capsys):
         "related_prompts",
         "related_designs",
         "related_roadmaps",
+        "related_jira",
     ]
 
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -100,6 +100,7 @@ def test_schema_json_requirement_shape(capsys):
         "related_prompts",
         "related_designs",
         "related_requirements",
+        "related_jira",
     ]
     assert "success_metrics" in payload["descriptions"]
     assert "success_metrics" in payload["guidance"]
@@ -118,6 +119,7 @@ def test_schema_json_decision_metadata_values(capsys):
         "related_roadmaps",
         "related_designs",
         "related_decisions",
+        "related_jira",
     ]
     assert payload["metadata"]["status"] == [
         "Proposed",

--- a/tests/test_schema_agreement.py
+++ b/tests/test_schema_agreement.py
@@ -35,7 +35,11 @@ from rac.core.markdown import parse
 from rac.core.metadata import ArtifactMetadata
 from rac.core.schema import available_schemas, schema_reference
 from rac.services.portfolio import build_portfolio_summary
-from rac.services.relationships import RELATED_SECTIONS, RELATIONSHIP_SECTIONS
+from rac.services.relationships import (
+    EXTERNAL_SECTIONS,
+    RELATED_SECTIONS,
+    RELATIONSHIP_SECTIONS,
+)
 
 # --- single sources of truth -------------------------------------------------
 
@@ -116,9 +120,10 @@ def test_status_enums_agree_across_consumers():
 
 
 def test_relationship_kinds_agree_across_consumers():
-    # The vocabulary is RELATED_SECTIONS (the per-type "related X" kinds) plus the
-    # standalone "supersedes"; get_related keys its `outgoing` object by it.
-    assert RELATIONSHIP_SECTIONS == RELATED_SECTIONS + ("supersedes",)
+    # The vocabulary is RELATED_SECTIONS (the per-type "related X" kinds), the
+    # standalone "supersedes", then the external-reference sections (ADR-087);
+    # get_related keys its `outgoing` object by it.
+    assert RELATIONSHIP_SECTIONS == RELATED_SECTIONS + ("supersedes",) + EXTERNAL_SECTIONS
 
     # No spec invents a relationship section outside the vocabulary, and none of
     # the vocabulary is orphaned: the relationship sections appearing across the

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -32,6 +32,29 @@ def test_valid_file_has_no_errors():
     assert codes(issues) == set()  # fully clean: no warnings either
 
 
+# --- External-reference format-lint (ADR-087) --------------------------------
+
+_DECISION_FOR_JIRA = (
+    "# D\n\n## Status\n\nAccepted\n\n## Context\n\nc\n\n## Decision\n\nd\n\n## Consequences\n\nq\n"
+)
+
+
+def test_related_jira_valid_key_and_url_are_not_flagged():
+    body = (
+        _DECISION_FOR_JIRA
+        + "\n## Related Jira\n\n- PROJ-1234\n- https://acme.atlassian.net/browse/AB-9\n"
+    )
+    assert "malformed-external-reference" not in codes(validate(parse(body)))
+
+
+def test_related_jira_malformed_entry_is_an_error():
+    body = _DECISION_FOR_JIRA + "\n## Related Jira\n\n- PROJ-1234\n- not a key\n"
+    bad = [i for i in validate(parse(body)) if i.code == "malformed-external-reference"]
+    assert len(bad) == 1
+    assert bad[0].severity == "error"
+    assert "not a key" in bad[0].message
+
+
 def test_minimal_file_is_valid_but_warns_on_optional_sections():
     issues = validate_fixture("valid", "minimal.md")
     assert not has_errors(issues)


### PR DESCRIPTION
Implements ADR-087 (External-Reference Relationships — Jira and Beyond), ratified in #206.

## What

Adds an **external-reference relationship family** to the code-defined registry (ADR-055): an edge whose target is an external identifier rather than an in-corpus artifact. First instance is `related_jira` (`## Related Jira`), turning "this ADR implements PROJ-1234" into typed corpus data instead of rotting prose.

The engine's scope is **format-lint only, offline and deterministic** (ADR-002). Ticket existence/state checks require a token and live in the `lore-atlassian` satellite (ADR-090), never the engine.

## Changes

- **Registry** (`core/relationship_types.py`): `EdgeSpec.external` flag exempting an edge from artifact-range resolution; `related_jira` edge with no artifact range, `external=True`.
- **Specs** (`core/artifacts.py`): `## Related Jira` declared as an optional section on all five artifact types (append-only, ADR-007).
- **Validation** (`core/validation.py`): `malformed-external-reference` (error, overridable per ADR-053). A Jira entry is a key (`PROJ-1234`) or an http(s) URL; per-external-kind validators keyed by edge name. The engine never contacts Jira.
- **Resolution** (`services/relationships.py`): external sections kept separate from the per-type `RELATED_SECTIONS`; `_resolve_references` skips them, and `relationships_from_corpus` emits them with `resolved_path=None`, `issue=None` — an edge for the graph, never "broken".
- **Graph export** (`services/export.py`): additive `external` field (ADR-074). A Jira edge is `resolved=false, external=true`, distinct from a dangling in-corpus link.
- **Docs** (`docs/relationships.md`): the `## Related Jira` syntax, offline format-lint, graph-export shape, and the satellite boundary.
- **ADR lifecycle**: ADR-087 flipped Proposed → Accepted; agent-rules managed block regenerated (drift-check stays in sync).

## Verification

- Full `pytest` suite green (1668 passed, 1 skipped).
- `ruff check` · `ruff format --check` clean; `mypy` clean (only environmental missing-stub noise for textual/mcp/yaml).
- Corpus gates exit 0: `rac validate rac/`, `rac relationships rac/ --validate` (1536 relationships, 0 issues), `rac review rac/` (no priority 1–2), `rac export rac/ --agent-rules --check` in-sync.