### PR TITLE
feat(relationships): add config-driven external ticketing edges

### DIFF
--- a/.cursor/rules
+++ b/.cursor/rules
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: 7ff46bfd5bc5da127399bcf1416d9b1cdaf42a3414212529fb231ae01d8700ea) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: b133cd2ff821db8329714794bebe19ca1fef61436f54f237f4f02fe38c835efe) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -61,4 +61,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KVTS86ZGVJV7** — ADR-077: The Two-Gate Capture Write Model _(Architecture)_
 - **RAC-KW2YW6XK593X** — ADR-084: Read-Access Audit Recorder _(Product)_
 - **RAC-KW47GFBHK31W** — ADR-086: Air-Gap Posture and Enterprise Telemetry Hard-Lock _(Product)_
+- **RAC-KW47GGS85CKG** — ADR-087: External-Reference Relationships (Jira and Beyond) _(Technical)_
 <!-- END RAC MANAGED BLOCK -->

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: 7ff46bfd5bc5da127399bcf1416d9b1cdaf42a3414212529fb231ae01d8700ea) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: b133cd2ff821db8329714794bebe19ca1fef61436f54f237f4f02fe38c835efe) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -61,4 +61,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KVTS86ZGVJV7** — ADR-077: The Two-Gate Capture Write Model _(Architecture)_
 - **RAC-KW2YW6XK593X** — ADR-084: Read-Access Audit Recorder _(Product)_
 - **RAC-KW47GFBHK31W** — ADR-086: Air-Gap Posture and Enterprise Telemetry Hard-Lock _(Product)_
+- **RAC-KW47GGS85CKG** — ADR-087: External-Reference Relationships (Jira and Beyond) _(Technical)_
 <!-- END RAC MANAGED BLOCK -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: 7ff46bfd5bc5da127399bcf1416d9b1cdaf42a3414212529fb231ae01d8700ea) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: b133cd2ff821db8329714794bebe19ca1fef61436f54f237f4f02fe38c835efe) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -61,4 +61,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KVTS86ZGVJV7** — ADR-077: The Two-Gate Capture Write Model _(Architecture)_
 - **RAC-KW2YW6XK593X** — ADR-084: Read-Access Audit Recorder _(Product)_
 - **RAC-KW47GFBHK31W** — ADR-086: Air-Gap Posture and Enterprise Telemetry Hard-Lock _(Product)_
+- **RAC-KW47GGS85CKG** — ADR-087: External-Reference Relationships (Jira and Beyond) _(Technical)_
 <!-- END RAC MANAGED BLOCK -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ to the corpus artifact and they load through the imports below.
 - Previous series: `rac/roadmaps/v0.21.x-editor/` (complete)
 - Decisions (ADRs): `rac/decisions/`
 
-<!-- BEGIN RAC MANAGED BLOCK (digest: 7ff46bfd5bc5da127399bcf1416d9b1cdaf42a3414212529fb231ae01d8700ea) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: b133cd2ff821db8329714794bebe19ca1fef61436f54f237f4f02fe38c835efe) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -86,4 +86,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KVTS86ZGVJV7** — ADR-077: The Two-Gate Capture Write Model _(Architecture)_
 - **RAC-KW2YW6XK593X** — ADR-084: Read-Access Audit Recorder _(Product)_
 - **RAC-KW47GFBHK31W** — ADR-086: Air-Gap Posture and Enterprise Telemetry Hard-Lock _(Product)_
+- **RAC-KW47GGS85CKG** — ADR-087: External-Reference Relationships (Jira and Beyond) _(Technical)_
 <!-- END RAC MANAGED BLOCK -->

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1049,10 +1049,16 @@ configuration, not artifact meaning — it never dictates folder structure.
 
 - **Input:** `rac init [directory]` — defaults to the current directory.
 - **Options:** `--key KEY` (default `RAC`; 2–10 uppercase alphanumeric
-  characters starting with a letter) · `--json`
+  characters starting with a letter) · `--ticketing PROVIDER` · `--json`
+- **`--ticketing PROVIDER`** records the external ticketing system for
+  `## Related Tickets` references (ADR-087) as `ticketing.provider` in
+  `.rac/config.yaml` — one of `jira`, `github`, `linear`, `azure-devops`,
+  `servicenow`, or `none`. Omit it to leave the provider unset (tickets stay
+  unvalidated). Written at creation; edit `.rac/config.yaml` to change it later.
+  See [relationships](relationships.md#external-tickets).
 - **Exit codes:** `0` initialized, or already initialized with the same key
   (idempotent) · `1` a different key is already established (never silently
-  rewritten) · `2` invalid key or not a directory
+  rewritten) · `2` invalid key, unknown ticketing provider, or not a directory
 
 After a successful init on a real terminal, `rac init` asks one one-time
 question — "Share anonymous usage to help shape Lore? [y/N]" — defaulting to
@@ -1062,6 +1068,7 @@ never appears with `--json`, in pipes, or in CI. See `rac telemetry`.
 ```bash
 rac init
 rac init --key PROJ
+rac init --key ACME --ticketing jira
 rac init docs/ --json
 ```
 

--- a/docs/relationships.md
+++ b/docs/relationships.md
@@ -34,6 +34,59 @@ is stripped; the rest of the line is the id, matched case-insensitively against 
 relationship section is only recognized on a type that declares it (so an unknown
 document contributes no relationships).
 
+## External tickets
+
+`## Related Tickets` links an artifact to a ticket in your tracker — an *external*
+reference that deliberately does **not** resolve to an in-corpus artifact (ADR-087).
+It turns change traceability ("this ADR implements PROJ-1234") into corpus data
+instead of prose, and the same heading works in every repository:
+
+```markdown
+## Related Tickets
+- PROJ-1234
+- https://acme.atlassian.net/browse/PROJ-5678
+```
+
+**Pick your tracker once, at init.** Organisations standardise on a single
+ticketing system, so the *provider* is repository configuration rather than a
+choice per reference — set it with `rac init --ticketing <provider>` (or edit
+`.rac/config.yaml`):
+
+```yaml
+# .rac/config.yaml
+ticketing:
+  provider: jira      # jira | github | linear | azure-devops | servicenow | none
+```
+
+Each entry is a provider-specific key or a full URL:
+
+| Provider | Key example | also accepts |
+| --- | --- | --- |
+| `jira` | `PROJ-1234` | any `https://…` URL |
+| `github` | `owner/repo#123` | any `https://…` URL |
+| `linear` | `ENG-123` | any `https://…` URL |
+| `azure-devops` | `1234` or `AB#1234` | any `https://…` URL |
+| `servicenow` | `INC0010023` | any `https://…` URL |
+
+The engine does **format-lint only, offline**: `rac validate` flags an entry that
+is not a well-formed key or URL for the configured provider
+(`malformed-ticket-reference`, overridable per
+[ADR-053](https://github.com/itsthelore/rac-core/blob/main/rac/decisions/adr-053-validation-severity-overrides.md)),
+and `rac relationships --validate` never reports a ticket as a broken reference.
+With no provider configured the section still works, simply unvalidated. Because
+the provider is named in config, shape-identical keys across trackers (Linear's
+`ENG-123` and Jira's `PROJ-1234` match the same pattern) are never ambiguous — the
+engine validates against exactly one format.
+
+The engine **never contacts the tracker**: checking that a ticket exists or is in
+an allowed state needs a token and lives in a satellite (`lore-atlassian` for Jira,
+ADR-090), not the engine (ADR-002).
+
+In `rac export --graph` an external edge carries `"external": true`,
+`"resolved": false`, and the configured `"provider"`, so a graph backend can tell a
+deliberate ticket link from a dangling in-corpus reference (both are unresolved,
+only the external one is marked).
+
 ## Viewing relationships
 
 ```bash

--- a/rac/decisions/adr-087-external-reference-relationships.md
+++ b/rac/decisions/adr-087-external-reference-relationships.md
@@ -7,7 +7,7 @@ type: decision
 
 ## Status
 
-Proposed
+Accepted
 
 ## Category
 
@@ -15,41 +15,63 @@ Technical
 
 ## Context
 
-Change traceability in many organisations runs through Jira. Without a typed way
-to link an artifact to its ticket, teams jam ticket IDs into prose and the link
+Change traceability in many organisations runs through a ticketing system —
+Jira, GitHub Issues, Linear, Azure DevOps, ServiceNow. Without a typed way to
+link an artifact to its ticket, teams jam ticket IDs into prose and the link
 goes stale; with one, the corpus gains regulator-grade traceability — "this ADR
-implements this Jira" becomes a typed edge.
+implements this ticket" becomes a typed edge.
 
 The relationship registry (ADR-055) is code-defined and enforces each edge's
 range to in-corpus artifact types; resolution is deterministic and Git-native
-(ADR-016). A Jira ticket is not an artifact, so it cannot be a normal edge
-target. ADR-052 defers fully custom, repo-declared edge kinds. ADR-010 already
+(ADR-016). A ticket is not an artifact, so it cannot be a normal edge target.
+ADR-052 defers fully custom, repo-declared edge kinds. ADR-010 already
 recognises that untyped targets exist and are legitimate. The need is a typed,
 lintable link to an *external* system that deliberately does not resolve to a
 local artifact.
 
+A key observation shapes the design: **an organisation standardises on one
+ticketing system.** It is rare for a corpus to reference Jira *and* GitHub *and*
+Linear at once. So the system is a per-repository choice, not a set of always-on
+edges the author must pick between — and that choice belongs in repository
+configuration set at `rac init` (ADR-088), the same place the repository key
+lives.
+
 ## Decision
 
-Introduce an **external-reference relationship family**: code-defined edges whose
-target is an external identifier rather than an in-corpus artifact, explicitly
-exempt from artifact-range resolution (the ADR-010 untyped-target shape,
-generalised).
+Introduce a single **external-reference relationship edge**, `related_tickets`
+(declared via `## Related Tickets`), whose target is an external ticket rather
+than an in-corpus artifact — explicitly exempt from artifact-range resolution
+(the ADR-010 untyped-target shape, generalised). The ticketing **provider is
+per-repository configuration**, not a per-provider edge.
 
-- The first instance is `related_jira`, declared via a `## Related Jira` section.
-  The mechanism is general so future external edges (for example GitHub issues or
-  ServiceNow records) reuse the same exemption rather than each re-litigating it.
-- **Syntax:** one item per line — a Jira key (`PROJ-1234`) or a full Jira URL.
-- **Engine scope is format-lint only.** `rac validate` checks the syntax
-  deterministically and offline and flags malformed entries; it never contacts
-  Jira and an external reference never affects whether the corpus is valid beyond
-  its format.
+- **One section, one edge.** `## Related Tickets` is recognised on all five
+  artifact types. There is no `## Related Jira` / `## Related GitHub` /
+  `## Related Linear` proliferation: the heading is stable across every repo, and
+  the system it points at is named once, centrally, in config.
+- **Provider is config (ADR-088).** `.rac/config.yaml` carries
+  `ticketing.provider`, one of `jira`, `github`, `linear`, `azure-devops`,
+  `servicenow`, or `none`, written by `rac init --ticketing <provider>`. Adding a
+  provider is a code change (a format validator), not a new ADR each time.
+- **Syntax:** one item per line — a provider-specific key or a full URL (e.g.
+  Jira `PROJ-1234`, GitHub `owner/repo#123`, Linear `ENG-123`, Azure DevOps
+  `1234`/`AB#1234`, ServiceNow `INC0010023`).
+- **Engine scope is format-lint only.** `rac validate` checks each entry against
+  the configured provider's key/URL format, deterministically and offline, and
+  flags malformed entries (`malformed-ticket-reference`, overridable per
+  ADR-053). With no provider configured the section still works, simply
+  unvalidated. The engine never contacts the ticketing system.
+- **Config disambiguates colliding key shapes.** Linear keys (`ENG-123`) are
+  shape-identical to Jira keys (`PROJ-1234`); because the provider is named in
+  config, the engine validates against exactly one format — there is nothing to
+  guess. This is a direct argument for config-over-format-guessing.
 - **Existence and state checks** (does the ticket exist; is it in an allowed
-  state) require a token and a network call and therefore live in the
-  `lore-atlassian` satellite (ADR-090), never in the engine (ADR-002, ADR-073).
+  state) require a token and a network call and therefore live in a satellite
+  (`lore-atlassian` for Jira, ADR-090), never in the engine (ADR-002, ADR-073).
   Enforcement is at write time, not agent time (ADR-067).
-- **Graph export** surfaces the external edge as a typed edge marked unresolved
-  or external (ADR-074), so graph backends see the relationship without the
-  engine pretending to resolve it.
+- **Graph export** surfaces the edge as typed, marked `external: true` and
+  `resolved: false`, carrying the configured `provider` (ADR-074), so graph
+  backends see the relationship and its system without the engine pretending to
+  resolve it.
 
 ## Consequences
 
@@ -57,8 +79,11 @@ generalised).
 
 - Typed, lintable change traceability the corpus can carry and the graph export
   can surface, without a database and without a network dependency in the engine.
-- A reusable external-reference shape means the next external system is additive,
-  not another exemption debate.
+- One stable section across all repositories: authors and agents never choose
+  among per-system headings, and the corpus does not grow an optional section per
+  provider.
+- The provider lives in committed config, so the ticketing system is a one-line
+  repository decision (ADR-088) and the key-shape collision dissolves.
 
 ### Negative
 
@@ -66,19 +91,33 @@ generalised).
   engine alone cannot tell a stale ticket from a live one.
 - A second class of edge (external-target) adds nuance to the registry and the
   graph export contract.
+- A repository that genuinely uses two ticketing systems is not supported; this
+  is an accepted trade-off given the one-system-per-org reality.
 
 ### Risks
 
-- Pressure to make the engine call Jira "just to validate the ticket".
-  Mitigation: the engine is format-lint only by decision; state checks are
-  satellite-only (ADR-002).
+- Pressure to make the engine call the ticketing system "just to validate the
+  ticket". Mitigation: the engine is format-lint only by decision; state checks
+  are satellite-only (ADR-002).
 - The exemption is read as the door to arbitrary custom edge kinds (ADR-052).
-  Mitigation: the family is code-defined here, not repo-declared; new external
-  kinds are added by ADR, like any registry change.
+  Mitigation: the edge is code-defined here, not repo-declared; the provider set
+  grows by code change, not by repo configuration of new edge kinds.
 
 ## Alternatives Considered
 
-### Keep Jira IDs in prose
+### A named edge per ticketing system
+
+One always-on edge per provider — `## Related Jira`, `## Related GitHub`,
+`## Related Linear`, … — each with its own registry entry.
+
+#### Disadvantages
+
+- Section proliferation across all five artifact types; the author must choose a
+  heading per reference. It does not match the one-system-per-org reality, and it
+  reintroduces the Linear/Jira key-shape collision (format alone cannot tell
+  `ENG-123` from a Jira key) that a configured provider removes outright.
+
+### Keep ticket IDs in prose
 
 No typed edge; mention the ticket in the body.
 
@@ -87,13 +126,13 @@ No typed edge; mention the ticket in the body.
 - Untyped, unlinted, and invisible to the graph export; the link rots and
   traceability is unverifiable.
 
-### Force a Jira edge into the existing artifact-range registry
+### Force a ticket edge into the existing artifact-range registry
 
-Add `related_jira` with a normal range.
+Add the edge with a normal artifact range.
 
 #### Disadvantages
 
-- A Jira ticket is not an artifact; range resolution would always fail. The
+- A ticket is not an artifact; range resolution would always fail. The
   external-target exemption is the correct mechanism, not a workaround.
 
 ### A full custom-relationship-type system
@@ -102,21 +141,25 @@ Let repos declare arbitrary edge kinds in config.
 
 #### Disadvantages
 
-- Deferred by ADR-052; far more surface than the need. A code-defined external
-  family covers the real requirement now.
+- Deferred by ADR-052; far more surface than the need. A single code-defined
+  external edge with a configured provider covers the real requirement now.
 
-The external-reference family with `related_jira` as its first instance is
-selected.
+A single configured external-ticket edge (`related_tickets`, provider in
+`.rac/config.yaml`) is selected.
 
 ## Relationship to Other Decisions
 
 - ADR-055, ADR-016: extends the code-defined registry with an external-target
   edge class; resolution stays deterministic and Git-native for in-corpus edges.
 - ADR-010: generalises the untyped-target exemption to typed external references.
-- ADR-052: custom repo-declared kinds remain deferred; this family is
-  code-defined.
-- ADR-074: external edges surface in the typed graph export, marked unresolved.
+- ADR-052: custom repo-declared kinds remain deferred; this edge is code-defined,
+  and the provider — not the edge kind — is the configured value.
+- ADR-074: the external edge surfaces in the typed graph export, marked
+  unresolved/external and carrying the provider.
+- ADR-088: the ticketing provider is a `rac init` / repository-config knob, set
+  alongside the repository key.
+- ADR-053: the format-lint severity is overridable like any validation rule.
 - ADR-067, ADR-073, ADR-090: write-time format-lint in the engine; token-gated
-  state checks in `lore-atlassian`.
+  state checks in the per-provider satellite.
 - ADR-085: an instance of the rule — the network half is a satellite, the
   deterministic half is the engine, decided for everyone.

--- a/src/rac/cli.py
+++ b/src/rac/cli.py
@@ -105,7 +105,7 @@ from rac.core.templates import (
     TemplateResourceMissing,
     available_templates,
 )
-from rac.core.validation import has_errors
+from rac.core.validation import TICKETING_PROVIDER_NAMES, has_errors
 from rac.output.portal import PortalSeamMissing, PortalShellMissing
 from rac.services import coverage as coverage_service
 from rac.services import doctor
@@ -136,6 +136,7 @@ from rac.services.ingest import ConversionError, UnsupportedDocument, ingest
 from rac.services.init import (
     DEFAULT_KEY,
     InvalidRepositoryKey,
+    InvalidTicketingProvider,
     MalformedRepositoryConfig,
     RepositoryKeyConflict,
     init_repository,
@@ -1008,8 +1009,8 @@ def cmd_init(args: argparse.Namespace) -> int:
         print(f"rac: not a directory: {args.directory}", file=sys.stderr)
         raise SystemExit(EXIT_USAGE)
     try:
-        result = init_repository(args.directory, key=args.key)
-    except InvalidRepositoryKey as exc:
+        result = init_repository(args.directory, key=args.key, ticketing=args.ticketing)
+    except (InvalidRepositoryKey, InvalidTicketingProvider) as exc:
         print(f"rac: {exc}", file=sys.stderr)
         raise SystemExit(EXIT_USAGE) from None
     except (RepositoryKeyConflict, MalformedRepositoryConfig) as exc:
@@ -1909,6 +1910,15 @@ def build_parser() -> argparse.ArgumentParser:
         default=DEFAULT_KEY,
         help="Repository key used as the artifact ID prefix (default: RAC; "
         "2-10 uppercase alphanumeric characters starting with a letter).",
+    )
+    p_init.add_argument(
+        "--ticketing",
+        choices=TICKETING_PROVIDER_NAMES,
+        default=None,
+        metavar="PROVIDER",
+        help="External ticketing provider for ## Related Tickets references "
+        f"(one of: {', '.join(TICKETING_PROVIDER_NAMES)}). Writes ticketing.provider "
+        "to .rac/config.yaml; omit to leave it unset (ADR-087).",
     )
     p_init.add_argument(
         "--json", action="store_true", help="Emit JSON instead of human-readable text."

--- a/src/rac/core/artifacts.py
+++ b/src/rac/core/artifacts.py
@@ -95,6 +95,8 @@ RELATIONSHIP_DESCRIPTIONS: dict[str, str] = {
     "related prompts": "Prompt artifacts this artifact references",
     "related designs": "Design artifacts this artifact references",
     "supersedes": "The artifact this one supersedes",
+    "related tickets": "External tickets this artifact traces to; provider set by"
+    " .rac/config.yaml ticketing.provider (ADR-087)",
 }
 
 
@@ -119,6 +121,7 @@ ARTIFACT_SPECS: tuple[ArtifactSpec, ...] = (
             "related prompts",
             "related designs",
             "related requirements",
+            "related tickets",
         ),
         # Lifecycle status (ADR-051): optional, validated-if-present. Status stays
         # a knowledge lifecycle (current vs replaced), never work/delivery state.
@@ -136,6 +139,7 @@ ARTIFACT_SPECS: tuple[ArtifactSpec, ...] = (
                 "related prompts",
                 "related designs",
                 "related requirements",
+                "related tickets",
             ),
         },
         guidance={
@@ -180,6 +184,7 @@ ARTIFACT_SPECS: tuple[ArtifactSpec, ...] = (
             "related roadmaps",
             "related designs",
             "related decisions",
+            "related tickets",
         ),
         metadata={
             "status": ("Proposed", "Accepted", "Superseded", "Deprecated"),
@@ -192,6 +197,7 @@ ARTIFACT_SPECS: tuple[ArtifactSpec, ...] = (
             "related roadmaps",
             "related designs",
             "related decisions",
+            "related tickets",
         ),
         guidance={
             "context": (
@@ -233,6 +239,7 @@ ARTIFACT_SPECS: tuple[ArtifactSpec, ...] = (
             "related prompts",
             "related designs",
             "related roadmaps",
+            "related tickets",
         ),
         # Lifecycle status (ADR-051, ADR-061): Planned is the live state and
         # Achieved is the live terminal state (the intent was delivered, so the
@@ -255,6 +262,7 @@ ARTIFACT_SPECS: tuple[ArtifactSpec, ...] = (
                 "related prompts",
                 "related designs",
                 "related roadmaps",
+                "related tickets",
             ),
         },
         guidance={
@@ -293,6 +301,7 @@ ARTIFACT_SPECS: tuple[ArtifactSpec, ...] = (
             "related decisions",
             "related roadmaps",
             "related designs",
+            "related tickets",
         ),
         # Lifecycle status (ADR-051): Active is the live state, Deprecated retired.
         metadata={"status": ("Active", "Deprecated")},
@@ -311,6 +320,7 @@ ARTIFACT_SPECS: tuple[ArtifactSpec, ...] = (
                 "related decisions",
                 "related roadmaps",
                 "related designs",
+                "related tickets",
             ),
         },
         guidance={
@@ -369,6 +379,7 @@ ARTIFACT_SPECS: tuple[ArtifactSpec, ...] = (
             "related decisions",
             "related roadmaps",
             "related prompts",
+            "related tickets",
         ),
         # Lifecycle status (ADR-051): same spine as decisions/requirements.
         metadata={"status": ("Proposed", "Accepted", "Superseded", "Deprecated")},
@@ -389,6 +400,7 @@ ARTIFACT_SPECS: tuple[ArtifactSpec, ...] = (
                 "related decisions",
                 "related roadmaps",
                 "related prompts",
+                "related tickets",
             ),
         },
         guidance={

--- a/src/rac/core/relationship_types.py
+++ b/src/rac/core/relationship_types.py
@@ -38,6 +38,12 @@ class EdgeSpec:
     # decision legitimately points at the one it retires.
     forbids_target_status: bool = True
     cardinality: str = "many"  # declared; not yet enforced
+    # External-reference family (ADR-087): the target is an external identifier
+    # (a ticket key or URL), not an in-corpus artifact. External edges are exempt
+    # from range and referential-integrity resolution and are format-linted
+    # instead (the provider is per-repo config, ADR-088); the graph export marks
+    # them external and unresolved.
+    external: bool = False
 
 
 def _related(target_type: str) -> EdgeSpec:
@@ -67,6 +73,13 @@ REGISTRY: dict[str, EdgeSpec] = {
             inverse="superseded-by",
             forbids_target_status=False,
         ),
+        # External-reference family (ADR-087): a single code-defined edge whose
+        # target is an external ticket (a key or URL), not an in-corpus artifact.
+        # No artifact range; format-linted against the per-repo ticketing provider
+        # (ADR-088), never resolved. Organisations standardise on one ticketing
+        # system, so the system is a repo-config choice rather than a per-provider
+        # edge — future external systems reuse this edge, not a sibling one.
+        EdgeSpec(name="related_tickets", range=(), external=True),
     )
 }
 

--- a/src/rac/core/validation.py
+++ b/src/rac/core/validation.py
@@ -34,13 +34,60 @@ _THEN_RE = re.compile(r"\bthen\b", re.IGNORECASE)
 _HORIZON_VALUES = ("now", "next", "later")
 _QUARTER_RE = re.compile(r"^Q[1-4]\s+\d{4}$")
 
+# External ticketing format-lint (ADR-087). ``## Related Tickets`` carries
+# external ticket identifiers, not artifact references; each entry must be a
+# well-formed key or URL for the repository's configured provider (ADR-088).
+# Pure and offline — the engine never contacts the ticketing system; existence
+# and state checks are a satellite's job (ADR-090). The provider is resolved from
+# ``.rac/config.yaml`` by the services layer and passed into ``validate``; core
+# stays config-free. Organisations standardise on one provider, so exactly one
+# validator is ever active per repository.
+MALFORMED_TICKET_REFERENCE = "malformed-ticket-reference"
+TICKETING_SECTION = "related tickets"  # normalized ## Related Tickets
+
+_TICKET_LIST_MARKER_RE = re.compile(r"^(?:[-*+]|\d+\.)\s+")
+_URL_RE = re.compile(r"^https?://\S+$")
+_JIRA_KEY_RE = re.compile(r"^[A-Z][A-Z0-9]+-\d+$")
+_LINEAR_KEY_RE = re.compile(r"^[A-Z][A-Z0-9]*-\d+$")
+_GITHUB_REF_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+#\d+$")
+_ADO_REF_RE = re.compile(r"^(?:AB#)?\d+$")
+_SERVICENOW_RE = re.compile(r"^[A-Z]{2,}\d{5,}$")
+
+
+def _ticket_validator(pattern: re.Pattern[str]) -> Callable[[str], bool]:
+    """An entry validator accepting ``pattern`` or any http(s) URL."""
+
+    def is_valid(entry: str) -> bool:
+        return bool(_URL_RE.match(entry) or pattern.match(entry))
+
+    return is_valid
+
+
+# Per ticketing provider: (entry validator, human label for the diagnostic). The
+# key set is the recognised provider vocabulary; ``none`` (no provider) skips the
+# format-lint entirely. Adding a provider is a code change here, not a new ADR.
+TICKETING_PROVIDERS: dict[str, tuple[Callable[[str], bool], str]] = {
+    "jira": (_ticket_validator(_JIRA_KEY_RE), "Jira key (e.g. PROJ-1234) or URL"),
+    "github": (_ticket_validator(_GITHUB_REF_RE), "GitHub issue (e.g. owner/repo#123) or URL"),
+    "linear": (_ticket_validator(_LINEAR_KEY_RE), "Linear key (e.g. ENG-123) or URL"),
+    "azure-devops": (
+        _ticket_validator(_ADO_REF_RE),
+        "Azure DevOps work item (e.g. 1234 or AB#1234) or URL",
+    ),
+    "servicenow": (_ticket_validator(_SERVICENOW_RE), "ServiceNow record (e.g. INC0010023) or URL"),
+}
+
+# The recognised provider names, plus ``none`` — the config layer validates a
+# ticketing.provider value against this set (ADR-088).
+TICKETING_PROVIDER_NAMES: tuple[str, ...] = (*TICKETING_PROVIDERS, "none")
+
 
 def has_errors(issues: list[Issue]) -> bool:
     """True if any issue is error-severity."""
     return any(issue.severity == "error" for issue in issues)
 
 
-def validate(product: Product) -> list[Issue]:
+def validate(product: Product, *, ticketing_provider: str | None = None) -> list[Issue]:
     """Check ``product`` and return all structural and quality findings.
 
     Dispatches on artifact type. Each type with its own schema is routed
@@ -48,8 +95,16 @@ def validate(product: Product) -> list[Issue]:
     backwards-compatibility fallback for Unknown/legacy documents (and RAC's
     original Requirement rules), *not* the long-term model — new artifact types
     must be routed explicitly above it.
+
+    ``ticketing_provider`` enables the external ticket format-lint (ADR-087): when
+    set to a recognised provider, ``## Related Tickets`` entries are checked
+    against that provider's key/URL format. It defaults to ``None`` so the many
+    pure ``validate(product)`` callers are unaffected; the config-aware service
+    layer injects the repository's configured provider (ADR-088). Stays
+    deterministic — a pure function of ``(product, ticketing_provider)``.
     """
     issues = _validate_metadata(product)
+    issues += _validate_ticketing_references(product, ticketing_provider)
     artifact_type = classify(product).type
     if artifact_type == "decision":
         return issues + _validate_decision(product)
@@ -182,6 +237,39 @@ def _validate_metadata(product: Product) -> list[Issue]:
                 "choose one",
             )
         )
+    return issues
+
+
+def _validate_ticketing_references(product: Product, provider: str | None) -> list[Issue]:
+    """Format-lint ``## Related Tickets`` against the configured provider (ADR-087).
+
+    Each entry must be a well-formed key or URL for the repository's ticketing
+    provider. A pure, offline syntax check — the engine never contacts the
+    ticketing system; existence and state checks live in a satellite (ADR-090).
+    No provider (``None`` or ``"none"``) means no lint: the edge still works, it
+    is simply unvalidated. Only an artifact type that declares the section is
+    linted. Overridable per ADR-053 like any rule.
+    """
+    if not provider or provider == "none":
+        return []
+    rule = TICKETING_PROVIDERS.get(provider)
+    if rule is None:
+        return []  # the config layer validates the name; be lenient here
+    spec = spec_for(classify(product).type)
+    if spec is None or TICKETING_SECTION not in spec.optional:
+        return []
+    is_valid, label = rule
+    issues: list[Issue] = []
+    for line in product.sections.get(TICKETING_SECTION, "").splitlines():
+        entry = _TICKET_LIST_MARKER_RE.sub("", line.strip(), count=1).strip()
+        if entry and not is_valid(entry):
+            issues.append(
+                Issue(
+                    "error",
+                    MALFORMED_TICKET_REFERENCE,
+                    f"## Related Tickets entry {entry!r} is not a valid {label}.",
+                )
+            )
     return issues
 
 

--- a/src/rac/services/export.py
+++ b/src/rac/services/export.py
@@ -52,6 +52,7 @@ from rac.core.identity import artifact_identifier, artifact_identifiers
 from rac.core.models import Product
 from rac.core.relationship_types import edge_spec
 
+from .init import load_ticketing_provider
 from .inspect import canonical_value
 from .relationships import relationships_from_corpus
 
@@ -222,7 +223,12 @@ class GraphEdge:
     …) and ``directed`` follows the registry (``supersedes`` is directed; the
     ``related_*`` edges are not). ``resolved`` is False when the reference does
     not resolve uniquely, in which case ``target`` is the literal reference text
-    (no phantom node is invented).
+    (no phantom node is invented). ``external`` is True for an external-reference
+    edge (``related_tickets``, ADR-087) whose target is an external ticket rather
+    than an in-corpus artifact — always unresolved by design, and distinguished
+    from a dangling in-corpus link (unresolved but not external); ``provider``
+    carries the repository's configured ticketing system (ADR-088) for external
+    edges, else None.
     """
 
     source: str
@@ -230,6 +236,8 @@ class GraphEdge:
     type: str
     directed: bool
     resolved: bool
+    external: bool = False
+    provider: str | None = None
 
     def to_dict(self) -> dict:
         return {
@@ -238,6 +246,8 @@ class GraphEdge:
             "type": self.type,
             "directed": self.directed,
             "resolved": self.resolved,
+            "external": self.external,
+            "provider": self.provider,
         }
 
 
@@ -390,6 +400,8 @@ def build_graph_export(directory: str, recursive: bool = True) -> GraphExport:
     False`` rather than dropped (REQ-004). Deterministic — no timestamps.
     """
     entries = list(walk_corpus(directory, recursive=recursive))
+    # The configured ticketing provider tags external edges (ADR-088); read once.
+    provider = load_ticketing_provider(directory)
 
     canonical_by_path: dict[str, str] = {}
     nodes: list[GraphNode] = []
@@ -412,6 +424,7 @@ def build_graph_export(directory: str, recursive: bool = True) -> GraphExport:
     edges: list[GraphEdge] = []
     for rel in relationships_from_corpus(entries):
         kind = edge_spec(rel.relationship)
+        external = kind.external if kind else False
         target = (
             canonical_by_path[rel.resolved_path] if rel.resolved_path is not None else rel.target
         )
@@ -422,6 +435,8 @@ def build_graph_export(directory: str, recursive: bool = True) -> GraphExport:
                 type=rel.relationship,
                 directed=kind.directional if kind else False,
                 resolved=rel.resolved_path is not None,
+                external=external,
+                provider=provider if external else None,
             )
         )
     edges.sort(key=lambda edge: (edge.source, edge.type, edge.target))

--- a/src/rac/services/init.py
+++ b/src/rac/services/init.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
     from rac.services.gate import EnforcementPolicy
 
 from rac.core.overrides import EMPTY, RULE_VALUES, TYPE_VALUES, SeverityOverrides
+from rac.core.validation import TICKETING_PROVIDER_NAMES
 from rac.errors import RACError
 
 # Repository key contract (v0.7.11): uppercase alphanumeric, leading letter,
@@ -44,6 +45,17 @@ class InvalidRepositoryKey(RACError):
         super().__init__(
             f"invalid repository key: {key!r} (expected 2-10 uppercase "
             "alphanumeric characters starting with a letter, e.g. RAC)"
+        )
+
+
+class InvalidTicketingProvider(RACError):
+    """The requested ticketing provider is not a recognised provider (usage error)."""
+
+    def __init__(self, provider: str):
+        self.provider = provider
+        super().__init__(
+            f"invalid ticketing provider: {provider!r} "
+            f"(expected one of {', '.join(TICKETING_PROVIDER_NAMES)})"
         )
 
 
@@ -249,16 +261,61 @@ def _parse_severity_map(
     return parsed
 
 
-def init_repository(directory: str, key: str = DEFAULT_KEY) -> InitResult:
+def load_ticketing_provider(start_dir: str) -> str | None:
+    """Read ``ticketing.provider`` from the nearest config (ADR-087 / ADR-088).
+
+    Returns the configured external ticketing provider (``jira``, ``github``,
+    ``linear``, ``azure-devops``, ``servicenow``, or ``none``), or ``None`` when
+    there is no config file or no ``ticketing`` section. An organisation
+    standardises on one provider, so this is the single value the external
+    ticket format-lint reads (ADR-087). A non-mapping section or an unrecognised
+    provider raises :class:`MalformedRepositoryConfig`, mirroring
+    :func:`load_overrides` — config is never silently ignored.
+    """
+    config_path = find_config_file(start_dir)
+    if config_path is None:
+        return None
+    try:
+        data = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise MalformedRepositoryConfig(str(config_path), f"invalid YAML: {exc}") from exc
+    section = data.get("ticketing") if isinstance(data, dict) else None
+    if section is None:
+        return None
+    if not isinstance(section, dict):
+        raise MalformedRepositoryConfig(str(config_path), "'ticketing' must be a mapping")
+    provider = section.get("provider")
+    if provider is None:
+        return None
+    if not isinstance(provider, str) or provider not in TICKETING_PROVIDER_NAMES:
+        raise MalformedRepositoryConfig(
+            str(config_path),
+            f"'ticketing.provider' must be one of {', '.join(TICKETING_PROVIDER_NAMES)}",
+        )
+    return provider
+
+
+def init_repository(
+    directory: str, key: str = DEFAULT_KEY, ticketing: str | None = None
+) -> InitResult:
     """Establish (or confirm) the repository identity namespace at ``directory``.
 
+    When ``ticketing`` is given (a recognised provider, ADR-087/088), a
+    ``ticketing.provider`` stanza is written alongside ``repository_key`` at
+    creation. It is creation-time configuration, like the key: an already-
+    initialized repository is left untouched (edit ``.rac/config.yaml`` to change
+    a provider later).
+
     Raises :class:`InvalidRepositoryKey` for a bad key,
+    :class:`InvalidTicketingProvider` for an unknown provider,
     :class:`RepositoryKeyConflict` when a different key is already established
     in this exact directory, and :class:`MalformedRepositoryConfig` when an
     existing file cannot be read.
     """
     if not KEY_RE.match(key):
         raise InvalidRepositoryKey(key)
+    if ticketing is not None and ticketing not in TICKETING_PROVIDER_NAMES:
+        raise InvalidTicketingProvider(ticketing)
     config_path = Path(directory) / CONFIG_DIR / CONFIG_FILE
     if config_path.is_file():
         existing = _read_config(config_path)
@@ -266,5 +323,8 @@ def init_repository(directory: str, key: str = DEFAULT_KEY) -> InitResult:
             raise RepositoryKeyConflict(existing.repository_key, key, str(config_path))
         return InitResult(repository_key=key, config_path=str(config_path), created=False)
     config_path.parent.mkdir(parents=True, exist_ok=True)
-    config_path.write_text(f"repository_key: {key}\n", encoding="utf-8")
+    body = f"repository_key: {key}\n"
+    if ticketing is not None:
+        body += f"ticketing:\n  provider: {ticketing}\n"
+    config_path.write_text(body, encoding="utf-8")
     return InitResult(repository_key=key, config_path=str(config_path), created=True)

--- a/src/rac/services/relationships.py
+++ b/src/rac/services/relationships.py
@@ -44,12 +44,21 @@ RELATED_SECTIONS: tuple[str, ...] = (
     "related designs",
 )
 
-# The full relationship-section vocabulary and its canonical ordering, including
-# ``supersedes``. This module owns the ordering; ``stats`` and the
-# ``relationships`` command both render by-type output in this order. ``supersedes``
-# is the one section that does *not* appear in the inspect ``relationships`` dict:
-# there it stays a top-level scalar for backwards compatibility (ADR-007).
-RELATIONSHIP_SECTIONS: tuple[str, ...] = RELATED_SECTIONS + ("supersedes",)
+# External-reference relationship sections (ADR-087): recognized sections whose
+# target is an external identifier (a ticket), not a peer artifact. They are
+# extracted and graphed like the others but format-linted (against the per-repo
+# ticketing provider, ADR-088), never resolved. Kept separate from
+# RELATED_SECTIONS, which is exactly the per-artifact-type vocabulary (one
+# ``related <type>s`` per type).
+EXTERNAL_SECTIONS: tuple[str, ...] = ("related tickets",)
+
+# The full relationship-section vocabulary and its canonical ordering: the per-type
+# ``related *`` sections, then ``supersedes``, then the external-reference sections.
+# This module owns the ordering; ``stats`` and the ``relationships`` command both
+# render by-type output in this order. ``supersedes`` is the one section that does
+# *not* appear in the inspect ``relationships`` dict: there it stays a top-level
+# scalar for backwards compatibility (ADR-007).
+RELATIONSHIP_SECTIONS: tuple[str, ...] = RELATED_SECTIONS + ("supersedes",) + EXTERNAL_SECTIONS
 
 # A *well-formed* leading Markdown list marker: ``-``, ``*``, ``+``, or ``N.``
 # followed by whitespace. Only these are stripped; any other leading text is
@@ -104,9 +113,10 @@ def extract_relationships(product: Product, spec: ArtifactSpec) -> dict[str, lis
     """Cross-artifact references for ``rac inspect``.
 
     Excludes ``supersedes`` — that stays a top-level scalar in inspect output
-    (ADR-007). Order follows ``spec.optional`` (the artifact's own schema order).
+    (ADR-007). External-reference sections (``related tickets``) are included.
+    Order follows ``spec.optional`` (the artifact's own schema order).
     """
-    return _collect(product, spec, RELATED_SECTIONS)
+    return _collect(product, spec, RELATED_SECTIONS + EXTERNAL_SECTIONS)
 
 
 def extract_relationships_full(product: Product, spec: ArtifactSpec) -> dict[str, list[str]]:
@@ -512,6 +522,9 @@ def _resolve_references(
         if spec is None:
             continue
         for section, refs in extract_relationships_full(product, spec).items():
+            edge = edge_spec(section)
+            if edge is not None and edge.external:
+                continue  # external refs (ADR-087) are format-linted, not resolved
             for ref in refs:
                 checked += 1
                 targets = [p for p, _ in index.get(ref.casefold(), [])]
@@ -669,8 +682,8 @@ def _validate(
             continue
         for section, refs in extract_relationships_full(product, spec).items():
             edge = edge_spec(section)
-            if edge is None:
-                continue
+            if edge is None or edge.external:
+                continue  # external edges (ADR-087) carry no artifact range
             for ref in refs:
                 target = _resolved(ref, path)
                 if target is None:
@@ -697,8 +710,8 @@ def _validate(
             continue  # unknown file, or a retired source (historical chains exempt)
         for section, refs in extract_relationships_full(product, spec).items():
             edge = edge_spec(section)
-            if edge is None or not edge.forbids_target_status:
-                continue  # supersedes legitimately points at the retired one
+            if edge is None or edge.external or not edge.forbids_target_status:
+                continue  # supersedes/external edges never gate on target status
             for ref in refs:
                 target = _resolved(ref, path)
                 if target is None:
@@ -944,10 +957,25 @@ def relationships_from_corpus(entries: list[CorpusEntry]) -> list[Relationship]:
         if spec is None:
             continue
         for section, refs in extract_relationships_full(product, spec).items():
+            edge = edge_spec(section)
+            external = edge is not None and edge.external
             for ref in refs:
-                targets = [p for p, _ in index.get(ref.casefold(), [])]
                 resolved: str | None = None
                 issue: str | None = None
+                if external:
+                    # External references (ADR-087) resolve to no in-corpus
+                    # artifact by design — an edge for the graph, never "broken".
+                    relationships.append(
+                        Relationship(
+                            source_path=path,
+                            relationship=section,
+                            target=ref,
+                            resolved_path=None,
+                            issue=None,
+                        )
+                    )
+                    continue
+                targets = [p for p, _ in index.get(ref.casefold(), [])]
                 if not targets:
                     issue = ISSUE_TARGET_NOT_FOUND
                 elif len(targets) > 1:

--- a/src/rac/services/validate.py
+++ b/src/rac/services/validate.py
@@ -21,7 +21,7 @@ from rac.core.models import Issue, Product
 from rac.core.overrides import SeverityOverrides, apply_overrides
 from rac.core.validation import has_errors, validate
 
-from .init import load_overrides
+from .init import load_overrides, load_ticketing_provider
 from .okf_conformance import OkfConformanceReport, check_okf_conformance
 from .relationships import RelationshipIssue, validate_document_against_corpus
 
@@ -194,7 +194,11 @@ def validate_product(product: Product, start: str = ".") -> list[Issue]:
     and SDK callers share this one composition, so behind-the-gate analysis never
     drifts from what the interface reports (ADR-015).
     """
-    return apply_overrides(validate(product), classify(product).type, load_overrides(start))
+    return apply_overrides(
+        validate(product, ticketing_provider=load_ticketing_provider(start)),
+        classify(product).type,
+        load_overrides(start),
+    )
 
 
 def validate_directory(
@@ -236,6 +240,9 @@ def validate_corpus(
     """
     if overrides is None:
         overrides = load_overrides(directory)
+    # The external ticket format-lint (ADR-087) reads the repository's configured
+    # provider once for the whole corpus — organisations standardise on one.
+    provider = load_ticketing_provider(directory)
     files: list[FileValidation] = []
     for entry in entries:
         path, product = entry.path, entry.product
@@ -252,7 +259,9 @@ def validate_corpus(
                 )
             )
             continue
-        issues = apply_overrides(validate(product), artifact_type, overrides)
+        issues = apply_overrides(
+            validate(product, ticketing_provider=provider), artifact_type, overrides
+        )
         files.append(
             FileValidation(
                 path=str(path),

--- a/tests/golden/schema_requirement_human.txt
+++ b/tests/golden/schema_requirement_human.txt
@@ -40,6 +40,8 @@ Optional Sections:
       Description: Design artifacts this artifact references
   - Related Requirements
       Description: Requirement artifacts this artifact references
+  - Related Tickets
+      Description: External tickets this artifact traces to; provider set by .rac/config.yaml ticketing.provider (ADR-087)
 
 Metadata Fields:
   - Status: Proposed | Accepted | Superseded | Deprecated

--- a/tests/test_design.py
+++ b/tests/test_design.py
@@ -142,6 +142,7 @@ def test_schema_reference_shape():
         "related decisions",
         "related roadmaps",
         "related prompts",
+        "related tickets",
     ]
 
 
@@ -163,6 +164,7 @@ def test_schema_json_includes_optional_relationship_sections(capsys):
         "related_decisions",
         "related_roadmaps",
         "related_prompts",
+        "related_tickets",
     ]
 
 

--- a/tests/test_graph_export.py
+++ b/tests/test_graph_export.py
@@ -79,6 +79,45 @@ def test_build_graph_deterministic():
     assert first == second
 
 
+# --- external ticket edges (ADR-087) -----------------------------------------
+
+
+def _corpus_with_tickets(tmp_path, provider: str | None) -> None:
+    config = tmp_path / ".rac"
+    config.mkdir()
+    body = "repository_key: ACME\n"
+    if provider is not None:
+        body += f"ticketing:\n  provider: {provider}\n"
+    (config / "config.yaml").write_text(body, encoding="utf-8")
+    (tmp_path / "adr-001.md").write_text(
+        "# A1\n\n## Context\n\nc\n\n## Decision\n\nd\n\n## Consequences\n\nq\n\n"
+        "## Related Tickets\n\n- PROJ-1234\n",
+        encoding="utf-8",
+    )
+
+
+def test_external_ticket_edge_is_marked_and_invents_no_node(tmp_path):
+    _corpus_with_tickets(tmp_path, "jira")
+    graph = build_graph_export(str(tmp_path))
+    ticket_edges = [e for e in graph.edges if e.type == "related_tickets"]
+    assert len(ticket_edges) == 1
+    edge = ticket_edges[0]
+    assert edge.target == "PROJ-1234"
+    assert edge.external is True
+    assert edge.resolved is False
+    assert edge.provider == "jira"
+    # The external target is never promoted to a node.
+    assert "PROJ-1234" not in {n.id for n in graph.nodes}
+
+
+def test_external_ticket_provider_is_none_when_unset(tmp_path):
+    _corpus_with_tickets(tmp_path, None)
+    graph = build_graph_export(str(tmp_path))
+    edge = next(e for e in graph.edges if e.type == "related_tickets")
+    assert edge.external is True and edge.resolved is False
+    assert edge.provider is None
+
+
 # --- CLI ---------------------------------------------------------------------
 
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -14,10 +14,12 @@ import pytest
 from rac.cli import main
 from rac.services.init import (
     InvalidRepositoryKey,
+    InvalidTicketingProvider,
     MalformedRepositoryConfig,
     RepositoryKeyConflict,
     init_repository,
     load_repository_config,
+    load_ticketing_provider,
 )
 
 # --- service -----------------------------------------------------------------
@@ -67,6 +69,63 @@ def test_discovery_walks_upward(tmp_path):
     config = load_repository_config(str(nested))
     assert config is not None
     assert config.repository_key == "RAC"
+
+
+# --- external ticketing provider (ADR-087 / ADR-088) -------------------------
+
+
+def test_init_writes_ticketing_provider(tmp_path):
+    result = init_repository(str(tmp_path), key="ACME", ticketing="jira")
+    assert result.created
+    config = (tmp_path / ".rac" / "config.yaml").read_text(encoding="utf-8")
+    assert config == "repository_key: ACME\nticketing:\n  provider: jira\n"
+    assert load_ticketing_provider(str(tmp_path)) == "jira"
+
+
+def test_init_without_ticketing_writes_no_stanza(tmp_path):
+    init_repository(str(tmp_path), key="ACME")
+    assert load_ticketing_provider(str(tmp_path)) is None
+
+
+def test_init_rejects_unknown_provider(tmp_path):
+    with pytest.raises(InvalidTicketingProvider):
+        init_repository(str(tmp_path), key="ACME", ticketing="bugzilla")
+
+
+def test_load_ticketing_provider_absent_when_no_config(tmp_path):
+    assert load_ticketing_provider(str(tmp_path)) is None
+
+
+def test_load_ticketing_provider_rejects_unknown_value(tmp_path):
+    config_dir = tmp_path / ".rac"
+    config_dir.mkdir()
+    (config_dir / "config.yaml").write_text(
+        "repository_key: ACME\nticketing:\n  provider: bogus\n", encoding="utf-8"
+    )
+    with pytest.raises(MalformedRepositoryConfig):
+        load_ticketing_provider(str(tmp_path))
+
+
+def test_load_ticketing_provider_rejects_non_mapping(tmp_path):
+    config_dir = tmp_path / ".rac"
+    config_dir.mkdir()
+    (config_dir / "config.yaml").write_text(
+        "repository_key: ACME\nticketing: jira\n", encoding="utf-8"
+    )
+    with pytest.raises(MalformedRepositoryConfig):
+        load_ticketing_provider(str(tmp_path))
+
+
+def test_cli_init_ticketing_flag(tmp_path):
+    assert main(["init", str(tmp_path), "--key", "ACME", "--ticketing", "github"]) == 0
+    assert load_ticketing_provider(str(tmp_path)) == "github"
+
+
+def test_cli_init_rejects_unknown_provider(tmp_path, capsys):
+    with pytest.raises(SystemExit) as exc:
+        main(["init", str(tmp_path), "--key", "ACME", "--ticketing", "bogus"])
+    assert exc.value.code == 2
+    assert "invalid choice" in capsys.readouterr().err
 
 
 def test_discovery_returns_none_when_uninitialized(tmp_path):

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -165,6 +165,7 @@ def test_schema_reference_shape():
         "related decisions",
         "related roadmaps",
         "related designs",
+        "related tickets",
     ]
 
 
@@ -179,6 +180,7 @@ def test_schema_json_includes_optional_relationship_sections(capsys):
         "related_decisions",
         "related_roadmaps",
         "related_designs",
+        "related_tickets",
     ]
 
 

--- a/tests/test_relationship_graph.py
+++ b/tests/test_relationship_graph.py
@@ -48,6 +48,7 @@ def test_registry_declares_built_in_edges():
         "related_prompts",
         "related_designs",
         "supersedes",
+        "related_tickets",
     }
     supersedes = edge_spec("supersedes")
     assert supersedes is not None
@@ -55,6 +56,11 @@ def test_registry_declares_built_in_edges():
     assert supersedes.forbids_target_status is False  # the exemption is data-driven
     assert edge_spec("related_decisions").range == ("decision",)
     assert edge_spec("related_decisions").forbids_target_status is True
+    # External-reference edge (ADR-087): no artifact range, format-linted not resolved.
+    tickets = edge_spec("related_tickets")
+    assert tickets is not None
+    assert tickets.external is True
+    assert tickets.range == ()
 
 
 # --- range -------------------------------------------------------------------

--- a/tests/test_relationship_validation.py
+++ b/tests/test_relationship_validation.py
@@ -73,6 +73,23 @@ def test_self_type_broken_reference_is_reported(tmp_path):
     assert report.validation_issues == 1
 
 
+# --- external ticket references (ADR-087) -----------------------------------
+
+
+def test_external_ticket_reference_is_never_broken(tmp_path):
+    # A ## Related Tickets entry resolves to no in-corpus artifact by design, so
+    # it is exempt from referential integrity — never reported not-found, and not
+    # counted among the resolved references (it is format-linted by `rac validate`).
+    (tmp_path / "adr-001.md").write_text(
+        _DECISION.format(t="A1") + "\n## Related Tickets\n\n- PROJ-1234\n- some-external-ref\n",
+        encoding="utf-8",
+    )
+    report = validate_relationships(str(tmp_path))
+    assert report.ok
+    assert report.relationships_checked == 0
+    assert ISSUE_TARGET_NOT_FOUND not in {i.code for i in report.issues}
+
+
 # --- resolved repository (REQ-003 / REQ-005) --------------------------------
 
 

--- a/tests/test_relationships.py
+++ b/tests/test_relationships.py
@@ -18,10 +18,11 @@ import pytest
 from conftest import fixture_path
 
 from rac.cli import main
+from rac.core.artifacts import spec_for
 from rac.core.markdown import parse
 from rac.core.validation import has_errors, validate
 from rac.services.inspect import inspect_file, inspect_text
-from rac.services.relationships import parse_references
+from rac.services.relationships import extract_relationships, parse_references
 from rac.services.stats import collect_stats
 
 # Each fixture and the relationship keys (snake_case) it should expose via inspect.
@@ -72,6 +73,20 @@ def test_parse_references_preserves_non_marker_text():
 
 def test_parse_references_drops_blank_lines():
     assert parse_references("\n- ADR-004\n\n- ADR-012\n") == ["ADR-004", "ADR-012"]
+
+
+# --- external ticket extraction (ADR-087) -----------------------------------
+
+
+def test_related_tickets_section_is_extracted():
+    spec = spec_for("decision")
+    assert spec is not None
+    body = (
+        "# D\n\n## Status\n\nAccepted\n\n## Context\n\nc\n\n## Decision\n\nd\n\n"
+        "## Consequences\n\nq\n\n## Related Tickets\n\n- PROJ-1234\n- owner/repo#7\n"
+    )
+    rels = extract_relationships(parse(body), spec)
+    assert rels["related_tickets"] == ["PROJ-1234", "owner/repo#7"]
 
 
 # --- inspect: extraction across all five artifact types (amendment 7) --------

--- a/tests/test_roadmap.py
+++ b/tests/test_roadmap.py
@@ -106,6 +106,7 @@ def test_schema_reference_shape():
         "related prompts",
         "related designs",
         "related roadmaps",
+        "related tickets",
     ]
 
 
@@ -121,6 +122,7 @@ def test_schema_json_includes_optional_relationship_sections(capsys):
         "related_prompts",
         "related_designs",
         "related_roadmaps",
+        "related_tickets",
     ]
 
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -100,6 +100,7 @@ def test_schema_json_requirement_shape(capsys):
         "related_prompts",
         "related_designs",
         "related_requirements",
+        "related_tickets",
     ]
     assert "success_metrics" in payload["descriptions"]
     assert "success_metrics" in payload["guidance"]
@@ -118,6 +119,7 @@ def test_schema_json_decision_metadata_values(capsys):
         "related_roadmaps",
         "related_designs",
         "related_decisions",
+        "related_tickets",
     ]
     assert payload["metadata"]["status"] == [
         "Proposed",

--- a/tests/test_schema_agreement.py
+++ b/tests/test_schema_agreement.py
@@ -35,7 +35,11 @@ from rac.core.markdown import parse
 from rac.core.metadata import ArtifactMetadata
 from rac.core.schema import available_schemas, schema_reference
 from rac.services.portfolio import build_portfolio_summary
-from rac.services.relationships import RELATED_SECTIONS, RELATIONSHIP_SECTIONS
+from rac.services.relationships import (
+    EXTERNAL_SECTIONS,
+    RELATED_SECTIONS,
+    RELATIONSHIP_SECTIONS,
+)
 
 # --- single sources of truth -------------------------------------------------
 
@@ -116,9 +120,10 @@ def test_status_enums_agree_across_consumers():
 
 
 def test_relationship_kinds_agree_across_consumers():
-    # The vocabulary is RELATED_SECTIONS (the per-type "related X" kinds) plus the
-    # standalone "supersedes"; get_related keys its `outgoing` object by it.
-    assert RELATIONSHIP_SECTIONS == RELATED_SECTIONS + ("supersedes",)
+    # The vocabulary is RELATED_SECTIONS (the per-type "related X" kinds), the
+    # standalone "supersedes", then the external-reference sections (ADR-087);
+    # get_related keys its `outgoing` object by it.
+    assert RELATIONSHIP_SECTIONS == RELATED_SECTIONS + ("supersedes",) + EXTERNAL_SECTIONS
 
     # No spec invents a relationship section outside the vocabulary, and none of
     # the vocabulary is orphaned: the relationship sections appearing across the

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -32,6 +32,104 @@ def test_valid_file_has_no_errors():
     assert codes(issues) == set()  # fully clean: no warnings either
 
 
+# --- External ticketing format-lint (ADR-087, config-driven per ADR-088) ------
+
+_DECISION_WITH_TICKETS = (
+    "# D\n\n## Status\n\nAccepted\n\n## Context\n\nc\n\n## Decision\n\nd\n\n"
+    "## Consequences\n\nq\n\n## Related Tickets\n\n{entries}\n"
+)
+
+
+def _decision_with(entries: str) -> str:
+    return _DECISION_WITH_TICKETS.format(entries=entries)
+
+
+def _config(tmp_path, provider: str | None) -> None:
+    config_dir = tmp_path / ".rac"
+    config_dir.mkdir(exist_ok=True)
+    body = "repository_key: ACME\n"
+    if provider is not None:
+        body += f"ticketing:\n  provider: {provider}\n"
+    (config_dir / "config.yaml").write_text(body, encoding="utf-8")
+
+
+def test_no_provider_does_not_format_lint_tickets(tmp_path):
+    # Pure validate() never lints (no provider passed), and a repo with no
+    # ticketing stanza leaves ## Related Tickets unvalidated.
+    product = parse(_decision_with("- literally anything"))
+    assert "malformed-ticket-reference" not in codes(validate(product))
+    _config(tmp_path, None)
+    (tmp_path / "d.md").write_text(_decision_with("- literally anything"), encoding="utf-8")
+    assert "malformed-ticket-reference" not in codes(
+        validate_product(parse_file(str(tmp_path / "d.md")), str(tmp_path))
+    )
+
+
+def test_jira_provider_accepts_key_and_url_flags_junk(tmp_path):
+    _config(tmp_path, "jira")
+    (tmp_path / "d.md").write_text(
+        _decision_with("- PROJ-1234\n- https://acme.atlassian.net/browse/AB-9\n- not a key"),
+        encoding="utf-8",
+    )
+    bad = [
+        i
+        for i in validate_product(parse_file(str(tmp_path / "d.md")), str(tmp_path))
+        if i.code == "malformed-ticket-reference"
+    ]
+    assert len(bad) == 1
+    assert bad[0].severity == "error"
+    assert "not a key" in bad[0].message
+
+
+def test_github_provider_rejects_jira_shaped_key(tmp_path):
+    _config(tmp_path, "github")
+    (tmp_path / "d.md").write_text(_decision_with("- owner/repo#42\n- PROJ-1234"), encoding="utf-8")
+    bad = [
+        i
+        for i in validate_product(parse_file(str(tmp_path / "d.md")), str(tmp_path))
+        if i.code == "malformed-ticket-reference"
+    ]
+    assert [i.message for i in bad] and all("PROJ-1234" in i.message for i in bad)
+
+
+def test_linear_jira_key_collision_resolved_by_provider(tmp_path):
+    # ENG-123 matches the Jira *shape*; the configured provider disambiguates —
+    # clean under linear, flagged under github (ADR-087 design point).
+    doc = _decision_with("- ENG-123")
+    _config(tmp_path, "linear")
+    (tmp_path / "d.md").write_text(doc, encoding="utf-8")
+    assert "malformed-ticket-reference" not in codes(
+        validate_product(parse_file(str(tmp_path / "d.md")), str(tmp_path))
+    )
+    _config(tmp_path, "github")
+    assert "malformed-ticket-reference" in codes(
+        validate_product(parse_file(str(tmp_path / "d.md")), str(tmp_path))
+    )
+
+
+def test_ticketing_lint_is_overridable(tmp_path):
+    # ADR-053: malformed-ticket-reference can be downgraded/silenced per repo.
+    config_dir = tmp_path / ".rac"
+    config_dir.mkdir()
+    (config_dir / "config.yaml").write_text(
+        "repository_key: ACME\nticketing:\n  provider: jira\n"
+        "validation:\n  rules:\n    malformed-ticket-reference: off\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "d.md").write_text(_decision_with("- not a key"), encoding="utf-8")
+    assert "malformed-ticket-reference" not in codes(
+        validate_product(parse_file(str(tmp_path / "d.md")), str(tmp_path))
+    )
+
+
+def test_directory_validation_applies_ticketing_provider(tmp_path):
+    _config(tmp_path, "jira")
+    (tmp_path / "d.md").write_text(_decision_with("- not a key"), encoding="utf-8")
+    result = validate_directory(str(tmp_path))
+    d = next(f for f in result.files if f.path.endswith("d.md"))
+    assert "malformed-ticket-reference" in {i.code for i in d.issues}
+
+
 def test_minimal_file_is_valid_but_warns_on_optional_sections():
     issues = validate_fixture("valid", "minimal.md")
     assert not has_errors(issues)


### PR DESCRIPTION
Implements ADR-087 (External-Reference Relationships), revised to a **config-driven** design and accepted in this PR. Supersedes #210.

## What

Adds a single external-reference edge, `related_tickets` (`## Related Tickets`), whose target is an external ticket rather than an in-corpus artifact (ADR-055 registry, ADR-010 untyped-target shape generalised). Change traceability ("this ADR implements PROJ-1234") becomes typed corpus data instead of rotting prose.

**The ticketing provider is per-repository config, not a per-system edge.** Organisations standardise on one tracker, so the system is chosen once at `rac init` rather than picked per reference:

```yaml
# .rac/config.yaml
ticketing:
  provider: jira      # jira | github | linear | azure-devops | servicenow | none
```

One stable `## Related Tickets` heading across every repo — no `## Related Jira` / `## Related GitHub` proliferation. This also dissolves the Linear/Jira key-shape collision: `ENG-123` matches the Jira pattern, but the configured provider tells the engine which format to validate against, so there is nothing to guess.

## Changes

- **Registry** (`core/relationship_types.py`): `EdgeSpec.external` flag; `related_tickets` edge, no artifact range, `external=True`.
- **Specs** (`core/artifacts.py`): `## Related Tickets` optional on all five artifact types (append-only, ADR-007).
- **Validation** (`core/validation.py`): `malformed-ticket-reference` (error, overridable per ADR-053); per-provider key/URL validators (jira, github, linear, azure-devops, servicenow). `validate()` takes an optional `ticketing_provider`; pure callers are unaffected. The engine never contacts the tracker.
- **Config** (`services/init.py`): `load_ticketing_provider` reads `ticketing.provider`; `rac init --ticketing <provider>` writes it; unknown values rejected.
- **Resolution** (`services/relationships.py`): external sections kept separate from per-type `RELATED_SECTIONS`; `_resolve_references` skips them; `relationships_from_corpus` emits them `resolved_path=None, issue=None` — an edge for the graph, never "broken".
- **Graph export** (`services/export.py`): additive `external` + `provider` fields (ADR-074). A ticket edge is `resolved=false, external=true`, distinct from a dangling in-corpus link.
- **Docs**: `docs/relationships.md` (External tickets), `docs/cli.md` (`rac init --ticketing`).
- **ADR lifecycle**: ADR-087 revised to the config-driven design, flipped Proposed → Accepted; agent-rules managed block regenerated.

## Verification

- Full `pytest` suite green (1680 passed, 1 skipped; golden refreshed).
- `ruff check` · `ruff format --check` clean; `mypy` clean (only environmental missing-stub noise).
- Corpus gates exit 0: `rac validate rac/`, `rac relationships rac/ --validate` (1536 relationships, 0 issues), `rac review rac/` (no priority 1–2), `rac export rac/ --agent-rules --check` in-sync.

## Design note

Closes #210, which implemented the earlier always-on `## Related Jira` shape. That branch never merged, so the surface is replaced rather than migrated.