### PR TITLE
feat(ingest): Logseq note-tool converter (ingest-sources #227)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,13 +63,14 @@ Obsidian vault, carrying its wikilink graph in as candidate relationships.
   covers when to run one, the container and authenticating-proxy recipe, keeping
   the checkout current with `main`, and where observability lives — the whole
   topology is deployment wrapper around an unchanged, database-free engine.
-- **Ingest an Obsidian vault (`rac ingest <dir>`).** Point `rac ingest` at a
-  note-tool export directory and each note becomes a reviewable RAC-shaped draft,
-  with `[[wikilinks]]` carried in as **candidate `## Related` references** for you
-  to promote — never asserted edges. Deterministic and offline (identical export
-  → byte-identical drafts), lossless (frontmatter and unmapped content preserved),
+- **Ingest an Obsidian vault or Logseq graph (`rac ingest <dir>`).** Point `rac
+  ingest` at a note-tool export directory and each note becomes a reviewable
+  RAC-shaped draft, with `[[wikilinks]]` / `[[page links]]` carried in as
+  **candidate `## Related` references** for you to promote — never asserted edges.
+  Deterministic and offline (identical export → byte-identical drafts), lossless
+  (frontmatter, and Logseq block references and properties, preserved verbatim),
   and it never overwrites an existing file. Ambiguous and unresolved links are
-  reported for review, never guessed (ADR-079). Logseq, Notion, and Roam follow.
+  reported for review, never guessed (ADR-079). Notion and Roam follow.
 
 ## 2026.06.5 — the "rename" release
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -197,16 +197,19 @@ Conversion uses optional extras. Install the readers you need:
 `pip install 'rac-core[ingest]'` (DOCX/HTML), `[ingest-pdf]`,
 `[ingest-office]` (PPTX/XLSX), or `[ingest-all]`.
 
-### Note-tool exports (Obsidian)
+### Note-tool exports (Obsidian, Logseq)
 
 Point `rac ingest` at a **note-tool export directory** and it normalises the
 whole vault — each note becomes a RAC-shaped draft, and the wikilink graph you
 already drew is carried in as **candidate `## Related` references** rather than
-flattened to plain text. Obsidian is supported today; the converters need no
-extra to install.
+flattened to plain text. Obsidian and Logseq are supported today; the converters
+need no extra to install.
 
-- **Input:** `rac ingest <dir>` — the export directory (a vault). The tool is
-  auto-detected from its layout; force it with `--from obsidian`.
+- **Input:** `rac ingest <dir>` — the export directory (an Obsidian vault or a
+  Logseq graph). The tool is auto-detected from its layout; force it with
+  `--from obsidian` or `--from logseq`. Logseq's `pages/` and `journals/` notes
+  are walked; its `[[page links]]` resolve like Obsidian's, while block
+  references (`((id))`) and `key:: value` properties are preserved verbatim.
 - **Output:** `-o <dir>` writes one draft per note (mirroring the vault's
   structure) and **never overwrites an existing file** — pass `--force` to
   replace. Without `-o`, a summary previews what would convert and what needs

--- a/src/rac/cli.py
+++ b/src/rac/cli.py
@@ -1414,7 +1414,7 @@ def build_parser() -> argparse.ArgumentParser:
         "ingest",
         help=(
             "Convert a document (DOCX, PDF, HTML, PPTX, XLSX, Markdown) — or a "
-            "note-tool export directory (Obsidian) — to RAC-shaped Markdown."
+            "note-tool export directory (Obsidian, Logseq) — to RAC-shaped Markdown."
         ),
         parents=[version_parent],
     )
@@ -1436,7 +1436,7 @@ def build_parser() -> argparse.ArgumentParser:
     p_ingest.add_argument(
         "--from",
         dest="from_tool",
-        choices=("obsidian",),
+        choices=("obsidian", "logseq"),
         help="Force a note-tool converter for a directory export (default: auto-detect).",
     )
     p_ingest.add_argument(

--- a/src/rac/services/note_ingest.py
+++ b/src/rac/services/note_ingest.py
@@ -28,7 +28,7 @@ from pathlib import Path
 from typing import Protocol, runtime_checkable
 
 # Directories that are tool configuration, not notes: never walked for content.
-_SKIP_DIRS = {".obsidian", ".trash", ".git"}
+_SKIP_DIRS = {".obsidian", ".trash", ".git", "logseq", "bak", ".recycle"}
 
 # A wikilink: optional ``!`` (embed/transclusion), then ``[[ ... ]]``. The inner
 # text is ``target`` with an optional ``#heading`` / ``^block`` fragment and an
@@ -270,6 +270,29 @@ def _walk_notes(root: Path) -> list[str]:
     return sorted(notes)
 
 
+def _convert_vault(root: Path, name: str) -> VaultIngestResult:
+    """Walk an export, normalise each note, and collect the drafts (ADR-079).
+
+    The shared body every wikilink-based note tool reuses: one deterministic walk
+    feeds the resolver and the per-note normalisation (frontmatter preserved,
+    resolved ``[[links]]`` rewritten and offered as candidate ``## Related``
+    references, everything else verbatim). Tool-specific syntax a converter does
+    not rewrite — Logseq block references and properties, media embeds — flows
+    through untouched, so losslessness holds by construction.
+    """
+    note_paths = _walk_notes(root)
+    resolver = _Resolver(note_paths)
+    result = VaultIngestResult(converter=name, root=str(root))
+    for rel in note_paths:
+        text = (root / rel).read_text(encoding="utf-8")
+        frontmatter, body = _split_frontmatter(text)
+        draft = NoteDraft(source_path=rel, suggested_filename=rel, markdown="")
+        normalised = _normalise_body(body, resolver, rel, draft)
+        draft.markdown = _assemble_draft(frontmatter, normalised, draft)
+        result.drafts.append(draft)
+    return result
+
+
 class ObsidianConverter:
     """Ingest an Obsidian vault: ``.md`` notes, ``[[wikilinks]]``, YAML frontmatter.
 
@@ -285,22 +308,33 @@ class ObsidianConverter:
         return (root / ".obsidian").is_dir()
 
     def convert_vault(self, root: Path) -> VaultIngestResult:
-        note_paths = _walk_notes(root)
-        resolver = _Resolver(note_paths)
-        result = VaultIngestResult(converter=self.name, root=str(root))
-        for rel in note_paths:
-            text = (root / rel).read_text(encoding="utf-8")
-            frontmatter, body = _split_frontmatter(text)
-            draft = NoteDraft(source_path=rel, suggested_filename=rel, markdown="")
-            normalised = _normalise_body(body, resolver, rel, draft)
-            draft.markdown = _assemble_draft(frontmatter, normalised, draft)
-            result.drafts.append(draft)
-        return result
+        return _convert_vault(root, self.name)
+
+
+class LogseqConverter:
+    """Ingest a Logseq graph: ``pages/`` and ``journals/`` Markdown, ``[[page links]]``.
+
+    Detects the graph by its ``logseq/`` configuration directory. Logseq shares
+    Obsidian's ``[[page]]`` link syntax, so it reuses the same resolver: page
+    links become candidate ``## Related`` references, ambiguous or unresolved ones
+    are reported, never guessed. Logseq-specific syntax — block references
+    ``((block-id))``, ``key:: value`` properties, and outliner ``- `` bullets — is
+    left verbatim (lossless); block-reference resolution and ``#tag`` page links
+    are later enhancements, not guessed here.
+    """
+
+    name = "logseq"
+
+    def detect(self, root: Path) -> bool:
+        return (root / "logseq").is_dir()
+
+    def convert_vault(self, root: Path) -> VaultIngestResult:
+        return _convert_vault(root, self.name)
 
 
 # Registry — first converter whose ``detect`` matches wins; ``--from`` selects by
-# name. Order is deterministic; adding Logseq/Notion/Roam appends here.
-_VAULT_CONVERTERS: list[VaultConverter] = [ObsidianConverter()]
+# name. Order is deterministic; adding Notion/Roam appends here.
+_VAULT_CONVERTERS: list[VaultConverter] = [ObsidianConverter(), LogseqConverter()]
 
 
 def vault_converters() -> list[VaultConverter]:

--- a/tests/test_note_ingest.py
+++ b/tests/test_note_ingest.py
@@ -20,6 +20,7 @@ import json
 
 from rac import cli
 from rac.services.note_ingest import (
+    LogseqConverter,
     ObsidianConverter,
     converter_by_name,
     converter_names,
@@ -81,10 +82,11 @@ def test_detect_returns_none_without_marker(tmp_path):
 
 
 def test_registry_lookup():
-    assert converter_names() == ["obsidian"]
+    assert converter_names() == ["logseq", "obsidian"]
     assert converter_by_name("obsidian").name == "obsidian"
-    assert converter_by_name("logseq") is None
-    assert [c.name for c in vault_converters()] == ["obsidian"]
+    assert converter_by_name("logseq").name == "logseq"
+    assert converter_by_name("notion") is None
+    assert {c.name for c in vault_converters()} == {"obsidian", "logseq"}
 
 
 # --- normalisation -----------------------------------------------------------
@@ -252,3 +254,72 @@ def test_cli_from_choices_match_registry(capsys):
         raise AssertionError("expected a parse error for an unknown --from value")
     except SystemExit:
         pass
+
+
+# --- Logseq (reuses the shared resolver; ADR-079) ----------------------------
+
+
+def _logseq_graph(tmp_path):
+    """A small Logseq graph: pages + journals, page links, block refs, properties."""
+    root = tmp_path / "graph"
+    (root / "logseq").mkdir(parents=True)
+    (root / "logseq" / "config.edn").write_text("{}\n", encoding="utf-8")
+    (root / "pages").mkdir()
+    (root / "journals").mkdir()
+    (root / "pages" / "Auth.md").write_text(
+        "type:: decision\n"
+        "- Depends on [[Login Policy]]\n"
+        "- Block ref ((64f-abc-123)) and #sometag\n"
+        "- Unknown [[Ghost Page]]\n",
+        encoding="utf-8",
+    )
+    (root / "pages" / "Login Policy.md").write_text("- Back to [[Auth]]\n", encoding="utf-8")
+    (root / "journals" / "2026_07_04.md").write_text("- Reviewed [[Auth]]\n", encoding="utf-8")
+    return root
+
+
+def test_detects_logseq_graph(tmp_path):
+    assert detect_converter(_logseq_graph(tmp_path)).name == "logseq"
+
+
+def test_logseq_walks_pages_and_journals(tmp_path):
+    result = LogseqConverter().convert_vault(_logseq_graph(tmp_path))
+    sources = {d.source_path for d in result.drafts}
+    assert sources == {
+        "pages/Auth.md",
+        "pages/Login Policy.md",
+        "journals/2026_07_04.md",
+    }
+    # The logseq/ config directory is never walked as a note.
+    assert not any(s.startswith("logseq/") for s in sources)
+
+
+def test_logseq_resolves_page_links_like_obsidian(tmp_path):
+    result = LogseqConverter().convert_vault(_logseq_graph(tmp_path))
+    auth = next(d for d in result.drafts if d.source_path == "pages/Auth.md")
+    assert auth.related == ["pages/Login Policy.md"]
+    assert "[Login Policy](<pages/Login Policy.md>)" in auth.markdown
+    assert any("unresolved" in w and "Ghost Page" in w for w in auth.warnings)
+
+
+def test_logseq_block_refs_properties_and_tags_preserved(tmp_path):
+    result = LogseqConverter().convert_vault(_logseq_graph(tmp_path))
+    auth = next(d for d in result.drafts if d.source_path == "pages/Auth.md")
+    assert "((64f-abc-123))" in auth.markdown  # block reference verbatim
+    assert "type:: decision" in auth.markdown  # property verbatim
+    assert "#sometag" in auth.markdown  # tag verbatim (not a page-link candidate yet)
+
+
+def test_logseq_reingest_is_byte_identical(tmp_path):
+    root = _logseq_graph(tmp_path)
+    first = LogseqConverter().convert_vault(root)
+    second = LogseqConverter().convert_vault(root)
+    assert [d.markdown for d in first.drafts] == [d.markdown for d in second.drafts]
+
+
+def test_cli_from_logseq(tmp_path, capsys):
+    root = _logseq_graph(tmp_path)
+    out = tmp_path / "drafts"
+    assert cli.main(["ingest", str(root), "--from", "logseq", "-o", str(out)]) == cli.EXIT_OK
+    written = {p.relative_to(out).as_posix() for p in out.rglob("*.md")}
+    assert "pages/Auth.md" in written and "journals/2026_07_04.md" in written


### PR DESCRIPTION
The Logseq slice of the **ingest-sources** roadmap (#227), following the Obsidian converter (#292). Logseq shares Obsidian's `[[page]]` link syntax, so this reuses PR-1's shared wikilink resolver almost entirely.

## What ships

- **`LogseqConverter`** in `note_ingest.py` — detects a Logseq graph by its `logseq/` config directory and walks the `pages/` and `journals/` notes. Obsidian's conversion body is factored into a shared `_convert_vault(root, name)` helper, so both tools share one walk → resolve → normalise → assemble path.
- **`[[page links]]` resolve exactly like Obsidian** — resolved → candidate `## Related` + inline link; ambiguous/unresolved reported, never guessed.
- **Logseq-specific syntax preserved verbatim (lossless):** block references `((id))`, `key:: value` properties, and outliner `- ` bullets pass through untouched. Block-reference resolution and `#tag`-as-page-link are noted as later enhancements — no over-linking, nothing guessed.
- **CLI:** `--from` gains `logseq`; auto-detection picks it up by the `logseq/` marker.

## Contract held

- Directory-in/set-out over `pages/`+`journals/`; the `logseq/` config dir is never walked as a note.
- Deterministic byte-identical re-ingest; lossless (block-refs/properties/tags survive verbatim).
- Candidates, not asserted edges (ADR-079, ADR-074/065).

## Gates

`rac validate` (375), `rac relationships --validate` (0), `rac review` (95/100, no P1–2); agent-rules in sync (no ADR change — ADR-079 already Accepted). 26 note-ingest tests (Obsidian + Logseq) + ingest/cli batteries green; ruff + mypy clean.

Part of #227. **Notion** (the CSV Open Question) and **Roam** follow, then a final determinism/docs sweep.