### PR TITLE
feat(resolve): add path-to-decisions lookup over CLI and MCP [roadmap:decision-to-code-proximity]

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -96,7 +96,7 @@ jobs:
           - name: relationships
             paths: "tests/test_relationships.py tests/test_relationships_cmd.py tests/test_relationship_validation.py tests/test_relationship_graph.py tests/test_lifecycle_status.py tests/test_rename.py"
           - name: resolve
-            paths: "tests/test_resolve.py tests/test_find_decisions.py tests/test_explain.py"
+            paths: "tests/test_resolve.py tests/test_find_decisions.py tests/test_scope.py tests/test_explain.py"
           - name: eval
             paths: "tests/test_eval.py"
           - name: review

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1274,6 +1274,57 @@ rac find markdown rac/ --explain        # show the relevance-score breakdown
 
 ---
 
+## decisions-for
+
+List the **live decisions whose `## Applies To` scope governs a code path** —
+the reverse of the [code-scope declaration](relationships.md#code-scope): given a
+file or directory, which recorded decisions constrain an edit there. The answer
+is a pure function of the declared scopes and the query path (no code parsing, no
+index); an ungoverned or outside-repository path is a valid empty result, not an
+error. Only *live* (Accepted, non-retired) decisions govern.
+
+Matching is deterministic and platform-independent (paths normalise to POSIX
+repository-relative form): a **literal path/directory** entry covers the query
+when the query equals it or is nested beneath it; a **glob** covers it
+segment-aware (`*` within a segment, `**` across — `src/**/*.py` matches
+`src/a/b.py`); **component-name** entries never match a path. The query resolves
+against the repository root (the nearest `.rac/`).
+
+- **Input:** `rac decisions-for <path> [directory]` — the corpus directory
+  defaults to the current directory.
+- **Options:** `--json` · `--top-level` · `--recursive`
+- **Exit codes:** `0` lookup completed (matches or none) · `2` the corpus
+  directory is not a directory
+
+```bash
+rac decisions-for src/rac/mcp/server.py rac/
+rac decisions-for .github/workflows/tests.yml rac/ --json
+```
+
+```json
+{
+  "schema_version": "1",
+  "query": "src/rac/mcp/server.py",
+  "in_repository": true,
+  "decisions": [
+    {
+      "id": "RAC-KTQ63DRPK57V",
+      "title": "ADR-023: Clean-Break Internal Refactors",
+      "status": "Accepted",
+      "path": "rac/decisions/adr-023-clean-break-internal-refactors.md",
+      "matching_entry": "src/rac/"
+    }
+  ]
+}
+```
+
+The same lookup is available to agents over MCP as an additive optional `path`
+argument on the `find_decisions` tool (the five-tool surface is unchanged);
+`find_decisions` called with a `topic` is byte-identical to before.
+
+
+---
+
 ## migrate
 
 Bring existing artifacts onto canonical frontmatter identity. Every

--- a/docs/relationships.md
+++ b/docs/relationships.md
@@ -119,6 +119,11 @@ cannot name an in-repository scope and is reported not-found. Like a ticket, the
 edge is `"external": true`/`"resolved": false` in `rac export --graph` (with no
 provider), so a backend can surface a decision's declared code scope.
 
+To query the scope from the other direction — *which decisions govern this
+path?* — use [`rac decisions-for <path>`](cli.md#decisions-for), or the additive
+`path` argument on the `find_decisions` MCP tool. The lookup is where glob
+patterns are matched (segment-aware: `*` within a segment, `**` across).
+
 ## Viewing relationships
 
 ```bash

--- a/src/rac/cli.py
+++ b/src/rac/cli.py
@@ -165,6 +165,7 @@ from rac.services.resolve import (
 )
 from rac.services.review import DEFAULT_STALE_AFTER_DAYS, build_review
 from rac.services.revisions import NotAGitRepository, RevisionNotFound
+from rac.services.scope import decisions_for_path
 from rac.services.skill import SkillFileExists, install_skills
 from rac.services.stats import collect_stats
 from rac.services.validate import (
@@ -943,6 +944,30 @@ def cmd_find(args: argparse.Namespace) -> int:
     else:
         print(outputs.render_find_human(result, explain=args.explain))
     # An empty result is a valid outcome, not an error (a query always succeeds).
+    return EXIT_OK
+
+
+def cmd_decisions_for(args: argparse.Namespace) -> int:
+    """List the live decisions whose `## Applies To` scope governs a code path.
+
+    The read side of the code-scope vocabulary (decision-to-code-proximity
+    Initiative 2): a pure function of declared `## Applies To` references and the
+    query path (ADR-066), reading fresh per call (ADR-032). An ungoverned or
+    outside-repository path is a valid empty result, not an error (a query always
+    succeeds).
+    """
+    if not Path(args.directory).is_dir():
+        print(f"rac: not a directory: {args.directory}", file=sys.stderr)
+        raise SystemExit(EXIT_USAGE)
+    result = decisions_for_path(
+        args.directory,
+        args.path,
+        recursive=not args.top_level,
+    )
+    if args.json:
+        print(outputs.render_decisions_for_json(result))
+    else:
+        print(outputs.render_decisions_for_human(result))
     return EXIT_OK
 
 
@@ -2045,6 +2070,36 @@ def build_parser() -> argparse.ArgumentParser:
         help="Recurse into subdirectories (the default; accepted for clarity).",
     )
     p_find.set_defaults(func=cmd_find)
+
+    p_decisions_for = sub.add_parser(
+        "decisions-for",
+        help="List the decisions whose `## Applies To` scope governs a code path.",
+        parents=[version_parent],
+    )
+    p_decisions_for.add_argument(
+        "path",
+        help="Repository file or directory path (POSIX or native; repo-relative or absolute).",
+    )
+    p_decisions_for.add_argument(
+        "directory",
+        nargs="?",
+        default=".",
+        help="Corpus directory to scan recursively for *.md (default: current directory).",
+    )
+    p_decisions_for.add_argument(
+        "--json", action="store_true", help="Emit JSON instead of human-readable text."
+    )
+    p_decisions_for.add_argument(
+        "--top-level",
+        action="store_true",
+        help="Only the top-level files in the corpus directory (no recursion).",
+    )
+    p_decisions_for.add_argument(
+        "--recursive",
+        action="store_true",
+        help="Recurse into subdirectories (the default; accepted for clarity).",
+    )
+    p_decisions_for.set_defaults(func=cmd_decisions_for)
 
     p_eval = sub.add_parser(
         "eval",

--- a/src/rac/mcp/server.py
+++ b/src/rac/mcp/server.py
@@ -80,6 +80,7 @@ from rac.services.resolve import (
     resolve_in_index,
     search_index,
 )
+from rac.services.scope import decisions_for_path
 
 SERVER_NAME = "lore"
 
@@ -119,16 +120,20 @@ DESC_GET_RELATED = (
 )
 
 DESC_FIND_DECISIONS = (
-    "Find the team's already-settled decisions about a topic. Call this whenever "
-    "the user (or you) asks 'what did we decide about X', 'is X ruled out', 'did "
-    "we already decide this', 'what's our policy on X', or before proposing, "
-    "changing, or arguing for anything a prior decision might have settled — so "
-    "you respect recorded decisions instead of re-litigating them. Returns the "
-    "live (Accepted, non-retired) decisions ranked by relevance to the topic, "
-    "each with its identifier, title, path, category, and a snippet. It tells you "
-    "which decisions bind the topic; read them and judge for yourself — it does "
-    "not decide whether a change contradicts them. Use get_artifact to read a "
-    "decision's full text."
+    "Find the team's already-settled decisions about a topic — or the decisions "
+    "that govern a specific code path. Call this whenever the user (or you) asks "
+    "'what did we decide about X', 'is X ruled out', 'did we already decide this', "
+    "'what's our policy on X', or before proposing, changing, or arguing for "
+    "anything a prior decision might have settled — so you respect recorded "
+    "decisions instead of re-litigating them. Pass `topic` for a keyword query, or "
+    "pass `path` (a repository file or directory) to get the decisions whose "
+    "declared scope governs that code — the recorded decisions that constrain an "
+    "edit there. Returns the live (Accepted, non-retired) decisions, each with its "
+    "identifier, title, and path; a topic query ranks by relevance with category "
+    "and a snippet, a path query reports each decision's status and the matching "
+    "declared scope. It tells you which decisions bind; read them and judge for "
+    "yourself — it does not decide whether a change contradicts them. Use "
+    "get_artifact to read a decision's full text."
 )
 
 DESC_GET_SUMMARY = (
@@ -195,15 +200,19 @@ def _search_artifacts(root: str, query: str, artifact_type: str | None, budget: 
     return serialize(result.to_dict(), budget)
 
 
-def _find_decisions(root: str, topic: str, budget: int) -> str:
-    """Ranked live decisions binding ``topic`` (ADR-067, deterministic retrieval).
+def _find_decisions(root: str, topic: str, path: str | None, budget: int) -> str:
+    """Live decisions binding a ``topic`` — or governing a code ``path``.
 
-    Calls the same ``find_decisions`` service the CLI ``--decisions`` face uses
-    (one source of truth): structural search restricted to live decisions, no
-    semantic verdict. The payload is the search contract plus the live-filter
-    intent in ``type``/``filter`` so a reader knows the result is the *settled*
-    decisions, not every match.
+    Two modes over one tool (additive, ADR-007). With ``path`` set, this is the
+    path→decisions lookup (``decisions_for_path``, the same core the ``rac
+    decisions-for`` CLI uses, ADR-031): the live decisions whose declared
+    ``## Applies To`` scope covers the path, each with its status and matching
+    entry. Without ``path`` it is the existing topic query (``find_decisions``):
+    structural search restricted to live decisions, byte-identical to before.
+    Neither mode returns a verdict — the agent reads and judges (ADR-034/067).
     """
+    if path:
+        return serialize(decisions_for_path(root, path, recursive=True).to_dict(), budget)
     result = find_decisions(root, topic, recursive=True)
     payload = result.to_dict()
     # Make the live-decision intent explicit on the wire (additive, ADR-007): the
@@ -337,10 +346,11 @@ def build_server(
         )
 
     @server.tool(name="find_decisions", description=DESC_FIND_DECISIONS)
-    def find_decisions_tool(topic: str) -> str:
-        return observed(
-            "find_decisions", {"topic": topic}, lambda: _find_decisions(root, topic, budget)
-        )
+    def find_decisions_tool(topic: str = "", path: str | None = None) -> str:
+        # ``path`` only rides the audit args when supplied, so a topic query's
+        # recorded shape is byte-identical to before (additive, ADR-007).
+        args = {"topic": topic} if path is None else {"topic": topic, "path": path}
+        return observed("find_decisions", args, lambda: _find_decisions(root, topic, path, budget))
 
     @server.tool(name="get_related", description=DESC_GET_RELATED)
     def get_related(id: str, depth: int = 1) -> str:

--- a/src/rac/output/__init__.py
+++ b/src/rac/output/__init__.py
@@ -9,6 +9,7 @@ without depending on the internal split between human/json/templates.
 from .github import render_watchkeeper_github, watchkeeper_annotations
 from .human import (
     render_agent_rules_human,
+    render_decisions_for_human,
     render_diff_human,
     render_dir_inspect_human,
     render_find_human,
@@ -45,6 +46,7 @@ from .human import (
 )
 from .json import (
     render_agent_rules_json,
+    render_decisions_for_json,
     render_diff_json,
     render_dir_inspect_json,
     render_documents_jsonl,
@@ -96,7 +98,9 @@ __all__ = [
     "render_agent_rules_json",
     "render_diff_human",
     "render_diff_json",
+    "render_decisions_for_human",
     "render_find_human",
+    "render_decisions_for_json",
     "render_find_json",
     "render_gate_human",
     "render_gate_json",

--- a/src/rac/output/human.py
+++ b/src/rac/output/human.py
@@ -75,6 +75,7 @@ from rac.services.review import (
     PRIORITY_UNKNOWN_ARTIFACT,
     ReviewReport,
 )
+from rac.services.scope import ScopeLookupResult
 from rac.services.skill import SkillInstallation
 from rac.services.stats import PortfolioStats
 from rac.services.validate import STATUS_INVALID, DirectoryValidation, StdinCorpusValidation
@@ -1000,6 +1001,29 @@ def render_resolve_human(result: ResolutionResult) -> str:
         f"Title: {artifact.title or '—'}\n"
         f"Path: {artifact.path}"
     )
+
+
+def render_decisions_for_human(result: ScopeLookupResult) -> str:
+    """Human `rac decisions-for` output: the decisions governing a path.
+
+    Aligned rows of ``id  status  title`` with the matching declared ``## Applies
+    To`` entry under each, or a valid empty result. An outside-repository query is
+    reported as such (a valid empty answer, not an error).
+    """
+    if not result.decisions:
+        if not result.in_repository:
+            return f"{result.query!r} is outside the repository — no governing decisions."
+        return f"No decisions declare scope over {result.query!r}."
+    id_w = max(len(d.id) for d in result.decisions)
+    status_w = max(len(d.status or "—") for d in result.decisions)
+    indent = f"{' ' * id_w}  {' ' * status_w}  "
+    lines: list[str] = []
+    for d in result.decisions:
+        lines.append(f"{d.id:<{id_w}}  {(d.status or '—'):<{status_w}}  {d.title or '—'}")
+        lines.append(f"{indent}↳ applies to: {d.matching_entry}")
+    lines.append("")
+    lines.append(f"{len(result.decisions)} decision(s) govern {result.query!r}.")
+    return "\n".join(lines)
 
 
 def render_find_human(result: SearchResult, *, explain: bool = False) -> str:

--- a/src/rac/output/json.py
+++ b/src/rac/output/json.py
@@ -32,6 +32,7 @@ from rac.services.relationships import RelationshipReport, RelationshipValidatio
 from rac.services.rename import RenamePlan, RenameResult
 from rac.services.resolve import ResolutionResult, SearchResult
 from rac.services.review import ReviewReport
+from rac.services.scope import ScopeLookupResult
 from rac.services.skill import SkillInstallation
 from rac.services.stats import PortfolioStats
 from rac.services.validate import DirectoryValidation, StdinCorpusValidation
@@ -378,6 +379,15 @@ def render_quickstart_json(result: QuickstartResult) -> str:
 
 def render_resolve_json(result: ResolutionResult) -> str:
     """JSON `rac resolve` output (stable contract, ADR-007)."""
+    return json.dumps(result.to_dict(), indent=2)
+
+
+def render_decisions_for_json(result: ScopeLookupResult) -> str:
+    """JSON `rac decisions-for` output (stable contract, ADR-007).
+
+    The same ``ScopeLookupResult`` the MCP ``find_decisions`` path argument
+    serializes, so the two faces stay payload-consistent (ADR-031).
+    """
     return json.dumps(result.to_dict(), indent=2)
 
 

--- a/src/rac/services/scope.py
+++ b/src/rac/services/scope.py
@@ -190,6 +190,8 @@ def _governing(entry: CorpusEntry, query: str) -> GoverningDecision | None:
     if entry.artifact_type != _DECISION_TYPE or not is_live_decision(entry.product):
         return None
     spec = spec_for(entry.artifact_type)
+    if spec is None:  # the decision spec is always registered; narrow for the type checker
+        return None
     relationships = extract_relationships_full(entry.product, spec)
     for section in SCOPE_SECTIONS:
         for declared in relationships.get(section.replace(" ", "_"), []):

--- a/src/rac/services/scope.py
+++ b/src/rac/services/scope.py
@@ -1,0 +1,226 @@
+"""Path-to-decisions lookup — the decisions governing a code path.
+
+Initiative 2 of the ``decision-to-code-proximity`` roadmap (``rac-path-decisions-lookup``).
+Given a file or directory path, return every *live* decision whose declared
+``## Applies To`` scope (Initiative 1) covers it. This is the read side of the
+code-scope vocabulary: Initiative 1 authors and validates the scope; this module
+queries it.
+
+The answer is a pure function of the declared references and the query path
+(ADR-066): no code parsing, no similarity, no persisted index (ADR-002/080). It
+reports which decisions bind and their status — never a compliance judgement
+(ADR-034). One shared core (ADR-031) serves both the ``rac decisions-for`` CLI
+and the additive ``path`` argument on the ``find_decisions`` MCP tool, so the two
+faces can never diverge.
+
+Only *live* decisions govern: a superseded or deprecated decision no longer binds
+(the same liveness predicate ``find_decisions`` uses, one source of truth). Glob
+matching is path-segment-aware (``*`` within a segment, ``**`` across segments)
+and platform-independent — declared entries and the query normalise to POSIX
+repo-relative form (ADR-002), so the same corpus yields identical results on any
+OS.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+
+from rac.core.artifacts import spec_for
+from rac.core.corpus import CorpusEntry, walk_corpus
+from rac.core.identity import artifact_identifier
+from rac.services.agent_rules import artifact_status, is_live_decision
+from rac.services.relationships import (
+    SCOPE_SECTIONS,
+    _classify_scope_entry,
+    _normalized_scope_path,
+    _repository_root,
+    extract_relationships_full,
+)
+
+_DECISION_TYPE = "decision"
+
+
+@dataclass(frozen=True)
+class GoverningDecision:
+    """One live decision whose ``## Applies To`` scope covers the query path."""
+
+    id: str
+    title: str
+    status: str
+    path: str
+    matching_entry: str  # the declared ## Applies To entry that covered the query
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "title": self.title,
+            "status": self.status,
+            "path": self.path,
+            "matching_entry": self.matching_entry,
+        }
+
+
+@dataclass(frozen=True)
+class ScopeLookupResult:
+    """The decisions governing a queried path (REQ-001/005).
+
+    ``query`` is the POSIX repo-relative form of the queried path when it lies
+    inside the repository, else the raw input. ``in_repository`` is False for an
+    absolute or escaping path outside the repository root — a valid empty answer,
+    never an error (REQ-004). ``decisions`` is deterministically ordered.
+    """
+
+    query: str
+    in_repository: bool
+    decisions: list[GoverningDecision]
+
+    def to_dict(self) -> dict:
+        return {
+            "schema_version": "1",
+            "query": self.query,
+            "in_repository": self.in_repository,
+            "decisions": [d.to_dict() for d in self.decisions],
+        }
+
+
+def _glob_to_regex(pattern: str) -> re.Pattern[str]:
+    """Compile a POSIX path glob into an anchored, segment-aware regex.
+
+    ``*`` and ``?`` match within a single path segment (never ``/``); ``**``
+    matches across segments. ``**/`` matches zero or more whole segments, so
+    ``src/**/*.py`` matches both ``src/a.py`` and ``src/a/b.py``. Character
+    classes (``[...]``) are preserved. Deterministic and platform-independent —
+    the whole path must match (``\\Z``).
+    """
+    i, n = 0, len(pattern)
+    out: list[str] = []
+    while i < n:
+        c = pattern[i]
+        if c == "*":
+            if pattern[i : i + 2] == "**":
+                i += 2
+                if pattern[i : i + 1] == "/":
+                    i += 1
+                    out.append("(?:[^/]+/)*")  # zero or more whole segments
+                else:
+                    out.append(".*")  # trailing ** — cross any remaining segments
+                continue
+            out.append("[^/]*")
+        elif c == "?":
+            out.append("[^/]")
+        elif c == "[":
+            j = i + 1
+            if j < n and pattern[j] in "!^":
+                j += 1
+            if j < n and pattern[j] == "]":
+                j += 1
+            while j < n and pattern[j] != "]":
+                j += 1
+            if j >= n:
+                out.append(re.escape(c))  # unterminated class → literal '['
+            else:
+                inner = pattern[i + 1 : j]
+                if inner and inner[0] in "!^":
+                    inner = "^" + inner[1:]
+                out.append("[" + inner + "]")
+                i = j + 1
+                continue
+        else:
+            out.append(re.escape(c))
+        i += 1
+    return re.compile("".join(out) + r"\Z")
+
+
+def _entry_covers(entry: str, query: str) -> bool:
+    """True when a declared ``## Applies To`` entry covers the query path.
+
+    A literal directory or file entry covers the query when the query equals it
+    or is nested beneath it; a glob entry covers the query when the pattern
+    matches it segment-aware. Component-name entries never match a path (no
+    registry this cycle). ``entry`` and ``query`` are POSIX repo-relative.
+    """
+    kind = _classify_scope_entry(entry)
+    if kind == "component":
+        return False
+    if kind == "glob":
+        return _glob_to_regex(entry.strip()).match(query) is not None
+    normalized = _normalized_scope_path(entry)
+    if normalized is None:
+        return False  # absolute/escaping declared entry cannot name an in-repo scope
+    return query == normalized or query.startswith(normalized + "/")
+
+
+def _normalize_query(path: str, root: Path) -> str | None:
+    """The query path as a POSIX repo-relative string, or None if outside the repo.
+
+    An absolute path is made relative to ``root``; a relative path is treated as
+    already repo-relative. Either way, ``.`` segments collapse and a path that
+    escapes the root (a leading ``..``, or an absolute path outside it) returns
+    None — an outside-repository query is a valid empty answer, not an error
+    (REQ-004). Matching is pure string work: the query need not exist on disk.
+    """
+    text = path.strip()
+    if not text:
+        return None
+    candidate = PurePosixPath(text)
+    if candidate.is_absolute():
+        try:
+            candidate = candidate.relative_to(PurePosixPath(root.as_posix()))
+        except ValueError:
+            return None
+    parts: list[str] = []
+    for part in candidate.parts:
+        if part in (".", "/"):
+            continue
+        if part == "..":
+            return None
+        parts.append(part)
+    return "/".join(parts) if parts else None
+
+
+def _governing(entry: CorpusEntry, query: str) -> GoverningDecision | None:
+    """The :class:`GoverningDecision` for ``entry`` if its scope covers ``query``.
+
+    Returns None when the entry is not a live decision, declares no ``## Applies
+    To`` scope, or none of its entries cover the query. The reported
+    ``matching_entry`` is the first covering entry in declared order (deterministic).
+    """
+    if entry.artifact_type != _DECISION_TYPE or not is_live_decision(entry.product):
+        return None
+    spec = spec_for(entry.artifact_type)
+    relationships = extract_relationships_full(entry.product, spec)
+    for section in SCOPE_SECTIONS:
+        for declared in relationships.get(section.replace(" ", "_"), []):
+            if _entry_covers(declared, query):
+                return GoverningDecision(
+                    id=artifact_identifier(entry.product, spec, str(entry.path)),
+                    title=entry.product.title or "",
+                    status=artifact_status(entry.product),
+                    path=str(entry.path),
+                    matching_entry=declared,
+                )
+    return None
+
+
+def decisions_for_path(directory: str, path: str, recursive: bool = True) -> ScopeLookupResult:
+    """Live decisions whose ``## Applies To`` scope governs ``path`` (REQ-001).
+
+    ``directory`` is the corpus to search; ``path`` is the queried code path,
+    resolved against the repository root (the nearest ``.rac/``, ADR-018). Reads
+    fresh per call (ADR-032); results are sorted by decision id so the answer is
+    byte-identical across runs and platforms (ADR-002). An ungoverned or
+    outside-repository path yields an empty ``decisions`` list, never an error.
+    """
+    root = _repository_root(directory)
+    query = _normalize_query(path, root)
+    if query is None:
+        return ScopeLookupResult(query=path.strip(), in_repository=False, decisions=[])
+    matches = [
+        governing
+        for entry in walk_corpus(directory, recursive=recursive)
+        if (governing := _governing(entry, query)) is not None
+    ]
+    matches.sort(key=lambda d: (d.id.casefold(), d.path))
+    return ScopeLookupResult(query=query, in_repository=True, decisions=matches)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -69,6 +69,11 @@ def test_descriptions_name_the_trigger_moment():
     assert "what did we decide about X" in mcp_server.DESC_FIND_DECISIONS
     assert "is X ruled out" in mcp_server.DESC_FIND_DECISIONS
     assert "judge for yourself" in mcp_server.DESC_FIND_DECISIONS
+    # The additive path→decisions mode (decision-to-code-proximity Initiative 2):
+    # the description names the `path` argument and its "governs this code" intent
+    # so an agent editing a file knows to reach for it (deliberate ADR-030 revision).
+    assert "path" in mcp_server.DESC_FIND_DECISIONS
+    assert "govern" in mcp_server.DESC_FIND_DECISIONS
 
 
 def test_cli_registers_the_mcp_subcommand():

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -1,0 +1,186 @@
+"""Path-to-decisions lookup — `rac decisions-for` and the `find_decisions` path arg.
+
+Initiative 2 of decision-to-code-proximity (`rac-path-decisions-lookup`): given a
+code path, return the live decisions whose declared `## Applies To` scope covers
+it. The answer is a pure function of the declared references and the query path
+(ADR-066) — no code parsing, no index — deterministic and platform-independent
+(POSIX-normalised, ADR-002). Only live decisions govern; a superseded one no
+longer binds. An ungoverned or outside-repository path is a valid empty result
+(exit 0), never an error (REQ-004). The CLI and the MCP `path` argument are one
+shared core (ADR-031), so they never diverge.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from rac.cli import main
+from rac.mcp.server import build_server
+from rac.services.scope import decisions_for_path
+
+# --- fixture corpus ----------------------------------------------------------
+
+
+def _decision(title: str, applies_to: list[str], status: str = "Accepted") -> str:
+    scope = "".join(f"- {e}\n" for e in applies_to)
+    return (
+        f"# {title}\n\n## Context\n\nc\n\n## Decision\n\nd\n\n## Consequences\n\nq\n"
+        f"\n## Status\n\n{status}\n\n## Applies To\n\n{scope}"
+    )
+
+
+@pytest.fixture
+def corpus(tmp_path):
+    """A corpus with a directory, glob, file, retired, and component scope."""
+    d = tmp_path / "decisions"
+    d.mkdir()
+    (d / "adr-a.md").write_text(_decision("A dir scope", ["src/auth/"]), encoding="utf-8")
+    (d / "adr-b.md").write_text(_decision("B glob scope", ["src/**/*.py"]), encoding="utf-8")
+    (d / "adr-c.md").write_text(_decision("C file scope", ["docs/config.md"]), encoding="utf-8")
+    (d / "adr-d.md").write_text(
+        _decision("D retired", ["src/auth/"], status="Superseded"), encoding="utf-8"
+    )
+    (d / "adr-e.md").write_text(_decision("E component", ["PaymentService"]), encoding="utf-8")
+    return str(tmp_path)
+
+
+def _ids(result):
+    return [d.id for d in result.decisions]
+
+
+# --- core service ------------------------------------------------------------
+
+
+def test_covering_dir_and_glob_both_bind_a_nested_file(corpus):
+    result = decisions_for_path(corpus, "src/auth/login.py")
+    # Both the directory scope (src/auth/) and the glob (src/**/*.py) cover it;
+    # the retired decision D is excluded even though its scope would match.
+    entries = {d.title.split()[0]: d.matching_entry for d in result.decisions}
+    assert entries == {"A": "src/auth/", "B": "src/**/*.py"}
+    assert result.in_repository is True
+
+
+def test_retired_decision_never_governs(corpus):
+    # D declares src/auth/ but is Superseded, so it does not bind (live-only).
+    titles = {d.title.split()[0] for d in decisions_for_path(corpus, "src/auth/x.py").decisions}
+    assert "D" not in titles
+
+
+def test_literal_file_scope_matches_exactly(corpus):
+    result = decisions_for_path(corpus, "docs/config.md")
+    assert [d.title.split()[0] for d in result.decisions] == ["C"]
+    assert result.decisions[0].matching_entry == "docs/config.md"
+
+
+def test_directory_query_does_not_pull_in_a_file_glob(corpus):
+    # Querying the directory itself matches the dir scope but not `src/**/*.py`
+    # (which requires a .py file), so segment-aware globbing holds.
+    titles = {d.title.split()[0] for d in decisions_for_path(corpus, "src/auth/").decisions}
+    assert titles == {"A"}
+
+
+def test_component_name_scope_never_matches_a_path(corpus):
+    # E declares a component label; no path query resolves it (no registry).
+    assert all(
+        d.title.split()[0] != "E"
+        for d in decisions_for_path(corpus, "src/pay/service.py").decisions
+    )
+
+
+def test_ungoverned_path_is_empty_but_in_repository(corpus):
+    result = decisions_for_path(corpus, "README.md")
+    assert result.decisions == []
+    assert result.in_repository is True
+
+
+def test_outside_repository_path_is_empty_and_flagged(corpus):
+    for outside in ("/etc/passwd", "../secrets/key"):
+        result = decisions_for_path(corpus, outside)
+        assert result.decisions == []
+        assert result.in_repository is False
+
+
+def test_glob_star_does_not_cross_a_segment(tmp_path):
+    (tmp_path / "d").mkdir()
+    (tmp_path / "d" / "adr.md").write_text(_decision("Flat", ["src/*.py"]), encoding="utf-8")
+    assert _ids(decisions_for_path(str(tmp_path), "src/top.py"))  # direct child matches
+    assert not _ids(decisions_for_path(str(tmp_path), "src/nested/deep.py"))  # `*` stops at `/`
+
+
+def test_result_is_sorted_and_byte_deterministic(corpus):
+    a = decisions_for_path(corpus, "src/auth/login.py").to_dict()
+    b = decisions_for_path(corpus, "src/auth/login.py").to_dict()
+    assert a == b
+    ids = [d["id"] for d in a["decisions"]]
+    assert ids == sorted(ids, key=str.casefold)
+
+
+# --- CLI: rac decisions-for --------------------------------------------------
+
+
+def test_cli_governed_path_lists_decisions_and_exits_zero(corpus, capsys):
+    code = main(["decisions-for", "src/auth/login.py", corpus])
+    out = capsys.readouterr().out
+    assert code == 0
+    assert "applies to: src/auth/" in out
+    assert "2 decision(s) govern" in out
+
+
+def test_cli_json_shape_is_stable(corpus, capsys):
+    code = main(["decisions-for", "docs/config.md", corpus, "--json"])
+    assert code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert list(payload) == ["schema_version", "query", "in_repository", "decisions"]
+    assert set(payload["decisions"][0]) == {"id", "title", "status", "path", "matching_entry"}
+
+
+def test_cli_ungoverned_and_outside_exit_zero(corpus, capsys):
+    assert main(["decisions-for", "README.md", corpus]) == 0
+    assert "No decisions declare scope" in capsys.readouterr().out
+    assert main(["decisions-for", "/etc/passwd", corpus]) == 0
+    assert "outside the repository" in capsys.readouterr().out
+
+
+def test_cli_bad_directory_is_usage_error(corpus):
+    with pytest.raises(SystemExit) as exc:
+        main(["decisions-for", "src/auth/x.py", str(corpus) + "/nope"])
+    assert exc.value.code == 2
+
+
+# --- MCP: additive find_decisions path argument ------------------------------
+
+
+def _call(root: str, args: dict) -> dict:
+    server = build_server(root)
+    contents, _structured = asyncio.run(server.call_tool("find_decisions", args))
+    return json.loads(contents[0].text)
+
+
+def test_mcp_path_argument_returns_governing_decisions(corpus):
+    payload = _call(corpus, {"path": "src/auth/login.py"})
+    assert list(payload) == ["schema_version", "query", "in_repository", "decisions"]
+    assert {d["matching_entry"] for d in payload["decisions"]} == {"src/auth/", "src/**/*.py"}
+
+
+def test_mcp_path_only_needs_no_topic(corpus):
+    # The path mode requires no topic — the additive argument stands alone.
+    payload = _call(corpus, {"path": "docs/config.md"})
+    assert [d["title"].split()[0] for d in payload["decisions"]] == ["C"]
+
+
+def test_mcp_topic_mode_is_unchanged_by_the_addition(corpus):
+    # Without a path the tool is the existing live-decision topic query, keyed by
+    # the same contract plus the live-filter marker (byte-identical, ADR-007).
+    payload = _call(corpus, {"topic": "dir scope"})
+    assert payload["filter"] == "live-decisions"
+    assert "matches" in payload
+
+
+def test_mcp_cli_and_tool_agree(corpus, capsys):
+    main(["decisions-for", "src/auth/login.py", corpus, "--json"])
+    cli_payload = json.loads(capsys.readouterr().out)
+    mcp_payload = _call(corpus, {"path": "src/auth/login.py"})
+    assert cli_payload == mcp_payload


### PR DESCRIPTION
# Summary

Implements Initiative 2 of the `decision-to-code-proximity` roadmap (epic #273, sub-issue #275), the read side of `rac-path-decisions-lookup`. Initiative 1 (#274, merged) made a decision's code scope declarable and validated; this makes it queryable: given a code path, return the live decisions whose `## Applies To` scope governs it, so an agent editing `src/auth/` is grounded in the decisions that constrain it without searching.

Adds:
- A shared core service `decisions_for_path` (ADR-031) behind both faces.
- A read-only `rac decisions-for PATH` CLI subcommand (human + `--json`).
- An additive optional `path` argument on the existing `find_decisions` MCP tool — the five-tool surface holds.
- Boundary + adjacent tests, the CI battery registration, and CLI/relationships docs.

# Roadmap / ADR Trace

Roadmap:
- `rac/roadmaps/decision-to-code-proximity.md` (Initiative 2)

Requirement:
- `rac/requirements/rac-path-decisions-lookup.md`

Relevant ADRs:
- `adr-005` — CLI-first (a new read-only subcommand)
- `adr-007` — additive: `find_decisions` without a path is byte-identical; no existing field changes
- `adr-030` — the pinned Guide tool surface: an optional argument holds the five-tool surface; description revised deliberately, no new tool
- `adr-031` — one shared core serves both faces (payload-consistent)
- `adr-032` — stateless, reads fresh per call
- `adr-033` — MCP payload respects the response budget
- `adr-034` — reports which decisions bind, never a verdict
- `adr-066` — pure function of declared references and the file tree; no parsing, no index
- `adr-002` / `adr-080` — deterministic, offline, no persisted index

# Scope

## Included
- `decisions_for_path(directory, path)` returning live decisions with `id`, `title`, `status`, `path`, and the matching declared `## Applies To` entry, sorted by decision id.
- `rac decisions-for PATH [directory]` — exit `0` even when empty; `2` when the corpus directory is not a directory.
- MCP: `find_decisions(topic="", path=None)` — with `path`, the scope lookup; without, today's topic query unchanged. `path` rides the audit args only when supplied, so a topic call's recorded shape is byte-identical.
- Matching (deterministic, POSIX-normalised): literal path/directory containment; path-segment-aware glob (`*` within a segment, `**` across); component-name entries excluded; absolute/escaping/outside-repo query → valid empty result.
- Only live (Accepted, non-retired) decisions govern — the same liveness predicate `find_decisions` uses (one source of truth).

## Excluded
- **Glob existence-checking** at declaration — recorded, matched here; still deferred (Initiative 1's documented later, advisory-first option).
- **Non-decision artifact types declaring code scope** — a later phase.
- **Explorer surfacing and the freshness drift-gate join** — #276 (this ships the reference both consume).
- **Component-id registry / resolution** — component names stay recorded labels; excluded from path matching this cycle.
- No change to `find_decisions`' topic-search behaviour or ranking.

# Product / Architecture Decisions

- **New CLI subcommand, not a `find` flag.** `rac find` is topic search; `rac decisions-for` is a distinct path→decisions query with its own result shape (`id`/`title`/`status`/`path`/`matching_entry`), so the two stay conceptually clean.
- **`topic` made optional on the MCP tool** so a path lookup needs no topic. This relaxes a required argument to optional (existing callers passing `topic` are unaffected) rather than changing any field — additive-compatible; the five-tool surface and every existing payload are unchanged.
- **ADR-030 handled as an additive revision, no new ADR.** Adding an optional argument is within ADR-030's anticipated additive latitude (no tool added, no resource/prompt); the pinned `find_decisions` description is revised deliberately with the battery updated in the same change. Note: the `guide-tool-surface` design artifact is already stale (says "four tools", predates ADR-067's fifth) — left untouched here as separate cleanup.
- **Path-segment-aware globs** (gitignore/pathlib semantics) over flat `fnmatch`, so `src/**/*.py` matches `src/a/b.py` but `src/*.py` does not — the meaning engineers expect from a path glob. Implemented as a deterministic, platform-independent translation (no reliance on 3.13-only `PurePath.full_match`).
- **Live-only** results: a superseded decision no longer governs. `status` is still reported (honest, forward-compatible).

# User-Facing Contract

## CLI
```bash
rac decisions-for src/rac/mcp/server.py rac/
rac decisions-for .github/workflows/tests.yml rac/ --json
```
Human output lists `id  status  title` with the matching `↳ applies to: ENTRY` under each; an ungoverned path prints `No decisions declare scope over ...`, an outside-repository path prints `... is outside the repository`.

## MCP
`find_decisions` gains an optional `path`. With it, the tool returns the scope-lookup payload; without it, the topic query is byte-identical to before (same keys plus the `live-decisions` filter marker). The pinned description names the new `path` mode while keeping its `topic` triggers.

## JSON Output
```json
{"schema_version": "1", "query": "src/rac/cli.py", "in_repository": true,
 "decisions": [{"id": "...", "title": "...", "status": "Accepted",
                "path": "...", "matching_entry": "src/rac/"}]}
```

## Exit Codes (CLI)
- `0`: lookup completed (governing decisions, or a valid empty result).
- `2`: the corpus directory argument is not a directory.

# Verification

## Ran
- `rac validate rac/` → `PASS — 372 valid, 0 invalid`; `rac relationships rac/ --validate` → exit `0`; `rac review rac/` → no priority 1–2 findings.
- `pytest tests/test_scope.py tests/test_mcp_server.py tests/test_mcp_tools.py tests/test_mcp_audit.py tests/test_find_decisions.py` → all pass. Full non-TUI suite: 1613 passed, 1 skipped (the two excluded failures — `test_explorer_app`, `test_hook` — reproduce on the pristine tree: an incompatible `textual` and `rac` not on `PATH`).
- `ruff check` and `ruff format --check` clean.

## Covered
- A covering directory scope and a glob both bind a nested file; a retired decision never governs; a literal file matches exactly; a directory query does not pull in a file glob; `*` does not cross a path segment; component labels never match; ungoverned and outside-repository paths return the empty shape (exit 0).
- The MCP `path` argument and `rac decisions-for` return byte-identical payloads; the topic mode is unchanged; the audit args for a topic call are byte-identical.
- The `find_decisions` description battery is extended for the path trigger; `test_scope.py` is registered in the resolve CI battery (ADR-027).

# Review Path

1. `src/rac/services/scope.py` — the core: glob translation, entry coverage, query normalisation, and `decisions_for_path`.
2. `src/rac/cli.py` — the `decisions-for` subcommand and handler.
3. `src/rac/mcp/server.py` — the additive `path` argument, the two-mode `_find_decisions`, and the revised description.
4. `src/rac/output/{human,json}.py` — the renderers.
5. `tests/test_scope.py`, `tests/test_mcp_server.py`, `.github/workflows/tests.yml` — coverage and battery registration.
6. `docs/cli.md`, `docs/relationships.md` — usage.

# Notes For Reviewer
- The `guide-tool-surface` design artifact (and the "four read-only tools" line in `docs/cli.md`'s `mcp` section) predate ADR-067's fifth tool — a pre-existing staleness left as separate cleanup, out of this initiative's scope.
- Post-merge bookkeeping intentionally not done here (needs the merge to land): tick #275 on epic #273.
- `CHANGELOG.md` untouched — organised strictly by shipped release with no "Unreleased" section (CalVer, ADR-076).

# Implementation Process

Implemented with AI assistance under the roadmap contract; the implementation contract (the CLI name, path-segment-aware glob semantics, and the additive ADR-030 handling) was ratified, and final scope, review, and acceptance decisions were made by the maintainer.