### PR TITLE
docs(roadmap): wire execution-tracking issues via Related Tickets

### DIFF
--- a/rac/roadmaps/ingest-sources.md
+++ b/rac/roadmaps/ingest-sources.md
@@ -117,3 +117,7 @@ the candidate-link review step.
 ## Related Designs
 
 - note-tool-ingest-sources
+
+## Related Tickets
+
+- itsthelore/rac-core#227

--- a/rac/roadmaps/link-suggestions.md
+++ b/rac/roadmaps/link-suggestions.md
@@ -126,3 +126,7 @@ is advisory, and how to promote a suggestion to a declared edge.
 ## Related Designs
 
 - mentioned-but-unlinked-detection
+
+## Related Tickets
+
+- itsthelore/rac-core#225

--- a/rac/roadmaps/relevance-ranking.md
+++ b/rac/roadmaps/relevance-ranking.md
@@ -125,3 +125,7 @@ the committed baseline before the ranking change ships.
 ## Related Designs
 
 - deterministic-relevance-ranking
+
+## Related Tickets
+
+- itsthelore/rac-core#226

--- a/rac/roadmaps/repo-topology/repo-topology-convergence.md
+++ b/rac/roadmaps/repo-topology/repo-topology-convergence.md
@@ -112,3 +112,7 @@ Each initiative is its own item in this series, executed independently:
 ## Related Requirements
 
 - rac-growth-extensibility
+
+## Related Tickets
+
+- itsthelore/rac-core#228


### PR DESCRIPTION
Populates the execution tracking the ADR-093 / ADR-087 workflow was built for — the corpus holds intent, GitHub issues hold execution, linked by `## Related Tickets`.

## Issues created (the work tracker)

| Issue | Roadmap |
| --- | --- |
| #225 | `link-suggestions` (feature) |
| #226 | `relevance-ranking` (feature) |
| #227 | `ingest-sources` (feature) |
| #228 | `repo-topology` convergence (epic; checklist of the 5 members) |

The three single-item engine features get one issue each; the repo-topology series gets one **epic** (#228) tracking its 5 members (which are mostly maintainer-run org actions in the other repos).

## Corpus change (this PR)

Adds a `## Related Tickets` section to each of the four roadmaps pointing at its issue (`itsthelore/rac-core#NNN`, the `github` provider format). The roadmap stays the durable record of *what & why*; the issue carries ordering/assignment/state (ADR-017).

## Verified end-to-end

- `rac validate rac/` → 323 valid, 0 invalid — the `github` provider **format-lints** the refs offline and they pass.
- `rac relationships rac/ --validate` → 1613 edges, 0 issues — external edges are exempt from in-corpus resolution.
- `rac export rac/ --graph` → 4 `related_tickets` edges, each `external: true, resolved: false, provider: github` (e.g. `RAC-KVSNP3C2T4WA → itsthelore/rac-core#225`). The engine never fetches issue state (ADR-002/032).
- `rac review rac/` no priority 1–2 · `rac gate rac/` 0.

This is the first real use of the `## Related Tickets` surface — the full ADR-087→093 loop working on live roadmaps.