### PR TITLE
feat(ingest): note-tool ingest — Obsidian vaults (ingest-sources #227)

### DIFF
--- a/.cursor/rules
+++ b/.cursor/rules
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: fdf6de5712cd9fcd3d6179d984795bf5c0eb312dbb5578632b42db966bb17333) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: 94fca31da6f1e31641a3f2ab086ecdd00d58a945930de99d13c1f6475d411c2a) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -58,6 +58,7 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KVK19NPWFYC9** — ADR-074: The Graph Export Surfaces Typed Relationship Edges _(Technical)_
 - **RAC-KVNM01QPBPXB** — ADR-075: The Pre-Merge Check Tier Is a Required Merge Gate on `main` _(Process)_
 - **RAC-KVPTVX3YZ87K** — ADR-076: Adopt CalVer (`YYYY.MM.N`) for RAC Releases _(Process)_
+- **RAC-KVSQ2A0BB9XF** — ADR-079: Note-Tool Exports Are Ingested by Normalisation, Not markitdown _(Architecture)_
 - **RAC-KVTS86ZGVJV7** — ADR-077: The Two-Gate Capture Write Model _(Architecture)_
 - **RAC-KW2YW6XK593X** — ADR-084: Read-Access Audit Recorder _(Product)_
 - **RAC-KW47GFBHK31W** — ADR-086: Air-Gap Posture and Enterprise Telemetry Hard-Lock _(Product)_

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: fdf6de5712cd9fcd3d6179d984795bf5c0eb312dbb5578632b42db966bb17333) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: 94fca31da6f1e31641a3f2ab086ecdd00d58a945930de99d13c1f6475d411c2a) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -58,6 +58,7 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KVK19NPWFYC9** — ADR-074: The Graph Export Surfaces Typed Relationship Edges _(Technical)_
 - **RAC-KVNM01QPBPXB** — ADR-075: The Pre-Merge Check Tier Is a Required Merge Gate on `main` _(Process)_
 - **RAC-KVPTVX3YZ87K** — ADR-076: Adopt CalVer (`YYYY.MM.N`) for RAC Releases _(Process)_
+- **RAC-KVSQ2A0BB9XF** — ADR-079: Note-Tool Exports Are Ingested by Normalisation, Not markitdown _(Architecture)_
 - **RAC-KVTS86ZGVJV7** — ADR-077: The Two-Gate Capture Write Model _(Architecture)_
 - **RAC-KW2YW6XK593X** — ADR-084: Read-Access Audit Recorder _(Product)_
 - **RAC-KW47GFBHK31W** — ADR-086: Air-Gap Posture and Enterprise Telemetry Hard-Lock _(Product)_

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,7 +74,7 @@ jobs:
           - name: index
             paths: "tests/test_index.py"
           - name: ingest
-            paths: "tests/test_ingest.py"
+            paths: "tests/test_ingest.py tests/test_note_ingest.py"
           - name: init
             paths: "tests/test_init.py tests/test_profiles.py"
           - name: quickstart

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: fdf6de5712cd9fcd3d6179d984795bf5c0eb312dbb5578632b42db966bb17333) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: 94fca31da6f1e31641a3f2ab086ecdd00d58a945930de99d13c1f6475d411c2a) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -58,6 +58,7 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KVK19NPWFYC9** — ADR-074: The Graph Export Surfaces Typed Relationship Edges _(Technical)_
 - **RAC-KVNM01QPBPXB** — ADR-075: The Pre-Merge Check Tier Is a Required Merge Gate on `main` _(Process)_
 - **RAC-KVPTVX3YZ87K** — ADR-076: Adopt CalVer (`YYYY.MM.N`) for RAC Releases _(Process)_
+- **RAC-KVSQ2A0BB9XF** — ADR-079: Note-Tool Exports Are Ingested by Normalisation, Not markitdown _(Architecture)_
 - **RAC-KVTS86ZGVJV7** — ADR-077: The Two-Gate Capture Write Model _(Architecture)_
 - **RAC-KW2YW6XK593X** — ADR-084: Read-Access Audit Recorder _(Product)_
 - **RAC-KW47GFBHK31W** — ADR-086: Air-Gap Posture and Enterprise Telemetry Hard-Lock _(Product)_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ validated, never inferred; deterministic and offline. Plus the completed
 always-current HTTP endpoint, with an optional content-addressed cache so
 per-call latency stops scaling with corpus size, per-caller audit attribution,
 and an operator guide for running it — servers and caches over git, no database.
+And the first of the **note-tool ingest sources**: `rac ingest` now imports an
+Obsidian vault, carrying its wikilink graph in as candidate relationships.
 
 ### Added
 
@@ -61,6 +63,13 @@ and an operator guide for running it — servers and caches over git, no databas
   covers when to run one, the container and authenticating-proxy recipe, keeping
   the checkout current with `main`, and where observability lives — the whole
   topology is deployment wrapper around an unchanged, database-free engine.
+- **Ingest an Obsidian vault (`rac ingest <dir>`).** Point `rac ingest` at a
+  note-tool export directory and each note becomes a reviewable RAC-shaped draft,
+  with `[[wikilinks]]` carried in as **candidate `## Related` references** for you
+  to promote — never asserted edges. Deterministic and offline (identical export
+  → byte-identical drafts), lossless (frontmatter and unmapped content preserved),
+  and it never overwrites an existing file. Ambiguous and unresolved links are
+  reported for review, never guessed (ADR-079). Logseq, Notion, and Roam follow.
 
 ## 2026.06.5 — the "rename" release
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ to the corpus artifact and they load through the imports below.
 - Previous series: `rac/roadmaps/v0.21.x-editor/` (complete)
 - Decisions (ADRs): `rac/decisions/`
 
-<!-- BEGIN RAC MANAGED BLOCK (digest: fdf6de5712cd9fcd3d6179d984795bf5c0eb312dbb5578632b42db966bb17333) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: 94fca31da6f1e31641a3f2ab086ecdd00d58a945930de99d13c1f6475d411c2a) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -83,6 +83,7 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KVK19NPWFYC9** — ADR-074: The Graph Export Surfaces Typed Relationship Edges _(Technical)_
 - **RAC-KVNM01QPBPXB** — ADR-075: The Pre-Merge Check Tier Is a Required Merge Gate on `main` _(Process)_
 - **RAC-KVPTVX3YZ87K** — ADR-076: Adopt CalVer (`YYYY.MM.N`) for RAC Releases _(Process)_
+- **RAC-KVSQ2A0BB9XF** — ADR-079: Note-Tool Exports Are Ingested by Normalisation, Not markitdown _(Architecture)_
 - **RAC-KVTS86ZGVJV7** — ADR-077: The Two-Gate Capture Write Model _(Architecture)_
 - **RAC-KW2YW6XK593X** — ADR-084: Read-Access Audit Recorder _(Product)_
 - **RAC-KW47GFBHK31W** — ADR-086: Air-Gap Posture and Enterprise Telemetry Hard-Lock _(Product)_

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -197,6 +197,42 @@ Conversion uses optional extras. Install the readers you need:
 `pip install 'rac-core[ingest]'` (DOCX/HTML), `[ingest-pdf]`,
 `[ingest-office]` (PPTX/XLSX), or `[ingest-all]`.
 
+### Note-tool exports (Obsidian)
+
+Point `rac ingest` at a **note-tool export directory** and it normalises the
+whole vault — each note becomes a RAC-shaped draft, and the wikilink graph you
+already drew is carried in as **candidate `## Related` references** rather than
+flattened to plain text. Obsidian is supported today; the converters need no
+extra to install.
+
+- **Input:** `rac ingest <dir>` — the export directory (a vault). The tool is
+  auto-detected from its layout; force it with `--from obsidian`.
+- **Output:** `-o <dir>` writes one draft per note (mirroring the vault's
+  structure) and **never overwrites an existing file** — pass `--force` to
+  replace. Without `-o`, a summary previews what would convert and what needs
+  review. `--json` emits the full structured result.
+
+```bash
+rac ingest ./my-vault                    # preview: notes, resolved links, ambiguities
+rac ingest ./my-vault -o drafts/         # write reviewable drafts
+rac ingest ./my-export --from obsidian -o drafts/
+```
+
+What the normaliser does, deterministically and offline (identical export →
+byte-identical drafts, nothing dropped):
+
+- **Wikilinks → candidates.** A resolved `[[Note]]` becomes an inline Markdown
+  link, and its target is added to a clearly-marked candidate `## Related`
+  section — a suggestion for you to promote, never an edge the tool asserts.
+  Ambiguous (`[[Name]]` matching two notes) and unresolved links are left inline
+  and listed for review, never guessed.
+- **Frontmatter and unmapped content are preserved verbatim**, so you review a
+  complete, faithful draft.
+
+The drafts are for **human review**: promote the candidate links and finalise the
+artifact frontmatter, then `rac validate`. This is an import step, not an
+auto-commit.
+
 ---
 
 ## inspect

--- a/rac/decisions/adr-079-note-tool-ingest-sources.md
+++ b/rac/decisions/adr-079-note-tool-ingest-sources.md
@@ -68,7 +68,7 @@ markitdown decision for binary documents.
 
 ## Status
 
-Proposed
+Accepted
 
 ## Category
 

--- a/src/rac/cli.py
+++ b/src/rac/cli.py
@@ -295,8 +295,16 @@ def cmd_stats(args: argparse.Namespace) -> int:
 
 def cmd_ingest(args: argparse.Namespace) -> int:
     path = Path(args.file)
+    if path.is_dir():
+        return _cmd_ingest_vault(args, path)
     if not path.is_file():
-        print(f"rac: file not found: {args.file}", file=sys.stderr)
+        print(f"rac: path not found: {args.file}", file=sys.stderr)
+        raise SystemExit(EXIT_USAGE)
+    if args.from_tool:
+        print(
+            "rac: --from applies to a note-tool export directory, not a single file.",
+            file=sys.stderr,
+        )
         raise SystemExit(EXIT_USAGE)
 
     try:
@@ -330,6 +338,53 @@ def cmd_ingest(args: argparse.Namespace) -> int:
             print(outputs.render_ingest_json(result, None))
         else:
             print(result.markdown)
+    return EXIT_OK
+
+
+def _cmd_ingest_vault(args: argparse.Namespace, root: Path) -> int:
+    """Ingest a note-tool export directory into RAC-shaped drafts (ADR-079).
+
+    Deterministic and offline: each note becomes a draft, wikilinks become
+    candidate ``## Related`` references (never asserted), and nothing is
+    overwritten. With ``-o`` the drafts are written for review; without it, a
+    summary previews what would convert and what needs human attention.
+    """
+    from rac.services.note_ingest import converter_by_name, converter_names, detect_converter
+
+    if args.stdout:
+        print(
+            "rac: --stdout is not supported for a directory export; use -o <dir>.", file=sys.stderr
+        )
+        raise SystemExit(EXIT_USAGE)
+
+    converter = converter_by_name(args.from_tool) if args.from_tool else detect_converter(root)
+    if converter is None:
+        print(
+            f"rac: could not detect a note-tool export in {root}. "
+            f"Pass --from with one of: {', '.join(converter_names())}",
+            file=sys.stderr,
+        )
+        raise SystemExit(EXIT_USAGE)
+
+    result = converter.convert_vault(root)
+
+    written: list[str] = []
+    skipped: list[str] = []
+    if args.output:
+        out_dir = Path(args.output)
+        for draft in result.drafts:
+            dest = out_dir / draft.suggested_filename
+            if dest.exists() and not args.force:
+                skipped.append(str(dest))  # never overwrite an existing artifact (REQ-006)
+                continue
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_text(draft.markdown, encoding="utf-8")
+            written.append(str(dest))
+
+    if args.json:
+        print(outputs.render_vault_ingest_json(result, written, skipped, args.output))
+    else:
+        print(outputs.render_vault_ingest_human(result, written, skipped, args.output))
     return EXIT_OK
 
 
@@ -1357,19 +1412,37 @@ def build_parser() -> argparse.ArgumentParser:
 
     p_ingest = sub.add_parser(
         "ingest",
-        help="Convert a document (DOCX, PDF, HTML, PPTX, XLSX, Markdown) to Markdown.",
+        help=(
+            "Convert a document (DOCX, PDF, HTML, PPTX, XLSX, Markdown) — or a "
+            "note-tool export directory (Obsidian) — to RAC-shaped Markdown."
+        ),
         parents=[version_parent],
     )
-    p_ingest.add_argument("file", help="Path to the source document.")
+    p_ingest.add_argument("file", help="Path to the source document or note-tool export directory.")
     ingest_dest = p_ingest.add_mutually_exclusive_group()
-    ingest_dest.add_argument("-o", "--output", help="Write Markdown here instead of printing it.")
+    ingest_dest.add_argument(
+        "-o",
+        "--output",
+        help="Write Markdown here (a file for a document, a directory for a note-tool export).",
+    )
     ingest_dest.add_argument(
         "--stdout",
         action="store_true",
-        help="Write Markdown to stdout (the default; explicit for pipelines).",
+        help="Write Markdown to stdout (the default for a document; explicit for pipelines).",
+    )
+    # Note-tool export ingest (ADR-079): choices are literals so the base CLI does
+    # not import the ingest layer just to build the parser; the converter registry
+    # is the runtime source of truth and a battery test pins these to it.
+    p_ingest.add_argument(
+        "--from",
+        dest="from_tool",
+        choices=("obsidian",),
+        help="Force a note-tool converter for a directory export (default: auto-detect).",
     )
     p_ingest.add_argument(
-        "--force", action="store_true", help="Overwrite the output file if it exists."
+        "--force",
+        action="store_true",
+        help="Overwrite existing output; never overwrites by default.",
     )
     p_ingest.add_argument(
         "--json", action="store_true", help="Emit JSON instead of human-readable text."

--- a/src/rac/output/__init__.py
+++ b/src/rac/output/__init__.py
@@ -42,6 +42,7 @@ from .human import (
     render_unknown_schema,
     render_validate_dir_human,
     render_validation_human,
+    render_vault_ingest_human,
     render_watchkeeper_human,
 )
 from .json import (
@@ -81,6 +82,7 @@ from .json import (
     render_templates_json,
     render_validate_dir_json,
     render_validation_json,
+    render_vault_ingest_json,
     render_watchkeeper_json,
 )
 from .okf import render_okf_bundle
@@ -172,6 +174,8 @@ __all__ = [
     "render_validate_sarif",
     "render_validation_human",
     "render_validation_json",
+    "render_vault_ingest_human",
+    "render_vault_ingest_json",
     "render_watchkeeper_github",
     "render_watchkeeper_human",
     "render_watchkeeper_json",

--- a/src/rac/output/human.py
+++ b/src/rac/output/human.py
@@ -42,6 +42,7 @@ from rac.services.migrate import (
     STATUS_SKIPPED_UNKNOWN,
     MigrationReport,
 )
+from rac.services.note_ingest import VaultIngestResult
 from rac.services.portfolio import PortfolioSummary
 from rac.services.quickstart import QuickstartResult
 from rac.services.relationships import (
@@ -1412,3 +1413,46 @@ def render_rename_result_human(result: RenameResult) -> str:
             ),
         ]
     )
+
+
+def render_vault_ingest_human(
+    result: VaultIngestResult,
+    written: list[str],
+    skipped: list[str],
+    output_dir: str | None,
+) -> str:
+    """Human summary for `rac ingest <dir>`: what converted, what needs review.
+
+    Leads with the conversion counts, then what needs human attention —
+    ambiguous and unresolved wikilinks — in the scannable style of the existing
+    ingest output. Candidate links are framed as suggestions to promote, never
+    edges the tool asserted (ADR-079).
+    """
+    lines = [
+        f"Ingested {result.note_count} note(s) from {result.root} via {result.converter}.",
+        f"  {result.resolved_link_count} wikilink(s) resolved to candidate ## Related references.",
+    ]
+    if result.warning_count:
+        lines.append(
+            f"  {result.warning_count} link(s) need review (ambiguous or unresolved) — "
+            "left inline, never guessed."
+        )
+    if output_dir is not None:
+        lines.append("")
+        lines.append(f"Wrote {len(written)} draft(s) to {output_dir}.")
+        if skipped:
+            lines.append(
+                f"Skipped {len(skipped)} draft(s) — an artifact already exists "
+                "(pass --force to overwrite):"
+            )
+            lines.extend(f"  - {path}" for path in skipped)
+    else:
+        lines.append("")
+        lines.append("Preview only — pass -o <dir> to write the drafts for review.")
+    if result.warning_count:
+        lines.append("")
+        lines.append("Links to review:")
+        for draft in result.drafts:
+            for warning in draft.warnings:
+                lines.append(f"  {draft.source_path}: {warning}")
+    return "\n".join(lines)

--- a/src/rac/output/json.py
+++ b/src/rac/output/json.py
@@ -26,6 +26,7 @@ from rac.services.ingest import IngestResult
 from rac.services.init import InitResult
 from rac.services.inspect import DirectoryInspection, InspectionResult
 from rac.services.migrate import MigrationReport
+from rac.services.note_ingest import VaultIngestResult
 from rac.services.portfolio import PortfolioSummary
 from rac.services.quickstart import QuickstartResult
 from rac.services.relationships import RelationshipReport, RelationshipValidation
@@ -289,6 +290,41 @@ def render_ingest_json(result: IngestResult, output_path: str | None) -> str:
         "converter": result.converter,
         "output": output_path,
         "markdown": result.markdown,
+    }
+    return json.dumps(payload, indent=2)
+
+
+def render_vault_ingest_json(
+    result: VaultIngestResult,
+    written: list[str],
+    skipped: list[str],
+    output_dir: str | None,
+) -> str:
+    """JSON `rac ingest <dir>` output (stable contract, ADR-007).
+
+    Carries every draft's normalised Markdown and its candidate relationships and
+    warnings, plus what was written or skipped, so a consumer can drive the review
+    step programmatically. Order mirrors the deterministic note walk.
+    """
+    payload = {
+        "converter": result.converter,
+        "root": result.root,
+        "output_dir": output_dir,
+        "note_count": result.note_count,
+        "resolved_link_count": result.resolved_link_count,
+        "warning_count": result.warning_count,
+        "written": written,
+        "skipped": skipped,
+        "drafts": [
+            {
+                "source": draft.source_path,
+                "suggested_filename": draft.suggested_filename,
+                "related": draft.related,
+                "warnings": draft.warnings,
+                "markdown": draft.markdown,
+            }
+            for draft in result.drafts
+        ],
     }
     return json.dumps(payload, indent=2)
 

--- a/src/rac/services/note_ingest.py
+++ b/src/rac/services/note_ingest.py
@@ -1,0 +1,329 @@
+"""Note-tool (PKM) ingest — Obsidian and its siblings (ADR-079).
+
+Note-tool exports (Obsidian, Logseq, Notion, Roam) are *already* Markdown,
+organised as a graph of interlinked notes, so they are ingested by
+**normalisation**, not markitdown (ADR-072): each note becomes a RAC-shaped
+draft, wikilinks become **candidate** ``## Related`` references for a human to
+promote (never asserted edges — ADR-074, ADR-065), and conversion is
+deterministic and offline (ADR-002) — identical export yields byte-identical
+drafts, nothing is dropped (lossless by default), and nothing is overwritten.
+
+This is the directory/graph analogue of :mod:`rac.services.ingest`'s file
+converters: a :class:`VaultConverter` takes an export *directory* and emits a
+*set* of drafts, whereas a ``DocumentConverter`` takes one binary file and emits
+one Markdown string. The markitdown path for binary documents is untouched, and
+these converters pull no third-party dependency — they are pure text
+normalisation over stdlib.
+
+Obsidian is the first tool (this module's reference converter); Logseq, Notion,
+and Roam register beside it and reuse the shared wikilink resolution below, so
+one tool's export-format drift cannot break another.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+# Directories that are tool configuration, not notes: never walked for content.
+_SKIP_DIRS = {".obsidian", ".trash", ".git"}
+
+# A wikilink: optional ``!`` (embed/transclusion), then ``[[ ... ]]``. The inner
+# text is ``target`` with an optional ``#heading`` / ``^block`` fragment and an
+# optional ``|alias``: ``[[target#frag|alias]]``.
+_WIKILINK_RE = re.compile(r"(?P<embed>!?)\[\[(?P<inner>[^\[\]]+)\]\]")
+
+
+@dataclass(frozen=True)
+class Wikilink:
+    """One parsed ``[[wikilink]]`` occurrence (ADR-079)."""
+
+    raw: str  # the full matched text, e.g. "[[Note|alias]]" or "![[embed]]"
+    target: str  # the note-name portion, trimmed
+    alias: str | None
+    fragment: str | None  # heading (#) or block (^) reference, without the sigil
+    embed: bool  # True for ![[...]] transclusions
+
+
+@dataclass
+class NoteDraft:
+    """One note normalised into a reviewable RAC-shaped draft (ADR-003).
+
+    ``related`` are the resolved wikilink targets offered as candidate
+    ``## Related`` references — candidates for human promotion, not asserted
+    edges. ``warnings`` records ambiguous and unresolved links left inline
+    verbatim, so the human review starts from a complete, honest draft.
+    """
+
+    source_path: str  # POSIX, relative to the vault root
+    suggested_filename: str  # POSIX, relative to the output root
+    markdown: str
+    related: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+
+@dataclass
+class VaultIngestResult:
+    """The full outcome of ingesting one export directory (ADR-003)."""
+
+    converter: str
+    root: str
+    drafts: list[NoteDraft] = field(default_factory=list)
+
+    @property
+    def note_count(self) -> int:
+        return len(self.drafts)
+
+    @property
+    def resolved_link_count(self) -> int:
+        return sum(len(d.related) for d in self.drafts)
+
+    @property
+    def warning_count(self) -> int:
+        return sum(len(d.warnings) for d in self.drafts)
+
+
+@runtime_checkable
+class VaultConverter(Protocol):
+    """Turns a note-tool export directory into a set of RAC-shaped drafts.
+
+    The graph analogue of ``DocumentConverter``: ``detect`` recognises the
+    export shape (a marker directory/file) so a bare ``rac ingest <dir>`` routes
+    deterministically, and ``convert_vault`` walks the export and normalises each
+    note. Implementations pull no third-party dependency.
+    """
+
+    name: str
+
+    def detect(self, root: Path) -> bool: ...
+
+    def convert_vault(self, root: Path) -> VaultIngestResult: ...
+
+
+# --- Shared normalisation (reused by every note-tool converter) --------------
+
+
+def parse_wikilinks(text: str) -> list[Wikilink]:
+    """Every ``[[wikilink]]`` in ``text``, in document order (deterministic)."""
+    links: list[Wikilink] = []
+    for match in _WIKILINK_RE.finditer(text):
+        inner = match.group("inner")
+        target_part, _, alias = inner.partition("|")
+        alias = alias.strip() or None
+        # A fragment is a #heading or ^block ref on the target; either sigil ends
+        # the note name. Split on the first of whichever appears.
+        target = target_part
+        fragment: str | None = None
+        for sigil in ("#", "^"):
+            if sigil in target:
+                target, _, fragment = target.partition(sigil)
+                fragment = fragment.strip() or None
+                break
+        links.append(
+            Wikilink(
+                raw=match.group(0),
+                target=target.strip(),
+                alias=alias,
+                fragment=fragment,
+                embed=match.group("embed") == "!",
+            )
+        )
+    return links
+
+
+def _split_frontmatter(text: str) -> tuple[str, str]:
+    """Split leading ``---`` YAML frontmatter from the body, both preserved.
+
+    Returns ``(frontmatter_block, body)`` where ``frontmatter_block`` includes
+    its ``---`` fences (or is empty when there is none). Lossless: the bytes are
+    partitioned, never rewritten.
+    """
+    if not text.startswith("---\n"):
+        return "", text
+    end = text.find("\n---", 4)
+    if end == -1:
+        return "", text
+    # Include the closing fence line and the newline after it, if present.
+    fence_end = text.find("\n", end + 1)
+    if fence_end == -1:
+        return text, ""
+    return text[: fence_end + 1], text[fence_end + 1 :]
+
+
+class _Resolver:
+    """Deterministic wikilink resolution over one export's note set.
+
+    Obsidian-style: a link names a note, resolved by exact relative path first,
+    then by unique basename stem. Multiple stems sharing a name are *ambiguous*
+    (reported, never guessed); no match is *unresolved* (left inline). Purely a
+    function of the note paths, so results are byte-identical across machines.
+    """
+
+    def __init__(self, note_paths: list[str]) -> None:
+        self._by_relpath = {p.casefold(): p for p in note_paths}
+        self._by_stem: dict[str, list[str]] = {}
+        for path in note_paths:
+            stem = Path(path).stem.casefold()
+            self._by_stem.setdefault(stem, []).append(path)
+
+    def resolve(self, target: str) -> tuple[str | None, bool]:
+        """Return ``(resolved_relpath, ambiguous)`` for a link target.
+
+        ``resolved_relpath`` is None when unresolved; ``ambiguous`` is True when
+        a bare name matched more than one note. A *path-qualified* target
+        (containing ``/``) resolves only by exact relative path; a *bare* name
+        resolves by unique basename stem, and a name shared by several notes is
+        ambiguous — reported, never guessed to one (REQ-003).
+        """
+        key = target.strip().replace("\\", "/")
+        if "/" in key:
+            for candidate in (key, f"{key}.md"):
+                hit = self._by_relpath.get(candidate.casefold())
+                if hit is not None:
+                    return hit, False
+            return None, False
+        stem_matches = self._by_stem.get(key.casefold(), [])
+        if len(stem_matches) == 1:
+            return stem_matches[0], False
+        if len(stem_matches) > 1:
+            return None, True
+        return None, False
+
+
+def _link_url(target: str) -> str:
+    """A link URL safe in inline Markdown: angle-bracketed when it needs it."""
+    if any(ch in target for ch in " ()"):
+        return f"<{target}>"
+    return target
+
+
+def _normalise_body(body: str, resolver: _Resolver, self_path: str, draft: NoteDraft) -> str:
+    """Rewrite resolved note links inline; leave the rest verbatim (lossless).
+
+    A resolved, non-embed ``[[Note]]`` becomes a plain Markdown link and its
+    target is recorded as a candidate ``## Related`` reference. Embeds
+    (``![[...]]``, often media), self-links, and ambiguous/unresolved links are
+    left exactly as written — nothing is dropped, nothing is guessed (REQ-003,
+    REQ-007). Deterministic: a single left-to-right pass.
+    """
+    related: list[str] = []
+    warnings: list[str] = []
+    result: list[str] = []
+    last = 0
+    for match in _WIKILINK_RE.finditer(body):
+        result.append(body[last : match.start()])
+        last = match.end()
+        link = parse_wikilinks(match.group(0))[0]
+        if link.embed:
+            result.append(link.raw)  # transclusions/media stay verbatim
+            continue
+        resolved, ambiguous = resolver.resolve(link.target)
+        if resolved is not None:
+            label = link.alias or link.target
+            result.append(f"[{label}]({_link_url(resolved)})")
+            # A note linking to itself is not a candidate relationship.
+            if resolved != self_path and resolved not in related:
+                related.append(resolved)
+        else:
+            result.append(link.raw)  # unresolved/ambiguous: leave inline
+            reason = "ambiguous" if ambiguous else "unresolved"
+            warnings.append(f"{reason} wikilink {link.raw}")
+    result.append(body[last:])
+    draft.related = related
+    draft.warnings = warnings
+    return "".join(result)
+
+
+_CANDIDATE_NOTE = (
+    "<!-- Candidate relationships imported from wikilinks (ADR-079): review and "
+    "promote to real references before this becomes an artifact; not asserted. -->"
+)
+
+
+def _assemble_draft(frontmatter: str, body: str, draft: NoteDraft) -> str:
+    """Compose the draft: preserved frontmatter, normalised body, candidate links.
+
+    Lossless (REQ-007): the frontmatter block and body bytes are preserved; the
+    only addition is a clearly-marked candidate ``## Related`` section listing the
+    resolved targets, appended so a human promotes them (never asserted).
+    """
+    parts = [frontmatter, body]
+    text = "".join(parts)
+    if draft.related:
+        if not text.endswith("\n"):
+            text += "\n"
+        related_lines = "\n".join(f"- {target}" for target in draft.related)
+        text += f"\n{_CANDIDATE_NOTE}\n\n## Related\n\n{related_lines}\n"
+    return text
+
+
+def _walk_notes(root: Path) -> list[str]:
+    """Every ``.md`` note under ``root``, POSIX-relative, sorted (deterministic)."""
+    notes: list[str] = []
+    for path in root.rglob("*.md"):
+        rel_parts = path.relative_to(root).parts
+        if any(part in _SKIP_DIRS for part in rel_parts[:-1]):
+            continue
+        notes.append(path.relative_to(root).as_posix())
+    return sorted(notes)
+
+
+class ObsidianConverter:
+    """Ingest an Obsidian vault: ``.md`` notes, ``[[wikilinks]]``, YAML frontmatter.
+
+    Detects the vault by its ``.obsidian/`` configuration directory. Each note is
+    normalised through the shared wikilink resolver, its frontmatter preserved
+    verbatim, and its resolved links offered as candidate ``## Related``
+    references — deterministic, offline, and lossless (ADR-079, ADR-002).
+    """
+
+    name = "obsidian"
+
+    def detect(self, root: Path) -> bool:
+        return (root / ".obsidian").is_dir()
+
+    def convert_vault(self, root: Path) -> VaultIngestResult:
+        note_paths = _walk_notes(root)
+        resolver = _Resolver(note_paths)
+        result = VaultIngestResult(converter=self.name, root=str(root))
+        for rel in note_paths:
+            text = (root / rel).read_text(encoding="utf-8")
+            frontmatter, body = _split_frontmatter(text)
+            draft = NoteDraft(source_path=rel, suggested_filename=rel, markdown="")
+            normalised = _normalise_body(body, resolver, rel, draft)
+            draft.markdown = _assemble_draft(frontmatter, normalised, draft)
+            result.drafts.append(draft)
+        return result
+
+
+# Registry — first converter whose ``detect`` matches wins; ``--from`` selects by
+# name. Order is deterministic; adding Logseq/Notion/Roam appends here.
+_VAULT_CONVERTERS: list[VaultConverter] = [ObsidianConverter()]
+
+
+def vault_converters() -> list[VaultConverter]:
+    """Every registered note-tool converter, in registration order."""
+    return list(_VAULT_CONVERTERS)
+
+
+def converter_by_name(name: str) -> VaultConverter | None:
+    """The converter with ``name`` (the ``--from`` selector), or None."""
+    for converter in _VAULT_CONVERTERS:
+        if converter.name == name:
+            return converter
+    return None
+
+
+def detect_converter(root: Path) -> VaultConverter | None:
+    """The converter whose export shape ``root`` matches, or None (deterministic)."""
+    for converter in _VAULT_CONVERTERS:
+        if converter.detect(root):
+            return converter
+    return None
+
+
+def converter_names() -> list[str]:
+    """The names accepted by ``--from``, sorted."""
+    return sorted(c.name for c in _VAULT_CONVERTERS)

--- a/tests/test_note_ingest.py
+++ b/tests/test_note_ingest.py
@@ -1,0 +1,254 @@
+"""Note-tool ingest — Obsidian normalisation, determinism, losslessness (ADR-079).
+
+Initiative 1 of the `ingest-sources` roadmap (itsthelore/rac-core#227): the
+Obsidian converter and the shared wikilink machinery the other note tools reuse.
+These tests hold the requirement's contract (`rac-note-tool-ingest-sources`):
+
+- **Wikilinks → candidates (REQ-003):** resolved links become candidate
+  ``## Related`` references and inline Markdown links; ambiguous/unresolved links
+  are left inline and reported, never guessed, never asserted.
+- **Directory in, set out (REQ-002):** a vault yields one draft per note.
+- **Deterministic + offline (REQ-006):** re-ingesting a vault is byte-identical;
+  drafts never overwrite existing files.
+- **Lossless (REQ-007):** frontmatter and unmapped content are preserved verbatim.
+- **Registry, not core (REQ-005):** converters register beside markitdown.
+"""
+
+from __future__ import annotations
+
+import json
+
+from rac import cli
+from rac.services.note_ingest import (
+    ObsidianConverter,
+    converter_by_name,
+    converter_names,
+    detect_converter,
+    parse_wikilinks,
+    vault_converters,
+)
+
+
+def _vault(tmp_path):
+    """A small Obsidian vault exercising every link and content shape."""
+    root = tmp_path / "vault"
+    (root / ".obsidian").mkdir(parents=True)
+    (root / "Decisions").mkdir()
+    (root / "Auth.md").write_text(
+        "---\ntitle: Auth Policy\ntags: [security, auth]\n---\n\n"
+        "See [[Login Policy]] and [[Decisions/ADR One|the ADR]].\n"
+        "Unknown [[Ghost Note]], self [[Auth]], ambiguous [[Dup]], embed ![[diagram.png]].\n"
+        "A plain sentence with unmapped_key: value preserved.\n",
+        encoding="utf-8",
+    )
+    (root / "Login Policy.md").write_text("# Login Policy\n\nBack to [[Auth]].\n", encoding="utf-8")
+    (root / "Decisions" / "ADR One.md").write_text("# ADR One\n\nBody.\n", encoding="utf-8")
+    (root / "Dup.md").write_text("root dup\n", encoding="utf-8")
+    (root / "Decisions" / "Dup.md").write_text("nested dup\n", encoding="utf-8")
+    # A config-dir file that must never be walked as a note.
+    (root / ".obsidian" / "workspace.md").write_text("not a note\n", encoding="utf-8")
+    return root
+
+
+def _ingest(tmp_path):
+    return ObsidianConverter().convert_vault(_vault(tmp_path))
+
+
+# --- parsing (unit) ----------------------------------------------------------
+
+
+def test_parse_wikilinks_shapes():
+    links = parse_wikilinks("[[Plain]] [[Note|alias]] [[Note#heading]] ![[embed.png]] [[a^block]]")
+    assert [(link.target, link.alias, link.fragment, link.embed) for link in links] == [
+        ("Plain", None, None, False),
+        ("Note", "alias", None, False),
+        ("Note", None, "heading", False),
+        ("embed.png", None, None, True),
+        ("a", None, "block", False),
+    ]
+
+
+# --- detection + registry ----------------------------------------------------
+
+
+def test_detects_obsidian_vault(tmp_path):
+    assert detect_converter(_vault(tmp_path)).name == "obsidian"
+
+
+def test_detect_returns_none_without_marker(tmp_path):
+    (tmp_path / "a.md").write_text("x\n", encoding="utf-8")
+    assert detect_converter(tmp_path) is None
+
+
+def test_registry_lookup():
+    assert converter_names() == ["obsidian"]
+    assert converter_by_name("obsidian").name == "obsidian"
+    assert converter_by_name("logseq") is None
+    assert [c.name for c in vault_converters()] == ["obsidian"]
+
+
+# --- normalisation -----------------------------------------------------------
+
+
+def test_one_draft_per_note_skipping_config(tmp_path):
+    result = _ingest(tmp_path)
+    sources = [d.source_path for d in result.drafts]
+    assert sources == [
+        "Auth.md",
+        "Decisions/ADR One.md",
+        "Decisions/Dup.md",
+        "Dup.md",
+        "Login Policy.md",
+    ]
+    assert ".obsidian/workspace.md" not in sources
+
+
+def test_resolved_links_become_candidates_and_inline(tmp_path):
+    auth = next(d for d in _ingest(tmp_path).drafts if d.source_path == "Auth.md")
+    # Bare unique + qualified-with-alias resolve; self is excluded from candidates.
+    assert auth.related == ["Login Policy.md", "Decisions/ADR One.md"]
+    assert "[Login Policy](<Login Policy.md>)" in auth.markdown
+    assert "[the ADR](<Decisions/ADR One.md>)" in auth.markdown
+    assert "## Related" in auth.markdown
+
+
+def test_unresolved_and_ambiguous_left_inline_and_warned(tmp_path):
+    auth = next(d for d in _ingest(tmp_path).drafts if d.source_path == "Auth.md")
+    assert "[[Ghost Note]]" in auth.markdown  # unresolved: verbatim
+    assert "[[Dup]]" in auth.markdown  # ambiguous: verbatim, not guessed
+    assert any("unresolved" in w and "Ghost Note" in w for w in auth.warnings)
+    assert any("ambiguous" in w and "Dup" in w for w in auth.warnings)
+    # An ambiguous name never becomes a candidate relationship.
+    assert not any("Dup" in r for r in auth.related)
+
+
+def test_self_link_inline_but_not_a_candidate(tmp_path):
+    auth = next(d for d in _ingest(tmp_path).drafts if d.source_path == "Auth.md")
+    assert "[Auth](Auth.md)" in auth.markdown
+    assert "Auth.md" not in auth.related
+
+
+def test_embed_left_verbatim(tmp_path):
+    auth = next(d for d in _ingest(tmp_path).drafts if d.source_path == "Auth.md")
+    assert "![[diagram.png]]" in auth.markdown
+
+
+def test_frontmatter_and_unmapped_content_preserved(tmp_path):
+    auth = next(d for d in _ingest(tmp_path).drafts if d.source_path == "Auth.md")
+    assert "title: Auth Policy" in auth.markdown
+    assert "tags: [security, auth]" in auth.markdown
+    assert "unmapped_key: value preserved." in auth.markdown  # nothing dropped
+
+
+def test_lossless_every_source_word_survives(tmp_path):
+    # Every non-wikilink word in a source note appears in its draft (REQ-007).
+    root = _vault(tmp_path)
+    result = ObsidianConverter().convert_vault(root)
+    import re as _re
+
+    for draft in result.drafts:
+        source = (root / draft.source_path).read_text(encoding="utf-8")
+        source_no_links = _re.sub(r"!?\[\[[^\]]+\]\]", " ", source)
+        for word in source_no_links.split():
+            assert word in draft.markdown, f"{word!r} dropped from {draft.source_path}"
+
+
+def test_reingest_is_byte_identical(tmp_path):
+    root = _vault(tmp_path)
+    first = ObsidianConverter().convert_vault(root)
+    second = ObsidianConverter().convert_vault(root)
+    assert [d.markdown for d in first.drafts] == [d.markdown for d in second.drafts]
+
+
+# --- CLI ---------------------------------------------------------------------
+
+
+def test_cli_writes_drafts_and_never_overwrites(tmp_path, capsys):
+    root = _vault(tmp_path)
+    out = tmp_path / "drafts"
+    assert cli.main(["ingest", str(root), "-o", str(out)]) == cli.EXIT_OK
+    written = sorted(p.relative_to(out).as_posix() for p in out.rglob("*.md"))
+    assert written == [
+        "Auth.md",
+        "Decisions/ADR One.md",
+        "Decisions/Dup.md",
+        "Dup.md",
+        "Login Policy.md",
+    ]
+    # Mutate a written draft, re-ingest: it must be skipped, not overwritten.
+    (out / "Auth.md").write_text("EDITED BY HUMAN\n", encoding="utf-8")
+    assert cli.main(["ingest", str(root), "-o", str(out)]) == cli.EXIT_OK
+    assert (out / "Auth.md").read_text(encoding="utf-8") == "EDITED BY HUMAN\n"
+    assert "Skipped" in capsys.readouterr().out
+
+
+def test_cli_force_overwrites(tmp_path):
+    root = _vault(tmp_path)
+    out = tmp_path / "drafts"
+    cli.main(["ingest", str(root), "-o", str(out)])
+    (out / "Auth.md").write_text("EDITED\n", encoding="utf-8")
+    cli.main(["ingest", str(root), "-o", str(out), "--force"])
+    assert "EDITED" not in (out / "Auth.md").read_text(encoding="utf-8")
+
+
+def test_cli_json_shape(tmp_path, capsys):
+    root = _vault(tmp_path)
+    assert cli.main(["ingest", str(root), "--json"]) == cli.EXIT_OK
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["converter"] == "obsidian"
+    assert payload["note_count"] == 5
+    assert payload["resolved_link_count"] >= 1
+    assert {d["source"] for d in payload["drafts"]} >= {"Auth.md", "Login Policy.md"}
+
+
+def test_cli_directory_without_marker_errors(tmp_path, capsys):
+    (tmp_path / "a.md").write_text("x\n", encoding="utf-8")
+    try:
+        cli.main(["ingest", str(tmp_path)])
+        raise AssertionError("expected SystemExit")
+    except SystemExit as exc:
+        assert exc.code == cli.EXIT_USAGE
+    assert "could not detect" in capsys.readouterr().err
+
+
+def test_cli_from_on_a_file_errors(tmp_path, capsys):
+    doc = tmp_path / "doc.md"
+    doc.write_text("hi\n", encoding="utf-8")
+    try:
+        cli.main(["ingest", str(doc), "--from", "obsidian"])
+        raise AssertionError("expected SystemExit")
+    except SystemExit as exc:
+        assert exc.code == cli.EXIT_USAGE
+    assert "--from applies to" in capsys.readouterr().err
+
+
+def test_cli_stdout_on_directory_errors(tmp_path, capsys):
+    root = _vault(tmp_path)
+    try:
+        cli.main(["ingest", str(root), "--stdout"])
+        raise AssertionError("expected SystemExit")
+    except SystemExit as exc:
+        assert exc.code == cli.EXIT_USAGE
+    assert "--stdout is not supported" in capsys.readouterr().err
+
+
+def test_cli_single_file_ingest_unchanged(tmp_path, capsys):
+    # A Markdown file still routes to the existing single-file path, byte-unchanged.
+    doc = tmp_path / "note.md"
+    doc.write_text("# Hi\n\nbody\n", encoding="utf-8")
+    assert cli.main(["ingest", str(doc)]) == cli.EXIT_OK
+    assert capsys.readouterr().out == "# Hi\n\nbody\n\n"
+
+
+def test_cli_from_choices_match_registry(capsys):
+    # The parser hardcodes --from choices to stay import-light; pin them to the
+    # converter registry so a new tool can't be added to one and forgotten in the
+    # other. Every registry name parses; a non-registry name is rejected.
+    parser = cli.build_parser()
+    for name in converter_names():
+        assert parser.parse_args(["ingest", "x", "--from", name]).from_tool == name
+    try:
+        parser.parse_args(["ingest", "x", "--from", "not-a-tool"])
+        raise AssertionError("expected a parse error for an unknown --from value")
+    except SystemExit:
+        pass


### PR DESCRIPTION
Initiative 1 of the **ingest-sources** roadmap (#227): `rac ingest` learns to import note-tool exports by **normalisation** (not markitdown), starting with Obsidian. This PR builds the shared directory-ingest + wikilink machinery through a complete Obsidian converter; Logseq, Notion, and Roam follow in later PRs, reusing it.

Implements `rac/requirements/rac-note-tool-ingest-sources.md` under **ADR-079** (flipped to Accepted).

## What ships

- **`src/rac/services/note_ingest.py`** — a `VaultConverter` directory/graph abstraction *beside* the existing markitdown file converters (REQ-005, the core and binary-document path untouched), plus:
  - **`ObsidianConverter`** — detects the vault by its `.obsidian/` marker; one draft per note.
  - **Shared wikilink resolver** — a resolved `[[Note]]` becomes an inline Markdown link and a candidate `## Related` reference; **ambiguous** (a bare name matching two notes) and **unresolved** links are left inline and reported, never guessed, never asserted (REQ-003, ADR-074/065). Self-links and `[[embeds]]` are left verbatim.
- **`rac ingest <dir>`** — auto-detects the tool (or `--from obsidian`); `-o <dir>` writes one draft per note and **never overwrites** an existing file (`--force` to replace); `--json`/human summaries. Single-file document ingest is byte-unchanged.

## Contract held

- **Directory in, set out (REQ-002):** a vault yields one draft per note, config dirs skipped.
- **Deterministic + offline (REQ-006):** re-ingesting a vault is byte-identical; no model, no network; never overwrites.
- **Lossless (REQ-007):** frontmatter and unmapped content preserved verbatim — a test asserts every non-wikilink source word survives into its draft.
- **Candidates, not edges (REQ-003):** imported links land under a clearly-marked candidate `## Related` section for human promotion; classification/finalisation stays the review step.

## Design Open Questions — resolved as

Forward-only candidate edges (inverse derivable later); detection by vault marker **plus** `--from` override; Notion-CSV mapping deferred to the Notion PR. Packaging: the converters pull **no dependency**, so they ship in core rather than behind empty `ingest-obsidian`-style extras.

## Gates

`rac validate rac/` (375 valid), `rac relationships rac/ --validate` (0 issues), `rac review rac/` (95/100, no priority 1–2), agent-rules regenerated for ADR-079. 20 note-ingest tests + ingest/cli/export batteries green; ruff + mypy clean.

Part of #227 (Obsidian slice). Logseq / Notion / Roam and the final determinism-and-docs sweep follow.