### PR TITLE
docs(decision): repository topology — one repo per concern, rac-* naming (ADR-092)

### DIFF
--- a/.cursor/rules
+++ b/.cursor/rules
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: ff93c1969a8eee6f49086132c52932b1b271bd9b029584c40a002911822c0cbe) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: 12912e7c05a94cab68210e645ee9deb3b36ce05783910746d22d15c580db0fe6) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -63,4 +63,6 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KW47GFBHK31W** — ADR-086: Air-Gap Posture and Enterprise Telemetry Hard-Lock _(Product)_
 - **RAC-KW47GGS85CKG** — ADR-087: External-Reference Relationships (Jira and Beyond) _(Technical)_
 - **RAC-KW47GJ749PKC** — ADR-088: Enterprise Profile Scaffold (`rac init --profile`) _(Product)_
+- **RAC-KW47GN4SB403** — ADR-090: Enterprise Integration Surfaces and Boundaries _(Architecture)_
+- **RAC-KW5A03ZHXN9F** — ADR-092: Repository Topology — One Repo Per Concern, rac-* Naming _(Architecture)_
 <!-- END RAC MANAGED BLOCK -->

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: ff93c1969a8eee6f49086132c52932b1b271bd9b029584c40a002911822c0cbe) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: 12912e7c05a94cab68210e645ee9deb3b36ce05783910746d22d15c580db0fe6) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -63,4 +63,6 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KW47GFBHK31W** — ADR-086: Air-Gap Posture and Enterprise Telemetry Hard-Lock _(Product)_
 - **RAC-KW47GGS85CKG** — ADR-087: External-Reference Relationships (Jira and Beyond) _(Technical)_
 - **RAC-KW47GJ749PKC** — ADR-088: Enterprise Profile Scaffold (`rac init --profile`) _(Product)_
+- **RAC-KW47GN4SB403** — ADR-090: Enterprise Integration Surfaces and Boundaries _(Architecture)_
+- **RAC-KW5A03ZHXN9F** — ADR-092: Repository Topology — One Repo Per Concern, rac-* Naming _(Architecture)_
 <!-- END RAC MANAGED BLOCK -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: ff93c1969a8eee6f49086132c52932b1b271bd9b029584c40a002911822c0cbe) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: 12912e7c05a94cab68210e645ee9deb3b36ce05783910746d22d15c580db0fe6) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -63,4 +63,6 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KW47GFBHK31W** — ADR-086: Air-Gap Posture and Enterprise Telemetry Hard-Lock _(Product)_
 - **RAC-KW47GGS85CKG** — ADR-087: External-Reference Relationships (Jira and Beyond) _(Technical)_
 - **RAC-KW47GJ749PKC** — ADR-088: Enterprise Profile Scaffold (`rac init --profile`) _(Product)_
+- **RAC-KW47GN4SB403** — ADR-090: Enterprise Integration Surfaces and Boundaries _(Architecture)_
+- **RAC-KW5A03ZHXN9F** — ADR-092: Repository Topology — One Repo Per Concern, rac-* Naming _(Architecture)_
 <!-- END RAC MANAGED BLOCK -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ to the corpus artifact and they load through the imports below.
 - Previous series: `rac/roadmaps/v0.21.x-editor/` (complete)
 - Decisions (ADRs): `rac/decisions/`
 
-<!-- BEGIN RAC MANAGED BLOCK (digest: ff93c1969a8eee6f49086132c52932b1b271bd9b029584c40a002911822c0cbe) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: 12912e7c05a94cab68210e645ee9deb3b36ce05783910746d22d15c580db0fe6) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -88,4 +88,6 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KW47GFBHK31W** — ADR-086: Air-Gap Posture and Enterprise Telemetry Hard-Lock _(Product)_
 - **RAC-KW47GGS85CKG** — ADR-087: External-Reference Relationships (Jira and Beyond) _(Technical)_
 - **RAC-KW47GJ749PKC** — ADR-088: Enterprise Profile Scaffold (`rac init --profile`) _(Product)_
+- **RAC-KW47GN4SB403** — ADR-090: Enterprise Integration Surfaces and Boundaries _(Architecture)_
+- **RAC-KW5A03ZHXN9F** — ADR-092: Repository Topology — One Repo Per Concern, rac-* Naming _(Architecture)_
 <!-- END RAC MANAGED BLOCK -->

--- a/rac/decisions/adr-090-enterprise-satellite-topology.md
+++ b/rac/decisions/adr-090-enterprise-satellite-topology.md
@@ -3,11 +3,11 @@ schema_version: 1
 id: RAC-KW47GN4SB403
 type: decision
 ---
-# ADR-090: Enterprise Satellite Topology
+# ADR-090: Enterprise Integration Surfaces and Boundaries
 
 ## Status
 
-Proposed
+Accepted
 
 ## Category
 
@@ -18,63 +18,66 @@ Architecture
 Beyond configuration, the enterprise asks are network, SDK, and write-back work:
 ingest from and publish to Confluence, resolve and comment on Jira, gate CI on
 Bitbucket and Jenkins, aggregate audit logs to a sink, and package the whole for
-Kubernetes. ADR-064, ADR-068, and ADR-073 already establish that such work lives
-in satellite repositories that depend only on the published package, CLI, and
-export contracts — never engine internals. This decision names the enterprise
-satellites and the boundaries they honour, so the engine-side contracts they
-imply are visible in one place.
+Kubernetes. ADR-002 keeps that work out of the engine; ADR-063/073 make each
+piece a consumer of the published contracts. ADR-092 sets where the pieces live:
+one repo per concern, subdir per member — so these are **members of the
+consolidated repos, not standalone satellite repos**. This decision records the
+enterprise integration *surfaces* (which member lives where) and the *boundaries*
+every one of them honours, so the engine-side contracts they imply are visible in
+one place.
 
 ## Decision
 
-Enterprise integrations are delivered as a small constellation of satellites, kept
-deliberately few rather than one-per-integration.
+Enterprise integrations are members of the `rac-*` family repos (ADR-092), not a
+constellation of per-integration satellite repositories.
 
-- **`lore-atlassian`** — one satellite for the Atlassian suite (shared Cloud
-  auth):
+- **Atlassian suite → `rac-connectors/atlassian/`** (shared Cloud auth, one
+  subdir spanning both directions):
   - inbound Confluence ingest, feeding `rac ingest` and the existing human-review
     loop (ADR-072, ADR-006);
   - outbound Confluence publish as a managed block, reusing the `agent_rules`
     managed-block pattern;
-  - Jira external-edge resolution and state checks (ADR-087);
-  - gatekeeper comment-mode, posting a blocking decision to the linked Jira
-    ticket and Confluence page.
-- **`lore-pipelines`** — a Bitbucket Pipelines pipe and a Jenkins shared-library
-  wrapper over the already-CI-neutral `rac gate` (ADR-049, ADR-054).
-- **`lore-audit`** — a collector that tails the ADR-084 audit JSONL to a sink
-  (Loki, S3, Elastic), shipped as a GitHub Action and a Bitbucket pipe.
-- Optional Helm/ArgoCD packaging lays down `lore-watchkeeper`, `lore-audit`, and
-  the Confluence sync cron as deployable applications.
+  - Jira external-ticket resolution and state checks (ADR-087);
+  - comment-mode, posting a blocking decision to the linked Jira ticket and
+    Confluence page.
+- **CI on Bitbucket and Jenkins → `rac-ci` platform subtrees** (`bitbucket/`,
+  `jenkins/`) of the `gatekeeper`/`watchkeeper` capabilities, over the
+  CI-neutral `rac gate` / `rac watchkeeper` (ADR-049, ADR-054). There is no
+  separate pipelines repo — a capability is never split across repos by platform
+  (ADR-092).
+- **Audit collector → `rac-ci/audit/`** — tails the ADR-084 audit JSONL to a sink
+  (Loki, S3, Elastic), shipped per platform like the other CI capabilities.
+- Optional Helm/ArgoCD packaging lays down the watchkeeper, audit, and Confluence
+  sync surfaces as deployable applications (built from their subdirs).
 
-Boundaries every enterprise satellite honours:
+Boundaries every enterprise integration honours:
 
 - Consumes only published contracts — the CLI, the `--documents` and `--graph`
   exports, and the audit JSONL — never engine internals (ADR-063, ADR-073).
 - All write-back is propose-only through human pull-request review (ADR-065,
   ADR-077); RAC never becomes a write-through path into a document platform.
-- Adds no network code to the engine; satellites own all network and SDK
+- Adds no network code to the engine; the integrations own all network and SDK
   dependencies (ADR-002).
 
-Engine-side contracts this topology implies (recorded here, each built under its
-own ADR): the audit JSONL (ADR-084), the external-edge graph marker (ADR-087,
-ADR-074), and a Bitbucket Code-Insights output format alongside SARIF
-(an ADR-054 extension).
+Engine-side contracts this implies (each built under its own ADR): the audit JSONL
+(ADR-084), the external-edge graph marker (ADR-087, ADR-074), and a Bitbucket
+Code-Insights output format alongside SARIF (an ADR-054 extension).
 
 ## Consequences
 
 ### Positive
 
-- One place names the enterprise satellites and the rules they obey, so the
-  engine stays the engine and the contracts they need are explicit.
-- Consolidating Atlassian into one satellite matches the single shared auth and
-  the cross-product comment-mode, avoiding two repos that share one auth layer.
+- One place names the enterprise integration surfaces and the rules they obey, so
+  the engine stays the engine and the contracts they need are explicit.
+- Placing them as members of the family repos (ADR-092) matches the shared auth
+  (Atlassian one subdir) and avoids a per-integration repo sprawl.
 
 ### Negative
 
-- Several satellites pinned to the export contract mean continuous
-  conformance-test carry against each engine release (ADR-073); the cost is real
-  and must be invested in, not assumed free.
-- A cross-satellite bug has no single owning repo; coordination falls to the
-  contracts and the reference configuration (ADR-091, the paved-path example).
+- The family repos pin the export contract, so each engine release carries a
+  conformance-test cost against its consumer subdirs (ADR-073); real, not free.
+- A cross-integration bug spans subdirs of different repos; coordination falls to
+  the contracts and the reference configuration (ADR-091, the paved-path example).
 
 ### Risks
 
@@ -86,14 +89,16 @@ ADR-074), and a Bitbucket Code-Insights output format alongside SARIF
 
 ## Alternatives Considered
 
-### One repository per provider/integration
+### A constellation of per-integration satellite repos
 
-Separate `lore-confluence`, `lore-jira`, `lore-bitbucket`, and so on.
+Separate `lore-atlassian`, `lore-pipelines`, `lore-audit` repositories (the
+earlier draft of this ADR).
 
 #### Disadvantages
 
-- Fragments shared auth and the cross-product comment-mode; more repos to keep
-  green against the contract (ADR-073). Consolidation is the cheaper carry.
+- A repo per integration is the sprawl ADR-092 exists to prevent; deployment and
+  multi-direction do not force a repo boundary. The integrations are members of
+  the consolidated family repos instead.
 
 ### In-engine connectors
 
@@ -104,16 +109,30 @@ Build the network/SDK work into `rac-core`.
 - Contradicts ADR-002 and the single-fenced-ping rule; the engine stops being
   offline and deterministic. Rejected.
 
-A small consolidated constellation of contract-consuming satellites is selected.
+Enterprise integrations as members of the `rac-*` family repos, under fixed
+boundaries, is selected.
 
 ## Relationship to Other Decisions
 
-- ADR-064, ADR-068, ADR-073, ADR-063: the satellite model and the
-  contract-consumer boundary this decision applies.
-- ADR-084: the audit JSONL the `lore-audit` collector consumes.
-- ADR-087, ADR-074: the external-edge graph marker `lore-atlassian` resolves.
-- ADR-049, ADR-054: the CI-neutral gate and SARIF output `lore-pipelines` wraps.
+- ADR-092: the repository topology this decision places its integrations within
+  (Atlassian a `rac-connectors` subdir; CI/audit `rac-ci` subtrees).
+- ADR-063, ADR-073: the contract-consumer boundary every integration honours.
+- ADR-084: the audit JSONL the `rac-ci/audit/` collector consumes.
+- ADR-087, ADR-074: the external-edge graph marker Atlassian resolves.
+- ADR-049, ADR-054: the CI-neutral gate and SARIF output the CI subtrees wrap.
 - ADR-065, ADR-077: write-back is propose-only via PR.
 - ADR-072, ADR-006: inbound ingest reuses the conversion and human-review loop.
 - ADR-085: the distribution half of "configuration plus distribution, not a
   mode".
+
+## Related Decisions
+
+- adr-092
+- adr-063
+- adr-073
+- adr-084
+- adr-087
+- adr-049
+- adr-065
+- adr-077
+- adr-085

--- a/rac/decisions/adr-092-repository-topology.md
+++ b/rac/decisions/adr-092-repository-topology.md
@@ -1,0 +1,224 @@
+---
+schema_version: 1
+id: RAC-KW5A03ZHXN9F
+type: decision
+tags: [structure, org, distribution, branding]
+---
+# ADR-092: Repository Topology — One Repo Per Concern, rac-* Naming
+
+## Status
+
+Accepted
+
+## Category
+
+Architecture
+
+## Context
+
+ADR-064 and ADR-068 set the first repository topology for the `itsthelore`
+organisation: a `lore-*` / `rac-*` split (install-surface vs engine), per-action
+repos (`lore-watchkeeper`, `lore-gatekeeper`), a per-client repo rule
+(`lore-vscode`, `lore-cursor`, …), and a per-language SDK repo (`rac-sdk-ts`).
+ADR-073 then consolidated export connectors into `lore-connectors`, and ADR-090
+(Proposed) added enterprise satellites.
+
+Enumerating the live org surfaced two problems. First, the naming is already
+inconsistent in practice — `rac-*` (rac-core, rac-actions, rac-sdk-ts), `lore-*`
+(connectors, watchkeeper, gatekeeper, vscode, proofkeeper), and own-brand
+(wayfinder-router, decisiongrounding) coexist with no rule a reader can apply.
+Second, the topology had drifted toward **one repo per member** — separate repos
+per action, per client, per SDK language — which trends toward many small repos to
+permission and maintain. The maintainer's stated preference is **a few
+high-quality repos over many small ones.**
+
+A single organising idea resolves both: a repository is defined by the **concern**
+it serves, with one subdir per **member** of that concern. The existing
+`lore-connectors` (one repo, subdir per backend) and the maintainer's request to
+treat benchmarks the same way (`rac-benchmarks`, subdir per benchmark) are the
+pattern; this ADR generalises it.
+
+Several decisions are touched and are reconciled in the Relationship section:
+ADR-036 freezes the PyPI distribution name; ADR-062/063 fix the SDK surfaces;
+ADR-064/068 set the prior topology; ADR-073 consolidates connectors; ADR-090 the
+satellites; ADR-069 makes Wayfinder a separate product. ADR-029 (engine + server
+one package) and the frozen CLI `rac` / server `lore` identities (ADR-036/039) are
+**not** changed.
+
+## Decision
+
+### Governing principle
+
+**One repo per concern, subdir per member; a separate repo only for a distinct
+product or an independently-owned/released surface.** Consolidate *within* a
+concern; separate *across* concerns. Not one repo per member (sprawl); not one
+mega-repo (a grab-bag that erodes quality).
+
+- **Consolidated family repo, subdir per member** — for thin contract-consumers
+  that version with the engine contract: integrations, language SDKs, benchmarks.
+- **Own repo** — for surfaces with genuinely independent versioning/ownership: the
+  IDE-client surface and the CI surface (each a published artifact the maintainer
+  versions on its own line).
+- **Separate product, own brand** — for distinct products: Wayfinder, Proofkeeper.
+
+### Naming
+
+Every repository in the RAC/Lore constellation is **`rac-*`**, consistent with
+`rac-core` and the `rac` CLI. The **brand "Lore" lives at the org (`itsthelore`)
+and the marketplace listings**, not in repository slugs — a `rac-vscode` repo
+still *lists* as "Lore for VS Code", exactly as `rac-core` is already the engine
+behind the product "Lore". This replaces ADR-068's `lore-*` / `rac-*` split.
+
+Distinct products keep their own brand and naming (`wayfinder-router`,
+`proofkeeper`); they are siblings of the constellation, not satellites of it.
+
+### Target topology
+
+| Repo | Concern / kind | Members (subdirs) |
+| --- | --- | --- |
+| `rac-core` | engine + Python SDK (ADR-062) | — |
+| `rac-ci` | CI delivery | `watchkeeper/`, `gatekeeper/`, `audit/` — each × platform (`github/`, `bitbucket/`, `jenkins/`) |
+| `rac-connectors` | integrations (inbound + outbound) | `atlassian/`, `supermemory/`, … |
+| `rac-sdk` | non-Python language SDKs (thin contract clients, ADR-063) | `ts/`, `go/`, … |
+| `rac-benchmarks` | benchmarks | `decisiongrounding/`, … |
+| `rac-editors` | IDE clients | `vscode/` (VS Code/Cursor) (+ `jetbrains/`, …) |
+| `wayfinder-router` | separate product (ADR-069) | — |
+| `proofkeeper` | separate product (BYO-model QA agent) | — |
+
+`rac-connectors` is the rename of the existing `lore-connectors`; `rac-ci` is the
+rename/absorption of `rac-actions` plus the standalone `lore-watchkeeper` /
+`lore-gatekeeper`; `rac-benchmarks` is `decisiongrounding` restructured with the
+benchmark as a subdir; `rac-editors` is the rename of `lore-vscode`; `rac-sdk` is
+the consolidation of `rac-sdk-ts` (→ `ts/`). The GitHub renames/archives are
+maintainer-run org actions, sequenced in the deferred roadmap rewrite.
+
+### Specific consequences of the principle
+
+- **CI delivery is one `rac-ci` repo**, subdir per capability, platform nested
+  within — restoring ADR-064's consolidation intent (which ADR-068 had split) and
+  retiring the standalone action repos. A capability is never split across repos
+  by platform, so the ADR-090 "capability-first" intent holds; `lore-pipelines` is
+  not created. Accepted tradeoffs: coupled version tags (one suite version, which
+  is simpler for consumers) and no per-action Marketplace listing (consumed via
+  `uses: itsthelore/rac-ci/<capability>@<ref>`).
+- **`rac-connectors` is one repo** covering inbound (`rac ingest`) + outbound
+  (`rac export`) + provider suites; **Atlassian is a subdir**, not its own repo —
+  deployment and multi-direction do not force a repo boundary.
+- **`rac-sdk` is one repo**, subdir per language; the **Python SDK stays in
+  `rac-core`** (its surface *is* `rac.__all__`, ADR-062). Polyglot-monorepo cost
+  (mixed toolchains, per-subdir release tags) is accepted; a language SDK
+  graduates to its own repo only if it grows an independent community/cadence.
+- **`rac-benchmarks` and `rac-editors`** follow the same family pattern.
+- **PyPI distribution renames `requirements-as-code` → `rac-core`** (verified
+  available; bare `rac` is taken), aligning the distribution name with the repo
+  and the `rac-*` scheme. The **import package `rac` and the `rac` CLI entry point
+  are unchanged** (zero code churn). A transitional `requirements-as-code` release
+  depending on `rac-core` keeps existing installs working through a deprecation
+  window. This lifts ADR-036's freeze on the PyPI name only; CLI `rac` and server
+  `lore` stay frozen.
+
+### Relationship to ADR-068 (amend-as-sibling)
+
+This ADR is the current authority on repository topology and naming and records
+what it overturns, **amending ADR-068 as a sibling rather than flipping its
+status** — exactly the mechanism ADR-068 used for ADR-064. ADR-068 remains in the
+record as the prior topology; where the two differ, ADR-092 governs. ADR-068's
+status-supersession and the rewrite of the `v0.22.x-housekeeping` extraction
+roadmaps (which encode the prior topology) are sequenced as deliberate follow-up,
+not done here.
+
+## Consequences
+
+### Positive
+
+- One rule decides every repository's shape and name; no surface re-litigates it.
+- A small, bounded, high-quality repo set (~6 `rac-*` repos) instead of a
+  per-member sprawl — fewer repos to permission, secure, and maintain.
+- The PyPI name matches the repo and CLI; the `rac-*` scheme is consistent end to
+  end, with the brand carried by the org and listings.
+
+### Negative
+
+- Reverses recently-recorded structure (ADR-068's split, the per-client rule) and
+  the in-flight `v0.22.x` extraction roadmaps, which must be rewritten as
+  follow-up.
+- Polyglot monorepos (`rac-sdk`, `rac-editors`) carry mixed toolchains and
+  per-subdir release tooling; `rac-ci` couples action version tags.
+- The PyPI rename needs a transitional shim and a documentation sweep, and lifts a
+  deliberately-frozen name (ADR-036).
+
+### Risks
+
+- A consolidated repo grows into a grab-bag. Mitigation: the line is *concern*, not
+  convenience; unlike concerns get unlike repos.
+- A consumer pinned to the old action paths or the old PyPI name breaks.
+  Mitigation: the shim + a sequenced, versioned cutover in the follow-up.
+
+## Alternatives Considered
+
+### Keep ADR-068's lore-/rac- split and per-member repos
+
+Retain the install-vs-engine prefix rule and a repo per action/client/SDK.
+
+#### Disadvantages
+
+- Trends toward many small repos and a naming rule already applied
+  inconsistently. The maintainer's explicit preference is fewer high-quality
+  repos; the org already carries the brand, so the slug split earns little.
+
+### One mega-repo for everything
+
+Collapse engine, CI, SDKs, benchmarks, and clients into a single repository.
+
+#### Disadvantages
+
+- Mixes unlike concerns with incompatible toolchains and release models into one
+  grab-bag — the opposite failure of sprawl, and it erodes quality.
+
+### Status-supersede ADR-068 now
+
+Flip ADR-068 to Superseded in this change.
+
+#### Disadvantages
+
+- It cascades `relationship-target-superseded` across the 12 artifacts that
+  reference ADR-068 in resolving sections — 8 of which are the `v0.22.x` roadmaps
+  slated for rewrite anyway. Amend-as-sibling now, and retire ADR-068 cleanly in
+  the deferred roadmap rewrite.
+
+## Relationship to Other Decisions
+
+- ADR-068: amended as a sibling (this ADR is the current topology/naming
+  authority); its status-supersession is deferred to the roadmap rewrite.
+- ADR-064: the `rac-actions` consolidation intent is restored as `rac-ci`.
+- ADR-036: the PyPI-name freeze is lifted for `requirements-as-code` → `rac-core`;
+  CLI `rac` and server `lore` stay frozen.
+- ADR-073: generalised — `rac-connectors` is the one integrations repo (inbound +
+  outbound + provider suites), the same family pattern as `rac-sdk` /
+  `rac-benchmarks`.
+- ADR-090: capability-first satellite topology realised as `rac-ci` capability
+  subdirs; no `lore-pipelines`.
+- ADR-062, ADR-063: the Python SDK stays in `rac-core`; non-Python SDKs are thin
+  contract clients consolidated in `rac-sdk`.
+- ADR-066: the grounding benchmark lives in `rac-benchmarks`.
+- ADR-069: Wayfinder is a separate product; Proofkeeper is its sibling.
+- ADR-029, ADR-039: engine + server stay one package; CLI `rac` and server `lore`
+  identities unchanged.
+
+## Related Decisions
+
+- adr-064
+- adr-068
+- adr-036
+- adr-073
+- adr-090
+- adr-062
+- adr-063
+- adr-066
+- adr-069
+
+## Review Date
+
+Revisit if a consolidated family repo's members diverge enough in cadence or
+ownership to warrant graduating one out (the escape hatch), or when the deferred
+`v0.22.x` roadmap rewrite lands and ADR-068 is formally retired.


### PR DESCRIPTION
PR A of the repository-topology work — the **decision record only** (corpus). The PyPI rename mechanics (PR B) and the v0.22.x extraction-roadmap rewrite (deferred follow-up) are separate.

## What

- **New `ADR-092` — Repository Topology** (Accepted). Records the governing principle and the full `rac-*` org topology:
  - **One repo per concern, subdir per member; separate repos only for distinct products.** Consolidate within a concern, separate across concerns.
  - **Topology:** `rac-core` (engine + Python SDK) · `rac-ci` (watchkeeper/gatekeeper/audit × platform) · `rac-connectors` (integrations, in+out, Atlassian a subdir) · `rac-sdk` (non-Python language SDKs) · `rac-benchmarks` · `rac-editors`; sibling products `wayfinder-router`, `proofkeeper`.
  - **`rac-*` naming** across the constellation; "Lore" lives at the org + marketplace listings, not the slugs.
  - **PyPI `requirements-as-code` → `rac-core`** (verified available; import package `rac` + CLI unchanged → zero code churn).
- **`ADR-090` reframed + accepted** — enterprise integrations are members of the ADR-092 family repos (Atlassian a `rac-connectors` subdir; CI/audit `rac-ci` subtrees; no `lore-pipelines`), keeping the contract-only + propose-only-write-back boundaries. Retitled "Enterprise Integration Surfaces and Boundaries".

## How it relates to existing decisions

- **Amends ADR-036** (lifts the PyPI-name freeze for `rac-core`; CLI `rac` + server `lore` stay frozen), **ADR-064** (`rac-actions` consolidation restored as `rac-ci`); **extends ADR-073** (`rac-connectors` = all integrations).
- **Amends ADR-068 as a sibling** — the exact mechanism ADR-068 used for ADR-064. ADR-068 keeps its status (no graph cascade); ADR-092 is the current authority. ADR-068's formal supersession + the v0.22.x roadmap rewrite are deferred (8 of 12 resolving `adr-068` refs are those roadmaps).
- No accepted ADR is mutated except the still-Proposed ADR-090; the amendments are recorded in ADR-092 itself.

## Verification

- `rac validate rac/` (315 valid), `rac relationships rac/ --validate` (1554 edges, 0 issues), `rac review rac/` (no priority 1–2), `rac export rac/ --agent-rules --check` in-sync — all exit 0.
- No Python touched (corpus + agent-rules markdown only).

## Not in this PR

- **PR B:** the `pyproject.toml` rename + publish workflows + transitional shim + packaging-reference sweep.
- **Deferred:** rewriting the `v0.22.x-housekeeping` extraction roadmaps to the consolidated topology (and ADR-068's formal retirement there); the actual GitHub repo renames/archives (maintainer-run, outside `rac-core`).