### PR TITLE
test(inspect): align dogfood classification with v0.4.x roadmap conversion

### DIFF
--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -76,11 +76,14 @@ def test_unknown_for_empty():
 
 
 def test_dogfood_repo_artifacts():
-    # RAC against RAC: an ADR is a Decision; a roadmap spec is a Requirement.
+    # RAC against RAC: an ADR is a Decision, a roadmap spec is a Roadmap,
+    # and a product capability is a Requirement.
     adr = REPO_ROOT / "rac/decisions/adr-010-documents-are-not-artifacts.md"
     roadmap = REPO_ROOT / "rac/roadmaps/v0.4.x-intelligence/v0.4-inspect.md"
+    requirement = REPO_ROOT / "rac/requirements/rac-growth-agent-skill.md"
     assert inspect_file(str(adr)).type == "decision"
-    assert inspect_file(str(roadmap)).type == "requirement"
+    assert inspect_file(str(roadmap)).type == "roadmap"
+    assert inspect_file(str(requirement)).type == "requirement"
 
 
 # --- synonyms ---------------------------------------------------------------


### PR DESCRIPTION
# Summary

Fixes the red `CI` workflow on `main`. The `tests / inspect (py3.11)` battery
(and the `coverage (report-only)` job, which runs the same full suite) has been
failing on every push since the v0.4.x-intelligence series was converted from
requirement to roadmap artifacts.

# Root cause

`tests/test_inspect.py::test_dogfood_repo_artifacts` classifies the *live*
corpus ("RAC against RAC"). It pinned
`rac/roadmaps/v0.4.x-intelligence/v0.4-inspect.md` as a `requirement`, but that
file (and its series) is now a `roadmap`. `inspect_file` correctly returns
`roadmap`, so the assertion was stale:

```
E       AssertionError: assert 'roadmap' == 'requirement'
```

The test variable was already named `roadmap` — the file was always
conceptually a roadmap spec, only mistyped as a requirement before the
conversion.

# Change

- Expect `roadmap` for the converted spec.
- Add a real requirement (`rac/requirements/rac-growth-agent-skill.md`) so the
  dogfood check still covers all three artifact families (decision, roadmap,
  requirement).

No production code changes; this is a stale-fixture correction.

# Verification

- `python -m pytest -q tests/test_inspect.py` → 26 passed.
- Grep confirms no other test referenced the converted v0.4.x files.
