### PR TITLE
feat(mcp): shared-server audit identity — per-request principals (lore-at-team-scale #265)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,15 @@ per-call latency stops scaling with corpus size.
   It is disposable and never authoritative: keyed on a corpus content hash so
   any byte change rebuilds it, byte-identical to the uncached path, and deleting
   it costs only latency (ADR-099). Off by default.
+- **Per-caller attribution on the shared server.** When serving over HTTP, each
+  caller asserts who it is with an `X-Lore-Principal` header, and the read-access
+  audit log records that per-request principal instead of the host identity — so
+  an auditor can answer "who read what, when" per caller. Records gain additive
+  `transport` and `attribution` fields marking asserted-over-HTTP versus locally
+  resolved identity. It stays attribution, not authentication (the engine never
+  verifies it; your proxy does), the principal never affects tool output, and
+  shared HTTP serving blocks a call if the audit sink write fails
+  (ADR-098). stdio behaviour is unchanged.
 
 ## 2026.06.5 — the "rename" release
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -332,7 +332,8 @@ audit:
   and keeps serving; `block` refuses the call with an `audit-unavailable` error
   rather than returning un-audited content.
 
-Each line records `ts`, a per-process `session`, the `principal`, the `tool`, the
+Each line records `ts`, a per-process `session`, the `principal`, the `transport`
+(`stdio` or `http`), the `attribution` (`asserted` or `local`), the `tool`, the
 `query`, the `returned` artifact IDs, `outcome`, and `duration_ms`. The
 **principal is attributable, not authenticated** (ADR-084): it defaults to the git
 `user.name`/`user.email` in the served repository and can be overridden with the
@@ -340,6 +341,29 @@ Each line records `ts`, a per-process `session`, the `principal`, the `tool`, th
 repository ACL plus human pull-request review — the log records who *claimed* to
 query, not a verified identity. When enabled, the server announces it on stderr at
 startup; it is never silent.
+
+### Per-caller attribution on a shared server
+
+On a shared HTTP endpoint (`--transport http`) one process serves the whole team,
+so a single construction-time principal would record every caller as the host.
+Each request instead asserts who it is with the **`X-Lore-Principal`** header, and
+the audit line records that per-request principal with `transport: http` and
+`attribution: asserted`
+([ADR-098](https://github.com/itsthelore/rac-core/blob/main/rac/decisions/adr-098-shared-http-mcp-serving.md)):
+
+```
+X-Lore-Principal: Alice Ng <alice@example.com>
+```
+
+This stays **attribution, not authentication**: the engine records what the caller
+claimed and never verifies it, and the principal is never an access-control input —
+tool responses are identical whatever the header says. If you need the assertion to
+be trustworthy, your fronting proxy authenticates the caller and sets the header it
+trusts (ADR-085). A request that asserts nothing is recorded with `attribution:
+local`, and the shared server's fallback **skips the host's git identity** (it
+resolves `RAC_AUDIT_PRINCIPAL`, else `unattributed`) so a caller's read is never
+mislabelled as the host. Shared HTTP serving is also mandatory audit-on: it refuses
+to start without a working sink, and a sink write failure blocks the call.
 
 ## 9. Shared HTTP endpoint (team scale)
 

--- a/rac/decisions/adr-098-shared-http-mcp-serving.md
+++ b/rac/decisions/adr-098-shared-http-mcp-serving.md
@@ -59,6 +59,18 @@ following boundaries.
   deployment proxy that fronts the endpoint. The standing red lines — no SSO on
   a shared MCP, no RBAC on MCP tools, no hosted multi-tenant service — stand.
 
+- **The attribution carrier is the `X-Lore-Principal` request header.** A caller
+  on the shared endpoint asserts who it is by setting the `X-Lore-Principal`
+  HTTP header (case-insensitive); the audit recorder records that assertion as
+  the per-request principal (`rac-shared-server-audit-identity`). It is
+  *attribution, not authentication* (ADR-084): the engine records what the
+  caller claimed and never verifies it, and the principal is never an
+  access-control input — tool responses are identical whatever the header says.
+  Verifying the claim, if a deployment needs it, is the fronting proxy's job
+  (ADR-085): the proxy authenticates and sets the header it trusts. An unasserted
+  call falls back to the recorder's resolution, never silently borrowing the host
+  process's own git identity as if it were the caller's.
+
 - **Mandatory audit-on for HTTP.** A shared endpoint serves reads no single
   developer's git identity can attribute, so HTTP serving refuses to start
   without a working audit sink (ADR-084's fail-loud posture): the audit log

--- a/rac/requirements/rac-shared-server-audit-identity.md
+++ b/rac/requirements/rac-shared-server-audit-identity.md
@@ -7,12 +7,18 @@ type: requirement
 
 ## Status
 
-Proposed
+Accepted
 
 Classification: `[internal]` — every caller on a shared endpoint is
 attributable. Initiative 3 of the `lore-at-team-scale` roadmap:
 per-request principal resolution in the audit recorder, with mandatory
-audit-on as the shared-deployment entry condition.
+audit-on as the shared-deployment entry condition. Delivered
+(itsthelore/rac-core#265): the audit recorder resolves a per-request
+principal from the `X-Lore-Principal` header (the carrier ADR-098 fixes),
+with precedence assertion > env override > git (skipped on the shared
+transport) > unattributed; records grow additive `transport` and
+`attribution` fields; HTTP forces `on_write_error: block`; and the
+principal never enters a tool body — attribution, never authorization.
 
 ## Problem
 
@@ -77,6 +83,7 @@ concrete.
 - adr-032
 - adr-084
 - adr-085
+- adr-098
 
 ## Related Roadmaps
 

--- a/src/rac/mcp/audit.py
+++ b/src/rac/mcp/audit.py
@@ -171,15 +171,24 @@ def _git_identity(root: str) -> str | None:
     return email or name
 
 
-def resolve_principal(root: str) -> str:
+def resolve_principal(root: str, *, allow_git: bool = True) -> str:
     """The audit principal: ``RAC_AUDIT_PRINCIPAL`` > git identity > ``unattributed``.
 
     Attributable, not authenticated (ADR-084): records who *claimed* to query.
+
+    ``allow_git`` is ``False`` on a shared server (ADR-098): the served checkout's
+    git identity is the *host* process's, not any caller's, so a shared endpoint
+    must never borrow it as a per-call fallback. There the chain is the explicit
+    ``RAC_AUDIT_PRINCIPAL`` override, else ``unattributed``; a caller attributes
+    itself per request via the ``X-Lore-Principal`` header instead
+    (``rac-shared-server-audit-identity``).
     """
     override = os.environ.get(PRINCIPAL_ENV)
     if override and override.strip():
         return override.strip()
-    return _git_identity(root) or UNATTRIBUTED
+    if allow_git:
+        return _git_identity(root) or UNATTRIBUTED
+    return UNATTRIBUTED
 
 
 class AuditRecorder:
@@ -191,10 +200,20 @@ class AuditRecorder:
     un-recordable call rather than disabling itself after the first.
     """
 
-    def __init__(self, path: Path, principal: str, on_write_error: str = "warn") -> None:
+    def __init__(
+        self,
+        path: Path,
+        principal: str,
+        on_write_error: str = "warn",
+        transport: str = "stdio",
+    ) -> None:
         self.path = path
         self.principal = principal
         self.on_write_error = on_write_error
+        # The transport this recorder serves ("stdio" | "http"): stamped on every
+        # event so an auditor can tell shared-endpoint records from local ones
+        # (rac-shared-server-audit-identity, ADR-098).
+        self.transport = transport
         self.session = secrets.token_hex(8)
         self._warned = False
 
@@ -216,19 +235,39 @@ class AuditRecorder:
             return False
 
 
-def create_recorder(config: AuditConfig, root: str) -> AuditRecorder | None:
-    """Build an audit recorder when enabled, else ``None`` (the default-absent path)."""
+def create_recorder(
+    config: AuditConfig, root: str, *, transport: str = "stdio"
+) -> AuditRecorder | None:
+    """Build an audit recorder when enabled, else ``None`` (the default-absent path).
+
+    ``transport`` shapes the shared-server posture (ADR-098,
+    ``rac-shared-server-audit-identity``). On ``"http"`` the recorder is
+    *shared*: its construction-time principal skips the host git identity
+    (per-call attribution comes from the ``X-Lore-Principal`` header instead), and
+    write failures block the call (``on_write_error: block``) rather than warn, so
+    a shared endpoint never serves un-recordable reads. ``"stdio"`` is the local
+    default and is byte-unchanged.
+    """
     if not config.enabled:
         return None
+    shared = transport == "http"
     path = audit_path(config)
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
     except OSError:
         pass  # the recorder's first write will fail loud
-    return AuditRecorder(path, resolve_principal(root), config.on_write_error)
+    principal = resolve_principal(root, allow_git=not shared)
+    on_write_error = "block" if shared else config.on_write_error
+    return AuditRecorder(path, principal, on_write_error, transport=transport)
 
 
-def observe(recorder: AuditRecorder | None, tool: str, args: dict, call: Callable[[], str]) -> str:
+def observe(
+    recorder: AuditRecorder | None,
+    tool: str,
+    args: dict,
+    call: Callable[[], str],
+    request_principal: str | None = None,
+) -> str:
     """Run ``call``, record one audit event, and return the payload unchanged.
 
     With no recorder this is exactly ``call()`` — audit off creates nothing and
@@ -237,16 +276,29 @@ def observe(recorder: AuditRecorder | None, tool: str, args: dict, call: Callabl
     (ADR-034). Under ``on_write_error: block`` a failed write refuses the call
     with a structured ``audit-unavailable`` error rather than serving un-audited
     content.
+
+    ``request_principal`` is the per-request attribution a shared endpoint
+    supplies (the ``X-Lore-Principal`` header, ADR-098): when present it is the
+    event's principal and the event is flagged ``attribution: "asserted"``;
+    otherwise the recorder's construction-time principal is used
+    (``attribution: "local"``). Attribution, never authorization
+    (``rac-shared-server-audit-identity``): the principal never enters ``call``,
+    so tool output is identical whatever it is.
     """
     if recorder is None:
         return call()
+    stripped = request_principal.strip() if request_principal else ""
+    asserted = bool(stripped)
+    principal = stripped if asserted else recorder.principal
     started = time.perf_counter()
     try:
         payload = call()
     except BaseException:
-        recorder.record(_event(recorder, tool, args, [], "exception", started))
+        recorder.record(_event(recorder, tool, args, [], "exception", started, principal, asserted))
         raise
-    event = _event(recorder, tool, args, _returned(payload), _outcome(payload), started)
+    event = _event(
+        recorder, tool, args, _returned(payload), _outcome(payload), started, principal, asserted
+    )
     if not recorder.record(event) and recorder.on_write_error == "block":
         return json.dumps(
             {"schema_version": SCHEMA_VERSION, "error": ERROR_AUDIT_UNAVAILABLE, "tool": tool},
@@ -262,12 +314,20 @@ def _event(
     returned: list[str],
     outcome: str,
     started: float,
+    principal: str,
+    asserted: bool,
 ) -> dict:
     return {
         "schema_version": SCHEMA_VERSION,
         "ts": datetime.now(UTC).isoformat(timespec="milliseconds").replace("+00:00", "Z"),
         "session": recorder.session,
-        "principal": recorder.principal,
+        "principal": principal,
+        # Provenance of the principal (additive, ADR-007): which transport served
+        # the call, and whether the principal was asserted per-request (over HTTP)
+        # or resolved locally at construction — so an auditor reads the trust
+        # status of each attribution straight from the record.
+        "transport": recorder.transport,
+        "attribution": "asserted" if asserted else "local",
         "tool": tool,
         "query": dict(args),
         "returned": returned,

--- a/src/rac/mcp/server.py
+++ b/src/rac/mcp/server.py
@@ -47,7 +47,7 @@ import sys
 from collections.abc import Callable
 from pathlib import Path
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp import Context, FastMCP
 
 from rac import consent as consent_record
 from rac.core.corpus import walk_corpus
@@ -85,6 +85,34 @@ from rac.services.resolve import (
 from rac.services.scope import decisions_for_path
 
 SERVER_NAME = "lore"
+
+# The per-request attribution carrier the serving ADR fixes (ADR-098): a caller
+# on the shared HTTP endpoint asserts who it is with this header, and the audit
+# recorder records the assertion as the per-request principal
+# (rac-shared-server-audit-identity). Case-insensitive, like all HTTP headers.
+# Attribution, not authentication — the engine never verifies it (ADR-085).
+PRINCIPAL_HEADER = "x-lore-principal"
+
+
+def _request_principal(ctx: Context) -> str | None:
+    """The caller's asserted principal from the ``X-Lore-Principal`` header, or None.
+
+    HTTP only: the header rides the request the streamable transport carries. On
+    stdio there is no HTTP request, so this is always ``None`` and attribution
+    stays the recorder's locally resolved identity (stdio is byte-unchanged,
+    ADR-007). Defensive throughout — a missing request context or header is just
+    "no assertion", never an error.
+    """
+    try:
+        request = ctx.request_context.request
+    except (ValueError, AttributeError):
+        return None
+    if request is None:
+        return None
+    try:
+        return request.headers.get(PRINCIPAL_HEADER)
+    except AttributeError:
+        return None
 
 # --- Verbatim tool descriptions (pinned by guide-tool-surface; ADR-030) ------
 #
@@ -384,47 +412,65 @@ def build_server(
     """
     server: FastMCP = FastMCP(SERVER_NAME)
 
-    def observed(tool: str, args: dict, call: Callable[[], str]) -> str:
+    def observed(
+        tool: str, args: dict, call: Callable[[], str], principal: str | None = None
+    ) -> str:
         # Audit (content-bearing, ADR-084) runs innermost so its duration is the
         # pure call time; telemetry (content-free, ADR-040) wraps it and still
         # sees the unchanged payload. Each is a no-op when its recorder is None,
-        # so the default response stays byte-identical.
+        # so the default response stays byte-identical. ``principal`` is the
+        # caller's per-request assertion (ADR-098); it reaches only the audit
+        # record, never the tool body — attribution, not authorization.
         return telemetry.observe(
-            recorder, tool, lambda: audit.observe(audit_recorder, tool, args, call)
+            recorder,
+            tool,
+            lambda: audit.observe(audit_recorder, tool, args, call, request_principal=principal),
         )
 
     @server.tool(name="get_artifact", description=DESC_GET_ARTIFACT)
-    def get_artifact(id: str) -> str:
-        return observed("get_artifact", {"id": id}, lambda: _get_artifact(root, id, budget, cache))
+    def get_artifact(id: str, ctx: Context) -> str:
+        return observed(
+            "get_artifact",
+            {"id": id},
+            lambda: _get_artifact(root, id, budget, cache),
+            _request_principal(ctx),
+        )
 
     @server.tool(name="search_artifacts", description=DESC_SEARCH_ARTIFACTS)
-    def search_artifacts(query: str, type: str | None = None) -> str:
+    def search_artifacts(query: str, ctx: Context, type: str | None = None) -> str:
         return observed(
             "search_artifacts",
             {"query": query, "type": type},
             lambda: _search_artifacts(root, query, type, budget, cache),
+            _request_principal(ctx),
         )
 
     @server.tool(name="find_decisions", description=DESC_FIND_DECISIONS)
-    def find_decisions_tool(topic: str = "", path: str | None = None) -> str:
+    def find_decisions_tool(ctx: Context, topic: str = "", path: str | None = None) -> str:
         # ``path`` only rides the audit args when supplied, so a topic query's
         # recorded shape is byte-identical to before (additive, ADR-007).
         args = {"topic": topic} if path is None else {"topic": topic, "path": path}
         return observed(
-            "find_decisions", args, lambda: _find_decisions(root, topic, path, budget, cache)
+            "find_decisions",
+            args,
+            lambda: _find_decisions(root, topic, path, budget, cache),
+            _request_principal(ctx),
         )
 
     @server.tool(name="get_related", description=DESC_GET_RELATED)
-    def get_related(id: str, depth: int = 1) -> str:
+    def get_related(id: str, ctx: Context, depth: int = 1) -> str:
         return observed(
             "get_related",
             {"id": id, "depth": depth},
             lambda: _get_related(root, id, budget, depth, cache),
+            _request_principal(ctx),
         )
 
     @server.tool(name="get_summary", description=DESC_GET_SUMMARY)
-    def get_summary() -> str:
-        return observed("get_summary", {}, lambda: _get_summary(root, budget))
+    def get_summary(ctx: Context) -> str:
+        return observed(
+            "get_summary", {}, lambda: _get_summary(root, budget), _request_principal(ctx)
+        )
 
     return server
 
@@ -524,8 +570,12 @@ def run_server(
         )
     # The read-access audit log is config-driven (ADR-084), not a flag: enabled
     # by an ``audit:`` stanza in .rac/config.yaml. Default-absent — no stanza,
-    # no recorder, no file, and the response stays byte-identical.
-    audit_recorder = audit.create_recorder(audit.load_audit_config(root), root)
+    # no recorder, no file, and the response stays byte-identical. The transport
+    # shapes the shared-server posture (ADR-098): HTTP skips the host git identity
+    # and blocks on write failure (rac-shared-server-audit-identity).
+    audit_recorder = audit.create_recorder(
+        audit.load_audit_config(root), root, transport=transport_name
+    )
     if audit_recorder is not None:
         print(
             "rac mcp: audit on — appending one line per read-tool call "

--- a/src/rac/mcp/server.py
+++ b/src/rac/mcp/server.py
@@ -114,6 +114,7 @@ def _request_principal(ctx: Context) -> str | None:
     except AttributeError:
         return None
 
+
 # --- Verbatim tool descriptions (pinned by guide-tool-surface; ADR-030) ------
 #
 # These strings are a designed product surface: the only interface an agent

--- a/tests/test_mcp_audit.py
+++ b/tests/test_mcp_audit.py
@@ -36,6 +36,11 @@ AUDIT_FIELDS = [
     "ts",
     "session",
     "principal",
+    # Additive provenance (rac-shared-server-audit-identity, ADR-098): the
+    # transport that served the call and whether the principal was asserted
+    # per-request or resolved locally. Present on every record, additively.
+    "transport",
+    "attribution",
     "tool",
     "query",
     "returned",
@@ -281,3 +286,77 @@ def test_block_mode_refuses_the_call_on_write_failure(tmp_path, capsys):
     assert data["error"] == "audit-unavailable"
     assert data["tool"] == "get_artifact"
     assert "refusing tool calls" in capsys.readouterr().err
+
+
+# --- Shared-server audit identity (rac-shared-server-audit-identity, ADR-098) ---
+
+
+def test_http_recorder_skips_git_and_blocks(tmp_path, monkeypatch):
+    # On the shared HTTP transport the recorder must not borrow the host's git
+    # identity, and it blocks on write failure regardless of config (REQ-002/003).
+    monkeypatch.delenv("RAC_AUDIT_PRINCIPAL", raising=False)
+    monkeypatch.setenv("RAC_AUDIT_PATH", str(tmp_path / "audit.jsonl"))
+    config = AuditConfig(enabled=True, path="", on_write_error="warn")
+    recorder = audit.create_recorder(config, ".", transport="http")
+    assert recorder is not None
+    assert recorder.transport == "http"
+    assert recorder.on_write_error == "block"  # elevated from warn for shared serving
+    assert recorder.principal == audit.UNATTRIBUTED  # git skipped; no env override
+
+
+def test_stdio_recorder_keeps_git_identity(tmp_path, monkeypatch):
+    # stdio is byte-unchanged: construction-time git identity still resolves.
+    monkeypatch.delenv("RAC_AUDIT_PRINCIPAL", raising=False)
+    monkeypatch.setenv("RAC_AUDIT_PATH", str(tmp_path / "audit.jsonl"))
+    config = AuditConfig(enabled=True, path="", on_write_error="warn")
+    recorder = audit.create_recorder(config, ".", transport="stdio")
+    assert recorder is not None
+    assert recorder.transport == "stdio"
+    assert recorder.on_write_error == "warn"
+    # A repo with a git identity resolves it; the sentinel only when git is absent.
+    assert recorder.principal  # non-empty either way
+
+
+def test_resolve_principal_env_override_wins_on_http(monkeypatch):
+    monkeypatch.setenv("RAC_AUDIT_PRINCIPAL", "svc-lore <svc@example.com>")
+    assert audit.resolve_principal(".", allow_git=False) == "svc-lore <svc@example.com>"
+
+
+def test_observe_records_asserted_per_request_principal(tmp_path):
+    recorder = AuditRecorder(tmp_path / "audit.jsonl", "host <h@example.com>", transport="http")
+    audit.observe(
+        recorder, "get_summary", {}, lambda: "{}", request_principal="alice <a@example.com>"
+    )
+    event = events_in(recorder)[-1]
+    assert event["principal"] == "alice <a@example.com>"
+    assert event["attribution"] == "asserted"
+    assert event["transport"] == "http"
+
+
+def test_observe_falls_back_to_local_when_unasserted(tmp_path):
+    recorder = AuditRecorder(tmp_path / "audit.jsonl", "host <h@example.com>", transport="http")
+    audit.observe(recorder, "get_summary", {}, lambda: "{}", request_principal=None)
+    event = events_in(recorder)[-1]
+    assert event["principal"] == "host <h@example.com>"
+    assert event["attribution"] == "local"
+
+
+def test_blank_assertion_is_treated_as_unasserted(tmp_path):
+    recorder = AuditRecorder(tmp_path / "audit.jsonl", "host <h@example.com>", transport="http")
+    audit.observe(recorder, "get_summary", {}, lambda: "{}", request_principal="   ")
+    event = events_in(recorder)[-1]
+    assert event["principal"] == "host <h@example.com>"
+    assert event["attribution"] == "local"
+
+
+def test_asserted_principal_never_reaches_the_tool_body(tmp_path):
+    # Attribution, never authorization (REQ-005): the tool body sees no principal,
+    # so its output is identical whatever the caller asserts.
+    recorder = AuditRecorder(tmp_path / "audit.jsonl", "host <h@example.com>", transport="http")
+    out_a = audit.observe(
+        recorder, "get_summary", {}, lambda: '{"payload": "same"}', request_principal="alice"
+    )
+    out_b = audit.observe(
+        recorder, "get_summary", {}, lambda: '{"payload": "same"}', request_principal="bob"
+    )
+    assert out_a == out_b == '{"payload": "same"}'

--- a/tests/test_mcp_http.py
+++ b/tests/test_mcp_http.py
@@ -17,6 +17,7 @@ gains a streamable HTTP transport. These tests hold the requirement's contract
 from __future__ import annotations
 
 import asyncio
+import json
 import socket
 import threading
 import time
@@ -237,3 +238,116 @@ def test_serve_http_configures_stateless_settings(monkeypatch):
     assert server.settings.stateless_http is True
     assert server.settings.json_response is True
     assert ran == ["streamable-http"]
+
+
+# --- shared-server audit identity over HTTP (#265) ---------------------------
+
+
+def _serve_with_audit(port: int, path: str, audit_recorder) -> threading.Thread:
+    from rac.mcp.server import build_server
+
+    def _serve() -> None:
+        server = build_server(str(CORPUS), audit_recorder=audit_recorder)
+        transport_mod.serve_http(server, host="127.0.0.1", port=port, path=path)
+
+    thread = threading.Thread(target=_serve, daemon=True)
+    thread.start()
+    _wait_for_port("127.0.0.1", port)
+    return thread
+
+
+async def _call_as(port: int, path: str, principal: str | None, count: int) -> None:
+    import httpx
+    from mcp.client.session import ClientSession
+    from mcp.client.streamable_http import streamable_http_client
+
+    headers = {"X-Lore-Principal": principal} if principal is not None else {}
+    async with httpx.AsyncClient(headers=headers, timeout=30.0) as http_client:
+        async with streamable_http_client(
+            f"http://127.0.0.1:{port}{path}", http_client=http_client
+        ) as (read, write, _sid):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                for _ in range(count):
+                    await session.call_tool("get_summary", {})
+
+
+def test_concurrent_clients_are_attributed_distinctly(tmp_path):
+    from rac.mcp.audit import AuditRecorder
+
+    recorder = AuditRecorder(tmp_path / "audit.jsonl", "host <h@example.com>", transport="http")
+    port, path = _free_port(), "/mcp"
+    _serve_with_audit(port, path, recorder)
+
+    async def _both() -> None:
+        await asyncio.gather(
+            _call_as(port, path, "alice <a@example.com>", 3),
+            _call_as(port, path, "bob <b@example.com>", 3),
+        )
+
+    asyncio.run(_both())
+
+    events = [
+        json.loads(line)
+        for line in (tmp_path / "audit.jsonl").read_text().splitlines()
+        if line.strip()
+    ]
+    principals = {ev["principal"] for ev in events}
+    assert "alice <a@example.com>" in principals
+    assert "bob <b@example.com>" in principals
+    assert "host <h@example.com>" not in principals  # host identity never leaks
+    for ev in events:
+        assert ev["transport"] == "http"
+        assert ev["attribution"] == "asserted"
+
+
+def test_unasserted_http_call_is_not_the_host_identity(tmp_path):
+    from rac.mcp.audit import AuditRecorder
+
+    # A shared recorder resolves its construction principal without git; an
+    # unasserted call is recorded with that fallback, never the host's identity.
+    recorder = AuditRecorder(tmp_path / "audit.jsonl", "unattributed", transport="http")
+    port, path = _free_port(), "/mcp"
+    _serve_with_audit(port, path, recorder)
+
+    asyncio.run(_call_as(port, path, None, 1))
+
+    events = [
+        json.loads(line)
+        for line in (tmp_path / "audit.jsonl").read_text().splitlines()
+        if line.strip()
+    ]
+    assert len(events) == 1
+    assert events[0]["principal"] == "unattributed"
+    assert events[0]["attribution"] == "local"
+    assert events[0]["transport"] == "http"
+
+
+def test_tool_output_is_identical_across_principals(tmp_path):
+    # Attribution never becomes authorization (REQ-005): two callers asserting
+    # different principals get byte-identical tool payloads.
+    import httpx
+    from mcp.client.session import ClientSession
+    from mcp.client.streamable_http import streamable_http_client
+
+    from rac.mcp.audit import AuditRecorder
+
+    recorder = AuditRecorder(tmp_path / "audit.jsonl", "unattributed", transport="http")
+    port, path = _free_port(), "/mcp"
+    _serve_with_audit(port, path, recorder)
+
+    async def _get(principal: str) -> str:
+        async with httpx.AsyncClient(headers={"X-Lore-Principal": principal}, timeout=30.0) as hc:
+            async with streamable_http_client(f"http://127.0.0.1:{port}{path}", http_client=hc) as (
+                read,
+                write,
+                _sid,
+            ):
+                async with ClientSession(read, write) as session:
+                    await session.initialize()
+                    result = await session.call_tool("get_summary", {})
+                    return result.content[0].text
+
+    alice = asyncio.run(_get("alice"))
+    bob = asyncio.run(_get("bob"))
+    assert alice == bob


### PR DESCRIPTION
Initiative 3 of the **lore-at-team-scale** epic (#262), closing sub-issue #265: the shared HTTP endpoint now attributes each caller distinctly instead of recording every read as the host identity.

Implements `rac/requirements/rac-shared-server-audit-identity.md` (now Accepted). No new ADR — the roadmap frames this as principal threading; the attribution carrier is fixed by amending the serving ADR.

## What ships

- **ADR-098 amended** to fix the attribution carrier: the **`X-Lore-Principal`** request header. Additive, consistent with its existing attributable-not-authenticated posture (the agent-rules digest is unaffected).
- **Per-request principal** in the audit path (`audit.observe`): precedence **asserted header → `RAC_AUDIT_PRINCIPAL` → git → `unattributed`**, with git **skipped on the HTTP transport** (it's the host's identity, never a caller's).
- **Server wiring:** each tool takes a `ctx: Context` (excluded from the tool schema — byte-identical client surface) and reads the header; the principal reaches only the audit record, never the tool body.
- **Additive record fields** (ADR-007): `transport` (`stdio`/`http`) and `attribution` (`asserted`/`local`) so an auditor reads the trust status of each line directly.
- **Mandatory-on hardening:** the HTTP recorder forces `on_write_error: block` — a sink write failure refuses the call on the shared transport (the runtime half of #263's startup guard).

## Contract held

- **Distinct attribution (acceptance):** two concurrent HTTP clients asserting different principals produce interleaved records with two distinct principals; the host identity never leaks.
- **Never the host (REQ-002):** an unasserted HTTP call is recorded with the fallback (`unattributed`/env), not the host's git identity.
- **Attribution ≠ authorization (REQ-005):** a test asserts tool output is byte-identical across principals; the principal is never an access-control input. No SSO/RBAC/user store added.
- **stdio unchanged (REQ-004):** construction-time git resolution and record shapes are unchanged except the two additive fields.
- **Fail-loud (REQ-003):** startup-without-sink still fails (#263); write failure now blocks on HTTP.

## Out of scope

Only **#266** (operate-it deployment recipe) remains in the epic.

## Gates

`rac validate rac/` (375 valid), `rac relationships rac/ --validate` (0 issues), `rac review rac/` (95/100, no priority 1–2), agent-rules in sync (no new ADR). 275 tests green across the mcp/resolve/cli batteries — including a concurrent-clients HTTP integration test; ruff + mypy clean.

Closes #265.