### PR TITLE
feat(roadmap): record the relationship-vocabulary gap programme

### DIFF
--- a/.agent-context/GAPS_TRACEABILITY.md
+++ b/.agent-context/GAPS_TRACEABILITY.md
@@ -1,130 +1,159 @@
 # Traceability gaps — consolidated report
 
-Growth programme, 2026-06-12, corpus at v0.10.3. Twenty raw gap records
-from five agents (`.agent-context/gaps/agent1..5.md`) consolidate into
-eight schema gaps and two authoring-friction findings. Every instance
-cites a real file in this repository; none is speculative. The original
-programme framed this report as justification for "the v0.8.0
-traceability work"; that shipped as the v0.7.x relationships series
-(ADR-016), so each gap instead names the future work it motivates.
+Growth-programme traceability gap audit. **Refreshed 2026-06-28 against the live
+corpus** (the original pass was 2026-06-12 at corpus v0.10.3). Each gap below
+carries its current status — **OPEN**, **PARTIAL** (a mechanism shipped but the
+gap is not fully closed), or **CLOSED** — with the shipped mechanism named, and
+≥3 concrete current instances for the ones still open. Every instance cites a
+real file in this repository; none is speculative.
 
-The linking mechanisms that exist today: untyped `## Related <Type>`
-sections (corpus-internal, by id) and `## Supersedes` (decisions only).
+The linking mechanisms that exist **today**: per-type `## Related <Type>`
+sections for all five families including **self-type** `related decisions` /
+`related roadmaps` (shipped v0.13.5), `## Supersedes` (decisions only), and
+external `## Related Tickets` (ADR-087). Relationship validation now flags
+broken, ambiguous, self, cyclic, **type-mismatched** (`relationship-target-type-
+mismatch`), **unsupported** (`relationship-edge-unsupported`), and **retired**
+targets, and `rac doctor` surfaces **mentioned-but-unlinked** body references
+(`unlinked-reference`, ADR-082, shipped #225).
 
-## 1. Links from artifacts to non-artifact repo files
+## Headline gap (self-type relationships) — CLOSED
 
-The most frequently hit gap — all five agents recorded it independently.
+roadmap→roadmap and decision→decision references produced zero edges at v0.10.3.
+**Closed:** `related roadmaps` and `related decisions` are now in the relationship
+vocabulary (v0.13.5); the audit entry `rac-traceability-self-relationships`
+(Accepted) records it. The 11 + 8 evidence instances now resolve.
 
-- Instances: `rac-growth-positioning` REQ-001..005 are satisfied by a
-  README section it cannot reference; `rac-growth-agent-skill` REQ-001
-  is satisfied by `.claude/skills/rac-artifacts/SKILL.md`;
-  `rac-growth-ecosystem-list` governs `docs/ecosystem.md`; pre-existing:
-  `rac-documentation-structure` places testable requirements on eight
-  doc files by bare path, and `adr-027` governs four CI workflow files
-  the same way. Renames break these silently.
-- Minimal addition: an optional `## Related Files` (or `## Satisfied
-  By`) section accepting repo-relative paths, validated for existence
-  by `rac relationships --validate`.
-- Motivates: requirement→artifact traceability in a future
-  relationships milestone; also gives Guide's `get_related` a way to
-  answer "what file satisfies this requirement".
+---
 
-## 2. External source and URL references as structured data
+## 1. Links from artifacts to non-artifact repo files — OPEN
 
-- Instances: the README comparison table's competitor sources
-  (spec-kit, OpenSpec) live in an HTML comment invisible to validation
-  and MCP; Kiro's exclusion (docs returned HTTP 403 on 2026-06-12)
-  has no machine-readable "re-verify later" marker; the essay series
-  mapped in `growth-essay-mapping` is unpublished and external, so the
-  article side of every mapping row is an unresolvable label.
-- Minimal addition: an optional `## Sources` section, one URL per line
-  with an optional status token, extracted and exposed via
-  `get_artifact` (not fetched by the engine — determinism holds).
-- Motivates: evidence-grounded artifacts; staleness checking as a
-  deterministic review finding.
+A requirement satisfied by a README section, a skill file, a CI workflow, or a
+doc page cannot reference it; renames break the link silently. ADR-019 added
+**asset** references (images), which narrows but does not close this — arbitrary
+repo-file traceability (`## Satisfied By` / `## Related Files`) is still missing.
 
-## 3. Typed edge semantics (implements / satisfies / depends-on / derived-from)
+- Current instances: `rac-growth-positioning` (satisfied by a README section it
+  cannot reference), `rac-growth-agent-skill` (satisfied by
+  `.claude/skills/rac-artifacts/SKILL.md`), `rac-documentation-structure` (places
+  testable requirements on doc files by bare path), `adr-027` (governs CI
+  workflow files the same way).
+- Minimal addition: an optional `## Satisfied By` / `## Related Files` section
+  accepting repo-relative paths, existence-checked by `rac relationships
+  --validate`.
 
-- Instances: `adr-028` invents unvalidated `### Implements`
-  sub-headings inside a non-schema section; the Explorer requirement
-  invents `### Depends On`; `v0.10.3-search-quality` lists the
-  decisions it implements (ADR-037/038) and the standing constraints it
-  must not break (ADR-007/027) in one flat `## Related Decisions` list;
-  `growth-essay-mapping`'s claim→capability mapping is unqueryable
-  table prose.
+## 2. External source / URL references as structured data — PARTIAL
+
+**Partially closed:** ADR-087 shipped the external-reference mechanism as
+`## Related Tickets` (format-linted, not fetched — determinism holds), now used
+in 7 artifacts. **Still open:** generic source/URL citations (a `## Sources`
+section) — competitor-comparison sources and the essay-series URLs remain
+unstructured prose/comments invisible to validation and MCP.
+
+- Current instances: `rac-growth-positioning` comparison sources, the
+  `growth-essay-mapping` external article side, `rac-grounding-eval-benchmark`
+  external references.
+- Minimal addition: an optional `## Sources` section, one URL per line with an
+  optional status token, exposed via `get_artifact`, never fetched.
+
+## 3. Typed edge semantics (implements / depends-on / satisfies) — OPEN (narrowing)
+
+ADR-074 made the **graph export** surface typed edges, but the **authoring**
+vocabulary is still invented and unvalidated: edge-label sub-headings inside
+non-schema sections. Down to 2 live instances (others archived).
+
+- Current instances: `adr-028-explorer-surface` (`### Implements`),
+  `rac-product-knowledge-navigator-explorer` (`### Depends On`).
 - Minimal addition: validated optional edge-label sub-headings
-  (`### Implements`, `### Depends On`, `### Satisfies`) inside existing
-  `Related <Type>` sections, defaulting to untyped when absent.
-- Motivates: relationship semantics in a post-v0.10 series; directly
-  improves `rac relationships` output and `get_related` answer quality.
+  (`### Implements`, `### Depends On`, `### Satisfies`) inside `Related <Type>`
+  sections, defaulting to untyped when absent.
 
-## 4. Machine-readable lifecycle and gate status
+## 4. Machine-readable lifecycle / gate status — PARTIAL
 
-- Instances: `rac-product-intent-ci-watchkeeper` carries Status
-  "Deferred", outside any vocabulary, accepted silently; shipped
-  requirements still read "Proposed" with no transition to record;
-  this programme's GATE-1/GATE-2 markers are free-text lines
-  (`Blocked: GATE-2 (CLA not yet in place)`) in four artifacts —
-  nothing can enumerate "everything blocked behind GATE-1", and the
-  section-level block on `rac-growth-extensibility`'s bundle convention
-  is pure prose.
-- Minimal addition: a validated Status vocabulary for requirements
-  (Proposed | Accepted | Implemented | Deferred | Blocked) with one
-  reason line for Blocked.
-- Motivates: the review engine (`future/v1.1-review-engine`) and CI
-  Watchkeeper intent analysis, both of which need lifecycle state.
+**Partially closed:** ADR-061 gave roadmaps a validated lifecycle vocabulary
+(Planned / Achieved / Superseded / Abandoned). **Still open:** requirements
+carry free-text Status (Proposed / Accepted / Deferred) with no validated
+vocabulary, and GATE-1/GATE-2 blocks are free-text lines nothing can enumerate.
 
-## 5. Supersession outside decisions
+- Current instances: `rac-growth-adoption` (Proposed), `rac-growth-positioning`
+  (Proposed), `rac-growth-contribution-policy` (Proposed, GATE-2 in prose).
+- Minimal addition: a validated Status vocabulary for requirements with one
+  reason line for a Blocked/Deferred state.
 
-- Instances: `archive/v0.8.0-service-api.md` and
-  `v0.8.x-explorer/v0.8.0-explorer-foundation.md` both claim the v0.8.0
-  identity with no marker between them; the entire archived v0.9 plan
-  was replaced by `v0.9.x-watchekeeper/` via directory move only;
-  `v0.10.0-guide-foundation` supersedes the deleted `v1.2-mcp-server`
-  stub in prose that now dangles invisibly.
-- Minimal addition: permit `## Supersedes` on roadmap artifacts,
-  validated for target existence including archived targets.
-- Motivates: roadmap lifecycle hygiene; makes `archive/` queryable
-  instead of conventional.
+## 5. Supersession outside decisions — PARTIAL
 
-## 6. Relationship directionality and back-references
+**Partially closed:** ADR-061 gave roadmaps a `Superseded` **status**. **Still
+open:** there is no roadmap→roadmap supersedes **edge** (the target it was
+replaced by); `## Supersedes` stays decision-only, so the link is a status flag,
+not a resolvable edge.
 
-- Instances: ADR-036 → v0.10.2 has no reverse edge; six early ADRs
-  cited by `rac-agent-context-guide` carry zero Related sections
-  themselves — an agent at the target cannot discover the citing
-  artifact.
+- Current instances: the archived single-item series flattened during the
+  v0.28–v0.30 → codename renames; `repo-extraction-programme` superseded by the
+  `repo-topology` series in prose only.
+- Minimal addition: permit `## Supersedes` on roadmaps, existence-checked
+  (including archived targets).
+
+## 6. Relationship directionality / back-references — OPEN
+
+`related_*` edges are undirected, so symmetry is implicit for declared links —
+but a target artifact still cannot advertise who cites it, and there is no
+advisory when an expected back-reference is absent. The new `unlinked-reference`
+finding (#225) is adjacent (it surfaces prose mentions), not this.
+
+- Current instances: ADR-036 ← `v0.10.2` (no reverse edge); early ADRs cited by
+  `rac-agent-context-guide` that carry no Related sections themselves.
 - Minimal addition: an advisory asymmetric-edge finding in
   `rac relationships --validate` (no schema change).
-- Motivates: relationship-quality findings in the review engine.
 
-## 7. Scoping / applies-to
+## 7. Scoping / applies-to — OPEN
 
-- Instances: ADR-018 governs `rac/`; ADR-023 scopes itself to
-  `src/rac/` internals in bold prose; ADR-027 applies to the CI
-  workflows; ADR-033 applies to the Guide tool surface — none of these
-  scopes is data.
-- Minimal addition: an optional `## Applies To` section on decisions
-  accepting paths or component names.
-- Motivates: scoped grounding — Guide could serve "decisions that apply
-  to the file you are editing".
+Decisions scope themselves to a path or component in **prose**, not data, so
+"which decisions apply to the file I'm editing" is unanswerable.
 
-## 8. Validation blind spots in relationship extraction
+- Current instances: `adr-035` (applies to RAC Core + OSS extensions),
+  `adr-018` (governs `rac/`), `adr-027` (CI workflows), `adr-033` (Guide tool
+  surface).
+- Minimal addition: an optional `## Applies To` section on decisions accepting
+  paths or component names; enables scoped grounding in the Lore MCP server.
 
-- Instances: `## Related Artifacts` (a non-schema section) appears in
-  eight artifacts with display-name targets that resolve to nothing
-  while CI stays green; `rac-growth-agent-skill` links
-  `v1.4-claude-skills`, whose file classifies as Unknown type, and
-  validation reports 0 issues — targets are not type-checked.
-- Minimal addition: advisory findings for unrecognised `Related *`
-  sections and for targets resolving to Unknown or mismatched types.
-- Motivates: near-term `rac review` / relationships hardening; cheap
-  relative to the schema gaps above.
+## 8. Validation blind spots in relationship extraction — CLOSED
+
+**Closed:** targets are now type-checked (`relationship-target-type-mismatch`),
+unrecognised/unsupported `Related *` sections are flagged
+(`relationship-edge-unsupported`), retired targets warn
+(`relationship-target-superseded`), and mentioned-but-unlinked body references
+surface in `rac doctor` (`unlinked-reference`, #225). The v0.10.3 instances
+(`## Related Artifacts` resolving to nothing; targets to Unknown types) now
+produce findings instead of silent passes.
 
 ## Authoring-friction findings (not schema gaps)
 
-- `[REQ-NNN]` statements cannot hard-wrap: continuation lines raise
-  `req-missing-id`, forcing one-line statements against the corpus's
-  72-column prose convention. Hit by three agents.
-- `rac new` does not create parent directories — the only zero-config
-  snag on the measured cold-start path (covered by Proposed REQ-005 in
-  `rac-growth-adoption`).
+- **`[REQ-NNN]` statements cannot hard-wrap** — still OPEN: a continuation line
+  raises `req-missing-id` (`validation.py:466`), forcing one-line statements
+  against the 72-column prose convention.
+- **`rac new` does not create parent directories** — still OPEN by design
+  (`create.py`: deliberate no-auto-create); mitigated for the cold-start path by
+  `rac quickstart`, which scaffolds the directory and the artifact in one step.
+
+---
+
+## Summary
+
+| # | Gap | Status |
+| --- | --- | --- |
+| — | Self-type relationships (roadmap/decision) | CLOSED (v0.13.5) |
+| 1 | Artifact → repo-file links | OPEN |
+| 2 | External source / URL references | PARTIAL (tickets via ADR-087; URLs open) |
+| 3 | Typed edge semantics | OPEN (narrowing) |
+| 4 | Lifecycle / gate status as data | PARTIAL (roadmaps via ADR-061; requirements open) |
+| 5 | Supersession outside decisions | PARTIAL (status via ADR-061; edge open) |
+| 6 | Directionality / back-references | OPEN |
+| 7 | Scoping / applies-to | OPEN |
+| 8 | Relationship-extraction blind spots | CLOSED |
+
+Four schema gaps remain squarely open (1, 3, 6, 7) and three are partial (2, 4,
+5). Each is specific enough to design a schema change from, which is the audit's
+purpose (growth-programme success measure). The pattern for promoting a ripe gap
+to a designable corpus record is `rac-traceability-self-relationships` (a
+requirement enumerating the gap, its evidence, and the contracts a fix must
+preserve); the open gaps above are candidates for the same treatment when
+scheduled.

--- a/.agent-context/GAPS_TRACEABILITY.md
+++ b/.agent-context/GAPS_TRACEABILITY.md
@@ -70,14 +70,17 @@ non-schema sections. Down to 2 live instances (others archived).
 ## 4. Machine-readable lifecycle / gate status — PARTIAL
 
 **Partially closed:** ADR-061 gave roadmaps a validated lifecycle vocabulary
-(Planned / Achieved / Superseded / Abandoned). **Still open:** requirements
-carry free-text Status (Proposed / Accepted / Deferred) with no validated
-vocabulary, and GATE-1/GATE-2 blocks are free-text lines nothing can enumerate.
+(Planned / Achieved / Superseded / Abandoned), and per-type **Status is already a
+validated enum** for requirements/decisions/designs/prompts (a value off the
+allowed set is an error). **Still open (narrowed):** the enum has no `Deferred`
+(parked) state distinct from `Proposed`, no structured `Blocked` state, and
+GATE-1/GATE-2 blocks are free-text lines nothing can enumerate.
 
-- Current instances: `rac-growth-adoption` (Proposed), `rac-growth-positioning`
-  (Proposed), `rac-growth-contribution-policy` (Proposed, GATE-2 in prose).
-- Minimal addition: a validated Status vocabulary for requirements with one
-  reason line for a Blocked/Deferred state.
+- Current instances: `rac-growth-contribution-policy` (GATE-2 in prose),
+  `rac-growth-positioning` (GATE-1 in prose), parked work reading `Proposed`
+  with no `Deferred` state.
+- Minimal addition: append `Deferred` / `Blocked` to the status enums plus a
+  structured gate-reason, so blocked artifacts are enumerable by gate.
 
 ## 5. Supersession outside decisions — PARTIAL
 
@@ -152,8 +155,20 @@ produce findings instead of silent passes.
 
 Four schema gaps remain squarely open (1, 3, 6, 7) and three are partial (2, 4,
 5). Each is specific enough to design a schema change from, which is the audit's
-purpose (growth-programme success measure). The pattern for promoting a ripe gap
-to a designable corpus record is `rac-traceability-self-relationships` (a
-requirement enumerating the gap, its evidence, and the contracts a fix must
-preserve); the open gaps above are candidates for the same treatment when
-scheduled.
+purpose (growth-programme success measure).
+
+## Recorded as corpus intent
+
+The open/partial gaps are now promoted to the trusted corpus (the pattern set by
+`rac-traceability-self-relationships`): the `relationship-vocabulary` roadmap with
+a requirement per gap, tracked under epic **itsthelore/rac-core#236**.
+
+| Gap(s) | Requirement |
+| --- | --- |
+| 1 + 2 | `rac-external-and-file-references` |
+| 5 | `rac-roadmap-supersession` |
+| 3 | `rac-typed-relationship-edges` |
+| 6 | `rac-relationship-back-references` |
+| 7 | `rac-decision-applies-to-scope` |
+| 4 | `rac-artifact-status-vocabulary` |
+| (closed) self-type | `rac-traceability-self-relationships` |

--- a/rac/requirements/rac-artifact-status-vocabulary.md
+++ b/rac/requirements/rac-artifact-status-vocabulary.md
@@ -1,0 +1,65 @@
+---
+schema_version: 1
+id: RAC-KW7VKPCEKR98
+type: requirement
+---
+# RAC Lifecycle — Status and Gate Vocabulary
+
+## Status
+
+Proposed
+
+## Problem
+
+Artifact Status is already a validated enum per type (for example a requirement
+is `Proposed | Accepted | Superseded | Deprecated`), but two lifecycle states the
+corpus uses in practice are missing, and gate state is unstructured. Work that is
+parked reads `Proposed` with no way to say `Deferred`; work blocked behind a gate
+records it as a free-text line (`Blocked: GATE-2 (CLA not yet in place)`) that
+nothing can enumerate. So "everything blocked behind GATE-1" is not a query.
+
+This is gap 4 of the traceability audit (narrowed: the status enum exists and is
+validated; the residue is the missing states and gate-status-as-data).
+
+## Evidence
+
+- `rac-growth-contribution-policy` is blocked behind GATE-2 in prose.
+- `rac-growth-positioning` and several growth requirements are gated behind GATE-1
+  in free-text assumptions, not enumerable.
+- Parked work reads `Proposed` with no `Deferred` state to distinguish it.
+
+## Requirements
+
+- [REQ-001] The validated status vocabulary gains a `Deferred` state (intentionally parked) distinct from `Proposed`, applied consistently across the artifact types that carry a status enum.
+
+- [REQ-002] A blocked state is expressible with a structured reason (for example a `Blocked` status plus a single gate-reason field), so blocked artifacts can be enumerated by gate.
+
+- [REQ-003] The additions are additive (ADR-007, ADR-051): existing status values keep their meaning and `retired_status` semantics; new values are appended, never repurposing existing ones.
+
+- [REQ-004] The new states are validated like the existing enum (a value off the allowed set is an error), and do not change which statuses count as retired unless explicitly specified.
+
+## Success Metrics
+
+- A query can list every artifact `Blocked` behind a named gate.
+- `Deferred` distinguishes parked work from `Proposed` in the corpus.
+- Existing status values validate byte-identically before and after.
+
+## Risks
+
+- Status creep blurs the knowledge-vs-work line (ADR-017); mitigated by keeping
+  the vocabulary small and lifecycle-oriented, not a task tracker.
+
+## Assumptions
+
+- A small fixed set of additional states suffices; arbitrary workflow states are
+  out of scope.
+
+## Related Decisions
+
+- adr-051
+- adr-017
+- adr-007
+
+## Related Roadmaps
+
+- relationship-vocabulary

--- a/rac/requirements/rac-decision-applies-to-scope.md
+++ b/rac/requirements/rac-decision-applies-to-scope.md
@@ -1,0 +1,61 @@
+---
+schema_version: 1
+id: RAC-KW7VKMG2TCW6
+type: requirement
+---
+# RAC Decision Scope — Applies-To
+
+## Status
+
+Proposed
+
+## Problem
+
+A decision often governs a specific part of the repository — a directory, a
+component, a surface — but says so only in prose ("this decision applies to RAC
+Core", "to the CI workflows"). So "which decisions apply to the file I am
+editing?" is unanswerable, and scoped grounding through the Lore MCP server is
+impossible. The scope is meaning the corpus holds but cannot express as data.
+
+This is gap 7 of the traceability audit.
+
+## Evidence
+
+- `adr-035` states it applies to RAC Core and open-source extensions, in prose.
+- `adr-018` governs `rac/`; `adr-023` scopes itself to `src/rac/` internals;
+  `adr-027` applies to the CI workflows; `adr-033` to the Guide tool surface —
+  none of these scopes is data.
+
+## Requirements
+
+- [REQ-001] The decision schema accepts an optional `## Applies To` section listing the paths or component names the decision governs, recognised and extracted like other optional sections.
+
+- [REQ-002] Path-style `## Applies To` entries are existence-checked by `rac relationships --validate`; component-name entries are recorded without resolution.
+
+- [REQ-003] The section is surfaced via the Lore MCP server / `get_related` so a consumer can ask which decisions apply to a given path (scoped grounding).
+
+- [REQ-004] The change is additive (ADR-007) and does not shift decision classification (adjacent-type tests hold).
+
+## Success Metrics
+
+- The evidence decisions declare a checkable `## Applies To` scope.
+- A query for "decisions applying to path X" returns them deterministically.
+- Decision classification is unchanged by the new section.
+
+## Risks
+
+- Scope expressed as free-text components is unresolvable; mitigated by
+  existence-checking the path form and treating component names as recorded labels.
+
+## Assumptions
+
+- Path-or-component scope covers the real need; a richer scope language is out of scope.
+
+## Related Decisions
+
+- adr-016
+- adr-007
+
+## Related Roadmaps
+
+- relationship-vocabulary

--- a/rac/requirements/rac-external-and-file-references.md
+++ b/rac/requirements/rac-external-and-file-references.md
@@ -1,0 +1,79 @@
+---
+schema_version: 1
+id: RAC-KW7VKD2AANC5
+type: requirement
+---
+# RAC Traceability — External and Repo-File References
+
+## Status
+
+Proposed
+
+## Problem
+
+Artifacts routinely depend on targets that are not peer artifacts: a requirement
+is satisfied by a README section, a `SKILL.md`, or a CI workflow file; a
+positioning claim rests on an external source URL. RAC can express references to
+peer artifacts (`## Related <Type>`) and to tickets (`## Related Tickets`,
+ADR-087), but a reference to a **repository file** or an **external URL** has no
+home. Authors either omit the link or bury it in prose, so a rename breaks the
+connection silently and the link is invisible to validation, `rac relationships`,
+and the Lore MCP server. (ADR-019 covers assets/images only.)
+
+This is gaps 1 and 2 of the traceability audit, consolidated: both are references
+to a non-artifact target, format/existence-checked, never resolved to a peer
+artifact and never fetched.
+
+## Evidence
+
+- **artifact → repo-file (≥3):** `rac-growth-positioning` (satisfied by a README
+  section it cannot reference), `rac-growth-agent-skill` (satisfied by
+  `.claude/skills/rac-artifacts/SKILL.md`), `rac-documentation-structure` (places
+  testable requirements on doc files by bare path), `adr-027` (governs CI
+  workflow files the same way).
+- **external URL (≥3):** `rac-growth-positioning` comparison sources,
+  `growth-essay-mapping` external article rows, `rac-grounding-eval-benchmark`
+  external references.
+
+## Requirements
+
+- [REQ-001] The relationship vocabulary can express a reference from an artifact to a repository file by repo-relative path (for example a `## Satisfied By` / `## Related Files` section), recognised and extracted like the existing relationship sections.
+
+- [REQ-002] A declared repo-file reference is existence-checked by `rac relationships --validate` against the repository, so a missing or renamed target is reported rather than failing silently.
+
+- [REQ-003] The relationship vocabulary can express an external source reference as a URL (for example a `## Sources` section), format-validated and surfaced via `get_artifact`, never fetched or resolved by the engine (ADR-002, ADR-066).
+
+- [REQ-004] Both additions are additive (ADR-007): new optional sections, `schema_version` unchanged, existing relationship sections and their JSON shape untouched; they reuse the non-artifact-reference mechanism established for `## Related Tickets` (ADR-087) rather than a parallel one.
+
+## Success Metrics
+
+- A renamed file referenced by `## Satisfied By` produces a `rac relationships
+  --validate` finding instead of a silent break.
+- The audit's evidence instances become declared, checkable references.
+- Re-running validation on an unchanged corpus is byte-stable; no network call is
+  on the path.
+
+## Risks
+
+- Path references can drift during repository moves (the topology re-org);
+  mitigated by deferring the repo-file half until target paths settle.
+- A new section shifts the classification surface; mitigated by additive-only
+  changes and the adjacent-type misclassification tests.
+
+## Assumptions
+
+- The relationship model stays "structural references in Markdown" (ADR-016).
+- Determinism holds: existence/format checks only, never fetching (ADR-002, ADR-066).
+
+## Related Decisions
+
+- adr-016
+- adr-087
+- adr-019
+- adr-007
+- adr-002
+- adr-066
+
+## Related Roadmaps
+
+- relationship-vocabulary

--- a/rac/requirements/rac-relationship-back-references.md
+++ b/rac/requirements/rac-relationship-back-references.md
@@ -1,0 +1,65 @@
+---
+schema_version: 1
+id: RAC-KW7VKJKDZV7B
+type: requirement
+---
+# RAC Traceability — Relationship Back-References
+
+## Status
+
+Proposed
+
+## Problem
+
+Relationships are declared on one side. An artifact that is heavily referenced
+cannot advertise who cites it, and nothing warns when an expected reverse edge is
+absent — so an agent landing on a target cannot discover the citing artifact, and
+asymmetric links go unnoticed. The `unlinked-reference` advisory (ADR-082)
+surfaces prose mentions, not this. No schema change is needed: this is a
+detection gap.
+
+This is gap 6 of the traceability audit.
+
+## Evidence
+
+- ADR-036 ← `v0.10.2`: the roadmap references the decision; the decision carries
+  no reverse link.
+- Several early ADRs cited by `rac-agent-context-guide` carry no `## Related`
+  sections themselves.
+- Decisions referenced by many requirements rarely link back to any of them.
+
+## Requirements
+
+- [REQ-001] `rac relationships --validate` (and/or `rac doctor`) emits an advisory finding when a resolved relationship edge is not reciprocated, naming the source, the target, and the missing reverse section.
+
+- [REQ-002] The finding is advisory: it exits zero and does not change the `rac validate` / `rac relationships --validate` contract, consistent with the existing advisory findings (ADR-075).
+
+- [REQ-003] The check is deterministic and offline (ADR-002): identical corpus bytes yield identical findings, with stable ordering and no schema change.
+
+## Success Metrics
+
+- The evidence asymmetries are surfaced as advisory findings.
+- Exit codes are unchanged with and without the new advisory present.
+- Re-running on an unchanged corpus is byte-identical.
+
+## Risks
+
+- Not every edge should be reciprocal, so a naive check is noisy; mitigated by
+  scoping the advisory to edge kinds where a back-reference is expected and
+  keeping it advisory, never gating.
+
+## Assumptions
+
+- `related_*` edges are undirected, so reciprocity is about discoverability, not
+  ordering semantics.
+
+## Related Decisions
+
+- adr-016
+- adr-082
+- adr-075
+- adr-002
+
+## Related Roadmaps
+
+- relationship-vocabulary

--- a/rac/requirements/rac-roadmap-supersession.md
+++ b/rac/requirements/rac-roadmap-supersession.md
@@ -1,0 +1,62 @@
+---
+schema_version: 1
+id: RAC-KW7VKEX21GW6
+type: requirement
+---
+# RAC Traceability — Roadmap Supersession Edge
+
+## Status
+
+Proposed
+
+## Problem
+
+A roadmap can be replaced by a successor — a series folded into another, a plan
+supplanted by a later one — but the relationship vocabulary cannot express it.
+`## Supersedes` exists for decisions only; roadmaps carry a `Superseded` lifecycle
+*status* (ADR-061) but no edge to the artifact that replaced them. So "what
+superseded this roadmap?" is unanswerable as a graph query, and the replacement
+link lives in prose that dangles when files move.
+
+This is gap 5 of the traceability audit.
+
+## Evidence
+
+- The single-item series flattened during the v0.28–v0.30 → codename renames,
+  whose predecessors are superseded with no edge.
+- `repo-extraction-programme` superseded by the `repo-topology` series in prose only.
+- `growth-programme` absorbed earlier `future/` items whose supersession is implicit.
+
+## Requirements
+
+- [REQ-001] The roadmap schema accepts a `## Supersedes` section, so a roadmap can reference the roadmap(s) it replaces as a resolved, validated edge.
+
+- [REQ-002] A roadmap `## Supersedes` target is existence-checked by `rac relationships --validate`, including targets under `archive/`, so a replaced roadmap stays reachable.
+
+- [REQ-003] The change is additive (ADR-007) and preserves the existing `supersedes` semantics: it extends the section to the roadmap type without altering its decision-only behaviour or JSON shape.
+
+## Success Metrics
+
+- A roadmap declaring `## Supersedes` resolves to an edge; a missing target is reported.
+- The evidence instances become declared edges, raising the resolved-edge count.
+- `supersedes` on decisions is byte-identical before and after.
+
+## Risks
+
+- Supersession chains could form cycles; mitigated by validating targets and
+  treating supersession as a directed-but-acyclic check, as for decisions.
+
+## Assumptions
+
+- `supersedes` remains the right home for replacement semantics (per the self-type
+  audit entry); this only extends which types may use it.
+
+## Related Decisions
+
+- adr-016
+- adr-061
+- adr-007
+
+## Related Roadmaps
+
+- relationship-vocabulary

--- a/rac/requirements/rac-typed-relationship-edges.md
+++ b/rac/requirements/rac-typed-relationship-edges.md
@@ -1,0 +1,65 @@
+---
+schema_version: 1
+id: RAC-KW7VKGRAN30J
+type: requirement
+---
+# RAC Traceability — Typed Relationship Edges
+
+## Status
+
+Proposed
+
+## Problem
+
+Authors want to say *how* one artifact relates to another — it implements a
+decision, depends on a requirement, satisfies a roadmap — but the vocabulary has
+only untyped `## Related <Type>` links. So authors invent edge-label sub-headings
+(`### Implements`, `### Depends On`) that nothing validates and that no consumer
+can query. The graph export already surfaces typed edges (ADR-074); the authoring
+side has no matching, validated vocabulary.
+
+This is gap 3 of the traceability audit.
+
+## Evidence
+
+- `adr-028-explorer-surface` uses `### Implements` inside a non-schema section.
+- `rac-product-knowledge-navigator-explorer` invents `### Depends On`.
+- Historic (now archived) `v0.10.3-search-quality` listed implemented decisions
+  and standing-constraint decisions in one flat `## Related Decisions` list.
+
+## Requirements
+
+- [REQ-001] The relationship vocabulary can type an edge within a `## Related <Type>` section using a recognised, validated edge label (for example `### Implements`, `### Depends On`, `### Satisfies`), defaulting to an untyped relationship when no label is present.
+
+- [REQ-002] Typed edges are surfaced consistently with the graph export's existing typed-edge representation (ADR-074), so authoring and export agree on the vocabulary.
+
+- [REQ-003] The change is additive (ADR-007): an untyped `## Related <Type>` section keeps its current meaning and JSON shape; typing is opt-in and labelled.
+
+- [REQ-004] Typed-edge labels do not change classification: adding labels to a section the schema already recognises must not shift how a document classifies (adjacent-type tests hold).
+
+## Success Metrics
+
+- The invented sub-headings in the evidence become validated typed edges.
+- `rac relationships` and the graph export report the same edge types.
+- Untyped relationships are byte-identical before and after.
+
+## Risks
+
+- Edge-label vocabulary can sprawl; mitigated by a small fixed, validated set
+  decided in the design/ADR.
+- Sub-headings inside sections complicate parsing; mitigated by reusing the
+  shared Markdown parser and additive extraction.
+
+## Assumptions
+
+- A small fixed label set covers the real need; free-text edge types are out of scope.
+
+## Related Decisions
+
+- adr-016
+- adr-074
+- adr-007
+
+## Related Roadmaps
+
+- relationship-vocabulary

--- a/rac/roadmaps/growth-programme.md
+++ b/rac/roadmaps/growth-programme.md
@@ -90,6 +90,10 @@ traceability work from real corpus usage.
 - growth-demo-gif
 - growth-essay-mapping
 
+## Related Roadmaps
+
+- relationship-vocabulary
+
 ## Related Tickets
 
 - itsthelore/rac-core#230

--- a/rac/roadmaps/relationship-vocabulary.md
+++ b/rac/roadmaps/relationship-vocabulary.md
@@ -1,0 +1,97 @@
+---
+schema_version: 1
+id: RAC-KW7VK36J3EXT
+type: roadmap
+---
+# Relationship Vocabulary — Closing the Traceability Gaps
+
+## Status
+
+Planned
+
+## Outcomes
+
+Make the relationship graph express what the corpus already means, so a declared
+`## Related …`-style link becomes a validated edge instead of silently producing
+none. This is the resolution programme for the growth-programme traceability gap
+audit (`.agent-context/GAPS_TRACEABILITY.md`); each gap is recorded as its own
+requirement, designable independently.
+
+- A reference to a non-artifact target — a repository file or an external URL —
+  is expressible and existence/format-checked, not invisible prose.
+- A roadmap can record what superseded it as a resolvable edge, not only a status.
+- An author can type a relationship (implements / depends-on / satisfies) within
+  a `## Related <Type>` section, validated, defaulting to untyped.
+- A missing reverse edge and an unrecognised edge-label are surfaced as advisory
+  findings rather than passing silently.
+- A decision can declare what it applies to, enabling scoped grounding.
+- Lifecycle and gate state (`Deferred` / `Blocked`) are enumerable data, not
+  free-text lines.
+
+## Initiatives
+
+- **Bucket A — advisory only (no schema change):** an asymmetric-edge finding in
+  `rac relationships --validate` (`rac-relationship-back-references`), plus
+  tightening detection of unrecognised edge-labels. Ships like the
+  `unlinked-reference` advisory (ADR-082); lowest risk.
+- **Bucket B — additive non-artifact reference sections:** `## Satisfied By`
+  (files) and `## Sources` (URLs) as one external-reference family
+  (`rac-external-and-file-references`), and `## Supersedes` on roadmaps
+  (`rac-roadmap-supersession`). Format/existence-checked, never fetched, reusing
+  the ADR-087 `## Related Tickets` pattern.
+- **Bucket C — model / lifecycle decisions (ADR-first):** typed relationship
+  edges (`rac-typed-relationship-edges`, aligned with ADR-074), an `## Applies
+  To` scope on decisions (`rac-decision-applies-to-scope`), and an extended
+  status vocabulary (`rac-artifact-status-vocabulary`).
+
+## Success Measures
+
+- Each previously-silent declared link in the audit's evidence resolves to an
+  edge or is surfaced as an advisory once its gap's fix ships.
+- Every change is additive (ADR-007): existing sections, `schema_version`, and
+  `supersedes`'s decision semantics are unchanged.
+- `rac validate rac/`, `rac relationships rac/ --validate`, and `rac review rac/`
+  stay clean across the programme; classification is unshifted (adjacent-type
+  tests hold).
+
+## Assumptions
+
+- The relationship model stays "structural references in Markdown sections"
+  (ADR-016); these gaps are about the vocabulary, not the mechanism.
+- Determinism and offline operation hold (ADR-002, ADR-066): files and URLs are
+  format/existence-checked, never fetched.
+
+## Risks
+
+- New sections shift the classification surface; mitigated by additive-only
+  changes and the adjacent-type misclassification tests.
+- Self-referential edges could invite cycles; mitigated by keeping `related_*`
+  undirected, as today.
+
+## Related Decisions
+
+- adr-016
+- adr-007
+- adr-002
+- adr-066
+- adr-074
+- adr-087
+- adr-019
+
+## Related Requirements
+
+- rac-external-and-file-references
+- rac-roadmap-supersession
+- rac-typed-relationship-edges
+- rac-relationship-back-references
+- rac-decision-applies-to-scope
+- rac-artifact-status-vocabulary
+- rac-traceability-self-relationships
+
+## Related Roadmaps
+
+- growth-programme
+
+## Related Tickets
+
+- itsthelore/rac-core#236


### PR DESCRIPTION
# Summary

Refreshes the growth-programme **traceability gap audit** against the live corpus
and promotes its resolution programme into the trusted corpus as durable, linked
intent — a roadmap plus a requirement per designable gap. **No schema change**:
each fix is scheduled later. Tracked under epic #236 (which stays open until the
gaps are resolved).

# Scope

- **Audit refresh** (`.agent-context/GAPS_TRACEABILITY.md`): re-validated all eight
  schema gaps + the friction findings against the current corpus (was v0.10.3).
  Net: 2 closed (self-type via v0.13.5; extraction blind spots via
  type-mismatch / edge-unsupported / `unlinked-reference`), 3 partial, 4 open.
- **Roadmap** `rac/roadmaps/relationship-vocabulary.md` (Planned): initiatives
  mirror the resolution buckets — (A) advisory-only findings, (B) additive
  non-artifact reference sections, (C) model/lifecycle decisions.
- **Six requirements** (one per designable gap; the external file + URL family is
  consolidated): each records the gap, the contracts a fix must satisfy, and ≥3
  current corpus instances — the pattern set by
  `rac-traceability-self-relationships`. Status `Proposed`.
- Reciprocal `growth-programme` → `relationship-vocabulary` link; report now maps
  each gap to its requirement.

# Gap → requirement

| Gap(s) | Requirement |
| --- | --- |
| artifact→file (1) + URLs (2) | `rac-external-and-file-references` |
| roadmap supersession (5) | `rac-roadmap-supersession` |
| typed edges (3) | `rac-typed-relationship-edges` |
| back-references (6) | `rac-relationship-back-references` |
| applies-to scope (7) | `rac-decision-applies-to-scope` |
| lifecycle/gate status (4) | `rac-artifact-status-vocabulary` |

# Verification

- `rac validate rac/`, `rac relationships rac/ --validate` (1651 edges, 0 issues),
  `rac export rac/ --agent-rules --check`, `rac review rac/` all clean.
- `rac doctor rac/` ok — no new orphans (the roadmap links the requirements;
  `growth-programme` links the roadmap).
- 146 dogfood-sensitive tests pass (portfolio / stats / coverage / inspect /
  relationships / dogfood). No `src/` or schema changes — corpus intent only.

# Non-goals

No change to `core/artifacts.py` specs, `relationships.py` vocabulary, validators,
or schemas. Promoting each requirement to an accepted/implemented state is the
first step of resolving that gap, done per-gap when scheduled.
