### PR TITLE
docs(roadmap): record SDK expansion strategy and agnostic-surfaces programme [roadmap:agnostic-surfaces]

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+# The image installs the built wheel; nothing else belongs in the context.
+*
+!dist/

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -97,3 +97,49 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist/
+
+  image-publish:
+    # Official container image, published in lockstep with the PyPI release
+    # (rac/roadmaps/future/oci-image.md): same trigger, same wheel, same
+    # CalVer tag. Runs after pypi-publish so the image never exists for a
+    # version PyPI does not have.
+    runs-on: ubuntu-latest
+    needs:
+      - pypi-publish
+    permissions:
+      contents: read
+      packages: write
+    env:
+      IMAGE: ghcr.io/itsthelore/rac
+      TAG: ${{ github.event.release.tag_name }}
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Retrieve release distributions
+        uses: actions/download-artifact@v7
+        with:
+          name: release-dists
+          path: dist/
+
+      - name: Build image
+        run: |
+          docker build \
+            --build-arg RAC_VERSION="$TAG" \
+            -t "$IMAGE:$TAG" \
+            -t "$IMAGE:latest" \
+            .
+
+      - name: Smoke-test image
+        run: docker run --rm "$IMAGE:$TAG" --version
+
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Push image
+        run: |
+          docker push "$IMAGE:$TAG"
+          docker push "$IMAGE:latest"
+
+      - name: Report pushed digest
+        run: docker inspect --format '{{ index .RepoDigests 0 }}' "$IMAGE:$TAG" >> "$GITHUB_STEP_SUMMARY"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# Official rac container image. Built from the release wheel in dist/ so the
+# image carries exactly the distribution published to PyPI for the same CalVer
+# tag (rac/roadmaps/future/oci-image.md). Packaging only: no behaviour,
+# flags, or configuration beyond the CLI's own.
+#
+# Local build:
+#   python -m build && docker build -t rac .
+#   docker run --rm -v "$PWD:/work" rac validate rac/
+FROM python:3.12-slim
+
+ARG RAC_VERSION=dev
+LABEL org.opencontainers.image.title="rac" \
+      org.opencontainers.image.description="RAC (Lore) requirements-as-code CLI" \
+      org.opencontainers.image.source="https://github.com/itsthelore/rac-core" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.version="${RAC_VERSION}"
+
+COPY dist/ /tmp/dist/
+RUN pip install --no-cache-dir /tmp/dist/*.whl && rm -rf /tmp/dist
+
+WORKDIR /work
+ENTRYPOINT ["rac"]
+CMD ["--help"]

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -24,6 +24,65 @@ This puts a single command on your path: `rac`. Check it:
 rac --version
 ```
 
+### No Python? Use the container image
+
+Every release also publishes an official container image to GHCR, versioned
+in lockstep with the PyPI package — the image tag is the same CalVer version:
+
+```bash
+docker run --rm -v "$PWD:/work" ghcr.io/itsthelore/rac:latest validate rac/
+```
+
+In CI, pin a release tag rather than `latest`, or pin by digest for
+immutable builds (the release run prints the pushed digest in its summary):
+
+```bash
+docker pull ghcr.io/itsthelore/rac:2026.6.1
+docker pull ghcr.io/itsthelore/rac@sha256:<digest>
+```
+
+The image is the CLI and nothing more, so it drops into any docker-native
+CI platform. GitLab CI (the image's entrypoint is `rac`; clear it so GitLab
+can run script steps):
+
+```yaml
+rac-gate:
+  image:
+    name: ghcr.io/itsthelore/rac:2026.6.1
+    entrypoint: [""]
+  script:
+    - rac gate rac/
+```
+
+Bitbucket Pipelines:
+
+```yaml
+pipelines:
+  pull-requests:
+    '**':
+      - step:
+          name: rac gate
+          image: ghcr.io/itsthelore/rac:2026.6.1
+          script:
+            - rac gate rac/
+```
+
+Jenkins (declarative pipeline, docker agent):
+
+```groovy
+pipeline {
+  agent { docker { image 'ghcr.io/itsthelore/rac:2026.6.1' } }
+  stages {
+    stage('rac gate') {
+      steps { sh 'rac gate rac/' }
+    }
+  }
+}
+```
+
+On GitHub, prefer the ready-made actions (see [Validation](validation.md)
+and [Watchkeeper](watchkeeper.md)) over the raw image.
+
 ## 2. Create your first artifact
 
 The fastest path is one command. From your repository root:

--- a/rac/designs/sdk-expansion-strategy.md
+++ b/rac/designs/sdk-expansion-strategy.md
@@ -1,0 +1,176 @@
+---
+schema_version: 1
+id: RAC-KWGKGGYW7YF7
+type: design
+---
+# SDK Expansion Strategy — Ranked Order for Non-Python Clients
+
+## Status
+
+Proposed
+
+The recorded outcome of a six-persona council (agent-ecosystem developer,
+Go-centric platform engineer, JVM/.NET enterprise architect, OSS
+maintainer, DevRel adoption strategist, Rust systems developer) convened
+to rank the next non-Python SDKs by adoption impact, with adversarial
+challenge on the top consensus candidates and a chaired synthesis. This
+design records the ranking, the rationale, the preserved dissents, and
+the triggers that reorder it — so future SDK work starts from evidence,
+not slideware completeness.
+
+## Context
+
+The only non-Python SDK today is the TypeScript thin client
+(`rac-sdk/ts/`, npm `@itsthelore/rac-sdk`, pre-1.0). ADR-063 fixes *how*
+any further client is built — a thin client over the stable contract
+(`--json` outputs, `rac export` payloads, exit codes, MCP), shelling out
+to the installed `rac` binary, never a native engine port without the two
+gates (a language-neutral `ARTIFACT_SPECS` data file and a cross-language
+conformance fixture suite). ADR-092 fixes *where* — a sibling subdir in
+the single `rac-sdk` repo. Neither decision says *which* languages come
+next or in what order; `go/` appears only as an illustrative placeholder.
+This design settles that ordering.
+
+## User Need
+
+Non-Python developers evaluating Lore need a first-class way in. Today
+they arrive through the language-agnostic surfaces — the `lore` MCP
+server from any agent harness, the VS Code/Cursor extension, the GitHub
+Actions, and the exported agent-rules files. The open question is which,
+if any, language SDK converts more of them next: agent-tooling builders
+(TypeScript), CI/platform teams (Go), enterprise platform teams
+(JVM/.NET), or the won't-install-Python segment (Rust/WASM).
+
+## Design
+
+The council's ranked order:
+
+1. **Deepen the language-agnostic surfaces — no new language SDK this
+   cycle** (5/6 first-place votes, mean composite 8.4/10, survived
+   skeptic challenge). Funded workstream, not a pause:
+   - an official OCI image bundling the CLI, unlocking GitLab CI,
+     Bitbucket Pipes, and Jenkins docker agents with zero SDK code;
+   - non-GitHub report formats (GitLab code-quality JSON, JUnit XML
+     alongside SARIF) plus GitLab component and Bitbucket pipe wrappers
+     mirroring the shipped GitHub Action;
+   - MCP tool depth and the existing `future/` backlog
+     (`integration-recipe-factory`, `lean-context-delivery`,
+     `retrieval-diagnostics`);
+   - start both ADR-063 native-port preconditions now — extract
+     `ARTIFACT_SPECS` to a language-neutral data file and build the
+     cross-language conformance fixture suite, running it against the
+     existing TypeScript SDK as its first consumer;
+   - drive the TypeScript SDK to a stable 1.0 so any second SDK copies a
+     proven surface.
+2. **JVM/Kotlin — trigger-gated second.** Build when the JetBrains
+   plugin (`rac-editors/jetbrains`, ADR-092) is scheduled: plugin first
+   with an in-repo ProcessBuilder client over `rac … --json`, extract to
+   `rac-sdk/jvm/` and publish to Maven Central only when a second JVM
+   consumer or recorded external demand warrants the ceremony. Ship with
+   air-gap install documentation (ADR-086).
+3. **Go — designated fast-follower on demand.** Pre-write the small
+   design note now (`rac-sdk/go/`, stdlib-only `os/exec` +
+   `encoding/json`, module path fixed with `go/vX.Y.Z` subdirectory tags
+   per ADR-092, error mapping ported from the TypeScript client); build
+   when demand evidence lands — a partner CI/bot integration or repeated
+   "call rac from Go" requests.
+4. **.NET — wait-for-demand.** Plausible enterprise-adjacent follower
+   once the JVM SDK proves the pattern; no ADR names a .NET surface.
+5. **Browser/WASM — rejected as an SDK candidate.** It is a second
+   engine, which ADR-063 explicitly rejects; its real payoff
+   (zero-install) is served by starting the two gates inside rank 1, and
+   it returns only via a new ADR, never as an SDK-ranking side effect.
+6. **Rust — rejected.** A subprocess crate is anti-idiomatic for exactly
+   the audience it targets; the Rust move is the gated native port, a
+   separate decision.
+7. **Ruby — rejected.** Cheap but pointless: no strategic surface, no
+   agent-tooling ecosystem.
+
+Reordering triggers:
+
+| Trigger | Effect |
+| --- | --- |
+| JetBrains plugin scheduled into a roadmap | JVM/Kotlin work begins as its substrate (rank 2 fires) |
+| Recorded Go demand (partner CI/bot integration, repeated requests) | Go SDK ships (rank 3 fires); analogous evidence promotes .NET |
+| Enterprise procurement stalls on "no library integration" | JVM trigger fires early |
+| Conversion data shows drop-off at `pip install` | Priority shifts to packaging (containers, standalone binaries) over any SDK |
+| Adoption stalls at "read-only MCP tools aren't enough" | Re-weight toward write-capable MCP tools or an SDK |
+| A community-owned wrapper SDK appears | Adopt or graduate it per ADR-092 rather than fragment the contract surface |
+| TS SDK 1.0 + conformance suite operational | Standing precondition for any second SDK satisfied; ranks 2–4 get cheaper |
+
+## Constraints
+
+- ADR-063: every language SDK is a thin client over the stable contract;
+  a native port stays gated behind the `ARTIFACT_SPECS` extraction and
+  the conformance fixture suite.
+- ADR-092: new SDKs land as subdirs of `rac-sdk`; graduation to an own
+  repo only on independent community/cadence.
+- ADR-007: the `--json` contract is additive-only; every SDK inherits
+  every contract change, so each additional SDK multiplies contract-churn
+  cost until the conformance suite exists.
+- ADR-086: any SDK aimed at enterprise estates needs an air-gap-ready,
+  procurement-friendly install story for the transitive Python CLI
+  dependency.
+- Capacity: effectively a solo-maintainer product; every published SDK
+  is a permanent release-checklist liability.
+
+## Rationale
+
+The consensus was structural, not preferential: under the ADR-063
+subprocess model every candidate SDK still requires a pip-installed
+Python `rac` CLI, so no wrapper removes the actual conversion blocker for
+non-Python users — while the surfaces where those users already meet
+Lore (MCP, editors, CI, agent-rules) are language-agnostic and shipping.
+The TypeScript SDK exists because a first-party consumer (the VS Code
+extension) forced it into existence; no second SDK has such a consumer.
+The ranking therefore ties each SDK to its consumer or demand signal:
+JVM to the JetBrains plugin, Go to a real CI/platform integration, .NET
+to recorded enterprise demand. Go scored the highest mean of any real
+SDK (6.5/10) without a single first-place vote — the safe second choice
+everywhere — which is precisely the profile of a fast-follower, not a
+proactive build.
+
+## Alternatives
+
+- **Build Go now** (`go/` placeholder made real): cheapest to build
+  (stdlib subprocess wrapper, tag-to-publish), but Go adopters pick Go
+  to avoid runtime dependencies, and a library requiring a Python CLI
+  converts fewer users than the ecosystem size suggests. Rejected in
+  favour of the fast-follower designation.
+- **Build JVM/Kotlin now** (enterprise-architect dissent, the only
+  non-null first-place vote): the strongest surviving argument is that
+  MCP and CI actions are agent- and pipeline-shaped, not a programmatic
+  API, and enterprise buyers embed governance tooling as typed Maven
+  libraries. Answered with an explicit trigger rather than a build — the
+  JetBrains plugin, when scheduled, gets the SDK as its substrate.
+- **Browser/WASM TypeScript**: rejected as posed; it violates ADR-063
+  and duplicates the engine. Its preconditions are absorbed into rank 1.
+- **Rust thin crate**: rejected; scored worst on fit by the Rust persona
+  itself. The segment it targets is served only by the gated native
+  port.
+
+## Open Questions
+
+- Which packaging form factor (OCI image, standalone binary, `uvx`)
+  best removes the `pip install` barrier, and should it precede all CI
+  wrapper work?
+- What demand-evidence threshold (issue count, named partner, telemetry
+  signal per ADR-041/046) formally fires the Go and .NET triggers?
+- Does the conformance fixture suite live in `rac-core` (beside the
+  contract) or `rac-sdk` (beside its consumers)?
+
+## Related Decisions
+
+- ADR-007
+- ADR-062
+- ADR-063
+- ADR-073
+- ADR-086
+- ADR-092
+
+## Related Roadmaps
+
+- rac-sdk
+- integration-recipe-factory
+- lean-context-delivery
+- retrieval-diagnostics

--- a/rac/designs/sdk-expansion-strategy.md
+++ b/rac/designs/sdk-expansion-strategy.md
@@ -170,6 +170,7 @@ proactive build.
 
 ## Related Roadmaps
 
+- agnostic-surfaces
 - rac-sdk
 - integration-recipe-factory
 - lean-context-delivery

--- a/rac/roadmaps/agnostic-surfaces.md
+++ b/rac/roadmaps/agnostic-surfaces.md
@@ -1,0 +1,143 @@
+---
+schema_version: 1
+id: RAC-KWGMT8B29552
+type: roadmap
+---
+# Language-Agnostic Surfaces Programme
+
+## Status
+
+Planned
+
+## Context
+
+The SDK expansion council (`sdk-expansion-strategy`) ranked "deepen the
+language-agnostic surfaces — no new language SDK this cycle" first, as a
+funded workstream. The structural finding: under ADR-063's thin-client
+model every language SDK still requires the pip-installed Python `rac`
+CLI, so no wrapper removes the real conversion blocker for non-Python
+users — while the surfaces where those users already meet Lore (MCP,
+editors, CI, agent-rules) are language-agnostic. This programme funds
+those surfaces and pays down the standing preconditions any future SDK
+inherits.
+
+## Outcomes
+
+Non-Python developers adopt Lore through contract surfaces, without a new
+language SDK and without the `pip install` barrier deciding the outcome:
+
+- A team can run the engine anywhere a container runs — GitLab CI,
+  Bitbucket Pipes, Jenkins docker agents — from one official image, with
+  no Python toolchain of their own.
+- CI platforms beyond GitHub consume findings natively: GitLab
+  code-quality widgets and JUnit-consuming dashboards render `rac`
+  results without translation glue.
+- The ADR-063 native-port preconditions stop being hypothetical: the
+  artifact specs live in a language-neutral data file and a conformance
+  fixture suite proves output parity, with the existing TypeScript SDK
+  as its first consumer.
+- The TypeScript SDK reaches a stable 1.0, so any future SDK copies a
+  proven, conformance-tested surface instead of a moving one.
+
+## Initiatives
+
+Two parallel tracks with no ordering between them; each is sequenced
+internally. Each member item is recorded in `rac/roadmaps/future/` and
+graduates to execution with a GitHub issue per ADR-093.
+
+- Track 1 — Distribution and CI reach:
+  - Official OCI image (`oci-image`): one published image bundling the
+    CLI; the single artifact that unlocks every docker-native CI
+    platform with zero wrapper code.
+  - CI report formats (`ci-report-formats`): GitLab code-quality JSON
+    and JUnit XML renderers beside the shipped SARIF output (ADR-054),
+    additive per ADR-007.
+  - Platform wrappers: delegated to the existing `rac-ci` topology item
+    (ADR-092), which consumes the image — a GitLab CI component and a
+    Bitbucket pipe mirroring the shipped GitHub Actions. This programme
+    adds no wrapper scope of its own.
+- Track 2 — Contract hardening:
+  - Artifact-spec extraction (`artifact-specs-extraction`): move
+    `ARTIFACT_SPECS` to a language-neutral data file the engine reads —
+    ADR-063 native-port precondition one.
+  - Conformance fixtures (`conformance-fixtures`): a cross-language
+    fixture suite proving output parity, seeded from the existing golden
+    outputs — ADR-063 native-port precondition two; the TypeScript SDK
+    is its first consumer. May start immediately; consumes the spec
+    extraction where useful.
+  - TypeScript SDK stable release (`ts-sdk-stable-release`): close the
+    documentation and CI gaps and publish 1.0 once the conformance suite
+    is green.
+- Delegated, not claimed: MCP tool depth and harness integration recipes
+  (`lean-context-delivery`, `integration-recipe-factory`) are sequenced
+  by the `deterministic-substrate` programme, Tranche A. This programme
+  relates to them and must not double-claim their scope.
+
+## Success Measures
+
+- Each member item graduates from `rac/roadmaps/future/` with a GitHub
+  issue per ADR-093 before implementation begins.
+- A non-GitHub CI platform runs a `rac` gate using only the official
+  image and documented snippets — no bespoke install steps.
+- The conformance suite runs in the TypeScript SDK's CI against a real
+  engine, replacing the currently skipped integration path.
+- `rac validate rac/`, `rac relationships rac/ --validate`, and
+  `rac review rac/` stay clean across the programme's output.
+- The reordering triggers recorded in `sdk-expansion-strategy` remain
+  the only mechanism that promotes new language SDK work; this
+  programme creates none.
+
+## Assumptions
+
+- ADR-063 holds: thin clients over the contract, native port gated
+  behind the two preconditions this programme funds.
+- ADR-092 topology holds: wrapper delivery consolidates under `rac-ci`;
+  language SDKs stay subdirs of `rac-sdk`.
+- The `deterministic-substrate` programme proceeds independently; its
+  Tranche A items are not blocked by, and do not block, either track
+  here.
+- Solo-maintainer capacity: tracks are parallel in dependency terms, not
+  necessarily in execution.
+
+## Risks
+
+- The image becomes a second, drifting install surface; mitigated by
+  building it in the engine repo, pinning it to the same CalVer releases
+  (ADR-076), and treating it as packaging of `rac-core`, not a fork.
+- New report renderers grow non-deterministic output (timestamps,
+  unordered findings) that breaks byte-pinned goldens; mitigated by
+  following the SARIF renderer's deterministic-ordering pattern
+  (ADR-002, ADR-066).
+- Spec extraction quietly changes validation semantics; mitigated by
+  extending the schema-agreement gate to assert data-file/engine parity
+  and keeping the change behaviour-neutral (ADR-023 clean break applies
+  to internals only).
+- A 1.0 label on the TypeScript SDK before the conformance suite exists
+  would freeze an unproven surface; mitigated by sequencing 1.0 after
+  the suite is green within Track 2.
+
+## Related Decisions
+
+- ADR-007
+- ADR-027
+- ADR-054
+- ADR-063
+- ADR-076
+- ADR-086
+- ADR-092
+- ADR-093
+- ADR-094
+
+## Related Designs
+
+- sdk-expansion-strategy
+
+## Related Roadmaps
+
+- oci-image
+- ci-report-formats
+- artifact-specs-extraction
+- conformance-fixtures
+- ts-sdk-stable-release
+- rac-ci
+- deterministic-substrate

--- a/rac/roadmaps/future/artifact-specs-extraction.md
+++ b/rac/roadmaps/future/artifact-specs-extraction.md
@@ -1,0 +1,102 @@
+---
+schema_version: 1
+id: RAC-KWGMTD67NRZW
+type: roadmap
+---
+# Artifact Spec Extraction to a Language-Neutral Data File
+
+## Status
+
+Planned
+
+Unscheduled member of the `agnostic-surfaces` programme, Track 2
+(contract hardening). This is the first of ADR-063's two native-port
+preconditions: "the artifact specs (`ARTIFACT_SPECS`) are first
+extracted to a shared, language-neutral data file both engines read."
+Starting it now is deliberate — the precondition is paid down before
+any concrete native-port need arrives.
+
+## Outcomes
+
+- The five artifact type specs (requirement, decision, roadmap, prompt,
+  design) — sections, metadata enums, synonyms, descriptions, guidance
+  — live in one language-neutral data file, and the Python engine reads
+  them from it.
+- Any future engine or tool in any language can read the same file and
+  agree with the Python engine about what an artifact type is, by
+  construction rather than by transcription.
+- Behaviour is unchanged: classification, validation, templates, and
+  every golden output are byte-identical before and after.
+
+## Initiatives
+
+- Record an ADR fixing the file format and location before
+  implementation (the format decision is the load-bearing part: it must
+  represent the current spec shape — section tuples, metadata enums,
+  synonyms, descriptions, guidance, retired-status — with a stable,
+  append-only field order per ADR-007, and stay trivially parseable
+  outside Python).
+- Extract the `ARTIFACT_SPECS` literals from the artifacts module into
+  that data file; the module loads it at import and rebuilds the same
+  frozen dataclasses, so every existing consumer keeps its current API.
+- Extend the schema-agreement test battery to assert data-file/engine
+  parity the same way it already asserts parity across the Python
+  consumers — failing loudly and naming the diverging field.
+- Ship the file inside the package distribution so installed engines
+  are self-contained, and document it as a read-only contract surface
+  for external consumers.
+
+## Constraints
+
+- Behaviour-neutral refactor (ADR-023 governs the internal seam): no
+  validation semantics, ordering, or template output may change; the
+  golden suite is the referee.
+- The dataclass API stays: consumers import the same names and shapes;
+  only the source of truth moves.
+- The data file is a contract artifact once published: additive
+  evolution only, per ADR-007.
+- No plugin or third-party spec loading in this item — dynamic
+  discovery is ADR-083 territory and out of scope here.
+
+## Success Measures
+
+- The full test battery, including the byte-pinned goldens and the
+  schema-agreement gate, passes with the specs loaded from the data
+  file.
+- Deleting the extracted literals from the Python module is total — no
+  duplicated spec fragments survive in code.
+- The conformance-fixtures item can point an external reader at the
+  file and get the same type definitions the engine uses.
+
+## Assumptions
+
+- The current spec shape (tuples of section names, string-enum
+  metadata, synonym maps — no regexes or code) is fully representable
+  in a static data format; exploration confirms nothing in the specs is
+  executable.
+- Import-time loading of a packaged data file costs nothing observable
+  on CLI startup.
+
+## Risks
+
+- A subtly lossy extraction (ordering, casing, synonym normalization)
+  changes classification on edge-case corpora; mitigated by the golden
+  suite plus the extended schema-agreement gate running both sources
+  during the transition.
+- The file invites hand-editing as if it were configuration; mitigated
+  by documenting it as a versioned contract owned by the engine, not a
+  user config surface (ADR-021's spirit: templates and specs are
+  creation contracts).
+
+## Related Decisions
+
+- ADR-007
+- ADR-021
+- ADR-023
+- ADR-060
+- ADR-063
+
+## Related Roadmaps
+
+- agnostic-surfaces
+- conformance-fixtures

--- a/rac/roadmaps/future/ci-report-formats.md
+++ b/rac/roadmaps/future/ci-report-formats.md
@@ -1,0 +1,92 @@
+---
+schema_version: 1
+id: RAC-KWGMTBJEQFMM
+type: roadmap
+---
+# CI Report Formats Beyond SARIF
+
+## Status
+
+Planned
+
+Unscheduled member of the `agnostic-surfaces` programme, Track 1
+(distribution and CI reach). SARIF shipped under ADR-054 and serves
+GitHub Code Scanning; GitLab and JUnit-consuming platforms need their
+own native shapes.
+
+## Outcomes
+
+- GitLab merge requests render `rac` findings in the code-quality
+  widget from a natively emitted report, with no translation glue.
+- Any dashboard or CI system that consumes JUnit XML (Jenkins, GitLab,
+  Bitbucket plugins, test-report tooling) can display `rac` gate
+  results as test outcomes.
+- The report surface stays one deterministic engine output away from
+  every finding-producing command, exactly as SARIF is today.
+
+## Initiatives
+
+- Add a GitLab code-quality JSON renderer and a JUnit XML renderer in
+  the output layer beside the SARIF renderer, reusing its shared
+  finding-collection path and its deterministic ordering discipline
+  (sorted results, no timestamps, version from the installed package).
+- Expose them with flags mirroring `--sarif` on the same commands —
+  `validate` (directory), `relationships --validate`, `review`, and
+  `gate` — with the same exit-code semantics.
+- Pin both formats with golden output tests alongside the existing
+  SARIF and JSON goldens.
+- Document both formats and per-platform wiring snippets (GitLab
+  `codequality` report artifact, JUnit report ingestion) in the CLI
+  docs; the snippets pair with the official OCI image.
+
+## Constraints
+
+- Additive only (ADR-007): new flags and outputs; no change to existing
+  JSON, SARIF, or exit-code contracts.
+- Deterministic and offline (ADR-002, ADR-066): byte-stable output for
+  a given corpus and version; no wall-clock timestamps.
+- Renderers translate the engine's existing findings; they compute no
+  new findings and hold no policy (policy stays in the engine commands,
+  as with the shipped actions).
+- Fidelity limits are documented, not papered over: JUnit's
+  test-case model and GitLab's severity set are narrower than SARIF;
+  the mapping is fixed and recorded in the docs.
+
+## Success Measures
+
+- A GitLab pipeline shows `rac` findings in the merge-request
+  code-quality widget using only documented flags and snippets.
+- A JUnit consumer renders a `rac gate` run as pass/fail test cases.
+- Golden tests pin both formats byte-for-byte; `rac validate rac/` and
+  the full test battery stay green.
+
+## Assumptions
+
+- The existing shared finding-collection path used by SARIF exposes
+  everything both formats need; no new engine-side finding fields are
+  required.
+- GitLab's code-quality schema and JUnit XML remain stable consumer
+  contracts.
+
+## Risks
+
+- Severity/level mapping disagreements between platforms invite ad-hoc
+  per-platform tweaks; mitigated by one fixed, documented mapping table
+  shared by both renderers.
+- Format sprawl: every new platform requests its own shape; mitigated
+  by holding the line at these two widely-consumed formats and pointing
+  the long tail at the stable JSON contract (ADR-007), the pattern
+  ADR-073 set for backends.
+
+## Related Decisions
+
+- ADR-002
+- ADR-007
+- ADR-054
+- ADR-066
+
+## Related Roadmaps
+
+- agnostic-surfaces
+- oci-image
+- rac-ci

--- a/rac/roadmaps/future/conformance-fixtures.md
+++ b/rac/roadmaps/future/conformance-fixtures.md
@@ -1,0 +1,110 @@
+---
+schema_version: 1
+id: RAC-KWGMTEW4T2D0
+type: roadmap
+---
+# Cross-Language Conformance Fixture Suite
+
+## Status
+
+Planned
+
+Unscheduled member of the `agnostic-surfaces` programme, Track 2
+(contract hardening). This is the second of ADR-063's two native-port
+preconditions: "a cross-language conformance fixture suite proves
+output parity." It also answers the risk four of six council ballots
+flagged — every additional client multiplies contract-churn cost until
+a fixture suite keeps them honest.
+
+## Outcomes
+
+- There is one runnable definition of "agrees with the engine": a
+  fixture corpus plus pinned expected outputs that any client in any
+  language can replay against its own deserialization.
+- The existing TypeScript SDK is the first consumer: its CI exercises a
+  real engine against the suite, replacing the integration path that is
+  currently skipped for lack of a `RAC_BIN`.
+- Contract drift is caught at the pull request that causes it, in
+  whichever repo it lands.
+
+## Initiatives
+
+- Settle the home question recorded as open in `sdk-expansion-strategy`
+  (proposed: fixtures and pinned outputs live beside the contract in
+  the engine repo, versioned with it; consumers fetch or vendor them by
+  release — decide and record at pickup).
+- Seed the suite from what already exists: the byte-pinned golden
+  `--json` outputs and the fixture corpora in the engine's test tree
+  already cover validate, resolve, find, relationships, review, stats,
+  export, and schema — package that pairing (corpus in, expected JSON
+  out) as a consumable artifact rather than inventing a parallel one.
+- Define the replay contract: for each case, the command argv, the
+  fixture corpus path, the expected stdout, and the expected exit code;
+  a conforming client must produce equal deserialized results (field
+  order per ADR-007, additive fields tolerated).
+- Wire the TypeScript SDK's CI to install the engine, run the suite,
+  and fail on divergence — converting its existing skipped integration
+  tests into a required conformance job (per-service battery, merge
+  gate per ADR-027 and ADR-075 practice).
+- Document the suite as the entry bar for any future client, per the
+  reordering trigger recorded by the council ("TS SDK 1.0 + conformance
+  suite operational" is the standing precondition for any second SDK).
+
+## Constraints
+
+- The suite tests the contract, not internals: only documented `--json`
+  outputs, export payloads, and exit codes are pinned (ADR-007,
+  ADR-063).
+- Additive tolerance is built in: a client must not fail when the
+  engine adds fields; it must fail when documented fields change shape
+  or disappear.
+- Deterministic and offline (ADR-002, ADR-066): fixtures are committed
+  corpora; no network, no generation at test time.
+- No native reimplementation is smuggled in: the suite proves clients
+  deserialize the one engine correctly; it does not certify a second
+  engine (that remains gated by ADR-063 in full).
+
+## Success Measures
+
+- The TypeScript SDK repo has a required CI job that replays the suite
+  against a real installed engine, and it is green.
+- A deliberate contract-breaking engine change fails the suite before
+  merge; a purely additive change passes without client edits.
+- The suite's case list covers every command the TypeScript client
+  wraps.
+
+## Assumptions
+
+- The existing golden corpus is a sufficient seed; gaps (for example
+  stdin validation and agent-rules output) are added as cases, not as a
+  new mechanism.
+- Cross-repo consumption (engine fixtures, SDK CI) is workable with
+  release-pinned fetching or vendoring; the exact mechanism is an
+  implementation detail decided at pickup.
+
+## Risks
+
+- Byte-pinning JSON across languages overreaches (key order, number
+  formatting) and produces false failures; mitigated by comparing
+  deserialized structures, not bytes, on the client side.
+- Fixture drift between repos if the suite is vendored and forgotten;
+  mitigated by pinning suite version to engine release and surfacing
+  the pin in the SDK's CI job.
+- The suite ossifies exploratory output surfaces too early; mitigated
+  by pinning only documented stable contracts and leaving experimental
+  flags out until documented.
+
+## Related Decisions
+
+- ADR-002
+- ADR-007
+- ADR-027
+- ADR-063
+- ADR-066
+- ADR-075
+
+## Related Roadmaps
+
+- agnostic-surfaces
+- artifact-specs-extraction
+- ts-sdk-stable-release

--- a/rac/roadmaps/future/oci-image.md
+++ b/rac/roadmaps/future/oci-image.md
@@ -1,0 +1,88 @@
+---
+schema_version: 1
+id: RAC-KWGMT9ZMN69Q
+type: roadmap
+---
+# Official OCI Image
+
+## Status
+
+Planned
+
+Unscheduled member of the `agnostic-surfaces` programme, Track 1
+(distribution and CI reach). Named by the SDK expansion council as the
+single highest-leverage artifact for non-Python adoption: one image
+unlocks every docker-native CI platform with zero wrapper code.
+
+## Outcomes
+
+- A team runs the `rac` CLI anywhere a container runs — GitLab CI
+  (`image:`), Bitbucket Pipes, Jenkins docker agents, local docker —
+  without installing Python or pip.
+- The image is official, pinned, and boring: built from the engine repo,
+  versioned with the same CalVer releases as the PyPI package (ADR-076),
+  reproducibly referenced by digest.
+- Air-gapped estates gain a procurement-friendly install path: mirror
+  one image instead of assembling a Python environment (ADR-086).
+
+## Initiatives
+
+- Add a Dockerfile to the engine repo that installs the released
+  `rac-core` package on a minimal Python base and sets `rac` as the
+  entrypoint; no engine code changes.
+- Add a publish workflow that builds and pushes the image on the same
+  release tags as the PyPI publish, tagging both the CalVer version and
+  `latest`, to an official registry home (for example
+  `ghcr.io/itsthelore/rac`; final home decided at pickup).
+- Document the image on the install page: pull, pin-by-digest, and
+  usage snippets for GitLab CI, Bitbucket Pipelines, and Jenkins docker
+  agents running `rac validate` / `rac gate`.
+- Record the image as the substrate the `rac-ci` platform wrappers
+  consume, so wrapper work never re-solves installation.
+
+## Constraints
+
+- Packaging only: the image wraps the released `rac-core` distribution;
+  it introduces no behaviour, flags, or configuration of its own.
+- Deterministic and offline by default, matching the engine posture
+  (ADR-002, ADR-086): no phone-home added by the image layer; telemetry
+  behaviour is exactly the CLI's own.
+- Per-platform wrapper logic (GitLab component, Bitbucket pipe, Jenkins
+  step) is out of scope — that is the `rac-ci` item's concern (ADR-092).
+- A standalone binary or `uvx`-based distribution is a recorded
+  alternative, not part of this item; revisit if image adoption shows
+  the container path is insufficient.
+
+## Success Measures
+
+- A documented GitLab CI job and a Bitbucket pipeline run a `rac` gate
+  using only the published image and the snippet — no install steps.
+- Image version and PyPI version are released together and match for
+  every CalVer release after the item ships.
+- The `rac-ci` wrappers, when built, consume the image rather than
+  pip-installing.
+
+## Assumptions
+
+- GitHub-hosted registry (or equivalent) is acceptable for the official
+  home; enterprise mirrors pull and re-host per their own policy.
+- The engine's Python version support fits a maintained slim base image.
+
+## Risks
+
+- The image drifts from the PyPI release if publishing is manual;
+  mitigated by publishing both from the same tag-triggered workflow.
+- A vulnerable base image inherits into the official artifact; mitigated
+  by pinning a maintained base, rebuilding on release, and including the
+  image in the existing SBOM practice.
+
+## Related Decisions
+
+- ADR-076
+- ADR-086
+- ADR-092
+
+## Related Roadmaps
+
+- agnostic-surfaces
+- rac-ci

--- a/rac/roadmaps/future/ts-sdk-stable-release.md
+++ b/rac/roadmaps/future/ts-sdk-stable-release.md
@@ -1,0 +1,106 @@
+---
+schema_version: 1
+id: RAC-KWGMTGNEJ0NN
+type: roadmap
+---
+# TypeScript SDK Stable Release
+
+## Status
+
+Planned
+
+Unscheduled member of the `agnostic-surfaces` programme, Track 2
+(contract hardening), sequenced after the conformance fixture suite is
+green. The council recorded "drive the TS SDK to a stable 1.0 so any
+second SDK copies a proven surface" as part of the rank-1 workstream;
+implementation lands in the `rac-sdk` repository (ADR-092), intent is
+recorded here.
+
+## Outcomes
+
+- `@itsthelore/rac-sdk` publishes 1.0: a stated stable surface with a
+  semver policy, so consumers (the VS Code extension first) can depend
+  on it without tracking pre-1.0 churn.
+- The documented API and the actual client surface are the same thing:
+  every public client method appears in the README's API documentation.
+- The SDK's CI proves the client against a real engine on every change,
+  via the conformance suite, instead of skipping integration entirely.
+- Any future language SDK starts by copying a proven, conformance-tested
+  surface — the standing precondition the council's reordering triggers
+  name ("TS SDK 1.0 + conformance suite operational").
+
+## Initiatives
+
+- Close the documentation drift: the README API table documents nine of
+  the eighteen public client methods; document the missing nine
+  (text/stdin validation, live-decision query, schema, rename, artifact
+  creation, init, quickstart, HTML export, agent-rules) with the same
+  usage-example quality as the existing entries.
+- Wire the conformance suite into the SDK's CI as a required job
+  against a real installed engine (delivered by the
+  `conformance-fixtures` item; this item consumes it).
+- State the stability policy for 1.0: what the public surface is (the
+  package's exported names — the analogue of ADR-062's `rac.__all__`
+  rule), semver semantics for the typed results under the engine's
+  additive JSON contract (ADR-007), and the supported engine version
+  range with the version-check behaviour on mismatch.
+- Sweep the pre-1.0 surface once before freezing: naming consistency,
+  error-hierarchy completeness, and removal of anything not worth
+  supporting forever; then publish 1.0 through the existing trusted
+  publishing release workflow.
+- Fix packaging metadata leftovers from the repo move (the repository
+  URL still points at the pre-consolidation repo slug).
+
+## Constraints
+
+- Thin client always (ADR-063): no engine logic enters the SDK on the
+  way to 1.0; the surface wraps `rac … --json`, export payloads, and
+  exit codes only.
+- 1.0 follows the conformance suite, never precedes it — a stable label
+  on an unproven surface is the failure mode this sequencing exists to
+  prevent.
+- The npm package name and repo home are settled (ADR-092,
+  `rac-sdk/ts/`); this item changes neither.
+- Corpus artifacts and gates live in the engine repo; the `rac-sdk`
+  repo carries the implementation and its own CI.
+
+## Success Measures
+
+- README API documentation covers one hundred percent of the exported
+  client surface, checked as part of the release sweep.
+- The conformance job is required and green in the SDK's CI at the 1.0
+  release commit.
+- A published stability policy tells a consumer exactly what semver
+  means for the typed surface and which engine versions are supported.
+- The VS Code extension consumes 1.0 without code changes beyond the
+  version bump.
+
+## Assumptions
+
+- The current eighteen-method surface is approximately the right 1.0
+  surface; the pre-freeze sweep trims or renames at the margin rather
+  than redesigning.
+- The engine's `--json` contract remains additive (ADR-007), so 1.0 can
+  promise forward compatibility with newer engines within a stated
+  range.
+
+## Risks
+
+- Freezing the surface before the VS Code extension's needs stabilise
+  forces an early 2.0; mitigated by the extension being the first
+  consumer reviewed in the pre-freeze sweep.
+- Engine and SDK version skew confuses users post-1.0; mitigated by the
+  stated supported-range policy and the client's existing version
+  check surfacing mismatches explicitly.
+
+## Related Decisions
+
+- ADR-007
+- ADR-062
+- ADR-063
+- ADR-092
+
+## Related Roadmaps
+
+- agnostic-surfaces
+- conformance-fixtures


### PR DESCRIPTION
# Summary

Implements the SDK expansion decision chain: council ruling recorded as a design, the rank-1 workstream scoped as a codenamed programme, and the programme's first item (the official container image) implemented.

Adds:
- `rac/designs/sdk-expansion-strategy.md` — the council-ranked order for non-Python SDK expansion (deepen agnostic surfaces first; JVM trigger-gated; Go fast-follower; .NET wait; browser/WASM, Rust, Ruby rejected), with dissents and reordering triggers.
- `rac/roadmaps/agnostic-surfaces.md` — the Language-Agnostic Surfaces Programme: two parallel tracks (distribution/CI reach; contract hardening), member items in `future/`.
- Five member items: `oci-image`, `ci-report-formats`, `artifact-specs-extraction`, `conformance-fixtures`, `ts-sdk-stable-release`.
- Official container image publishing: `Dockerfile`, `.dockerignore`, and an `image-publish` job in the release workflow pushing `ghcr.io/itsthelore/rac` in lockstep with the PyPI release.
- Install-page documentation for the image (pull, tag/digest pinning, GitLab CI, Bitbucket Pipelines, Jenkins snippets).

# Roadmap / ADR Trace

Roadmap:
- `rac/roadmaps/agnostic-surfaces.md` (programme, new)
- `rac/roadmaps/future/oci-image.md` (implemented here)
- `rac/roadmaps/future/ci-report-formats.md`, `artifact-specs-extraction.md`, `conformance-fixtures.md`, `ts-sdk-stable-release.md` (scoped, not implemented)

Relevant ADRs:
- `rac/decisions/adr-063-non-python-clients-are-thin.md` (thin clients; the two native-port preconditions the programme funds)
- `rac/decisions/adr-092-repository-topology.md` (SDKs as `rac-sdk` subdirs; wrappers in `rac-ci`)
- `rac/decisions/adr-007-json-contract-stability.md`, `adr-054-sarif-validation-output.md`, `adr-076-calver.md`, `adr-086-air-gap-posture.md`, `adr-093-roadmap-execution-in-issues.md`, `adr-094-roadmaps-identified-by-codename.md`

# Scope

## Included
- Corpus record of the full council deliberation outcome (ranking, dissents, triggers) as a Proposed design.
- Programme + five scoped member items following the `deterministic-substrate.md` precedent (flat codenamed programme, members in `future/`, graduation via GitHub issues per ADR-093).
- Container image as packaging only: installs the release wheel from `dist/` on `python:3.12-slim`, `rac` entrypoint, OCI source/license/version labels; publish job runs after `pypi-publish` from the same `release-dists` artifact, smoke-tests `--version`, pushes the CalVer tag and `latest`, and writes the pushed digest to the run summary.

## Excluded
- No new language SDK — that is the recorded decision, not an omission; SDK work is trigger-gated (JVM on JetBrains plugin scheduling, Go on demand evidence).
- No per-platform CI wrapper logic (GitLab component, Bitbucket pipe, Jenkins step) — delegated to the `rac-ci` topology item, which consumes this image.
- No implementation of the other four member items (report formats, spec extraction, conformance fixtures, TS 1.0) — each graduates separately.
- No standalone binary or uvx distribution — recorded as an open alternative in `oci-image.md`.
- MCP depth and harness recipes — owned by the `deterministic-substrate` programme; related, deliberately not claimed.

# Product / Architecture Decisions

- The image is built from the release wheel, not from source or PyPI, so image and PyPI package are byte-identical for a CalVer tag and the publish has no PyPI-propagation race.
- `image-publish` needs `pypi-publish` so an image never exists for a version PyPI does not have; a failed image job after a PyPI success is recoverable by rerun.
- Entrypoint is `rac` per the roadmap item; the GitLab snippet documents the required `entrypoint: [""]` override for script jobs (Bitbucket and Jenkins override entrypoints themselves).
- Programme structure mirrors `deterministic-substrate.md` (ADR-094 codename, members in `future/`) rather than inventing a new series shape.

# User-Facing Contract

## CLI
No CLI changes. Distribution only: `docker run --rm -v "$PWD:/work" ghcr.io/itsthelore/rac:latest validate rac/`.

## Exit Codes
Unchanged; the container surfaces the CLI's own exit codes.

# Verification

## Ran
- `rac validate rac/` — 340 artifacts, 340 valid, 0 invalid.
- `rac relationships rac/ --validate` — 1749 checked, 0 issues.
- `rac review rac/` — no priority 1–2 findings.
- `python -m pytest` — 1730 passed, 1 skipped.
- Wheel-install path (what the Dockerfile `RUN` executes): built the wheel with `python -m build`, installed into a clean venv, `rac --version` and `rac validate` on a corpus artifact both pass.
- Workflow YAML parse-checked.

## Covered
- Corpus gates cover the seven new/edited artifacts (classification at 100% confidence, codename resolution, relationship integrity including the design/programme/item links).
- Not verified: the `docker build` itself — the development environment's network policy blocks container-registry pulls. The `image-publish` job's build + smoke-test step covers it on the GitHub runner; first real exercise is the next release.

# Review Path

1. `rac/designs/sdk-expansion-strategy.md` (the decision record everything hangs off)
2. `rac/roadmaps/agnostic-surfaces.md` (programme scoping and delegation boundaries)
3. The five `rac/roadmaps/future/` member items
4. `Dockerfile`, `.dockerignore`, `.github/workflows/python-publish.yml` (`image-publish` job)
5. `docs/quickstart.md` (install section)

# Notes For Reviewer

- After the first publish, `ghcr.io/itsthelore/rac` may need to be flipped to public in the org package settings (GHCR defaults to private).
- `sdk-expansion-strategy.md` carries Status: Proposed — merging this PR is the human ratification gate for that record.
- Open question deliberately left in the conformance item: whether the fixture suite lives in rac-core or rac-sdk (recommendation recorded: rac-core, beside the contract).

# Implementation Process

Implemented with AI assistance under the roadmap contract; final scope, review, and acceptance decisions were made by the maintainer.