### PR TITLE
feat(relationships): add external-target verified_by edge (ADR-096)

### DIFF
--- a/.cursor/rules
+++ b/.cursor/rules
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: c441ea04601aa8f4721362e40e4025b41f6dd750045fa582178c4884b3a98975) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: 7f693642352f74bd5ca870cc752ced16f41d665303b41779f38bc68d52be5f78) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -68,4 +68,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KW6HY8W1CBK6** — ADR-093: Roadmap Intent Lives in the Corpus; Execution Is Tracked in GitHub Issues _(Process)_
 - **RAC-KW6NQ4Y814N7** — ADR-094: Roadmaps Are Identified by Stable Codename, Not a vX.Y.Z Scope-Fence _(Process)_
 - **RAC-KW8ZTVEQJ366** — ADR-095: rac-connectors Repackage, PyPI Rename, and Outbound Field Rename _(Architecture)_
+- **RAC-KWBJJRZR84PT** — ADR-096: External-Target Verification Edge (`verified_by`) _(Technical)_
 <!-- END RAC MANAGED BLOCK -->

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: c441ea04601aa8f4721362e40e4025b41f6dd750045fa582178c4884b3a98975) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: 7f693642352f74bd5ca870cc752ced16f41d665303b41779f38bc68d52be5f78) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -68,4 +68,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KW6HY8W1CBK6** — ADR-093: Roadmap Intent Lives in the Corpus; Execution Is Tracked in GitHub Issues _(Process)_
 - **RAC-KW6NQ4Y814N7** — ADR-094: Roadmaps Are Identified by Stable Codename, Not a vX.Y.Z Scope-Fence _(Process)_
 - **RAC-KW8ZTVEQJ366** — ADR-095: rac-connectors Repackage, PyPI Rename, and Outbound Field Rename _(Architecture)_
+- **RAC-KWBJJRZR84PT** — ADR-096: External-Target Verification Edge (`verified_by`) _(Technical)_
 <!-- END RAC MANAGED BLOCK -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: c441ea04601aa8f4721362e40e4025b41f6dd750045fa582178c4884b3a98975) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: 7f693642352f74bd5ca870cc752ced16f41d665303b41779f38bc68d52be5f78) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -68,4 +68,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KW6HY8W1CBK6** — ADR-093: Roadmap Intent Lives in the Corpus; Execution Is Tracked in GitHub Issues _(Process)_
 - **RAC-KW6NQ4Y814N7** — ADR-094: Roadmaps Are Identified by Stable Codename, Not a vX.Y.Z Scope-Fence _(Process)_
 - **RAC-KW8ZTVEQJ366** — ADR-095: rac-connectors Repackage, PyPI Rename, and Outbound Field Rename _(Architecture)_
+- **RAC-KWBJJRZR84PT** — ADR-096: External-Target Verification Edge (`verified_by`) _(Technical)_
 <!-- END RAC MANAGED BLOCK -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ to the corpus artifact and they load through the imports below.
 - Previous series: `rac/roadmaps/v0.21.x-editor/` (complete)
 - Decisions (ADRs): `rac/decisions/`
 
-<!-- BEGIN RAC MANAGED BLOCK (digest: c441ea04601aa8f4721362e40e4025b41f6dd750045fa582178c4884b3a98975) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: 7f693642352f74bd5ca870cc752ced16f41d665303b41779f38bc68d52be5f78) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -93,4 +93,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KW6HY8W1CBK6** — ADR-093: Roadmap Intent Lives in the Corpus; Execution Is Tracked in GitHub Issues _(Process)_
 - **RAC-KW6NQ4Y814N7** — ADR-094: Roadmaps Are Identified by Stable Codename, Not a vX.Y.Z Scope-Fence _(Process)_
 - **RAC-KW8ZTVEQJ366** — ADR-095: rac-connectors Repackage, PyPI Rename, and Outbound Field Rename _(Architecture)_
+- **RAC-KWBJJRZR84PT** — ADR-096: External-Target Verification Edge (`verified_by`) _(Technical)_
 <!-- END RAC MANAGED BLOCK -->

--- a/rac/decisions/adr-096-external-target-verification-edge.md
+++ b/rac/decisions/adr-096-external-target-verification-edge.md
@@ -1,0 +1,102 @@
+---
+schema_version: 1
+id: RAC-KWBJJRZR84PT
+type: decision
+---
+# ADR-096: External-Target Verification Edge (`verified_by`)
+
+## Context
+
+The graph export surfaces the corpus as typed nodes and edges (ADR-074) for
+graph backends and external consumers. The relationship registry (ADR-055) is
+code-defined and resolves each edge's target to an in-corpus artifact, except
+for the external-reference family (ADR-087), where the target is an external
+identifier — today a ticket — that is exempt from resolution, range, and
+status checks and is marked `external`/unresolved in the export.
+
+A sibling product, Proofkeeper, is a contract consumer of the graph export
+(ADR-063): it reads `rac export --graph` to learn which product capabilities
+(requirements, ADR-020) have a verifying test, and proposes linking a capability
+to the test that verifies it through a human-reviewed pull request (the trust
+boundary, ADR-065). For that to work the corpus needs a typed way to record
+"this capability is verified by this test/trace" — a link whose target is a
+**file path outside the corpus** (a `.spec.ts`, a trace artifact), not a peer
+artifact and not a ticket.
+
+The external-reference machinery added for tickets (ADR-087) already models an
+edge whose target deliberately does not resolve to a local artifact. A
+verification link is the same shape with one difference: its target is a file
+reference, which has no ticketing provider. Without a typed edge, verification
+links would sit in prose and go stale, and the graph export — the published
+contract — could not carry the signal a verification consumer needs.
+
+## Decision
+
+Introduce a single **external-target verification edge**, `verified_by`,
+declared via a `## Verified By` section, legal **only on requirements**
+(capabilities, ADR-020).
+
+- **External target, no provider.** Like `related_tickets` it is `external`:
+  exempt from referential-integrity resolution, range, and status-consistency
+  checks, and emitted in the graph export with `resolved: false` and the literal
+  reference text as `target`. Unlike `related_tickets` it is **not**
+  provider-tagged — its targets are test/trace file paths, so the export's
+  `provider` is `null`. The registry distinguishes the two with an
+  `external_provider` flag; only ticket edges carry the configured ticketing
+  provider (ADR-088).
+- **Directional capability→verifier.** The edge is directional with the declared
+  inverse `verifies` (display only, not enforced, per ADR-055).
+- **Requirement-only.** `## Verified By` is added to the requirement artifact
+  spec's optional sections; declared on any other type it is an unsupported edge
+  (`relationship-edge-unsupported`, ADR-049), exactly as for any mis-placed
+  relationship section.
+- **Engine scope is the edge only.** RAC emits and validates the edge; it does
+  not run tests or compute verification coverage. Deriving "which capabilities
+  are unverified" from the edge is the consumer's concern (Proofkeeper), keeping
+  RAC a knowledge engine, not a test runner (ADR-017).
+
+The graph `schema_version` is unchanged: this is an additive edge kind, and the
+export shape (`type`, `external`, `resolved`, `provider`) is the existing one
+(ADR-007, ADR-074).
+
+## Consequences
+
+- A capability can carry a typed, durable link to the evidence that verifies it,
+  surfaced in the published graph contract for any consumer — verification
+  coverage becomes derivable without RAC owning test execution.
+- The external family now has two members (ticket, verification); the
+  `external_provider` flag keeps provider tagging correct for each, so a
+  verification edge is never mislabelled with a ticketing provider.
+- `## Verified By` on a non-requirement is reported as an unsupported edge, so
+  the section stays where capabilities live (ADR-020).
+- A new relationship kind is one more thing the registry carries; it is additive
+  and rides the existing external-edge code paths, so the blast radius is small.
+
+## Status
+
+Accepted
+
+## Category
+
+Technical
+
+## Alternatives Considered
+
+- **Reuse `related_tickets` for verification links.** Rejected: a test path is
+  not a ticket; it would be linted against the ticketing provider's key format
+  and mislabelled with that provider in the export.
+- **A general in-corpus edge to a "test" artifact type.** Rejected: tests are
+  external files, not corpus artifacts (ADR-010); inventing a test artifact type
+  would pull execution evidence into the knowledge corpus, against ADR-017/ADR-024.
+- **Let the consumer infer verification from prose or naming conventions.**
+  Rejected: undurable and unvalidated; the point of a typed edge is a stable,
+  machine-readable contract (ADR-074).
+- **Compute verification coverage inside RAC.** Rejected: RAC manages knowledge,
+  not work or test execution (ADR-017); coverage derivation belongs to the
+  consumer over the published contract (ADR-063).
+
+## Related Decisions
+
+- ADR-074
+- ADR-087
+- ADR-063

--- a/src/rac/core/artifacts.py
+++ b/src/rac/core/artifacts.py
@@ -97,6 +97,8 @@ RELATIONSHIP_DESCRIPTIONS: dict[str, str] = {
     "supersedes": "The artifact this one supersedes",
     "related tickets": "External tickets this artifact traces to; provider set by"
     " .rac/config.yaml ticketing.provider (ADR-087)",
+    "verified by": "External tests or traces that verify this capability; targets"
+    " are file paths, not in-corpus artifacts (ADR-096)",
 }
 
 
@@ -122,6 +124,7 @@ ARTIFACT_SPECS: tuple[ArtifactSpec, ...] = (
             "related designs",
             "related requirements",
             "related tickets",
+            "verified by",
         ),
         # Lifecycle status (ADR-051): optional, validated-if-present. Status stays
         # a knowledge lifecycle (current vs replaced), never work/delivery state.
@@ -140,6 +143,7 @@ ARTIFACT_SPECS: tuple[ArtifactSpec, ...] = (
                 "related designs",
                 "related requirements",
                 "related tickets",
+                "verified by",
             ),
         },
         guidance={

--- a/src/rac/core/relationship_types.py
+++ b/src/rac/core/relationship_types.py
@@ -44,6 +44,11 @@ class EdgeSpec:
     # instead (the provider is per-repo config, ADR-088); the graph export marks
     # them external and unresolved.
     external: bool = False
+    # Whether an external edge's target lives in the repository's configured
+    # external *provider* (ticketing, ADR-088), so the graph export tags it with
+    # that provider. ``related_tickets`` sets this; ``verified_by`` (ADR-096) does
+    # not — its targets are test/trace file paths, which have no provider.
+    external_provider: bool = False
 
 
 def _related(target_type: str) -> EdgeSpec:
@@ -79,7 +84,21 @@ REGISTRY: dict[str, EdgeSpec] = {
         # (ADR-088), never resolved. Organisations standardise on one ticketing
         # system, so the system is a repo-config choice rather than a per-provider
         # edge — future external systems reuse this edge, not a sibling one.
-        EdgeSpec(name="related_tickets", range=(), external=True),
+        EdgeSpec(name="related_tickets", range=(), external=True, external_provider=True),
+        # External-target verification edge (ADR-096): a capability (requirement,
+        # ADR-020) points at the external tests/traces that verify it. Like an
+        # external ticket it skips resolution, range, and status checks, but its
+        # target is a file path with no ticketing provider, so it is external
+        # without being provider-tagged. Directional capability→verifier; the
+        # consumer is Proofkeeper's coverage read-model (ADR-074).
+        EdgeSpec(
+            name="verified_by",
+            range=(),
+            external=True,
+            directional=True,
+            symmetric=False,
+            inverse="verifies",
+        ),
     )
 }
 

--- a/src/rac/services/export.py
+++ b/src/rac/services/export.py
@@ -436,7 +436,7 @@ def build_graph_export(directory: str, recursive: bool = True) -> GraphExport:
                 directed=kind.directional if kind else False,
                 resolved=rel.resolved_path is not None,
                 external=external,
-                provider=provider if external else None,
+                provider=provider if (kind and kind.external_provider) else None,
             )
         )
     edges.sort(key=lambda edge: (edge.source, edge.type, edge.target))

--- a/src/rac/services/relationships.py
+++ b/src/rac/services/relationships.py
@@ -50,7 +50,7 @@ RELATED_SECTIONS: tuple[str, ...] = (
 # ticketing provider, ADR-088), never resolved. Kept separate from
 # RELATED_SECTIONS, which is exactly the per-artifact-type vocabulary (one
 # ``related <type>s`` per type).
-EXTERNAL_SECTIONS: tuple[str, ...] = ("related tickets",)
+EXTERNAL_SECTIONS: tuple[str, ...] = ("related tickets", "verified by")
 
 # The full relationship-section vocabulary and its canonical ordering: the per-type
 # ``related *`` sections, then ``supersedes``, then the external-reference sections.

--- a/tests/golden/schema_requirement_human.txt
+++ b/tests/golden/schema_requirement_human.txt
@@ -42,6 +42,8 @@ Optional Sections:
       Description: Requirement artifacts this artifact references
   - Related Tickets
       Description: External tickets this artifact traces to; provider set by .rac/config.yaml ticketing.provider (ADR-087)
+  - Verified By
+      Description: External tests or traces that verify this capability; targets are file paths, not in-corpus artifacts (ADR-096)
 
 Metadata Fields:
   - Status: Proposed | Accepted | Superseded | Deprecated

--- a/tests/test_graph_export.py
+++ b/tests/test_graph_export.py
@@ -118,6 +118,49 @@ def test_external_ticket_provider_is_none_when_unset(tmp_path):
     assert edge.provider is None
 
 
+# --- external-target verification edges (ADR-096) ----------------------------
+
+
+def _corpus_with_verified_by(tmp_path, provider: str | None) -> None:
+    """A requirement declaring ## Verified By, with an optional ticketing provider."""
+    config = tmp_path / ".rac"
+    config.mkdir()
+    body = "repository_key: ACME\n"
+    if provider is not None:
+        body += f"ticketing:\n  provider: {provider}\n"
+    (config / "config.yaml").write_text(body, encoding="utf-8")
+    (tmp_path / "req-001.md").write_text(
+        "# Cap\n\n## Problem\n\np\n\n## Requirements\n\n- [REQ-001] r\n\n"
+        "## Verified By\n\n- `tests/cap.spec.ts`\n",
+        encoding="utf-8",
+    )
+
+
+def test_verified_by_edge_is_external_directed_and_invents_no_node(tmp_path):
+    _corpus_with_verified_by(tmp_path, None)
+    graph = build_graph_export(str(tmp_path))
+    edges = [e for e in graph.edges if e.type == "verified_by"]
+    assert len(edges) == 1
+    edge = edges[0]
+    assert edge.target == "`tests/cap.spec.ts`"  # literal reference text
+    assert edge.external is True
+    assert edge.resolved is False
+    assert edge.directed is True  # capability -> verifier (ADR-096)
+    # The external file target is never promoted to a node.
+    assert "`tests/cap.spec.ts`" not in {n.id for n in graph.nodes}
+
+
+def test_verified_by_edge_is_never_tagged_with_the_ticketing_provider(tmp_path):
+    # verified_by is external but its target is a file path, not a ticket — so
+    # even when a ticketing provider is configured it must stay unprovidered
+    # (distinct from related_tickets, ADR-096).
+    _corpus_with_verified_by(tmp_path, "jira")
+    graph = build_graph_export(str(tmp_path))
+    edge = next(e for e in graph.edges if e.type == "verified_by")
+    assert edge.external is True
+    assert edge.provider is None
+
+
 # --- CLI ---------------------------------------------------------------------
 
 

--- a/tests/test_relationship_graph.py
+++ b/tests/test_relationship_graph.py
@@ -49,6 +49,7 @@ def test_registry_declares_built_in_edges():
         "related_designs",
         "supersedes",
         "related_tickets",
+        "verified_by",
     }
     supersedes = edge_spec("supersedes")
     assert supersedes is not None
@@ -61,6 +62,15 @@ def test_registry_declares_built_in_edges():
     assert tickets is not None
     assert tickets.external is True
     assert tickets.range == ()
+    assert tickets.external_provider is True  # ticket targets carry the provider
+    # External-target verification edge (ADR-096): external like a ticket, but its
+    # target is a file path with no ticketing provider, and it is directional.
+    verified = edge_spec("verified_by")
+    assert verified is not None
+    assert verified.external is True
+    assert verified.range == ()
+    assert verified.external_provider is False
+    assert verified.directional is True
 
 
 # --- range -------------------------------------------------------------------

--- a/tests/test_relationship_validation.py
+++ b/tests/test_relationship_validation.py
@@ -90,6 +90,49 @@ def test_external_ticket_reference_is_never_broken(tmp_path):
     assert ISSUE_TARGET_NOT_FOUND not in {i.code for i in report.issues}
 
 
+# --- external-target verification references (ADR-096) ----------------------
+
+_REQUIREMENT = "# {t}\n\n## Problem\n\np\n\n## Requirements\n\n- [REQ-001] r\n"
+
+
+def test_verified_by_reference_is_never_broken(tmp_path):
+    # A ## Verified By entry targets an external test/trace path, so like a
+    # ticket it is exempt from referential integrity — never not-found, never
+    # counted among resolved references (ADR-096).
+    (tmp_path / "req-001.md").write_text(
+        _REQUIREMENT.format(t="Cap") + "\n## Verified By\n\n- `tests/cap.spec.ts`\n",
+        encoding="utf-8",
+    )
+    report = validate_relationships(str(tmp_path))
+    assert report.ok
+    assert report.relationships_checked == 0
+    assert ISSUE_TARGET_NOT_FOUND not in {i.code for i in report.issues}
+
+
+def test_verified_by_on_non_requirement_is_unsupported(tmp_path):
+    # `verified by` is requirement-only (capabilities, ADR-020); a decision
+    # declaring it is an illegal edge (ADR-049 edge-legality).
+    (tmp_path / "adr-001.md").write_text(
+        _DECISION.format(t="A1") + "\n## Verified By\n\n- `tests/x.spec.ts`\n",
+        encoding="utf-8",
+    )
+    report = validate_relationships(str(tmp_path))
+    assert [i.code for i in report.issues] == [ISSUE_EDGE_UNSUPPORTED]
+    issue = report.issues[0]
+    assert issue.relationship == "verified_by"
+
+
+def test_verified_by_on_requirement_is_supported(tmp_path):
+    # A requirement MAY declare `verified by`; it must not be edge-unsupported.
+    (tmp_path / "req-001.md").write_text(
+        _REQUIREMENT.format(t="Cap") + "\n## Verified By\n\n- `tests/cap.spec.ts`\n",
+        encoding="utf-8",
+    )
+    report = validate_relationships(str(tmp_path))
+    assert report.ok
+    assert ISSUE_EDGE_UNSUPPORTED not in [i.code for i in report.issues]
+
+
 # --- resolved repository (REQ-003 / REQ-005) --------------------------------
 
 

--- a/tests/test_relationships.py
+++ b/tests/test_relationships.py
@@ -89,6 +89,20 @@ def test_related_tickets_section_is_extracted():
     assert rels["related_tickets"] == ["PROJ-1234", "owner/repo#7"]
 
 
+# --- external-target verification extraction (ADR-096) ----------------------
+
+
+def test_verified_by_section_is_extracted():
+    spec = spec_for("requirement")
+    assert spec is not None
+    body = (
+        "# Cap\n\n## Problem\n\np\n\n## Requirements\n\n- [REQ-001] r\n\n"
+        "## Verified By\n\n- `tests/cap.spec.ts`\n- `traces/cap.zip`\n"
+    )
+    rels = extract_relationships(parse(body), spec)
+    assert rels["verified_by"] == ["`tests/cap.spec.ts`", "`traces/cap.zip`"]
+
+
 # --- inspect: extraction across all five artifact types (amendment 7) --------
 
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -101,6 +101,7 @@ def test_schema_json_requirement_shape(capsys):
         "related_designs",
         "related_requirements",
         "related_tickets",
+        "verified_by",
     ]
     assert "success_metrics" in payload["descriptions"]
     assert "success_metrics" in payload["guidance"]


### PR DESCRIPTION
## What & why

Adds a typed, external-target **`verified_by`** edge to the graph export so a capability (requirement, ADR-020) can link to the external tests/traces that verify it. This is the engine-side contract that Proofkeeper — a contract consumer of `rac export --graph` (ADR-063) — reads to compute verification coverage.

Motivation: Proofkeeper's coverage read-model depends on `verified_by` edges, but that edge only existed on an old, stale branch (8 ahead / 81 behind `main`), so against current `main` Proofkeeper saw zero verified capabilities. Rather than rebase the stale branch, this **re-implements the edge cleanly on current `main`**, riding the external-reference machinery `main` already grew for `related_tickets` (ADR-087).

## How

- **`relationship_types.py`** — register `EdgeSpec(name="verified_by", range=(), external=True, directional=True, inverse="verifies")`. Add an `external_provider` flag to `EdgeSpec`; `related_tickets` sets it (ticket targets carry the configured provider), `verified_by` does not.
- **`relationships.py`** — add `"verified by"` to `EXTERNAL_SECTIONS`, so it skips referential-integrity, range, and status checks like a ticket edge.
- **`artifacts.py`** — make `## Verified By` a legal **requirement-only** optional section (with its `rac schema` description). Declared on any other type it is reported as `relationship-edge-unsupported` (ADR-049).
- **`export.py`** — tag the ticketing provider onto provider edges only (`external_provider`), so a `verified_by` edge — whose target is a file path, not a ticket — is emitted `external: true`, `resolved: false`, `provider: null`.

Additive to the graph contract: `schema_version` is unchanged (ADR-007, ADR-074).

## Decision

- **ADR-096: External-Target Verification Edge (`verified_by`)** — `rac/decisions/adr-096-external-target-verification-edge.md`. Builds on ADR-074 (typed graph edges), ADR-087 (external-reference relationships), ADR-063 (thin clients over the contract).

## Tests & gates

- New coverage: extraction; requirement-only edge legality (unsupported elsewhere); external never-broken resolution; graph-export contract (external, directional, unresolved, **`provider: null` even when a ticketing provider is configured**). Registry/schema vocab assertions and the requirement schema golden updated additively.
- **Full suite: 1741 passed.**
- Corpus gates: `rac validate rac/` 332/332 valid; `rac relationships rac/ --validate` 0 issues; `rac review rac/` no Priority 1–2 findings (health 94/100, pre-existing advisory items only).

## Downstream

With this on `main` (and a release), Proofkeeper's `verified_by` contract is published, unblocking its self-coverage gate. Verified locally: against this branch's `rac`, `proofkeeper coverage --corpus lore-proofkeeper/` returns all capabilities verified, exit 0.

Scope note: ADR-085 (Proofkeeper HTTP modality) from the old branch is intentionally **not** included here — separate concern, separate follow-up.