### PR TITLE
feat(relationships): mentioned-but-unlinked reference detection (link-suggestions)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -102,7 +102,7 @@ jobs:
           - name: review
             paths: "tests/test_review.py tests/test_cadence.py"
           - name: doctor
-            paths: "tests/test_doctor.py"
+            paths: "tests/test_doctor.py tests/test_links.py"
           - name: coverage-report
             paths: "tests/test_coverage.py"
           - name: usage

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -378,6 +378,56 @@ so it is safe in CI; it needs git history and is silent outside a git repository
 or on an empty corpus. The framing is capture cadence, not work tracking
 (ADR-017).
 
+## doctor
+
+One front door for **corpus health**. `rac doctor` runs validation and
+relationship-integrity checks in a single pass and adds the diagnostics no other
+command provides, returning one verdict with a paste-ready fix per finding. It is
+deterministic and offline (no AI, no network) and never edits content — every
+finding is a report or a suggestion you act on (ADR-065).
+
+- **Input:** `rac doctor <directory>` — scanned recursively for `*.md`.
+- **Options:** `--json` · `--hub-threshold N` (default 20) · `--top-level` ·
+  `--recursive`
+- **Exit codes:** `0` no errors (warnings are advisory and do not fail) · `1` a
+  structural-validation or relationship-integrity **error** · `2` not a directory
+
+```bash
+rac doctor rac/
+rac doctor rac/ --json
+```
+
+Finding codes (the `error`-severity ones set the exit code; `warning`-severity
+ones are advisory and exit `0`):
+
+| Code | Severity | Meaning |
+| --- | --- | --- |
+| `invalid-artifact` | error | structural validation failed (see `rac validate`) |
+| `relationship-*` | error / warning | relationship-integrity issues (see `rac relationships --validate`) |
+| `orphaned-artifact` | warning | nothing references this artifact |
+| `high-fan-out-hub` | warning | more resolved edges than `--hub-threshold` |
+| `injection-style-content` | warning | instruction-like content flagged for review |
+| `unlinked-reference` | warning | the body names another artifact with no declared edge |
+
+### unlinked-reference
+
+An artifact's body often names another artifact in prose — an ADR id such as
+`adr-074`, or a filename stem — without a matching `## Related` edge. The link is
+real and intended; the declared graph just does not carry it. `unlinked-reference`
+surfaces each such mention as an advisory suggestion with a paste-ready line, so
+the validated graph gets as complete as the prose already implies (ADR-082).
+
+It **suggests, never applies** (ADR-082): the detector writes no edge — promotion
+stays a reviewed human edit (ADR-074, ADR-065), so it never changes the
+`rac validate` / `rac relationships --validate` contract and always exits `0`.
+Matching is deterministic and offline (ADR-002, ADR-066): a mention is a body
+token that resolves — through the same resolver validation uses — to another
+artifact by **canonical id, `<letters>-<digits>` filename ref, or declared
+alias**. The `## Related` sections themselves, fenced code blocks, and
+self-references are excluded; title and free-text matching are out of scope. To
+promote a suggestion, add its line (for example `- adr-074`) under the named
+`## Related <Type>` section.
+
 ## coverage
 
 Report typed **traceability coverage gaps** over the corpus relationship graph —

--- a/rac/roadmaps/link-suggestions.md
+++ b/rac/roadmaps/link-suggestions.md
@@ -7,7 +7,7 @@ type: roadmap
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/src/rac/services/doctor.py
+++ b/src/rac/services/doctor.py
@@ -36,6 +36,7 @@ from typing import Any
 
 from rac.core.artifacts import spec_for
 from rac.core.corpus import CorpusCache, CorpusEntry
+from rac.services.links import detect_unlinked_references
 from rac.services.relationships import (
     ISSUE_DUPLICATE_IDENTIFIER,
     ISSUE_RELATIONSHIP_CYCLE,
@@ -61,6 +62,7 @@ CODE_INVALID_ARTIFACT = "invalid-artifact"
 CODE_ORPHANED_ARTIFACT = "orphaned-artifact"
 CODE_HIGH_FAN_OUT_HUB = "high-fan-out-hub"
 CODE_INJECTION_CONTENT = "injection-style-content"
+CODE_UNLINKED_REFERENCE = "unlinked-reference"
 
 # Heuristic injection-style idioms (REQ-005): instruction overrides, role/system
 # impersonation, concealment from the user, and steering away from recorded
@@ -180,6 +182,7 @@ def diagnose(
     findings.extend(_relationship_findings(directory, recursive, cache))
     findings.extend(_degree_findings(entries, hub_threshold))
     findings.extend(_injection_findings(entries))
+    findings.extend(_unlinked_reference_findings(directory, entries, recursive))
     # Deterministic order: errors before warnings, then path, code, problem.
     findings.sort(key=lambda f: (_SEVERITY_RANK[f.severity], f.path, f.code, f.problem))
     return DoctorReport(directory=directory, hub_threshold=hub_threshold, findings=findings)
@@ -304,6 +307,36 @@ def _degree_findings(entries: list[CorpusEntry], hub_threshold: int) -> list[Doc
                     ),
                 )
             )
+    return findings
+
+
+def _unlinked_reference_findings(
+    directory: str, entries: list[CorpusEntry], recursive: bool
+) -> list[DoctorFinding]:
+    """Body references to other artifacts with no declared edge (ADR-082).
+
+    Advisory WARNINGs that suggest a `## Related` link the prose already implies;
+    the detector writes nothing (suggest, never apply). Reuses the shared corpus
+    snapshot so no second walk happens.
+    """
+    findings: list[DoctorFinding] = []
+    for ref in detect_unlinked_references(directory, entries=entries, recursive=recursive):
+        findings.append(
+            DoctorFinding(
+                path=ref.source_path,
+                code=CODE_UNLINKED_REFERENCE,
+                severity=SEVERITY_WARNING,
+                problem=(
+                    f"body references {ref.matched_token} but declares no "
+                    f"{ref.related_section} link to it"
+                ),
+                fix=(
+                    f"Add `{ref.suggested_line}` under `## {ref.related_section}` "
+                    "if the link is intended — a suggestion to review; RAC writes "
+                    "no edge (ADR-082)."
+                ),
+            )
+        )
     return findings
 
 

--- a/src/rac/services/links.py
+++ b/src/rac/services/links.py
@@ -1,0 +1,140 @@
+"""Mentioned-but-unlinked reference detection (link-suggestions, ADR-082).
+
+A surface-agnostic detector: for each artifact, find the references its *body*
+makes to other corpus artifacts that are not declared as ``## Related`` edges,
+and return them as advisory suggestions. ``rac doctor`` is the first surface;
+``rac coverage`` is a candidate second one (left as a design open question).
+
+Boundaries this honours:
+
+- **Suggest, never apply (ADR-082).** The detector emits findings only; it
+  writes no edge. The declared ``## Related`` sections stay the source of truth
+  (ADR-074) and promotion stays a human review act (ADR-065).
+- **Deterministic and offline (ADR-002, ADR-066).** A pure function of corpus
+  bytes: same corpus, byte-identical findings. No model, embedding, or network.
+- **Reuse, don't reinvent.** Resolution goes through the same resolver
+  validation uses (:func:`resolve_in_index`), the body comes from the shared
+  parser's sections, the declared graph from :func:`relationships_from_corpus`,
+  and the relationship-section vocabulary from :data:`RELATIONSHIP_SECTIONS`.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+from rac.core.corpus import CorpusEntry, walk_corpus
+from rac.services.index import index_from_corpus
+from rac.services.relationships import RELATIONSHIP_SECTIONS, relationships_from_corpus
+from rac.services.resolve import OUTCOME_RESOLVED, resolve_in_index
+
+# A reference candidate is a maximal run of alphanumerics with internal single
+# hyphens kept, so ``adr-074`` and ``RAC-KW47GGS85CKG`` each survive as one
+# token. ``tokenize`` (ADR-037) would split these on the hyphen; here the hyphen
+# is part of the token, and any other character is a boundary — so matching stays
+# on token boundaries without substring false positives.
+_CANDIDATE_RE = re.compile(r"[0-9A-Za-z]+(?:-[0-9A-Za-z]+)*")
+
+# Canonical short reference for a target in a suggested line: a
+# ``<letters>-<digits>`` alias such as ``adr-074`` when one exists (the form the
+# corpus writes for decisions), otherwise the filename stem (the form it writes
+# for every other artifact type).
+_NUMBERED_REF_RE = re.compile(r"^[A-Za-z]+-\d+$")
+
+# Relationship-section headings, normalized, that must not be scanned for
+# mentions — their references are the *declared* edges, not body mentions.
+_RELATIONSHIP_HEADINGS = frozenset(RELATIONSHIP_SECTIONS)
+
+
+@dataclass(frozen=True)
+class UnlinkedReference:
+    """One advisory suggestion: a body mention with no declared edge.
+
+    ``A``'s body names ``B`` (by id, filename-style ref, or alias), ``B != A``,
+    and ``B`` is not already a declared ``## Related`` target of ``A``.
+    """
+
+    source_path: str
+    target_path: str
+    target_id: str
+    matched_token: str
+    related_section: str  # display heading, e.g. "Related Decisions"
+    suggested_line: str  # paste-ready, e.g. "- adr-074"
+
+
+def _related_section_for(target_type: str) -> str:
+    """Display heading of the ``## Related <Type>s`` section for ``target_type``."""
+    return f"related {target_type}s".title()
+
+
+def _preferred_ref(aliases: list[str], path: str) -> str:
+    """The corpus-idiomatic short reference for the target (``adr-074`` / stem)."""
+    numbered = sorted((a for a in aliases if _NUMBERED_REF_RE.fullmatch(a)), key=len)
+    if numbered:
+        return numbered[0]
+    return Path(path).stem
+
+
+def detect_unlinked_references(
+    directory: str,
+    entries: list[CorpusEntry] | None = None,
+    recursive: bool = True,
+) -> list[UnlinkedReference]:
+    """References an artifact's body names but does not declare as edges.
+
+    ``entries`` lets a caller (such as ``rac doctor``) pass an already-walked
+    corpus snapshot so the corpus is parsed once; when omitted the directory is
+    walked here. The result is sorted by ``(source_path, target_id)`` so output
+    is byte-stable.
+    """
+    if entries is None:
+        entries = list(walk_corpus(directory, recursive=recursive))
+    index = index_from_corpus(directory, entries, recursive=recursive).artifacts
+    by_path = {entry.path: entry for entry in index}
+
+    # Declared edges, keyed by source, using the same resolution validation uses
+    # (resolved, unique targets only) so "already linked" cannot drift.
+    declared: dict[str, set[str]] = {}
+    for rel in relationships_from_corpus(entries):
+        if rel.resolved_path is not None:
+            declared.setdefault(rel.source_path, set()).add(rel.resolved_path)
+
+    findings: list[UnlinkedReference] = []
+    for source in index:
+        self_aliases = {alias.casefold() for alias in source.aliases}
+        already = declared.get(source.path, set())
+        seen_targets: set[str] = set()
+        for section in source.search_sections:
+            if section.heading.strip().casefold() in _RELATIONSHIP_HEADINGS:
+                continue  # declared edges, not body mentions
+            for line in section.lines:
+                for match in _CANDIDATE_RE.finditer(line):
+                    token = match.group(0)
+                    if token.casefold() in self_aliases:
+                        continue  # self-reference
+                    result = resolve_in_index(index, token)
+                    if result.outcome != OUTCOME_RESOLVED:
+                        continue  # not a unique corpus artifact
+                    target = result.artifact
+                    assert target is not None  # resolved outcome implies an artifact
+                    if target.path == source.path or target.path in already:
+                        continue
+                    if target.path in seen_targets:
+                        continue  # one finding per (source, target) pair
+                    seen_targets.add(target.path)
+                    target_entry = by_path[target.path]
+                    findings.append(
+                        UnlinkedReference(
+                            source_path=source.path,
+                            target_path=target.path,
+                            target_id=target.id,
+                            matched_token=token,
+                            related_section=_related_section_for(target.type),
+                            suggested_line=(
+                                f"- {_preferred_ref(list(target_entry.aliases), target.path)}"
+                            ),
+                        )
+                    )
+    findings.sort(key=lambda f: (f.source_path, f.target_id))
+    return findings

--- a/tests/fixtures/doctor/unlinked/adr-001-alpha.md
+++ b/tests/fixtures/doctor/unlinked/adr-001-alpha.md
@@ -1,0 +1,23 @@
+---
+schema_version: 1
+id: RAC-AAAAAAAAAAA1
+type: decision
+---
+# Alpha
+
+## Status
+
+Accepted
+
+## Context
+
+This decision builds on the boundary recorded in adr-002, but declares no
+relationship edge to it.
+
+## Decision
+
+Proceed.
+
+## Consequences
+
+Acceptable.

--- a/tests/fixtures/doctor/unlinked/adr-002-beta.md
+++ b/tests/fixtures/doctor/unlinked/adr-002-beta.md
@@ -1,0 +1,22 @@
+---
+schema_version: 1
+id: RAC-AAAAAAAAAAA2
+type: decision
+---
+# Beta
+
+## Status
+
+Accepted
+
+## Context
+
+Background.
+
+## Decision
+
+Proceed.
+
+## Consequences
+
+Acceptable.

--- a/tests/golden/doctor_unlinked_human.txt
+++ b/tests/golden/doctor_unlinked_human.txt
@@ -1,0 +1,17 @@
+Repository health: tests/fixtures/doctor/unlinked
+
+0 error(s), 3 warning(s)
+
+WARNING  tests/fixtures/doctor/unlinked/adr-001-alpha.md
+  [orphaned-artifact] no other artifact references this one (orphaned)
+  fix: Reference it from a related artifact (a `## Related ...` section), or confirm it is intentionally standalone.
+
+WARNING  tests/fixtures/doctor/unlinked/adr-001-alpha.md
+  [unlinked-reference] body references adr-002 but declares no Related Decisions link to it
+  fix: Add `- adr-002` under `## Related Decisions` if the link is intended — a suggestion to review; RAC writes no edge (ADR-082).
+
+WARNING  tests/fixtures/doctor/unlinked/adr-002-beta.md
+  [orphaned-artifact] no other artifact references this one (orphaned)
+  fix: Reference it from a related artifact (a `## Related ...` section), or confirm it is intentionally standalone.
+
+✓ No errors (warnings are advisory).

--- a/tests/golden/doctor_unlinked_json.txt
+++ b/tests/golden/doctor_unlinked_json.txt
@@ -1,0 +1,33 @@
+{
+  "schema_version": "1",
+  "directory": "tests/fixtures/doctor/unlinked",
+  "hub_threshold": 20,
+  "ok": true,
+  "summary": {
+    "errors": 0,
+    "warnings": 3
+  },
+  "findings": [
+    {
+      "path": "tests/fixtures/doctor/unlinked/adr-001-alpha.md",
+      "code": "orphaned-artifact",
+      "severity": "warning",
+      "problem": "no other artifact references this one (orphaned)",
+      "fix": "Reference it from a related artifact (a `## Related ...` section), or confirm it is intentionally standalone."
+    },
+    {
+      "path": "tests/fixtures/doctor/unlinked/adr-001-alpha.md",
+      "code": "unlinked-reference",
+      "severity": "warning",
+      "problem": "body references adr-002 but declares no Related Decisions link to it",
+      "fix": "Add `- adr-002` under `## Related Decisions` if the link is intended — a suggestion to review; RAC writes no edge (ADR-082)."
+    },
+    {
+      "path": "tests/fixtures/doctor/unlinked/adr-002-beta.md",
+      "code": "orphaned-artifact",
+      "severity": "warning",
+      "problem": "no other artifact references this one (orphaned)",
+      "fix": "Reference it from a related artifact (a `## Related ...` section), or confirm it is intentionally standalone."
+    }
+  ]
+}

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -199,6 +199,29 @@ def test_clean_corpus_has_no_injection_false_positive(tmp_path):
     assert doctor.CODE_INJECTION_CONTENT not in _codes(report)
 
 
+def test_unlinked_reference_warns_but_run_still_exits_zero(tmp_path):
+    root = _clean(tmp_path)
+    # A new decision whose body names decision-alpha but declares no edge to it.
+    _decision(
+        root,
+        "decision-mentions",
+        "RAC-MMMMMMMMMMMM",
+        context="This extends the choice recorded in decision-alpha.",
+    )
+    report = doctor.diagnose(str(root))
+    unlinked = [f for f in report.findings if f.code == doctor.CODE_UNLINKED_REFERENCE]
+    assert any(f.path.endswith("decision-mentions.md") for f in unlinked)
+    assert all(f.severity == "warning" for f in unlinked)
+    assert any("decision-alpha" in f.fix for f in unlinked)
+    # No error-severity finding -> the advisory still exits zero (ADR-082, ADR-075).
+    assert report.ok
+
+
+def test_clean_corpus_has_no_unlinked_false_positive(tmp_path):
+    report = doctor.diagnose(str(_clean(tmp_path)))
+    assert doctor.CODE_UNLINKED_REFERENCE not in _codes(report)
+
+
 # --- contract: fixes, drift, determinism, exit codes -------------------------
 
 

--- a/tests/test_golden.py
+++ b/tests/test_golden.py
@@ -106,6 +106,10 @@ CASES = [
     ("mcp_stats_human", ["mcp-stats"], 0),
     ("mcp_stats_json", ["mcp-stats", "--json"], 0),
     ("mcp_stats_share", ["mcp-stats", "--share"], 0),
+    # Advisory unlinked-reference finding (link-suggestions, ADR-082): a body
+    # mention with no declared edge, surfaced as a warning that exits zero.
+    ("doctor_unlinked_human", ["doctor", "tests/fixtures/doctor/unlinked"], 0),
+    ("doctor_unlinked_json", ["doctor", "tests/fixtures/doctor/unlinked", "--json"], 0),
 ]
 
 

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -1,0 +1,194 @@
+"""Mentioned-but-unlinked reference detection battery (link-suggestions, ADR-082).
+
+Pins the detector contract: a body reference to another artifact with no declared
+`## Related` edge becomes one advisory suggestion; declared edges, self-references,
+fenced code, and repeated mentions never produce spurious findings; the suggested
+line uses the corpus-idiomatic ref form; and output is deterministic.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from rac.services.links import detect_unlinked_references
+
+DECISION = """\
+---
+schema_version: 1
+id: {id}
+type: decision
+---
+# {title}
+
+## Status
+
+Accepted
+
+## Context
+
+{context}
+
+## Decision
+
+Do it.
+
+## Consequences
+
+Fine.
+"""
+
+REQUIREMENT = """\
+---
+schema_version: 1
+id: {id}
+type: requirement
+---
+# {title}
+
+## Problem
+
+A problem worth solving.
+
+## Requirements
+
+- [REQ-001] The system MUST do the thing.
+{related}
+"""
+
+
+def _decision(root: Path, name: str, aid: str, *, context: str = "Background.") -> None:
+    (root / f"{name}.md").write_text(
+        DECISION.format(id=aid, title=name.title(), context=context), encoding="utf-8"
+    )
+
+
+def _requirement(
+    root: Path, name: str, aid: str, *, problem_ref: str = "", related: list[str] | None = None
+) -> None:
+    rel = ""
+    if related:
+        rel = "\n## Related Decisions\n\n" + "\n".join(f"- {r}" for r in related) + "\n"
+    body = REQUIREMENT.format(id=aid, title=name.title(), related=rel)
+    if problem_ref:
+        body = body.replace(
+            "A problem worth solving.", f"A problem worth solving; see {problem_ref}."
+        )
+    (root / f"{name}.md").write_text(body, encoding="utf-8")
+
+
+def _corpus(tmp_path: Path) -> Path:
+    root = tmp_path / "corpus"
+    root.mkdir()
+    return root
+
+
+def test_body_mention_without_edge_is_detected(tmp_path):
+    root = _corpus(tmp_path)
+    _decision(root, "adr-001-alpha", "RAC-AAAAAAAAAAAA", context="This builds on adr-002.")
+    _decision(root, "adr-002-beta", "RAC-BBBBBBBBBBBB")
+    refs = detect_unlinked_references(str(root))
+    assert len(refs) == 1
+    found = refs[0]
+    assert found.source_path.endswith("adr-001-alpha.md")
+    assert found.target_path.endswith("adr-002-beta.md")
+    assert found.matched_token == "adr-002"
+    assert found.related_section == "Related Decisions"
+    assert found.suggested_line == "- adr-002"
+
+
+def test_declared_edge_is_not_flagged(tmp_path):
+    root = _corpus(tmp_path)
+    _decision(root, "adr-002-beta", "RAC-BBBBBBBBBBBB")
+    # The requirement both mentions the decision in prose AND declares the edge.
+    _requirement(
+        root,
+        "requirement-gamma",
+        "RAC-GGGGGGGGGGGG",
+        problem_ref="adr-002",
+        related=["adr-002"],
+    )
+    assert detect_unlinked_references(str(root)) == []
+
+
+def test_self_reference_is_ignored(tmp_path):
+    root = _corpus(tmp_path)
+    # adr-001 names its own id and filename ref in its body.
+    _decision(
+        root,
+        "adr-001-alpha",
+        "RAC-AAAAAAAAAAAA",
+        context="As established in adr-001 (RAC-AAAAAAAAAAAA), this holds.",
+    )
+    assert detect_unlinked_references(str(root)) == []
+
+
+def test_fenced_code_is_excluded(tmp_path):
+    root = _corpus(tmp_path)
+    _decision(root, "adr-002-beta", "RAC-BBBBBBBBBBBB")
+    # The only mention of adr-002 lives inside a fenced code block.
+    fenced = "An example follows:\n\n```\nrac resolve adr-002\n```\n\nNo prose mention here."
+    _decision(root, "adr-001-alpha", "RAC-AAAAAAAAAAAA", context=fenced)
+    assert detect_unlinked_references(str(root)) == []
+
+
+def test_one_finding_per_pair(tmp_path):
+    root = _corpus(tmp_path)
+    _decision(root, "adr-002-beta", "RAC-BBBBBBBBBBBB")
+    _decision(
+        root,
+        "adr-001-alpha",
+        "RAC-AAAAAAAAAAAA",
+        context="First adr-002 mention. Then adr-002 again, and RAC-BBBBBBBBBBBB once more.",
+    )
+    refs = detect_unlinked_references(str(root))
+    assert len(refs) == 1
+    assert refs[0].target_path.endswith("adr-002-beta.md")
+
+
+def test_unresolvable_token_is_not_a_finding(tmp_path):
+    root = _corpus(tmp_path)
+    _decision(
+        root,
+        "adr-001-alpha",
+        "RAC-AAAAAAAAAAAA",
+        context="A normal sentence mentioning req-999 and some-other-slug.",
+    )
+    assert detect_unlinked_references(str(root)) == []
+
+
+def test_suggested_ref_uses_stem_for_non_decision(tmp_path):
+    root = _corpus(tmp_path)
+    _requirement(root, "growth-target", "RAC-TTTTTTTTTTTT")
+    _decision(
+        root, "adr-001-alpha", "RAC-AAAAAAAAAAAA", context="This relates to growth-target work."
+    )
+    refs = detect_unlinked_references(str(root))
+    assert len(refs) == 1
+    assert refs[0].related_section == "Related Requirements"
+    assert refs[0].suggested_line == "- growth-target"
+
+
+def test_findings_sorted_by_source_then_target(tmp_path):
+    root = _corpus(tmp_path)
+    _decision(root, "adr-002-beta", "RAC-BBBBBBBBBBBB")
+    _decision(root, "adr-003-gamma", "RAC-CCCCCCCCCCCC")
+    _decision(
+        root,
+        "adr-001-alpha",
+        "RAC-AAAAAAAAAAAA",
+        context="References adr-003 first, then adr-002.",
+    )
+    refs = detect_unlinked_references(str(root))
+    keys = [(r.source_path, r.target_id) for r in refs]
+    assert keys == sorted(keys)
+    # Sorted by target id, not document order: RAC-BBB... before RAC-CCC...
+    assert [r.target_id for r in refs] == ["RAC-BBBBBBBBBBBB", "RAC-CCCCCCCCCCCC"]
+
+
+def test_deterministic_across_runs(tmp_path):
+    root = _corpus(tmp_path)
+    _decision(root, "adr-002-beta", "RAC-BBBBBBBBBBBB")
+    _decision(root, "adr-001-alpha", "RAC-AAAAAAAAAAAA", context="Builds on adr-002.")
+    first = detect_unlinked_references(str(root))
+    second = detect_unlinked_references(str(root))
+    assert first == second


### PR DESCRIPTION
# Summary

Implements the **link-suggestions** roadmap (ADR-082): a new advisory `rac doctor`
finding, `unlinked-reference`, that surfaces references an artifact's *body* makes
to other corpus artifacts which are not declared as `## Related` edges — as
suggestions a human promotes, never an edge the tool writes.

Closes #225.

# Scope

## Included
- **Detector** (`src/rac/services/links.py`): surface-agnostic
  `detect_unlinked_references()`. Pure over corpus bytes (ADR-002, ADR-066),
  reusing the shared resolver, index, parser, and relationship-section
  vocabulary — no parallel mechanism. Matched forms: canonical ids,
  `<letters>-<digits>` filename refs (e.g. `adr-074`), and declared aliases.
  Excludes the `## Related` sections, fenced code blocks, and self-references;
  one finding per `(source, target)` pair; sorted for byte-stable output.
- **`rac doctor` surface**: the advisory `unlinked-reference` code (a WARNING with
  a paste-ready Related line), alongside the existing orphan/hub/injection
  warnings, reusing the single corpus snapshot.
- **Tests**: detector boundary battery + doctor-surface tests + human/JSON
  goldens over a new fixture; `tests/test_links.py` registered in the doctor CI
  battery (ADR-027).
- **Docs**: a new `rac doctor` section in `docs/cli.md` (the command had none)
  with its finding-code table and an `unlinked-reference` subsection.
- Roadmap `link-suggestions` Status → Achieved.

## Excluded (by design — ADR-082 / the design's open questions)
- No auto-creation or writing of any edge — suggest, never apply (ADR-074, ADR-065).
- No model, embedding, or similarity matching (ADR-002, ADR-066).
- No title or free-text matching (deferred design open question).
- `rac coverage` as a second surface (left to a follow-up).

# Contract / boundaries

- **Advisory only**: severity is WARNING, so `rac doctor`'s exit code is
  unchanged and the `rac validate` / `rac relationships --validate` contract is
  untouched (ADR-075). The detector writes nothing.
- **Deterministic and offline**: same corpus → byte-identical findings; goldens
  pin the human and JSON output.

# Verification

- Full suite: **1706 passed, 1 skipped**.
- `rac doctor rac/` exits **0** (advisory); `rac validate rac/`,
  `rac relationships rac/ --validate`, `rac export rac/ --agent-rules --check`,
  and `rac review rac/` all exit **0**.
- `rac doctor rac/ --json` byte-identical across runs.
- ruff clean; mypy clean on the new code.
- On the live corpus the detector flags 473 unlinked references — the expected
  volume for a corpus whose prose leads its declared graph; each is
  precise-by-construction (exact resolution only) and advisory.

# Review path
1. `src/rac/services/links.py` — the detector + `UnlinkedReference`.
2. `src/rac/services/doctor.py` — the advisory wire-in (`_unlinked_reference_findings`).
3. `tests/test_links.py` — boundary coverage.
4. `docs/cli.md` — the new `rac doctor` section.

Implements `rac/roadmaps/link-suggestions.md`.
