### PR TITLE
docs(roadmap): mark decision-to-code-proximity Achieved [roadmap:decision-to-code-proximity]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ User-visible changes to RAC, by release. Follows the spirit of
 [Keep a Changelog](https://keepachangelog.com/): user impact over implementation
 details, release history over commit history.
 
+## Unreleased
+
+The **decision-to-code-proximity** programme: recorded decisions now know which
+code they govern, and you can ask which decisions govern a path — declared and
+validated, never inferred; deterministic and offline.
+
+### Added
+
+- **Decisions can declare the code they govern.** A decision may list the paths
+  or components it applies to in an optional `## Applies To` section. Literal
+  path and directory entries are existence-checked by
+  `rac relationships --validate` — a new `applies-to-target-not-found` finding
+  flags a declared path that no longer exists; glob patterns and component-name
+  labels are recorded without existence-checking.
+- **`rac decisions-for <path>`** — a new read-only command listing the live
+  decisions whose declared scope governs a file or directory, so you see which
+  recorded decisions constrain an edit before you make it. An ungoverned or
+  outside-repository path is a valid empty result, never an error.
+- **`find_decisions` gains an optional `path` argument (MCP).** The Guide tool
+  that answers "what did we decide about X" now also answers "which decisions
+  govern this code path," over the same five-tool surface; called with a topic
+  it is unchanged.
+- **Explorer `/decisions-for <path>`** — the same lookup in the TUI: type a code
+  path to list the governing decisions, each openable like any other result.
+
 ## 2026.06.5 — the "rename" release
 
 The release that renames the package to match the project. The PyPI distribution

--- a/rac/requirements/rac-path-decisions-lookup.md
+++ b/rac/requirements/rac-path-decisions-lookup.md
@@ -7,11 +7,14 @@ type: requirement
 
 ## Status
 
-Proposed
+Accepted
 
 Classification: `[internal]` — the decisions binding a file, in one call.
-Initiative 2 of the `decision-to-code-proximity` roadmap; consumes the
-`## Applies To` vocabulary of `rac-decision-applies-to-scope`.
+Delivered as Initiative 2 of the `decision-to-code-proximity` roadmap
+(itsthelore/rac-core#275): the `rac decisions-for` CLI subcommand and the
+additive `path` argument on the `find_decisions` MCP tool, over one shared
+core, consuming the `## Applies To` vocabulary of
+`rac-decision-applies-to-scope`.
 
 ## Problem
 

--- a/rac/roadmaps/decision-to-code-proximity.md
+++ b/rac/roadmaps/decision-to-code-proximity.md
@@ -7,17 +7,18 @@ type: roadmap
 
 ## Status
 
-Planned
+Achieved
 
-Prioritised as the rank-1 Tranche A item of the deterministic-substrate
-programme, graduated out of `future/` now the programme's rank-3 and rank-4
-items are live: corpus export shipped and its evolution continues under
-`corpus-sync`, and team-scale serving is live as its own roadmap. The
-programme's constraint pattern is carried verbatim: **proximity references
-are declared and validated, never inferred; drift findings are advisory
-before they are ever a gate.** Execution is tracked in GitHub (ADR-093):
-the epic in `## Related Tickets` carries ordering and task state, with a
-sub-issue per initiative.
+Delivered across all three initiatives (epic itsthelore/rac-core#273):
+decisions declare validated code scope via `## Applies To` (#274); a
+deterministic path→decisions lookup answers over the `rac decisions-for` CLI
+and the additive `find_decisions` MCP `path` argument (#275); and the Explorer
+consumes the same shared reader through `/decisions-for` while the drift-gate
+handoff is recorded in the `code-scope-consumption` design (#276). Graduated as
+the rank-1 Tranche A item of the deterministic-substrate programme; its
+constraint pattern held throughout — **proximity references are declared and
+validated, never inferred; drift findings are advisory before they are ever a
+gate.** Execution was tracked in GitHub (ADR-093), a sub-issue per initiative.
 
 ## Context
 


### PR DESCRIPTION
# Summary

Closing hygiene for the now-complete `decision-to-code-proximity` programme (epic #273, all three initiatives merged via #284/#285/#286): move the roadmap to its terminal lifecycle status, correct a missed requirement status, and record the user-visible changes in the changelog.

Changes:
- **Roadmap → `Achieved`** (ADR-061) with a delivery summary of the three initiatives.
- **`rac-path-decisions-lookup` → `Accepted`** — it shipped in #275 but was left `Proposed`.
- **CHANGELOG `Unreleased` section** capturing the programme's user-visible surface.

# Roadmap / ADR Trace

- `rac/roadmaps/decision-to-code-proximity.md` — the roadmap being closed out
- `adr-061` — Roadmaps Carry an "Achieved" Terminal Lifecycle Status
- `adr-076` — CalVer releases: the changelog entry is renamed to the release heading when the next release is cut

# Scope

## Included
- Roadmap `Status: Planned → Achieved`, prose updated to a delivery summary (which initiative shipped what, over which surfaces).
- `rac-path-decisions-lookup` `Status: Proposed → Accepted`, with a delivery note (the `rac decisions-for` CLI and the `find_decisions` MCP `path` argument).
- A CHANGELOG `## Unreleased` section: the `## Applies To` code-scope declaration and its validation finding, `rac decisions-for`, the additive `find_decisions` `path` argument, and the Explorer `/decisions-for` command — framed by user impact.

## Excluded
- No code or behaviour changes; corpus and changelog only.
- No release cut — the `Unreleased` heading is renamed to a CalVer version when the maintainer publishes (per `verify_release`, ADR-076).

# Product / Architecture Decisions

- **Documentation trail, for the record.** The programme's *what/why* already lives in the corpus (roadmap, the two requirements, the `code-scope-consumption` design, the four dogfooded evidence ADRs) and its *usage* in the docs (`docs/relationships.md` code-scope section, `docs/cli.md` `decisions-for`). The one gap was the changelog — added here as `Unreleased` so a user scanning release notes sees the capability, consistent with the file's stated "spirit of Keep a Changelog."
- **`Achieved`, not closed-and-gone.** Per ADR-061 an achieved roadmap is a live terminal record — still valid to reference — so no inbound reference to it becomes a retired-target finding (`rac relationships --validate` stays clean).

# Verification

## Ran
- `rac validate rac/` → `PASS — 373 valid, 0 invalid` (roadmap now `Achieved`, requirement now `Accepted`).
- `rac relationships rac/ --validate` → exit `0`; `rac review rac/` → no priority 1–2 findings.
- `pytest tests/test_release_version.py` → 25 passed (the `Unreleased` heading is inert to `changelog_has_entry`, which matches a `## <version>` heading; the real-file check runs only at release with a version).

# Review Path

1. `rac/roadmaps/decision-to-code-proximity.md` — the status flip and delivery summary.
2. `rac/requirements/rac-path-decisions-lookup.md` — the missed `Accepted` flip.
3. `CHANGELOG.md` — the `Unreleased` section.

# Notes For Reviewer
- Rename `## Unreleased` to the CalVer version heading when the next release is cut; `verify_release` will then find the entry.
- Post-merge: no further bookkeeping — epic #273 and all sub-issues are already closed.

# Implementation Process

Implemented with AI assistance; the status flip was requested and the changelog capture confirmed by the maintainer.