### PR TITLE
feat(init): add enterprise config profile to rac init

### DIFF
--- a/.cursor/rules
+++ b/.cursor/rules
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: b133cd2ff821db8329714794bebe19ca1fef61436f54f237f4f02fe38c835efe) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: ff93c1969a8eee6f49086132c52932b1b271bd9b029584c40a002911822c0cbe) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -62,4 +62,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KW2YW6XK593X** — ADR-084: Read-Access Audit Recorder _(Product)_
 - **RAC-KW47GFBHK31W** — ADR-086: Air-Gap Posture and Enterprise Telemetry Hard-Lock _(Product)_
 - **RAC-KW47GGS85CKG** — ADR-087: External-Reference Relationships (Jira and Beyond) _(Technical)_
+- **RAC-KW47GJ749PKC** — ADR-088: Enterprise Profile Scaffold (`rac init --profile`) _(Product)_
 <!-- END RAC MANAGED BLOCK -->

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: b133cd2ff821db8329714794bebe19ca1fef61436f54f237f4f02fe38c835efe) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: ff93c1969a8eee6f49086132c52932b1b271bd9b029584c40a002911822c0cbe) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -62,4 +62,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KW2YW6XK593X** — ADR-084: Read-Access Audit Recorder _(Product)_
 - **RAC-KW47GFBHK31W** — ADR-086: Air-Gap Posture and Enterprise Telemetry Hard-Lock _(Product)_
 - **RAC-KW47GGS85CKG** — ADR-087: External-Reference Relationships (Jira and Beyond) _(Technical)_
+- **RAC-KW47GJ749PKC** — ADR-088: Enterprise Profile Scaffold (`rac init --profile`) _(Product)_
 <!-- END RAC MANAGED BLOCK -->

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,7 +76,7 @@ jobs:
           - name: ingest
             paths: "tests/test_ingest.py"
           - name: init
-            paths: "tests/test_init.py"
+            paths: "tests/test_init.py tests/test_profiles.py"
           - name: quickstart
             paths: "tests/test_quickstart.py tests/test_empty_corpus.py"
           - name: inspect

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: b133cd2ff821db8329714794bebe19ca1fef61436f54f237f4f02fe38c835efe) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: ff93c1969a8eee6f49086132c52932b1b271bd9b029584c40a002911822c0cbe) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -62,4 +62,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KW2YW6XK593X** — ADR-084: Read-Access Audit Recorder _(Product)_
 - **RAC-KW47GFBHK31W** — ADR-086: Air-Gap Posture and Enterprise Telemetry Hard-Lock _(Product)_
 - **RAC-KW47GGS85CKG** — ADR-087: External-Reference Relationships (Jira and Beyond) _(Technical)_
+- **RAC-KW47GJ749PKC** — ADR-088: Enterprise Profile Scaffold (`rac init --profile`) _(Product)_
 <!-- END RAC MANAGED BLOCK -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ to the corpus artifact and they load through the imports below.
 - Previous series: `rac/roadmaps/v0.21.x-editor/` (complete)
 - Decisions (ADRs): `rac/decisions/`
 
-<!-- BEGIN RAC MANAGED BLOCK (digest: b133cd2ff821db8329714794bebe19ca1fef61436f54f237f4f02fe38c835efe) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: ff93c1969a8eee6f49086132c52932b1b271bd9b029584c40a002911822c0cbe) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -87,4 +87,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KW2YW6XK593X** — ADR-084: Read-Access Audit Recorder _(Product)_
 - **RAC-KW47GFBHK31W** — ADR-086: Air-Gap Posture and Enterprise Telemetry Hard-Lock _(Product)_
 - **RAC-KW47GGS85CKG** — ADR-087: External-Reference Relationships (Jira and Beyond) _(Technical)_
+- **RAC-KW47GJ749PKC** — ADR-088: Enterprise Profile Scaffold (`rac init --profile`) _(Product)_
 <!-- END RAC MANAGED BLOCK -->

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1049,16 +1049,32 @@ configuration, not artifact meaning — it never dictates folder structure.
 
 - **Input:** `rac init [directory]` — defaults to the current directory.
 - **Options:** `--key KEY` (default `RAC`; 2–10 uppercase alphanumeric
-  characters starting with a letter) · `--ticketing PROVIDER` · `--json`
+  characters starting with a letter) · `--ticketing PROVIDER` · `--profile NAME`
+  · `--json`
 - **`--ticketing PROVIDER`** records the external ticketing system for
   `## Related Tickets` references (ADR-087) as `ticketing.provider` in
   `.rac/config.yaml` — one of `jira`, `github`, `linear`, `azure-devops`,
   `servicenow`, or `none`. Omit it to leave the provider unset (tickets stay
   unvalidated). Written at creation; edit `.rac/config.yaml` to change it later.
   See [relationships](relationships.md#external-tickets).
+- **`--profile NAME`** applies a built-in **configuration** profile on a fresh
+  init (ADR-088) — `default` or `enterprise`. It writes *configuration only*,
+  never authored prose, and **never overwrites an existing file**:
+  - `default` — writes the lore MCP client wiring for Claude Code (`.mcp.json`)
+    and Cursor (`.cursor/mcp.json`).
+  - `enterprise` — the client wiring **plus** an `enforcement:` policy stanza
+    (ADR-049) committing relationship-integrity findings as gate-blocking, so the
+    policy is auditable. Requirement-quality severities stay at their defaults —
+    escalate per repo with `validation:` overrides (ADR-053) if desired.
+
+  Profiles are creation-time configuration, composable with `--key`/`--ticketing`
+  and the [`quickstart`](#quickstart) scaffold. Plain `rac init` (no `--profile`)
+  is unchanged. A parent-corpus line is added once corpus federation ships
+  (ADR-089); until then the enterprise profile is hollow on it.
 - **Exit codes:** `0` initialized, or already initialized with the same key
   (idempotent) · `1` a different key is already established (never silently
-  rewritten) · `2` invalid key, unknown ticketing provider, or not a directory
+  rewritten) · `2` invalid key, unknown ticketing provider, unknown profile, or
+  not a directory
 
 After a successful init on a real terminal, `rac init` asks one one-time
 question — "Share anonymous usage to help shape Lore? [y/N]" — defaulting to
@@ -1069,6 +1085,7 @@ never appears with `--json`, in pipes, or in CI. See `rac telemetry`.
 rac init
 rac init --key PROJ
 rac init --key ACME --ticketing jira
+rac init --key ACME --profile enterprise
 rac init docs/ --json
 ```
 
@@ -1077,7 +1094,9 @@ rac init docs/ --json
   "schema_version": "1",
   "repository_key": "PROJ",
   "config_path": ".rac/config.yaml",
-  "created": true
+  "created": true,
+  "profile": "enterprise",
+  "files_written": [".mcp.json", ".cursor/mcp.json"]
 }
 ```
 

--- a/rac/decisions/adr-088-enterprise-profile-scaffold.md
+++ b/rac/decisions/adr-088-enterprise-profile-scaffold.md
@@ -7,7 +7,7 @@ type: decision
 
 ## Status
 
-Proposed
+Accepted
 
 ## Category
 

--- a/src/rac/cli.py
+++ b/src/rac/cli.py
@@ -135,6 +135,7 @@ from rac.services.index import build_repository_index
 from rac.services.ingest import ConversionError, UnsupportedDocument, ingest
 from rac.services.init import (
     DEFAULT_KEY,
+    InvalidProfile,
     InvalidRepositoryKey,
     InvalidTicketingProvider,
     MalformedRepositoryConfig,
@@ -144,6 +145,7 @@ from rac.services.init import (
 from rac.services.inspect import build_inspection, inspect_directory
 from rac.services.migrate import migrate_metadata
 from rac.services.portfolio import build_portfolio_summary
+from rac.services.profiles import PROFILE_NAMES
 from rac.services.quickstart import DEFAULT_TYPE, CorpusNotEmpty, quickstart
 from rac.services.recency import artifact_recency
 from rac.services.relationships import (
@@ -1009,8 +1011,10 @@ def cmd_init(args: argparse.Namespace) -> int:
         print(f"rac: not a directory: {args.directory}", file=sys.stderr)
         raise SystemExit(EXIT_USAGE)
     try:
-        result = init_repository(args.directory, key=args.key, ticketing=args.ticketing)
-    except (InvalidRepositoryKey, InvalidTicketingProvider) as exc:
+        result = init_repository(
+            args.directory, key=args.key, ticketing=args.ticketing, profile=args.profile
+        )
+    except (InvalidRepositoryKey, InvalidTicketingProvider, InvalidProfile) as exc:
         print(f"rac: {exc}", file=sys.stderr)
         raise SystemExit(EXIT_USAGE) from None
     except (RepositoryKeyConflict, MalformedRepositoryConfig) as exc:
@@ -1919,6 +1923,16 @@ def build_parser() -> argparse.ArgumentParser:
         help="External ticketing provider for ## Related Tickets references "
         f"(one of: {', '.join(TICKETING_PROVIDER_NAMES)}). Writes ticketing.provider "
         "to .rac/config.yaml; omit to leave it unset (ADR-087).",
+    )
+    p_init.add_argument(
+        "--profile",
+        choices=PROFILE_NAMES,
+        default=None,
+        metavar="NAME",
+        help="Apply a built-in config profile on a fresh init "
+        f"(one of: {', '.join(PROFILE_NAMES)}). Writes .mcp.json client wiring and "
+        "(enterprise) an enforcement-policy stanza — configuration only, never "
+        "prose; never overwrites an existing file (ADR-088).",
     )
     p_init.add_argument(
         "--json", action="store_true", help="Emit JSON instead of human-readable text."

--- a/src/rac/output/human.py
+++ b/src/rac/output/human.py
@@ -964,7 +964,11 @@ def render_new_human(created: CreatedArtifact) -> str:
 def render_init_human(result: InitResult) -> str:
     """Human `rac init` output: the established identity namespace."""
     verb = "Initialized" if result.created else "Already initialized:"
-    return f"{verb} repository key {result.repository_key}\nConfig: {result.config_path}"
+    lines = [f"{verb} repository key {result.repository_key}", f"Config: {result.config_path}"]
+    if result.profile is not None:
+        lines.append(f"Profile: {result.profile}")
+    lines.extend(f"Wrote: {path}" for path in result.files_written)
+    return "\n".join(lines)
 
 
 def render_quickstart_human(result: QuickstartResult) -> str:

--- a/src/rac/services/init.py
+++ b/src/rac/services/init.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
 from rac.core.overrides import EMPTY, RULE_VALUES, TYPE_VALUES, SeverityOverrides
 from rac.core.validation import TICKETING_PROVIDER_NAMES
 from rac.errors import RACError
+from rac.services.profiles import PROFILE_NAMES, get_profile, write_mcp_configs
 
 # Repository key contract (v0.7.11): uppercase alphanumeric, leading letter,
 # 2-10 characters. The key is the human-recognizable ID prefix, e.g. RAC.
@@ -56,6 +57,16 @@ class InvalidTicketingProvider(RACError):
         super().__init__(
             f"invalid ticketing provider: {provider!r} "
             f"(expected one of {', '.join(TICKETING_PROVIDER_NAMES)})"
+        )
+
+
+class InvalidProfile(RACError):
+    """The requested init profile is not a recognised built-in profile (usage error)."""
+
+    def __init__(self, profile: str):
+        self.profile = profile
+        super().__init__(
+            f"invalid profile: {profile!r} (expected one of {', '.join(PROFILE_NAMES)})"
         )
 
 
@@ -103,6 +114,10 @@ class InitResult:
     repository_key: str
     config_path: str
     created: bool  # False when init was idempotent (key already established)
+    # The applied profile (ADR-088), and the extra files it wrote (e.g. .mcp.json).
+    # Additive contract fields (ADR-007): null/empty when no profile was used.
+    profile: str | None = None
+    files_written: tuple[str, ...] = ()
 
     def to_dict(self) -> dict:
         return {
@@ -110,6 +125,8 @@ class InitResult:
             "repository_key": self.repository_key,
             "config_path": self.config_path,
             "created": self.created,
+            "profile": self.profile,
+            "files_written": list(self.files_written),
         }
 
 
@@ -296,7 +313,10 @@ def load_ticketing_provider(start_dir: str) -> str | None:
 
 
 def init_repository(
-    directory: str, key: str = DEFAULT_KEY, ticketing: str | None = None
+    directory: str,
+    key: str = DEFAULT_KEY,
+    ticketing: str | None = None,
+    profile: str | None = None,
 ) -> InitResult:
     """Establish (or confirm) the repository identity namespace at ``directory``.
 
@@ -306,8 +326,17 @@ def init_repository(
     initialized repository is left untouched (edit ``.rac/config.yaml`` to change
     a provider later).
 
+    When ``profile`` is given (a built-in profile name, ADR-088), the profile's
+    config-only bundle is layered on a fresh init: its ``.rac/config.yaml``
+    stanza is appended after the key, and its client wiring (``.mcp.json`` and
+    ``.cursor/mcp.json``) is written without ever overwriting an existing file.
+    Like the key and ticketing, a profile applies only at creation — an
+    already-initialized repository is left untouched. A profile writes
+    *configuration only*, never authored prose (ADR-024, ADR-044, ADR-085).
+
     Raises :class:`InvalidRepositoryKey` for a bad key,
     :class:`InvalidTicketingProvider` for an unknown provider,
+    :class:`InvalidProfile` for an unknown profile,
     :class:`RepositoryKeyConflict` when a different key is already established
     in this exact directory, and :class:`MalformedRepositoryConfig` when an
     existing file cannot be read.
@@ -316,6 +345,11 @@ def init_repository(
         raise InvalidRepositoryKey(key)
     if ticketing is not None and ticketing not in TICKETING_PROVIDER_NAMES:
         raise InvalidTicketingProvider(ticketing)
+    resolved_profile = None
+    if profile is not None:
+        resolved_profile = get_profile(profile)
+        if resolved_profile is None:
+            raise InvalidProfile(profile)
     config_path = Path(directory) / CONFIG_DIR / CONFIG_FILE
     if config_path.is_file():
         existing = _read_config(config_path)
@@ -326,5 +360,16 @@ def init_repository(
     body = f"repository_key: {key}\n"
     if ticketing is not None:
         body += f"ticketing:\n  provider: {ticketing}\n"
+    if resolved_profile is not None and resolved_profile.config_stanza:
+        body += resolved_profile.config_stanza
     config_path.write_text(body, encoding="utf-8")
-    return InitResult(repository_key=key, config_path=str(config_path), created=True)
+    files_written: tuple[str, ...] = ()
+    if resolved_profile is not None and resolved_profile.mcp_wiring:
+        files_written = tuple(write_mcp_configs(directory))
+    return InitResult(
+        repository_key=key,
+        config_path=str(config_path),
+        created=True,
+        profile=resolved_profile.name if resolved_profile is not None else None,
+        files_written=files_written,
+    )

--- a/src/rac/services/profiles.py
+++ b/src/rac/services/profiles.py
@@ -1,0 +1,103 @@
+"""Built-in init profiles — `rac init --profile <name>` (ADR-088).
+
+A profile is a named bundle of *configuration only* (ADR-085): the
+``.rac/config.yaml`` stanzas and the ``.mcp.json`` client wiring a careful admin
+would otherwise hand-write. A profile never writes authored prose (ADR-024,
+ADR-044) — firm ADR/prompt content lives in a referenced standards corpus
+(ADR-089), not in generated files.
+
+Profiles are creation-time configuration: they apply on a fresh `rac init`, layer
+onto the repository key, and never overwrite a file that already exists. Built-in
+and named (``default``, ``enterprise``); a profile adds no code path a solo
+developer cannot reach (the ADR-085 backstop) — it emits exactly the files a
+careful admin would hand-write.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+# The lore MCP server wiring, identical for Claude Code (root ``.mcp.json``) and
+# Cursor (``.cursor/mcp.json``). Mirrors examples/cursor/mcp.example.json.
+MCP_JSON = (
+    "{\n"
+    '  "mcpServers": {\n'
+    '    "lore": {\n'
+    '      "command": "rac",\n'
+    '      "args": ["mcp", "--root", "."]\n'
+    "    }\n"
+    "  }\n"
+    "}\n"
+)
+
+# Enterprise enforcement (ADR-049): relationship-integrity findings block the
+# gate, committed explicitly so the policy is auditable rather than implicit
+# (these are blocking by default; the profile makes the posture a committed,
+# git-diffable artifact). Requirement-quality severities are left at their
+# defaults — escalate per repo (ADR-053) for stricter authoring discipline.
+_ENTERPRISE_CONFIG = """\
+# Enterprise profile (ADR-088): relationship-integrity findings block `rac gate`,
+# committed explicitly so the enforcement policy is auditable (ADR-049).
+enforcement:
+  blocking:
+    - relationship-target-not-found
+    - relationship-target-ambiguous
+    - relationship-self-reference
+    - relationship-target-type-mismatch
+    - relationship-target-superseded
+    - relationship-cycle
+    - relationship-edge-unsupported
+    - duplicate-artifact-identifier
+"""
+
+
+@dataclass(frozen=True)
+class Profile:
+    """A built-in init profile: config-only, never prose (ADR-088).
+
+    ``config_stanza`` is extra ``.rac/config.yaml`` YAML appended after the
+    repository key (empty for none); ``mcp_wiring`` requests the Claude Code and
+    Cursor ``.mcp.json`` client configs.
+    """
+
+    name: str
+    config_stanza: str
+    mcp_wiring: bool
+
+
+PROFILES: dict[str, Profile] = {
+    # default: just the client wiring — broadly useful, no policy stanza.
+    "default": Profile(name="default", config_stanza="", mcp_wiring=True),
+    # enterprise: client wiring plus an explicit, auditable enforcement policy.
+    "enterprise": Profile(name="enterprise", config_stanza=_ENTERPRISE_CONFIG, mcp_wiring=True),
+}
+
+# The recognised profile names, for CLI choices and config validation.
+PROFILE_NAMES: tuple[str, ...] = tuple(PROFILES)
+
+# The ``.mcp.json`` client targets a profile wires, relative to the repo root.
+_MCP_TARGETS: tuple[str, ...] = (".mcp.json", ".cursor/mcp.json")
+
+
+def get_profile(name: str) -> Profile | None:
+    """The :class:`Profile` with the given name, or None."""
+    return PROFILES.get(name)
+
+
+def write_mcp_configs(directory: str) -> list[str]:
+    """Write the lore MCP wiring for Claude Code and Cursor, never overwriting.
+
+    Returns the paths actually written, in target order; an existing file is left
+    untouched and omitted, so `rac init` can report exactly what landed and a
+    user's own ``.mcp.json`` is never clobbered.
+    """
+    written: list[str] = []
+    for target in _MCP_TARGETS:
+        path = Path(directory) / target
+        if path.exists():
+            continue
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(MCP_JSON, encoding="utf-8")
+        written.append(str(path))
+    return written

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -1,0 +1,153 @@
+"""Tests for built-in init profiles — `rac init --profile <name>` (ADR-088).
+
+A profile writes *configuration only* (never prose): the `.mcp.json` client wiring
+and, for `enterprise`, an enforcement-policy stanza. It applies on a fresh init,
+never overwrites an existing file, and leaves plain `rac init` unchanged.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from rac.cli import main
+from rac.services.init import (
+    InvalidProfile,
+    init_repository,
+    load_enforcement_policy,
+    load_overrides,
+)
+from rac.services.profiles import MCP_JSON, PROFILE_NAMES, get_profile
+
+_LORE_MCP = {"mcpServers": {"lore": {"command": "rac", "args": ["mcp", "--root", "."]}}}
+
+
+def _config(tmp_path) -> str:
+    return (tmp_path / ".rac" / "config.yaml").read_text(encoding="utf-8")
+
+
+# --- the profile definitions -------------------------------------------------
+
+
+def test_built_in_profile_names():
+    assert PROFILE_NAMES == ("default", "enterprise")
+    assert get_profile("nope") is None
+
+
+def test_mcp_json_is_the_lore_server_wiring():
+    # The emitted .mcp.json mirrors examples/cursor/mcp.example.json exactly.
+    assert json.loads(MCP_JSON) == _LORE_MCP
+
+
+# --- default profile: client wiring only -------------------------------------
+
+
+def test_default_profile_writes_mcp_configs_only(tmp_path):
+    result = init_repository(str(tmp_path), key="ACME", profile="default")
+    assert result.created
+    assert result.profile == "default"
+    # Both client configs written; no policy stanza in .rac/config.yaml.
+    assert (tmp_path / ".mcp.json").exists()
+    assert (tmp_path / ".cursor" / "mcp.json").exists()
+    assert json.loads((tmp_path / ".mcp.json").read_text(encoding="utf-8")) == _LORE_MCP
+    assert _config(tmp_path) == "repository_key: ACME\n"
+    assert load_enforcement_policy(str(tmp_path)).blocking == frozenset()
+    assert {str(tmp_path / ".mcp.json"), str(tmp_path / ".cursor" / "mcp.json")} == set(
+        result.files_written
+    )
+
+
+# --- enterprise profile: wiring + enforcement policy -------------------------
+
+
+def test_enterprise_profile_writes_enforcement_policy(tmp_path):
+    result = init_repository(str(tmp_path), key="ACME", profile="enterprise")
+    assert result.profile == "enterprise"
+    assert (tmp_path / ".mcp.json").exists()
+    # The committed enforcement stanza loads as a policy (ADR-049): relationship
+    # integrity findings block the gate.
+    policy = load_enforcement_policy(str(tmp_path))
+    assert "relationship-target-superseded" in policy.blocking
+    assert "duplicate-artifact-identifier" in policy.blocking
+    assert len(policy.blocking) == 8
+    # Moderate preset: no validation-severity escalation.
+    overrides = load_overrides(str(tmp_path))
+    assert overrides.rules == {} and overrides.types == {}
+
+
+def test_enterprise_config_is_valid_yaml_with_key_preserved(tmp_path):
+    init_repository(str(tmp_path), key="ACME", profile="enterprise")
+    body = _config(tmp_path)
+    assert body.startswith("repository_key: ACME\n")
+    assert "enforcement:" in body
+
+
+def test_profile_and_ticketing_compose(tmp_path):
+    init_repository(str(tmp_path), key="ACME", ticketing="jira", profile="enterprise")
+    body = _config(tmp_path)
+    assert "ticketing:\n  provider: jira\n" in body
+    assert "enforcement:" in body
+
+
+# --- plain init is unchanged -------------------------------------------------
+
+
+def test_plain_init_writes_no_mcp_configs(tmp_path):
+    result = init_repository(str(tmp_path), key="ACME")
+    assert result.profile is None
+    assert result.files_written == ()
+    assert not (tmp_path / ".mcp.json").exists()
+    assert not (tmp_path / ".cursor").exists()
+    assert _config(tmp_path) == "repository_key: ACME\n"
+
+
+# --- never overwrites, creation-time only ------------------------------------
+
+
+def test_profile_never_overwrites_existing_mcp_json(tmp_path):
+    (tmp_path / ".mcp.json").write_text('{"mine": true}\n', encoding="utf-8")
+    result = init_repository(str(tmp_path), key="ACME", profile="default")
+    # The user's file is preserved; only the absent Cursor config is written.
+    assert json.loads((tmp_path / ".mcp.json").read_text(encoding="utf-8")) == {"mine": True}
+    assert result.files_written == (str(tmp_path / ".cursor" / "mcp.json"),)
+
+
+def test_profile_applies_only_on_fresh_init(tmp_path):
+    init_repository(str(tmp_path), key="ACME")  # plain, no profile
+    result = init_repository(str(tmp_path), key="ACME", profile="enterprise")
+    assert not result.created
+    # An already-initialized repo is left untouched — no policy, no client wiring.
+    assert not (tmp_path / ".mcp.json").exists()
+    assert "enforcement:" not in _config(tmp_path)
+
+
+def test_unknown_profile_rejected(tmp_path):
+    with pytest.raises(InvalidProfile):
+        init_repository(str(tmp_path), key="ACME", profile="bespoke")
+
+
+# --- CLI ---------------------------------------------------------------------
+
+
+def test_cli_init_profile_enterprise(tmp_path, capsys):
+    rc = main(["init", str(tmp_path), "--key", "ACME", "--profile", "enterprise"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Profile: enterprise" in out
+    assert (tmp_path / ".mcp.json").exists()
+
+
+def test_cli_init_profile_json_reports_files(tmp_path, capsys):
+    rc = main(["init", str(tmp_path), "--key", "ACME", "--profile", "default", "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["profile"] == "default"
+    assert len(payload["files_written"]) == 2
+
+
+def test_cli_init_rejects_unknown_profile(tmp_path, capsys):
+    with pytest.raises(SystemExit) as exc:
+        main(["init", str(tmp_path), "--key", "ACME", "--profile", "bespoke"])
+    assert exc.value.code == 2
+    assert "invalid choice" in capsys.readouterr().err


### PR DESCRIPTION
Implements ADR-088 (Enterprise Profile Scaffold), accepted in this PR.

## What

`rac init --profile <name>` applies a built-in **configuration** bundle on a fresh init — *configuration only, never authored prose* (ADR-024, ADR-044, ADR-085). Lowers the activation energy of a firm-shaped start to one command.

Two built-in profiles:
- **`default`** — writes the lore MCP client wiring for Claude Code (`.mcp.json`) and Cursor (`.cursor/mcp.json`).
- **`enterprise`** — the wiring **plus** an `enforcement:` policy stanza (ADR-049) committing relationship-integrity findings as gate-blocking, so the policy is auditable and git-diffable. Requirement-quality severities stay at defaults (escalate per repo via `validation:` overrides, ADR-053).

Per the maintainer decisions for this PR: **moderate** enterprise preset (no severity escalation), **`default` = `.mcp.json` only**, **CI gate stanza deferred** to the `lore-pipelines` satellite (ADR-090).

## Guarantees (the ADR bounds)

- **Config only, never prose** — no starter ADRs/prompts; firm standards live in a referenced corpus (ADR-089), not generated files.
- **Plain `rac init` is byte-for-byte unchanged** — `--profile` is opt-in.
- **Never overwrites** an existing `.mcp.json` / `.cursor/mcp.json`.
- **Creation-time only** — an already-initialized repo is left untouched.
- **Hollow-on-parent** — the parent-corpus line waits for federation (ADR-089).
- **ADR-085 backstop** — emits exactly the files a careful admin would hand-write; no code path a solo developer can't reach.

## Changes

- **`services/profiles.py`** (new) — declarative built-in profiles + `.mcp.json` writer (skips existing files).
- **`services/init.py`** — `init_repository(..., profile=)`; `InvalidProfile`; additive `InitResult.profile` + `files_written` (ADR-007).
- **`cli.py`** — `rac init --profile {default,enterprise}` (unknown value exits 2).
- **`output/human.py`** — reports the applied profile and each written file.
- **Docs** — `docs/cli.md` init section.
- **ADR lifecycle** — ADR-088 Proposed → Accepted; agent-rules managed block regenerated.

## Verification

- Full `pytest` suite green (1694 passed, 1 skipped), incl. `test_profiles.py` registered in the `init` CI battery (ADR-027).
- `ruff check` · `ruff format --check` clean; `mypy` clean (only environmental missing-stub noise).
- Corpus gates exit 0: `rac validate rac/`, `rac relationships rac/ --validate` (1536 relationships, 0 issues), `rac review rac/` (no priority 1–2), `rac export rac/ --agent-rules --check` in-sync.