### PR TITLE
docs(decision): rename live roadmaps to codenames (ADR-094)

### DIFF
--- a/.cursor/rules
+++ b/.cursor/rules
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: 6d6744e61bad8dfd623d6fff733ed9f339145b8b8d75e50cbd071eac8727bd3c) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: f34044b0a7ab94f78fd3932cf090ddc8c993c3c0bd9f864b97aef20fe354abd9) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -66,4 +66,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KW47GN4SB403** — ADR-090: Enterprise Integration Surfaces and Boundaries _(Architecture)_
 - **RAC-KW5A03ZHXN9F** — ADR-092: Repository Topology — One Repo Per Concern, rac-* Naming _(Architecture)_
 - **RAC-KW6HY8W1CBK6** — ADR-093: Roadmap Intent Lives in the Corpus; Execution Is Tracked in GitHub Issues _(Process)_
+- **RAC-KW6NQ4Y814N7** — ADR-094: Roadmaps Are Identified by Stable Codename, Not a vX.Y.Z Scope-Fence _(Process)_
 <!-- END RAC MANAGED BLOCK -->

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: 6d6744e61bad8dfd623d6fff733ed9f339145b8b8d75e50cbd071eac8727bd3c) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: f34044b0a7ab94f78fd3932cf090ddc8c993c3c0bd9f864b97aef20fe354abd9) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -66,4 +66,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KW47GN4SB403** — ADR-090: Enterprise Integration Surfaces and Boundaries _(Architecture)_
 - **RAC-KW5A03ZHXN9F** — ADR-092: Repository Topology — One Repo Per Concern, rac-* Naming _(Architecture)_
 - **RAC-KW6HY8W1CBK6** — ADR-093: Roadmap Intent Lives in the Corpus; Execution Is Tracked in GitHub Issues _(Process)_
+- **RAC-KW6NQ4Y814N7** — ADR-094: Roadmaps Are Identified by Stable Codename, Not a vX.Y.Z Scope-Fence _(Process)_
 <!-- END RAC MANAGED BLOCK -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: 6d6744e61bad8dfd623d6fff733ed9f339145b8b8d75e50cbd071eac8727bd3c) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: f34044b0a7ab94f78fd3932cf090ddc8c993c3c0bd9f864b97aef20fe354abd9) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -66,4 +66,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KW47GN4SB403** — ADR-090: Enterprise Integration Surfaces and Boundaries _(Architecture)_
 - **RAC-KW5A03ZHXN9F** — ADR-092: Repository Topology — One Repo Per Concern, rac-* Naming _(Architecture)_
 - **RAC-KW6HY8W1CBK6** — ADR-093: Roadmap Intent Lives in the Corpus; Execution Is Tracked in GitHub Issues _(Process)_
+- **RAC-KW6NQ4Y814N7** — ADR-094: Roadmaps Are Identified by Stable Codename, Not a vX.Y.Z Scope-Fence _(Process)_
 <!-- END RAC MANAGED BLOCK -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ to the corpus artifact and they load through the imports below.
 - Previous series: `rac/roadmaps/v0.21.x-editor/` (complete)
 - Decisions (ADRs): `rac/decisions/`
 
-<!-- BEGIN RAC MANAGED BLOCK (digest: 6d6744e61bad8dfd623d6fff733ed9f339145b8b8d75e50cbd071eac8727bd3c) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: f34044b0a7ab94f78fd3932cf090ddc8c993c3c0bd9f864b97aef20fe354abd9) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -91,4 +91,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KW47GN4SB403** — ADR-090: Enterprise Integration Surfaces and Boundaries _(Architecture)_
 - **RAC-KW5A03ZHXN9F** — ADR-092: Repository Topology — One Repo Per Concern, rac-* Naming _(Architecture)_
 - **RAC-KW6HY8W1CBK6** — ADR-093: Roadmap Intent Lives in the Corpus; Execution Is Tracked in GitHub Issues _(Process)_
+- **RAC-KW6NQ4Y814N7** — ADR-094: Roadmaps Are Identified by Stable Codename, Not a vX.Y.Z Scope-Fence _(Process)_
 <!-- END RAC MANAGED BLOCK -->

--- a/rac/decisions/adr-064-multi-repo-extraction-strategy.md
+++ b/rac/decisions/adr-064-multi-repo-extraction-strategy.md
@@ -22,7 +22,7 @@ Architecture
 > member* model under uniform `rac-*` naming — `rac-ci` (CI delivery),
 > `rac-connectors`, `rac-sdk`, `rac-benchmarks`, `rac-editors`. ADR-092 governs
 > where the two differ; this ADR remains the record of the first topology.
-> Execution is re-planned in the `v0.31.x-repo-topology` series.
+> Execution is re-planned in the `repo-topology` series.
 
 `requirements-as-code` has moved from a personal GitHub account
 (`tcballard`) into the `itsthelore` organisation. The repository is a

--- a/rac/decisions/adr-068-extension-sdk-and-brand-architecture.md
+++ b/rac/decisions/adr-068-extension-sdk-and-brand-architecture.md
@@ -23,7 +23,7 @@ Architecture
 > and the marketplace listings, not in repository slugs. ADR-068's
 > non-topology decisions still hold: the single shared-VSIX client surface, and
 > the Python SDK staying inside `rac-core` (ADR-062). ADR-092 governs where the
-> two differ; execution is re-planned in the `v0.31.x-repo-topology` series.
+> two differ; execution is re-planned in the `repo-topology` series.
 
 ADR-064 settled the first repository topology for the `itsthelore`
 organisation: extract `decisiongrounding` and the GitHub Actions, keep the

--- a/rac/decisions/adr-073-backend-connectors-consolidate.md
+++ b/rac/decisions/adr-073-backend-connectors-consolidate.md
@@ -13,7 +13,7 @@ type: decision
 > suites alike — Atlassian is a subdir, not its own repo. The decision below —
 > connectors are export-contract consumers, consolidated, never one repo per
 > provider — is unchanged; it is the pattern ADR-092 generalises across the
-> `rac-*` family. Execution is planned in the `v0.31.x-repo-topology` series.
+> `rac-*` family. Execution is planned in the `repo-topology` series.
 
 The export-to-RAG work (the umbrella roadmap `corpus-export-to-rag-backends`, the
 interplay design `lore-supermemory-interplay`, and the wire-shape design

--- a/rac/decisions/adr-078-deterministic-relevance-ranking.md
+++ b/rac/decisions/adr-078-deterministic-relevance-ranking.md
@@ -115,4 +115,4 @@ Technical
 
 ## Related Roadmaps
 
-- v0.29.0-relevance-ranking
+- relevance-ranking

--- a/rac/decisions/adr-079-note-tool-ingest-sources.md
+++ b/rac/decisions/adr-079-note-tool-ingest-sources.md
@@ -107,4 +107,4 @@ Architecture
 
 ## Related Roadmaps
 
-- v0.30.0-note-tool-ingest-sources
+- ingest-sources

--- a/rac/decisions/adr-082-suggested-relationship-edges-advisory.md
+++ b/rac/decisions/adr-082-suggested-relationship-edges-advisory.md
@@ -113,4 +113,4 @@ Architecture
 
 ## Related Roadmaps
 
-- v0.28.0-link-suggestions
+- link-suggestions

--- a/rac/decisions/adr-092-repository-topology.md
+++ b/rac/decisions/adr-092-repository-topology.md
@@ -219,7 +219,7 @@ Flip ADR-068 to Superseded in this change.
 
 ## Related Roadmaps
 
-- v0.31.0-repo-topology-convergence
+- repo-topology-convergence
 
 ## Review Date
 

--- a/rac/decisions/adr-093-roadmap-execution-in-issues.md
+++ b/rac/decisions/adr-093-roadmap-execution-in-issues.md
@@ -54,8 +54,9 @@ issues; the two are linked by `## Related Tickets`.
   deterministic (ADR-002, ADR-032); the edge is a reference, not a sync.
 - **Ordering is the board's job, not the roadmap number's.** Because the project
   board carries execution order, the `vX.Y.Z` scope-fence label no longer needs to
-  imply sequence; it remains a stable identifier (whether to drop the numeric
-  scheme entirely is a separate decision, not settled here).
+  imply sequence; it remains a stable identifier (ADR-094 subsequently settled the
+  open question — the numeric scheme is retired for live roadmaps in favour of
+  codenames; shipped/historical series keep their versioned names).
 
 This operationalises ADR-017 for roadmaps: the corpus answers "what capability,
 and why"; GitHub answers "what's being worked, by whom, in what order, now."

--- a/rac/decisions/adr-094-roadmaps-identified-by-codename.md
+++ b/rac/decisions/adr-094-roadmaps-identified-by-codename.md
@@ -1,0 +1,124 @@
+---
+schema_version: 1
+id: RAC-KW6NQ4Y814N7
+type: decision
+tags: [process, roadmap, naming, identity]
+---
+# ADR-094: Roadmaps Are Identified by Stable Codename, Not a vX.Y.Z Scope-Fence
+
+## Context
+
+Roadmap artifacts carried a `vX.Y.Z-<slug>` filename inside a `vX.Y.x-<theme>`
+series directory. That numbering was a planning **scope-fence**: ADR-076 records
+that "Roadmap `vX.Y.Z` numbers stay as internal scope-fences, decoupled from
+release identifiers. They schedule and bound work; they are not releases," and the
+session-start prompt distilled it to "Version numbers are scope fences."
+
+Two later decisions emptied the fence:
+
+- **ADR-076** decoupled the number from releases — releases are CalVer
+  (`YYYY.MM.N`).
+- **ADR-093** decoupled it from execution order — "Ordering is the board's job,
+  not the roadmap number's," and it explicitly left "whether to drop the numeric
+  scheme entirely … a separate decision, not settled here."
+
+What remained was a fence with nothing to fence: it does not bound a release, does
+not order work, and does not identify the artifact (identity is the opaque
+frontmatter `id`, ADR-026). It only imposed costs — it implies a sequence that is
+fiction, blocks order-independent work, and competes with the bare-codename
+convention the `future/` series already uses. This decision retires it.
+
+## Decision
+
+A roadmap is identified by a **stable, human-meaningful codename**, not a
+`vX.Y.Z` scope-fence.
+
+1. **Codename is the label.** A roadmap's filename and its series directory use a
+   descriptive slug with no version prefix (`rac/roadmaps/repo-topology/rac-ci.md`,
+   not `v0.31.x-repo-topology/v0.31.1-rac-ci.md`) — the `future/` convention. The
+   H1 title drops the version too (display-only). Single-item series may flatten to
+   a flat file.
+2. **The codename is not identity.** Per ADR-026 the canonical reference is the
+   opaque `id`; the codename is a filename-stem alias. A rename never changes
+   identity, so it is graph-neutral when every stem reference is repointed.
+3. **Sequence is not in the name.** Ordering lives on the GitHub board (ADR-093);
+   lifecycle lives in `## Status` (ADR-061). No `order:` field is added.
+4. **Codenames must be globally unique** across the roadmap tree (the filename
+   stem is a resolvable alias); they should be self-describing.
+5. **History stays versioned.** Achieved/shipped roadmaps and `archive/` keep
+   their `vX.Y.Z` names: *versioned = shipped record; codename = live intent.* The
+   versioned name on a shipped item is a timestamp of record, not a stale fence.
+6. **CalVer and the SemVer tags are unaffected.** Release identity stays
+   `YYYY.MM.N` (ADR-076); the immutable `v0.1.0`…`v0.19.0` tags stand. "Version"
+   now means the *release* version only.
+
+This amends **ADR-076 as a sibling** (not a status flip — ADR-076 is the live
+CalVer authority and flipping it would cascade and wrongly retire CalVer): where
+ADR-076 keeps `vX.Y.Z` as a roadmap scope-fence, ADR-094 governs for live
+roadmaps. It also reconciles the corpus statements of the old convention: the
+session-start prompt line, the `[roadmap:vX.Y.Z]` commit-trailer guidance (live
+roadmaps use `[roadmap:<codename>]`), and the scope-fence wording in the
+release-versioning requirement; and it closes the question ADR-093 left open.
+
+## Consequences
+
+### Positive
+
+- Live roadmaps read truthfully — a codename claims no sequence, so order-
+  independent work is honest, not contradicted by the filename.
+- Converges live with the `future/` convention; the corpus stops carrying two
+  roadmap-naming styles for active work.
+- Graph-neutral: identity is the opaque `id`, so renames never break edges.
+
+### Negative
+
+- A mixed corpus during and after migration (versioned history, codenamed live).
+  Accepted: the split maps cleanly to lifecycle and is legible.
+- A one-time migration must repoint every stem reference (edges + prose + the
+  directory token + the H1 version), verified by a fail-closed sweep.
+
+### Risks
+
+- Stem collisions once the version prefix is dropped (real ones exist among
+  historical items). Mitigation: codenames must be globally unique; the migration
+  asserts it before any move; a future `rac validate` stem-uniqueness check can
+  enforce it.
+
+## Status
+
+Accepted
+
+## Category
+
+Process
+
+## Alternatives Considered
+
+### Keep the vX.Y.Z scheme for roadmaps
+
+Rejected: the number no longer bounds a release (ADR-076), orders work (ADR-093),
+or identifies the artifact (ADR-026); it only implies a false sequence and blocks
+order-independent work.
+
+### Rename every roadmap, including shipped history
+
+Rejected: it rewrites ~87 historical items and ~150 external references (CHANGELOG,
+docs) that are correct as-is, surfaces real cross-series stem collisions, and
+destroys the version-as-timestamp audit value. History stays versioned.
+
+### Encode order in a frontmatter field instead of the number
+
+Rejected: ADR-093 already moved ordering to the board; re-encoding it in the
+artifact re-imports the coupling that decision removed.
+
+## Related Decisions
+
+- adr-093
+- adr-076
+- adr-061
+- adr-026
+- adr-047
+
+## Related Requirements
+
+- rac-release-versioning

--- a/rac/designs/deterministic-relevance-ranking.md
+++ b/rac/designs/deterministic-relevance-ranking.md
@@ -154,4 +154,4 @@ semantic judgement of meaning.
 
 ## Related Roadmaps
 
-- v0.29.0-relevance-ranking
+- relevance-ranking

--- a/rac/designs/mentioned-but-unlinked-detection.md
+++ b/rac/designs/mentioned-but-unlinked-detection.md
@@ -174,4 +174,4 @@ review*, never as an assertion that an edge exists.
 
 ## Related Roadmaps
 
-- v0.28.0-link-suggestions
+- link-suggestions

--- a/rac/designs/note-tool-ingest-sources.md
+++ b/rac/designs/note-tool-ingest-sources.md
@@ -145,4 +145,4 @@ as edges the tool has asserted.
 
 ## Related Roadmaps
 
-- v0.30.0-note-tool-ingest-sources
+- ingest-sources

--- a/rac/prompts/rac-agent-commit-guidelines.md
+++ b/rac/prompts/rac-agent-commit-guidelines.md
@@ -117,7 +117,9 @@ The goal is not commit quantity; it is preserving the implementation story.
 
 ### References
 
-Roadmap work — use `[roadmap:vX.Y.Z]`:
+Roadmap work — use `[roadmap:<codename>]` (a live roadmap's codename, e.g.
+`[roadmap:rac-ci]`, per ADR-094; a frozen/historical series may still cite its
+`vX.Y.Z` fence):
 
 ```text
 feat(relationships): add validation command [roadmap:v0.7.2]

--- a/rac/prompts/rac-agent-session-start.md
+++ b/rac/prompts/rac-agent-session-start.md
@@ -31,7 +31,7 @@ families include Requirements, Decisions, Roadmaps, Prompts, and Design.
 - Deterministic classification.
 - Structural validation, not semantic scoring unless explicitly planned.
 - CLI contracts matter: human output, JSON output, exit codes, and templates must be specified.
-- Version numbers are scope fences.
+- Roadmaps are identified by codename, not a version; release versions are CalVer dates (ADR-094, ADR-076).
 - Prefer schema/artifact-spec-driven behavior over artifact-specific branches.
 - Keep classification separate from validation.
 - Invalid but recognizable artifacts may still classify as their artifact type, then fail validation.

--- a/rac/requirements/rac-deterministic-relevance-ranking.md
+++ b/rac/requirements/rac-deterministic-relevance-ranking.md
@@ -78,7 +78,7 @@ the right artifact lands inside the response budget more often.
 
 ## Related Roadmaps
 
-- v0.29.0-relevance-ranking
+- relevance-ranking
 
 ## Related Requirements
 

--- a/rac/requirements/rac-note-tool-ingest-sources.md
+++ b/rac/requirements/rac-note-tool-ingest-sources.md
@@ -71,4 +71,4 @@ right now it stops at office documents.
 
 ## Related Roadmaps
 
-- v0.30.0-note-tool-ingest-sources
+- ingest-sources

--- a/rac/requirements/rac-release-versioning.md
+++ b/rac/requirements/rac-release-versioning.md
@@ -36,9 +36,11 @@ two concerns are separated cleanly rather than overloaded onto one identifier.
 This requirement is `Accepted` and adopted by ADR-076. The release cadence is
 monthly rather than daily, so the identifier is month-granular with a
 within-month counter (`YYYY.MM.N`) rather than a full calendar date. The
-versioned roadmap series (`vX.Y.Z`) stand, now explicitly as **internal
-scope-fences** decoupled from release identifiers; the pre-cutover SemVer tags
-stand immutably.
+versioned roadmap series (`vX.Y.Z`) were, at the time of the CalVer cutover,
+explicitly **internal scope-fences** decoupled from release identifiers (ADR-094
+later retired that scheme for *live* roadmaps in favour of codenames; shipped and
+historical series keep their versioned names as the record); the pre-cutover
+SemVer tags stand immutably.
 
 ## Requirements
 
@@ -110,3 +112,4 @@ how RAC labels its own releases, not what `rac validate` or `rac relationships
 
 - ADR-007
 - ADR-076
+- ADR-094

--- a/rac/requirements/rac-unlinked-reference-detection.md
+++ b/rac/requirements/rac-unlinked-reference-detection.md
@@ -72,7 +72,7 @@ consume the graph: both see a sparser graph than the text supports.
 
 ## Related Roadmaps
 
-- v0.28.0-link-suggestions
+- link-suggestions
 
 ## Related Requirements
 

--- a/rac/roadmaps/future/repo-extraction-programme.md
+++ b/rac/roadmaps/future/repo-extraction-programme.md
@@ -12,14 +12,14 @@ Planned
 
 ## Context
 
-> **Superseded by ADR-092; re-planned as the `v0.31.x-repo-topology` series.**
+> **Superseded by ADR-092; re-planned as the `repo-topology` series.**
 > This programme sequenced the *first* (`lore-*` / one-repo-per-component)
 > extraction topology, and its low-risk moves landed (`decisiongrounding`,
 > v0.22.4; the TypeScript stack → `rac-sdk-ts` + `lore-vscode`, v0.22.5).
 > ADR-092 then replaced that topology with *one repo per concern* under uniform
 > `rac-*` naming. The remaining work — consolidating those already-extracted
 > repos into `rac-connectors` / `rac-sdk` / `rac-benchmarks` / `rac-editors` and
-> the actions into `rac-ci` — is carried by the `v0.31.x-repo-topology` series.
+> the actions into `rac-ci` — is carried by the `repo-topology` series.
 > This item is retained as the record of the original programme.
 
 ADR-064 records the decision to adopt a small multi-repo topology under the

--- a/rac/roadmaps/ingest-sources.md
+++ b/rac/roadmaps/ingest-sources.md
@@ -3,7 +3,7 @@ schema_version: 1
 id: RAC-KVSQ2CV0AM13
 type: roadmap
 ---
-# RAC v0.30.0 — Note-Tool Ingest Sources
+# Note-Tool Ingest Sources
 
 ## Status
 

--- a/rac/roadmaps/link-suggestions.md
+++ b/rac/roadmaps/link-suggestions.md
@@ -3,7 +3,7 @@ schema_version: 1
 id: RAC-KVSNP3C2T4WA
 type: roadmap
 ---
-# RAC v0.28.0 — Relationship Link Suggestions
+# Relationship Link Suggestions
 
 ## Status
 

--- a/rac/roadmaps/relevance-ranking.md
+++ b/rac/roadmaps/relevance-ranking.md
@@ -3,7 +3,7 @@ schema_version: 1
 id: RAC-KVSQ27BCJ0TC
 type: roadmap
 ---
-# RAC v0.29.0 — Deterministic Relevance Ranking
+# Deterministic Relevance Ranking
 
 ## Status
 

--- a/rac/roadmaps/repo-topology/rac-benchmarks.md
+++ b/rac/roadmaps/repo-topology/rac-benchmarks.md
@@ -4,7 +4,7 @@ id: RAC-KW6F4BCY46EQ
 type: roadmap
 tags: [structure, org, benchmark, distribution]
 ---
-# RAC v0.31.4 — Restructure decisiongrounding into rac-benchmarks
+# Restructure decisiongrounding into rac-benchmarks
 
 ## Status
 
@@ -69,5 +69,5 @@ repos.
 
 ## Related Roadmaps
 
-- v0.31.0-repo-topology-convergence
+- repo-topology-convergence
 - v0.22.4-extract-decisiongrounding

--- a/rac/roadmaps/repo-topology/rac-ci.md
+++ b/rac/roadmaps/repo-topology/rac-ci.md
@@ -4,7 +4,7 @@ id: RAC-KW6F45V3NGFF
 type: roadmap
 tags: [structure, org, ci, distribution]
 ---
-# RAC v0.31.1 — Consolidate CI Delivery into rac-ci
+# Consolidate CI Delivery into rac-ci
 
 ## Status
 
@@ -87,6 +87,6 @@ GitHub→other-platform work is in the thin wrappers, not the engine.
 
 ## Related Roadmaps
 
-- v0.31.0-repo-topology-convergence
+- repo-topology-convergence
 - v0.22.6-split-actions
 - repo-extraction-programme

--- a/rac/roadmaps/repo-topology/rac-connectors.md
+++ b/rac/roadmaps/repo-topology/rac-connectors.md
@@ -4,7 +4,7 @@ id: RAC-KW6F47QRN0ND
 type: roadmap
 tags: [structure, org, distribution]
 ---
-# RAC v0.31.2 — Rename lore-connectors to rac-connectors
+# Rename lore-connectors to rac-connectors
 
 ## Status
 
@@ -73,5 +73,5 @@ item applies the `rac-*` name and the wider remit.
 
 ## Related Roadmaps
 
-- v0.31.0-repo-topology-convergence
+- repo-topology-convergence
 - corpus-export-to-rag-backends

--- a/rac/roadmaps/repo-topology/rac-editors.md
+++ b/rac/roadmaps/repo-topology/rac-editors.md
@@ -4,7 +4,7 @@ id: RAC-KW6F4D6J27WS
 type: roadmap
 tags: [structure, org, editor, distribution]
 ---
-# RAC v0.31.5 — Rename lore-vscode into rac-editors
+# Rename lore-vscode into rac-editors
 
 ## Status
 
@@ -68,5 +68,5 @@ lives at the marketplace listing, not the repository name (ADR-092).
 
 ## Related Roadmaps
 
-- v0.31.0-repo-topology-convergence
+- repo-topology-convergence
 - v0.22.5-extract-typescript-stack

--- a/rac/roadmaps/repo-topology/rac-sdk.md
+++ b/rac/roadmaps/repo-topology/rac-sdk.md
@@ -4,7 +4,7 @@ id: RAC-KW6F49KET6TB
 type: roadmap
 tags: [structure, org, sdk, distribution]
 ---
-# RAC v0.31.3 — Consolidate Language SDKs into rac-sdk
+# Consolidate Language SDKs into rac-sdk
 
 ## Status
 
@@ -73,6 +73,6 @@ stable `--json` surface (ADR-063).
 
 ## Related Roadmaps
 
-- v0.31.0-repo-topology-convergence
+- repo-topology-convergence
 - v0.22.5-extract-typescript-stack
 - v0.20.1-python-sdk-docs

--- a/rac/roadmaps/repo-topology/repo-topology-convergence.md
+++ b/rac/roadmaps/repo-topology/repo-topology-convergence.md
@@ -4,7 +4,7 @@ id: RAC-KW6F43XVSPCX
 type: roadmap
 tags: [structure, org, distribution, branding]
 ---
-# RAC v0.31.0 — Repository Topology Convergence
+# Repository Topology Convergence
 
 ## Status
 
@@ -48,15 +48,15 @@ package, CLI, or server-identity change (ADR-029/036/039 hold).
 
 Each initiative is its own item in this series, executed independently:
 
-- **`rac-ci`** (v0.31.1) — consolidate `rac-actions`, `lore-watchkeeper`, and
+- **`rac-ci`** — consolidate `rac-actions`, `lore-watchkeeper`, and
   `lore-gatekeeper` into one CI-delivery repo, subdir per capability.
-- **`rac-connectors`** (v0.31.2) — rename `lore-connectors`; subdir per
+- **`rac-connectors`** — rename `lore-connectors`; subdir per
   integration, inbound and outbound.
-- **`rac-sdk`** (v0.31.3) — consolidate `rac-sdk-ts` into `rac-sdk/ts/`; the
+- **`rac-sdk`** — consolidate `rac-sdk-ts` into `rac-sdk/ts/`; the
   Python SDK stays in `rac-core` (ADR-062).
-- **`rac-benchmarks`** (v0.31.4) — restructure `decisiongrounding` into
+- **`rac-benchmarks`** — restructure `decisiongrounding` into
   `rac-benchmarks/decisiongrounding/`.
-- **`rac-editors`** (v0.31.5) — rename `lore-vscode` into `rac-editors/vscode/`.
+- **`rac-editors`** — rename `lore-vscode` into `rac-editors/vscode/`.
 - **Naming/brand cutover** — apply the `rac-*` slug rule across the
   constellation as each repo lands; the "Lore" brand stays at the org and the
   marketplace listings (ADR-092).
@@ -102,11 +102,11 @@ Each initiative is its own item in this series, executed independently:
 
 ## Related Roadmaps
 
-- v0.31.1-rac-ci
-- v0.31.2-rac-connectors
-- v0.31.3-rac-sdk
-- v0.31.4-rac-benchmarks
-- v0.31.5-rac-editors
+- rac-ci
+- rac-connectors
+- rac-sdk
+- rac-benchmarks
+- rac-editors
 - repo-extraction-programme
 
 ## Related Requirements

--- a/rac/roadmaps/v0.22.x-housekeeping/v0.22.6-split-actions.md
+++ b/rac/roadmaps/v0.22.x-housekeeping/v0.22.6-split-actions.md
@@ -21,11 +21,11 @@ the branded path — and a PyPI engine release is available for
 
 ## Context
 
-> **Superseded by ADR-092 / the `v0.31.x-repo-topology` series.** The two-repo
+> **Superseded by ADR-092 / the `repo-topology` series.** The two-repo
 > split recorded here (`lore-gatekeeper` + `lore-watchkeeper`) is replaced by
 > ADR-092's single `rac-ci` repo — a subdir per capability, platform nested
 > within — so the actions are never split across repos by platform. The work is
-> re-planned as `v0.31.1-rac-ci`; this item is retained as the record of the
+> re-planned as `rac-ci`; this item is retained as the record of the
 > deferred two-repo plan.
 
 ADR-068 amends ADR-064: the GitHub Actions split into two product-branded repos,


### PR DESCRIPTION
Retires the `vX.Y.Z` scope-fence for **live** roadmaps in favour of stable codenames, converging the live convention on the one `future/` already uses. Designed with a multi-agent workflow (analyze → design → adversarial critic); the critic's P1/P2 findings are baked in. **Scope: all four forward series** (the `repo-topology` pilot + v0.28/29/30).

## Why

The roadmap number no longer means anything: CalVer (ADR-076) owns releases, ADR-093 moved execution order to the GitHub board, and identity is the opaque `id` (ADR-026). The `vX.Y.Z` only implied a false sequence and blocked order-independent work. ADR-093 explicitly left "drop the numbers entirely" as a separate decision — **ADR-094** is it.

## Commits

1. **`docs(decision)`** — ADR-094 (Process, Accepted), amend-as-sibling of ADR-076 (no status flip → no cascade). Reconciles the session-start principle line, the `[roadmap:<codename>]` commit-trailer guidance, the release-versioning requirement, and an ADR-093 forward-pointer. Agent-rules regenerated.
2. **`docs(roadmap)`** — `v0.31.x-repo-topology/` → `repo-topology/` (6 items → codename files; titles de-versioned). Repoints edges, the directory token, `(v0.31.N)` parentheticals, and the frozen→live ref in `v0.22.6`.
3. **`docs(roadmap)`** — the three single-item forward series flatten to codename files: `link-suggestions`, `relevance-ranking`, and **`ingest-sources`** (chosen over `note-tool-ingest-sources` to avoid colliding with the existing design of that name). Repoints edges in `adr-078/079/082` + the relevance/unlinked designs and requirements.

## Safety

- **Graph-neutral:** the opaque frontmatter ids never change, so only alias text moves. `rac relationships --validate` was unchanged across **both** rename passes (1606→1606 for the pilot; 1613→1613 for v0.28–30), 0 issues.
- **Global stem-uniqueness enforced** before any move. The first v0.28–30 run surfaced a real cross-type collision (a roadmap flattening onto the existing `note-tool-ingest-sources` *design*); the script's uniqueness check was tightened to scan all of `rac/`, and the codename changed to `ingest-sources`.
- **History stays versioned:** ~87 Achieved items, `archive/`, and stray `Planned`-in-frozen items (`v0.21.10`, `v0.22.6`) keep their `vX.Y.Z` names. *Versioned = shipped record; codename = live intent.*

## Gates

`rac validate rac/` 0 · `rac relationships rac/ --validate` 0 · `rac review rac/` no priority 1–2 · `rac export rac/ --agent-rules --check` in-sync · `rac gate rac/` 0. Renames render as `git mv` (R99) for reviewability.

After this, every **live/future** roadmap is codenamed; the only versioned names left are the shipped/historical record.