### PR TITLE
chore(release): add requirements-as-code → rac-core redirect shim

### DIFF
--- a/.github/workflows/publish-shim.yml
+++ b/.github/workflows/publish-shim.yml
@@ -1,0 +1,40 @@
+# One-time Trusted Publishing of the requirements-as-code -> rac-core redirect
+# shim (ADR-092). Manual, single-shot: run it once, AFTER rac-core's first
+# release exists on PyPI, then delete the trusted publisher (see
+# packaging/requirements-as-code-shim/PUBLISHING.md).
+#
+# Requires a Trusted Publisher on the **requirements-as-code** PyPI project:
+#   repo itsthelore/rac-core · workflow publish-shim.yml · environment pypi
+# (same shape as the rac-core publisher, different project + workflow).
+name: Publish requirements-as-code shim
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish-shim:
+    runs-on: ubuntu-latest
+    permissions:
+      # Mandatory for Trusted Publishing (OIDC); no PyPI token is used.
+      id-token: write
+    environment:
+      name: pypi
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+
+      - name: Build the redirect shim (metadata-only)
+        run: |
+          python -m pip install --quiet build
+          python -m build packaging/requirements-as-code-shim --outdir dist
+
+      - name: Publish to PyPI (Trusted Publishing)
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/

--- a/packaging/requirements-as-code-shim/PUBLISHING.md
+++ b/packaging/requirements-as-code-shim/PUBLISHING.md
@@ -1,0 +1,47 @@
+# Publishing the requirements-as-code redirect (one-time)
+
+This is a **one-time, final** release of the old `requirements-as-code` PyPI
+project. After it, the old name is frozen; all real engine releases go to
+`rac-core`. The redirect keeps pointing at the latest `rac-core` forever via its
+unpinned dependency floor — it never needs republishing when `rac-core` updates.
+(Maintainer-facing — not shipped in the wheel.)
+
+## Order of operations
+
+1. **Publish `rac-core` first** (the normal release: tag → `python-publish.yml`).
+   The redirect depends on `rac-core`, so it should exist on PyPI first.
+2. **Confirm the version** in `pyproject.toml` is strictly greater than the last
+   real `requirements-as-code` release (currently `2026.06.4`), so an unpinned
+   `pip install requirements-as-code` resolves here. `2026.6.99` satisfies this
+   and signals "final". Optionally tighten `dependencies` to
+   `rac-core>=<first rac-core version>`.
+3. **Publish** via the workflow below.
+
+## Publish — Trusted Publishing via `publish-shim.yml` (no token)
+
+1. On PyPI, register a Trusted Publisher on the **`requirements-as-code`** project
+   (Manage → Publishing → Add a pending/trusted publisher → GitHub):
+   - Owner: `itsthelore` · Repository: `rac-core`
+   - **Workflow name: `publish-shim.yml`** · Environment name: `pypi`
+   (Same shape as the `rac-core` publisher — different project + workflow.)
+2. Run it once: **Actions → "Publish requirements-as-code shim" → Run workflow**
+   (`workflow_dispatch`). It builds the metadata-only shim and uploads via OIDC.
+3. **Verify:**
+   ```bash
+   python -m venv /tmp/shimcheck && /tmp/shimcheck/bin/pip install requirements-as-code
+   /tmp/shimcheck/bin/rac --version   # comes from rac-core, pulled in transitively
+   ```
+4. **Delete the Trusted Publisher** you just added from the `requirements-as-code`
+   project. This is a single final upload — removing it ensures nothing can ever
+   publish to the old name again. (The `publish-shim.yml` workflow can stay in the
+   repo, inert: with no trusted publisher it cannot upload.)
+
+## Fallback — manual (token)
+
+If you would rather not register a publisher:
+
+```bash
+cd packaging/requirements-as-code-shim
+python -m build                 # metadata-only sdist + wheel
+python -m twine upload dist/*   # username __token__, a PyPI token scoped to requirements-as-code
+```

--- a/packaging/requirements-as-code-shim/README.md
+++ b/packaging/requirements-as-code-shim/README.md
@@ -1,0 +1,16 @@
+# requirements-as-code → **rac-core**
+
+> **This package has been renamed.** `requirements-as-code` is now published as
+> [`rac-core`](https://pypi.org/project/rac-core/).
+
+```bash
+pip install rac-core
+```
+
+The import package and CLI are unchanged — you still `import rac` and run `rac`.
+Only the PyPI distribution name changed (see ADR-092).
+
+This release of `requirements-as-code` is a **transitional redirect**: it contains
+no code of its own and simply depends on `rac-core`, so existing
+`pip install requirements-as-code` and CI keep working. It will not be updated
+further — point new installs at `rac-core`.

--- a/packaging/requirements-as-code-shim/pyproject.toml
+++ b/packaging/requirements-as-code-shim/pyproject.toml
@@ -1,0 +1,37 @@
+# Transitional redirect package for the rename requirements-as-code -> rac-core
+# (ADR-092). This builds a metadata-only distribution under the OLD name whose
+# only job is to depend on `rac-core`, so existing `pip install requirements-as-code`
+# keeps working. It ships NO code of its own — the `rac` import and CLI come from
+# rac-core. Published once, then frozen; real engine releases go to rac-core.
+#
+# This directory is NOT part of the main rac-core build (that discovers packages
+# under src/ only); it is built and published on its own. See PUBLISHING.md.
+[build-system]
+requires = ["setuptools>=77"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "requirements-as-code"
+# Must be strictly greater than the final real requirements-as-code release so an
+# unpinned `pip install requirements-as-code` resolves to this redirect. `==<old>`
+# pins still resolve to the real historical releases. Confirm/bump before publish.
+version = "2026.6.99"
+description = "Renamed to rac-core. Transitional redirect — install rac-core instead."
+readme = "README.md"
+requires-python = ">=3.11"
+license = "Apache-2.0"
+authors = [{ name = "Tom Ballard", email = "tom@armytage.co" }]
+keywords = ["requirements-as-code", "rac", "rac-core", "moved", "renamed"]
+# The whole point: pulling this in pulls in the renamed package. Pin the floor to
+# the first rac-core release so the redirect can never resolve to nothing
+# (tighten to the exact first rac-core version once it is published).
+dependencies = ["rac-core>=2026.6"]
+
+[project.urls]
+Homepage = "https://github.com/itsthelore/rac-core"
+Repository = "https://github.com/itsthelore/rac-core"
+
+[tool.setuptools]
+# Metapackage: no modules, no packages. The wheel carries metadata + the
+# rac-core dependency only, so it never shadows rac-core's `rac` import.
+packages = []


### PR DESCRIPTION
PR C of the rename work — the **transition shim** that keeps `pip install requirements-as-code` working after the rename to `rac-core` (PR B, #214). Implements ADR-092.

## What

A self-contained metapackage under `packaging/requirements-as-code-shim/` plus a one-time publish workflow:
- `pyproject.toml` — `name = "requirements-as-code"`, `packages = []` (ships **no code**, so it never shadows `rac-core`'s `rac` import), `dependencies = ["rac-core>=2026.6"]`.
- `README.md` — the PyPI page for the old name ("renamed → rac-core").
- `PUBLISHING.md` — maintainer steps: the Trusted-Publishing route (primary) and a manual-twine fallback.
- `.github/workflows/publish-shim.yml` — `workflow_dispatch`-only, token-free Trusted Publishing of the shim.

Verified: builds to a metadata-only wheel with `Requires-Dist: rac-core>=2026.6` and no modules.

## How the redirect works (and why it's one-time)

The dependency is a **floor, not a pin**, so the redirect resolves at the *user's* install time: `pip install requirements-as-code` → installs the shim → pip pulls **the latest `rac-core` available then**. So it's published **once and frozen** — it does **not** (and should not) republish on every `rac-core` release. Pinned `requirements-as-code==` installs still resolve to the real historical releases.

## Publishing (maintainer-run, one-time, token-free)

1. Release `rac-core` first (so the dependency resolves).
2. Register a Trusted Publisher on the **`requirements-as-code`** PyPI project: repo `itsthelore/rac-core`, workflow `publish-shim.yml`, env `pypi`.
3. Run **Actions → "Publish requirements-as-code shim" → Run workflow** once.
4. **Delete that Trusted Publisher** — a single final upload; removing it locks the old name so nothing can ever publish to it again. The workflow stays in the repo, inert (no publisher = no upload).

## Scope / boundaries

- **Not part of the main `rac-core` build** — package discovery is `where = ["src"]`, so this `packaging/` dir is inert to the engine build and CI.
- Deliberately **no `on: release` automation** — the floor dependency, not republishing, does the ongoing redirect.

## Sequencing

Merge order: PR B (#214, the rename) → release `rac-core` → run `publish-shim.yml` → delete the shim's trusted publisher. PR C can merge anytime; it only adds files.