### PR TITLE
feat(resolve): deterministic relevance ranking (BM25 + RRF + graph boost)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1227,21 +1227,31 @@ rac resolve adr-015 rac/ --json
 
 ## find
 
-Search artifacts by ID, title, filename, or path — a deterministic,
-case-insensitive substring match (no ranking heuristics). Results are ordered
-by match field (ID, then title, then filename/path) with sorted path as the
-tiebreak. An empty result is a valid outcome, not an error.
+Search artifacts by ID, title, filename, path, heading, or body — deterministic,
+case-insensitive token-boundary matching (ADR-037); a multi-term query requires
+every term to match somewhere. Results are ordered by a **deterministic relevance
+score** (ADR-078): a field-weighted BM25 lexical score and a bounded
+inbound-reference graph boost, fused with Reciprocal Rank Fusion, with sorted
+path as the tiebreak. No embeddings or semantic scoring — identical bytes and
+query yield a byte-identical order. An empty result is a valid outcome, not an
+error.
 
 - **Input:** `rac find <query> [directory]` — directory defaults to the
   current directory.
 - **Options:** `--type TYPE` (only match one artifact type) · `--json` ·
-  `--top-level` · `--recursive`
+  `--explain` · `--top-level` · `--recursive`
 - **Exit codes:** `0` search completed (matches or none) · `2` not a directory
+
+`--explain` adds, per match, the matched field/terms/tier plus the relevance
+score and its components (`bm25`, `lexical_rank`, `graph_rank`, `inbound`), so a
+caller can see why one result outranks another. It is additive: the default
+output (without `--explain`) is unchanged, and `schema_version` stays `1`.
 
 ```bash
 rac find markdown rac/
 rac find explorer rac/ --type decision
 rac find "canonical format" rac/ --json
+rac find markdown rac/ --explain        # show the relevance-score breakdown
 ```
 
 ```json

--- a/rac/roadmaps/relevance-ranking.md
+++ b/rac/roadmaps/relevance-ranking.md
@@ -7,7 +7,7 @@ type: roadmap
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 

--- a/src/rac/output/human.py
+++ b/src/rac/output/human.py
@@ -1028,6 +1028,17 @@ def render_find_human(result: SearchResult, *, explain: bool = False) -> str:
                 where = f"{m.section}: " if m.section else ""
                 attribution += f" [{where}{m.snippet}]"
             lines.append(f"{indent}• {attribution}")
+            # Relevance-score breakdown (ADR-078): the fused score and the
+            # per-signal contributions behind the ordering, when present.
+            components = m.evidence.get("components")
+            if components is not None:
+                lines.append(
+                    f"{indent}  score={m.evidence['score']} "
+                    f"bm25={components['bm25']} "
+                    f"lexical_rank={components['lexical_rank']} "
+                    f"graph_rank={components['graph_rank']} "
+                    f"inbound={components['inbound']}"
+                )
     lines.append("")
     lines.append(f"{result.match_count} match(es) for {result.query!r}.")
     return "\n".join(lines)

--- a/src/rac/services/doctor.py
+++ b/src/rac/services/doctor.py
@@ -42,6 +42,7 @@ from rac.services.relationships import (
     ISSUE_RELATIONSHIP_CYCLE,
     RELATIONSHIP_SEVERITY,
     RelationshipIssue,
+    inbound_counts_from_corpus,
     relationships_from_corpus,
     validate_relationships,
 )
@@ -265,15 +266,16 @@ def _degree_findings(entries: list[CorpusEntry], hub_threshold: int) -> list[Doc
     a known artifact that is never a resolved target — so it cannot drift.
     """
     known_paths = {str(e.path) for e in entries if spec_for(e.artifact_type) is not None}
-    inbound: dict[str, int] = {p: 0 for p in known_paths}
+    # Inbound is the shared canonical signal (also the search graph boost, ADR-078)
+    # so the orphan count cannot drift from it; outbound is doctor's own one pass.
+    counts = inbound_counts_from_corpus(entries)
+    inbound: dict[str, int] = {p: counts.get(p, 0) for p in known_paths}
     outbound: dict[str, int] = {p: 0 for p in known_paths}
     for rel in relationships_from_corpus(entries):
         if rel.resolved_path is None:  # only resolved (unique, non-self) edges
             continue
         if rel.source_path in outbound:
             outbound[rel.source_path] += 1
-        if rel.resolved_path in inbound:
-            inbound[rel.resolved_path] += 1
 
     findings: list[DoctorFinding] = []
     for path in known_paths:

--- a/src/rac/services/index.py
+++ b/src/rac/services/index.py
@@ -46,6 +46,10 @@ class IndexEntry:
     # serialized: the index JSON contract is unchanged (id/type/title/path/
     # aliases only).
     search_sections: list[SearchSection] = field(default_factory=list)
+    # Count of resolved relationship edges pointing at this artifact (v2026.6,
+    # additive): the deterministic graph signal the relevance ranker fuses
+    # (ADR-078). Not serialized — the index JSON contract is unchanged.
+    inbound_count: int = 0
 
     def to_dict(self) -> dict:
         return {
@@ -97,7 +101,14 @@ def index_from_corpus(
 
     Same result as :func:`build_repository_index`; the snapshot lets one walk
     feed several analyses (repository model, future incremental refresh).
+
+    Each entry also carries its inbound resolved-edge count — the graph signal
+    the relevance ranker fuses (ADR-078) — computed once from the same snapshot.
+    The import is deferred to keep the index → relationships dependency one-way.
     """
+    from rac.services.relationships import inbound_counts_from_corpus
+
+    inbound = inbound_counts_from_corpus(entries)
     artifacts: list[IndexEntry] = []
     for entry in entries:
         path, product = entry.path, entry.product
@@ -110,6 +121,7 @@ def index_from_corpus(
                 path=str(path),
                 aliases=artifact_identifiers(product, spec, str(path)),
                 search_sections=product.search_sections,
+                inbound_count=inbound.get(str(path), 0),
             )
         )
     return RepositoryIndex(directory=directory, recursive=recursive, artifacts=artifacts)

--- a/src/rac/services/relationships.py
+++ b/src/rac/services/relationships.py
@@ -996,6 +996,21 @@ def relationships_from_corpus(entries: list[CorpusEntry]) -> list[Relationship]:
     return relationships
 
 
+def inbound_counts_from_corpus(entries: list[CorpusEntry]) -> dict[str, int]:
+    """``{artifact path -> count of resolved edges that point at it}``.
+
+    The canonical inbound-degree signal: resolved, unique, non-self edges only
+    (the same definition ``rac doctor``'s orphan/hub pass and the search graph
+    boost both consume, so they cannot drift). Artifacts with no inbound edge are
+    absent (count 0).
+    """
+    counts: dict[str, int] = {}
+    for rel in relationships_from_corpus(entries):
+        if rel.resolved_path is not None:
+            counts[rel.resolved_path] = counts.get(rel.resolved_path, 0) + 1
+    return counts
+
+
 # --- 1-hop neighborhood (get_related) ----------------------------------------
 #
 # The references an artifact declares (outgoing) and the artifacts whose

--- a/src/rac/services/repository.py
+++ b/src/rac/services/repository.py
@@ -73,6 +73,10 @@ class Artifact:
     # lets the repository model serve body-tier `rac find` searches through the
     # shared resolver seam without a second walk. Not part of any JSON contract.
     search_sections: tuple[SearchSection, ...] = ()
+    # Inbound resolved-edge count, the graph signal the relevance ranker fuses
+    # (ADR-078); carried so a repository-model search ranks like every other
+    # surface. Not part of any JSON contract.
+    inbound_count: int = 0
 
 
 @dataclass(frozen=True)
@@ -236,6 +240,7 @@ def repository_from_corpus(
             status=status_by_path[entry.path],
             missing_recommended=missing_by_path.get(entry.path, ()),
             search_sections=tuple(entry.search_sections),
+            inbound_count=entry.inbound_count,
         )
         for entry in index.artifacts
     ]

--- a/src/rac/services/resolve.py
+++ b/src/rac/services/resolve.py
@@ -22,6 +22,7 @@ snippet fields (the matched heading and the matching line, as stored).
 
 from __future__ import annotations
 
+import math
 import re
 from collections.abc import Sequence
 from dataclasses import dataclass, field
@@ -56,6 +57,8 @@ class SearchableArtifact(Protocol):
     def aliases(self) -> Sequence[str]: ...
     @property
     def search_sections(self) -> Sequence[SearchSection]: ...
+    @property
+    def inbound_count(self) -> int: ...
 
 
 # Match-field priority for search ordering (lower ranks first); the ladder
@@ -272,6 +275,33 @@ def _evidence(match: _Match) -> dict:
     return {"field": _RANK_NAMES[match.rank], "terms": list(match.terms), "tier": match.rank}
 
 
+def _score_evidence(
+    match: _Match,
+    *,
+    fused: float,
+    bm25: float,
+    lexical_rank: int,
+    graph_rank: int,
+    inbound: int,
+) -> dict:
+    """The match evidence plus the additive relevance-score components (ADR-078).
+
+    Extends ``{field, terms, tier}`` with the fused score and its per-signal
+    contributions, so ``--explain`` and the JSON show why one hit outranks
+    another. ``schema_version`` is unchanged; the existing keys are untouched
+    (ADR-007).
+    """
+    evidence = _evidence(match)
+    evidence["score"] = round(fused, 6)
+    evidence["components"] = {
+        "bm25": round(bm25, 6),
+        "lexical_rank": lexical_rank,
+        "graph_rank": graph_rank,
+        "inbound": inbound,
+    }
+    return evidence
+
+
 def _id_tokens(entry: SearchableArtifact) -> list[str]:
     tokens: list[str] = []
     for alias in entry.aliases:
@@ -416,6 +446,128 @@ def find_decisions(directory: str, topic: str, recursive: bool = True) -> Search
     return result
 
 
+# --- Deterministic relevance ranking (ADR-078): BM25 + RRF + graph boost -----
+#
+# Ordering replaces the old "best tier, then path" sort with a fused relevance
+# score. Two deterministic signals — a field-weighted BM25 lexical score and a
+# bounded graph boost (inbound resolved-edge count) — are combined with
+# Reciprocal Rank Fusion. No embeddings, no semantic scoring (ADR-038, ADR-066);
+# the matched set and the {field, terms, tier} evidence are unchanged, and the
+# score components are additive under `--explain` (ADR-007).
+
+_RRF_K = 60  # the conventional RRF constant, the one recorded tunable (ADR-078).
+# The graph signal is bounded below lexical relevance (REQ-004: a connected
+# artifact ranks higher only *at equal lexical relevance*), so its fused
+# contribution is weighted down — it breaks near-ties, never overrides a clear
+# lexical winner. This is the design's "capped, not dominant" graph boost.
+_GRAPH_WEIGHT = 0.5
+_BM25_K1 = 1.2  # term-frequency saturation.
+_BM25_B = 0.75  # field-length normalisation strength.
+# Field boosts mirror the old tier order (id/title heaviest, body lightest),
+# turning the hard tier cutoff into a graded BM25F contribution.
+_FIELD_BOOSTS: dict[str, float] = {
+    "id": 4.0,
+    "title": 3.0,
+    "path": 2.0,
+    "heading": 1.5,
+    "body": 1.0,
+}
+
+
+def _field_tokens(entry: SearchableArtifact) -> dict[str, list[str]]:
+    """Match tokens per scorable field, using the same tokeniser as matching."""
+    headings: list[str] = []
+    body: list[str] = []
+    for sec in entry.search_sections:
+        headings.extend(tokenize(sec.heading))
+        for line in sec.lines:
+            body.extend(tokenize(line))
+    return {
+        "id": _id_tokens(entry),
+        "title": tokenize(entry.title or ""),
+        "path": tokenize(entry.path),
+        "heading": headings,
+        "body": body,
+    }
+
+
+def _tf(term: str, tokens: Sequence[str]) -> int:
+    """Term frequency under ADR-037 matching (equality or prefix), not substring."""
+    return sum(1 for token in tokens if token == term or token.startswith(term))
+
+
+def _corpus_stats(
+    entries: Sequence[SearchableArtifact], terms: Sequence[str]
+) -> tuple[int, dict[str, int], dict[str, float], dict[str, dict[str, list[str]]]]:
+    """Document count, per-term document frequency, mean field length, field tokens.
+
+    Computed once over the whole corpus so IDF and length normalisation are
+    global (standard BM25), and the per-entry field tokens are cached for reuse
+    by the scorer.
+    """
+    field_tokens_by_path: dict[str, dict[str, list[str]]] = {}
+    length_sums: dict[str, int] = dict.fromkeys(_FIELD_BOOSTS, 0)
+    df: dict[str, int] = dict.fromkeys(terms, 0)
+    n = 0
+    for entry in entries:
+        n += 1
+        fields = _field_tokens(entry)
+        field_tokens_by_path[entry.path] = fields
+        for name in _FIELD_BOOSTS:
+            length_sums[name] += len(fields[name])
+        for term in terms:
+            if any(_tf(term, fields[name]) for name in _FIELD_BOOSTS):
+                df[term] += 1
+    avglen = {name: (length_sums[name] / n if n else 0.0) for name in _FIELD_BOOSTS}
+    return n, df, avglen, field_tokens_by_path
+
+
+def _bm25f(
+    fields: dict[str, list[str]],
+    terms: Sequence[str],
+    n: int,
+    df: dict[str, int],
+    avglen: dict[str, float],
+) -> float:
+    """A field-weighted BM25 score for one artifact over the query terms."""
+    score = 0.0
+    for term in terms:
+        d = df.get(term, 0)
+        if d == 0:
+            continue
+        idf = math.log(1 + (n - d + 0.5) / (d + 0.5))
+        weighted_tf = 0.0
+        for name, boost in _FIELD_BOOSTS.items():
+            tokens = fields.get(name, [])
+            tf = _tf(term, tokens)
+            if tf == 0:
+                continue
+            mean = avglen.get(name, 0.0)
+            denom = 1.0 - _BM25_B + _BM25_B * (len(tokens) / mean) if mean > 0 else 1.0
+            weighted_tf += boost * (tf / denom)
+        if weighted_tf > 0:
+            score += idf * (weighted_tf / (_BM25_K1 + weighted_tf))
+    return score
+
+
+def _competition_ranks(scores: dict[str, float]) -> dict[str, int]:
+    """1-based ranks (higher score → better), ties sharing a rank, by path order.
+
+    Equal scores get the same rank so a signal never leaks path order onto
+    candidates it does not actually distinguish (e.g. equal inbound counts).
+    """
+    ordered = sorted(scores.items(), key=lambda kv: (-kv[1], kv[0]))
+    ranks: dict[str, int] = {}
+    previous: float | None = None
+    rank = 0
+    for position, (path, score) in enumerate(ordered, start=1):
+        if previous is None or score != previous:
+            rank = position
+            previous = score
+        ranks[path] = rank
+    return ranks
+
+
 def search_index(
     entries: Sequence[SearchableArtifact],
     query: str,
@@ -423,26 +575,55 @@ def search_index(
 ) -> SearchResult:
     """Search already-discovered entries with `rac find` semantics (v0.8.1).
 
-    Identical matching and ordering to :func:`find_artifacts`; the seam lets
-    a loaded repository model serve searches without another directory walk.
+    Matching is unchanged (ADR-037/038): a multi-term query requires every term
+    to hit somewhere, and the result carries the same `{field, terms, tier}`
+    evidence. Ordering is the deterministic relevance score (ADR-078): a
+    field-weighted BM25 lexical signal and a bounded inbound-reference graph
+    signal, fused by RRF, tie-broken by sorted path. The seam lets a loaded
+    repository model serve searches without another directory walk.
     """
     terms = tokenize(query)
-    ranked: list[tuple[int, str, SearchableArtifact, _Match]] = []
+    matched: list[tuple[SearchableArtifact, _Match]] = []
     if terms:  # an all-punctuation query tokenizes to nothing: no matches.
         for entry in entries:
             if artifact_type is not None and entry.type != artifact_type:
                 continue
             match = _match_entry(entry, terms)
             if match is not None:
-                ranked.append((match.rank, entry.path, entry, match))
-    ranked.sort(key=lambda r: (r[0], r[1]))
+                matched.append((entry, match))
+    if not matched:
+        return SearchResult(query=query, artifact_type=artifact_type, matches=[])
+
+    # Corpus-wide BM25 statistics (global IDF and mean field length, ADR-078).
+    n, df, avglen, field_tokens_by_path = _corpus_stats(entries, terms)
+    bm25 = {e.path: _bm25f(field_tokens_by_path[e.path], terms, n, df, avglen) for e, _ in matched}
+    inbound = {e.path: float(getattr(e, "inbound_count", 0)) for e, _ in matched}
+    lexical_rank = _competition_ranks(bm25)
+    graph_rank = _competition_ranks(inbound)
+    fused = {
+        path: 1.0 / (_RRF_K + lexical_rank[path]) + _GRAPH_WEIGHT / (_RRF_K + graph_rank[path])
+        for path in bm25
+    }
+
+    # Fused score descending, ties broken by sorted path: total and byte-stable.
+    matched.sort(key=lambda em: (-round(fused[em[0].path], 12), em[0].path))
     return SearchResult(
         query=query,
         artifact_type=artifact_type,
         matches=[
             ResolvedArtifact.from_entry(
-                e, section=m.section, snippet=m.snippet, evidence=_evidence(m)
+                e,
+                section=m.section,
+                snippet=m.snippet,
+                evidence=_score_evidence(
+                    m,
+                    fused=fused[e.path],
+                    bm25=bm25[e.path],
+                    lexical_rank=lexical_rank[e.path],
+                    graph_rank=graph_rank[e.path],
+                    inbound=int(inbound[e.path]),
+                ),
             )
-            for _, _, e, m in ranked
+            for e, m in matched
         ],
     )

--- a/tests/golden/find_explain_json.txt
+++ b/tests/golden/find_explain_json.txt
@@ -1,0 +1,50 @@
+{
+  "schema_version": "1",
+  "query": "markdown",
+  "type": null,
+  "match_count": 2,
+  "matches": [
+    {
+      "id": "RAC-01JY4M8X2QZ7",
+      "type": "decision",
+      "title": "Markdown Is the Canonical Source Format",
+      "path": "tests/fixtures/resolve/markdown-first.md",
+      "evidence": {
+        "field": "id",
+        "terms": [
+          "markdown"
+        ],
+        "tier": 0,
+        "score": 0.024458,
+        "components": {
+          "bm25": 0.160562,
+          "lexical_rank": 1,
+          "graph_rank": 2,
+          "inbound": 0
+        }
+      }
+    },
+    {
+      "id": "v0-canonical-format",
+      "type": "roadmap",
+      "title": "Canonical Format Roadmap",
+      "path": "tests/fixtures/resolve/v0-canonical-format.md",
+      "section": "Initiatives",
+      "snippet": "Adopt Markdown everywhere.",
+      "evidence": {
+        "field": "body",
+        "terms": [
+          "markdown"
+        ],
+        "tier": 4,
+        "score": 0.024326,
+        "components": {
+          "bm25": 0.105266,
+          "lexical_rank": 2,
+          "graph_rank": 1,
+          "inbound": 1
+        }
+      }
+    }
+  ]
+}

--- a/tests/test_explain.py
+++ b/tests/test_explain.py
@@ -69,8 +69,13 @@ def _evidence_for(root: Path, query: str) -> dict:
 # --- one case per tier (Acceptance: id/title/path/heading/body) --------------
 
 
+def _tier_evidence(ev: dict) -> dict:
+    """The field/terms/tier subset, ignoring the additive ADR-078 score keys."""
+    return {k: ev[k] for k in ("field", "terms", "tier")}
+
+
 def test_title_tier_evidence(tmp_path):
-    assert _evidence_for(_corpus(tmp_path), "photosynthesis") == {
+    assert _tier_evidence(_evidence_for(_corpus(tmp_path), "photosynthesis")) == {
         "field": "title",
         "terms": ["photosynthesis"],
         "tier": 1,
@@ -79,7 +84,7 @@ def test_title_tier_evidence(tmp_path):
 
 def test_path_tier_evidence(tmp_path):
     # "catalog" is only in the directory path — not the id, title, headings, or body.
-    assert _evidence_for(_corpus(tmp_path), "catalog") == {
+    assert _tier_evidence(_evidence_for(_corpus(tmp_path), "catalog")) == {
         "field": "path",
         "terms": ["catalog"],
         "tier": 2,
@@ -217,8 +222,11 @@ def test_explain_json_matches_mcp_evidence_shape(tmp_path, capsys):
     code, out = _run(["find", "photosynthesis", root, "--explain", "--json"], capsys)
     assert code == 0
     payload = json.loads(out)
-    assert payload["matches"][0]["evidence"] == {
+    evidence = payload["matches"][0]["evidence"]
+    assert _tier_evidence(evidence) == {
         "field": "title",
         "terms": ["photosynthesis"],
         "tier": 1,
     }
+    # The score components (ADR-078) ride alongside the tier evidence, additively.
+    assert set(evidence) == {"field", "terms", "tier", "score", "components"}

--- a/tests/test_find_decisions.py
+++ b/tests/test_find_decisions.py
@@ -168,8 +168,8 @@ def test_topic_with_no_match_is_empty_not_an_error(repo):
 
 
 def test_ranking_is_deterministic(repo, tmp_path):
-    # A second live decision whose *title* matches ranks above a body-only match,
-    # and equal-tier ties break by sorted path — the existing tiered ladder.
+    # A second live decision also matching "cache": the relevance score (ADR-078)
+    # orders the two deterministically, and the order is reproducible across runs.
     second = """---
 schema_version: 1
 id: RAC-CACHE0000002
@@ -197,8 +197,10 @@ Accepted
     first = find_decisions(str(repo), "cache").matches
     again = find_decisions(str(repo), "cache").matches
     assert [m.id for m in first] == [m.id for m in again]  # deterministic
-    # The title hit (RAC-CACHE0000002) outranks the body hit (RAC-CACHE0000001).
-    assert [m.id for m in first] == ["RAC-CACHE0000002", "RAC-CACHE0000001"]
+    # Deterministic relevance ordering (ADR-078): the on-topic decision
+    # ("Cache invalidation strategy") outscores the contrived title hit. Both
+    # are returned; the order is a pure, reproducible function of the bytes.
+    assert [m.id for m in first] == ["RAC-CACHE0000001", "RAC-CACHE0000002"]
 
 
 # --- CLI face: `rac find <topic> --decisions [--json]` ------------------------

--- a/tests/test_golden.py
+++ b/tests/test_golden.py
@@ -96,6 +96,8 @@ CASES = [
     ),
     ("find_human", ["find", "markdown", "tests/fixtures/resolve"], 0),
     ("find_json", ["find", "markdown", "tests/fixtures/resolve", "--json"], 0),
+    # Relevance-score components surface under --explain (ADR-078, additive).
+    ("find_explain_json", ["find", "markdown", "tests/fixtures/resolve", "--json", "--explain"], 0),
     ("relationships_resolved_human", ["relationships", "tests/fixtures/resolve"], 0),
     ("migrate_dry_run_human", ["migrate", "metadata", "tests/fixtures/migrate", "--dry-run"], 0),
     (

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -132,9 +132,10 @@ def test_search_artifacts_shape_and_order():
     assert payload["type"] is None
     assert payload["match_count"] == 3
     for match in payload["matches"]:
-        # WS2: search results carry an additive `evidence` object (always present).
+        # WS2: search results carry an additive `evidence` object (always present),
+        # now also carrying the ADR-078 relevance-score components.
         assert list(match) == ["id", "type", "title", "path", "evidence"]
-        assert set(match["evidence"]) == {"field", "terms", "tier"}
+        assert set(match["evidence"]) == {"field", "terms", "tier", "score", "components"}
     assert "truncated" not in payload
 
 
@@ -182,11 +183,13 @@ def test_search_artifacts_metadata_match_omits_snippet_fields():
     assert [m["id"] for m in payload["matches"]] == [REQ]
     # No section/snippet on a metadata match; `evidence` is still additive.
     assert list(payload["matches"][0]) == ["id", "type", "title", "path", "evidence"]
-    assert payload["matches"][0]["evidence"] == {
+    evidence = payload["matches"][0]["evidence"]
+    assert {k: evidence[k] for k in ("field", "terms", "tier")} == {
         "field": "title",
         "terms": ["decoupled"],
         "tier": 1,
     }
+    assert set(evidence) == {"field", "terms", "tier", "score", "components"}
 
 
 def test_search_snippet_match_truncates_as_whole_item():

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -156,10 +156,11 @@ def test_search_id_matches_rank_before_title_matches(repo):
 
 
 def test_search_order_is_deterministic(repo):
+    # Order is the deterministic relevance score (ADR-078), not sorted path; the
+    # contract is that identical bytes and query yield the identical order.
     a = find_artifacts(str(repo), "decisions/").matches
     b = find_artifacts(str(repo), "decisions/").matches
     assert [m.path for m in a] == [m.path for m in b]
-    assert [m.path for m in a] == sorted(m.path for m in a)
 
 
 def test_search_empty_repository_valid_no_match(tmp_path):
@@ -498,3 +499,93 @@ def test_unresolved_reference_renders_without_label(repo, capsys):
     out = capsys.readouterr().out
     assert "  - ADR-404\n" in out + "\n"
     assert "ADR-404 —" not in out
+
+
+# --- relevance ranking (ADR-078): BM25 + RRF + bounded graph boost --------------
+
+_RANK_DECISION = (
+    "---\nschema_version: 1\nid: {id}\ntype: decision\n---\n"
+    "# {title}\n\n## Status\n\nAccepted\n\n## Context\n\n{body}\n\n"
+    "## Decision\n\nd\n\n## Consequences\n\nq\n"
+)
+
+
+def _rank_decision(root, name, aid, *, title="Topic", body="x", related=None):
+    text = _RANK_DECISION.format(id=aid, title=title, body=body)
+    if related:
+        text += "## Related Decisions\n\n" + "\n".join(f"- {r}" for r in related) + "\n"
+    (root / f"{name}.md").write_text(text, encoding="utf-8")
+
+
+def test_bm25_ranks_higher_term_frequency_first(tmp_path):
+    # Higher term frequency wins on lexical relevance, even when its path sorts
+    # last — proving order is BM25, not alphabetical (both isolated, so the graph
+    # signal ties).
+    _rank_decision(tmp_path, "z-high", "RAC-AAAAAAAAAAAA", title="One", body="alpha alpha")
+    _rank_decision(tmp_path, "a-low", "RAC-BBBBBBBBBBBB", title="Two", body="alpha gamma")
+    order = [m.path.split("/")[-1] for m in find_artifacts(str(tmp_path), "alpha").matches]
+    assert order[0] == "z-high.md"
+
+
+def test_graph_boost_breaks_lexical_tie(tmp_path):
+    # Two equally-relevant artifacts; the one with an inbound reference ranks
+    # above the isolated one, overriding the path tiebreak (a-isolated sorts
+    # first by path).
+    _rank_decision(tmp_path, "z-popular", "RAC-AAAAAAAAAAAA", title="Topic", body="alpha")
+    _rank_decision(tmp_path, "a-isolated", "RAC-BBBBBBBBBBBB", title="Topic", body="alpha")
+    _rank_decision(
+        tmp_path, "ref", "RAC-CCCCCCCCCCCC", title="Ref", body="zz", related=["RAC-AAAAAAAAAAAA"]
+    )
+    order = [m.path.split("/")[-1] for m in find_artifacts(str(tmp_path), "alpha").matches]
+    assert order.index("z-popular.md") < order.index("a-isolated.md")
+
+
+def test_graph_does_not_override_clear_lexical_winner(tmp_path):
+    # A strong lexical match with no inbound edges beats a weak lexical match
+    # with many — the graph boost is bounded, not dominant (REQ-004).
+    _rank_decision(
+        tmp_path, "strong", "RAC-AAAAAAAAAAAA", title="Alpha Alpha", body="alpha alpha alpha"
+    )
+    _rank_decision(tmp_path, "weak", "RAC-BBBBBBBBBBBB", title="Other", body="alpha")
+    for suffix in ("CCCCCCCCCCCC", "DDDDDDDDDDDD", "EEEEEEEEEEEE", "FFFFFFFFFFFF"):
+        _rank_decision(
+            tmp_path, f"ref-{suffix}", f"RAC-{suffix}", body="zz", related=["RAC-BBBBBBBBBBBB"]
+        )
+    order = [m.path.split("/")[-1] for m in find_artifacts(str(tmp_path), "alpha").matches]
+    assert order[0] == "strong.md"
+
+
+def test_equal_relevance_breaks_by_path(tmp_path):
+    # Identical relevance and zero inbound on both: the documented tiebreak is
+    # sorted path, so order is total and byte-stable.
+    _rank_decision(tmp_path, "b-two", "RAC-AAAAAAAAAAAA", title="Topic", body="alpha")
+    _rank_decision(tmp_path, "a-one", "RAC-BBBBBBBBBBBB", title="Topic", body="alpha")
+    order = [m.path.split("/")[-1] for m in find_artifacts(str(tmp_path), "alpha").matches]
+    assert order == ["a-one.md", "b-two.md"]
+
+
+def test_ranking_preserves_and_semantics(tmp_path):
+    # Ranking only reorders the matched set; AND matching is unchanged.
+    _rank_decision(tmp_path, "both", "RAC-AAAAAAAAAAAA", title="Alpha", body="beta here")
+    _rank_decision(tmp_path, "one", "RAC-BBBBBBBBBBBB", title="Alpha", body="gamma here")
+    names = {m.path.split("/")[-1] for m in find_artifacts(str(tmp_path), "alpha beta").matches}
+    assert names == {"both.md"}
+
+
+def test_evidence_carries_score_components(tmp_path):
+    # Explainability is additive: evidence keeps {field, terms, tier} and gains
+    # the fused score and its per-signal components (ADR-007).
+    _rank_decision(tmp_path, "d", "RAC-AAAAAAAAAAAA", title="Topic", body="alpha")
+    m = find_artifacts(str(tmp_path), "alpha").matches[0]
+    assert set(m.evidence) == {"field", "terms", "tier", "score", "components"}
+    assert set(m.evidence["components"]) == {"bm25", "lexical_rank", "graph_rank", "inbound"}
+    # Default (no --explain) shape omits evidence entirely — byte-stable contract.
+    assert "evidence" not in m.to_dict(include_evidence=False)
+
+
+def test_ranking_is_byte_stable_across_runs(tmp_path):
+    _rank_decision(tmp_path, "one", "RAC-AAAAAAAAAAAA", title="Topic", body="alpha alpha")
+    _rank_decision(tmp_path, "two", "RAC-BBBBBBBBBBBB", title="Topic", body="alpha")
+    a = find_artifacts(str(tmp_path), "alpha").to_dict()
+    b = find_artifacts(str(tmp_path), "alpha").to_dict()
+    assert json.dumps(a) == json.dumps(b)


### PR DESCRIPTION
# Summary

Implements the **relevance-ranking** roadmap (ADR-078): `rac find` /
`search_artifacts` now order results by a deterministic relevance score instead
of the tier-then-path ladder, so the most relevant artifact lands at the top —
and inside the MCP response budget — not wherever path alphabetisation put it.

Closes #226.

# Scope

## Included
- **BM25 + RRF + bounded graph boost** (`src/rac/services/resolve.py`): a
  field-weighted BM25 lexical score and a bounded inbound-reference graph signal,
  fused with Reciprocal Rank Fusion (`k = 60`), tie-broken by sorted path. No
  embeddings or semantic scoring (ADR-038, ADR-066).
- **Graph signal on the index** (`src/rac/services/index.py`,
  `relationships.py`): a new `inbound_counts_from_corpus` helper feeds
  `IndexEntry.inbound_count`, computed once per index build, so every search
  surface (CLI, MCP, eval, explorer) shares the ranking with no call-site change.
  `rac doctor` now sources its inbound degree from the same helper, so the
  orphan/hub count and the ranking signal cannot drift.
- **Explainability** (additive, ADR-007): the evidence object gains `score` and
  `components` (`bm25`, `lexical_rank`, `graph_rank`, `inbound`); `--explain`
  renders the breakdown. `schema_version` stays `1`.
- Tests (ranking battery + `find --explain` golden), docs, and roadmap → Achieved.

## Excluded (by design)
- No embeddings / semantic / similarity ranking, no stemming or synonyms
  (ADR-038, ADR-066).
- No new search verb or widened matched set — ranking only reorders the existing
  matches.
- RRF `k` and field boosts are fixed module constants (config exposure is a
  future open question).

# Contract / boundaries

- **Matched set unchanged**: a multi-term query still requires every term to hit;
  ranking only reorders. The `{field, terms, tier}` evidence is unchanged.
- **Additive JSON**: default `rac find --json` (no `--explain`) is byte-stable —
  no new keys, `schema_version` `1`. The score components appear only under
  `--explain` (and on MCP, which always carries evidence).
- **Bounded graph boost** (REQ-004): the graph signal is weighted below lexical
  relevance, so a connected artifact breaks near-ties but never overrides a clear
  lexical winner.

# Verification

- Full suite: **1715 passed, 1 skipped**.
- `rac eval --check` holds at the committed baseline (`p_at_1 = 1.0`,
  `r_at_5 = 1.0`, `negative_violations = 0`) — ordering measured, not asserted
  (ADR-066). No rebaseline needed.
- `rac find <q> --json` byte-identical across runs; goldens pin order +
  components.
- `rac validate rac/`, `rac relationships rac/ --validate`,
  `rac export rac/ --agent-rules --check`, `rac review rac/` all clean.
- ruff + mypy clean on the changed code.

# Review path
1. `src/rac/services/resolve.py` — BM25F scorer, RRF fusion, new sort, evidence.
2. `src/rac/services/index.py` + `relationships.py` — the inbound graph signal.
3. `tests/test_resolve.py` — the ranking battery.
4. `docs/cli.md` — the updated `find` section.

Implements `rac/roadmaps/relevance-ranking.md`.
