### PR TITLE
feat(mcp): content-addressed derived-index cache (lore-at-team-scale #264)

### DIFF
--- a/.cursor/rules
+++ b/.cursor/rules
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: 6d0950ce0ec346d9bcb9ae758fc3dca55a867a9cf0b4ec23ac74a5ed4ea7a6da) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: fdf6de5712cd9fcd3d6179d984795bf5c0eb312dbb5578632b42db966bb17333) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -71,4 +71,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KWBJJRZR84PT** — ADR-096: External-Target Verification Edge (`verified_by`) _(Technical)_
 - **RAC-KWFVA38YT2C0** — ADR-097: Benchmark Family Contract _(Technical)_
 - **RAC-KWMW45KXHZJP** — ADR-098: Shared HTTP MCP Serving _(Architecture)_
+- **RAC-KWMZ3MR9DZ09** — ADR-099: Derived-Index Cache _(Technical)_
 <!-- END RAC MANAGED BLOCK -->

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: 6d0950ce0ec346d9bcb9ae758fc3dca55a867a9cf0b4ec23ac74a5ed4ea7a6da) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: fdf6de5712cd9fcd3d6179d984795bf5c0eb312dbb5578632b42db966bb17333) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -71,4 +71,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KWBJJRZR84PT** — ADR-096: External-Target Verification Edge (`verified_by`) _(Technical)_
 - **RAC-KWFVA38YT2C0** — ADR-097: Benchmark Family Contract _(Technical)_
 - **RAC-KWMW45KXHZJP** — ADR-098: Shared HTTP MCP Serving _(Architecture)_
+- **RAC-KWMZ3MR9DZ09** — ADR-099: Derived-Index Cache _(Technical)_
 <!-- END RAC MANAGED BLOCK -->

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,7 +92,7 @@ jobs:
           - name: explorer
             paths: "tests/test_explorer_adapter.py tests/test_explorer_app.py tests/test_explorer_cli.py tests/test_explorer_commands.py tests/test_explorer_editor.py tests/test_explorer_isolation.py tests/test_explorer_workspace.py"
           - name: mcp
-            paths: "tests/test_mcp_server.py tests/test_mcp_tools.py tests/test_mcp_isolation.py tests/test_mcp_telemetry.py tests/test_mcp_ping.py tests/test_mcp_audit.py tests/test_mcp_http.py"
+            paths: "tests/test_mcp_server.py tests/test_mcp_tools.py tests/test_mcp_isolation.py tests/test_mcp_telemetry.py tests/test_mcp_ping.py tests/test_mcp_audit.py tests/test_mcp_http.py tests/test_derived_cache.py"
           - name: relationships
             paths: "tests/test_relationships.py tests/test_relationships_cmd.py tests/test_relationship_validation.py tests/test_relationship_graph.py tests/test_lifecycle_status.py tests/test_rename.py"
           - name: resolve

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: 6d0950ce0ec346d9bcb9ae758fc3dca55a867a9cf0b4ec23ac74a5ed4ea7a6da) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: fdf6de5712cd9fcd3d6179d984795bf5c0eb312dbb5578632b42db966bb17333) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -71,4 +71,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KWBJJRZR84PT** — ADR-096: External-Target Verification Edge (`verified_by`) _(Technical)_
 - **RAC-KWFVA38YT2C0** — ADR-097: Benchmark Family Contract _(Technical)_
 - **RAC-KWMW45KXHZJP** — ADR-098: Shared HTTP MCP Serving _(Architecture)_
+- **RAC-KWMZ3MR9DZ09** — ADR-099: Derived-Index Cache _(Technical)_
 <!-- END RAC MANAGED BLOCK -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,10 @@ details, release history over commit history.
 
 The **decision-to-code-proximity** programme: recorded decisions now know which
 code they govern, and you can ask which decisions govern a path — declared and
-validated, never inferred; deterministic and offline. Plus the first build of
+validated, never inferred; deterministic and offline. Plus the first builds of
 **lore-at-team-scale**: `rac mcp` can now serve the whole team over one
-always-current HTTP endpoint.
+always-current HTTP endpoint, with an optional content-addressed cache so
+per-call latency stops scaling with corpus size.
 
 ### Added
 
@@ -38,6 +39,13 @@ always-current HTTP endpoint.
   endpoint is read-only and unauthenticated by design — authentication belongs
   to your deployment proxy — and it is mandatory audit-on: it refuses to start
   without a working read-access audit log (ADR-098).
+- **Derived-index cache (`rac mcp --cache`).** For large corpora, an opt-in
+  content-addressed cache reuses the expensive derived structures — the
+  repository index, the relationship graph, and the search token vectors — so
+  repeated reads of an unchanged corpus skip re-indexing and re-tokenising.
+  It is disposable and never authoritative: keyed on a corpus content hash so
+  any byte change rebuilds it, byte-identical to the uncached path, and deleting
+  it costs only latency (ADR-099). Off by default.
 
 ## 2026.06.5 — the "rename" release
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ to the corpus artifact and they load through the imports below.
 - Previous series: `rac/roadmaps/v0.21.x-editor/` (complete)
 - Decisions (ADRs): `rac/decisions/`
 
-<!-- BEGIN RAC MANAGED BLOCK (digest: 6d0950ce0ec346d9bcb9ae758fc3dca55a867a9cf0b4ec23ac74a5ed4ea7a6da) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: fdf6de5712cd9fcd3d6179d984795bf5c0eb312dbb5578632b42db966bb17333) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -96,4 +96,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KWBJJRZR84PT** — ADR-096: External-Target Verification Edge (`verified_by`) _(Technical)_
 - **RAC-KWFVA38YT2C0** — ADR-097: Benchmark Family Contract _(Technical)_
 - **RAC-KWMW45KXHZJP** — ADR-098: Shared HTTP MCP Serving _(Architecture)_
+- **RAC-KWMZ3MR9DZ09** — ADR-099: Derived-Index Cache _(Technical)_
 <!-- END RAC MANAGED BLOCK -->

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -380,6 +380,26 @@ Keeping the fronted checkout current with `main` — a merge webhook or a period
 `git pull` — is a deployment concern outside the engine; a full container-and-
 keep-current recipe is documented separately for operators.
 
+### Derived-index cache (large corpora)
+
+By default every tool call rebuilds the derived structures — the repository
+index, the relationship graph, and the search token vectors — from disk. On a
+large corpus that re-indexing and re-tokenising costs real latency. Add
+`--cache` to reuse those structures across calls
+([ADR-099](https://github.com/itsthelore/rac-core/blob/main/rac/decisions/adr-099-derived-index-cache.md)):
+
+```bash
+rac mcp --root /path/to/your/repo --transport http --cache
+```
+
+The cache is **content-addressed and disposable**. It is keyed on a hash of the
+corpus bytes, so any change to any artifact — an edit, add, remove, or rename —
+changes the key and forces a rebuild; the key is recomputed every call, so no
+call ever serves stale state. Output with `--cache` is **byte-identical** to the
+uncached path. The cache lives at `$XDG_CACHE_HOME/rac/derived` (override with
+`RAC_CACHE_DIR`); deleting it costs only latency, never correctness — the files
+in git remain the single source of truth. It is off by default.
+
 ## 10. Troubleshooting
 
 ### Server not listed in the client

--- a/rac/decisions/adr-099-derived-index-cache.md
+++ b/rac/decisions/adr-099-derived-index-cache.md
@@ -1,0 +1,163 @@
+---
+schema_version: 1
+id: RAC-KWMZ3MR9DZ09
+type: decision
+---
+# ADR-099: Derived-Index Cache
+
+## Status
+
+Accepted
+
+## Category
+
+Technical
+
+## Context
+
+Every read rebuilds the same expensive derived structures from disk: the
+repository index, the resolved relationship graph, and the tokenised field
+vectors BM25 scores over. ADR-032 chose that re-read-per-call model
+deliberately — correctness over speed — and recorded its own review trigger:
+"optimized only when a real user reports it, behind the corpus-snapshot seam,
+without breaking the determinism contract," with a concrete threshold ("a
+1000-artifact corpus" / "a real user reports Guide latency"). The
+`lore-at-team-scale` rollout is that report: an organisation-scale corpus where
+per-call re-tokenisation and re-indexing cost real latency.
+
+ADR-080 already anticipated the answer and deferred it: "a *persistent derived
+index* may be warranted at scale, but it is a rebuildable cache behind ADR-032's
+snapshot seam … not a database and not authoritative." What is missing is the
+recorded contract that lets such a cache exist without eroding ADR-032's
+determinism-and-freshness guarantee — and the deliberate revision of ADR-032's
+"no persistent cache, no session state in the server" pin, which a cache on the
+serving path plainly touches. ADR-032 lists the failure mode to avoid by name: a
+modification-time cache whose invalidation is unreliable, serving silent
+staleness. The cache must be invalidated on content, not clocks.
+
+## Decision
+
+RAC gains an optional, content-addressed **derived-index cache** behind the
+corpus-snapshot seam, and ADR-032's "no persistent cache on the serving path"
+pin is revised — by this decision, for everyone — to permit it under strict
+conditions.
+
+- **Content-addressed, never clock- or event-addressed.** The cache is keyed on
+  a corpus-level content hash that extends the per-file `content_hash` primitive:
+  the sorted `(repository-relative path, per-file digest)` pairs hashed together.
+  Any byte change to any artifact — or any add, remove, or rename — changes the
+  key and forces a rebuild. This is precisely the invalidation ADR-032's
+  rejected mtime cache lacked; there is no time- or event-based invalidation.
+
+- **Freshness holds on the serving path.** The key is recomputed on every call,
+  so every call still detects any corpus change since the previous one (ADR-032's
+  contract). Derived structures are reused only under an unchanged key; the agent
+  can never observe stale state. Re-hashing per call is cheap relative to the
+  parse, tokenise, and index work it guards.
+
+- **Byte-parity is the coherency guarantee.** With the cache enabled, every CLI
+  and MCP output is byte-identical to the uncached path for any corpus state —
+  the structures are serialised and rehydrated losslessly and every consumer
+  produces identical output whether a structure came from cache or fresh compute.
+  This is asserted over golden fixtures in CI, cache-on versus cache-off.
+
+- **Disposable, never authoritative.** The files in git are the source of truth
+  (ADR-080); the cache is a rebuildable index. Deleting the cache directory — or
+  a corrupt, unreadable, or wrong-version cache file — costs only latency: the
+  reader falls back to a fresh build. No daemon, no lockfile protocol, no
+  datastore semantics. The cache writes only to its own disposable directory
+  (`$XDG_CACHE_HOME/rac/derived`, `RAC_CACHE_DIR` overriding), never to the
+  corpus.
+
+- **Opt-in, off by default.** The default serving path is unchanged
+  (re-read-per-call, ADR-032); the cache is enabled explicitly (`rac mcp
+  --cache`). This keeps cache-on-versus-cache-off the byte-parity test toggle and
+  leaves the zero-state posture exactly as before.
+
+## Consequences
+
+### Positive
+
+- Per-call work stops scaling with corpus size once warm: an unchanged corpus
+  skips re-tokenisation and re-indexing, so latency stays agent-tolerable at
+  organisation scale.
+- The ADR-032 review clause is answered on the record, and its "no persistent
+  cache" pin is revised by decision, not by an innocent-looking cache slipped in
+  against the determinism tests.
+- No new datastore: the only moving parts remain a git checkout, a stateless
+  reader, and a disposable derived index (ADR-080).
+
+### Negative
+
+- A second representation of the derived structures exists on disk; its
+  correctness rests on the content hash being exact and the serialisation being
+  lossless — both asserted in CI, but both now things to maintain.
+- The first call on a changed corpus pays the full rebuild plus the cache write;
+  the win is on repeated reads of an unchanged corpus.
+
+### Risks
+
+- Wrong invalidation serves stale results. Mitigation: pure content addressing
+  (any byte change changes the key) plus the byte-parity assertion — staleness
+  cannot survive both, and there is no mtime or event path to get wrong.
+- The cache drifts into a datastore. Mitigation: disposability is pinned — it is
+  never read as authoritative, deleting it changes only latency, and it holds no
+  state git does not.
+- A serialisation change silently rehydrates a stale shape. Mitigation: a pinned
+  cache schema version; a mismatch is treated as a miss and rebuilt.
+
+## Alternatives Considered
+
+### Keep re-read-per-call unconditionally (ADR-032 unchanged)
+
+Leave the serving path rebuilding everything each call.
+
+#### Disadvantages
+
+- Ignores ADR-032's own review trigger, which has now fired; per-call latency on
+  a large corpus degrades the agent experience the tool exists to serve.
+
+### A modification-time (mtime) cache
+
+Invalidate cached structures when file mtimes change.
+
+#### Disadvantages
+
+- ADR-032 already rejected this: mtime granularity and editor behaviours make
+  invalidation unreliable — the silent-staleness failure the tool cannot afford.
+  Content addressing is the correct key.
+
+### A central database as a shared derived store
+
+Stand up a database that holds the derived index for the team.
+
+#### Disadvantages
+
+- ADR-080's red line: a second authoritative representation to reconcile with
+  `main`, losing git's diffability and offline operation. The cache is a
+  disposable rebuildable index, not a store.
+
+A content-addressed, disposable, opt-in cache with byte-parity to the uncached
+path is selected.
+
+## Relationship to Other Decisions
+
+- ADR-032: this decision answers its recorded review clause and revises its "no
+  persistent cache on the serving path" pin, preserving its determinism and
+  freshness contract.
+- ADR-080: the cache is the "rebuildable derived index behind the snapshot seam"
+  that ADR-080 deferred — disposable, never authoritative.
+- ADR-002: content addressing and lossless serialisation keep output
+  deterministic and byte-identical across runs and platforms.
+- ADR-066: no embeddings or semantic structures are cached — only the
+  deterministic derived index, graph, and token vectors.
+- ADR-007: the cache is additive and off by default; no existing contract field
+  changes and the uncached path is byte-unchanged.
+
+## Related Requirements
+
+- rac-derived-index-cache
+
+## Related Roadmaps
+
+- lore-at-team-scale

--- a/rac/requirements/rac-derived-index-cache.md
+++ b/rac/requirements/rac-derived-index-cache.md
@@ -7,12 +7,17 @@ type: requirement
 
 ## Status
 
-Proposed
+Accepted
 
 Classification: `[internal]` — per-call work stops scaling with corpus
 size. Initiative 2 of the `lore-at-team-scale` roadmap: a
 content-addressed, rebuild-on-change cache behind the ADR-032 seam,
-shipped under its own ADR.
+shipped under its own ADR. Delivered (itsthelore/rac-core#264): the
+`DerivedIndexCache` persists the repository index, resolved relationship
+graph, and tokenised field vectors keyed on `corpus_content_hash`, enabled
+opt-in via `rac mcp --cache`, byte-identical to the uncached path — under
+ADR-099, which answers ADR-032's review clause and revises its
+no-persistent-cache pin.
 
 ## Problem
 
@@ -79,6 +84,7 @@ uncached path.
 - adr-032
 - adr-066
 - adr-080
+- adr-099
 
 ## Related Roadmaps
 

--- a/rac/roadmaps/lore-at-team-scale.md
+++ b/rac/roadmaps/lore-at-team-scale.md
@@ -197,6 +197,7 @@ engine.
 - adr-093
 - adr-094
 - adr-098
+- adr-099
 
 ## Related Roadmaps
 

--- a/src/rac/cli.py
+++ b/src/rac/cli.py
@@ -834,6 +834,7 @@ def cmd_mcp(args: argparse.Namespace) -> int:
             host=args.host,
             port=args.port,
             path=args.path,
+            cache_enabled=args.cache,
         )
     except MalformedAuditConfig as exc:  # bad `audit:` stanza (ADR-084)
         print(f"rac: {exc}", file=sys.stderr)
@@ -1874,6 +1875,19 @@ def build_parser() -> argparse.ArgumentParser:
         "--path",
         default="/mcp",
         help="HTTP path to serve for --transport http (default: /mcp).",
+    )
+    # Derived-index cache (ADR-099): opt-in, off by default. Reuses the expensive
+    # derived structures under an unchanged corpus content hash, byte-identically
+    # to the uncached path; location is $XDG_CACHE_HOME/rac/derived (RAC_CACHE_DIR
+    # overrides). Deleting the cache costs only latency.
+    p_mcp.add_argument(
+        "--cache",
+        action="store_true",
+        help=(
+            "Reuse content-addressed derived structures across calls for large "
+            "corpora; disposable and byte-identical to the uncached path "
+            "(off by default, ADR-099)."
+        ),
     )
     p_mcp.set_defaults(func=cmd_mcp)
 

--- a/src/rac/core/corpus.py
+++ b/src/rac/core/corpus.py
@@ -93,6 +93,33 @@ def content_hash(path: Path) -> str:
         return hashlib.sha256(b"\x00rac-unreadable-artifact").hexdigest()
 
 
+def corpus_content_hash(directory: str, *, recursive: bool = True) -> str:
+    """A corpus-level content digest, extending the per-file :func:`content_hash`.
+
+    Hashes the sorted ``(repository-relative POSIX path, per-file content_hash)``
+    pairs together, so the digest is a pure function of the corpus's declared
+    bytes and layout (ADR-002): any byte change to any artifact, or any add,
+    remove, or rename, changes the digest, and nothing else does. Repository-
+    relative POSIX paths make it byte-identical across platforms; the per-file
+    primitive it composes is the same one ``CorpusCache`` keys on, so the two
+    cannot disagree about what "changed" means.
+
+    This is the content-addressed key a derived-index cache invalidates on: an
+    unchanged key means every artifact's bytes are unchanged, so the expensive
+    derived structures may be reused; any change forces a rebuild (ADR-080 — the
+    index is disposable, the files are truth).
+    """
+    root = Path(directory)
+    hasher = hashlib.sha256()
+    for path in find_markdown_files(directory, recursive=recursive):
+        rel = path.relative_to(root).as_posix()
+        hasher.update(rel.encode("utf-8"))
+        hasher.update(b"\0")
+        hasher.update(content_hash(path).encode("ascii"))
+        hasher.update(b"\0")
+    return hasher.hexdigest()
+
+
 class CorpusCache:
     """Per-invocation, content-hash-keyed corpus snapshot reuse (v0.23.0, WS8).
 

--- a/src/rac/mcp/server.py
+++ b/src/rac/mcp/server.py
@@ -64,7 +64,8 @@ from rac.mcp.budget import (
 )
 from rac.mcp.telemetry import TelemetryRecorder
 from rac.services.agent_rules import artifact_status
-from rac.services.index import build_repository_index, index_from_corpus
+from rac.services.derived_cache import DerivedIndexCache
+from rac.services.index import IndexEntry, build_repository_index, index_from_corpus
 from rac.services.portfolio import build_portfolio_summary
 from rac.services.recency import artifact_provenance
 from rac.services.relationships import (
@@ -77,6 +78,7 @@ from rac.services.resolve import (
     OUTCOME_RESOLVED,
     ResolutionResult,
     find_decisions,
+    find_decisions_in,
     resolve_in_index,
     search_index,
 )
@@ -154,18 +156,34 @@ def _read_content(path: str) -> str:
     return Path(path).read_text(encoding="utf-8")
 
 
-def _resolve(root: str, artifact_id: str) -> ResolutionResult:
-    """Resolve ``artifact_id`` against a fresh read of ``root`` (ADR-032).
+def _index_entries(root: str, cache: DerivedIndexCache | None) -> list[IndexEntry]:
+    """The repository index rows, from the derived-index cache or a fresh walk.
+
+    With ``cache`` set (ADR-099) the rows come from the content-addressed cache —
+    byte-identical to the fresh build, only the walk/index is skipped under an
+    unchanged corpus key. With ``cache`` None the serving path is exactly as
+    before (ADR-032): a fresh read every call.
+    """
+    if cache is not None:
+        return cache.load_or_build(root).index_entries
+    return build_repository_index(root, recursive=True).artifacts
+
+
+def _resolve(
+    root: str, artifact_id: str, cache: DerivedIndexCache | None = None
+) -> ResolutionResult:
+    """Resolve ``artifact_id`` against the repository index (ADR-032).
 
     Uses the repository index and the resolver's in-index semantics so a single
     walk serves both resolution and any follow-on shaping the tool needs.
     """
-    entries = build_repository_index(root, recursive=True).artifacts
-    return resolve_in_index(entries, artifact_id)
+    return resolve_in_index(_index_entries(root, cache), artifact_id)
 
 
-def _get_artifact(root: str, artifact_id: str, budget: int) -> str:
-    result = _resolve(root, artifact_id)
+def _get_artifact(
+    root: str, artifact_id: str, budget: int, cache: DerivedIndexCache | None = None
+) -> str:
+    result = _resolve(root, artifact_id, cache)
     if result.outcome != OUTCOME_RESOLVED or result.artifact is None:
         return serialize(errors.from_resolution(result), budget)
     try:
@@ -194,13 +212,34 @@ def _get_artifact(root: str, artifact_id: str, budget: int) -> str:
     return serialize(payload, budget)
 
 
-def _search_artifacts(root: str, query: str, artifact_type: str | None, budget: int) -> str:
-    entries = build_repository_index(root, recursive=True).artifacts
-    result = search_index(entries, query, artifact_type=artifact_type)
+def _search_artifacts(
+    root: str,
+    query: str,
+    artifact_type: str | None,
+    budget: int,
+    cache: DerivedIndexCache | None = None,
+) -> str:
+    if cache is not None:
+        derived = cache.load_or_build(root)
+        result = search_index(
+            derived.index_entries,
+            query,
+            artifact_type=artifact_type,
+            field_tokens_by_path=derived.field_tokens_by_path,
+        )
+    else:
+        entries = build_repository_index(root, recursive=True).artifacts
+        result = search_index(entries, query, artifact_type=artifact_type)
     return serialize(result.to_dict(), budget)
 
 
-def _find_decisions(root: str, topic: str, path: str | None, budget: int) -> str:
+def _find_decisions(
+    root: str,
+    topic: str,
+    path: str | None,
+    budget: int,
+    cache: DerivedIndexCache | None = None,
+) -> str:
     """Live decisions binding a ``topic`` — or governing a code ``path``.
 
     Two modes over one tool (additive, ADR-007). With ``path`` set, this is the
@@ -213,7 +252,16 @@ def _find_decisions(root: str, topic: str, path: str | None, budget: int) -> str
     """
     if path:
         return serialize(decisions_for_path(root, path, recursive=True).to_dict(), budget)
-    result = find_decisions(root, topic, recursive=True)
+    if cache is not None:
+        derived = cache.load_or_build(root)
+        result = find_decisions_in(
+            derived.index_entries,
+            derived.live_decision_paths,
+            topic,
+            field_tokens_by_path=derived.field_tokens_by_path,
+        )
+    else:
+        result = find_decisions(root, topic, recursive=True)
     payload = result.to_dict()
     # Make the live-decision intent explicit on the wire (additive, ADR-007): the
     # type is always "decision" and the result is filtered to live decisions.
@@ -221,19 +269,27 @@ def _find_decisions(root: str, topic: str, path: str | None, budget: int) -> str
     return serialize(payload, budget)
 
 
-def _get_related(root: str, artifact_id: str, budget: int, depth: int = 1) -> str:
-    # One corpus walk feeds resolution, outgoing, and incoming, so the whole
-    # response reflects a single atomic snapshot of the repository (ADR-032):
-    # there is no window in which the relationship view drifts mid-call.
-    # Caching across calls remains forbidden — the snapshot lives and dies
-    # inside this call.
-    entries = list(walk_corpus(root, recursive=True))
-    index = index_from_corpus(root, entries, recursive=True).artifacts
+def _get_related(
+    root: str, artifact_id: str, budget: int, depth: int = 1, cache: DerivedIndexCache | None = None
+) -> str:
+    # One corpus snapshot feeds resolution, outgoing, and incoming, so the whole
+    # response reflects a single atomic view of the repository (ADR-032): there
+    # is no window in which the relationship view drifts mid-call. With the
+    # derived-index cache (ADR-099) the index and relationship graph come from
+    # one content-addressed snapshot; without it, one fresh walk feeds both.
+    # Either way the two are from the same snapshot and the output is identical.
+    if cache is not None:
+        derived = cache.load_or_build(root)
+        index = derived.index_entries
+        relationships = derived.relationships
+    else:
+        entries = list(walk_corpus(root, recursive=True))
+        index = index_from_corpus(root, entries, recursive=True).artifacts
+        relationships = relationships_from_corpus(entries)
     result = resolve_in_index(index, artifact_id)
     if result.outcome != OUTCOME_RESOLVED or result.artifact is None:
         return serialize(errors.from_resolution(result), budget)
     artifact = result.artifact
-    relationships = relationships_from_corpus(entries)
     identity_by_path = {entry.path: (entry.id, entry.type, entry.title) for entry in index}
     outgoing = outgoing_references(relationships, artifact.path)
     incoming_result = incoming_references(relationships, identity_by_path, artifact.path)
@@ -311,6 +367,7 @@ def build_server(
     budget: int = DEFAULT_BUDGET,
     recorder: TelemetryRecorder | None = None,
     audit_recorder: audit.AuditRecorder | None = None,
+    cache: DerivedIndexCache | None = None,
 ) -> FastMCP:
     """Build the Guide MCP server bound to repository ``root``.
 
@@ -318,9 +375,12 @@ def build_server(
     startup; there is no per-call override. ``recorder`` enables opt-in usage
     telemetry (ADR-040) and ``audit_recorder`` enables the read-access audit log
     (ADR-084): with both ``None`` — the default — nothing is recorded and every
-    call is exactly the bare tool body. The returned :class:`FastMCP` instance
-    has the five pinned tools registered and is ready to run over any transport —
-    the CLI runs it over stdio.
+    call is exactly the bare tool body. ``cache`` enables the derived-index cache
+    (ADR-099): with ``None`` — the default — every tool re-reads and rebuilds from
+    disk (ADR-032); with a cache, the expensive derived structures are reused
+    under an unchanged corpus content hash, byte-identically. The returned
+    :class:`FastMCP` instance has the five pinned tools registered and is ready to
+    run over any transport — the CLI runs it over stdio.
     """
     server: FastMCP = FastMCP(SERVER_NAME)
 
@@ -335,14 +395,14 @@ def build_server(
 
     @server.tool(name="get_artifact", description=DESC_GET_ARTIFACT)
     def get_artifact(id: str) -> str:
-        return observed("get_artifact", {"id": id}, lambda: _get_artifact(root, id, budget))
+        return observed("get_artifact", {"id": id}, lambda: _get_artifact(root, id, budget, cache))
 
     @server.tool(name="search_artifacts", description=DESC_SEARCH_ARTIFACTS)
     def search_artifacts(query: str, type: str | None = None) -> str:
         return observed(
             "search_artifacts",
             {"query": query, "type": type},
-            lambda: _search_artifacts(root, query, type, budget),
+            lambda: _search_artifacts(root, query, type, budget, cache),
         )
 
     @server.tool(name="find_decisions", description=DESC_FIND_DECISIONS)
@@ -350,12 +410,16 @@ def build_server(
         # ``path`` only rides the audit args when supplied, so a topic query's
         # recorded shape is byte-identical to before (additive, ADR-007).
         args = {"topic": topic} if path is None else {"topic": topic, "path": path}
-        return observed("find_decisions", args, lambda: _find_decisions(root, topic, path, budget))
+        return observed(
+            "find_decisions", args, lambda: _find_decisions(root, topic, path, budget, cache)
+        )
 
     @server.tool(name="get_related", description=DESC_GET_RELATED)
     def get_related(id: str, depth: int = 1) -> str:
         return observed(
-            "get_related", {"id": id, "depth": depth}, lambda: _get_related(root, id, budget, depth)
+            "get_related",
+            {"id": id, "depth": depth},
+            lambda: _get_related(root, id, budget, depth, cache),
         )
 
     @server.tool(name="get_summary", description=DESC_GET_SUMMARY)
@@ -425,6 +489,7 @@ def run_server(
     host: str = transport.DEFAULT_HOST,
     port: int = transport.DEFAULT_PORT,
     path: str = transport.DEFAULT_PATH,
+    cache_enabled: bool = False,
 ) -> int:
     """Run the Guide server over stdio (default) or streamable HTTP.
 
@@ -437,6 +502,11 @@ def run_server(
     ``host``/``port``/``path`` and served statelessly (ADR-032). HTTP serving is
     mandatory-audit-on: it refuses to start without a working audit sink
     (ADR-084), asserted before the endpoint opens.
+
+    ``cache_enabled`` turns on the derived-index cache (ADR-099): the expensive
+    derived structures are persisted content-addressed and reused under an
+    unchanged corpus hash, byte-identically to the uncached path. Off by default —
+    the serving path is exactly ADR-032's re-read-per-call otherwise.
 
     Emits a one-line notice to stderr when the repository root contains no
     recognized artifacts (v0.10.1 startup hardening), and another when
@@ -463,7 +533,18 @@ def run_server(
             f"{audit_recorder.path}",
             file=sys.stderr,
         )
-    server = build_server(root, budget=budget, recorder=recorder, audit_recorder=audit_recorder)
+    cache: DerivedIndexCache | None = None
+    if cache_enabled:
+        cache = DerivedIndexCache()
+        print(
+            "rac mcp: derived-index cache on — reusing content-addressed derived "
+            f"structures under {cache.cache_dir} (disposable; byte-identical to the "
+            "uncached path, ADR-099).",
+            file=sys.stderr,
+        )
+    server = build_server(
+        root, budget=budget, recorder=recorder, audit_recorder=audit_recorder, cache=cache
+    )
     if transport_name == transport.TRANSPORT_HTTP:
         # Mandatory-audit-on entry condition (ADR-084): a shared endpoint
         # without a working auditor refuses to start rather than serving reads

--- a/src/rac/services/derived_cache.py
+++ b/src/rac/services/derived_cache.py
@@ -1,0 +1,249 @@
+"""Content-addressed derived-index cache (ADR-099, `lore-at-team-scale` #264).
+
+Every read rebuilds the same expensive derived structures from disk: the
+repository index, the resolved relationship graph, and the tokenised field
+vectors BM25 scores over. ADR-032 deliberately kept that rebuild on the serving
+path and recorded its own review trigger — a real user reporting latency at
+scale. That report has arrived, and ADR-099 answers it: a *disposable,
+content-addressed* cache of those structures, byte-identical to the uncached
+path, revising the "no persistent cache on the serving path" pin by decision.
+
+The cache is a pure optimisation behind the corpus-snapshot seam:
+
+- **Content-addressed** (ADR-002): keyed on :func:`corpus_content_hash`, so any
+  byte change to any artifact — or any add, remove, or rename — changes the key
+  and forces a rebuild. There is no time- or event-based invalidation.
+- **Fresh per call** (ADR-032): the key is recomputed every call, so no call can
+  observe stale state; derived structures are reused only under an unchanged key.
+- **Disposable, never authoritative** (ADR-080): the files in git are the truth;
+  this is a rebuildable index. Deleting the cache directory — or a corrupt or
+  unreadable cache file — costs only latency, never correctness: the reader falls
+  back to a fresh build. No daemon, no lockfile protocol, no datastore semantics.
+- **Byte-parity is the coherency guarantee** (REQ-002): the structures are
+  serialised and rehydrated losslessly, and every consumer produces identical
+  output whether a structure came from cache or fresh compute.
+
+This is a read-only cache service; it writes only to its own disposable cache
+directory (default ``$XDG_CACHE_HOME/rac/derived``), never to the corpus.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+from rac.core.corpus import corpus_content_hash, walk_corpus
+from rac.core.models import SearchSection
+from rac.services.index import IndexEntry, index_from_corpus
+from rac.services.relationships import Relationship, relationships_from_corpus
+from rac.services.resolve import field_tokens_for_entries, live_decision_paths
+
+# Bumping this discards every existing cache file (they carry it and a mismatch
+# is treated as a miss), so a serialisation change can never rehydrate stale
+# shapes. A recorded decision, like any pinned schema (ADR-007).
+SCHEMA_VERSION = "1"
+
+CACHE_DIRNAME = "derived"
+CACHE_DIR_ENV = "RAC_CACHE_DIR"
+
+
+@dataclass(frozen=True)
+class DerivedIndex:
+    """The expensive derived structures for one corpus snapshot (ADR-099).
+
+    Each field is a pure function of the corpus bytes, so the whole bundle is
+    content-addressable and losslessly serialisable:
+
+    - ``index_entries`` — the repository index rows (identity, type, title, path,
+      aliases, searchable sections, inbound edge count).
+    - ``relationships`` — the resolved relationship graph.
+    - ``field_tokens_by_path`` — the tokenised BM25 field vectors, keyed by path.
+    - ``live_decision_paths`` — the Accepted, non-retired decision paths, so the
+      ``find_decisions`` liveness filter needs no parsed products.
+    """
+
+    index_entries: list[IndexEntry]
+    relationships: list[Relationship]
+    field_tokens_by_path: dict[str, dict[str, list[str]]]
+    live_decision_paths: list[str]
+
+
+def build_derived_index(directory: str, *, recursive: bool = True) -> DerivedIndex:
+    """Build the derived structures fresh from one corpus walk (the cache miss path).
+
+    One walk feeds every structure, exactly as the uncached consumers build them
+    individually, so a cache-populated call and a fresh call are byte-identical.
+    """
+    entries = list(walk_corpus(directory, recursive=recursive))
+    index = index_from_corpus(directory, entries, recursive=recursive)
+    return DerivedIndex(
+        index_entries=index.artifacts,
+        relationships=relationships_from_corpus(entries),
+        field_tokens_by_path=field_tokens_for_entries(index.artifacts),
+        live_decision_paths=live_decision_paths(entries),
+    )
+
+
+def _index_entry_to_obj(entry: IndexEntry) -> dict:
+    return {
+        "id": entry.id,
+        "type": entry.type,
+        "title": entry.title,
+        "path": entry.path,
+        "aliases": list(entry.aliases),
+        "search_sections": [
+            {"heading": sec.heading, "lines": list(sec.lines)} for sec in entry.search_sections
+        ],
+        "inbound_count": entry.inbound_count,
+    }
+
+
+def _index_entry_from_obj(obj: dict) -> IndexEntry:
+    return IndexEntry(
+        id=obj["id"],
+        type=obj["type"],
+        title=obj["title"],
+        path=obj["path"],
+        aliases=list(obj["aliases"]),
+        search_sections=[
+            SearchSection(heading=sec["heading"], lines=list(sec["lines"]))
+            for sec in obj["search_sections"]
+        ],
+        inbound_count=obj["inbound_count"],
+    )
+
+
+def _relationship_to_obj(rel: Relationship) -> dict:
+    return {
+        "source_path": rel.source_path,
+        "relationship": rel.relationship,
+        "target": rel.target,
+        "resolved_path": rel.resolved_path,
+        "issue": rel.issue,
+    }
+
+
+def _relationship_from_obj(obj: dict) -> Relationship:
+    return Relationship(
+        source_path=obj["source_path"],
+        relationship=obj["relationship"],
+        target=obj["target"],
+        resolved_path=obj["resolved_path"],
+        issue=obj["issue"],
+    )
+
+
+def to_json_obj(derived: DerivedIndex) -> dict:
+    """Serialise a :class:`DerivedIndex` to a JSON-ready object (lossless)."""
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "index_entries": [_index_entry_to_obj(e) for e in derived.index_entries],
+        "relationships": [_relationship_to_obj(r) for r in derived.relationships],
+        "field_tokens_by_path": derived.field_tokens_by_path,
+        "live_decision_paths": list(derived.live_decision_paths),
+    }
+
+
+def from_json_obj(obj: dict) -> DerivedIndex:
+    """Rehydrate a :class:`DerivedIndex` from :func:`to_json_obj` output.
+
+    Raises on a shape or version mismatch; the cache treats any raise as a miss
+    and rebuilds, so a bad file is never fatal.
+    """
+    if obj.get("schema_version") != SCHEMA_VERSION:
+        raise ValueError(f"derived-cache schema mismatch: {obj.get('schema_version')!r}")
+    return DerivedIndex(
+        index_entries=[_index_entry_from_obj(e) for e in obj["index_entries"]],
+        relationships=[_relationship_from_obj(r) for r in obj["relationships"]],
+        field_tokens_by_path={
+            path: {field: list(tokens) for field, tokens in fields.items()}
+            for path, fields in obj["field_tokens_by_path"].items()
+        },
+        live_decision_paths=list(obj["live_decision_paths"]),
+    )
+
+
+def default_cache_dir() -> Path:
+    """The derived-cache directory: ``RAC_CACHE_DIR`` > ``$XDG_CACHE_HOME/rac/derived``.
+
+    A cache location, not a state location — deleting it is always safe (ADR-080).
+    """
+    override = os.environ.get(CACHE_DIR_ENV)
+    if override:
+        return Path(override)
+    base = os.environ.get("XDG_CACHE_HOME") or str(Path.home() / ".cache")
+    return Path(base) / "rac" / CACHE_DIRNAME
+
+
+class DerivedIndexCache:
+    """Disposable, content-addressed persistence of the derived structures (ADR-099).
+
+    :meth:`load_or_build` is the whole surface: it hashes the corpus, returns the
+    cached structures under an unchanged key, and otherwise rebuilds and persists
+    them. Every failure mode degrades to a fresh build — an unwritable directory,
+    a corrupt file, a schema mismatch — so enabling the cache can never change an
+    answer or fail a call, only its latency.
+    """
+
+    def __init__(self, cache_dir: Path | None = None) -> None:
+        self.cache_dir = cache_dir if cache_dir is not None else default_cache_dir()
+
+    def _path_for(self, corpus_hash: str) -> Path:
+        return self.cache_dir / f"{corpus_hash}.json"
+
+    def load_or_build(self, directory: str, *, recursive: bool = True) -> DerivedIndex:
+        # Freshness (REQ-006): the key is recomputed every call, so any corpus
+        # change since the previous call is observed before anything is reused.
+        corpus_hash = corpus_content_hash(directory, recursive=recursive)
+        cached = self._read(corpus_hash)
+        if cached is not None:
+            return cached
+        derived = build_derived_index(directory, recursive=recursive)
+        self._write(corpus_hash, derived)
+        return derived
+
+    def _read(self, corpus_hash: str) -> DerivedIndex | None:
+        path = self._path_for(corpus_hash)
+        try:
+            obj = json.loads(path.read_text(encoding="utf-8"))
+            return from_json_obj(obj)
+        except (OSError, ValueError, KeyError, TypeError):
+            # Missing, unreadable, corrupt, or wrong-shaped: a miss, never fatal.
+            return None
+
+    def _write(self, corpus_hash: str, derived: DerivedIndex) -> None:
+        try:
+            self.cache_dir.mkdir(parents=True, exist_ok=True)
+            payload = json.dumps(to_json_obj(derived), ensure_ascii=False)
+            # Atomic replace so a concurrent reader never sees a half-written file
+            # (two shared-server requests may build the same key at once; the
+            # content is identical, so last-writer-wins is safe).
+            handle = tempfile.NamedTemporaryFile(
+                mode="w",
+                encoding="utf-8",
+                dir=self.cache_dir,
+                prefix=f".{corpus_hash}.",
+                suffix=".tmp",
+                delete=False,
+            )
+            try:
+                with handle:
+                    handle.write(payload)
+                os.replace(handle.name, self._path_for(corpus_hash))
+            except OSError:
+                _silent_unlink(handle.name)
+                raise
+        except OSError:
+            # The cache is a nicety, not a requirement: if it cannot be written,
+            # the freshly built structures are already being returned (ADR-080).
+            pass
+
+
+def _silent_unlink(path: str) -> None:
+    try:
+        os.unlink(path)
+    except OSError:
+        pass

--- a/src/rac/services/resolve.py
+++ b/src/rac/services/resolve.py
@@ -28,7 +28,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any, Protocol
 
-from rac.core.corpus import walk_corpus
+from rac.core.corpus import CorpusEntry, walk_corpus
 from rac.core.models import SearchSection
 from rac.services.index import build_repository_index, index_from_corpus
 
@@ -428,21 +428,53 @@ def find_decisions(directory: str, topic: str, recursive: bool = True) -> Search
     bind the topic and lets the agent judge contradiction (ADR-067). No semantic
     score is computed here or anywhere downstream.
     """
-    # Reuse the liveness predicate from the agent-rules projection rather than
-    # re-deriving "Accepted and not retired" — the definition must not fork
-    # (the same rule the committed rules block is built from).
+    entries = list(walk_corpus(directory, recursive=recursive))
+    live_paths = live_decision_paths(entries)
+    index = index_from_corpus(directory, entries, recursive=recursive).artifacts
+    return find_decisions_in(index, live_paths, topic)
+
+
+def live_decision_paths(entries: Sequence[CorpusEntry]) -> list[str]:
+    """The paths of the live (Accepted, non-retired) decisions in a snapshot.
+
+    A pure function of the corpus, so the derived-index cache (ADR-099) can
+    persist it alongside the index. Reuses the agent-rules liveness predicate
+    rather than re-deriving "Accepted and not retired" — the definition must not
+    fork (the same rule the committed rules block is built from).
+    """
     from rac.services.agent_rules import is_live_decision
 
-    entries = list(walk_corpus(directory, recursive=recursive))
-    live_paths = {
+    return [
         str(entry.path)
         for entry in entries
         if entry.artifact_type == _DECISION_TYPE and is_live_decision(entry.product)
-    }
-    index = index_from_corpus(directory, entries, recursive=recursive).artifacts
-    result = search_index(index, topic, artifact_type=_DECISION_TYPE)
+    ]
+
+
+def find_decisions_in(
+    index_entries: Sequence[SearchableArtifact],
+    live_paths: Sequence[str],
+    topic: str,
+    *,
+    field_tokens_by_path: dict[str, dict[str, list[str]]] | None = None,
+) -> SearchResult:
+    """Live-decision topic search over already-derived structures (ADR-067).
+
+    The cache-friendly core of :func:`find_decisions`: given the repository index,
+    the live-decision paths, and optionally the precomputed field tokens (all pure
+    functions of the corpus the derived-index cache persists, ADR-099), it runs
+    the same type-restricted tiered search and liveness filter, byte-identical to
+    the fresh path. Ranking/order is preserved; an empty result is a valid answer.
+    """
+    result = search_index(
+        index_entries,
+        topic,
+        artifact_type=_DECISION_TYPE,
+        field_tokens_by_path=field_tokens_by_path,
+    )
+    live = set(live_paths)
     # Drop matches that are decisions but not live; ranking/order is preserved.
-    result.matches = [m for m in result.matches if m.path in live_paths]
+    result.matches = [m for m in result.matches if m.path in live]
     return result
 
 
@@ -491,28 +523,48 @@ def _field_tokens(entry: SearchableArtifact) -> dict[str, list[str]]:
     }
 
 
+def field_tokens_for_entries(
+    entries: Sequence[SearchableArtifact],
+) -> dict[str, dict[str, list[str]]]:
+    """The per-entry BM25 field tokens for a whole corpus — the tokenised field
+    vectors the derived-index cache persists (ADR-099).
+
+    Uses the same tokeniser (:func:`_field_tokens`) the scorer consumes, so cached
+    tokens yield byte-identical search statistics and scores to the fresh path.
+    """
+    return {entry.path: _field_tokens(entry) for entry in entries}
+
+
 def _tf(term: str, tokens: Sequence[str]) -> int:
     """Term frequency under ADR-037 matching (equality or prefix), not substring."""
     return sum(1 for token in tokens if token == term or token.startswith(term))
 
 
 def _corpus_stats(
-    entries: Sequence[SearchableArtifact], terms: Sequence[str]
+    entries: Sequence[SearchableArtifact],
+    terms: Sequence[str],
+    field_tokens_by_path: dict[str, dict[str, list[str]]] | None = None,
 ) -> tuple[int, dict[str, int], dict[str, float], dict[str, dict[str, list[str]]]]:
     """Document count, per-term document frequency, mean field length, field tokens.
 
     Computed once over the whole corpus so IDF and length normalisation are
     global (standard BM25), and the per-entry field tokens are cached for reuse
     by the scorer.
+
+    ``field_tokens_by_path`` may be supplied precomputed — the derived-index cache
+    (ADR-099) persists exactly this tokenisation, the expensive per-call work — in
+    which case the re-tokenisation is skipped and only the cheap query-dependent
+    document frequencies are recounted. The derived counts (``n``, ``avglen``,
+    ``df``) are byte-identical either way: they are pure aggregates of the same
+    tokens, independent of how the tokens were obtained.
     """
-    field_tokens_by_path: dict[str, dict[str, list[str]]] = {}
+    if field_tokens_by_path is None:
+        field_tokens_by_path = {entry.path: _field_tokens(entry) for entry in entries}
     length_sums: dict[str, int] = dict.fromkeys(_FIELD_BOOSTS, 0)
     df: dict[str, int] = dict.fromkeys(terms, 0)
     n = 0
-    for entry in entries:
+    for fields in field_tokens_by_path.values():
         n += 1
-        fields = _field_tokens(entry)
-        field_tokens_by_path[entry.path] = fields
         for name in _FIELD_BOOSTS:
             length_sums[name] += len(fields[name])
         for term in terms:
@@ -572,6 +624,8 @@ def search_index(
     entries: Sequence[SearchableArtifact],
     query: str,
     artifact_type: str | None = None,
+    *,
+    field_tokens_by_path: dict[str, dict[str, list[str]]] | None = None,
 ) -> SearchResult:
     """Search already-discovered entries with `rac find` semantics (v0.8.1).
 
@@ -581,6 +635,10 @@ def search_index(
     field-weighted BM25 lexical signal and a bounded inbound-reference graph
     signal, fused by RRF, tie-broken by sorted path. The seam lets a loaded
     repository model serve searches without another directory walk.
+
+    ``field_tokens_by_path`` may be supplied precomputed (the derived-index cache,
+    ADR-099): it must cover exactly ``entries``, and the result is byte-identical
+    to computing it fresh — only the per-call re-tokenisation is skipped.
     """
     terms = tokenize(query)
     matched: list[tuple[SearchableArtifact, _Match]] = []
@@ -595,7 +653,7 @@ def search_index(
         return SearchResult(query=query, artifact_type=artifact_type, matches=[])
 
     # Corpus-wide BM25 statistics (global IDF and mean field length, ADR-078).
-    n, df, avglen, field_tokens_by_path = _corpus_stats(entries, terms)
+    n, df, avglen, field_tokens_by_path = _corpus_stats(entries, terms, field_tokens_by_path)
     bm25 = {e.path: _bm25f(field_tokens_by_path[e.path], terms, n, df, avglen) for e, _ in matched}
     inbound = {e.path: float(getattr(e, "inbound_count", 0)) for e, _ in matched}
     lexical_rank = _competition_ranks(bm25)

--- a/tests/test_derived_cache.py
+++ b/tests/test_derived_cache.py
@@ -1,0 +1,269 @@
+"""Derived-index cache — content addressing, byte-parity, freshness (ADR-099).
+
+Initiative 2 of ``lore-at-team-scale`` (itsthelore/rac-core#264). The cache
+persists the expensive derived structures keyed on a corpus content hash. These
+tests hold the requirement's contract (``rac-derived-index-cache``):
+
+- **Byte-parity (REQ-002):** cache-on output is byte-identical to cache-off for
+  every MCP tool and at the shared service seams the CLI uses.
+- **Content addressing + freshness (REQ-004/REQ-006):** any byte change forces a
+  rebuild and the next call reflects it; there is no time- or event-based path.
+- **Disposable, never authoritative (REQ-003):** deleting the cache — or a
+  corrupt or unwritable one — costs only latency, never correctness.
+- **Latency floor (REQ-007):** repeated unchanged-corpus calls skip
+  re-tokenisation, shown deterministically by a work counter.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import shutil
+
+from conftest import fixture_path
+
+from rac import cli
+from rac.core.corpus import corpus_content_hash
+from rac.services import derived_cache
+from rac.services.derived_cache import (
+    DerivedIndexCache,
+    build_derived_index,
+    from_json_obj,
+    to_json_obj,
+)
+from rac.services.index import build_repository_index
+from rac.services.resolve import (
+    field_tokens_for_entries,
+    find_decisions,
+    find_decisions_in,
+    live_decision_paths,
+    search_index,
+)
+
+CORPUS = fixture_path("mcp", "corpus")
+
+DEC = "RAC-MCPDEC000001"
+REQ = "RAC-MCPREQ000001"
+
+TOOL_CALLS: tuple[tuple[str, dict], ...] = (
+    ("get_artifact", {"id": DEC}),
+    ("search_artifacts", {"query": "RAC-MCP"}),
+    ("find_decisions", {"topic": "RAC"}),
+    ("find_decisions", {"topic": "", "path": "src/rac/mcp/server.py"}),
+    ("get_related", {"id": REQ}),
+    ("get_summary", {}),
+)
+
+# --- corpus content hash (REQ-001, REQ-004) ----------------------------------
+
+
+def _make_corpus(root, files: dict[str, str]) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    for name, body in files.items():
+        (root / name).write_text(body, encoding="utf-8")
+
+
+def test_corpus_hash_is_stable_across_runs(tmp_path):
+    root = tmp_path / "c"
+    _make_corpus(root, {"a.md": "# A\n\nbody\n", "b.md": "# B\n\nmore\n"})
+    assert corpus_content_hash(str(root)) == corpus_content_hash(str(root))
+
+
+def test_corpus_hash_changes_on_any_byte_change(tmp_path):
+    root = tmp_path / "c"
+    _make_corpus(root, {"a.md": "# A\n\nbody\n"})
+    before = corpus_content_hash(str(root))
+    (root / "a.md").write_text("# A\n\nbody edited\n", encoding="utf-8")
+    assert corpus_content_hash(str(root)) != before
+
+
+def test_corpus_hash_changes_on_add_remove_rename(tmp_path):
+    root = tmp_path / "c"
+    _make_corpus(root, {"a.md": "# A\n"})
+    base = corpus_content_hash(str(root))
+    (root / "b.md").write_text("# B\n", encoding="utf-8")
+    added = corpus_content_hash(str(root))
+    assert added != base
+    (root / "b.md").unlink()
+    assert corpus_content_hash(str(root)) == base  # removal returns to base
+    (root / "a.md").rename(root / "z.md")
+    assert corpus_content_hash(str(root)) != base  # rename changes the path set
+
+
+# --- serialization round-trip (REQ-002) --------------------------------------
+
+
+def test_derived_index_json_round_trip_is_identity():
+    derived = build_derived_index(CORPUS)
+    assert from_json_obj(to_json_obj(derived)) == derived
+
+
+# --- byte-parity across MCP tools (REQ-002) ----------------------------------
+
+
+def _tool_text(server, name, args) -> str:
+    content, _structured = asyncio.run(server.call_tool(name, args))
+    return content[0].text
+
+
+def test_cache_on_matches_cache_off_across_all_tools(tmp_path):
+    from rac.mcp.server import build_server
+
+    off = build_server(CORPUS)
+    on = build_server(CORPUS, cache=DerivedIndexCache(tmp_path / "cache"))
+    for name, args in TOOL_CALLS:
+        assert _tool_text(off, name, args) == _tool_text(on, name, args), f"parity drift: {name}"
+
+
+# --- byte-parity at the CLI-facing service seams (REQ-002) -------------------
+
+
+def test_search_index_parity_with_injected_field_tokens():
+    entries = build_repository_index(CORPUS).artifacts
+    fresh = search_index(entries, "RAC-MCP")
+    injected = search_index(
+        entries, "RAC-MCP", field_tokens_by_path=field_tokens_for_entries(entries)
+    )
+    assert fresh.to_dict() == injected.to_dict()
+
+
+def test_find_decisions_parity_with_derived_core():
+    from rac.core.corpus import walk_corpus
+
+    entries = list(walk_corpus(CORPUS))
+    index = build_repository_index(CORPUS).artifacts
+    fresh = find_decisions(CORPUS, "RAC")
+    derived = find_decisions_in(
+        index,
+        live_decision_paths(entries),
+        "RAC",
+        field_tokens_by_path=field_tokens_for_entries(index),
+    )
+    assert fresh.to_dict() == derived.to_dict()
+
+
+# --- cache hit / miss, corruption, unwritable (REQ-003) ----------------------
+
+
+def test_second_call_is_a_hit_not_a_rebuild(tmp_path, monkeypatch):
+    builds: list[int] = []
+    original = derived_cache.build_derived_index
+    monkeypatch.setattr(
+        derived_cache,
+        "build_derived_index",
+        lambda *a, **k: (builds.append(1), original(*a, **k))[1],
+    )
+    cache = DerivedIndexCache(tmp_path / "cache")
+    first = cache.load_or_build(CORPUS)
+    second = cache.load_or_build(CORPUS)
+    assert builds == [1], "the second unchanged-corpus call must read the cache, not rebuild"
+    assert first == second
+
+
+def test_corrupt_cache_file_is_a_miss_not_a_failure(tmp_path):
+    cache = DerivedIndexCache(tmp_path / "cache")
+    expected = cache.load_or_build(CORPUS)
+    # Corrupt the on-disk file; the next load must rebuild transparently.
+    cache_file = next((tmp_path / "cache").glob("*.json"))
+    cache_file.write_text("{not valid json", encoding="utf-8")
+    assert cache.load_or_build(CORPUS) == expected
+
+
+def test_schema_mismatch_is_a_miss(tmp_path):
+    cache = DerivedIndexCache(tmp_path / "cache")
+    expected = cache.load_or_build(CORPUS)
+    cache_file = next((tmp_path / "cache").glob("*.json"))
+    obj = to_json_obj(expected)
+    obj["schema_version"] = "999"
+    cache_file.write_text(__import__("json").dumps(obj), encoding="utf-8")
+    assert cache.load_or_build(CORPUS) == expected
+
+
+def test_unwritable_cache_dir_degrades_to_build(tmp_path):
+    # Point the cache dir *inside* a regular file: it can never be created.
+    blocker = tmp_path / "blocker"
+    blocker.write_text("i am a file", encoding="utf-8")
+    cache = DerivedIndexCache(blocker / "cache")
+    result = cache.load_or_build(CORPUS)
+    assert result == build_derived_index(CORPUS)  # correct output, no raise
+
+
+# --- freshness + disposability (REQ-006, REQ-003) ----------------------------
+
+
+def test_edit_forces_rebuild_and_next_call_reflects_it(tmp_path):
+    root = tmp_path / "corpus"
+    shutil.copytree(CORPUS, root)
+    cache = DerivedIndexCache(tmp_path / "cache")
+    before = cache.load_or_build(str(root))
+
+    # Edit one artifact's title; the corpus hash changes, so the next call must
+    # reflect the edit rather than serve the cached structures.
+    target = next(p for p in root.rglob("*.md"))
+    target.write_text(
+        target.read_text(encoding="utf-8").replace("# ", "# Edited ", 1), encoding="utf-8"
+    )
+    after = cache.load_or_build(str(root))
+    assert after != before
+    assert after == build_derived_index(str(root))
+
+
+def test_deleting_cache_mid_session_rebuilds_identically(tmp_path):
+    cache_dir = tmp_path / "cache"
+    cache = DerivedIndexCache(cache_dir)
+    first = cache.load_or_build(CORPUS)
+    shutil.rmtree(cache_dir)  # disposable: gone mid-session
+    second = cache.load_or_build(CORPUS)
+    assert second == first
+
+
+# --- latency floor: repeated calls skip re-tokenisation (REQ-007) ------------
+
+
+def test_warm_cache_skips_retokenization(tmp_path, monkeypatch):
+    # A deterministic larger corpus so the floor is meaningful.
+    root = tmp_path / "big"
+    _make_corpus(
+        root, {f"doc-{i:03d}.md": f"# Doc {i}\n\nalpha beta gamma {i}\n" for i in range(200)}
+    )
+
+    tokenizations: list[int] = []
+    original = derived_cache.field_tokens_for_entries
+    monkeypatch.setattr(
+        derived_cache,
+        "field_tokens_for_entries",
+        lambda entries: (tokenizations.append(len(entries)), original(entries))[1],
+    )
+    cache = DerivedIndexCache(tmp_path / "cache")
+    cache.load_or_build(str(root))  # cold: tokenizes all 200
+    cache.load_or_build(str(root))  # warm: tokenizes nothing
+    cache.load_or_build(str(root))  # warm: tokenizes nothing
+    assert tokenizations == [200], "warm unchanged-corpus calls must skip re-tokenisation"
+
+
+# --- CLI wiring (REQ-001) ----------------------------------------------------
+
+
+def test_cache_flag_defaults_off_and_parses():
+    parser = cli.build_parser()
+    assert parser.parse_args(["mcp", "--root", CORPUS]).cache is False
+    assert parser.parse_args(["mcp", "--root", CORPUS, "--cache"]).cache is True
+
+
+def test_run_server_cache_enabled_builds_a_cache(monkeypatch):
+    from rac.mcp import server as mcp_server
+
+    captured: dict = {}
+
+    class _FakeServer:
+        def run(self, transport: str) -> None:
+            pass
+
+    def _fake_build(root, *, budget, recorder, audit_recorder, cache):
+        captured["cache"] = cache
+        return _FakeServer()
+
+    monkeypatch.setattr(mcp_server, "build_server", _fake_build)
+    monkeypatch.setattr(mcp_server, "_maybe_start_sharing", lambda *a, **k: None)
+    monkeypatch.setattr(mcp_server, "_check_corpus", lambda *a, **k: None)
+    assert mcp_server.run_server(CORPUS, cache_enabled=True) == 0
+    assert isinstance(captured["cache"], DerivedIndexCache)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -116,10 +116,12 @@ def test_cli_valid_root_runs_server_and_returns_zero(monkeypatch):
         host: str = "127.0.0.1",
         port: int = 8000,
         path: str = "/mcp",
+        cache_enabled: bool = False,
     ) -> int:
         captured["root"] = root
         captured["telemetry"] = telemetry_enabled
         captured["transport"] = transport_name
+        captured["cache"] = cache_enabled
         return 0
 
     monkeypatch.setattr("rac.mcp.server.run_server", _fake_run)


### PR DESCRIPTION
Initiative 2 of the **lore-at-team-scale** epic (#262), closing sub-issue #264: an opt-in, content-addressed cache of the expensive derived structures, so per-call latency stops scaling with corpus size at organisation scale.

Implements `rac/requirements/rac-derived-index-cache.md` (now Accepted) under a new ADR that answers ADR-032's now-triggered review clause.

## What ships

- **ADR-099 — Derived-Index Cache** (Accepted, Technical). Answers ADR-032's recorded review trigger ("a real user reports Guide latency") and revises its "no persistent cache on the serving path" pin *by decision*, not code drift. Frames the cache as ADR-080's deferred "rebuildable derived index behind the snapshot seam" — disposable, never authoritative.
- **`corpus_content_hash`** (`core/corpus.py`) — a corpus-level digest that composes the per-file `content_hash`: SHA-256 over the sorted `(repo-relative path, per-file digest)` pairs. The content-addressed key (REQ-001).
- **`DerivedIndexCache`** (`services/derived_cache.py`) — one JSON blob per corpus hash holding the repository index, the resolved relationship graph, the tokenised BM25 field vectors, and the live-decision paths. Lossless (de)serialization; every failure mode (missing / corrupt / schema-mismatch / unwritable) degrades to a fresh build.
- **`rac mcp --cache`** — opt-in, off by default; location `$XDG_CACHE_HOME/rac/derived` (`RAC_CACHE_DIR` overrides). Threaded through `get_artifact`, `search_artifacts`, `find_decisions` (topic), and `get_related`; the resolve/search seams accept the precomputed structures so the fresh path stays byte-unchanged.

## Contract held

- **Byte-parity (REQ-002):** cache-on output is byte-identical to cache-off across all five MCP tools and at the shared CLI service seams; JSON round-trip is the identity.
- **Content-addressed + fresh (REQ-004/REQ-006):** the key is recomputed every call, so any byte change — edit, add, remove, rename — forces a rebuild and the next call reflects it. No time- or event-based invalidation.
- **Disposable (REQ-003):** deleting the cache dir, or a corrupt / unwritable / wrong-version file, costs only latency — the reader falls back to a fresh build. No daemon, no lockfile, no datastore; writes only to its own cache dir, never the corpus (ADR-080).
- **Latency floor (REQ-007):** a deterministic 200-artifact fixture shows warm unchanged-corpus calls perform **zero** re-tokenisation (asserted by a work counter).
- **Additive (REQ-005/ADR-007):** off by default; the uncached path is byte-unchanged.

## Out of scope (later sub-issues)

Per-request audit *identity* threading (#265) and the operator deployment recipe (#266). CLI-wide `--cache` flags on every read command are also deferred — the cache is enabled on the serving path this initiative targets; the shared seams are byte-parity-tested for CLI use.

## Gates

`rac validate rac/` (375 valid), `rac relationships rac/ --validate` (0 issues), `rac review rac/` (95/100, no priority 1–2), agent-rules blocks regenerated for ADR-099. 438 tests green across the mcp/resolve/relationships/index/portfolio/profiles/cli batteries; ruff + mypy clean.

Closes #264.