### PR TITLE
docs(mcp): shared-server operator guide + close lore-at-team-scale (#266)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,11 @@ details, release history over commit history.
 
 The **decision-to-code-proximity** programme: recorded decisions now know which
 code they govern, and you can ask which decisions govern a path — declared and
-validated, never inferred; deterministic and offline. Plus the first builds of
-**lore-at-team-scale**: `rac mcp` can now serve the whole team over one
+validated, never inferred; deterministic and offline. Plus the completed
+**lore-at-team-scale** programme: `rac mcp` can now serve the whole team over one
 always-current HTTP endpoint, with an optional content-addressed cache so
-per-call latency stops scaling with corpus size.
+per-call latency stops scaling with corpus size, per-caller audit attribution,
+and an operator guide for running it — servers and caches over git, no database.
 
 ### Added
 
@@ -55,6 +56,11 @@ per-call latency stops scaling with corpus size.
   verifies it; your proxy does), the principal never affects tool output, and
   shared HTTP serving blocks a call if the audit sink write fails
   (ADR-098). stdio behaviour is unchanged.
+- **Operator guide for the shared server.** A new
+  [Shared Server](https://itsthelore.github.io/rac-core/shared-server/) doc
+  covers when to run one, the container and authenticating-proxy recipe, keeping
+  the checkout current with `main`, and where observability lives — the whole
+  topology is deployment wrapper around an unchanged, database-free engine.
 
 ## 2026.06.5 — the "rename" release
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -401,8 +401,9 @@ to start without a working audit log** — enable the `audit:` stanza (see
 exits with an actionable error. stdio is unaffected.
 
 Keeping the fronted checkout current with `main` — a merge webhook or a periodic
-`git pull` — is a deployment concern outside the engine; a full container-and-
-keep-current recipe is documented separately for operators.
+`git pull` — is a deployment concern outside the engine. The full recipe —
+container, authenticating proxy, keep-current step, and observability — is on the
+[Shared Server](shared-server.md) page.
 
 ### Derived-index cache (large corpora)
 

--- a/docs/shared-server.md
+++ b/docs/shared-server.md
@@ -1,0 +1,174 @@
+# Operating a Shared Lore Server
+
+By default Lore runs as one `rac mcp` process per developer, over stdio, against
+that developer's own checkout. That is the right model for almost everyone and
+needs no operations at all.
+
+At organisation scale a team may instead want **one always-current endpoint**
+every agent queries, so reads come from a single `main`-backed source of truth
+rather than checkouts that lag between pulls. This page is the recipe for
+standing that up: a container running the HTTP transport, an authenticating
+proxy in front, a step that keeps the checkout current with `main`, and where
+observability lives. It assumes you have read the [MCP Server](mcp.md) page.
+
+Everything here is deployment wrapper — containers, proxies, collectors — around
+an unchanged engine. Lore gains no hosted service, no database, and no
+authentication code; git stays the source of truth
+([ADR-080](https://github.com/itsthelore/rac-core/blob/main/rac/decisions/adr-080-single-source-of-truth-git-not-database.md)).
+
+## 1. Do you need it?
+
+You probably do **not**. The local-clone default is correct whenever developers
+already clone the knowledge repo, because git keeps a team consistent the same
+way it keeps a codebase consistent: a checkout is either current with `main` or
+a `git pull` behind it, never authoritative-and-divergent. A stale answer is
+resolved exactly as stale code is — pull.
+
+Reach for a shared server when:
+
+- you want **every agent to read one always-current endpoint** rather than each
+  developer's own checkout, or
+- callers cannot or should not each hold a full clone, or
+- you want **one place** where read access is audited per caller.
+
+If none of these apply, stay on the per-developer stdio server — it is simpler,
+needs no proxy, and has no operational surface.
+
+## 2. The shape
+
+```
+ agents ──TLS──▶  authenticating proxy  ──HTTP──▶  rac mcp --transport http
+                  (terminates TLS,                 (read-only, stateless,
+                   authenticates the caller,        mandatory audit-on,
+                   sets X-Lore-Principal)           serves one main checkout)
+                                                          ▲
+                                        keep-current  ────┘
+                                        (merge webhook or periodic git pull)
+```
+
+Three moving parts, and not one of them is a database:
+
+- a **git checkout** of your knowledge repo's `main` branch,
+- a **stateless reader** (`rac mcp` over HTTP), and
+- an **authenticating proxy** that the engine never knows about.
+
+## 3. The container
+
+Run the HTTP transport against a read-only checkout. The `--cache` flag enables
+the disposable [derived-index cache](mcp.md#derived-index-cache-large-corpora)
+so per-call latency stays flat as the corpus grows.
+
+```dockerfile
+FROM python:3.12-slim
+RUN pip install --no-cache-dir rac-core
+# Your knowledge repo's main branch, mounted read-only at runtime (see §5).
+WORKDIR /corpus
+EXPOSE 8000
+CMD ["rac", "mcp", "--root", "/corpus", \
+     "--transport", "http", "--host", "0.0.0.0", "--port", "8000", "--cache"]
+```
+
+HTTP serving is **mandatory audit-on**: the server refuses to start without a
+working audit sink. Enable it in the corpus's `.rac/config.yaml` (committed, so
+an auditor has one git-diffable artifact) — see
+[the audit section](mcp.md#8-read-access-audit-log-enterprise-opt-in):
+
+```yaml
+audit:
+  enabled: true
+  path: /var/log/lore/audit.jsonl   # a writable volume; on_write_error blocks on HTTP
+```
+
+No secrets belong in this container: it holds no credentials, terminates no TLS,
+and authenticates nobody. Bind it to the proxy's network, never to the public
+internet.
+
+## 4. The authenticating proxy
+
+The engine does not authenticate — by design
+([ADR-085](https://github.com/itsthelore/rac-core/blob/main/rac/decisions/adr-085-enterprise-configuration-not-mode.md)).
+Put a reverse proxy in front to terminate TLS, authenticate the caller, and
+assert the caller's identity to the audit log via the **`X-Lore-Principal`**
+header. The engine records that header as the per-request principal
+([ADR-098](https://github.com/itsthelore/rac-core/blob/main/rac/decisions/adr-098-shared-http-mcp-serving.md)).
+
+```nginx
+location /mcp {
+    auth_request /_authn;                              # your authenticator
+    auth_request_set $principal $upstream_http_x_user; # identity it resolved
+
+    # Overwrite the header from the *authenticated* identity. This also strips
+    # any client-supplied X-Lore-Principal, so a caller cannot forge another's
+    # identity in the audit log.
+    proxy_set_header X-Lore-Principal $principal;
+
+    proxy_pass http://lore:8000/mcp;
+}
+```
+
+The critical line is the last `proxy_set_header`: the proxy must **overwrite**
+`X-Lore-Principal` with the identity it authenticated, never pass through a
+client-supplied value. Attribution in Lore is *attributable, not
+authenticated* — the engine records what it is told and never verifies it, so
+the trust of the header is exactly the trust of the proxy that sets it. If you
+run the endpoint with no authenticating proxy, principals are self-asserted and
+the audit log records claims, not verified identities.
+
+## 5. Keeping the checkout current with `main`
+
+The server re-reads the corpus on every call, so it is only ever as fresh as the
+checkout it fronts. Keeping that checkout current with `main` is a deployment
+concern outside the engine (ADR-080). Two shapes work:
+
+- **Merge webhook** — your git host calls a small endpoint on merge to `main`
+  that runs `git -C /corpus pull --ff-only`. Fresh within seconds of a merge.
+- **Periodic pull** — a sidecar that pulls on an interval:
+
+  ```bash
+  while true; do
+    git -C /corpus pull --ff-only origin main
+    sleep 60
+  done
+  ```
+
+Because the server re-reads per call, staleness is bounded by the pull interval
+and is observable, never silent. Mount the checkout read-only into the server
+container: knowledge changes only by pull from `main`, never by the server.
+
+## 6. Observability, and the engine boundary
+
+Observability for the shared server lives in the **wrapper**, not the engine
+([ADR-091](https://github.com/itsthelore/rac-core/blob/main/rac/decisions/adr-091-engine-observability-boundary.md)):
+
+- **Engine diagnostics go to stderr.** `rac mcp` writes startup and operational
+  notices to stderr (stdout is the protocol channel). Collect the container's
+  stderr with your normal log pipeline.
+- **The audit log is your read-access record.** It is a local JSONL file by
+  design; shipping it to Loki, S3, or Elastic is a collector's job, never the
+  engine's ([ADR-084](https://github.com/itsthelore/rac-core/blob/main/rac/decisions/adr-084-read-access-audit-recorder.md),
+  [ADR-073](https://github.com/itsthelore/rac-core/blob/main/rac/decisions/adr-073-backend-connectors-consolidate.md)).
+  Tail the audit volume with a sidecar and forward it.
+- **A metrics scrape endpoint belongs to the wrapper, not the engine.** The
+  engine ships no Prometheus `/metrics` surface. If you need scrape metrics,
+  expose them from the proxy or a sidecar (request counts, latencies, and status
+  codes all live there); the engine stays a stateless reader.
+- **Error reporting is bring-your-own.** There is no Lore-hosted sink; supply
+  your own DSN if you want error aggregation (ADR-091).
+
+## 7. What the engine will never do
+
+The shared server is a transport in front of the same engine, so its red lines
+stand (ADR-085):
+
+- **No SSO, RBAC, tool-level authorization, or user store.** The principal is an
+  attribution string in the audit record, never an access-control input — tool
+  responses are identical whatever the header says. Authorisation, if you need
+  it, is the proxy's (allow/deny at the edge).
+- **No database or hosted multi-tenant service.** Git `main` is the single
+  source of truth; the server is one reader of it (ADR-080).
+- **No write path.** Knowledge changes only by pull request to `main` behind
+  human review ([ADR-065](https://github.com/itsthelore/rac-core/blob/main/rac/decisions/adr-065-artifact-content-untrusted.md));
+  no transport exposes a write.
+
+These are not limitations to work around — they are the properties that let one
+engine serve the solo developer and the regulated enterprise unchanged.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,6 +30,7 @@ nav:
   - Home: index.md
   - Quickstart: quickstart.md
   - MCP Server: mcp.md
+  - Shared Server: shared-server.md
   - CLI Reference: cli.md
   - Watchkeeper: watchkeeper.md
   - Artifacts: artifacts.md

--- a/rac/roadmaps/lore-at-team-scale.md
+++ b/rac/roadmaps/lore-at-team-scale.md
@@ -7,18 +7,29 @@ type: roadmap
 
 ## Status
 
-Planned
+Achieved
 
-The recorded entry trigger has been met: an adopting organisation is
-expanding Lore toward multi-thousand-seat scale, far past the 50+ developer
-signal this artifact named. Per this artifact's own graduation clause and
-the deterministic-substrate programme's deferred list, it graduates out of
-`future/` as a live scoped roadmap. The substrate programme's two entry
-conditions are carried here explicitly: **mandatory audit-on for shared
-deployments** and **cache coherency guaranteed as byte-parity with the
-uncached path**. Execution is tracked in GitHub (ADR-093): the epic in
-`## Related Tickets` carries ordering and task state, with a sub-issue per
-initiative.
+Delivered across all four initiatives (epic itsthelore/rac-core#262). `rac mcp`
+gained a streamable HTTP transport so a team points every agent at one
+always-current `main`-backed endpoint (#263, under the serving decision ADR-098);
+an opt-in, content-addressed derived-index cache keeps per-call latency flat as
+the corpus grows, byte-identical to the uncached path (#264, ADR-099); the audit
+recorder resolves a per-request principal from the `X-Lore-Principal` header so
+every caller on the shared endpoint is attributed distinctly, never as the host
+(#265); and an operator recipe — container, authenticating proxy, keep-current
+step, and the observability boundary — documents how to run it (#266). Both
+substrate entry conditions held throughout: **mandatory audit-on for shared
+deployments** (HTTP refuses to start without a working sink and blocks on write
+failure) and **cache coherency guaranteed as byte-parity with the uncached
+path**. No database, no hosted service, no authentication in the engine — servers
+and caches over git `main`, exactly as scoped. Execution was tracked in GitHub
+(ADR-093), a sub-issue per initiative.
+
+The recorded entry trigger had been met: an adopting organisation expanding Lore
+toward multi-thousand-seat scale, far past the 50+ developer signal this artifact
+named. Per this artifact's own graduation clause and the deterministic-substrate
+programme's deferred list, it graduated out of `future/` as a live scoped
+roadmap.
 
 ## Context
 


### PR DESCRIPTION
Initiative 4 — the final one — of the **lore-at-team-scale** epic (#262). A documentation deliverable (no requirement, no ADR, no code), plus the epic close.

## What ships

- **New `docs/shared-server.md` — "Operating a Shared Lore Server"**, covering the four scoped areas:
  1. **When you need it** — shared endpoint vs. the local-clone default (most teams stay local; ADR-080's tradeoff stated plainly).
  2. **Deployment recipe** — a container running `rac mcp --transport http --cache`, read-only, no secrets; the mandatory `audit:` stanza.
  3. **Authenticating proxy** — an nginx example that terminates TLS, authenticates, and **overwrites** `X-Lore-Principal` from the authenticated identity (with the explicit anti-spoofing note that the proxy must strip any client-supplied value). Attribution, not authentication.
  4. **Keep-current from `main`** — merge webhook or periodic `git pull` sidecar, external to the engine.
  5. **Observability within ADR-091** — engine diagnostics to stderr; a metrics scrape endpoint belongs to the wrapper, never the engine; audit-log shipping is the collector's job.
  6. **What the engine never does** — the ADR-085 red lines restated.
- Added to the mkdocs nav; the `docs/mcp.md` placeholder now links the new page.

## Epic close

- **`rac/roadmaps/lore-at-team-scale.md` → Status: Achieved** (ADR-061) with a four-initiative delivery summary: HTTP transport (#263/ADR-098), derived-index cache (#264/ADR-099), shared-server audit identity (#265), operate-it guide (#266). Both substrate entry conditions held — mandatory audit-on and cache byte-parity.
- CHANGELOG marks the programme complete.

## Verification

`rac validate rac/` (375 valid), `rac relationships rac/ --validate` (0 issues), `rac review rac/` (exit 0), agent-rules in sync (roadmap Status doesn't touch the digest), `ruff format --check` clean tree-wide. All internal doc links and both mcp.md anchors resolve; all seven ADR links point to real files. Docs-only — no code, no tests.

Closes #266. This completes epic #262 — all four sub-issues delivered.