### PR TITLE
fix(validate): harden the CLI contract and write surfaces

### DIFF
--- a/sbom.json
+++ b/sbom.json
@@ -6,9 +6,9 @@
     "component": {
       "type": "library",
       "name": "rac-core",
-      "version": "2026.6.5.dev62+g6a8e6675f.d20260627",
-      "bom-ref": "rac-core@2026.6.5.dev62+g6a8e6675f.d20260627",
-      "purl": "pkg:pypi/rac-core@2026.6.5.dev62+g6a8e6675f.d20260627"
+      "version": "2026.06.5",
+      "bom-ref": "rac-core@2026.06.5",
+      "purl": "pkg:pypi/rac-core@2026.06.5"
     }
   },
   "components": [

--- a/scripts/generate_sbom.py
+++ b/scripts/generate_sbom.py
@@ -15,6 +15,12 @@ byte-identical ``sbom.json``. The committed ``sbom.json`` at the repository root
 is produced by this script; ``tests/test_sbom.py`` guards it against drift from
 the declared dependencies.
 
+The root component's version is the latest release heading in ``CHANGELOG.md``,
+not the installed package metadata: a working checkout carries a setuptools-scm
+``.devN`` version that matches no published artifact, and an SBOM attesting to a
+version nobody can install defeats its purpose. The committed document therefore
+always describes the most recent release.
+
 Usage::
 
     python scripts/generate_sbom.py            # write sbom.json at the repo root
@@ -34,8 +40,12 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 PYPROJECT = REPO_ROOT / "pyproject.toml"
 SBOM_PATH = REPO_ROOT / "sbom.json"
+CHANGELOG = REPO_ROOT / "CHANGELOG.md"
 
 PACKAGE_NAME = "rac-core"
+
+# The latest release heading in CHANGELOG.md: `## YYYY.MM.N — …` (ADR-076).
+_RELEASE_HEADING_RE = re.compile(r"^## (\d{4}\.\d{2}\.\d+)\b", re.MULTILINE)
 
 # A PEP 508 requirement string starts with the distribution name; strip any
 # version specifier, extras, or environment marker to recover the bare name.
@@ -67,6 +77,18 @@ def _installed_version(name: str) -> str:
         return "unknown"
 
 
+def _released_version() -> str:
+    """The most recent release version recorded in ``CHANGELOG.md``.
+
+    Fails loud when no release heading parses: an SBOM with an unknown root
+    version is worse than no SBOM.
+    """
+    match = _RELEASE_HEADING_RE.search(CHANGELOG.read_text(encoding="utf-8"))
+    if not match:
+        raise SystemExit("no release heading (## YYYY.MM.N) found in CHANGELOG.md")
+    return match.group(1)
+
+
 def _component(name: str, version: str) -> dict:
     """One CycloneDX ``library`` component for ``name`` at ``version``."""
     return {
@@ -81,11 +103,12 @@ def _component(name: str, version: str) -> dict:
 def build_sbom() -> dict:
     """The CycloneDX 1.5 SBOM document for RAC and its runtime dependencies.
 
-    The package itself is the root metadata component; the runtime dependencies
-    are the ``components`` list, sorted by name for determinism. No timestamp is
-    emitted so the document is byte-stable across runs (ADR-002).
+    The package itself is the root metadata component, at the latest released
+    version from ``CHANGELOG.md``; the runtime dependencies are the
+    ``components`` list, sorted by name for determinism. No timestamp is emitted
+    so the document is byte-stable across runs (ADR-002).
     """
-    root = _component(PACKAGE_NAME, _installed_version(PACKAGE_NAME))
+    root = _component(PACKAGE_NAME, _released_version())
 
     dependencies = sorted(_dependency_names(), key=str.casefold)
     components = [_component(name, _installed_version(name)) for name in dependencies]

--- a/src/rac/cli.py
+++ b/src/rac/cli.py
@@ -82,6 +82,7 @@ Exit codes:
 from __future__ import annotations
 
 import argparse
+import os
 import sys
 import time
 from pathlib import Path
@@ -2200,6 +2201,15 @@ def main(argv: list[str] | None = None) -> int:
     except SystemExit as exc:
         outcome = usage.OUTCOME_OK if exc.code in (0, None) else usage.OUTCOME_ERROR
         raise
+    except BrokenPipeError:
+        # The downstream consumer closed the pipe (e.g. `rac export … | head`):
+        # die quietly instead of dumping a traceback. Pointing stdout's fd at
+        # devnull absorbs the interpreter's exit-time flush of the dead pipe,
+        # which would otherwise print "Exception ignored" noise to stderr.
+        outcome = usage.OUTCOME_ERROR
+        devnull = os.open(os.devnull, os.O_WRONLY)
+        os.dup2(devnull, sys.stdout.fileno())
+        return 1
     finally:
         usage.record_command(command, outcome, int((time.monotonic() - start) * 1000))
 

--- a/src/rac/explorer/adapter.py
+++ b/src/rac/explorer/adapter.py
@@ -821,7 +821,10 @@ class ExplorerAdapter:
     def write_import(self, preview: ImportPreview) -> str:
         """Write a confirmed import; never overwrites (Initiative 4)."""
         path = Path(preview.target)
-        if path.exists():
+        # is_symlink() catches a dangling symlink, which exists() reports as
+        # absent — writing there would follow the link and create a file at
+        # its target, outside the path the user confirmed.
+        if path.is_symlink() or path.exists():
             return f"Refusing to overwrite existing file: {preview.target}"
         try:
             if path.parent != Path():

--- a/src/rac/output/json.py
+++ b/src/rac/output/json.py
@@ -44,9 +44,15 @@ if TYPE_CHECKING:
 
 
 def render_validation_json(product: Product, issues: list[Issue]) -> str:
+    """JSON single-file `rac validate` output (stable contract, ADR-007).
+
+    Carries the same ``schema_version`` stamp as the directory and stdin-corpus
+    forms, so every `rac validate --json` shape is version-gated.
+    """
     errors = [asdict(i) for i in issues if i.severity == "error"]
     warnings = [asdict(i) for i in issues if i.severity == "warning"]
     payload = {
+        "schema_version": "1",
         "file": product.source_path or None,
         "valid": not errors,
         "errors": errors,

--- a/src/rac/output/sarif.py
+++ b/src/rac/output/sarif.py
@@ -14,6 +14,7 @@ timestamps are emitted, so the same corpus state yields a byte-identical documen
 from __future__ import annotations
 
 import json
+from urllib.parse import quote
 
 from rac import __version__
 from rac.services.gate import GateReport
@@ -43,7 +44,11 @@ _LEVEL = {"error": "error", "warning": "warning", "info": "note"}
 
 
 def _result(rule_id: str, level: str, message: str, uri: str, line: int | None) -> dict:
-    location: dict = {"physicalLocation": {"artifactLocation": {"uri": uri}}}
+    # SARIF artifactLocation.uri is an RFC 3986 URI, not a raw path: a filename
+    # with a space or a non-ASCII character must be percent-encoded or Code
+    # Scanning may reject or mislocate the finding. Path separators stay literal.
+    encoded = quote(uri, safe="/")
+    location: dict = {"physicalLocation": {"artifactLocation": {"uri": encoded}}}
     if line is not None:
         location["physicalLocation"]["region"] = {"startLine": line}
     return {

--- a/src/rac/services/rename.py
+++ b/src/rac/services/rename.py
@@ -251,8 +251,11 @@ def _replace_token(text: str, old_ref: str, new_ref: str) -> str | None:
     start, so only a reference that *names* ``old_ref`` is rewritten. Returns the
     rewritten text, or None when ``text`` does not begin with the token.
     """
+    # Fold exactly the prefix that is sliced off below: casefold can change a
+    # string's length (ß → ss), so folding all of ``text`` and slicing by
+    # ``len(old_ref)`` could split mid-token and corrupt the reference.
     folded_old = old_ref.casefold()
-    if not text.casefold().startswith(folded_old):
+    if text[: len(old_ref)].casefold() != folded_old:
         return None
     rest = text[len(old_ref) :]
     # The token must be whole: the next character (if any) must not be an

--- a/tests/golden/validate_invalid_json.txt
+++ b/tests/golden/validate_invalid_json.txt
@@ -1,4 +1,5 @@
 {
+  "schema_version": "1",
   "file": "tests/fixtures/invalid/duplicate_ids.md",
   "valid": false,
   "errors": [

--- a/tests/golden/validate_valid_json.txt
+++ b/tests/golden/validate_valid_json.txt
@@ -1,4 +1,5 @@
 {
+  "schema_version": "1",
   "file": "tests/fixtures/valid/feature.md",
   "valid": true,
   "errors": [],

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,12 +3,17 @@
 from __future__ import annotations
 
 import json
+import subprocess
+import sys
+from pathlib import Path
 
 import pytest
 from conftest import fixture_path
 
 from rac import __version__
 from rac.cli import main
+
+REPO_ROOT = Path(__file__).parent.parent
 
 
 @pytest.mark.parametrize(
@@ -84,3 +89,29 @@ def test_diff_json_shape(capsys):
     assert [r["id"] for r in payload["added_requirements"]] == ["REQ-004"]
     assert [r["id"] for r in payload["removed_requirements"]] == ["REQ-003"]
     assert [c["id"] for c in payload["modified_requirements"]] == ["REQ-002"]
+
+
+def test_broken_pipe_exits_quietly():
+    # A downstream consumer closing the pipe early (`rac export … | head`) must
+    # not dump a BrokenPipeError traceback: stderr stays clean, the process
+    # exits non-zero without "Exception ignored" shutdown noise. Runs in a
+    # subprocess because EPIPE only occurs on a real OS pipe.
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            "from rac.cli import main; raise SystemExit(main(['export', 'rac', '--json']))",
+        ],
+        cwd=REPO_ROOT,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    assert proc.stdout is not None and proc.stderr is not None
+    proc.stdout.read(1024)  # consume a little, like `head`
+    proc.stdout.close()  # then hang up
+    stderr = proc.stderr.read().decode(errors="replace")
+    proc.stderr.close()
+    rc = proc.wait()
+    assert rc == 1
+    assert "Traceback" not in stderr
+    assert "BrokenPipeError" not in stderr

--- a/tests/test_explorer_adapter.py
+++ b/tests/test_explorer_adapter.py
@@ -462,6 +462,23 @@ def test_write_import_writes_and_refuses_overwrite(tmp_path):
     assert "Refusing to overwrite" in again
 
 
+def test_write_import_refuses_dangling_symlink_target(tmp_path):
+    from rac.explorer.state import ImportPreview
+
+    # A dangling symlink reports exists() False, but writing through it would
+    # follow the link and create a file at its target — outside the path the
+    # user confirmed. The write must be refused and the link target untouched.
+    elsewhere = tmp_path / "elsewhere.md"
+    target = tmp_path / "link.md"
+    target.symlink_to(elsewhere)
+    preview = ImportPreview(
+        source="src.md", converter="markdown", target=str(target), markdown="# Hi\n"
+    )
+    message = ExplorerAdapter(str(tmp_path)).write_import(preview)
+    assert "Refusing to overwrite" in message
+    assert not elsewhere.exists()
+
+
 def test_export_recommendations_renders_markdown_without_writing():
     from rac.explorer.state import ImportPreview
 

--- a/tests/test_rename.py
+++ b/tests/test_rename.py
@@ -25,6 +25,7 @@ from rac.services.rename import (
     REASON_OLD_AMBIGUOUS,
     REASON_OLD_FILENAME_ONLY,
     REASON_OLD_NOT_FOUND,
+    _replace_token,
     apply_rename,
     compute_rename,
 )
@@ -287,3 +288,14 @@ def test_cli_not_a_directory_is_usage_error(tmp_path: Path):
     with pytest.raises(SystemExit) as exc:
         main(["rename", "ADR-001", "ADR-099", str(target)])
     assert exc.value.code == 2
+
+
+def test_replace_token_folds_only_the_sliced_prefix():
+    # casefold can change a string's length (ß → ss). Folding all of the text
+    # but slicing by the unfolded token length would split mid-token: here the
+    # old behavior matched "ß" against "ss", sliced two characters ("ß "), and
+    # returned a corrupted "REQ-002(kept)". The prefix that is compared must be
+    # exactly the prefix that is sliced.
+    assert _replace_token("ß (kept)", "ss", "REQ-002") is None
+    # Case-insensitive ASCII matching is unchanged.
+    assert _replace_token("adr-001 (kept)", "ADR-001", "ADR-100") == "ADR-100 (kept)"

--- a/tests/test_sarif.py
+++ b/tests/test_sarif.py
@@ -88,6 +88,22 @@ def test_sarif_deterministic(tmp_path):
     assert render_validate_sarif(result) == render_validate_sarif(result)
 
 
+def test_sarif_uris_are_percent_encoded(tmp_path):
+    # artifactLocation.uri is an RFC 3986 URI, not a raw path: a filename with
+    # a space (or non-ASCII) must be percent-encoded or Code Scanning may
+    # reject or mislocate the finding. Path separators stay literal.
+    (tmp_path / "bad decision.md").write_text(BAD_DECISION, encoding="utf-8")
+    doc = json.loads(render_validate_sarif(validate_directory(str(tmp_path))))
+    uris = {
+        r["locations"][0]["physicalLocation"]["artifactLocation"]["uri"]
+        for r in doc["runs"][0]["results"]
+    }
+    assert uris, "expected at least one finding for the invalid decision"
+    assert all(" " not in uri for uri in uris)
+    assert any(uri.endswith("bad%20decision.md") for uri in uris)
+    assert all("/" in uri for uri in uris)  # separators are not encoded
+
+
 def test_sarif_omits_suppressed_findings(tmp_path):
     (tmp_path / ".rac").mkdir()
     (tmp_path / ".rac" / "config.yaml").write_text(

--- a/tests/test_sbom.py
+++ b/tests/test_sbom.py
@@ -63,3 +63,16 @@ def test_sbom_is_deterministic_no_timestamp():
     assert "timestamp" not in sbom.get("metadata", {})
     names = [c["name"] for c in sbom["components"]]
     assert names == sorted(names, key=str.casefold)
+
+
+def test_sbom_root_version_is_the_latest_release():
+    # The root component attests to the latest released version (the newest
+    # CHANGELOG.md heading), never a setuptools-scm dev build that matches no
+    # published artifact — an SBOM for an uninstallable version attests nothing.
+    changelog = (REPO_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+    heading = re.search(r"^## (\d{4}\.\d{2}\.\d+)\b", changelog, re.MULTILINE)
+    assert heading, "no release heading (## YYYY.MM.N) in CHANGELOG.md"
+    root = _sbom()["metadata"]["component"]
+    assert root["version"] == heading.group(1)
+    assert ".dev" not in root["version"]
+    assert root["purl"] == f"pkg:pypi/rac-core@{heading.group(1)}"

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -294,6 +294,19 @@ def test_cli_single_file_behavior_unchanged(capsys):
     assert rc == 1
 
 
+def test_cli_single_file_json_contract(capsys):
+    # The single-file JSON shape carries the same schema_version stamp as the
+    # directory and stdin-corpus forms (ADR-007), so every `--json` shape is
+    # version-gated.
+    rc = main(["validate", fixture_path("valid", "feature.md"), "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["schema_version"] == "1"
+    assert payload["file"] == fixture_path("valid", "feature.md")
+    assert payload["valid"] is True
+    assert payload["errors"] == []
+
+
 # --- validate_product (v0.20.0: single-file composition behind the gate) ------
 
 


### PR DESCRIPTION
# Summary

Maintenance hardening accepted from the 2026-07-01 technical implementation review. No roadmap item: these are defect fixes on already-shipped contract surfaces, not new release scope.

Adds:
- `schema_version` on single-file `rac validate FILE --json` output (the last unstamped `--json` shape).
- Percent-encoded SARIF `artifactLocation.uri` values.
- Quiet non-zero exit when a downstream pipe closes (`rac export … --json | head`).
- A casefold-safe token matcher in `rac rename`.
- A symlink guard on Explorer import writes.
- An SBOM root version pinned to the latest released version, with a drift test.
- Six regression tests, one per fix; two refreshed goldens.

# Roadmap / ADR Trace

Roadmap:
- None — repository maintenance from a code review, within existing contracts.

Relevant ADRs:
- `rac/decisions/adr-007-json-contract-stability.md` — the schema_version addition is additive
- `rac/decisions/adr-054-sarif-validation-output.md` — SARIF is a derived machine contract
- `rac/decisions/adr-005-cli-first.md`, `rac/decisions/adr-063-non-python-clients-are-thin.md` — thin clients parse these outputs; the contract must be uniform
- `rac/decisions/adr-002-ai-optional.md` — SBOM stays deterministic and offline
- `rac/decisions/adr-076-calver-release-versioning.md` — the SBOM root version is the CalVer release identifier

# Scope

## Included
- `src/rac/output/json.py`: single-file validation JSON gains `schema_version: "1"` as its first key; existing keys and order unchanged.
- `src/rac/output/sarif.py`: `artifactLocation.uri` is percent-encoded (`quote(uri, safe="/")`); path separators stay literal, so typical corpus paths are byte-identical.
- `src/rac/cli.py`: `BrokenPipeError` is caught at the dispatch boundary; stdout is repointed at devnull so the interpreter's exit-time flush stays silent.
- `src/rac/services/rename.py`: `_replace_token` compares exactly the prefix it slices off, closing a corruption path for casefolds that change string length (ß → ss).
- `src/rac/explorer/adapter.py`: `write_import` refuses symlinked targets — a dangling symlink reports `exists()` False but a write would follow it outside the confirmed path.
- `scripts/generate_sbom.py` + `sbom.json`: the root component version is read from the newest `CHANGELOG.md` release heading, fail-loud when none parses.

## Excluded
- Raising the `textual` dependency floor (`explorer`/`dev` extras declare a minimum the code no longer supports) — a packaging decision, deferred to the maintainer.
- A publish-workflow guard confirming tests ran for the tagged ref — a process decision, deferred.
- Rejecting `..` path traversal in Explorer import targets — the target is typed by the local user in a local TUI; only the symlink case silently escapes the confirmed path.
- Regenerating SBOM dependency component versions — unchanged, to keep the diff to the defect.

# Product / Architecture Decisions

- Every `rac validate --json` shape (single-file, directory, stdin-corpus) now carries the same `schema_version` stamp; the addition is additive per ADR-007, so existing parsers keep working.
- A closed pipe exits `1` (general failure) rather than the Unix-conventional `141`: the documented exit-code contract is the closed set 0/1/2, and inventing a fourth code for an external interruption would be the larger contract change.
- The rename matcher got stricter, not looser: a reference whose prefix only equals the token after a length-changing casefold no longer matches at all, rather than matching and corrupting. RAC identifiers are ASCII, so no in-corpus behavior changes.
- The committed SBOM attests to the latest release (currently `2026.06.5`), never a setuptools-scm dev build that matches no published artifact. Generation stays deterministic and offline: the version comes from a committed file, not the environment.

# User-Facing Contract

## CLI
No commands, flags, or human output changed.

## JSON Output
`rac validate FILE --json` gains `schema_version: "1"` (first key). All other shapes unchanged.

## SARIF Output
URIs containing spaces or non-ASCII are now valid RFC 3986 (`bad decision.md` → `bad%20decision.md`). ASCII slug paths are byte-identical.

## Exit Codes
- `0` / `1` / `2`: unchanged meanings.
- New: a broken output pipe exits `1` with clean stderr (previously: traceback, exit 1).

# Verification

## Ran
- `python -m pytest -q` — 1730 passed, 1 skipped (six tests added by this PR)
- `ruff check src/ tests/ scripts/`, `ruff format --check` (touched files), `mypy` (strict) — clean
- `rac validate rac/`, `rac relationships rac/ --validate`, `rac export rac/ --agent-rules --check` — exit 0
- `rac review rac/` — no priority 1–2 findings, health 94/100
- `RAC_UPDATE_GOLDEN=1 python -m pytest tests/test_golden.py` — only the two single-file validate goldens changed (one added line each)

## Covered
- `test_cli_single_file_json_contract`: the stamped single-file shape, positive path.
- `test_sarif_uris_are_percent_encoded`: space in filename encodes, separators stay literal, findings still render.
- `test_broken_pipe_exits_quietly`: real-subprocess EPIPE — exit 1, no `Traceback`/`BrokenPipeError` on stderr.
- `test_replace_token_folds_only_the_sliced_prefix`: the ß/ss corruption case returns no-match; ASCII case-insensitive matching unchanged.
- `test_write_import_refuses_dangling_symlink_target`: refusal message, link target untouched.
- `test_sbom_root_version_is_the_latest_release`: root version equals the newest CHANGELOG heading, never a dev build; purl agrees.

# Review Path

1. `src/rac/output/json.py` + the two goldens — the contract change.
2. `src/rac/output/sarif.py` — one-line encode plus comment.
3. `src/rac/cli.py` — the EPIPE branch in `main()`.
4. `src/rac/services/rename.py` — the prefix-fold correction.
5. `src/rac/explorer/adapter.py` — the symlink guard.
6. `scripts/generate_sbom.py`, `sbom.json`, `tests/test_sbom.py` — the release-version pin.

# Notes For Reviewer

- The golden diff is the reviewed product change, per the golden-test contract (`tests/test_golden.py`).
- The pipe test reads 1KB then closes; `rac export rac/ --json` emits ~2.4MB, so EPIPE is guaranteed past the 64KB pipe buffer.
- Squash-merge title is commit-form per `rac-agent-pr-guidelines.md`; the lead commit's type/area (`fix(validate)`) is used as the dominant change.

# Implementation Process

Implemented with AI assistance from a technical review of the implementation; final scope, review, and acceptance decisions are the maintainer's.