### PR TITLE
feat(mcp): shared HTTP transport for rac mcp (lore-at-team-scale #263)

### DIFF
--- a/.cursor/rules
+++ b/.cursor/rules
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: 33d890a7929472f7fb724e706d1db9f28a81afe911f02fc5562235ca79c2d430) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: 6d0950ce0ec346d9bcb9ae758fc3dca55a867a9cf0b4ec23ac74a5ed4ea7a6da) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -70,4 +70,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KW8ZTVEQJ366** — ADR-095: rac-connectors Repackage, PyPI Rename, and Outbound Field Rename _(Architecture)_
 - **RAC-KWBJJRZR84PT** — ADR-096: External-Target Verification Edge (`verified_by`) _(Technical)_
 - **RAC-KWFVA38YT2C0** — ADR-097: Benchmark Family Contract _(Technical)_
+- **RAC-KWMW45KXHZJP** — ADR-098: Shared HTTP MCP Serving _(Architecture)_
 <!-- END RAC MANAGED BLOCK -->

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: 33d890a7929472f7fb724e706d1db9f28a81afe911f02fc5562235ca79c2d430) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: 6d0950ce0ec346d9bcb9ae758fc3dca55a867a9cf0b4ec23ac74a5ed4ea7a6da) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -70,4 +70,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KW8ZTVEQJ366** — ADR-095: rac-connectors Repackage, PyPI Rename, and Outbound Field Rename _(Architecture)_
 - **RAC-KWBJJRZR84PT** — ADR-096: External-Target Verification Edge (`verified_by`) _(Technical)_
 - **RAC-KWFVA38YT2C0** — ADR-097: Benchmark Family Contract _(Technical)_
+- **RAC-KWMW45KXHZJP** — ADR-098: Shared HTTP MCP Serving _(Architecture)_
 <!-- END RAC MANAGED BLOCK -->

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,7 +92,7 @@ jobs:
           - name: explorer
             paths: "tests/test_explorer_adapter.py tests/test_explorer_app.py tests/test_explorer_cli.py tests/test_explorer_commands.py tests/test_explorer_editor.py tests/test_explorer_isolation.py tests/test_explorer_workspace.py"
           - name: mcp
-            paths: "tests/test_mcp_server.py tests/test_mcp_tools.py tests/test_mcp_isolation.py tests/test_mcp_telemetry.py tests/test_mcp_ping.py tests/test_mcp_audit.py"
+            paths: "tests/test_mcp_server.py tests/test_mcp_tools.py tests/test_mcp_isolation.py tests/test_mcp_telemetry.py tests/test_mcp_ping.py tests/test_mcp_audit.py tests/test_mcp_http.py"
           - name: relationships
             paths: "tests/test_relationships.py tests/test_relationships_cmd.py tests/test_relationship_validation.py tests/test_relationship_graph.py tests/test_lifecycle_status.py tests/test_rename.py"
           - name: resolve

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: 33d890a7929472f7fb724e706d1db9f28a81afe911f02fc5562235ca79c2d430) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: 6d0950ce0ec346d9bcb9ae758fc3dca55a867a9cf0b4ec23ac74a5ed4ea7a6da) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -70,4 +70,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KW8ZTVEQJ366** — ADR-095: rac-connectors Repackage, PyPI Rename, and Outbound Field Rename _(Architecture)_
 - **RAC-KWBJJRZR84PT** — ADR-096: External-Target Verification Edge (`verified_by`) _(Technical)_
 - **RAC-KWFVA38YT2C0** — ADR-097: Benchmark Family Contract _(Technical)_
+- **RAC-KWMW45KXHZJP** — ADR-098: Shared HTTP MCP Serving _(Architecture)_
 <!-- END RAC MANAGED BLOCK -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ details, release history over commit history.
 
 The **decision-to-code-proximity** programme: recorded decisions now know which
 code they govern, and you can ask which decisions govern a path — declared and
-validated, never inferred; deterministic and offline.
+validated, never inferred; deterministic and offline. Plus the first build of
+**lore-at-team-scale**: `rac mcp` can now serve the whole team over one
+always-current HTTP endpoint.
 
 ### Added
 
@@ -28,6 +30,14 @@ validated, never inferred; deterministic and offline.
   it is unchanged.
 - **Explorer `/decisions-for <path>`** — the same lookup in the TUI: type a code
   path to list the governing decisions, each openable like any other result.
+- **Shared HTTP MCP transport (`rac mcp --transport http`).** Serve one
+  always-current endpoint for a whole team instead of a local server per
+  developer: `--transport http` (with `--host`, `--port`, `--path`) speaks the
+  streamable HTTP transport, stateless per call and payload-identical to stdio.
+  stdio stays the default, so every existing `.mcp.json` is unchanged. The
+  endpoint is read-only and unauthenticated by design — authentication belongs
+  to your deployment proxy — and it is mandatory audit-on: it refuses to start
+  without a working read-access audit log (ADR-098).
 
 ## 2026.06.5 — the "rename" release
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ to the corpus artifact and they load through the imports below.
 - Previous series: `rac/roadmaps/v0.21.x-editor/` (complete)
 - Decisions (ADRs): `rac/decisions/`
 
-<!-- BEGIN RAC MANAGED BLOCK (digest: 33d890a7929472f7fb724e706d1db9f28a81afe911f02fc5562235ca79c2d430) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: 6d0950ce0ec346d9bcb9ae758fc3dca55a867a9cf0b4ec23ac74a5ed4ea7a6da) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -95,4 +95,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KW8ZTVEQJ366** — ADR-095: rac-connectors Repackage, PyPI Rename, and Outbound Field Rename _(Architecture)_
 - **RAC-KWBJJRZR84PT** — ADR-096: External-Target Verification Edge (`verified_by`) _(Technical)_
 - **RAC-KWFVA38YT2C0** — ADR-097: Benchmark Family Contract _(Technical)_
+- **RAC-KWMW45KXHZJP** — ADR-098: Shared HTTP MCP Serving _(Architecture)_
 <!-- END RAC MANAGED BLOCK -->

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -341,7 +341,46 @@ repository ACL plus human pull-request review — the log records who *claimed* 
 query, not a verified identity. When enabled, the server announces it on stderr at
 startup; it is never silent.
 
-## 9. Troubleshooting
+## 9. Shared HTTP endpoint (team scale)
+
+By default `rac mcp` speaks **stdio**: one server process per developer, against
+that developer's own checkout. At team scale you may instead want **one
+always-current endpoint** every agent points at, so reads come from a single
+`main`-backed source of truth rather than checkouts that lag between pulls. The
+server gains a streamable **HTTP transport** for exactly this
+([ADR-098](https://github.com/itsthelore/rac-core/blob/main/rac/decisions/adr-098-shared-http-mcp-serving.md)):
+
+```bash
+rac mcp --root /path/to/your/repo --transport http --host 127.0.0.1 --port 8000 --path /mcp
+```
+
+- **`--transport`** — `stdio` (default) or `http`. Bare `rac mcp` is unchanged,
+  so every existing `.mcp.json` keeps working.
+- **`--host` / `--port` / `--path`** — where the HTTP server binds and serves
+  (defaults `127.0.0.1`, `8000`, `/mcp`). It binds to loopback by default;
+  exposing it to a network is a deliberate deployment choice.
+
+The HTTP transport is **serving-layer only**: the five tools are unchanged, the
+server re-reads the repository per call (no cache, no session state), and an
+HTTP response is **payload-identical to stdio** for the same corpus bytes.
+
+**Authentication is your proxy's job, not the engine's.** The endpoint is
+read-only and unauthenticated by design — the engine grows no SSO, RBAC, or
+credential handling (ADR-085). Front it with a reverse proxy that authenticates
+callers and terminates TLS; identity in the audit log stays *attributable, not
+authenticated* (ADR-084).
+
+**HTTP serving is mandatory audit-on.** Because a shared endpoint serves reads
+no single developer's git identity can attribute, the HTTP transport **refuses
+to start without a working audit log** — enable the `audit:` stanza (see
+[section 8](#8-read-access-audit-log-enterprise-opt-in)) first, or the server
+exits with an actionable error. stdio is unaffected.
+
+Keeping the fronted checkout current with `main` — a merge webhook or a periodic
+`git pull` — is a deployment concern outside the engine; a full container-and-
+keep-current recipe is documented separately for operators.
+
+## 10. Troubleshooting
 
 ### Server not listed in the client
 

--- a/rac/decisions/adr-098-shared-http-mcp-serving.md
+++ b/rac/decisions/adr-098-shared-http-mcp-serving.md
@@ -1,0 +1,154 @@
+---
+schema_version: 1
+id: RAC-KWMW45KXHZJP
+type: decision
+---
+# ADR-098: Shared HTTP MCP Serving
+
+## Status
+
+Accepted
+
+## Category
+
+Architecture
+
+## Context
+
+Lore's MCP server is stdio-only: one process per developer against that
+developer's own checkout (ADR-031, ADR-032). ADR-091's context reasons from
+that model — "the MCP server is stdio-only … a hosted or shared server is a
+non-goal" — to rule a Prometheus scrape endpoint out of the engine. But
+ADR-080 records the opposite intent for the *serving* question: a shared,
+`main`-backed read endpoint is blessed, "a transport feature, not a datastore".
+The `lore-at-team-scale` roadmap graduated on a real trigger — an adopting
+organisation expanding toward multi-thousand-seat scale — and its first
+initiative (`rac-mcp-http-transport`) needs one always-current endpoint the
+whole team can point every agent at, instead of individual checkouts that lag.
+
+These two recorded positions must be reconciled deliberately, for everyone,
+rather than by code drift (ADR-085): does adding an HTTP transport cross a
+bright line, and if not, what keeps it from becoming the hosted, authenticated,
+stateful service the red lines forbid? The MCP isolation battery also
+deliberately forbids network imports outside the fenced `ping` module, so an
+HTTP transport cannot land without an explicit, recorded revision of that
+assertion.
+
+## Decision
+
+`rac mcp` gains a streamable HTTP transport, decided for everyone, under the
+following boundaries.
+
+- **A transport, not a datastore.** The HTTP server fronts one `main`-backed
+  checkout and re-reads it per call (ADR-032); it holds no state beyond that
+  checkout (ADR-080). It is served statelessly — no session store, one JSON
+  response per request — so an HTTP response is payload-identical to stdio for
+  identical corpus bytes (ADR-002). stdio stays the default: every existing
+  `.mcp.json`, including ADR-088 profile output, is byte-unchanged.
+
+- **This resolves ADR-091's premise, not its conclusion.** ADR-091's
+  stdio-only *reasoning* is superseded for the serving question — a shared
+  endpoint is now sanctioned intent (ADR-080) — but its *conclusion* stands:
+  the engine still ships no Prometheus `/metrics` scrape endpoint. A scrape
+  surface, if ever justified, remains the deployment wrapper's concern, never
+  the engine's.
+
+- **No authentication in the engine (ADR-085).** The HTTP transport grows no
+  authentication, authorization, SSO, or RBAC. Identity stays the attributable
+  principal (ADR-084), not a verified one; authentication belongs to the
+  deployment proxy that fronts the endpoint. The standing red lines — no SSO on
+  a shared MCP, no RBAC on MCP tools, no hosted multi-tenant service — stand.
+
+- **Mandatory audit-on for HTTP.** A shared endpoint serves reads no single
+  developer's git identity can attribute, so HTTP serving refuses to start
+  without a working audit sink (ADR-084's fail-loud posture): the audit log
+  must be enabled and writable, proven at startup, or the server exits
+  non-zero. stdio is unchanged — audit stays config-driven and default-absent
+  there.
+
+- **The isolation battery is revised, scoped to the transport layer.** The
+  network-import allowance widens from the `ping` module alone to `ping` plus a
+  fenced `transport` module; every other module, including all tool logic,
+  stays network-import-free, and the battery still fails if a tool-logic module
+  imports a network module. Keeping the checkout current with `main` — a merge
+  webhook or periodic pull — is an external concern, never engine code.
+
+## Consequences
+
+### Positive
+
+- A team points every agent at one always-current endpoint and gets the same
+  answer for the same query at a given moment, without the engine becoming a
+  hosted service or a database.
+- The stdio-versus-shared tension between ADR-091 and ADR-080 is resolved on
+  the record, so the next reader sees a decision rather than a contradiction.
+- The trust story holds at shared scale: reads are attributable by mandatory
+  audit, authentication is honestly the proxy's job, and the network surface is
+  still answerable by reading two files.
+
+### Negative
+
+- Operators must front the endpoint with their own authenticating proxy; the
+  engine offers no turnkey auth, by design.
+- HTTP serving has a hard precondition (a working audit sink) that stdio does
+  not, so a misconfigured shared deployment fails to start rather than serving.
+
+### Risks
+
+- The endpoint is mistaken for an authenticated surface. Mitigation: the
+  proxy-owned authentication posture is documented honestly and the ADR-085 red
+  lines are restated with the transport.
+- The isolation-battery relaxation leaks network I/O into tool logic.
+  Mitigation: the allowance is scoped to the fenced `transport` module and the
+  battery retains a tool-logic-modules-network-free assertion.
+- A shared server drifts from `main` if the keep-current step fails.
+  Mitigation: the server re-reads per call (ADR-032), so staleness is bounded
+  and observable, and the keep-current step lives in the deployment recipe.
+
+## Alternatives Considered
+
+### Keep the engine stdio-only and require a per-developer sidecar
+
+Leave `rac mcp` stdio-only and tell teams to run a local proxy that bridges to
+HTTP.
+
+#### Disadvantages
+
+- Pushes the same streamable-HTTP machinery into every deployment as bespoke
+  glue, forks the serving story, and still leaves ADR-091 and ADR-080
+  unreconciled. ADR-080 already blessed the shared server as engine intent.
+
+### Ship HTTP with built-in token authentication
+
+Add an auth layer to the HTTP transport so the endpoint is self-protecting.
+
+#### Disadvantages
+
+- Crosses ADR-085's bright line (no SSO/RBAC/credential handling in the
+  engine), forks the trust model, and duplicates what a deployment proxy does
+  better. Authentication belongs to the proxy.
+
+A stateless, unauthenticated, mandatory-audit-on HTTP transport, with
+authentication delegated to the deployment proxy, is selected.
+
+## Relationship to Other Decisions
+
+- ADR-080: records the shared `main`-backed server as blessed intent — "a
+  transport feature, not a datastore" — which this ADR implements.
+- ADR-091: its stdio-only premise is resolved for the serving question; its
+  no-engine-scrape-endpoint conclusion stands.
+- ADR-032: the stateless, per-call re-read contract the HTTP transport
+  preserves.
+- ADR-084: the read-access audit recorder HTTP serving makes mandatory.
+- ADR-085: enterprise capability is configuration for everyone, never a mode;
+  the red lines this ADR restates.
+- ADR-002: deterministic, offline, byte-identical output across transports.
+- ADR-033: the response budget the transport does not change.
+
+## Related Requirements
+
+- rac-mcp-http-transport
+
+## Related Roadmaps
+
+- lore-at-team-scale

--- a/rac/requirements/rac-mcp-http-transport.md
+++ b/rac/requirements/rac-mcp-http-transport.md
@@ -7,11 +7,16 @@ type: requirement
 
 ## Status
 
-Proposed
+Accepted
 
 Classification: `[internal]` — one always-current endpoint for the whole
 team. Initiative 1 of the `lore-at-team-scale` roadmap: an HTTP transport
-for `rac mcp`, shipped under its own serving ADR.
+for `rac mcp`, shipped under its own serving ADR. Delivered
+(itsthelore/rac-core#263): `rac mcp --transport http` serves the five tools
+statelessly over streamable HTTP, payload-identical to stdio, mandatory
+audit-on, with authentication delegated to the deployment proxy — under
+ADR-098, which resolves the ADR-091 stdio-only premise against ADR-080's
+recorded shared-server intent.
 
 ## Problem
 
@@ -81,6 +86,7 @@ posture.
 - adr-084
 - adr-085
 - adr-091
+- adr-098
 
 ## Related Roadmaps
 

--- a/rac/roadmaps/lore-at-team-scale.md
+++ b/rac/roadmaps/lore-at-team-scale.md
@@ -196,6 +196,7 @@ engine.
 - adr-091
 - adr-093
 - adr-094
+- adr-098
 
 ## Related Roadmaps
 

--- a/src/rac/cli.py
+++ b/src/rac/cli.py
@@ -824,10 +824,21 @@ def cmd_mcp(args: argparse.Namespace) -> int:
     # to the MCP protocol, so any diagnostics here go to stderr.
     from rac.mcp.audit import MalformedAuditConfig
     from rac.mcp.server import run_server
+    from rac.mcp.transport import AuditSinkUnavailable
 
     try:
-        return run_server(args.root, telemetry_enabled=args.telemetry)
+        return run_server(
+            args.root,
+            telemetry_enabled=args.telemetry,
+            transport_name=args.transport,
+            host=args.host,
+            port=args.port,
+            path=args.path,
+        )
     except MalformedAuditConfig as exc:  # bad `audit:` stanza (ADR-084)
+        print(f"rac: {exc}", file=sys.stderr)
+        raise SystemExit(EXIT_USAGE) from None
+    except AuditSinkUnavailable as exc:  # HTTP without a working audit sink (ADR-084)
         print(f"rac: {exc}", file=sys.stderr)
         raise SystemExit(EXIT_USAGE) from None
 
@@ -1816,7 +1827,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     p_mcp = sub.add_parser(
         "mcp",
-        help="Serve RAC repository knowledge to agents over MCP (stdio).",
+        help="Serve RAC repository knowledge to agents over MCP (stdio or HTTP).",
         parents=[version_parent],
     )
     p_mcp.add_argument(
@@ -1831,6 +1842,38 @@ def build_parser() -> argparse.ArgumentParser:
             "Record tool-call counts and metadata (never arguments or content) "
             "to a local log; off by default (ADR-040)."
         ),
+    )
+    # HTTP transport (ADR-098): stdio stays the default so every existing
+    # `.mcp.json` — including ADR-088 profile output — is byte-unchanged. HTTP
+    # fronts one always-current checkout for the whole team; it is mandatory
+    # audit-on and grows no authentication (auth belongs to the deployment
+    # proxy, ADR-085). Choices and defaults are literals here so the base CLI
+    # never pays the MCP SDK import cost; ``rac.mcp.transport`` is the runtime
+    # source of truth and a battery test pins these to it.
+    p_mcp.add_argument(
+        "--transport",
+        choices=("stdio", "http"),
+        default="stdio",
+        help=(
+            "Transport to serve on: 'stdio' (default, one process per developer) "
+            "or 'http' (one shared endpoint; mandatory audit-on, ADR-098)."
+        ),
+    )
+    p_mcp.add_argument(
+        "--host",
+        default="127.0.0.1",
+        help="Host to bind for --transport http (default: 127.0.0.1; loopback).",
+    )
+    p_mcp.add_argument(
+        "--port",
+        type=int,
+        default=8000,
+        help="Port to bind for --transport http (default: 8000).",
+    )
+    p_mcp.add_argument(
+        "--path",
+        default="/mcp",
+        help="HTTP path to serve for --transport http (default: /mcp).",
     )
     p_mcp.set_defaults(func=cmd_mcp)
 

--- a/src/rac/mcp/server.py
+++ b/src/rac/mcp/server.py
@@ -53,7 +53,7 @@ from rac import consent as consent_record
 from rac.core.corpus import walk_corpus
 from rac.core.limits import MAX_TRAVERSAL_DEPTH
 from rac.core.markdown import parse
-from rac.mcp import audit, errors, ping, telemetry
+from rac.mcp import audit, errors, ping, telemetry, transport
 from rac.mcp.budget import (
     DEFAULT_BUDGET,
     HINT_RELATED,
@@ -417,11 +417,26 @@ def _maybe_start_sharing(root: str) -> None:
         )
 
 
-def run_server(root: str, budget: int = DEFAULT_BUDGET, telemetry_enabled: bool = False) -> int:
-    """Run the Guide server over stdio until the client disconnects.
+def run_server(
+    root: str,
+    budget: int = DEFAULT_BUDGET,
+    telemetry_enabled: bool = False,
+    transport_name: str = transport.TRANSPORT_STDIO,
+    host: str = transport.DEFAULT_HOST,
+    port: int = transport.DEFAULT_PORT,
+    path: str = transport.DEFAULT_PATH,
+) -> int:
+    """Run the Guide server over stdio (default) or streamable HTTP.
 
     Returns ``0`` on clean shutdown. stdout belongs to the MCP protocol; any
     diagnostics a caller emits go to stderr (the CLI owns that channel).
+
+    ``transport_name`` selects the transport (ADR-098): ``"stdio"`` is the
+    default and byte-unchanged; ``"http"`` fronts an always-current
+    ``main``-backed checkout for the whole team over one endpoint, configured by
+    ``host``/``port``/``path`` and served statelessly (ADR-032). HTTP serving is
+    mandatory-audit-on: it refuses to start without a working audit sink
+    (ADR-084), asserted before the endpoint opens.
 
     Emits a one-line notice to stderr when the repository root contains no
     recognized artifacts (v0.10.1 startup hardening), and another when
@@ -448,8 +463,22 @@ def run_server(root: str, budget: int = DEFAULT_BUDGET, telemetry_enabled: bool 
             f"{audit_recorder.path}",
             file=sys.stderr,
         )
+    server = build_server(root, budget=budget, recorder=recorder, audit_recorder=audit_recorder)
+    if transport_name == transport.TRANSPORT_HTTP:
+        # Mandatory-audit-on entry condition (ADR-084): a shared endpoint
+        # without a working auditor refuses to start rather than serving reads
+        # no one can attribute. Checked before the port opens, and before the
+        # daily-sharing daemon starts, so a refused start is inert.
+        transport.ensure_audit_sink(audit_recorder)
+        print(
+            f"rac mcp: serving over HTTP at http://{host}:{port}{path} "
+            "(read-only, stateless per call; authentication belongs to the "
+            "deployment proxy, ADR-085).",
+            file=sys.stderr,
+        )
+        _maybe_start_sharing(root)
+        transport.serve_http(server, host=host, port=port, path=path)
+        return 0
     _maybe_start_sharing(root)
-    build_server(root, budget=budget, recorder=recorder, audit_recorder=audit_recorder).run(
-        transport="stdio"
-    )
+    server.run(transport="stdio")
     return 0

--- a/src/rac/mcp/transport.py
+++ b/src/rac/mcp/transport.py
@@ -1,0 +1,105 @@
+"""HTTP serving layer for the Guide MCP server (ADR-098).
+
+This is the fenced *transport layer* the serving ADR (ADR-098) names: the one
+module besides ``ping`` permitted to reach network/serving machinery, kept
+apart from the read-only tool logic in :mod:`rac.mcp.server`. The serving ADR
+resolves the ADR-091 stdio-only premise against ADR-080's recorded
+shared-``main``-backed-server intent — the shared HTTP endpoint is a transport
+feature, not a datastore. The isolation battery
+(``tests/test_mcp_isolation.py``) enforces the split: tool-logic modules stay
+network-import-free; only ``ping`` and this module may reach network code.
+
+The engine grows no authentication (ADR-085): identity stays the attributable
+principal (ADR-084), and authentication belongs to the deployment proxy. HTTP
+serving is stateless per call (ADR-032) — no sessions, no server-held state
+(``stateless_http``, ``json_response``) — so an HTTP response is payload-
+identical to stdio for identical corpus bytes (ADR-002).
+
+HTTP serving is mandatory-audit-on (ADR-084, this roadmap's entry condition):
+a shared endpoint without a *working* audit sink refuses to start rather than
+serving reads no auditor can attribute. :func:`ensure_audit_sink` proves the
+sink writable at startup and fails loud otherwise.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from mcp.server.fastmcp import FastMCP
+
+from rac.errors import RACError
+from rac.mcp import audit
+
+# CLI transport choices. ``stdio`` is the default and byte-unchanged; ``http``
+# selects the SDK's streamable-HTTP transport below.
+TRANSPORT_STDIO = "stdio"
+TRANSPORT_HTTP = "http"
+TRANSPORTS: tuple[str, ...] = (TRANSPORT_STDIO, TRANSPORT_HTTP)
+
+# The MCP SDK transport identifier the ``http`` choice maps to.
+_SDK_STREAMABLE_HTTP: Literal["streamable-http"] = "streamable-http"
+
+# Transport-layer defaults (mirrored from the SDK so the CLI can advertise
+# them). Loopback by default: exposing the endpoint to a network is the
+# operator's deliberate act via the deployment proxy (ADR-085).
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 8000
+DEFAULT_PATH = "/mcp"
+
+
+class AuditSinkUnavailable(RACError):
+    """HTTP serving was requested without a working audit sink (ADR-084).
+
+    A shared HTTP endpoint is mandatory-audit-on: without an auditor every
+    caller's reads would be un-attributable, so the server refuses to start
+    rather than serving them. The message names the fix — configure an
+    ``audit:`` stanza in ``.rac/config.yaml``.
+    """
+
+
+def ensure_audit_sink(recorder: audit.AuditRecorder | None) -> None:
+    """Prove the audit sink exists and is writable, or raise (ADR-084 fail-loud).
+
+    The HTTP entry condition: no recorder means audit is not enabled, and an
+    unwritable path means the sink is configured but not *working*. Either way
+    the shared endpoint must not start. A stdio server never calls this — audit
+    stays config-driven and default-absent there (ADR-084's strict superset).
+    """
+    if recorder is None:
+        raise AuditSinkUnavailable(
+            "HTTP serving requires the read-access audit log, but it is not "
+            "enabled. Add an `audit:` stanza with `enabled: true` to "
+            ".rac/config.yaml before serving over HTTP (ADR-084)."
+        )
+    try:
+        recorder.path.parent.mkdir(parents=True, exist_ok=True)
+        with open(recorder.path, "a", encoding="utf-8"):
+            pass
+    except OSError as exc:
+        raise AuditSinkUnavailable(
+            f"HTTP serving requires a writable audit log, but {recorder.path} "
+            f"could not be opened for append ({exc}). Fix the audit path or "
+            "permissions before serving over HTTP (ADR-084)."
+        ) from None
+
+
+def serve_http(
+    server: FastMCP,
+    host: str = DEFAULT_HOST,
+    port: int = DEFAULT_PORT,
+    path: str = DEFAULT_PATH,
+) -> None:
+    """Serve ``server`` over streamable HTTP until interrupted.
+
+    Configures the transport on the server's settings and runs the SDK's
+    streamable-HTTP transport statelessly (ADR-032): no session store, a single
+    JSON response per request, so the payload matches stdio byte-for-byte for
+    identical corpus bytes (REQ-006). The tools themselves are untouched — this
+    is serving-layer only (REQ-002).
+    """
+    server.settings.host = host
+    server.settings.port = port
+    server.settings.streamable_http_path = path
+    server.settings.stateless_http = True
+    server.settings.json_response = True
+    server.run(transport=_SDK_STREAMABLE_HTTP)

--- a/tests/test_mcp_http.py
+++ b/tests/test_mcp_http.py
@@ -1,0 +1,239 @@
+"""Shared HTTP MCP transport — parity, mandatory audit, CLI wiring (ADR-098).
+
+Initiative 1 of ``lore-at-team-scale`` (itsthelore/rac-core#263): ``rac mcp``
+gains a streamable HTTP transport. These tests hold the requirement's contract
+(``rac-mcp-http-transport``):
+
+- **Parity (REQ-006):** an HTTP round-trip returns payloads byte-identical to
+  the direct handler output for the same fixture corpus, for all five tools —
+  the transport changes the wire, never the answer (ADR-002, ADR-032).
+- **Mandatory audit-on (REQ-007):** HTTP serving refuses to start without a
+  working audit sink (ADR-084 fail-loud); stdio is unchanged.
+- **Additive CLI (REQ-001):** stdio stays the default and the new flags are
+  wired; the CLI defaults are pinned to the transport module's constants so the
+  two never drift.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+import threading
+import time
+from contextlib import closing
+
+import pytest
+from conftest import fixture_path
+
+from rac import cli
+from rac.mcp import audit
+from rac.mcp import transport as transport_mod
+from rac.mcp.server import build_server, run_server
+from rac.mcp.transport import AuditSinkUnavailable
+
+CORPUS = fixture_path("mcp", "corpus")
+
+DEC = "RAC-MCPDEC000001"
+REQ = "RAC-MCPREQ000001"
+
+# One representative call per pinned tool, plus both find_decisions modes
+# (topic and the additive path lookup), so parity holds across the surface.
+# Each is labelled because find_decisions appears twice.
+CALLS: tuple[tuple[str, str, dict], ...] = (
+    ("get_artifact", "get_artifact", {"id": DEC}),
+    ("search_artifacts", "search_artifacts", {"query": "RAC-MCP"}),
+    ("find_decisions:topic", "find_decisions", {"topic": "RAC"}),
+    ("find_decisions:path", "find_decisions", {"topic": "", "path": "src/rac/mcp/server.py"}),
+    ("get_related", "get_related", {"id": REQ}),
+    ("get_summary", "get_summary", {}),
+)
+
+
+# --- helpers -----------------------------------------------------------------
+
+
+def _free_port() -> int:
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _wait_for_port(host: str, port: int, timeout: float = 15.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+            if sock.connect_ex((host, port)) == 0:
+                return
+        time.sleep(0.05)
+    raise RuntimeError(f"HTTP server never bound {host}:{port}")
+
+
+def _direct_payloads() -> dict[str, str]:
+    """The tool payloads served over stdio: the direct handler return text."""
+
+    async def _run() -> dict[str, str]:
+        server = build_server(str(CORPUS))
+        out: dict[str, str] = {}
+        for label, name, args in CALLS:
+            content, _structured = await server.call_tool(name, args)
+            out[label] = content[0].text
+        return out
+
+    return asyncio.run(_run())
+
+
+def _http_payloads(port: int, path: str) -> dict[str, str]:
+    """The same tool payloads fetched over the streamable HTTP transport."""
+    from mcp.client.session import ClientSession
+    from mcp.client.streamable_http import streamable_http_client
+
+    async def _run() -> dict[str, str]:
+        url = f"http://127.0.0.1:{port}{path}"
+        async with streamable_http_client(url) as (read, write, _get_session_id):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                out: dict[str, str] = {}
+                for label, name, args in CALLS:
+                    result = await session.call_tool(name, args)
+                    out[label] = result.content[0].text
+                return out
+
+    return asyncio.run(_run())
+
+
+# --- parity (REQ-006) --------------------------------------------------------
+
+
+def test_http_payloads_are_identical_to_stdio():
+    port = _free_port()
+    path = "/mcp"
+
+    def _serve() -> None:
+        transport_mod.serve_http(build_server(str(CORPUS)), host="127.0.0.1", port=port, path=path)
+
+    thread = threading.Thread(target=_serve, daemon=True)
+    thread.start()
+    _wait_for_port("127.0.0.1", port)
+
+    http_payloads = _http_payloads(port, path)
+    direct_payloads = _direct_payloads()
+
+    assert set(http_payloads) == {label for label, _, _ in CALLS}
+    for label, _name, _args in CALLS:
+        assert http_payloads[label] == direct_payloads[label], f"payload drift on {label}"
+
+
+# --- mandatory audit-on (REQ-007) --------------------------------------------
+
+
+def test_ensure_audit_sink_refuses_when_audit_disabled():
+    # No recorder means audit is not enabled: HTTP must not start.
+    with pytest.raises(AuditSinkUnavailable) as excinfo:
+        transport_mod.ensure_audit_sink(None)
+    assert "audit" in str(excinfo.value).lower()
+
+
+def test_ensure_audit_sink_refuses_when_path_unwritable(tmp_path):
+    # A configured-but-unwritable sink is not a *working* sink (REQ-007).
+    unwritable = tmp_path / "nodir" / "audit.jsonl"
+    recorder = audit.AuditRecorder(unwritable, principal="x <x@example.com>")
+    # Make the parent un-creatable: turn the grandparent into a file.
+    (tmp_path / "nodir").write_text("not a directory", encoding="utf-8")
+    with pytest.raises(AuditSinkUnavailable):
+        transport_mod.ensure_audit_sink(recorder)
+
+
+def test_ensure_audit_sink_accepts_a_writable_sink(tmp_path):
+    recorder = audit.AuditRecorder(tmp_path / "audit.jsonl", principal="x <x@example.com>")
+    transport_mod.ensure_audit_sink(recorder)  # must not raise
+
+
+def test_http_without_audit_exits_usage(capsys):
+    # The fixture corpus has no `audit:` stanza, so an HTTP start must be refused
+    # with the usage exit code and an actionable message — never a silent serve.
+    parser = cli.build_parser()
+    args = parser.parse_args(["mcp", "--root", CORPUS, "--transport", "http"])
+    with pytest.raises(SystemExit) as excinfo:
+        args.func(args)
+    assert excinfo.value.code == cli.EXIT_USAGE
+    err = capsys.readouterr().err
+    assert "audit" in err.lower()
+
+
+def test_run_server_http_without_audit_raises(monkeypatch):
+    # Below the CLI: run_server itself refuses the HTTP start. serve_http must
+    # never be reached when the sink is missing.
+    served: list[str] = []
+    monkeypatch.setattr(transport_mod, "serve_http", lambda *a, **k: served.append("served"))
+    with pytest.raises(AuditSinkUnavailable):
+        run_server(CORPUS, transport_name="http")
+    assert served == [], "serve_http must not run without a working audit sink"
+
+
+# --- additive CLI (REQ-001) --------------------------------------------------
+
+
+def test_bare_mcp_defaults_to_stdio():
+    parser = cli.build_parser()
+    args = parser.parse_args(["mcp", "--root", CORPUS])
+    assert args.transport == "stdio"
+    assert args.host == "127.0.0.1"
+    assert args.port == 8000
+    assert args.path == "/mcp"
+
+
+def test_http_flags_parse():
+    parser = cli.build_parser()
+    args = parser.parse_args(
+        ["mcp", "--transport", "http", "--host", "0.0.0.0", "--port", "9100", "--path", "/lore"]
+    )
+    assert args.transport == "http"
+    assert args.host == "0.0.0.0"
+    assert args.port == 9100
+    assert args.path == "/lore"
+
+
+def test_cli_transport_defaults_match_transport_module():
+    # The CLI hardcodes the choices/defaults to stay SDK-free at parser build;
+    # this guard pins them to the transport module's source of truth (no drift).
+    parser = cli.build_parser()
+    args = parser.parse_args(["mcp"])
+    assert args.transport == transport_mod.TRANSPORT_STDIO
+    assert args.host == transport_mod.DEFAULT_HOST
+    assert args.port == transport_mod.DEFAULT_PORT
+    assert args.path == transport_mod.DEFAULT_PATH
+    # The choice set the parser accepts is exactly the transport module's, so a
+    # future third transport can't be added to one and forgotten in the other.
+    assert set(transport_mod.TRANSPORTS) == {"stdio", "http"}
+    parser.parse_args(["mcp", "--transport", transport_mod.TRANSPORT_HTTP])
+
+
+def test_run_server_stdio_default_does_not_require_audit(monkeypatch):
+    # The default stdio path must not gain the HTTP audit precondition: a
+    # fixture with no audit config still serves. Stub the blocking run.
+    calls: list[str] = []
+
+    class _FakeServer:
+        def run(self, transport: str) -> None:
+            calls.append(transport)
+
+    monkeypatch.setattr("rac.mcp.server.build_server", lambda *a, **k: _FakeServer())
+    monkeypatch.setattr("rac.mcp.server._maybe_start_sharing", lambda *a, **k: None)
+    monkeypatch.setattr("rac.mcp.server._check_corpus", lambda *a, **k: None)
+    assert run_server(CORPUS) == 0
+    assert calls == ["stdio"]
+
+
+def test_serve_http_configures_stateless_settings(monkeypatch):
+    # serve_http must set the transport up statelessly (no server-held state,
+    # REQ-002/REQ-008) and dispatch the SDK's streamable-http transport.
+    server = build_server(str(CORPUS))
+    ran: list[str] = []
+    monkeypatch.setattr(type(server), "run", lambda self, transport: ran.append(transport))
+    transport_mod.serve_http(server, host="127.0.0.1", port=8123, path="/lore")
+    assert server.settings.host == "127.0.0.1"
+    assert server.settings.port == 8123
+    assert server.settings.streamable_http_path == "/lore"
+    assert server.settings.stateless_http is True
+    assert server.settings.json_response is True
+    assert ran == ["streamable-http"]

--- a/tests/test_mcp_isolation.py
+++ b/tests/test_mcp_isolation.py
@@ -76,15 +76,46 @@ def test_only_the_server_package_imports_the_mcp_sdk():
     assert _violations(other, ("mcp",)) == []
 
 
-# Network client modules; the ping module is RAC's entire network surface
+# Network client modules; the ping module is RAC's fenced outbound surface
 # (ADR-041). ``urllib.parse`` (string formatting for the share URL) is
 # deliberately not in this list.
 NETWORK_MODULES: tuple[str, ...] = ("urllib.request", "http.client")
 
+# The transport-layer modules the serving ADR (ADR-098) permits to reach
+# network/serving code: ``ping`` (the fenced outbound ping, ADR-041) and
+# ``transport`` (the HTTP serving layer). Every other module — all tool logic —
+# stays network-free. Widening this allowance is a recorded decision, never a
+# silent drift (REQ-005).
+NETWORK_ALLOWED: tuple[Path, ...] = (
+    SRC / "mcp" / "ping.py",
+    SRC / "mcp" / "transport.py",
+)
 
-def test_only_the_ping_module_imports_network_modules():
-    # The strongest trust statement in the codebase: "what does RAC phone
-    # home" is answerable by reading one file.
-    files = [f for f in SRC.rglob("*.py") if f != SRC / "mcp" / "ping.py"]
+# The Guide tool-logic modules: the server body and the read-only helpers it
+# calls. None of them may import a network module — the serving allowance above
+# is scoped to the transport layer, not to tool logic (ADR-098, REQ-005).
+TOOL_LOGIC_MODULES: tuple[str, ...] = (
+    "server",
+    "budget",
+    "errors",
+    "telemetry",
+    "audit",
+)
+
+
+def test_network_imports_are_confined_to_the_transport_layer():
+    # The trust statement, revised for HTTP serving (ADR-098): "what does RAC
+    # reach the network for" is answerable by reading two files — the outbound
+    # ping and the serving transport — and nothing else.
+    files = [f for f in SRC.rglob("*.py") if f not in NETWORK_ALLOWED]
     assert files
+    assert _violations(files, NETWORK_MODULES) == []
+
+
+def test_tool_logic_modules_are_network_free():
+    # The retained guard (ADR-098, REQ-005): the network allowance is scoped to
+    # the transport layer only. A tool-logic module that imports a network
+    # module must still fail this battery.
+    files = [SRC / "mcp" / f"{module}.py" for module in TOOL_LOGIC_MODULES]
+    assert all(f.exists() for f in files), "every named tool-logic module must exist"
     assert _violations(files, NETWORK_MODULES) == []

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -109,9 +109,17 @@ def test_cli_bad_root_exits_usage_without_serving(monkeypatch):
 def test_cli_valid_root_runs_server_and_returns_zero(monkeypatch):
     captured = {}
 
-    def _fake_run(root: str, telemetry_enabled: bool = False) -> int:
+    def _fake_run(
+        root: str,
+        telemetry_enabled: bool = False,
+        transport_name: str = "stdio",
+        host: str = "127.0.0.1",
+        port: int = 8000,
+        path: str = "/mcp",
+    ) -> int:
         captured["root"] = root
         captured["telemetry"] = telemetry_enabled
+        captured["transport"] = transport_name
         return 0
 
     monkeypatch.setattr("rac.mcp.server.run_server", _fake_run)
@@ -120,6 +128,7 @@ def test_cli_valid_root_runs_server_and_returns_zero(monkeypatch):
     assert args.func(args) == cli.EXIT_OK
     assert captured["root"] == CORPUS
     assert captured["telemetry"] is False, "telemetry is opt-in, default off (ADR-040)"
+    assert captured["transport"] == "stdio", "stdio is the default transport (ADR-098)"
 
 
 def test_run_server_returns_zero_on_clean_shutdown(monkeypatch):


### PR DESCRIPTION
Initiative 1 of the **lore-at-team-scale** epic (#262), closing sub-issue #263 — the load-bearing build: `rac mcp` gains a streamable HTTP transport so a whole team can point every agent at one always-current `main`-backed endpoint instead of a local server per developer.

Implements `rac/requirements/rac-mcp-http-transport.md` (now Accepted) under a new serving ADR.

## What ships

- **ADR-098 — Shared HTTP MCP Serving** (`rac/decisions/adr-098-shared-http-mcp-serving.md`, Accepted). Resolves ADR-091's stdio-only *premise* against ADR-080's recorded shared-server *intent* (the endpoint is a transport, not a datastore) while keeping ADR-091's no-engine-scrape-endpoint conclusion. Restates the no-auth-in-engine posture (ADR-085) and makes HTTP serving mandatory audit-on (ADR-084).
- **`rac mcp --transport {stdio,http}`** plus `--host` / `--port` / `--path`. stdio stays the default, so every existing `.mcp.json` — including ADR-088 profile output — is byte-unchanged.
- **`src/rac/mcp/transport.py`** — the fenced serving layer: streamable-HTTP dispatch, stateless per call (no sessions, no server-held state), and the startup audit guard.
- **Mandatory audit-on:** starting `--transport http` without a *working* audit sink (unconfigured or unwritable) exits non-zero with an actionable message. stdio is untouched — audit stays config-driven and default-absent there.
- **Isolation battery revised** (ADR-backed, REQ-005): the network-import allowance widens from `ping` alone to `ping` + `transport`; tool-logic modules stay network-import-free, and the battery still fails if a tool-logic module imports a network module.

## Contract held

- **Parity (REQ-006):** a new in-process test spins the HTTP server on an ephemeral port and round-trips all five tools (both `find_decisions` modes) via the SDK client — payloads are byte-identical to the direct handler output for the same fixture corpus.
- **Additive (REQ-001/REQ-006):** bare `rac mcp` is unchanged; `test_profiles` confirms ADR-088 `.mcp.json` output is byte-identical.
- **No auth in the engine (REQ-004):** identity stays the attributable principal; authentication belongs to the deployment proxy, documented in `docs/mcp.md`.

## Out of scope (later sub-issues)

Derived-index cache (#264), per-request audit *identity* threading (#265 — here HTTP only requires the sink exists), and the operator deployment recipe (#266).

## Gates

`rac validate rac/`, `rac relationships rac/ --validate`, and `rac review rac/` all clean (health 95/100, no priority 1–2 findings). Full MCP battery (177) + relationships/resolve/profiles/init/CLI batteries green; ruff + mypy clean.

Closes #263.