### PR TITLE
docs(roadmap): record benchmark suite contract and evidence roadmaps [roadmap:tool-benchmarks]

### DIFF
--- a/.cursor/rules
+++ b/.cursor/rules
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: 7f693642352f74bd5ca870cc752ced16f41d665303b41779f38bc68d52be5f78) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: 33d890a7929472f7fb724e706d1db9f28a81afe911f02fc5562235ca79c2d430) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -69,4 +69,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KW6NQ4Y814N7** — ADR-094: Roadmaps Are Identified by Stable Codename, Not a vX.Y.Z Scope-Fence _(Process)_
 - **RAC-KW8ZTVEQJ366** — ADR-095: rac-connectors Repackage, PyPI Rename, and Outbound Field Rename _(Architecture)_
 - **RAC-KWBJJRZR84PT** — ADR-096: External-Target Verification Edge (`verified_by`) _(Technical)_
+- **RAC-KWFVA38YT2C0** — ADR-097: Benchmark Family Contract _(Technical)_
 <!-- END RAC MANAGED BLOCK -->

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: 7f693642352f74bd5ca870cc752ced16f41d665303b41779f38bc68d52be5f78) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: 33d890a7929472f7fb724e706d1db9f28a81afe911f02fc5562235ca79c2d430) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -69,4 +69,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KW6NQ4Y814N7** — ADR-094: Roadmaps Are Identified by Stable Codename, Not a vX.Y.Z Scope-Fence _(Process)_
 - **RAC-KW8ZTVEQJ366** — ADR-095: rac-connectors Repackage, PyPI Rename, and Outbound Field Rename _(Architecture)_
 - **RAC-KWBJJRZR84PT** — ADR-096: External-Target Verification Edge (`verified_by`) _(Technical)_
+- **RAC-KWFVA38YT2C0** — ADR-097: Benchmark Family Contract _(Technical)_
 <!-- END RAC MANAGED BLOCK -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: 7f693642352f74bd5ca870cc752ced16f41d665303b41779f38bc68d52be5f78) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: 33d890a7929472f7fb724e706d1db9f28a81afe911f02fc5562235ca79c2d430) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -69,4 +69,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KW6NQ4Y814N7** — ADR-094: Roadmaps Are Identified by Stable Codename, Not a vX.Y.Z Scope-Fence _(Process)_
 - **RAC-KW8ZTVEQJ366** — ADR-095: rac-connectors Repackage, PyPI Rename, and Outbound Field Rename _(Architecture)_
 - **RAC-KWBJJRZR84PT** — ADR-096: External-Target Verification Edge (`verified_by`) _(Technical)_
+- **RAC-KWFVA38YT2C0** — ADR-097: Benchmark Family Contract _(Technical)_
 <!-- END RAC MANAGED BLOCK -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ to the corpus artifact and they load through the imports below.
 - Previous series: `rac/roadmaps/v0.21.x-editor/` (complete)
 - Decisions (ADRs): `rac/decisions/`
 
-<!-- BEGIN RAC MANAGED BLOCK (digest: 7f693642352f74bd5ca870cc752ced16f41d665303b41779f38bc68d52be5f78) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: 33d890a7929472f7fb724e706d1db9f28a81afe911f02fc5562235ca79c2d430) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -94,4 +94,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KW6NQ4Y814N7** — ADR-094: Roadmaps Are Identified by Stable Codename, Not a vX.Y.Z Scope-Fence _(Process)_
 - **RAC-KW8ZTVEQJ366** — ADR-095: rac-connectors Repackage, PyPI Rename, and Outbound Field Rename _(Architecture)_
 - **RAC-KWBJJRZR84PT** — ADR-096: External-Target Verification Edge (`verified_by`) _(Technical)_
+- **RAC-KWFVA38YT2C0** — ADR-097: Benchmark Family Contract _(Technical)_
 <!-- END RAC MANAGED BLOCK -->

--- a/rac/decisions/adr-097-benchmark-family-contract.md
+++ b/rac/decisions/adr-097-benchmark-family-contract.md
@@ -1,0 +1,104 @@
+---
+schema_version: 1
+id: RAC-KWFVA38YT2C0
+type: decision
+---
+# ADR-097: Benchmark Family Contract
+
+## Context
+
+ADR-066 fixed the scoring posture for the grounding eval: deterministic,
+offline, no embeddings, no vector search, no LLM judge — a pure function of
+`(corpus, query set, retrieval code)`. ADR-092 fixed the home: one
+`rac-benchmarks` repository, one subdir per benchmark. The per-tool suite
+(one benchmark per Lore MCP tool: `search_artifacts`, `find_decisions`,
+`get_artifact`, `get_related`, `get_summary`) now generalizes that posture
+into a family, and the stress-test of the existing grounding benchmark
+exposed three measurement gaps the family must close:
+
+- `find_decisions` — the one tool with a structural supersession defense —
+  had zero benchmark coverage anywhere; supersession was tested only through
+  `search_artifacts`, which applies no liveness filter.
+- The hard-negative window was top-5 while `search_artifacts` serves the
+  full match list, so a superseded decision at rank 6 reached agents
+  unflagged.
+- The gate (P@1, R@5) is blind to ordering within ranks 2–5, although the
+  shipped ranking work was justified by exactly that within-window ordering.
+
+Contract-shaped tools (`get_artifact`, `get_summary`) additionally have no
+ranked list at all: for a given lookup there is exactly one correct outcome,
+which ranked-retrieval metrics cannot express.
+
+## Decision
+
+The benchmark family contract **extends ADR-066; it does not supersede it**.
+
+Kept from ADR-066, unchanged: scoring is deterministic and offline — no
+embeddings, no LLM judge, no network, no randomness, no clock in the scored
+path; Precision@k and Recall@k at `k ∈ {1, 3, 5}`, macro-averaged (equal
+weight per case); hard-negative violations gate at zero; re-baselining is
+human-gated and CI never rebaselines; the serialized `metrics` block is
+byte-identical across runs on an unchanged corpus.
+
+Added for the family:
+
+- **MRR** (mean reciprocal rank) joins the gated retrieval metrics —
+  rank-aware and deterministic, it catches within-top-5 ordering regressions
+  the P@1 / R@5 floors are blind to.
+- **Full-returned-list negative window**: a `must_not_return` id appearing
+  ANYWHERE in the returned list is a violation. The top-5 window
+  under-enforced the "never surface a superseded decision" claim.
+- **Conformance pass-rate** is the metric for contract-shaped tools
+  (`get_artifact`, `get_summary`, and the CLI-scoped `get_related` edge
+  sets), gated at 1.0 with zero tolerance: a contract is either honoured or
+  it is not.
+
+Recorded scope: the v1 harness drives `rac` strictly as an external CLI on
+`PATH` per the benchmark repository's DG-ADR-0001 — zero engine imports. The
+MCP-only behaviours — `get_related` depth-greater-than-one neighborhoods and
+the ADR-033 response budget / truncation markers — are invisible to the CLI
+and are named future work (the MCP-stdio harness workstream), not silently
+dropped. The port of `decisiongrounding` onto the shared harness is a
+`tool-benchmarks` roadmap initiative and must not expand the frozen
+restructure item's scope.
+
+## Consequences
+
+Every Lore MCP tool gains a gated benchmark with a committed baseline, and a
+retrieval or contract regression in any of them fails CI in
+`rac-benchmarks`. Fixture corpora become load-bearing: the full-list negative
+window means hard-negative artifacts must share no query vocabulary, so
+corpus edits must re-run their benchmark before commit. The scorecard JSON
+(`{metrics, metadata, per_query}`) is an additive, stable contract per
+ADR-007 — emitted fields are never removed or renamed.
+
+## Status
+
+Accepted
+
+## Category
+
+Technical
+
+## Alternatives Considered
+
+- Superseding ADR-066 with a single new contract: rejected — ADR-066's
+  posture is unchanged and still governs the existing grounding eval; the
+  family adds to it.
+- Keeping the top-5 negative window for symmetry with `rac eval`: rejected —
+  the tools serve the full match list, so the window must cover what agents
+  actually receive.
+- Scoring contract-shaped tools with P@k over a single-item list: rejected —
+  it blurs "wrong outcome" into a partial score; conformance at 1.0 states
+  the contract plainly.
+- An LLM judge for the conformance checks: rejected outright by ADR-066.
+
+## Related Decisions
+
+- adr-066
+- adr-092
+- adr-007
+
+## Related Roadmaps
+
+- tool-benchmarks

--- a/rac/designs/tool-benchmark-harness.md
+++ b/rac/designs/tool-benchmark-harness.md
@@ -1,0 +1,144 @@
+---
+schema_version: 1
+id: RAC-KWFVACN74BHW
+type: design
+---
+# Tool Benchmark Harness and Scorecard
+
+## Context
+
+The `tool-benchmarks` roadmap builds one benchmark per Lore MCP tool in
+`itsthelore/rac-benchmarks` (subdir per benchmark, ADR-092). The non-trivial
+structure worth recording — sibling to `grounding-eval-scorecard` — is the
+shared harness those subdirs consume and the scorecard/gate shapes it emits,
+so five benchmarks stay one design rather than five drifting ones. Scoring
+posture is fixed by ADR-097 (extending ADR-066); this design pins the data
+shapes and seams.
+
+## User Need
+
+The maintainer and CI need one answer per tool, deterministically and
+offline: "does this tool still honour its retrieval or resolution contract,
+and did this change make it worse?" — with a human-readable summary, a
+machine-readable scorecard to diff against a committed baseline, and an exit
+code CI can gate on.
+
+## Design
+
+### Tool-to-CLI seam
+
+The harness drives `rac` strictly as an external CLI on `PATH` (the
+benchmark repository's DG-ADR-0001 — zero engine imports), so the scored
+surface is exactly the published CLI contract:
+
+- `search_artifacts` → `rac find <query> <root> --json [--type T]`
+- `find_decisions` → `rac find <query> <root> --decisions --json`
+- `get_artifact` → `rac resolve <id> <root> --json`
+- `get_related` → `rac relationships <root> --json`, with
+  `rac resolve` / `rac index` as id↔path plumbing that never re-orders tool
+  output
+- `get_summary` → `rac portfolio <root> --json`
+
+Production output is consumed verbatim: no re-sort, no re-rank, membership
+compared by id only.
+
+### Benchmark kinds
+
+The benchmark's committed `config.json` names its tool, which picks the case
+shape and metrics:
+
+- **Retrieval** (`search_artifacts`, `find_decisions`): ranked cases with
+  `relevant` (≥ 1) and optional `must_not_return`. Metrics: P@k / R@k at
+  `k ∈ {1, 3, 5}` and MRR, macro-averaged, reported `overall` and
+  `by_category`; `negative_violations` counts `must_not_return` ids anywhere
+  in the FULL returned list.
+- **Conformance** (`get_artifact`, `get_related`, `get_summary`): contract
+  cases scored as named deterministic checks. Metrics: `conformance` pass
+  rate (gated 1.0, zero tolerance), `cases_passed`, `cases_total`, and
+  `negative_violations` for edge-set negatives.
+
+### Scorecard shape
+
+Three top-level objects; only `metrics` is gate-compared, `metadata` and
+`per_query` are diagnostic, so a clock or hash never fails a build. Floats
+round to six decimals so the serialized `metrics` block is byte-identical
+across runs on an unchanged corpus. `metadata` records the `rac --version`
+string, `corpus_hash` (`sha256:…` over the fixture files), `query_set_hash`,
+`n_queries`, and `generated_at`. The scorecard JSON is an additive, stable
+contract (ADR-007).
+
+### Entry point and gate
+
+Every subdir ships a thin `run.py` over the harness with the `rac eval` flag
+surface: `--check | --update-baseline`, `--json`, `--root`, `--queries`,
+`--baseline`, `--config`; exit 0 clean, 1 gate failure, 2 usage error. The
+gate fails when `negative_violations` exceeds its limit, a gated metric is
+below its configured floor, or a gated metric is below
+`baseline − tolerance`; it prints one line per fired rule with the rule
+name, metric, and both values. Gated metrics are whatever the config's
+floors declare, so retrieval and conformance benchmarks share one gate
+implementation. Re-baselining is human-gated; CI never passes
+`--update-baseline` (asserted by a test).
+
+## Constraints
+
+- Deterministic and offline (ADR-066/ADR-097): no network, keys, randomness,
+  or clock in the scored path.
+- No engine imports anywhere in the benchmark repository (DG-ADR-0001),
+  enforced by a test that scans for `import rac` / `from rac`.
+- Per-category floors only where a category has at least four cases: with
+  two cases the metrics quantize to {0, 0.5, 1.0} and a 0.9 floor is
+  theater.
+- Fixture corpora are schema-valid (`rac validate` exit 0) with a distinct
+  id prefix per benchmark (`SAB-`, `FDB-`, `GAB-`, `GRB-`, `GSB-`).
+
+## Rationale
+
+One shared harness with config-declared gated metrics keeps five benchmarks
+byte-compatible in scorecard shape while letting retrieval and contract
+tools score in their own terms. Mirroring the `rac eval` flag surface and
+exit codes means CI treats every benchmark identically, and mirroring the
+grounding-eval-scorecard split (gated `metrics` vs diagnostic `metadata` /
+`per_query`) keeps the gate byte-stable without hiding run context.
+
+## Alternatives
+
+- One benchmark with a `tool` field per case (the `rac eval` shape):
+  rejected — ADR-092's family form wants one subdir per benchmark, and
+  per-tool corpora need deliberately partitioned vocabulary.
+- Importing rac-core's `eval` service instead of a subprocess seam:
+  rejected — DG-ADR-0001 makes engine decoupling the repository's contract,
+  and the CLI JSON is the surface agents actually consume.
+- Scoring conformance tools with ranked metrics: rejected in ADR-097.
+
+## Accessibility
+
+The human summary prints plain-text tables (overall, by-category) and an
+explicit Violations section listing each offending case with its returned
+ids or failed checks — legible in a terminal and in CI logs without colour.
+
+## Style Guidance
+
+Failure output names the rule, metric, and both values on one line each,
+matching `rac eval --check`. JSON output follows the scorecard shape
+exactly; `--update-baseline` writes the `metrics` object alone.
+
+## Open Questions
+
+- When the MCP-stdio harness workstream lands, whether budget-truncated
+  responses are scored as a separate kind or as a variant seam on the
+  retrieval kind.
+- Whether the decisiongrounding backport defines its equivalence surface as
+  a new `metrics` projection of its existing run results or by freezing its
+  current report shape.
+
+## Related Decisions
+
+- adr-097
+- adr-066
+- adr-092
+- adr-007
+
+## Related Roadmaps
+
+- tool-benchmarks

--- a/rac/roadmaps/benchmarks/tool-benchmarks.md
+++ b/rac/roadmaps/benchmarks/tool-benchmarks.md
@@ -1,0 +1,118 @@
+---
+schema_version: 1
+id: RAC-KWFVAB1XD9AC
+type: roadmap
+---
+# Per-Tool Benchmark Suite (tool-benchmarks)
+
+## Status
+
+Planned
+
+## Context
+
+A stress-test of the existing grounding benchmark against rac-core's claims
+found the coverage uneven: `find_decisions` — the one tool with a structural
+supersession defense — had no benchmark anywhere; the hard-negative window
+was top-5 while `search_artifacts` serves the full match list; the P@1 / R@5
+gate was blind to ordering within ranks 2–5; `get_related`'s outgoing
+direction was unscored; and the eval scores pre-budget output while agents
+receive ADR-033 budget-truncated responses. This roadmap builds one benchmark
+per Lore MCP tool in `itsthelore/rac-benchmarks` (subdir per benchmark,
+ADR-092) on a shared harness, under the family contract of ADR-097.
+
+Known corpus inconsistencies observed during the stress-test, flagged here
+rather than silently fixed: ADR-066 records an ascending-artifact-id
+tie-break that was never implemented (production ties break by path), and
+ADR-078 is `Status: Proposed` while its BM25+RRF ranking is shipped and
+gating CI.
+
+## Outcomes
+
+- Five per-tool benchmark subdirs (`search-artifacts`, `find-decisions`,
+  `get-artifact`, `get-related`, `get-summary`) green in `rac-benchmarks`
+  CI, each with a committed baseline, calibrated floors, and regression
+  proofs.
+- A shared harness package the benchmarks consume as thin entry points,
+  driving `rac` strictly as an external CLI on `PATH` (DG-ADR-0001), with
+  the `rac eval` flag surface and exit-code contract.
+- `decisiongrounding` ported onto the shared harness without changing its
+  scored results, once its restructure move has settled.
+
+## Initiatives
+
+- **Shared harness** — subprocess runner, deterministic scorer (P@k, R@k,
+  MRR, full-list negatives, conformance), scorecard writer, and gate in
+  `rac-benchmarks/harness/`.
+- **find-decisions benchmark** — the supersession defense under test:
+  retired decisions must never surface, even as the lexically best match.
+- **search-artifacts benchmark** — ranked retrieval at realistic scale:
+  thirty artifacts across all five types, six query categories, MRR gated.
+- **get-artifact benchmark** — resolution conformance: exact-id, alias, and
+  case-insensitive hits; duplicate and not-found error shapes.
+- **get-related benchmark** — exact incoming AND outgoing edge sets per
+  artifact (the outgoing direction was previously unguarded).
+- **get-summary benchmark** — portfolio contract: counts by type, the
+  empty-corpus shape, byte stability.
+- **decisiongrounding backport** — port the moved benchmark onto the shared
+  harness with byte-equal scored results as the acceptance bar. Recorded
+  finding: `decisiongrounding` is a scenario/provider benchmark with a
+  structural adherence scorer and has no `{metrics, baseline}` scorecard
+  today, so the port first needs an equivalence surface defined; it must not
+  expand the frozen restructure item's scope.
+- **MCP-stdio harness (deferred)** — the workstream that closes what the
+  CLI cannot see: `get_related` depth-greater-than-one neighborhoods, the
+  ADR-033 response budget and truncation markers, and provenance enrichment
+  on `get_artifact` payloads.
+
+## Success Measures
+
+- `rac-benchmarks` CI runs every benchmark's `--check` on every push and
+  pull request; a deliberately injected retrieval regression fails it.
+- Each benchmark's serialized `metrics` block is byte-identical across
+  repeated runs on an unchanged corpus (asserted by tests).
+- Three regression-injection proofs per benchmark assert exit codes and the
+  named fired rules.
+- No benchmark or harness file imports engine code (asserted by a test).
+
+## Assumptions
+
+- The `rac` CLI's JSON contracts (`find`, `resolve`, `relationships`,
+  `portfolio`, `index`) stay additive per ADR-007.
+- The decisiongrounding restructure item (repo-topology) remains frozen in
+  scope; this roadmap's backport initiative is where port work is tracked.
+
+## Risks
+
+- **Fixture vocabulary drift**: the full-list negative window means a query
+  token leaking into a hard-negative artifact fails the gate for lexical
+  rather than structural reasons. Mitigation: corpus edits re-run their
+  benchmark before commit; the benchmark-local ADRs record the partitioning
+  rule.
+- **Floating rac version in CI**: benchmarks install rac from source, so an
+  engine ranking change can fail the gate before the baseline is reviewed.
+  Mitigation: that is the point — the gate exists to make such changes
+  reviewed, and re-baselining stays human-gated.
+
+## Related Decisions
+
+- adr-097
+- adr-066
+- adr-092
+- adr-093
+- adr-007
+
+## Related Roadmaps
+
+- rac-benchmarks
+
+## Related Tickets
+
+- itsthelore/rac-benchmarks#2
+- itsthelore/rac-benchmarks#3
+- itsthelore/rac-benchmarks#4
+- itsthelore/rac-benchmarks#5
+- itsthelore/rac-benchmarks#6
+- itsthelore/rac-benchmarks#7
+- itsthelore/rac-benchmarks#8
+- itsthelore/rac-benchmarks#9

--- a/rac/roadmaps/future/external-benchmark-evidence.md
+++ b/rac/roadmaps/future/external-benchmark-evidence.md
@@ -1,0 +1,120 @@
+---
+schema_version: 1
+id: RAC-KWGKQMZ68A1Z
+type: roadmap
+---
+# External Benchmark Evidence (Future)
+
+## Status
+
+Planned
+
+Unscheduled — captured as future intent, not yet on a release. Codename:
+`external-benchmark-evidence`.
+
+## Context
+
+The evidence for "rac-core is actually useful" is currently self-authored: the
+per-tool suite (`tool-benchmarks`) proves the retrieval and contract
+mechanisms, and SWE-DecisionBench proves the outcome on our own scenario set.
+Third-party credibility needs recognized external benchmarks — the kind hosted
+on HuggingFace and cited in vendor comparison tables. The agent-memory market
+already runs on exactly such a table: Mem0, Zep, Letta, and newer entrants all
+publish LoCoMo and LongMemEval numbers, and buyers read those comparisons.
+Lore does not appear in any of them.
+
+A survey of the landscape (July 2026) found two joint first-priority
+candidates and a tracked tier:
+
+- **LongMemEval** — around five hundred questions over interaction histories
+  of roughly 115k tokens; its *knowledge update* and *temporal reasoning*
+  categories are the closest external analogue to Lore's supersession
+  defense. This is the arena where memory vendors publish. Caveats: a
+  conversational-QA contract (needs a capture adapter from sessions to
+  artifacts) and partially LLM-judged scoring.
+- **GitChameleon 2.0** — 116 version-conditioned Python problems with
+  executable unit tests. "Code against the superseded API" is Lore's thesis
+  in code form, and execution-based scoring is deterministic — the only
+  external candidate that fits the ADR-066 posture natively.
+- Tracked tier: LoCoMo (the most widely reported memory benchmark; shares the
+  LongMemEval adapter), tau-bench and tau2-bench (policy-adherent agents;
+  stochastic simulated users), SWE-ContextBench (arXiv:2602.08316, already
+  the SWE-DecisionBench paper's named neighbour), ContextBench
+  (arXiv:2602.05892, context retrieval in coding agents), CRAG / RAGTruth /
+  FreshQA (RAG correctness, faithfulness, and recency; thematic support
+  only), and the newer memory wave (MemBench, StreamMemBench, BEAM).
+
+## Outcomes
+
+- Lore appears in at least one recognized external benchmark table
+  (LongMemEval first) with reproducible, honestly framed numbers and a
+  published one-command reproduction path.
+- A deterministic external result (the GitChameleon rac-grounding arm)
+  showing version-correct code generation improving when the agent is
+  grounded in version-governing decisions, scored by the benchmark's own
+  executable tests.
+- External evidence runs stay structurally distinct from merge gates:
+  upstream scoring (including LLM judges) never gates CI (ADR-066, ADR-097);
+  evidence reports are labelled with the upstream harness version and scoring
+  mode.
+
+## Initiatives
+
+- **LongMemEval adapter arm** — a new `rac-benchmarks` subdir (ADR-092 family
+  form) wrapping the upstream harness with a Lore arm: ingest interaction
+  history as captured artifacts, answer from Lore retrieval, score with the
+  upstream scorer. Report per-category results, leading with knowledge-update
+  and temporal-reasoning.
+- **GitChameleon rac-grounding arm** — a new subdir reusing the benchmark
+  repository's DG-ADR-0001 provider pattern: a held-constant answering model
+  with arms differing only in grounding (none, RAG, a rac corpus of
+  version-governing decisions), scored by the upstream executable tests.
+- **Licensing and provenance check per dataset** before anything is
+  committed (upstream licenses vary; ADR-071 posture on our side).
+- **LoCoMo extension** — reuse the LongMemEval capture adapter once it
+  exists.
+- **Publish SWE-DecisionBench to HuggingFace** (dataset plus leaderboard
+  space) — the flip side of the same credibility goal; extends the
+  `publish-swe-decisionbench` roadmap's submit initiative without expanding
+  this item.
+
+## Success Measures
+
+- A published Lore LongMemEval result with a reproduction command, cited in
+  at least one third-party comparison within two quarters of publication.
+- The GitChameleon rac arm shows a statistically defensible delta over
+  no-grounding on version-correct generation, or the losing result is
+  published plainly (the SWE-DecisionBench honesty rule applies).
+- No external benchmark's scoring path ever appears in a CI merge gate.
+
+## Assumptions
+
+- Upstream datasets remain available under licenses compatible with running
+  and publishing results.
+- The memory-vendor comparison table remains the buying-decision surface for
+  agent-memory products.
+
+## Risks
+
+- **Vendor-tuned-harness credibility trap.** Self-reported memory benchmark
+  numbers are widely discounted (independent reproductions of vendor scores
+  differ by tens of points). Mitigation: publish the exact reproduction
+  command and upstream harness pin with every number; never report a number
+  that cannot be reproduced from a clean clone.
+- **Contract mismatch.** LongMemEval's conversational-QA shape is not Lore's
+  document-corpus shape; a weak adapter would measure the adapter, not Lore.
+  Mitigation: the adapter is reviewed as its own design artifact before any
+  funded run.
+- **LLM-judge scoring drift.** Upstream judges change; evidence numbers are
+  dated and pinned, never treated as stable contracts.
+
+## Related Decisions
+
+- adr-066
+- adr-092
+- adr-097
+- adr-071
+
+## Related Roadmaps
+
+- tool-benchmarks

--- a/rac/roadmaps/future/external-benchmark-evidence.md
+++ b/rac/roadmaps/future/external-benchmark-evidence.md
@@ -118,3 +118,7 @@ candidates and a tracked tier:
 ## Related Roadmaps
 
 - tool-benchmarks
+
+## Related Tickets
+
+- itsthelore/rac-benchmarks#10

--- a/rac/roadmaps/repo-topology/rac-benchmarks.md
+++ b/rac/roadmaps/repo-topology/rac-benchmarks.md
@@ -71,3 +71,4 @@ repos.
 
 - repo-topology-convergence
 - v0.22.4-extract-decisiongrounding
+- tool-benchmarks


### PR DESCRIPTION
# Summary

Implements the corpus side of the `tool-benchmarks` roadmap: the decisions and intent behind the benchmark suite that lands in itsthelore/rac-benchmarks#12.

Adds:
- `rac/decisions/` ADR-097 — Benchmark Family Contract (Accepted): scorecard shape, gate semantics, determinism posture, and the engine boundary every rac-benchmarks member follows.
- `rac/roadmaps/tool-benchmarks.md` — the suite's scope, including the deliberately deferred decisiongrounding backport.
- `rac/roadmaps/future/external-benchmark-evidence.md` — the external-evidence strategy (LongMemEval, GitChameleon, tracked tier), unscheduled per ADR-094.
- `rac/designs/` — the tool benchmark harness design (runner/scorer/gate split).
- Regenerated agent rules after ADR-097.

# Roadmap / ADR Trace

Roadmap:
- `rac/roadmaps/tool-benchmarks.md` (added here)
- `rac/roadmaps/future/external-benchmark-evidence.md` (added here)

Relevant ADRs:
- ADR-097 (added here); builds on ADR-092 (repo topology), ADR-066 (deterministic grounding-eval scoring), ADR-093 (roadmap intent in corpus, execution in issues), ADR-094 (codename identity).

# Scope

## Included
- Corpus artifacts only — no engine code changes.
- Ticket links per ADR-093: rac-benchmarks#10 (gitchameleon) and #11 (gateway backend) referenced from the roadmap artifacts.

## Excluded
- No implementation (lives in rac-benchmarks).
- No scheduling of the external-evidence roadmap — it stays in `future/` until funded.
- No change to any settled decision; ADR-097 extends ADR-092/ADR-066 rather than amending them.

# Product / Architecture Decisions

- Benchmark scoring paths never appear in a merge gate for external suites; only the deterministic per-tool suites gate CI (ADR-097 boundary).
- The decisiongrounding backport onto the shared harness is recorded as deferred with the reason (scorecard shape mismatch), not silently dropped.

# User-Facing Contract

Corpus-only change: no CLI, output, or exit-code changes.

# Verification

## Ran
- `rac validate rac/` → exit 0
- `rac relationships rac/ --validate` → exit 0
- `rac review rac/` → 94/100, no priority 1–2 findings
- `rac gate rac/` → 0 blocking

## Covered
Artifact structure, relationship integrity (including the new ADR/roadmap/design cross-references), and gate cleanliness.

# Review Path

1. ADR-097 (the contract).
2. `tool-benchmarks` roadmap, then the harness design.
3. `external-benchmark-evidence` future roadmap.
4. Regenerated agent rules (mechanical).

# Notes For Reviewer

Companion implementation PR: itsthelore/rac-benchmarks#12. The two merge independently, but reading ADR-097 first makes the rac-benchmarks review faster.

# Implementation Process

Implemented with AI assistance under the roadmap contract; final scope, review, and acceptance decisions rest with the maintainer.