### PR TITLE
docs(roadmap): close out the rac-editors convergence item [roadmap:rac-editors]

### DIFF
--- a/rac/designs/lore-frontend-optionality.md
+++ b/rac/designs/lore-frontend-optionality.md
@@ -31,8 +31,8 @@ greenfield. It already ships five human- and agent-facing surfaces:
 - a Textual TUI Explorer — keyboard-first terminal browsing (ADR-028);
 - `rac-localview` — a single-file React Portal (`rac export --html`) with a
   force-directed graph view; and
-- the `lore-vscode` extension — in-editor validation, navigation, and an
-  embedded graph webview (the v0.21.x editor series).
+- the `rac-editors` VS Code extension (`vscode/`) — in-editor validation,
+  navigation, and an embedded graph webview (the v0.21.x editor series).
 
 So the real question is **optionality**: which *thin shell over the stable
 contract* earns further investment, and what — if anything — Lore should borrow

--- a/rac/roadmaps/repo-topology/rac-editors.md
+++ b/rac/roadmaps/repo-topology/rac-editors.md
@@ -8,7 +8,7 @@ tags: [structure, org, editor, distribution]
 
 ## Status
 
-Planned
+Achieved
 
 ## Context
 


### PR DESCRIPTION
# Summary

Implements the closeout of `rac/roadmaps/repo-topology/rac-editors.md`.

Adds:
- `rac-editors` roadmap item status flipped `Planned` → `Achieved` — the family repo exists with the extension under `vscode/` (rac-editors#1, merged), the epic (#228) has the member item checked off, and the Marketplace/OpenVSX identity is unchanged.
- The one live corpus reference to `lore-vscode` (`rac/designs/lore-frontend-optionality.md`, present-tense surfaces list) repointed to the `rac-editors` VS Code extension, satisfying the roadmap's "no `rac-core` reference points at `lore-vscode`" success measure for live references.

# Roadmap / ADR Trace

Roadmap:
- `rac/roadmaps/repo-topology/rac-editors.md`

Relevant ADRs:
- `rac/decisions/adr-061-roadmap-achieved-status.md` — `Achieved` terminal status, set by a human at delivery
- `rac/decisions/adr-092-repository-topology.md` — one repo per concern, `rac-*` naming
- `rac/decisions/adr-063-non-python-clients-thin-clients.md` — extension stays a thin client over the contract

# Scope

## Included
- The status flip and the single live-reference repoint. Nothing else.

## Excluded
- Sibling member items (`rac-ci`, `rac-connectors`, `rac-sdk`, `rac-benchmarks`) and the `repo-topology-convergence` umbrella stay `Planned` — their delivery is not verified from this session, and the umbrella's naming/brand cutover initiative is still open.
- Historical `lore-vscode` mentions are deliberately untouched: accepted ADRs (064/068/071/073/092), `CHANGELOG.md`, the archived `repo-extraction-programme`, the Achieved v0.22.x items, and `docs/v0.22-housekeeping-runbook.md` (kept as the record of how the v0.22.x extraction was actually run).
- The rename-subject mentions inside `rac-editors.md` and `repo-topology-convergence.md` — they name the source repo because it is the thing being renamed.
- No engine, contract, CLI, or schema change; per ADR-061 no closeout note or body rewrite is added on `Achieved`.

# Product / Architecture Decisions

- `Achieved` is a status flip only, matching the v0.22.4/v0.22.5 precedent; the delivery event stays in Git history and the tracking epic, not the roadmap body (ADR-061).
- The roadmap success measure "No `rac-core` reference points at `lore-vscode`" is read as covering live, present-tense references — the corpus must keep naming the source repo in its historical record.

# User-Facing Contract

Documentation-only change; no CLI, output, JSON, or exit-code change.

# Verification

## Ran
- `rac validate rac/` — PASS, 333 artifacts checked, 333 valid, 0 invalid
- `rac relationships rac/ --validate` — 1687 relationships checked, 0 validation issues (edit is graph-neutral)
- `rac review rac/` — no priority 1–2 findings; health score 94/100 (pre-existing priority 3–4 baseline unchanged)
- `pytest` — 1747 passed
- `grep -ril lore-vscode` — hits only the historical/subject files listed under Excluded

## Covered
- `Achieved` is in the roadmap spec enum (`src/rac/core/artifacts.py`), so structural validation accepts the flip without code change; relationship validation confirms no edge was broken by the design-artifact edit.

# Review Path

1. `rac/roadmaps/repo-topology/rac-editors.md` (status flip)
2. `rac/designs/lore-frontend-optionality.md` (reference repoint)

# Notes For Reviewer

Two org actions remain outside this repo, tracked from rac-editors#1: set `main` as the default branch of `itsthelore/rac-editors` (still pointing at the merged convergence branch) and archive `itsthelore/lore-vscode` with a redirect note.

# Implementation Process

Implemented with AI assistance under the roadmap contract; final scope, review, and acceptance decisions were made by the maintainer.