### PR TITLE
docs(decision): accept ADR-093 and enable the github ticketing provider

### DIFF
--- a/.cursor/rules
+++ b/.cursor/rules
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: 12912e7c05a94cab68210e645ee9deb3b36ce05783910746d22d15c580db0fe6) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: 6d6744e61bad8dfd623d6fff733ed9f339145b8b8d75e50cbd071eac8727bd3c) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -65,4 +65,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KW47GJ749PKC** — ADR-088: Enterprise Profile Scaffold (`rac init --profile`) _(Product)_
 - **RAC-KW47GN4SB403** — ADR-090: Enterprise Integration Surfaces and Boundaries _(Architecture)_
 - **RAC-KW5A03ZHXN9F** — ADR-092: Repository Topology — One Repo Per Concern, rac-* Naming _(Architecture)_
+- **RAC-KW6HY8W1CBK6** — ADR-093: Roadmap Intent Lives in the Corpus; Execution Is Tracked in GitHub Issues _(Process)_
 <!-- END RAC MANAGED BLOCK -->

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: 12912e7c05a94cab68210e645ee9deb3b36ce05783910746d22d15c580db0fe6) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: 6d6744e61bad8dfd623d6fff733ed9f339145b8b8d75e50cbd071eac8727bd3c) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -65,4 +65,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KW47GJ749PKC** — ADR-088: Enterprise Profile Scaffold (`rac init --profile`) _(Product)_
 - **RAC-KW47GN4SB403** — ADR-090: Enterprise Integration Surfaces and Boundaries _(Architecture)_
 - **RAC-KW5A03ZHXN9F** — ADR-092: Repository Topology — One Repo Per Concern, rac-* Naming _(Architecture)_
+- **RAC-KW6HY8W1CBK6** — ADR-093: Roadmap Intent Lives in the Corpus; Execution Is Tracked in GitHub Issues _(Process)_
 <!-- END RAC MANAGED BLOCK -->

--- a/.rac/config.yaml
+++ b/.rac/config.yaml
@@ -1,5 +1,12 @@
 repository_key: RAC
 
+# External ticketing provider (ADR-087, ADR-093). Roadmap intent lives in the
+# corpus; execution is tracked in GitHub issues, linked from a live artifact's
+# `## Related Tickets` section. `rac validate` format-lints those references as
+# `owner/repo#123` or a URL — offline; the engine never fetches issue state.
+ticketing:
+  provider: github
+
 # Warnings-first onboarding (ADR-053), dogfooded: RAC's own corpus predates the
 # v0.17.1 requirement-quality checks (29148 / EARS / BCP-14, ADR-056), so they are
 # disabled here pending incremental cleanup. The checks ship at full strength for

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: 12912e7c05a94cab68210e645ee9deb3b36ce05783910746d22d15c580db0fe6) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: 6d6744e61bad8dfd623d6fff733ed9f339145b8b8d75e50cbd071eac8727bd3c) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -65,4 +65,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KW47GJ749PKC** — ADR-088: Enterprise Profile Scaffold (`rac init --profile`) _(Product)_
 - **RAC-KW47GN4SB403** — ADR-090: Enterprise Integration Surfaces and Boundaries _(Architecture)_
 - **RAC-KW5A03ZHXN9F** — ADR-092: Repository Topology — One Repo Per Concern, rac-* Naming _(Architecture)_
+- **RAC-KW6HY8W1CBK6** — ADR-093: Roadmap Intent Lives in the Corpus; Execution Is Tracked in GitHub Issues _(Process)_
 <!-- END RAC MANAGED BLOCK -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ to the corpus artifact and they load through the imports below.
 - Previous series: `rac/roadmaps/v0.21.x-editor/` (complete)
 - Decisions (ADRs): `rac/decisions/`
 
-<!-- BEGIN RAC MANAGED BLOCK (digest: 12912e7c05a94cab68210e645ee9deb3b36ce05783910746d22d15c580db0fe6) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: 6d6744e61bad8dfd623d6fff733ed9f339145b8b8d75e50cbd071eac8727bd3c) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -90,4 +90,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KW47GJ749PKC** — ADR-088: Enterprise Profile Scaffold (`rac init --profile`) _(Product)_
 - **RAC-KW47GN4SB403** — ADR-090: Enterprise Integration Surfaces and Boundaries _(Architecture)_
 - **RAC-KW5A03ZHXN9F** — ADR-092: Repository Topology — One Repo Per Concern, rac-* Naming _(Architecture)_
+- **RAC-KW6HY8W1CBK6** — ADR-093: Roadmap Intent Lives in the Corpus; Execution Is Tracked in GitHub Issues _(Process)_
 <!-- END RAC MANAGED BLOCK -->

--- a/rac/decisions/adr-093-roadmap-execution-in-issues.md
+++ b/rac/decisions/adr-093-roadmap-execution-in-issues.md
@@ -88,7 +88,7 @@ and why"; GitHub answers "what's being worked, by whom, in what order, now."
 
 ## Status
 
-Proposed
+Accepted
 
 ## Category
 


### PR DESCRIPTION
Activates ADR-093 (merged Proposed in #221) — the corpus-side half of the roadmap-intent / issue-execution workflow.

## What

- **ADR-093 → Accepted** and the **agent-rules block regenerated** so it enters the settled-decisions list (AGENTS.md, CLAUDE.md, Copilot, Cursor).
- **`ticketing.provider: github`** added to `.rac/config.yaml`, so a live roadmap item can link its GitHub execution issue(s) via `## Related Tickets` and `rac validate` format-lints those references (`owner/repo#123` or URL) **offline** — the engine never fetches issue state (ADR-002/032).

## Scope / boundary

This is the corpus + config activation only. It does **not** create any tracking issues or add `## Related Tickets` edges yet — populating execution tracking is a planning step (which roadmap items to actively track, and at what granularity, is the maintainer's call, per ADR-017). No artifact carries the section yet, so the provider lints nothing today.

## Gates

- `rac validate rac/` → 322 valid, 0 invalid (no `malformed-ticket-reference`; the `## Related Tickets` strings in ADR-087/093 are prose, not sections).
- `rac relationships rac/ --validate` → 1606 edges, 0 issues.
- `rac export rac/ --agent-rules --check` → in-sync.
- `rac review rac/` → no priority 1–2.

## Next (separate, on your go)

Create GitHub tracking issues for the items you want to actively work (e.g. v0.28/29/30, the v0.31.x convergence) and wire their `## Related Tickets` edges. I can do that once you say which items to track.