### PR TITLE
docs(decision): align the topology ADR set to ADR-092 and add the v0.31.x-repo-topology series

### DIFF
--- a/rac/decisions/adr-064-multi-repo-extraction-strategy.md
+++ b/rac/decisions/adr-064-multi-repo-extraction-strategy.md
@@ -16,6 +16,14 @@ Architecture
 
 ## Context
 
+> **Topology superseded by ADR-092.** The multi-repo, one-repo-per-component
+> strategy recorded here (a standalone `decisiongrounding`, a single
+> `rac-actions`) is replaced by ADR-092's *one repo per concern, subdir per
+> member* model under uniform `rac-*` naming — `rac-ci` (CI delivery),
+> `rac-connectors`, `rac-sdk`, `rac-benchmarks`, `rac-editors`. ADR-092 governs
+> where the two differ; this ADR remains the record of the first topology.
+> Execution is re-planned in the `v0.31.x-repo-topology` series.
+
 `requirements-as-code` has moved from a personal GitHub account
 (`tcballard`) into the `itsthelore` organisation. The repository is a
 monorepo for **Lore** (the product) whose engine is **RAC** — the
@@ -178,6 +186,7 @@ Lift the web viewer in the same pass.
 - adr-039
 - adr-058
 - adr-062
+- adr-092
 
 ## Related Requirements
 

--- a/rac/decisions/adr-068-extension-sdk-and-brand-architecture.md
+++ b/rac/decisions/adr-068-extension-sdk-and-brand-architecture.md
@@ -16,6 +16,15 @@ Architecture
 
 ## Context
 
+> **Topology and naming superseded by ADR-092.** The `lore-*` (install) /
+> `rac-*` (engine) prefix split and the per-client / per-action repositories
+> recorded here are replaced by ADR-092's *one repo per concern, subdir per
+> member* model with uniform `rac-*` naming — the brand "Lore" lives at the org
+> and the marketplace listings, not in repository slugs. ADR-068's
+> non-topology decisions still hold: the single shared-VSIX client surface, and
+> the Python SDK staying inside `rac-core` (ADR-062). ADR-092 governs where the
+> two differ; execution is re-planned in the `v0.31.x-repo-topology` series.
+
 ADR-064 settled the first repository topology for the `itsthelore`
 organisation: extract `decisiongrounding` and the GitHub Actions, keep the
 engine, its shipped resources, the dogfood corpus, and `examples/` in
@@ -213,6 +222,7 @@ Lift the Python SDK out of the engine package into a `rac-sdk-py` repo.
 - adr-058
 - adr-062
 - adr-063
+- adr-092
 
 ## Related Roadmaps
 

--- a/rac/decisions/adr-073-backend-connectors-consolidate.md
+++ b/rac/decisions/adr-073-backend-connectors-consolidate.md
@@ -7,6 +7,14 @@ type: decision
 
 ## Context
 
+> **Renamed and generalised by ADR-092.** `lore-connectors` is now
+> `rac-connectors`, and ADR-092 broadens this one-repo consolidation to cover
+> inbound (`rac ingest`) and outbound (`rac export`) integrations and provider
+> suites alike — Atlassian is a subdir, not its own repo. The decision below —
+> connectors are export-contract consumers, consolidated, never one repo per
+> provider — is unchanged; it is the pattern ADR-092 generalises across the
+> `rac-*` family. Execution is planned in the `v0.31.x-repo-topology` series.
+
 The export-to-RAG work (the umbrella roadmap `corpus-export-to-rag-backends`, the
 interplay design `lore-supermemory-interplay`, and the wire-shape design
 `corpus-export-shape-contract`) introduces *connectors* that push the corpus into
@@ -115,6 +123,7 @@ real code. `lore-connectors` is the home for that; recipes cover the rest.
 - adr-064
 - adr-066
 - adr-068
+- adr-092
 
 ## Related Designs
 

--- a/rac/decisions/adr-092-repository-topology.md
+++ b/rac/decisions/adr-092-repository-topology.md
@@ -217,6 +217,10 @@ Flip ADR-068 to Superseded in this change.
 - adr-066
 - adr-069
 
+## Related Roadmaps
+
+- v0.31.0-repo-topology-convergence
+
 ## Review Date
 
 Revisit if a consolidated family repo's members diverge enough in cadence or

--- a/rac/roadmaps/future/repo-extraction-programme.md
+++ b/rac/roadmaps/future/repo-extraction-programme.md
@@ -12,6 +12,16 @@ Planned
 
 ## Context
 
+> **Superseded by ADR-092; re-planned as the `v0.31.x-repo-topology` series.**
+> This programme sequenced the *first* (`lore-*` / one-repo-per-component)
+> extraction topology, and its low-risk moves landed (`decisiongrounding`,
+> v0.22.4; the TypeScript stack → `rac-sdk-ts` + `lore-vscode`, v0.22.5).
+> ADR-092 then replaced that topology with *one repo per concern* under uniform
+> `rac-*` naming. The remaining work — consolidating those already-extracted
+> repos into `rac-connectors` / `rac-sdk` / `rac-benchmarks` / `rac-editors` and
+> the actions into `rac-ci` — is carried by the `v0.31.x-repo-topology` series.
+> This item is retained as the record of the original programme.
+
 ADR-064 records the decision to adopt a small multi-repo topology under the
 `itsthelore` organisation: extract the standalone components and keep the
 engine, its shipped resources, and its governing corpus in `itsthelore/rac-core`

--- a/rac/roadmaps/v0.22.x-housekeeping/v0.22.6-split-actions.md
+++ b/rac/roadmaps/v0.22.x-housekeeping/v0.22.6-split-actions.md
@@ -21,6 +21,13 @@ the branded path — and a PyPI engine release is available for
 
 ## Context
 
+> **Superseded by ADR-092 / the `v0.31.x-repo-topology` series.** The two-repo
+> split recorded here (`lore-gatekeeper` + `lore-watchkeeper`) is replaced by
+> ADR-092's single `rac-ci` repo — a subdir per capability, platform nested
+> within — so the actions are never split across repos by platform. The work is
+> re-planned as `v0.31.1-rac-ci`; this item is retained as the record of the
+> deferred two-repo plan.
+
 ADR-068 amends ADR-064: the GitHub Actions split into two product-branded repos,
 `lore-watchkeeper` (the Watchkeeper action, root `action.yml`) and
 `lore-gatekeeper` (the gate action `pr-gate-action`, `rac gate`), and the older

--- a/rac/roadmaps/v0.31.x-repo-topology/v0.31.0-repo-topology-convergence.md
+++ b/rac/roadmaps/v0.31.x-repo-topology/v0.31.0-repo-topology-convergence.md
@@ -1,0 +1,114 @@
+---
+schema_version: 1
+id: RAC-KW6F43XVSPCX
+type: roadmap
+tags: [structure, org, distribution, branding]
+---
+# RAC v0.31.0 — Repository Topology Convergence
+
+## Status
+
+Planned
+
+## Context
+
+ADR-092 set the current repository topology for the `itsthelore` organisation:
+**one repo per concern, subdir per member, uniform `rac-*` naming**, with the
+brand "Lore" living at the org and the marketplace listings rather than in
+repository slugs. It supersedes the first topology (ADR-064/ADR-068, the
+`lore-*` / `rac-*` split and per-member repos) and generalises the connector
+consolidation (ADR-073).
+
+The first extraction phase — the `repo-extraction-programme` and the
+`v0.22.x-housekeeping` series — already moved the standalone components out of
+the engine repo: `decisiongrounding` (v0.22.4) and the TypeScript stack
+(`rac-sdk-ts` + `lore-vscode`, v0.22.5) now live in their own repositories, and
+the GitHub Actions split was deferred (v0.22.6). Those moves landed under the
+*old* topology, so the org now carries a mix of `rac-*`, `lore-*`, and own-brand
+slugs.
+
+This series converges the live org onto ADR-092's target. It is a new series —
+not a rewrite of the v0.22.x items, which stand as the record of the first phase
+— with one item per family repo, each an independently-executable org action.
+The work is repository topology only: no engine behaviour, public surface,
+package, CLI, or server-identity change (ADR-029/036/039 hold).
+
+## Outcomes
+
+- The `itsthelore` org matches ADR-092's target table: a bounded set of `rac-*`
+  family repos — `rac-core`, `rac-ci`, `rac-connectors`, `rac-sdk`,
+  `rac-benchmarks`, `rac-editors` — one per concern, subdir per member.
+- No contradictory `lore-*` or per-member slug remains in the RAC/Lore
+  constellation; the separate products keep their own brands
+  (`wayfinder-router`, `proofkeeper`).
+- Every cross-repo consumer reference (action `uses:` paths, the npm package,
+  install docs) resolves after the renames, with no stranded reference.
+
+## Initiatives
+
+Each initiative is its own item in this series, executed independently:
+
+- **`rac-ci`** (v0.31.1) — consolidate `rac-actions`, `lore-watchkeeper`, and
+  `lore-gatekeeper` into one CI-delivery repo, subdir per capability.
+- **`rac-connectors`** (v0.31.2) — rename `lore-connectors`; subdir per
+  integration, inbound and outbound.
+- **`rac-sdk`** (v0.31.3) — consolidate `rac-sdk-ts` into `rac-sdk/ts/`; the
+  Python SDK stays in `rac-core` (ADR-062).
+- **`rac-benchmarks`** (v0.31.4) — restructure `decisiongrounding` into
+  `rac-benchmarks/decisiongrounding/`.
+- **`rac-editors`** (v0.31.5) — rename `lore-vscode` into `rac-editors/vscode/`.
+- **Naming/brand cutover** — apply the `rac-*` slug rule across the
+  constellation as each repo lands; the "Lore" brand stays at the org and the
+  marketplace listings (ADR-092).
+
+## Success Measures
+
+- Every repository in ADR-092's target table exists under its `rac-*` name; no
+  `lore-*` slug remains except the separate-product brands.
+- Consumers of the actions, the npm SDK, and the install docs resolve to the new
+  locations; no issue traces to a stranded `uses:` path, npm name, or repo URL.
+- The `rac-core` corpus gates (`rac validate`, `rac relationships --validate`,
+  `rac review`) stay green throughout; no engine or contract change ships with
+  the topology move.
+
+## Assumptions
+
+- The maintainer can create, rename, permission, and archive repositories under
+  `itsthelore`; the GitHub-side moves are org actions outside `rac-core`.
+- The components being consolidated already exist as their own repos (the first
+  phase's output) or in-repo (`rac-actions`), so this phase renames and groups
+  rather than extracts from the engine.
+- ADR-092 stands as the governing topology decision for the duration of the
+  series.
+
+## Risks
+
+- **Stranded references on rename.** Renaming a repo or npm package breaks
+  pinned consumers. Mitigation: GitHub redirects on rename, a versioned cutover
+  for the actions, and a deprecation note on the old npm name.
+- **Brand confusion mid-migration.** Some repos carry the old slug until their
+  item lands. Mitigation: the rule is recorded (ADR-092) and each rename is an
+  explicit, documented org action.
+- **Scope creep into engine changes.** Mitigation: this series is topology only;
+  any engine-side support (for example a Bitbucket renderer for `rac-ci`) is
+  scoped in its own item, not assumed here.
+
+## Related Decisions
+
+- adr-092
+- adr-064
+- adr-068
+- adr-073
+
+## Related Roadmaps
+
+- v0.31.1-rac-ci
+- v0.31.2-rac-connectors
+- v0.31.3-rac-sdk
+- v0.31.4-rac-benchmarks
+- v0.31.5-rac-editors
+- repo-extraction-programme
+
+## Related Requirements
+
+- rac-growth-extensibility

--- a/rac/roadmaps/v0.31.x-repo-topology/v0.31.1-rac-ci.md
+++ b/rac/roadmaps/v0.31.x-repo-topology/v0.31.1-rac-ci.md
@@ -1,0 +1,92 @@
+---
+schema_version: 1
+id: RAC-KW6F45V3NGFF
+type: roadmap
+tags: [structure, org, ci, distribution]
+---
+# RAC v0.31.1 — Consolidate CI Delivery into rac-ci
+
+## Status
+
+Planned
+
+## Context
+
+ADR-092 places all CI delivery in a single `rac-ci` repository — one subdir per
+capability (`watchkeeper/`, `gatekeeper/`, `audit/`), with delivery platforms
+nested inside each (`github/`, `bitbucket/`, `jenkins/`). This restores ADR-064's
+single-`rac-actions` consolidation intent, which ADR-068 had split into the
+per-action `lore-watchkeeper` / `lore-gatekeeper` repos, and supersedes the
+deferred two-repo plan in `v0.22.6-split-actions`. A capability is never split
+across repos by platform, so ADR-090's capability-first intent holds and no
+`lore-pipelines` is created.
+
+The engine is already platform-neutral — `rac gate` and `rac watchkeeper` emit
+SARIF and JSON, and the GitHub annotations are one output flavour — so the
+GitHub→other-platform work is in the thin wrappers, not the engine.
+
+## Outcomes
+
+- A single `itsthelore/rac-ci` repository holds every CI wrapper, a subdir per
+  capability, consumed as `uses: itsthelore/rac-ci/<capability>@<ref>`.
+- `rac-actions`, `lore-watchkeeper`, and `lore-gatekeeper` are consolidated into
+  it and archived; the in-repo `action.yml`, `pr-gate-action/`, and
+  `validate-action/` sources are removed from `rac-core` once `rac-ci` carries
+  them.
+- This repository's own dogfood CI consumes the `rac-ci` capabilities (or a
+  documented source-install equivalent), with no stranded `uses:` path.
+
+## Initiatives
+
+- **Seed `rac-ci`** with the watchkeeper and gatekeeper wrappers under
+  `watchkeeper/` and `gatekeeper/` (`github/` first), history preserved, plus an
+  `audit/` placeholder for the ADR-084 recorder's future wrapper; tag a suite
+  version consumers can pin.
+- **Repoint and remove** the in-repo action sources: switch `rac-core`'s own
+  workflows to the `rac-ci` capabilities (or keep the source-install dogfood and
+  document it), then remove the in-repo action dirs and update
+  `tests/test_*_action.py` and `docs/`.
+- **Archive predecessors** `rac-actions`, `lore-watchkeeper`, `lore-gatekeeper`
+  with a redirect note to `rac-ci`.
+
+## Success Measures
+
+- `itsthelore/rac-ci` exists with the capability subdirs and a pinnable suite
+  tag; the three predecessor action repos are archived with redirects.
+- No consumer reference traces to an in-repo action path or a `lore-*` action
+  repo; `rac-core`'s dogfood CI is green against the new locations.
+- The `rac-core` corpus gates stay green after the in-repo action sources are
+  removed.
+
+## Assumptions
+
+- The actions consume only the public `rac` CLI, never engine internals, so they
+  run from any repo once published.
+- Coupled suite version tags (one `rac-ci` version) and consumption via
+  `uses: itsthelore/rac-ci/<capability>@<ref>` rather than per-action
+  Marketplace listings are acceptable (ADR-092).
+- The maintainer can create `rac-ci` and archive the predecessor repos.
+
+## Risks
+
+- **Stranded `uses:` references** break consumers pinned to the in-repo or
+  `lore-*` paths. Mitigation: seed and tag `rac-ci` first, then cut over behind a
+  documented version, leaving redirect notes on the archived repos.
+- **Non-GitHub wrappers underspecified.** Mitigation: ship `github/` first; add
+  `bitbucket/` (with any engine-side Code-Insights renderer scoped separately)
+  and `jenkins/` when demanded.
+
+## Related Decisions
+
+- adr-092
+- adr-064
+- adr-068
+- adr-049
+- adr-058
+- adr-090
+
+## Related Roadmaps
+
+- v0.31.0-repo-topology-convergence
+- v0.22.6-split-actions
+- repo-extraction-programme

--- a/rac/roadmaps/v0.31.x-repo-topology/v0.31.2-rac-connectors.md
+++ b/rac/roadmaps/v0.31.x-repo-topology/v0.31.2-rac-connectors.md
@@ -1,0 +1,77 @@
+---
+schema_version: 1
+id: RAC-KW6F47QRN0ND
+type: roadmap
+tags: [structure, org, distribution]
+---
+# RAC v0.31.2 — Rename lore-connectors to rac-connectors
+
+## Status
+
+Planned
+
+## Context
+
+ADR-073 established that backend connectors are export-contract consumers
+consolidated in one repository, not one repo per provider. ADR-092 renames that
+repository `lore-connectors` → `rac-connectors` and generalises its scope: one
+integrations repo covering **inbound** (`rac ingest`) and **outbound**
+(`rac export`) alike, plus provider suites — Atlassian is a subdir
+(`atlassian/`), not its own repo. The consolidation principle is unchanged; this
+item applies the `rac-*` name and the wider remit.
+
+## Outcomes
+
+- `itsthelore/lore-connectors` is renamed `rac-connectors`, a subdir per
+  integration (`atlassian/`, `supermemory/`, …), spanning inbound and outbound
+  adapters.
+- A provider grows its own repo only via the ADR-073 escape hatch (an installable
+  product with independent cadence/ownership) — not by default.
+- Documentation that points at the connectors companion resolves to
+  `rac-connectors`.
+
+## Initiatives
+
+- **Rename the repo** `lore-connectors` → `rac-connectors` (GitHub redirect
+  preserves existing links) and adopt the subdir-per-integration layout.
+- **Fold in the inbound axis**: the would-be separate inbound work (e.g.
+  Atlassian/Confluence ingestion, the long tail of source fetchers) lands as
+  subdirs here rather than a separate `lore-sources` repo.
+- **Update `rac-core` references** to the connectors companion (for example the
+  README "Export the corpus" note) from `lore-connectors` to `rac-connectors`.
+
+## Success Measures
+
+- `itsthelore/rac-connectors` exists with the subdir-per-integration layout; the
+  old name redirects.
+- No `rac-core` doc or corpus reference points to `lore-connectors`.
+- Connectors still consume only the published export/ingest contracts and the
+  public CLI — no engine internals (ADR-002, ADR-063).
+
+## Assumptions
+
+- Connectors remain thin contract-consumers without independent
+  cadence/ownership, so consolidation holds (ADR-073).
+- The export and ingest contracts (`rac export --documents` / `--graph`,
+  `rac ingest`) are stable enough to consume across providers.
+- The maintainer can rename the repository under `itsthelore`.
+
+## Risks
+
+- **The repo becomes a grab-bag** as integrations accumulate. Mitigation: the
+  line is *concern* (integrations), and a provider that grows into a product
+  graduates out via the ADR-073 escape hatch.
+- **Stranded links** to `lore-connectors`. Mitigation: GitHub rename redirect
+  plus a `rac-core` reference sweep.
+
+## Related Decisions
+
+- adr-092
+- adr-073
+- adr-063
+- adr-002
+
+## Related Roadmaps
+
+- v0.31.0-repo-topology-convergence
+- corpus-export-to-rag-backends

--- a/rac/roadmaps/v0.31.x-repo-topology/v0.31.3-rac-sdk.md
+++ b/rac/roadmaps/v0.31.x-repo-topology/v0.31.3-rac-sdk.md
@@ -1,0 +1,78 @@
+---
+schema_version: 1
+id: RAC-KW6F49KET6TB
+type: roadmap
+tags: [structure, org, sdk, distribution]
+---
+# RAC v0.31.3 — Consolidate Language SDKs into rac-sdk
+
+## Status
+
+Planned
+
+## Context
+
+ADR-092 places the non-Python language SDKs in a single `rac-sdk` repository,
+subdir per language (`ts/`, `go/`, …). The existing `rac-sdk-ts` (extracted in
+v0.22.5, published to npm as `@itsthelore/rac-sdk`) becomes `rac-sdk/ts/`. The
+**Python SDK stays in `rac-core`** — its public surface *is* `rac.__all__`
+shipped inside the engine package (ADR-062), and the engine plus its server are
+one package (ADR-029). Non-Python clients remain thin contract clients over the
+stable `--json` surface (ADR-063).
+
+## Outcomes
+
+- `itsthelore/rac-sdk` exists with `ts/` holding the former `rac-sdk-ts`; further
+  languages land as sibling subdirs.
+- The published npm package name is unchanged (`@itsthelore/rac-sdk`), so no
+  consumer break — only the source repository moves.
+- The Python SDK remains in `rac-core`; no Python SDK repo is created.
+
+## Initiatives
+
+- **Seed `rac-sdk`** with the `rac-sdk-ts` history under `ts/`; archive
+  `rac-sdk-ts` with a redirect note.
+- **Preserve the npm identity**: continue publishing `@itsthelore/rac-sdk` from
+  `rac-sdk/ts/`, with per-subdir release tags (polyglot-monorepo cost accepted,
+  ADR-092).
+- **Update references** in `rac-core` docs/corpus that point at `rac-sdk-ts` to
+  the `rac-sdk` repo (the npm package name itself does not change).
+
+## Success Measures
+
+- `itsthelore/rac-sdk` exists with `ts/`; `rac-sdk-ts` is archived with a
+  redirect.
+- `@itsthelore/rac-sdk` continues to publish and resolve for existing consumers
+  with no version break.
+- The Python SDK surface (`rac.__all__`) stays in `rac-core`; no `rac-sdk-py`
+  repo appears.
+
+## Assumptions
+
+- Non-Python SDKs are thin clients over the published contract, so they belong
+  outside `rac-core` and consolidate cleanly (ADR-063).
+- The mixed-toolchain monorepo cost (per-subdir release tooling) is acceptable; a
+  language SDK graduates to its own repo only if it grows an independent
+  community/cadence (the ADR-092 escape hatch).
+- The maintainer can create `rac-sdk` and archive `rac-sdk-ts`.
+
+## Risks
+
+- **npm-consumer break** if the package name or publish flow changes. Mitigation:
+  keep `@itsthelore/rac-sdk` exactly; move only the source repo, behind a GitHub
+  redirect.
+- **Toolchain friction** across languages in one repo. Mitigation: isolate each
+  language in its subdir with its own build and release tag.
+
+## Related Decisions
+
+- adr-092
+- adr-062
+- adr-063
+- adr-029
+
+## Related Roadmaps
+
+- v0.31.0-repo-topology-convergence
+- v0.22.5-extract-typescript-stack
+- v0.20.1-python-sdk-docs

--- a/rac/roadmaps/v0.31.x-repo-topology/v0.31.4-rac-benchmarks.md
+++ b/rac/roadmaps/v0.31.x-repo-topology/v0.31.4-rac-benchmarks.md
@@ -1,0 +1,73 @@
+---
+schema_version: 1
+id: RAC-KW6F4BCY46EQ
+type: roadmap
+tags: [structure, org, benchmark, distribution]
+---
+# RAC v0.31.4 — Restructure decisiongrounding into rac-benchmarks
+
+## Status
+
+Planned
+
+## Context
+
+ADR-092 places benchmarks in a single `rac-benchmarks` repository, subdir per
+benchmark, with the existing grounding benchmark as `decisiongrounding/`. The
+`decisiongrounding` repository was extracted in v0.22.4 (history-preserving) and
+treats `rac` as an external CLI on `PATH`, importing no engine code; ADR-066
+fixes its scoring as deterministic. This item reshapes that standalone repo into
+the family form so future benchmarks join as sibling subdirs rather than new
+repos.
+
+## Outcomes
+
+- `itsthelore/rac-benchmarks` exists with the grounding benchmark under
+  `decisiongrounding/`; new benchmarks land as sibling subdirs.
+- The benchmark still consumes `rac` only as an external CLI on `PATH`, with no
+  engine coupling and no change to its deterministic scoring (ADR-066).
+- `rac-core` references to the benchmark's home resolve to `rac-benchmarks`.
+
+## Initiatives
+
+- **Create `rac-benchmarks`** and move the `decisiongrounding` repo's contents
+  under `decisiongrounding/` (history preserved); archive the standalone
+  `decisiongrounding` repo with a redirect note.
+- **Establish the subdir convention** so a second benchmark is a new subdir, not
+  a new repo (the family pattern, ADR-092).
+- **Update references** in `rac-core` docs/corpus from the standalone
+  `decisiongrounding` repo to `rac-benchmarks/decisiongrounding/`.
+
+## Success Measures
+
+- `itsthelore/rac-benchmarks` exists with `decisiongrounding/`; the standalone
+  repo is archived with a redirect.
+- The benchmark runs unchanged against the published `rac` CLI; its determinism
+  guarantees (ADR-066) are untouched.
+- No `rac-core` reference points at the standalone `decisiongrounding` repo.
+
+## Assumptions
+
+- The benchmark continues to consume `rac` only as an external CLI on `PATH`
+  (DG-ADR-0001 holds), so the restructure needs no code change.
+- ADR-066's deterministic scoring contract is independent of where the benchmark
+  lives.
+- The maintainer can create `rac-benchmarks` and archive the standalone repo.
+
+## Risks
+
+- **Stranded links** to the old `decisiongrounding` repo. Mitigation: GitHub
+  rename/redirect and a `rac-core` reference sweep.
+- **Single-benchmark repo looks premature.** Mitigation: the family form is the
+  point — it makes the next benchmark a subdir, not a repo decision to
+  re-litigate.
+
+## Related Decisions
+
+- adr-092
+- adr-066
+
+## Related Roadmaps
+
+- v0.31.0-repo-topology-convergence
+- v0.22.4-extract-decisiongrounding

--- a/rac/roadmaps/v0.31.x-repo-topology/v0.31.5-rac-editors.md
+++ b/rac/roadmaps/v0.31.x-repo-topology/v0.31.5-rac-editors.md
@@ -1,0 +1,72 @@
+---
+schema_version: 1
+id: RAC-KW6F4D6J27WS
+type: roadmap
+tags: [structure, org, editor, distribution]
+---
+# RAC v0.31.5 — Rename lore-vscode into rac-editors
+
+## Status
+
+Planned
+
+## Context
+
+ADR-092 places the IDE clients in a single `rac-editors` repository, subdir per
+client. The existing `lore-vscode` (the VS Code / Cursor extension, extracted in
+v0.22.5) becomes `rac-editors/vscode/`; future editors (for example
+`jetbrains/`) join as sibling subdirs. The repo takes the uniform `rac-*` slug,
+while the published extension still **lists** as "Lore for VS Code" — the brand
+lives at the marketplace listing, not the repository name (ADR-092).
+
+## Outcomes
+
+- `itsthelore/rac-editors` exists with the VS Code / Cursor extension under
+  `vscode/`; further IDE clients land as sibling subdirs.
+- The Marketplace / OpenVSX listing identity and the published extension id are
+  unchanged, so installed users are unaffected — only the source repo moves.
+- `rac-core` references to the editor client resolve to `rac-editors`.
+
+## Initiatives
+
+- **Seed `rac-editors`** with the `lore-vscode` history under `vscode/`; archive
+  `lore-vscode` with a redirect note.
+- **Preserve the listing identity**: continue publishing the same VSIX to
+  Marketplace + OpenVSX from `rac-editors/vscode/`, listed as "Lore for VS Code".
+- **Update references** in `rac-core` docs/corpus from `lore-vscode` to
+  `rac-editors`.
+
+## Success Measures
+
+- `itsthelore/rac-editors` exists with `vscode/`; `lore-vscode` is archived with
+  a redirect.
+- The extension continues to publish and update for existing users with no
+  identity break.
+- No `rac-core` reference points at `lore-vscode`.
+
+## Assumptions
+
+- The extension consumes the published `@itsthelore/rac-sdk` and the public CLI,
+  never engine internals (ADR-063), so the repo move needs no contract change.
+- A shared VSIX serves VS Code and its Cursor fork (ADR-068's surviving client
+  decision), so `vscode/` covers both today.
+- The maintainer can create `rac-editors` and archive `lore-vscode`.
+
+## Risks
+
+- **Listing/identity break** if the publish flow changes. Mitigation: keep the
+  Marketplace/OpenVSX identity and VSIX id; move only the source repo, behind a
+  GitHub redirect.
+- **Premature single-client repo.** Mitigation: the family form makes the next
+  editor a subdir, not a new repo decision.
+
+## Related Decisions
+
+- adr-092
+- adr-068
+- adr-063
+
+## Related Roadmaps
+
+- v0.31.0-repo-topology-convergence
+- v0.22.5-extract-typescript-stack


### PR DESCRIPTION
Resolves the corpus self-contradiction left after ADR-092 shipped: ADR-092 governs repository topology (one repo per concern, subdir per member, `rac-*` naming), but ADR-064/068/073 still read as the current `lore-*` / multi-repo authority. This aligns them and records the execution plan as a **new series** (per the maintainer's request — not a rewrite of the v0.22.x items).

## ADR amendments (amend-in-place, statuses stay Accepted)

Forward-pointer banners + an `adr-092` edge on each:
- **ADR-064** — multi-repo extraction marked superseded-on-topology by ADR-092.
- **ADR-068** — the `lore-*`/`rac-*` split and per-member repos superseded-on-topology/naming; its **non-topology** decisions (shared-VSIX client surface, Python SDK staying in `rac-core`) are explicitly left intact.
- **ADR-073** — `lore-connectors → rac-connectors`, generalised to inbound + outbound + provider suites; the consolidation principle is unchanged.

Amend-in-place is deliberate: a status-supersession of ADR-064/068 would cascade `relationship-target-superseded` (a warning that **still fails `--validate`**) across the artifacts that reference them — the exact cascade ADR-092 chose to defer. Banners + back-edges resolve the contradiction with zero cascade.

## New series — `v0.31.x-repo-topology`

Converges the live org onto ADR-092's target; one item per family repo:

| Item | Repo | Move |
| --- | --- | --- |
| v0.31.0 | — | convergence overview |
| v0.31.1 | `rac-ci` | consolidate `rac-actions` + `lore-watchkeeper` + `lore-gatekeeper`, subdir per capability |
| v0.31.2 | `rac-connectors` | rename `lore-connectors`; inbound + outbound |
| v0.31.3 | `rac-sdk` | `rac-sdk-ts → ts/`; Python SDK stays in `rac-core` |
| v0.31.4 | `rac-benchmarks` | `decisiongrounding →` a subdir |
| v0.31.5 | `rac-editors` | `lore-vscode → vscode/` |

ADR-092 gains a `Related Roadmaps → v0.31.0` edge; the now-superseded extraction roadmaps (`repo-extraction-programme`, `v0.22.6-split-actions`) get in-place forward banners (no status flip → no cascade).

## Scope

Corpus only — these are planning artifacts. The actual GitHub renames/archives are maintainer-run org actions (out of `rac-core` scope). No engine, contract, package, CLI, or server-identity change (ADR-029/036/039 hold).

## Gates

- `rac validate rac/` → exit 0; the new series is 6/6 valid, OKF conformant.
- `rac relationships rac/ --validate` → 1600 edges, 0 issues.
- `rac review rac/` → health 94/100, no priority 1–2 findings.
- `rac export rac/ --agent-rules --check` → in-sync (no regen needed).