### PR TITLE
feat(explorer): surface decisions governing a code path [roadmap:decision-to-code-proximity]

### DIFF
--- a/rac/designs/code-scope-consumption.md
+++ b/rac/designs/code-scope-consumption.md
@@ -1,0 +1,142 @@
+---
+schema_version: 1
+id: RAC-KWMHNQTQ17AK
+type: design
+---
+# Code-Scope Consumption Seam
+
+## Status
+
+Accepted
+
+## Context
+
+The `decision-to-code-proximity` roadmap authors code scope once — a decision's
+`## Applies To` section (Initiative 1) — and reads it everywhere. Initiative 2
+shipped the single deterministic reader, `decisions_for_path` in
+`src/rac/services/scope.py`: given a repository path, it returns the live
+decisions whose declared scope covers it, a pure function of the declared
+references and the file tree (ADR-066).
+
+Initiative 3 (this design) records how that one reader is consumed, so the
+"authored once, read everywhere" property is a documented architectural
+invariant rather than an accident. It exists now because a second and a third
+consumer are arriving — the Explorer's "decisions for this area" surface (this
+batch) and `freshness-and-drift-detection` phase-2 code-scope drift (a later
+phase, #279) — and each must resolve the *same* declared entries with no adapter
+layer and no parallel vocabulary. Without a recorded seam, a consumer could
+re-derive scope matching and the vocabulary would silently fork.
+
+## User Need
+
+The consumers are code, not people; the "user" is a future contributor wiring a
+new consumer of code scope. They need one obvious, stable entry point so they
+join on the declared `## Applies To` entries directly — not a re-implementation
+of glob or path-containment matching, and not a second scope section invented for
+their surface. The need this records: any consumer of "which decisions govern
+this path" calls `decisions_for_path` and maps its result to its own display or
+finding shape, nothing more.
+
+## Design
+
+`decisions_for_path(directory, path, recursive=True) -> ScopeLookupResult` is the
+sole seam. Every consumer calls it and adapts only *presentation*:
+
+- **CLI** (`rac decisions-for`, Initiative 2) — renders `ScopeLookupResult` as
+  human or `--json`.
+- **MCP** (`find_decisions` `path` argument, Initiative 2) — serializes the same
+  result within the response budget (ADR-033).
+- **Explorer** (`/decisions-for <path>`, this batch) — `ExplorerAdapter.governing_decisions`
+  calls the seam and maps each `GoverningDecision` to an artifact row by path,
+  reusing the existing results surface. No new view, no code-path browser.
+- **Freshness phase-2 code-scope drift** (later phase, #279) — the recorded
+  future consumer: it extends the advisory suspect finding
+  (`rac-drift-advisory-finding` REQ-007) with governed-code drift by reading the
+  same seam. Nothing here builds it; this design guarantees the seam stays
+  consumable for it — additively, without renaming the stable finding code.
+
+The invariant: mapping a `ScopeLookupResult` to a consumer's own row or finding
+shape is *presentation* and is allowed; re-deriving scope matching, or declaring
+a second scope vocabulary, is not. The matching semantics (literal
+path/directory containment, segment-aware glob, component-name exclusion,
+POSIX-normalisation) live once, in the seam.
+
+## Constraints
+
+- One reader (ADR-031): all consumers resolve the same declared entries through
+  `decisions_for_path`; no consumer re-implements matching.
+- One vocabulary: `## Applies To` (Initiative 1) is the only code-scope
+  declaration; no consumer introduces a parallel section.
+- Deterministic and offline (ADR-002, ADR-066): the seam is a pure function of
+  declared references and the file tree — no code parsing, no index, no
+  embeddings — so every consumer's answer is byte-identical across runs.
+- Reported facts, never verdicts (ADR-034): consumers surface which decisions
+  bind and their status; none layer a compliance judgement.
+- Additive (ADR-007): a new consumer is new wiring around the existing seam,
+  never a change to it.
+
+## Rationale
+
+Recording the seam is what makes "authored once, read everywhere" enforceable.
+The alternative — each surface owning its own path→decisions logic — is exactly
+the vocabulary fork the roadmap's constraint pattern forbids: two consumers would
+drift on glob semantics or scope precedence and the corpus would answer the same
+question two ways. A single core reader keeps the CLI, MCP, Explorer, and the
+future drift gate consistent by construction, and keeps the matching semantics
+tested in one place (`tests/test_scope.py`).
+
+## Alternatives
+
+- **A shared "scope adapter" layer between the core and each consumer.** Rejected:
+  it is the adapter the acceptance proof explicitly forbids ("no adapter layer") —
+  an extra indirection that would itself become a place for semantics to fork.
+- **Let each consumer read `## Applies To` and match paths itself.** Rejected: it
+  forks the vocabulary and the glob/containment semantics, the precise failure the
+  initiative exists to prevent.
+- **Precompute a path→decisions index at load time.** Rejected: a persisted index
+  (ADR-080) the roadmap rules out; the seam resolves at read time, fresh per call
+  (ADR-032).
+
+## Accessibility
+
+Not a presentation surface of its own. Each consumer owns its own accessibility:
+the CLI and MCP emit plain text and JSON; the Explorer renders governing
+decisions through its existing results surface, inheriting its keyboard
+navigation and theme. The seam imposes no new interaction affordance to make
+accessible.
+
+## Style Guidance
+
+Consumers name the capability consistently so it reads as one feature across
+surfaces: the CLI subcommand `rac decisions-for` and the Explorer command
+`/decisions-for` share a name; the MCP surface exposes it as the `path` argument
+on `find_decisions`. A new consumer should follow this naming rather than coin a
+synonym.
+
+## Open Questions
+
+- Whether component-name scope entries ever gain registry resolution (a later
+  decision, per `rac-decision-applies-to-scope`); if so, the seam gains the
+  resolution and every consumer inherits it with no change.
+- Whether the future drift consumer needs per-artifact change sets beyond what
+  the recency service exposes (the Watchkeeper materialisation seam, ADR-043);
+  that is `rac-drift-advisory-finding`'s question, not the seam's.
+
+## Related Requirements
+
+- rac-path-decisions-lookup
+- rac-decision-applies-to-scope
+- rac-drift-advisory-finding
+
+## Related Decisions
+
+- adr-031
+- adr-032
+- adr-034
+- adr-066
+- adr-080
+
+## Related Roadmaps
+
+- decision-to-code-proximity
+- freshness-and-drift-detection

--- a/rac/roadmaps/decision-to-code-proximity.md
+++ b/rac/roadmaps/decision-to-code-proximity.md
@@ -205,6 +205,10 @@ everywhere.
 - rac-decision-applies-to-scope
 - rac-path-decisions-lookup
 
+## Related Designs
+
+- code-scope-consumption
+
 ## Related Tickets
 
 - itsthelore/rac-core#273

--- a/src/rac/explorer/adapter.py
+++ b/src/rac/explorer/adapter.py
@@ -45,6 +45,7 @@ from rac.services.review import (
     ReviewIssue,
     review_from_portfolio,
 )
+from rac.services.scope import decisions_for_path
 from rac.services.stats import collect_stats
 
 from . import editor as editor_mod
@@ -488,6 +489,28 @@ class ExplorerAdapter:
         rows = tuple(_row(a) for a in repository.artifacts_of_type(artifact_type))
         if not rows:
             return LookupState(rows=(), message=f"Nothing to browse: {artifact_type}")
+        return LookupState(rows=rows)
+
+    def governing_decisions(self, path: str) -> LookupState:
+        """Decisions whose `## Applies To` scope governs a code path (`/decisions-for`).
+
+        Consumes the same `decisions_for_path` core the `rac decisions-for` CLI
+        and the `find_decisions` MCP `path` argument use (decision-to-code-proximity
+        Initiative 2) — the one seam, no second vocabulary — and maps each governing
+        decision to its artifact row so a result opens like any other lookup. An
+        ungoverned or outside-repository path is a valid empty result with an
+        explanatory message, never an error.
+        """
+        repository = self.repository
+        if repository is None:
+            return LookupState(rows=(), message="Repository not loaded yet")
+        result = decisions_for_path(self.directory, path, recursive=self.recursive)
+        by_path = {a.path: a for a in repository.artifacts}
+        rows = tuple(_row(by_path[d.path]) for d in result.decisions if d.path in by_path)
+        if not rows:
+            if not result.in_repository:
+                return LookupState(rows=(), message=f"{result.query} is outside the repository")
+            return LookupState(rows=(), message=f"No decisions declare scope over {result.query}")
         return LookupState(rows=rows)
 
     def health_state(self) -> HealthState | None:

--- a/src/rac/explorer/commands.py
+++ b/src/rac/explorer/commands.py
@@ -50,6 +50,9 @@ REGISTRY: tuple[CommandSpec, ...] = (
     CommandSpec("new", "new <type> <path>", "Create an artifact from its template"),
     CommandSpec("import", "import <source> [target]", "Convert a document into Markdown"),
     CommandSpec("relationships", "relationships <ref>", "Traverse an artifact's relationships"),
+    CommandSpec(
+        "decisions-for", "decisions-for <path>", "List decisions whose scope governs a code path"
+    ),
     CommandSpec("resume", "resume", "Reopen the last artifact in this repository"),
     CommandSpec("schema", "schema [type]", "Show an artifact type's expected structure"),
     CommandSpec("settings", "settings", "View and change Explorer settings"),

--- a/src/rac/explorer/screens/main.py
+++ b/src/rac/explorer/screens/main.py
@@ -684,6 +684,11 @@ class MainScreen(Screen[None]):
                 self._show_lookup(lookup)
                 return
             self.open_artifact(lookup.rows[0].path, tab="tab-links")
+        elif invocation.command == "decisions-for":
+            if not invocation.args:
+                self._show_message("Usage: /decisions-for <path>")
+                return
+            self._show_lookup(self.adapter.governing_decisions(invocation.args))
         elif invocation.command == "import":
             parts = invocation.args.split()
             if not parts:

--- a/tests/test_explorer_adapter.py
+++ b/tests/test_explorer_adapter.py
@@ -752,3 +752,67 @@ def test_stats_state_renders_the_dashboard_sections():
     assert any("Requirements" in line and "valid" in line for line in lines)
     quality = dict(stats.sections)["Requirements & Quality"]
     assert any(line.startswith("Requirements    7") for line in quality)
+
+
+# --- governing decisions (/decisions-for, decision-to-code-proximity Init 3) -----
+
+
+def _decision_scoped(title: str, applies_to: list[str], status: str = "Accepted") -> str:
+    scope = "".join(f"- {e}\n" for e in applies_to)
+    return (
+        f"# {title}\n\n## Context\n\nc\n\n## Decision\n\nd\n\n## Consequences\n\nq\n"
+        f"\n## Status\n\n{status}\n\n## Applies To\n\n{scope}"
+    )
+
+
+def _scoped_corpus(tmp_path) -> ExplorerAdapter:
+    d = tmp_path / "decisions"
+    d.mkdir()
+    (d / "adr-a.md").write_text(_decision_scoped("A dir", ["src/auth/"]), encoding="utf-8")
+    (d / "adr-b.md").write_text(_decision_scoped("B glob", ["src/**/*.py"]), encoding="utf-8")
+    (d / "adr-c.md").write_text(
+        _decision_scoped("C retired", ["src/auth/"], status="Superseded"), encoding="utf-8"
+    )
+    adapter = ExplorerAdapter(str(tmp_path))
+    adapter.load()
+    return adapter
+
+
+def test_governing_decisions_returns_covering_live_decisions_as_rows(tmp_path):
+    # The directory scope and the glob both cover the nested file; the retired
+    # decision is excluded (live-only), and each row is an openable artifact row.
+    adapter = _scoped_corpus(tmp_path)
+    lookup = adapter.governing_decisions("src/auth/login.py")
+    assert lookup.message is None
+    assert {row.title for row in lookup.rows} == {"A dir", "B glob"}
+    assert all(row.path.endswith(".md") for row in lookup.rows)
+
+
+def test_governing_decisions_consumes_the_shared_core_no_second_vocabulary(tmp_path):
+    # The adapter answer is exactly the decisions_for_path service answer mapped
+    # to rows — the same seam the CLI and MCP faces read (authored once).
+    from rac.services.scope import decisions_for_path
+
+    adapter = _scoped_corpus(tmp_path)
+    lookup = adapter.governing_decisions("src/auth/login.py")
+    service = decisions_for_path(str(tmp_path), "src/auth/login.py")
+    assert [row.path for row in lookup.rows] == [d.path for d in service.decisions]
+
+
+def test_governing_decisions_ungoverned_path_is_an_explained_empty(tmp_path):
+    lookup = _scoped_corpus(tmp_path).governing_decisions("README.md")
+    assert lookup.rows == ()
+    assert "No decisions declare scope" in (lookup.message or "")
+
+
+def test_governing_decisions_outside_repository_is_an_explained_empty(tmp_path):
+    lookup = _scoped_corpus(tmp_path).governing_decisions("/etc/passwd")
+    assert lookup.rows == ()
+    assert "outside the repository" in (lookup.message or "")
+
+
+def test_governing_decisions_requires_a_loaded_repository(tmp_path):
+    adapter = ExplorerAdapter(str(tmp_path))  # not loaded
+    lookup = adapter.governing_decisions("src/auth/login.py")
+    assert lookup.rows == ()
+    assert "not loaded" in (lookup.message or "")

--- a/tests/test_explorer_app.py
+++ b/tests/test_explorer_app.py
@@ -2345,3 +2345,48 @@ async def test_returning_users_never_see_the_editor_prompt():
         text = await _settled_panel_text(app, pilot)
         assert "Choose your editor" not in text
         assert not app.screen.query_one("#firstrun-editor", Input).display
+
+
+# --- /decisions-for path→decisions surface (decision-to-code-proximity Init 3) ---
+
+
+@pytest.mark.asyncio
+async def test_slash_decisions_for_lists_governing_decisions_in_results(tmp_path):
+    d = tmp_path / "decisions"
+    d.mkdir()
+    (d / "adr.md").write_text(
+        "# Scoped decision\n\n## Context\n\nc\n\n## Decision\n\nx\n\n## Consequences\n\nq\n"
+        "\n## Status\n\nAccepted\n\n## Applies To\n\n- src/auth/\n",
+        encoding="utf-8",
+    )
+    app = ExplorerApp(str(tmp_path))
+    async with app.run_test() as pilot:
+        await _settled_panel_text(app, pilot)
+        # A governed path lists the decision in the results view, openable.
+        app.screen.route_command("decisions-for src/auth/login.py")
+        await pilot.pause()
+        assert app.screen.current_view == "view-results"
+        region = app.screen.query_one("#context-region")
+        assert str(region.border_title) == "Results · 1"
+        # An ungoverned path is an explained empty, not an error.
+        app.screen.route_command("decisions-for docs/guide.md")
+        await pilot.pause()
+        results = app.screen.query_one("#command-results", OptionList)
+        listing = "\n".join(
+            str(results.get_option_at_index(i).prompt) for i in range(results.option_count)
+        )
+        assert "No decisions declare scope" in listing
+
+
+@pytest.mark.asyncio
+async def test_slash_decisions_for_without_a_path_shows_usage():
+    app = ExplorerApp(str(FIXTURES / "valid_clean"))
+    async with app.run_test() as pilot:
+        await _settled_panel_text(app, pilot)
+        app.screen.route_command("decisions-for")
+        await pilot.pause()
+        results = app.screen.query_one("#command-results", OptionList)
+        listing = "\n".join(
+            str(results.get_option_at_index(i).prompt) for i in range(results.option_count)
+        )
+        assert "Usage: /decisions-for <path>" in listing

--- a/tests/test_explorer_commands.py
+++ b/tests/test_explorer_commands.py
@@ -22,6 +22,7 @@ def test_registry_is_the_v0810_contract():
         "new",
         "import",
         "relationships",
+        "decisions-for",
         "resume",
         "schema",
         "settings",
@@ -30,6 +31,14 @@ def test_registry_is_the_v0810_contract():
         "quit",
     ]
     assert all(spec.usage and spec.summary for spec in REGISTRY)
+
+
+def test_decisions_for_command_parses_with_a_path_argument():
+    # The path→decisions surface (decision-to-code-proximity Initiative 3) is a
+    # registered command whose argument is a code path, routed like `/open <ref>`.
+    invocation = parse("/decisions-for src/rac/mcp/server.py")
+    assert invocation.command == "decisions-for"
+    assert invocation.args == "src/rac/mcp/server.py"
 
 
 def test_action_commands_are_discoverable():


### PR DESCRIPTION
# Summary

Implements Initiative 3 of the `decision-to-code-proximity` roadmap (epic #273, sub-issue #276) — the downstream joins. Initiative 1 (#274) made code scope declarable; Initiative 2 (#275) made it queryable via one core reader, `decisions_for_path`. This wires the first downstream consumer (the Explorer) onto that reader and records the "authored once, read everywhere" invariant so the future drift consumer joins the same seam.

Adds:
- An Explorer `/decisions-for <path>` command consuming the shared `decisions_for_path` core — no second vocabulary, no adapter re-implementation.
- A `code-scope-consumption` design artifact recording the single-reader seam and the drift-gate handoff.
- Adapter, command-registry, and app-routing tests.

# Roadmap / ADR Trace

Roadmap:
- `rac/roadmaps/decision-to-code-proximity.md` (Initiative 3 — **no requirement of its own**; it records the joins)

Design added:
- `rac/designs/code-scope-consumption.md`

Relevant ADRs:
- `adr-031` — one shared core serves every consumer; the Explorer filters/shapes, never recomputes
- `adr-028` — the Explorer TUI is the surface "decisions for this area" lands on
- `adr-015` — the Explorer is a consumer of Core services (routing is the only Explorer-side logic)
- `adr-034` — reports which decisions bind and their status, never a verdict
- `adr-066` / `adr-002` — deterministic, offline; pure function of declared references and the file tree
- `adr-007` — a new consumer is additive wiring, never a change to the seam

# Scope

## Included
- **Explorer surfacing** (the epic's build item): `/decisions-for <path>` in the command registry; `ExplorerAdapter.governing_decisions(path)` calling `decisions_for_path(self.directory, path)` and mapping each `GoverningDecision` to an artifact row by path; a routing branch reusing the existing `_show_lookup` → `ResultsView`. Result rows open decisions on their existing tabs. Ungoverned / outside-repository / not-yet-loaded are explained empties.
- **Drift-gate handoff** (the epic's record item): the `code-scope-consumption` design records that `decisions_for_path` is the single reader the CLI, MCP, Explorer (now), and freshness phase-2 code-scope drift (#279, later) all consume — no adapter, no parallel vocabulary — guaranteeing the seam stays consumable. Nothing here builds the drift finding.

## Excluded
- Any code-path/area **browser**, a persistent "Area" panel, or reverse code→artifact linking — a large feature with no existing Explorer infrastructure, and not what Initiative 3 asks.
- The drift finding itself and its code-scope extension (freshness #279 / later phase). No change to `decisions_for_path`.

# Product / Architecture Decisions

- **A command into the existing results surface, not a new view.** `/decisions-for` mirrors `/browse <type>` and `/relationships` exactly — one `CommandSpec`, one adapter method returning `LookupState`, one routing branch — so it reuses filtering, opening, and theming for free. The Explorer gains a code-path consumer without gaining a code-path browser.
- **The Explorer consumes the core directly.** `governing_decisions` calls `decisions_for_path` and maps its result to rows; it does not re-read `## Applies To` or re-derive matching. This is the acceptance proof ("resolve the same declared entries with no adapter layer") demonstrated by the one consumer available now.
- **The join is recorded as a design, not left implicit.** With a second consumer arriving now and a third (drift) later, the `code-scope-consumption` design makes "one reader, one vocabulary" an enforceable invariant rather than a convention, and names the drift consumer's seam (`rac-drift-advisory-finding` REQ-007).
- **Command name `/decisions-for`** matches the `rac decisions-for` CLI, so the capability reads as one feature across surfaces.

# User-Facing Contract

## Explorer
A new command on the `/` surface:
```
/decisions-for src/auth/login.py
```
Lists the live decisions whose `## Applies To` scope governs the path in the results view; each row opens the decision. A path no decision governs shows `No decisions declare scope over ...`; a path outside the repository shows `... is outside the repository`; a bare `/decisions-for` shows `Usage: /decisions-for <path>`. The command appears in `/help` and the registry.

No CLI, MCP, or JSON contract changes — this initiative only adds an Explorer consumer of the existing lookup.

# Verification

## Ran
- `rac validate rac/` → `PASS — 373 valid, 0 invalid`; `rac relationships rac/ --validate` → exit `0` (2162 checked); `rac review rac/` → no priority 1–2 findings.
- `pytest tests/test_explorer_adapter.py tests/test_explorer_commands.py` → 78 passed (includes the new `governing_decisions` and registry tests). Full non-TUI suite: 1619 passed, 1 skipped.
- `ruff check`, `ruff format --check`, and `mypy src/` all clean.

## Covered
- `governing_decisions`: a covering directory scope and a glob both bind a nested file; the retired decision is excluded (live-only); the adapter rows equal the `decisions_for_path` service result mapped by path (the shared-seam proof); ungoverned, outside-repository, and unloaded cases are explained empties.
- The command-registry contract test is extended for `decisions-for`; parsing a path argument is covered.
- App routing (`test_explorer_app.py`): a governed path lists in the results view (`Results · 1`) and an ungoverned one renders the explained empty; a path-less invocation shows usage.

# Review Path

1. `src/rac/explorer/adapter.py` — `governing_decisions`, the one new Core import and the mapping to rows.
2. `src/rac/explorer/commands.py`, `src/rac/explorer/screens/main.py` — the registry entry and the routing branch.
3. `rac/designs/code-scope-consumption.md` — the recorded seam and drift-gate handoff.
4. `tests/test_explorer_adapter.py`, `tests/test_explorer_commands.py`, `tests/test_explorer_app.py` — coverage.

# Notes For Reviewer
- The Explorer app tests (`test_explorer_app.py`) run in CI's `explorer` battery; they could not be executed in my sandbox (an incompatible Textual version there breaks `App.run_test`), so I mirrored the existing `/browse` app-test pattern exactly and verified the adapter and registry logic directly. Worth a glance that the two new app tests pass in CI.
- Post-merge bookkeeping intentionally not done here (needs the merge to land): tick #276 on epic #273, which completes the `decision-to-code-proximity` programme.
- `CHANGELOG.md` untouched — organised strictly by shipped release with no "Unreleased" section (CalVer, ADR-076).

# Implementation Process

Implemented with AI assistance under the roadmap contract; the scope (Explorer command plus a design record, not a code-path browser) and the command name were ratified, and final review and acceptance decisions were made by the maintainer.