### PR TITLE
docs(readme): fix the broken license badge after the PyPI rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 <a href="https://pypi.org/project/rac-core/"><img src="https://img.shields.io/pypi/v/rac-core" alt="PyPI"></a>
 <a href="https://pypi.org/project/rac-core/"><img src="https://img.shields.io/pypi/pyversions/rac-core" alt="Python"></a>
 <a href="https://mypy-lang.org/"><img src="https://img.shields.io/badge/types-Mypy-blue.svg" alt="Typed"></a>
-<a href="https://github.com/itsthelore/rac-core/blob/main/LICENSE"><img src="https://img.shields.io/pypi/l/rac-core" alt="License: Apache 2.0"></a>
+<a href="https://github.com/itsthelore/rac-core/blob/main/LICENSE"><img src="https://img.shields.io/github/license/itsthelore/rac-core" alt="License: Apache 2.0"></a>
 </p>
 
 > **Give your coding agent the decisions your team already made — so it stops re-doing things you ruled out.**


### PR DESCRIPTION
The README license badge renders **"package or version not found"** since the rename.

## Cause

The badge used `img.shields.io/pypi/l/rac-core`. rac-core declares its license as a **PEP 639 SPDX expression** (`license = "Apache-2.0"`) with no legacy `License:` field or trove classifier, and shields' `pypi/l` endpoint can't read `license_expression`. PyPI's JSON confirms it:

```
license:            None
license_expression: "Apache-2.0"
classifiers:        []   (no "License :: ..." classifier)
```

The sibling `pypi/v` and `pypi/pyversions` badges resolve fine — only the license lookup fails.

## Fix

Switch to `img.shields.io/github/license/itsthelore/rac-core`, which reads the repository's GitHub-detected license. The GitHub API confirms detection:

```
spdx_id: Apache-2.0
name:    Apache License 2.0
```

So the badge renders **Apache-2.0** correctly, is unaffected by the PEP 639 metadata gap, and stays self-maintaining. The link still points at `LICENSE`.

One-line change; `README.md` only.