### PR TITLE
docs(roadmap): re-type the v0.4.x-intelligence release-specs as Achieved roadmaps

### DIFF
--- a/rac/roadmaps/v0.4.x-intelligence/v0.4-inspect.md
+++ b/rac/roadmaps/v0.4.x-intelligence/v0.4-inspect.md
@@ -1,9 +1,13 @@
 ---
 schema_version: 1
 id: RAC-KTQ63DVKK49N
-type: requirement
+type: roadmap
 ---
 # v0.4 Artifact Inspection
+
+## Status
+
+Achieved
 
 ## Problem
 
@@ -13,7 +17,14 @@ Before RAC can offer guidance or AI-assisted analysis, it must first understand 
 
 RAC should provide a lightweight inspection capability that identifies artifact types and reports structural completeness without modifying content.
 
-## Requirements
+## Outcomes
+
+- Users can inspect a Markdown document and learn its artifact type, the
+  classification confidence, and which expected sections are present or
+  missing — observationally, in human-readable text or JSON, without
+  modifying content.
+
+## Initiatives
 
 [REQ-001] User can inspect a Markdown document
 [REQ-002] RAC attempts to identify the artifact type
@@ -29,7 +40,7 @@ RAC should provide a lightweight inspection capability that identifies artifact 
 [REQ-012] User can inspect a file path or stdin
 [REQ-013] RAC reports unsupported file types with actionable guidance
 
-## Success Metrics
+## Success Measures
 
 - RAC correctly identifies Requirement and Decision artifacts in the repository
 - Inspection completes in under one second for typical artifacts

--- a/rac/roadmaps/v0.4.x-intelligence/v0.4.1-expansion.md
+++ b/rac/roadmaps/v0.4.x-intelligence/v0.4.1-expansion.md
@@ -1,9 +1,13 @@
 ---
 schema_version: 1
 id: RAC-KTQ63DVM2EE9
-type: requirement
+type: roadmap
 ---
 # v0.4.1 Inspection Expansion
+
+## Status
+
+Achieved
 
 ## Problem
 
@@ -13,7 +17,13 @@ As repositories grow, users need visibility across collections of artifacts rath
 
 RAC should support inspecting directories, explaining classifications, and tolerating common heading variants — while remaining purely observational.
 
-## Requirements
+## Outcomes
+
+- Inspection scales from a single file to whole directories, with
+  explainable, deterministic classification and tolerant heading-synonym
+  matching — still purely observational.
+
+## Initiatives
 
 [REQ-001] User can inspect a directory
 [REQ-002] Directory inspection summarizes detected artifact types
@@ -29,7 +39,7 @@ RAC should support inspecting directories, explaining classifications, and toler
 [REQ-012] RAC supports artifact-specific heading synonyms
 [REQ-013] Synonym matching is deterministic and case-insensitive
 
-## Success Metrics
+## Success Measures
 
 - Repository inspection correctly classifies well-formed artifacts
 - Inspection remains deterministic and explainable

--- a/rac/roadmaps/v0.4.x-intelligence/v0.4.1-inspect-expansion.md
+++ b/rac/roadmaps/v0.4.x-intelligence/v0.4.1-inspect-expansion.md
@@ -1,9 +1,13 @@
 ---
 schema_version: 1
 id: RAC-KTQ63DVQYZ6S
-type: requirement
+type: roadmap
 ---
 # RAC v0.4.1 — Inspection Expansion
+
+## Status
+
+Achieved
 
 ## Context
 
@@ -47,7 +51,7 @@ Additionally, documents that use alternative but equivalent headings may be clas
 
 ---
 
-## Goals
+## Outcomes
 
 Expand inspection to support:
 
@@ -68,7 +72,7 @@ while remaining:
 
 ---
 
-## Requirements
+## Initiatives
 
 ### REQ-001 — Directory Inspection
 
@@ -287,7 +291,7 @@ Classification shall remain schema-based and deterministic.
 
 ---
 
-## Success Metrics
+## Success Measures
 
 ### Functional
 

--- a/rac/roadmaps/v0.4.x-intelligence/v0.4.2-decision-metadata.md
+++ b/rac/roadmaps/v0.4.x-intelligence/v0.4.2-decision-metadata.md
@@ -1,9 +1,13 @@
 ---
 schema_version: 1
 id: RAC-KTQ63DVVW9WZ
-type: requirement
+type: roadmap
 ---
 # RAC v0.4.2 — Decision Metadata
+
+## Status
+
+Achieved
 
 ## Context
 
@@ -44,7 +48,7 @@ Users must manually inspect documents to understand their relevance and status.
 
 ---
 
-## Goals
+## Outcomes
 
 Introduce optional metadata for Decision artifacts.
 
@@ -64,7 +68,7 @@ without:
 
 ---
 
-## Requirements
+## Initiatives
 
 ### REQ-001 — Decision Status
 
@@ -247,7 +251,7 @@ ADR-001 → ADR-004 → ADR-008
 
 ---
 
-## Success Metrics
+## Success Measures
 
 ### Functional
 


### PR DESCRIPTION
Sorts the "misfiled" `v0.4.2-decision-metadata` — which turned out to be **one of four**. The whole `v0.4.x-intelligence` series is early release-specs mis-typed as `requirement` while sitting in a roadmap series directory.

## Finding

All four (`v0.4-inspect`, `v0.4.1-expansion`, `v0.4.1-inspect-expansion`, `v0.4.2-decision-metadata`) are `type: requirement` but are release specs ("This release introduces…", Goals/Acceptance Criteria) living under `rac/roadmaps/`. Their capabilities — artifact inspection, directory/verbose inspection, and decision Status/Category/Supersedes metadata — shipped in the project's infancy and are now **core schema, not living requirements**. All four are unreferenced. No current requirement models the decision-metadata capability (it's schema).

## Change

Convert each to a roadmap (chosen disposition):
- `type: requirement` → `roadmap`; add `## Status` → **Achieved** (ADR-061).
- Relabel sections to the roadmap schema, fence-aware so code-block examples are untouched: `Goals → Outcomes`, `Requirements → Initiatives`, `Success Metrics → Success Measures`. The two items lacking a Goals section get a concise `## Outcomes` derived from their Problem statement.
- Frontmatter **ids unchanged** (ADR-026); historical content preserved; versioned titles kept (versioned = shipped record, ADR-094).

`v0.4.x-intelligence` now reads as a normal Achieved roadmap series like every other `vX.Y.x` directory — fixing the misfiling at the root rather than relocating it.

## Gates

`rac validate rac/` → 323 valid, 0 invalid · `rac relationships rac/ --validate` → 0 issues (confirms no inbound `Related Requirements` edge broke — they were unreferenced) · `rac review rac/` no priority 1–2 · `rac export rac/ --agent-rules --check` in-sync · `rac gate rac/` 0.