### PR TITLE
feat(ingest): Notion note-tool converter (ingest-sources #227)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,14 +63,17 @@ Obsidian vault, carrying its wikilink graph in as candidate relationships.
   covers when to run one, the container and authenticating-proxy recipe, keeping
   the checkout current with `main`, and where observability lives — the whole
   topology is deployment wrapper around an unchanged, database-free engine.
-- **Ingest an Obsidian vault or Logseq graph (`rac ingest <dir>`).** Point `rac
-  ingest` at a note-tool export directory and each note becomes a reviewable
-  RAC-shaped draft, with `[[wikilinks]]` / `[[page links]]` carried in as
-  **candidate `## Related` references** for you to promote — never asserted edges.
-  Deterministic and offline (identical export → byte-identical drafts), lossless
-  (frontmatter, and Logseq block references and properties, preserved verbatim),
-  and it never overwrites an existing file. Ambiguous and unresolved links are
-  reported for review, never guessed (ADR-079). Notion and Roam follow.
+- **Ingest an Obsidian vault, Logseq graph, or Notion export (`rac ingest
+  <dir>`).** Point `rac ingest` at a note-tool export directory and each note
+  becomes a reviewable RAC-shaped draft, with the links you already drew
+  (`[[wikilinks]]`, Logseq `[[page links]]`, or Notion's Markdown links) carried
+  in as **candidate `## Related` references** for you to promote — never asserted
+  edges. Deterministic and offline (identical export → byte-identical drafts),
+  lossless (frontmatter, Logseq block references and properties, and Notion's
+  inline properties preserved verbatim), and it never overwrites an existing
+  file. Ambiguous and unresolved links are reported for review, never guessed;
+  Notion database CSVs are reported and skipped (rows arrive as their own pages).
+  Roam follows (ADR-079).
 
 ## 2026.06.5 — the "rename" release
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -197,19 +197,22 @@ Conversion uses optional extras. Install the readers you need:
 `pip install 'rac-core[ingest]'` (DOCX/HTML), `[ingest-pdf]`,
 `[ingest-office]` (PPTX/XLSX), or `[ingest-all]`.
 
-### Note-tool exports (Obsidian, Logseq)
+### Note-tool exports (Obsidian, Logseq, Notion)
 
 Point `rac ingest` at a **note-tool export directory** and it normalises the
-whole vault — each note becomes a RAC-shaped draft, and the wikilink graph you
+whole vault — each note becomes a RAC-shaped draft, and the link graph you
 already drew is carried in as **candidate `## Related` references** rather than
-flattened to plain text. Obsidian and Logseq are supported today; the converters
-need no extra to install.
+flattened to plain text. Obsidian, Logseq, and Notion are supported today; the
+converters need no extra to install.
 
-- **Input:** `rac ingest <dir>` — the export directory (an Obsidian vault or a
-  Logseq graph). The tool is auto-detected from its layout; force it with
-  `--from obsidian` or `--from logseq`. Logseq's `pages/` and `journals/` notes
-  are walked; its `[[page links]]` resolve like Obsidian's, while block
-  references (`((id))`) and `key:: value` properties are preserved verbatim.
+- **Input:** `rac ingest <dir>` — the export directory (an Obsidian vault, a
+  Logseq graph, or a Notion "Markdown & CSV" export). The tool is auto-detected
+  from its layout; force it with `--from obsidian`, `--from logseq`, or
+  `--from notion`. Logseq's `pages/` and `journals/` notes are walked, its
+  `[[page links]]` resolve like Obsidian's, and block references (`((id))`) and
+  `key:: value` properties are preserved verbatim. Notion pages use standard
+  Markdown links (resolved to candidate references the same way); its database
+  CSVs are reported and skipped, since Notion exports each row as its own page.
 - **Output:** `-o <dir>` writes one draft per note (mirroring the vault's
   structure) and **never overwrites an existing file** — pass `--force` to
   replace. Without `-o`, a summary previews what would convert and what needs

--- a/rac/designs/note-tool-ingest-sources.md
+++ b/rac/designs/note-tool-ingest-sources.md
@@ -126,10 +126,17 @@ as edges the tool has asserted.
 ## Open Questions
 
 - Whether vault-internal link resolution should also propose the *inverse*
-  candidate edge on the target note, or only the forward one.
+  candidate edge on the target note, or only the forward one. **Resolved (v1):
+  forward-only** — the inverse is derivable and would double the candidate noise;
+  a later enhancement may add it.
 - How Notion database CSVs map — as artifact metadata, as relationships, or as
-  separate artifacts.
+  separate artifacts. **Resolved (v1): skipped and reported** — Notion already
+  exports each database row as its own `.md` page, so the CSV is a redundant
+  index; converting it too would double-import. Mapping CSVs to artifacts (for
+  databases whose rows carry no page body) is a later enhancement.
 - Whether detection of export shape is automatic, flag-driven (`--from`), or both.
+  **Resolved (v1): both** — auto-detected by each tool's export marker, with
+  `--from <tool>` as an explicit override.
 
 ## Related Decisions
 

--- a/src/rac/cli.py
+++ b/src/rac/cli.py
@@ -1414,7 +1414,7 @@ def build_parser() -> argparse.ArgumentParser:
         "ingest",
         help=(
             "Convert a document (DOCX, PDF, HTML, PPTX, XLSX, Markdown) — or a "
-            "note-tool export directory (Obsidian, Logseq) — to RAC-shaped Markdown."
+            "note-tool export directory (Obsidian, Logseq, Notion) — to RAC-shaped Markdown."
         ),
         parents=[version_parent],
     )
@@ -1436,7 +1436,7 @@ def build_parser() -> argparse.ArgumentParser:
     p_ingest.add_argument(
         "--from",
         dest="from_tool",
-        choices=("obsidian", "logseq"),
+        choices=("obsidian", "logseq", "notion"),
         help="Force a note-tool converter for a directory export (default: auto-detect).",
     )
     p_ingest.add_argument(

--- a/src/rac/output/human.py
+++ b/src/rac/output/human.py
@@ -1437,6 +1437,11 @@ def render_vault_ingest_human(
             f"  {result.warning_count} link(s) need review (ambiguous or unresolved) — "
             "left inline, never guessed."
         )
+    if result.skipped_sources:
+        lines.append(
+            f"  {len(result.skipped_sources)} database CSV(s) skipped — Notion exports "
+            "each row as its own page; the CSV is a redundant index."
+        )
     if output_dir is not None:
         lines.append("")
         lines.append(f"Wrote {len(written)} draft(s) to {output_dir}.")

--- a/src/rac/output/json.py
+++ b/src/rac/output/json.py
@@ -313,6 +313,7 @@ def render_vault_ingest_json(
         "note_count": result.note_count,
         "resolved_link_count": result.resolved_link_count,
         "warning_count": result.warning_count,
+        "skipped_sources": result.skipped_sources,
         "written": written,
         "skipped": skipped,
         "drafts": [

--- a/src/rac/services/note_ingest.py
+++ b/src/rac/services/note_ingest.py
@@ -35,6 +35,10 @@ _SKIP_DIRS = {".obsidian", ".trash", ".git", "logseq", "bak", ".recycle"}
 # optional ``|alias``: ``[[target#frag|alias]]``.
 _WIKILINK_RE = re.compile(r"(?P<embed>!?)\[\[(?P<inner>[^\[\]]+)\]\]")
 
+# A standard Markdown inline link ``[text](url)``. Notion exports use these (with
+# URL-encoded relative paths to hashed ``.md`` files) rather than wikilinks.
+_MD_LINK_RE = re.compile(r"\[(?P<text>[^\]]*)\]\((?P<url>[^)]+)\)")
+
 
 @dataclass(frozen=True)
 class Wikilink:
@@ -66,11 +70,18 @@ class NoteDraft:
 
 @dataclass
 class VaultIngestResult:
-    """The full outcome of ingesting one export directory (ADR-003)."""
+    """The full outcome of ingesting one export directory (ADR-003).
+
+    ``skipped_sources`` names export files that were recognised but not converted
+    — Notion database CSVs, whose rows already arrive as their own ``.md`` page
+    exports (so converting the CSV too would double-import). Reported, never
+    silently dropped.
+    """
 
     converter: str
     root: str
     drafts: list[NoteDraft] = field(default_factory=list)
+    skipped_sources: list[str] = field(default_factory=list)
 
     @property
     def note_count(self) -> int:
@@ -184,7 +195,9 @@ class _Resolver:
                 if hit is not None:
                     return hit, False
             return None, False
-        stem_matches = self._by_stem.get(key.casefold(), [])
+        # A bare name resolves by stem, whether or not the link wrote the ``.md``
+        # extension (Obsidian omits it, Notion includes it).
+        stem_matches = self._by_stem.get(Path(key).stem.casefold(), [])
         if len(stem_matches) == 1:
             return stem_matches[0], False
         if len(stem_matches) > 1:
@@ -234,6 +247,39 @@ def _normalise_body(body: str, resolver: _Resolver, self_path: str, draft: NoteD
     draft.related = related
     draft.warnings = warnings
     return "".join(result)
+
+
+def _normalise_notion_body(body: str, resolver: _Resolver, self_path: str, draft: NoteDraft) -> str:
+    """Collect candidate links from a Notion page; leave the body verbatim.
+
+    Notion exports use standard Markdown links (``[text](Page%20Name%20<hash>.md)``)
+    with URL-encoded relative paths, not wikilinks. An internal link to another
+    exported ``.md`` page becomes a candidate ``## Related`` reference; external
+    links (``http``/``mailto``) and non-page links are left alone. The body is not
+    rewritten — the links are already valid Markdown — so it is lossless by
+    construction (REQ-007). Deterministic: a single left-to-right pass.
+    """
+    from urllib.parse import unquote
+
+    related: list[str] = []
+    warnings: list[str] = []
+    for match in _MD_LINK_RE.finditer(body):
+        url = match.group("url").strip()
+        if url.startswith(("http://", "https://", "mailto:", "#", "//")):
+            continue
+        target = unquote(url.split("#", 1)[0].split("?", 1)[0])
+        if not target.endswith(".md"):
+            continue  # only links to other exported pages are relationships
+        resolved, ambiguous = resolver.resolve(target)
+        if resolved is not None:
+            if resolved != self_path and resolved not in related:
+                related.append(resolved)
+        else:
+            reason = "ambiguous" if ambiguous else "unresolved"
+            warnings.append(f"{reason} link [{match.group('text')}]({url})")
+    draft.related = related
+    draft.warnings = warnings
+    return body
 
 
 _CANDIDATE_NOTE = (
@@ -332,9 +378,53 @@ class LogseqConverter:
         return _convert_vault(root, self.name)
 
 
+# The Notion export signature: a page filename ends in a space plus the page's
+# 32-hex id (dashes stripped), e.g. ``My Page 1a2b…f9.md``.
+_NOTION_FILE_RE = re.compile(r" [0-9a-f]{32}\.md$")
+
+
+class NotionConverter:
+    """Ingest a Notion "Markdown & CSV" export: hashed pages, standard links, CSVs.
+
+    Detected by Notion's hashed page filenames. Notion uses standard Markdown
+    links (not wikilinks), so it normalises through :func:`_normalise_notion_body`
+    rather than the wikilink resolver — internal page links become candidate
+    ``## Related`` references, everything else verbatim (lossless). Database CSVs
+    are reported as ``skipped_sources`` rather than converted: Notion already
+    exports each row as its own ``.md`` page, so the CSV is a redundant index
+    (mapping CSVs to artifacts is a later enhancement, per the design's open
+    question).
+    """
+
+    name = "notion"
+
+    def detect(self, root: Path) -> bool:
+        return any(_NOTION_FILE_RE.search(path.name) for path in root.rglob("*.md"))
+
+    def convert_vault(self, root: Path) -> VaultIngestResult:
+        note_paths = _walk_notes(root)
+        resolver = _Resolver(note_paths)
+        result = VaultIngestResult(converter=self.name, root=str(root))
+        for rel in note_paths:
+            text = (root / rel).read_text(encoding="utf-8")
+            frontmatter, body = _split_frontmatter(text)
+            draft = NoteDraft(source_path=rel, suggested_filename=rel, markdown="")
+            normalised = _normalise_notion_body(body, resolver, rel, draft)
+            draft.markdown = _assemble_draft(frontmatter, normalised, draft)
+            result.drafts.append(draft)
+        result.skipped_sources = sorted(
+            path.relative_to(root).as_posix() for path in root.rglob("*.csv")
+        )
+        return result
+
+
 # Registry — first converter whose ``detect`` matches wins; ``--from`` selects by
-# name. Order is deterministic; adding Notion/Roam appends here.
-_VAULT_CONVERTERS: list[VaultConverter] = [ObsidianConverter(), LogseqConverter()]
+# name. Order is deterministic; adding Roam appends here.
+_VAULT_CONVERTERS: list[VaultConverter] = [
+    ObsidianConverter(),
+    LogseqConverter(),
+    NotionConverter(),
+]
 
 
 def vault_converters() -> list[VaultConverter]:

--- a/tests/test_note_ingest.py
+++ b/tests/test_note_ingest.py
@@ -21,6 +21,7 @@ import json
 from rac import cli
 from rac.services.note_ingest import (
     LogseqConverter,
+    NotionConverter,
     ObsidianConverter,
     converter_by_name,
     converter_names,
@@ -82,11 +83,12 @@ def test_detect_returns_none_without_marker(tmp_path):
 
 
 def test_registry_lookup():
-    assert converter_names() == ["logseq", "obsidian"]
+    assert converter_names() == ["logseq", "notion", "obsidian"]
     assert converter_by_name("obsidian").name == "obsidian"
     assert converter_by_name("logseq").name == "logseq"
-    assert converter_by_name("notion") is None
-    assert {c.name for c in vault_converters()} == {"obsidian", "logseq"}
+    assert converter_by_name("notion").name == "notion"
+    assert converter_by_name("roam") is None
+    assert {c.name for c in vault_converters()} == {"obsidian", "logseq", "notion"}
 
 
 # --- normalisation -----------------------------------------------------------
@@ -323,3 +325,78 @@ def test_cli_from_logseq(tmp_path, capsys):
     assert cli.main(["ingest", str(root), "--from", "logseq", "-o", str(out)]) == cli.EXIT_OK
     written = {p.relative_to(out).as_posix() for p in out.rglob("*.md")}
     assert "pages/Auth.md" in written and "journals/2026_07_04.md" in written
+
+
+# --- Notion (standard Markdown links, hashed files, CSVs; ADR-079) -----------
+
+_H1 = "a" * 32
+_H2 = "b" * 32
+_H3 = "c" * 32
+
+
+def _notion_export(tmp_path):
+    """A small Notion "Markdown & CSV" export: hashed pages, links, a database."""
+    root = tmp_path / "export"
+    root.mkdir()
+    (root / f"Auth Policy {_H1}.md").write_text(
+        f"# Auth Policy\n\nStatus: Active\n\n"
+        f"Depends on [Login Policy](Login%20Policy%20{_H2}.md).\n"
+        f"An [external site](https://example.com) and a [missing]({'d' * 32}.md).\n",
+        encoding="utf-8",
+    )
+    (root / f"Login Policy {_H2}.md").write_text(
+        f"# Login Policy\n\nBack to [Auth Policy](Auth%20Policy%20{_H1}.md).\n",
+        encoding="utf-8",
+    )
+    # A database: a CSV index plus its rows exported as pages in a folder.
+    (root / f"Tasks {_H3}.csv").write_text("Name,Status\nTask A,Done\n", encoding="utf-8")
+    (root / f"Tasks {_H3}").mkdir()
+    (root / f"Tasks {_H3}" / f"Task A {'e' * 32}.md").write_text(
+        "# Task A\n\nRow page body.\n", encoding="utf-8"
+    )
+    return root
+
+
+def test_detects_notion_export(tmp_path):
+    assert detect_converter(_notion_export(tmp_path)).name == "notion"
+
+
+def test_notion_resolves_internal_markdown_links(tmp_path):
+    result = NotionConverter().convert_vault(_notion_export(tmp_path))
+    auth = next(d for d in result.drafts if d.source_path.startswith("Auth Policy"))
+    assert auth.related == [f"Login Policy {_H2}.md"]
+    # External links and unresolved page links never become candidates.
+    assert not any("example.com" in r for r in auth.related)
+    assert any("unresolved" in w and "missing" in w for w in auth.warnings)
+
+
+def test_notion_body_is_preserved_verbatim(tmp_path):
+    result = NotionConverter().convert_vault(_notion_export(tmp_path))
+    auth = next(d for d in result.drafts if d.source_path.startswith("Auth Policy"))
+    assert "Status: Active" in auth.markdown  # inline properties kept
+    assert "https://example.com" in auth.markdown  # external link untouched
+
+
+def test_notion_row_pages_ingested_and_csv_skipped(tmp_path):
+    result = NotionConverter().convert_vault(_notion_export(tmp_path))
+    sources = {d.source_path for d in result.drafts}
+    # The database row exported as a page is ingested...
+    assert any(s.startswith(f"Tasks {_H3}/Task A") for s in sources)
+    # ...and the redundant CSV index is reported, not converted.
+    assert result.skipped_sources == [f"Tasks {_H3}.csv"]
+    assert not any(s.endswith(".csv") for s in sources)
+
+
+def test_notion_reingest_is_byte_identical(tmp_path):
+    root = _notion_export(tmp_path)
+    first = NotionConverter().convert_vault(root)
+    second = NotionConverter().convert_vault(root)
+    assert [d.markdown for d in first.drafts] == [d.markdown for d in second.drafts]
+
+
+def test_cli_notion_json_reports_skipped_csv(tmp_path, capsys):
+    root = _notion_export(tmp_path)
+    assert cli.main(["ingest", str(root), "--from", "notion", "--json"]) == cli.EXIT_OK
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["converter"] == "notion"
+    assert payload["skipped_sources"] == [f"Tasks {_H3}.csv"]


### PR DESCRIPTION
The Notion slice of the **ingest-sources** roadmap (#227), following Obsidian (#292) and Logseq (#297). Notion is the most different of the note tools — it uses standard Markdown links (not wikilinks), hashed filenames, and CSV database exports — so it gets its own link-normaliser while reusing the shared path resolver and draft assembly.

## What ships

- **`NotionConverter`** in `note_ingest.py` — detected by Notion's hashed page filenames (`Page Name <32-hex>.md`). Walks the exported `.md` pages (including database-row pages) and resolves internal **standard Markdown links** (`[Title](Page%20Name%20<hash>.md)`, URL-decoded) into candidate `## Related` references; external links (`http`/`mailto`) and non-page links are left alone. The body is preserved verbatim (Notion has no YAML frontmatter — inline properties are kept as-is), so it's lossless by construction.
- **Database CSVs are reported, not converted** (`skipped_sources`) — Notion already exports each row as its own `.md` page, so the CSV is a redundant index; converting it too would double-import.
- **Resolver fix:** a bare link name now matches by stem whether or not the link wrote the `.md` extension (Obsidian omits it, Notion includes it) — verified against the existing Obsidian/Logseq suites.
- **CLI:** `--from notion`; auto-detection by the hashed-filename signature.

## CSV Open Question — resolved

The design's "how do Notion database CSVs map" question is resolved for v1 (**skipped + reported**), recorded on `rac/designs/note-tool-ingest-sources.md` along with the other two Open Questions (forward-only candidates; detection auto+`--from`).

## Contract held

- Directory-in/set-out; deterministic byte-identical re-ingest; lossless (body + inline properties verbatim); candidates never asserted (ADR-079).

## Gates

`rac validate` (375), `rac relationships --validate` (0), `rac review` (95/100, no P1–2); agent-rules in sync (no ADR change). 32 note-ingest tests (Obsidian + Logseq + Notion) + ingest/cli/export batteries green; ruff + mypy clean.

Part of #227. **Roam** and a final determinism/docs sweep follow.