### PR TITLE
chore(release): rename PyPI distribution to rac-core

### DIFF
--- a/.claude/skills/rac-import/SKILL.md
+++ b/.claude/skills/rac-import/SKILL.md
@@ -50,7 +50,7 @@ rac ingest decision.docx          # preview Markdown on stdout
 `rac ingest <file>` converts DOCX / PDF / HTML / PPTX / XLSX / Markdown to
 Markdown text, preserving structure — it does not judge whether the result is a
 valid artifact. Pasted Markdown needs no conversion. Rich formats need the
-optional extras (`pip install 'requirements-as-code[ingest]'`, `[ingest-pdf]`,
+optional extras (`pip install 'rac-core[ingest]'`, `[ingest-pdf]`,
 `[ingest-office]`); the command names the missing extra when one is needed.
 
 ## 3. Choose the type and read its real schema

--- a/.claude/skills/rac-ingest/SKILL.md
+++ b/.claude/skills/rac-ingest/SKILL.md
@@ -36,7 +36,7 @@ rac ingest spec.docx -o rac/requirements/spec.md  # write into the RAC directory
 (pass-through) to Markdown, preserving structure. It does not judge
 whether the result is a valid artifact — that comes next. `-o` never
 overwrites an existing file unless `--force` is passed. Rich formats need
-the optional ingest extras (`pip install 'requirements-as-code[ingest]'`
+the optional ingest extras (`pip install 'rac-core[ingest]'`
 for DOCX/HTML, `[ingest-pdf]`, `[ingest-office]`, or `[ingest-all]`); the
 command names the missing extra when one is needed.
 

--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -12,7 +12,7 @@
 #     keeps rehearsal uploads unique per commit (e.g. 0.10.0.dev3).
 #
 # One-time setup before the first run:
-#   1. On test.pypi.org, add a trusted publisher for requirements-as-code
+#   1. On test.pypi.org, add a trusted publisher for rac-core
 #      pointing at this repository, this workflow file (test-publish.yml),
 #      and the `testpypi` environment.
 #   2. In the repository settings, create the `testpypi` environment.
@@ -20,7 +20,7 @@
 # Install a rehearsal build (deps come from real PyPI via the extra index):
 #   pip install --index-url https://test.pypi.org/simple/ \
 #       --extra-index-url https://pypi.org/simple/ \
-#       requirements-as-code==<rehearsal version>
+#       rac-core==<rehearsal version>
 
 name: Test Publish (TestPyPI)
 
@@ -75,7 +75,7 @@ jobs:
 
     environment:
       name: testpypi
-      url: https://test.pypi.org/p/requirements-as-code
+      url: https://test.pypi.org/p/rac-core
 
     steps:
       - name: Retrieve release distributions

--- a/.github/workflows/watchkeeper.yml
+++ b/.github/workflows/watchkeeper.yml
@@ -38,7 +38,7 @@ on:
         required: false
         default: true
       rac-version:
-        description: "Exact requirements-as-code version from PyPI (empty: latest)."
+        description: "Exact rac-core version from PyPI (empty: latest)."
         type: string
         required: false
         default: ""

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@
 
 <p align="center">
 <a href="https://github.com/itsthelore/rac-core/actions/workflows/ci.yml"><img src="https://github.com/itsthelore/rac-core/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-<a href="https://pypi.org/project/requirements-as-code/"><img src="https://img.shields.io/pypi/v/requirements-as-code" alt="PyPI"></a>
-<a href="https://pypi.org/project/requirements-as-code/"><img src="https://img.shields.io/pypi/pyversions/requirements-as-code" alt="Python"></a>
+<a href="https://pypi.org/project/rac-core/"><img src="https://img.shields.io/pypi/v/rac-core" alt="PyPI"></a>
+<a href="https://pypi.org/project/rac-core/"><img src="https://img.shields.io/pypi/pyversions/rac-core" alt="Python"></a>
 <a href="https://mypy-lang.org/"><img src="https://img.shields.io/badge/types-Mypy-blue.svg" alt="Typed"></a>
-<a href="https://github.com/itsthelore/rac-core/blob/main/LICENSE"><img src="https://img.shields.io/pypi/l/requirements-as-code" alt="License: Apache 2.0"></a>
+<a href="https://github.com/itsthelore/rac-core/blob/main/LICENSE"><img src="https://img.shields.io/pypi/l/rac-core" alt="License: Apache 2.0"></a>
 </p>
 
 > **Give your coding agent the decisions your team already made — so it stops re-doing things you ruled out.**
@@ -49,7 +49,7 @@ recall fuzzily, then verify in Lore.
 1. **Install** the engine:
 
    ```bash
-   pip install requirements-as-code
+   pip install rac-core
    ```
 
 2. **Scaffold** identity and your first artifact:
@@ -74,12 +74,12 @@ recall fuzzily, then verify in Lore.
 
 | Command | Gets you |
 |---|---|
-| `pip install requirements-as-code` | the `rac` CLI + the `lore` MCP server |
-| `pip install 'requirements-as-code[ingest]'` | + DOCX / HTML import |
-| `pip install 'requirements-as-code[ingest-all]'` | + PDF / PPTX / XLSX import |
-| `pip install 'requirements-as-code[explorer]'` | + the terminal Explorer (`rac explorer`) |
+| `pip install rac-core` | the `rac` CLI + the `lore` MCP server |
+| `pip install 'rac-core[ingest]'` | + DOCX / HTML import |
+| `pip install 'rac-core[ingest-all]'` | + PDF / PPTX / XLSX import |
+| `pip install 'rac-core[explorer]'` | + the terminal Explorer (`rac explorer`) |
 
-Requires Python 3.11+. `uv tool install requirements-as-code` also works.
+Requires Python 3.11+. `uv tool install rac-core` also works.
 
 ## How it works
 

--- a/action.yml
+++ b/action.yml
@@ -42,7 +42,7 @@ inputs:
     default: "true"
   rac-version:
     description: >-
-      Exact requirements-as-code version to install from PyPI. Empty
+      Exact rac-core version to install from PyPI. Empty
       installs the latest release. Ignored when `install-from` is `source`.
     required: false
     default: ""
@@ -73,9 +73,9 @@ runs:
           # so this path requires `uses: ./` on a real checkout.
           python -m pip install --quiet "$GITHUB_ACTION_PATH"
         elif [ -n "$RAC_VERSION" ]; then
-          python -m pip install --quiet "requirements-as-code==$RAC_VERSION"
+          python -m pip install --quiet "rac-core==$RAC_VERSION"
         else
-          python -m pip install --quiet requirements-as-code
+          python -m pip install --quiet rac-core
         fi
 
     - name: Resolve base revision

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -194,7 +194,7 @@ rac ingest report.pdf -o report.md --force
 ```
 
 Conversion uses optional extras. Install the readers you need:
-`pip install 'requirements-as-code[ingest]'` (DOCX/HTML), `[ingest-pdf]`,
+`pip install 'rac-core[ingest]'` (DOCX/HTML), `[ingest-pdf]`,
 `[ingest-office]` (PPTX/XLSX), or `[ingest-all]`.
 
 ---
@@ -862,7 +862,7 @@ it shows is also available through `rac portfolio`, `rac index`, `rac resolve`,
 The TUI dependency ships as an optional extra, so the core install stays light:
 
 ```bash
-pip install 'requirements-as-code[explorer]'
+pip install 'rac-core[explorer]'
 rac explorer rac/
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,7 +41,7 @@ Spec-driven development (SDD) tools — GitHub Spec Kit, OpenSpec, Kiro — mana
 | Change management | None — RAC does not manage the change cycle; pair it with an SDD tool | Slash-command workflow: specify, clarify, plan, tasks, implement | Slash-command workflow: propose, apply, archive |
 | Traceability | Typed `Related` links between artifacts; `rac relationships --validate` checks them in CI | `/speckit.analyze` runs cross-artifact consistency and coverage analysis | `openspec validate` checks changes and specs for structural issues |
 | Tool coupling | Read-only MCP server; works with any MCP client | Slash commands or skills installed per agent at init (GitHub Copilot, Claude Code, Cursor, and others) | Slash commands for 20+ AI assistants |
-| Install footprint | `pip install requirements-as-code` (Python 3.11+) | `uv tool install specify-cli` from the Git repository (Python 3.11+) | `npm install -g @fission-ai/openspec` (Node.js 20.19+) |
+| Install footprint | `pip install rac-core` (Python 3.11+) | `uv tool install specify-cli` from the Git repository (Python 3.11+) | `npm install -g @fission-ai/openspec` (Node.js 20.19+) |
 
 <!--
 Comparison sources, verified 2026-06-12:

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -2,14 +2,14 @@
 
 RAC Guide is an MCP server that serves your repository's requirements,
 decisions, designs, and roadmaps to coding agents as callable tools. It ships
-inside the `requirements-as-code` package — no separate install.
+inside the `rac-core` package — no separate install.
 
 ## 1. Install
 
 ```bash
-pip install requirements-as-code
+pip install rac-core
 # or
-uv tool install requirements-as-code
+uv tool install rac-core
 ```
 
 Requires Python 3.11+. The MCP SDK is a standard dependency; no extra flag is

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -9,13 +9,13 @@ artifact, and run the three commands you'll use most: `validate`, `inspect`, and
 RAC is a Python package (requires Python 3.11+). Install it with `pip`:
 
 ```bash
-pip install requirements-as-code
+pip install rac-core
 ```
 
 Or with [uv](https://docs.astral.sh/uv/):
 
 ```bash
-uv tool install requirements-as-code
+uv tool install rac-core
 ```
 
 This puts a single command on your path: `rac`. Check it:

--- a/docs/v0.22-housekeeping-runbook.md
+++ b/docs/v0.22-housekeeping-runbook.md
@@ -24,9 +24,9 @@ Never delete from the engine repo until the content lives elsewhere (ADR-064).
 1. **Never delete before the content lives elsewhere.** Seed → verify → then the
    removal PR.
 2. **History-preserving moves only** (`git filter-repo`), never a flat copy.
-3. **Frozen names never change** (ADR-036/039): PyPI `requirements-as-code`, CLI
-   `rac`, import `rac`, server `lore`. The repo *rename* to `rac-core` touches
-   none of these.
+3. **Frozen identities** (ADR-036/039): CLI `rac`, import `rac`, server `lore`
+   stay frozen. The PyPI distribution renames `requirements-as-code` → `rac-core`
+   (ADR-092 lifts that one freeze; a transitional shim keeps old installs working).
 4. After each engine PR merges, the corpus gates stay green
    (`rac validate rac/`, `rac relationships rac/ --validate`, `rac gate rac/`).
 

--- a/examples/amp/README.md
+++ b/examples/amp/README.md
@@ -13,7 +13,7 @@ the full text and relationships when it needs them.
 ## Prerequisites
 
 ```bash
-pip install requirements-as-code   # the `rac` CLI and the `lore` MCP server
+pip install rac-core   # the `rac` CLI and the `lore` MCP server
 ```
 
 You also need a repository with a RAC corpus under `rac/` (run `rac quickstart`

--- a/examples/claude-code/README.md
+++ b/examples/claude-code/README.md
@@ -9,7 +9,7 @@ bundled authoring **skill** and the only platform seam that allows a real
 ## Prerequisites
 
 ```bash
-pip install requirements-as-code   # the `rac` CLI and the `lore` MCP server
+pip install rac-core   # the `rac` CLI and the `lore` MCP server
 ```
 
 A repository with a RAC corpus under `rac/` (run `rac quickstart`, or use this

--- a/examples/codex/README.md
+++ b/examples/codex/README.md
@@ -8,7 +8,7 @@ Codex-specific RAC code. A stranger can reproduce this from the file alone.
 ## Prerequisites
 
 ```bash
-pip install requirements-as-code   # the `rac` CLI and the `lore` MCP server
+pip install rac-core   # the `rac` CLI and the `lore` MCP server
 ```
 
 A repository with a RAC corpus under `rac/` (run `rac quickstart`, or use this

--- a/examples/copilot/README.md
+++ b/examples/copilot/README.md
@@ -8,7 +8,7 @@ file alone.
 ## Prerequisites
 
 ```bash
-pip install requirements-as-code   # the `rac` CLI and the `lore` MCP server
+pip install rac-core   # the `rac` CLI and the `lore` MCP server
 ```
 
 A repository with a RAC corpus under `rac/` (run `rac quickstart`, or use this

--- a/examples/cursor/README.md
+++ b/examples/cursor/README.md
@@ -7,7 +7,7 @@ reproduce this from the file alone.
 ## Prerequisites
 
 ```bash
-pip install requirements-as-code   # the `rac` CLI and the `lore` MCP server
+pip install rac-core   # the `rac` CLI and the `lore` MCP server
 ```
 
 A repository with a RAC corpus under `rac/` (run `rac quickstart`, or use this

--- a/examples/omnigent/README.md
+++ b/examples/omnigent/README.md
@@ -14,7 +14,7 @@ test it against your Omnigent version before relying on it in production.
 ## Prerequisites
 
 ```bash
-pip install requirements-as-code   # the `rac` CLI and the `lore` MCP server
+pip install rac-core   # the `rac` CLI and the `lore` MCP server
 ```
 
 A repository with a RAC corpus under `rac/` (run `rac quickstart`, or use this

--- a/overrides/home.html
+++ b/overrides/home.html
@@ -25,7 +25,7 @@
   <div class="lore-splash__actions">
     <div class="lore-install">
       <span class="lore-install__prompt">$</span>
-      <code id="lore-install-cmd">pip install requirements-as-code</code>
+      <code id="lore-install-cmd">pip install rac-core</code>
       <button class="lore-install__copy" type="button" data-clipboard-target="#lore-install-cmd" aria-label="Copy install command">copy</button>
     </div>
     <p class="lore-splash__note">Requires Python 3.11+ &middot; <code>uv tool install requirements-as-code</code> also works.</p>

--- a/pr-gate-action/action.yml
+++ b/pr-gate-action/action.yml
@@ -41,7 +41,7 @@ inputs:
     default: "rac-sarif"
   rac-version:
     description: >-
-      Exact requirements-as-code version to install from PyPI. Empty installs the
+      Exact rac-core version to install from PyPI. Empty installs the
       latest release. Ignored when `install-from` is `source`.
     required: false
     default: ""
@@ -70,9 +70,9 @@ runs:
         if [ "$INSTALL_FROM" = "source" ]; then
           python -m pip install --quiet "$GITHUB_ACTION_PATH/.."
         elif [ -n "$RAC_VERSION" ]; then
-          python -m pip install --quiet "requirements-as-code==$RAC_VERSION"
+          python -m pip install --quiet "rac-core==$RAC_VERSION"
         else
-          python -m pip install --quiet requirements-as-code
+          python -m pip install --quiet rac-core
         fi
 
     # The CLI is the source of truth (ADR-058). `set +e` lets a non-zero exit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=77", "setuptools-scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "requirements-as-code"
+name = "rac-core"
 # Version is derived from the git tag by setuptools-scm (see [tool.setuptools_scm]).
 # Release flow: tag vX.Y.Z -> the build is version X.Y.Z. No manual edits.
 dynamic = ["version"]

--- a/rac-localview/scripts/record-demo.sh
+++ b/rac-localview/scripts/record-demo.sh
@@ -21,7 +21,7 @@ run() {
 }
 
 sleep 0.5
-run 'pip install requirements-as-code'
+run 'pip install rac-core'
 run 'claude mcp add lore -- rac mcp'
 run 'rac find "test topology" rac/'
 run 'rac resolve ADR-027 rac/'

--- a/rac-localview/src/landing/LandingApp.tsx
+++ b/rac-localview/src/landing/LandingApp.tsx
@@ -15,7 +15,7 @@ import './landing.css';
 const REPO_URL = 'https://github.com/itsthelore/rac-core';
 
 const DEMO_ALT =
-  'Recorded terminal session: pip install requirements-as-code, ' +
+  'Recorded terminal session: pip install rac-core, ' +
   'claude mcp add lore -- rac mcp, then rac find, rac resolve and ' +
   "rac validate run against this repository's corpus, ending in PASS";
 
@@ -223,7 +223,7 @@ export function LandingApp() {
                 <div className="get__steps">
                   <p className="get__step">
                     <span className="get__lead">Install:</span>{' '}
-                    <CopyCommand command="pip install requirements-as-code" />
+                    <CopyCommand command="pip install rac-core" />
                   </p>
                   <p className="get__step">
                     <span className="get__lead">

--- a/sbom.json
+++ b/sbom.json
@@ -5,10 +5,10 @@
   "metadata": {
     "component": {
       "type": "library",
-      "name": "requirements-as-code",
-      "version": "0.19.1.dev105+g1942d0d88.d20260616",
-      "bom-ref": "requirements-as-code@0.19.1.dev105+g1942d0d88.d20260616",
-      "purl": "pkg:pypi/requirements-as-code@0.19.1.dev105+g1942d0d88.d20260616"
+      "name": "rac-core",
+      "version": "2026.6.5.dev62+g6a8e6675f.d20260627",
+      "bom-ref": "rac-core@2026.6.5.dev62+g6a8e6675f.d20260627",
+      "purl": "pkg:pypi/rac-core@2026.6.5.dev62+g6a8e6675f.d20260627"
     }
   },
   "components": [
@@ -22,9 +22,9 @@
     {
       "type": "library",
       "name": "mcp",
-      "version": "1.27.2",
-      "bom-ref": "mcp@1.27.2",
-      "purl": "pkg:pypi/mcp@1.27.2"
+      "version": "1.28.1",
+      "bom-ref": "mcp@1.28.1",
+      "purl": "pkg:pypi/mcp@1.28.1"
     },
     {
       "type": "library",

--- a/scripts/generate_sbom.py
+++ b/scripts/generate_sbom.py
@@ -35,7 +35,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 PYPROJECT = REPO_ROOT / "pyproject.toml"
 SBOM_PATH = REPO_ROOT / "sbom.json"
 
-PACKAGE_NAME = "requirements-as-code"
+PACKAGE_NAME = "rac-core"
 
 # A PEP 508 requirement string starts with the distribution name; strip any
 # version specifier, extras, or environment marker to recover the bare name.

--- a/server.json
+++ b/server.json
@@ -3,14 +3,14 @@
   "name": "io.github.tcballard/lore",
   "description": "Serve your repo's recorded product knowledge - requirements, decisions (ADRs), designs, roadmaps - to coding agents. Deterministic, read-only.",
   "repository": {
-    "url": "https://github.com/tcballard/requirements-as-code",
+    "url": "https://github.com/itsthelore/rac-core",
     "source": "github"
   },
   "version": "0.11.0",
   "packages": [
     {
       "registryType": "pypi",
-      "identifier": "requirements-as-code",
+      "identifier": "rac-core",
       "version": "0.11.0",
       "transport": {
         "type": "stdio"

--- a/src/rac/__init__.py
+++ b/src/rac/__init__.py
@@ -59,7 +59,7 @@ from rac.services import (
 try:
     # Single source of truth: the version declared in pyproject.toml and
     # baked into the installed distribution. Keeps `rac --version` in sync.
-    __version__ = version("requirements-as-code")
+    __version__ = version("rac-core")
 except PackageNotFoundError:  # running from a source tree that isn't installed
     __version__ = "0.0.0+unknown"
 

--- a/src/rac/explorer/launch.py
+++ b/src/rac/explorer/launch.py
@@ -15,9 +15,7 @@ from rac.errors import RACError
 if TYPE_CHECKING:  # pragma: no cover — typing only, never at runtime
     from rac.explorer.app import ExplorerApp
 
-MISSING_EXTRA_HINT = (
-    "explorer needs the explorer extra: pip install 'requirements-as-code[explorer]'"
-)
+MISSING_EXTRA_HINT = "explorer needs the explorer extra: pip install 'rac-core[explorer]'"
 
 
 class ExplorerUnavailable(RACError):

--- a/src/rac/services/ingest.py
+++ b/src/rac/services/ingest.py
@@ -102,10 +102,7 @@ _EXTRA_FOR_SUFFIX = {
 
 def _missing_extra_message(suffix: str) -> str:
     extra = _EXTRA_FOR_SUFFIX.get(suffix.lower(), "ingest")
-    return (
-        f"converting '{suffix}' needs the {extra} extra: "
-        f"pip install 'requirements-as-code[{extra}]'"
-    )
+    return f"converting '{suffix}' needs the {extra} extra: pip install 'rac-core[{extra}]'"
 
 
 def _is_missing_dependency(exc: Exception) -> bool:

--- a/src/rac/skills/rac-import/SKILL.md
+++ b/src/rac/skills/rac-import/SKILL.md
@@ -50,7 +50,7 @@ rac ingest decision.docx          # preview Markdown on stdout
 `rac ingest <file>` converts DOCX / PDF / HTML / PPTX / XLSX / Markdown to
 Markdown text, preserving structure — it does not judge whether the result is a
 valid artifact. Pasted Markdown needs no conversion. Rich formats need the
-optional extras (`pip install 'requirements-as-code[ingest]'`, `[ingest-pdf]`,
+optional extras (`pip install 'rac-core[ingest]'`, `[ingest-pdf]`,
 `[ingest-office]`); the command names the missing extra when one is needed.
 
 ## 3. Choose the type and read its real schema

--- a/src/rac/skills/rac-ingest/SKILL.md
+++ b/src/rac/skills/rac-ingest/SKILL.md
@@ -36,7 +36,7 @@ rac ingest spec.docx -o rac/requirements/spec.md  # write into the RAC directory
 (pass-through) to Markdown, preserving structure. It does not judge
 whether the result is a valid artifact — that comes next. `-o` never
 overwrites an existing file unless `--force` is passed. Rich formats need
-the optional ingest extras (`pip install 'requirements-as-code[ingest]'`
+the optional ingest extras (`pip install 'rac-core[ingest]'`
 for DOCX/HTML, `[ingest-pdf]`, `[ingest-office]`, or `[ingest-all]`); the
 command names the missing extra when one is needed.
 

--- a/tests/test_explorer_cli.py
+++ b/tests/test_explorer_cli.py
@@ -89,7 +89,7 @@ def test_missing_extra_exits_2_with_install_hint(tmp_path, monkeypatch, capsys):
         main(["explorer", str(tmp_path)])
     assert excinfo.value.code == 2
     err = capsys.readouterr().err
-    assert "pip install 'requirements-as-code[explorer]'" in err
+    assert "pip install 'rac-core[explorer]'" in err
 
 
 def test_unavailable_error_carries_the_hint(monkeypatch):
@@ -99,7 +99,7 @@ def test_unavailable_error_carries_the_hint(monkeypatch):
     monkeypatch.setattr(launch, "_import_app", import_fails)
     with pytest.raises(ExplorerUnavailable, match="explorer extra"):
         run_explorer(".")
-    assert "requirements-as-code[explorer]" in MISSING_EXTRA_HINT
+    assert "rac-core[explorer]" in MISSING_EXTRA_HINT
 
 
 def test_other_import_errors_are_real_bugs(monkeypatch):

--- a/tests/test_sbom.py
+++ b/tests/test_sbom.py
@@ -45,7 +45,7 @@ def test_sbom_is_cyclonedx():
 
 def test_sbom_includes_the_package_as_root_component():
     root = _sbom()["metadata"]["component"]
-    assert root["name"] == "requirements-as-code"
+    assert root["name"] == "rac-core"
     assert root["type"] == "library"
 
 

--- a/tests/test_watchkeeper.py
+++ b/tests/test_watchkeeper.py
@@ -242,7 +242,7 @@ def test_action_supports_source_installs_for_dogfooding():
     action = _load_yaml("action.yml")
     install = next(s["run"] for s in action["runs"]["steps"] if "pip install" in s.get("run", ""))
     assert "$GITHUB_ACTION_PATH" in install  # source mode
-    assert "requirements-as-code" in install  # pypi mode
+    assert "rac-core" in install  # pypi mode
 
 
 def test_reusable_workflow_passes_inputs_through():

--- a/validate-action/action.yml
+++ b/validate-action/action.yml
@@ -33,7 +33,7 @@ inputs:
     default: "rac.sarif"
   rac-version:
     description: >-
-      Exact requirements-as-code version to install from PyPI. Empty installs the
+      Exact rac-core version to install from PyPI. Empty installs the
       latest release. Ignored when `install-from` is `source`.
     required: false
     default: ""
@@ -62,9 +62,9 @@ runs:
         if [ "$INSTALL_FROM" = "source" ]; then
           python -m pip install --quiet "$GITHUB_ACTION_PATH/.."
         elif [ -n "$RAC_VERSION" ]; then
-          python -m pip install --quiet "requirements-as-code==$RAC_VERSION"
+          python -m pip install --quiet "rac-core==$RAC_VERSION"
         else
-          python -m pip install --quiet requirements-as-code
+          python -m pip install --quiet rac-core
         fi
 
     # The CLI is the source of truth (ADR-058). `set +e` lets a non-zero exit


### PR DESCRIPTION
PR B of the repository-topology work — the **PyPI distribution rename** authorized by ADR-092 (which lifted ADR-036's freeze on the PyPI name). PR A (#213) landed the decision; this is the mechanics.

## What

Renames the distribution `requirements-as-code` → **`rac-core`**, aligning it with the repo and the `rac` CLI. **The import package `rac` and the `rac` CLI entry point are unchanged — zero API churn.**

- **Packaging:** `pyproject.toml` `name`, the `version("rac-core")` lookup in `rac/__init__.py`, the SBOM (`generate_sbom.py` `PACKAGE_NAME` + regenerated `sbom.json`), and `server.json` (pypi identifier + repo URL).
- **Install surfaces:** action wrappers (`action.yml`, `pr-gate-action/`, `validate-action/`), the TestPyPI rehearsal notes + watchkeeper version input, README badges + install table, `docs/*` install commands, the example READMEs, the landing page / demo script / docs-site override, and the bundled skills' extra-install hints.
- **Tests:** the package-name assertions (`test_sbom`, `test_explorer_cli`, `test_watchkeeper`).

`python-publish.yml` is untouched — Trusted Publishing derives the project from the built distribution. The PyPI trusted publisher for `rac-core` (workflow `python-publish.yml`, env `pypi`) is already registered.

## Left intentionally unchanged

- The **methodology name** "requirements-as-code" in prose (the product *is* requirements-as-code).
- **Historical** mentions in the `rac/` corpus, `CHANGELOG.md`, and past-version roadmaps — reconciled (if needed) in the deferred corpus/roadmap pass.

## Maintainer-run, outside this PR

- **Transitional shim:** publish a final `requirements-as-code` release that depends on `rac-core` (+ deprecation note) so existing `pip install requirements-as-code` and pins keep working through a deprecation window.
- The first tagged release publishes `rac-core` to PyPI via the existing Trusted Publisher.

## Verification

- Full `pytest` suite green (1694 passed, 1 skipped).
- `ruff check` · `ruff format --check` clean; `mypy` clean (only environmental missing-stub noise).
- SBOM regenerated deterministically with root component `rac-core` at the current version; `tests/test_sbom.py` green.
- `version("rac-core")` resolves against the reinstalled distribution.