### PR TITLE
test(ingest): golden fixture + close ingest-sources (#227)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,9 @@ validated, never inferred; deterministic and offline. Plus the completed
 always-current HTTP endpoint, with an optional content-addressed cache so
 per-call latency stops scaling with corpus size, per-caller audit attribution,
 and an operator guide for running it — servers and caches over git, no database.
-And the first of the **note-tool ingest sources**: `rac ingest` now imports an
-Obsidian vault, carrying its wikilink graph in as candidate relationships.
+And the completed **note-tool ingest sources**: `rac ingest` now imports
+Obsidian, Logseq, Notion, and Roam exports, carrying each source's link graph in
+as candidate relationships.
 
 ### Added
 

--- a/rac/roadmaps/ingest-sources.md
+++ b/rac/roadmaps/ingest-sources.md
@@ -7,7 +7,21 @@ type: roadmap
 
 ## Status
 
-Planned
+Achieved
+
+Delivered across all four initiatives (itsthelore/rac-core#227). `rac ingest`
+now imports note-tool exports by normalisation through the ADR-072 registry
+(ADR-079): Obsidian vaults (#292), Logseq graphs (#297), Notion "Markdown & CSV"
+exports (#298), and Roam JSON graphs (#303). Each note becomes a reviewable
+RAC-shaped draft; the source's wikilinks / page links become **candidate**
+`## Related` references a human promotes, never asserted edges (ADR-074, ADR-065);
+conversion is deterministic and offline, lossless by default, and never
+overwrites an existing artifact (ADR-002). The four tool converters share one
+resolver and draft-assembly path so a format's drift cannot break another, and a
+committed golden fixture pins byte-identical drafts. The engine core and the
+markitdown binary-document path are unchanged. The design's Open Questions
+closed as recorded on `note-tool-ingest-sources` (forward-only candidates; Notion
+CSVs skipped as a redundant index; detection auto plus `--from`).
 
 ## Context
 

--- a/tests/fixtures/note-ingest/obsidian-golden/Architecture Decision.md
+++ b/tests/fixtures/note-ingest/obsidian-golden/Architecture Decision.md
@@ -1,0 +1,20 @@
+---
+title: Architecture Decision
+tags: [adr, architecture]
+status: accepted
+---
+
+# Architecture Decision
+
+We route requests through the [Login Flow](<Login Flow.md>) and rely on the
+[session model](Concepts/Session.md) for state.
+
+An open question links to [[Rate Limiting]] which has no note yet.
+See also the diagram ![[topology.png]].
+
+<!-- Candidate relationships imported from wikilinks (ADR-079): review and promote to real references before this becomes an artifact; not asserted. -->
+
+## Related
+
+- Login Flow.md
+- Concepts/Session.md

--- a/tests/fixtures/note-ingest/obsidian-golden/Concepts/Session.md
+++ b/tests/fixtures/note-ingest/obsidian-golden/Concepts/Session.md
@@ -1,0 +1,11 @@
+# Session
+
+A session is created by the [Login Flow](<Login Flow.md>) and referenced by the
+[Architecture Decision](<Architecture Decision.md>).
+
+<!-- Candidate relationships imported from wikilinks (ADR-079): review and promote to real references before this becomes an artifact; not asserted. -->
+
+## Related
+
+- Login Flow.md
+- Architecture Decision.md

--- a/tests/fixtures/note-ingest/obsidian-golden/Login Flow.md
+++ b/tests/fixtures/note-ingest/obsidian-golden/Login Flow.md
@@ -1,0 +1,11 @@
+# Login Flow
+
+The login flow establishes a [Concepts/Session](Concepts/Session.md) and is governed by the
+[Architecture Decision](<Architecture Decision.md>).
+
+<!-- Candidate relationships imported from wikilinks (ADR-079): review and promote to real references before this becomes an artifact; not asserted. -->
+
+## Related
+
+- Concepts/Session.md
+- Architecture Decision.md

--- a/tests/fixtures/note-ingest/obsidian-vault/.obsidian/app.json
+++ b/tests/fixtures/note-ingest/obsidian-vault/.obsidian/app.json
@@ -1,0 +1,1 @@
+{"theme":"obsidian"}

--- a/tests/fixtures/note-ingest/obsidian-vault/Architecture Decision.md
+++ b/tests/fixtures/note-ingest/obsidian-vault/Architecture Decision.md
@@ -1,0 +1,13 @@
+---
+title: Architecture Decision
+tags: [adr, architecture]
+status: accepted
+---
+
+# Architecture Decision
+
+We route requests through the [[Login Flow]] and rely on the
+[[Concepts/Session|session model]] for state.
+
+An open question links to [[Rate Limiting]] which has no note yet.
+See also the diagram ![[topology.png]].

--- a/tests/fixtures/note-ingest/obsidian-vault/Concepts/Session.md
+++ b/tests/fixtures/note-ingest/obsidian-vault/Concepts/Session.md
@@ -1,0 +1,4 @@
+# Session
+
+A session is created by the [[Login Flow]] and referenced by the
+[[Architecture Decision]].

--- a/tests/fixtures/note-ingest/obsidian-vault/Login Flow.md
+++ b/tests/fixtures/note-ingest/obsidian-vault/Login Flow.md
@@ -1,0 +1,4 @@
+# Login Flow
+
+The login flow establishes a [[Concepts/Session]] and is governed by the
+[[Architecture Decision]].

--- a/tests/test_note_ingest.py
+++ b/tests/test_note_ingest.py
@@ -489,3 +489,23 @@ def test_cli_non_roam_json_still_errors(tmp_path, capsys):
     except SystemExit as exc:
         assert exc.code == cli.EXIT_USAGE
     assert "unsupported" in capsys.readouterr().err.lower()
+
+
+# --- committed golden fixture (Initiative 4: pin byte-identical drafts) -------
+
+
+def test_obsidian_golden_fixture_is_byte_identical():
+    from pathlib import Path
+
+    base = Path(__file__).parent / "fixtures" / "note-ingest"
+    vault, golden = base / "obsidian-vault", base / "obsidian-golden"
+    generated = {
+        d.suggested_filename: d.markdown for d in ObsidianConverter().convert_vault(vault).drafts
+    }
+    expected = {
+        p.relative_to(golden).as_posix(): p.read_text(encoding="utf-8")
+        for p in golden.rglob("*.md")
+    }
+    assert set(generated) == set(expected), "draft set drifted from the golden fixture"
+    for name, text in expected.items():
+        assert generated[name] == text, f"golden drift on {name} — regenerate if intended"


### PR DESCRIPTION
The closing sweep for the **ingest-sources** roadmap (#227) — Initiative 4's determinism anchor plus the roadmap close. All four converters (Obsidian #292, Logseq #297, Notion #298, Roam #303) are already merged.

## What ships

- **Committed golden fixture** — `tests/fixtures/note-ingest/obsidian-vault/` (a small realistic Obsidian vault: frontmatter, resolved bare + aliased-qualified links, an unresolved link, an embed, a subfolder note) and its `obsidian-golden/` drafts. A new test re-ingests the vault and asserts each draft is **byte-identical** to its committed golden — the durable regression anchor Initiative 4 calls for, complementing the existing in-memory determinism tests.
- **`ingest-sources` roadmap → Achieved** (ADR-061) with a four-initiative delivery summary; CHANGELOG marks the programme complete.

## Roadmap recap

| Initiative | Delivered |
|---|---|
| 1 — converter family (registry) | Obsidian/Logseq/Notion/Roam register beside markitdown |
| 2 — directory ingest (a vault is a set) | one draft per note; never overwrites |
| 3 — wikilink & frontmatter normalisation | resolved → candidate `## Related`; ambiguous/unresolved reported; lossless |
| 4 — determinism, losslessness, docs | golden fixture + per-tool determinism tests; `docs/cli.md` |

The design's Open Questions closed as recorded on `note-tool-ingest-sources` (forward-only candidates; Notion CSVs skipped as a redundant index; detection auto plus `--from`).

## Gates

`rac validate` (375), `rac relationships --validate` (0), `rac review` (95/100, no P1–2); agent-rules in sync (roadmap Status doesn't touch the decisions digest). 42 note-ingest tests green; ruff + format clean.

Closes out #227 — the note-tool ingest programme is complete.