### PR TITLE
feat(ingest): Roam JSON graph converter (ingest-sources #227)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,17 +63,18 @@ Obsidian vault, carrying its wikilink graph in as candidate relationships.
   covers when to run one, the container and authenticating-proxy recipe, keeping
   the checkout current with `main`, and where observability lives — the whole
   topology is deployment wrapper around an unchanged, database-free engine.
-- **Ingest an Obsidian vault, Logseq graph, or Notion export (`rac ingest
-  <dir>`).** Point `rac ingest` at a note-tool export directory and each note
-  becomes a reviewable RAC-shaped draft, with the links you already drew
-  (`[[wikilinks]]`, Logseq `[[page links]]`, or Notion's Markdown links) carried
-  in as **candidate `## Related` references** for you to promote — never asserted
-  edges. Deterministic and offline (identical export → byte-identical drafts),
-  lossless (frontmatter, Logseq block references and properties, and Notion's
-  inline properties preserved verbatim), and it never overwrites an existing
-  file. Ambiguous and unresolved links are reported for review, never guessed;
-  Notion database CSVs are reported and skipped (rows arrive as their own pages).
-  Roam follows (ADR-079).
+- **Ingest a note-tool export — Obsidian, Logseq, Notion, or Roam (`rac
+  ingest`).** Point `rac ingest` at a note-tool export directory (or a Roam
+  `graph.json`) and each note becomes a reviewable RAC-shaped draft, with the
+  links you already drew (`[[wikilinks]]`, Logseq/Roam `[[page links]]`, or
+  Notion's Markdown links) carried in as **candidate `## Related` references** for
+  you to promote — never asserted edges. Deterministic and offline (identical
+  export → byte-identical drafts), lossless (frontmatter, block references,
+  properties, and inline metadata preserved verbatim), and it never overwrites an
+  existing file. Ambiguous and unresolved links are reported for review, never
+  guessed; Notion database CSVs are reported and skipped (rows arrive as their
+  own pages); a Roam JSON graph is flattened to outliner Markdown per page
+  (ADR-079).
 
 ## 2026.06.5 — the "rename" release
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -197,22 +197,24 @@ Conversion uses optional extras. Install the readers you need:
 `pip install 'rac-core[ingest]'` (DOCX/HTML), `[ingest-pdf]`,
 `[ingest-office]` (PPTX/XLSX), or `[ingest-all]`.
 
-### Note-tool exports (Obsidian, Logseq, Notion)
+### Note-tool exports (Obsidian, Logseq, Notion, Roam)
 
-Point `rac ingest` at a **note-tool export directory** and it normalises the
-whole vault — each note becomes a RAC-shaped draft, and the link graph you
-already drew is carried in as **candidate `## Related` references** rather than
-flattened to plain text. Obsidian, Logseq, and Notion are supported today; the
+Point `rac ingest` at a **note-tool export** and it normalises the whole graph —
+each note becomes a RAC-shaped draft, and the link graph you already drew is
+carried in as **candidate `## Related` references** rather than flattened to
+plain text. Obsidian, Logseq, Notion, and Roam are supported today; the
 converters need no extra to install.
 
-- **Input:** `rac ingest <dir>` — the export directory (an Obsidian vault, a
-  Logseq graph, or a Notion "Markdown & CSV" export). The tool is auto-detected
-  from its layout; force it with `--from obsidian`, `--from logseq`, or
-  `--from notion`. Logseq's `pages/` and `journals/` notes are walked, its
-  `[[page links]]` resolve like Obsidian's, and block references (`((id))`) and
-  `key:: value` properties are preserved verbatim. Notion pages use standard
-  Markdown links (resolved to candidate references the same way); its database
-  CSVs are reported and skipped, since Notion exports each row as its own page.
+- **Input:** `rac ingest <dir>` — an export directory (an Obsidian vault, a
+  Logseq graph, or a Notion "Markdown & CSV" export) — or `rac ingest <graph>.json`
+  for a Roam JSON export. The tool is auto-detected; force a directory's with
+  `--from obsidian|logseq|notion|roam`. Logseq's `pages/` and `journals/` notes
+  are walked, its `[[page links]]` resolve like Obsidian's, and block references
+  (`((id))`) and `key:: value` properties are preserved verbatim. Notion pages
+  use standard Markdown links (resolved the same way); its database CSVs are
+  reported and skipped, since Notion exports each row as its own page. Roam's
+  single JSON graph is parsed and each page's block tree is flattened to outliner
+  Markdown, with `[[page links]]` resolved and block references left verbatim.
 - **Output:** `-o <dir>` writes one draft per note (mirroring the vault's
   structure) and **never overwrites an existing file** — pass `--force` to
   replace. Without `-o`, a summary previews what would convert and what needs

--- a/src/rac/cli.py
+++ b/src/rac/cli.py
@@ -86,6 +86,7 @@ import os
 import sys
 import time
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from rac import consent, usage
 from rac import output as outputs
@@ -176,6 +177,9 @@ from rac.services.validate import (
 from rac.services.watchkeeper import build_watchkeeper_report
 
 from . import __version__
+
+if TYPE_CHECKING:
+    from rac.services.note_ingest import VaultIngestResult
 
 EXIT_OK = 0
 EXIT_VALIDATION_FAILED = 1
@@ -300,6 +304,14 @@ def cmd_ingest(args: argparse.Namespace) -> int:
     if not path.is_file():
         print(f"rac: path not found: {args.file}", file=sys.stderr)
         raise SystemExit(EXIT_USAGE)
+    # A bare Roam JSON graph export ingests directly (its canonical export is one
+    # .json file, not a directory); non-Roam .json falls through to the error.
+    if path.suffix.lower() == ".json":
+        from rac.services.note_ingest import roam_result_for_file
+
+        roam_result = roam_result_for_file(path)
+        if roam_result is not None:
+            return _emit_vault_result(args, roam_result)
     if args.from_tool:
         print(
             "rac: --from applies to a note-tool export directory, not a single file.",
@@ -366,8 +378,11 @@ def _cmd_ingest_vault(args: argparse.Namespace, root: Path) -> int:
         )
         raise SystemExit(EXIT_USAGE)
 
-    result = converter.convert_vault(root)
+    return _emit_vault_result(args, converter.convert_vault(root))
 
+
+def _emit_vault_result(args: argparse.Namespace, result: VaultIngestResult) -> int:
+    """Write drafts (never overwriting) and print the summary for a vault ingest."""
     written: list[str] = []
     skipped: list[str] = []
     if args.output:
@@ -1414,7 +1429,8 @@ def build_parser() -> argparse.ArgumentParser:
         "ingest",
         help=(
             "Convert a document (DOCX, PDF, HTML, PPTX, XLSX, Markdown) — or a "
-            "note-tool export directory (Obsidian, Logseq, Notion) — to RAC-shaped Markdown."
+            "note-tool export (Obsidian, Logseq, Notion, or a Roam JSON graph) — "
+            "to RAC-shaped Markdown."
         ),
         parents=[version_parent],
     )
@@ -1436,7 +1452,7 @@ def build_parser() -> argparse.ArgumentParser:
     p_ingest.add_argument(
         "--from",
         dest="from_tool",
-        choices=("obsidian", "logseq", "notion"),
+        choices=("obsidian", "logseq", "notion", "roam"),
         help="Force a note-tool converter for a directory export (default: auto-detect).",
     )
     p_ingest.add_argument(

--- a/src/rac/services/note_ingest.py
+++ b/src/rac/services/note_ingest.py
@@ -22,6 +22,7 @@ one tool's export-format drift cannot break another.
 
 from __future__ import annotations
 
+import json
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -418,12 +419,131 @@ class NotionConverter:
         return result
 
 
+# --- Roam (a JSON graph export, not a directory of Markdown) -----------------
+
+
+def parse_roam_pages(text: str) -> list[dict] | None:
+    """Parse Roam's JSON graph export, or None if ``text`` is not that shape.
+
+    Roam exports the whole graph as one JSON file: a list of page objects, each
+    with a ``title`` and a tree of ``children`` blocks (``{"string": ...,
+    "children": [...]}``). Recognised structurally so detection needs no marker
+    file.
+    """
+    try:
+        data = json.loads(text)
+    except ValueError:
+        return None
+    if not isinstance(data, list) or not data:
+        return None
+    if not all(isinstance(page, dict) for page in data):
+        return None
+    if not any("title" in page and "children" in page for page in data):
+        return None
+    return data
+
+
+def _flatten_roam_blocks(blocks: object, depth: int = 0) -> list[str]:
+    """Flatten a Roam block tree into indented Markdown outliner bullets.
+
+    Each block's ``string`` becomes a ``- `` bullet indented by its depth; nested
+    ``children`` recurse. Block strings (the content, including ``[[links]]``,
+    ``#tags``, and ``((block refs))``) are preserved verbatim; Roam's internal
+    block metadata (uids, timestamps) is structural, not content, and is not
+    carried.
+    """
+    lines: list[str] = []
+    if not isinstance(blocks, list):
+        return lines
+    for block in blocks:
+        if not isinstance(block, dict):
+            continue
+        string = block.get("string", "")
+        if not isinstance(string, str):
+            string = ""
+        lines.append("  " * depth + "- " + string)
+        lines.extend(_flatten_roam_blocks(block.get("children"), depth + 1))
+    return lines
+
+
+def _roam_filename(title: str) -> str:
+    """A flat, deterministic draft filename for a Roam page title."""
+    return f"{title.replace('/', '-').replace(chr(92), '-').strip()}.md"
+
+
+def convert_roam_pages(pages: list[dict], source: str) -> VaultIngestResult:
+    """Turn parsed Roam pages into drafts, reusing the shared wikilink machinery.
+
+    Each page's block tree is flattened to outliner Markdown with its title as an
+    ``# H1`` (so the title is never lost), then run through the same
+    ``[[wikilink]]`` normalisation as Obsidian and Logseq: ``[[Page]]`` links
+    resolve to candidate ``## Related`` references, ``((block refs))`` and
+    ``#tags`` stay verbatim. Deterministic and offline (ADR-079, ADR-002).
+    """
+    titled = [page for page in pages if isinstance(page.get("title"), str)]
+    note_paths = [_roam_filename(page["title"]) for page in titled]
+    resolver = _Resolver(note_paths)
+    result = VaultIngestResult(converter="roam", root=source)
+    for page in titled:
+        title = page["title"]
+        rel = _roam_filename(title)
+        body_lines = _flatten_roam_blocks(page.get("children"))
+        body = f"# {title}\n\n" + "\n".join(body_lines)
+        if body_lines:
+            body += "\n"
+        draft = NoteDraft(source_path=title, suggested_filename=rel, markdown="")
+        normalised = _normalise_body(body, resolver, rel, draft)
+        draft.markdown = _assemble_draft("", normalised, draft)
+        result.drafts.append(draft)
+    return result
+
+
+def roam_result_for_file(path: Path) -> VaultIngestResult | None:
+    """Ingest a bare Roam ``.json`` export file, or None if it is not one.
+
+    Lets ``rac ingest graph.json`` work directly — the common case, since Roam
+    exports the graph as a single JSON download rather than a directory.
+    """
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    pages = parse_roam_pages(text)
+    if pages is None:
+        return None
+    return convert_roam_pages(pages, str(path))
+
+
+class RoamConverter:
+    """Ingest a Roam JSON graph export: one file, a tree of pages and blocks.
+
+    Detects a Roam ``.json`` export inside the directory (Roam exports one JSON
+    file for the whole graph). Unlike the Markdown-directory tools, its input is a
+    block tree, so it flattens each page to outliner Markdown and then reuses the
+    shared wikilink normalisation — ``[[page links]]`` become candidate
+    ``## Related`` references, block references and tags stay verbatim.
+    """
+
+    name = "roam"
+
+    def detect(self, root: Path) -> bool:
+        return any(roam_result_for_file(path) is not None for path in sorted(root.glob("*.json")))
+
+    def convert_vault(self, root: Path) -> VaultIngestResult:
+        for path in sorted(root.glob("*.json")):
+            result = roam_result_for_file(path)
+            if result is not None:
+                return result
+        return VaultIngestResult(converter=self.name, root=str(root))
+
+
 # Registry — first converter whose ``detect`` matches wins; ``--from`` selects by
-# name. Order is deterministic; adding Roam appends here.
+# name. Order is deterministic.
 _VAULT_CONVERTERS: list[VaultConverter] = [
     ObsidianConverter(),
     LogseqConverter(),
     NotionConverter(),
+    RoamConverter(),
 ]
 
 

--- a/tests/test_note_ingest.py
+++ b/tests/test_note_ingest.py
@@ -26,7 +26,9 @@ from rac.services.note_ingest import (
     converter_by_name,
     converter_names,
     detect_converter,
+    parse_roam_pages,
     parse_wikilinks,
+    roam_result_for_file,
     vault_converters,
 )
 
@@ -83,12 +85,11 @@ def test_detect_returns_none_without_marker(tmp_path):
 
 
 def test_registry_lookup():
-    assert converter_names() == ["logseq", "notion", "obsidian"]
-    assert converter_by_name("obsidian").name == "obsidian"
-    assert converter_by_name("logseq").name == "logseq"
-    assert converter_by_name("notion").name == "notion"
-    assert converter_by_name("roam") is None
-    assert {c.name for c in vault_converters()} == {"obsidian", "logseq", "notion"}
+    assert converter_names() == ["logseq", "notion", "obsidian", "roam"]
+    for name in ("obsidian", "logseq", "notion", "roam"):
+        assert converter_by_name(name).name == name
+    assert converter_by_name("evernote") is None
+    assert {c.name for c in vault_converters()} == {"obsidian", "logseq", "notion", "roam"}
 
 
 # --- normalisation -----------------------------------------------------------
@@ -400,3 +401,91 @@ def test_cli_notion_json_reports_skipped_csv(tmp_path, capsys):
     payload = json.loads(capsys.readouterr().out)
     assert payload["converter"] == "notion"
     assert payload["skipped_sources"] == [f"Tasks {_H3}.csv"]
+
+
+# --- Roam (a JSON graph export, not a Markdown directory; ADR-079) -----------
+
+
+def _roam_graph():
+    return [
+        {
+            "title": "Auth Policy",
+            "children": [
+                {
+                    "string": "Depends on [[Login Policy]]",
+                    "children": [{"string": "nested detail ((abc-123)) and #security"}],
+                },
+                {"string": "Unknown [[Ghost Page]] and self [[Auth Policy]]"},
+            ],
+        },
+        {"title": "Login Policy", "children": [{"string": "Back to [[Auth Policy]]"}]},
+    ]
+
+
+def _roam_file(tmp_path):
+    path = tmp_path / "my-graph.json"
+    path.write_text(json.dumps(_roam_graph()), encoding="utf-8")
+    return path
+
+
+def test_parse_roam_pages_accepts_graph_rejects_others():
+    assert parse_roam_pages(json.dumps(_roam_graph())) is not None
+    assert parse_roam_pages("not json") is None
+    assert parse_roam_pages("[]") is None
+    assert parse_roam_pages(json.dumps([{"no": "title"}])) is None
+
+
+def test_detects_roam_json_export(tmp_path):
+    _roam_file(tmp_path)
+    assert detect_converter(tmp_path).name == "roam"
+
+
+def test_roam_flattens_blocks_with_title_and_indent(tmp_path):
+    result = roam_result_for_file(_roam_file(tmp_path))
+    auth = next(d for d in result.drafts if d.source_path == "Auth Policy")
+    assert auth.markdown.startswith("# Auth Policy\n")
+    assert "- Depends on [Login Policy](<Login Policy.md>)" in auth.markdown
+    assert "  - nested detail" in auth.markdown  # nested block indented
+
+
+def test_roam_resolves_page_links_excluding_self(tmp_path):
+    result = roam_result_for_file(_roam_file(tmp_path))
+    auth = next(d for d in result.drafts if d.source_path == "Auth Policy")
+    assert auth.related == ["Login Policy.md"]  # self-link excluded
+    assert any("unresolved" in w and "Ghost Page" in w for w in auth.warnings)
+
+
+def test_roam_block_refs_and_tags_preserved(tmp_path):
+    result = roam_result_for_file(_roam_file(tmp_path))
+    auth = next(d for d in result.drafts if d.source_path == "Auth Policy")
+    assert "((abc-123))" in auth.markdown
+    assert "#security" in auth.markdown
+    assert "[[Ghost Page]]" in auth.markdown  # unresolved left verbatim
+
+
+def test_roam_reingest_is_byte_identical(tmp_path):
+    path = _roam_file(tmp_path)
+    first = roam_result_for_file(path)
+    second = roam_result_for_file(path)
+    assert [d.markdown for d in first.drafts] == [d.markdown for d in second.drafts]
+
+
+def test_cli_roam_bare_json_file_writes_drafts(tmp_path, capsys):
+    path = _roam_file(tmp_path)
+    out = tmp_path / "drafts"
+    assert cli.main(["ingest", str(path), "-o", str(out)]) == cli.EXIT_OK
+    written = {p.relative_to(out).as_posix() for p in out.rglob("*.md")}
+    assert written == {"Auth Policy.md", "Login Policy.md"}
+    assert "via roam" in capsys.readouterr().out
+
+
+def test_cli_non_roam_json_still_errors(tmp_path, capsys):
+    # A .json that is not a Roam export falls through to the unsupported-type error.
+    doc = tmp_path / "data.json"
+    doc.write_text('{"just": "config"}', encoding="utf-8")
+    try:
+        cli.main(["ingest", str(doc)])
+        raise AssertionError("expected SystemExit")
+    except SystemExit as exc:
+        assert exc.code == cli.EXIT_USAGE
+    assert "unsupported" in capsys.readouterr().err.lower()


### PR DESCRIPTION
The Roam slice of the **ingest-sources** roadmap (#227), completing the four note tools after Obsidian (#292), Logseq (#297), and Notion (#298). Roam is the one non-Markdown shape: its canonical export is a single JSON graph of nested blocks, not a directory of `.md` files.

## What ships

- **`RoamConverter`** in `note_ingest.py` — parses Roam's JSON graph (a list of pages, each a tree of `{"string", "children"}` blocks, recognised structurally — no marker file). Each page's block tree is **flattened to outliner Markdown** with the title as an `# H1` (so the title is never lost), then run through the **same `[[wikilink]]` normalisation** as Obsidian/Logseq: `[[page links]]` become candidate `## Related` references; `((block refs))` and `#tags` stay verbatim.
- **`rac ingest graph.json` works directly** — Roam's canonical export is a single JSON download, so a bare `.json` file auto-routes to Roam (the CLI's emit path is factored into a shared `_emit_vault_result`); `--from roam` forces a directory containing the export. A non-Roam `.json` falls through to the usual unsupported-type error.
- **CLI:** `--from` gains `roam`; auto-detection by the JSON graph shape.

## Contract held

- Deterministic byte-identical re-ingest; block strings (the content) preserved verbatim; candidates never asserted (ADR-079). Roam's internal block metadata (uids, timestamps) is structural, not content, and is not carried.

## Gates

`rac validate` (375), `rac relationships --validate` (0), `rac review` (95/100, no P1–2); agent-rules in sync (no ADR change). 40 note-ingest tests (Obsidian + Logseq + Notion + Roam) + ingest/cli batteries green; ruff + mypy clean.

Completes the four note-tool converters for #227. A final determinism/docs sweep (committed golden fixtures + roadmap → Achieved) can close the roadmap.