### PR TITLE
docs(roadmap): plan the decision-grounding paper and its benchmark evidence pillars [roadmap:decision-grounding-paper]

### DIFF
--- a/rac/designs/artifact-completeness-diagnostic.md
+++ b/rac/designs/artifact-completeness-diagnostic.md
@@ -1,0 +1,172 @@
+---
+schema_version: 1
+id: RAC-KWPC5RFTWA8G
+type: design
+---
+# Design: SWE-CompletenessBench — Artifact-Completeness Diagnostic
+
+## Status
+
+Proposed
+
+The design of **SWE-CompletenessBench**, the benchmark recorded by the
+`artifact-completeness-benchmark` roadmap. It measures how completely a
+recorded corpus specifies a system by reconstructing a component from its
+Lore artifacts and reporting the *residual* that cannot be recovered. The
+framing is a completeness diagnostic, not a reconstruction scoreboard — the
+guardrail that keeps it clear of the spec-as-source lane the corpus refuses
+(ADR-081). The harness lives in `rac-benchmarks` (ADR-092); this is its
+design, referenced in prose because there is no corpus edge for an
+external-repository artifact.
+
+## Context
+
+The corpus records both a thesis and its honest frontier. Thesis: durable,
+typed, human-ratified decision knowledge is the layer coding agents miss
+(ADR-081). Frontier: tacit product knowledge is built from *unrecorded*
+observable decisions, and capture-at-the-moment is the single capability
+Lore flags as absent (`growth-essay-mapping`, Row 6 — "the absence itself is
+honest essay material"). Nothing measures that frontier. A reconstruction
+benchmark can — if it reports the *gap*, not the rebuild.
+
+The design must clear one landmine. "Rebuild the system from the spec" reads
+as spec-as-source — code generated from specifications — which the corpus
+refuses in four places (ADR-081: "Lore is not an SDD/codegen tool";
+`decision-grounding-thesis`; `commercial-layer-positioning` discipline
+boundary; ADR-036). The reframe is what makes it safe and on-thesis: the
+metric is completeness, the hero number is the residual, and Lore never
+generates.
+
+## User Need
+
+The **research/practitioner** audience needs the tacit frontier made
+measurable — "how much of a system is knowable from what a team wrote down."
+**Teams adopting Lore** need to know which artifact families carry the most
+reconstruction signal, so they record what matters. The **maintainer** needs
+a completeness pillar to sit beside SWE-DecisionBench's adherence pillar in
+the paper, without any claim that Lore generates code.
+
+## Design
+
+### The task
+
+Given a target component and its recorded Lore artifact bundle (the
+requirements, decisions, and designs that govern it), an **external,
+bring-your-own coding agent** reconstructs the component. Lore's only role is
+to *serve* the recorded corpus deterministically (ADR-002, ADR-036) — it does
+no generation. The build runs entirely in `rac-benchmarks`.
+
+### The arms (isolate the variable)
+
+Four arms feed the same fixed answering agent with the same scaffold, so only
+the knowledge source varies:
+
+- `none` — the task, no recorded knowledge.
+- `RAG` — the same artifacts, retrieved semantically (embedding + top-k).
+- `rac-corpus` — the same artifacts, served deterministically by Lore
+  (typed, whole-artifact, relationship-aware).
+- `oracle` — the full original source as a ceiling arm.
+
+### The metrics (deterministic, executable, ADR-066/097-native)
+
+Scoring is the target's own executable tests — no LLM judge, no embeddings in
+the scored path, offline, byte-stable metrics, human-gated baseline.
+
+- **Residual = oracle − rac** — the hero metric: the fraction of tested
+  behaviour recoverable from full source but *not* from the recorded
+  artifacts. This is the measured tacit frontier.
+- **Reconstruction pass-rate per arm** — a *proxy* for completeness, reported
+  but never the headline (leading with it drifts spec-as-source).
+- **Lift = rac − none / rac − RAG** — does recorded knowledge move
+  reconstruction toward the ceiling, and does typed deterministic serving
+  beat semantic retrieval.
+- **Per-artifact-family ablation** — hold out requirements vs decisions vs
+  designs to attribute reconstruction signal, answering "what is worth
+  recording."
+
+### Family and lineage
+
+A new `rac-benchmarks` subdir under the ADR-097 benchmark-family contract
+(shared harness, CLI-only, zero engine imports). It extends the SWE-* lineage
+as a fourth node: SWE-bench (issue *resolution*) → SWE-ContextBench (episodic
+*context*) → SWE-DecisionBench (governing-*decision* adherence) →
+**SWE-CompletenessBench** (*completeness* of the record).
+
+## Constraints
+
+- Lore serves, never generates (ADR-002, ADR-036); the answering agent is
+  external and BYO; all building lives in `rac-benchmarks`, never `rac-core`
+  (ADR-092).
+- Deterministic executable scoring; no embeddings or LLM judge in the scored
+  path; byte-stable metrics; human-gated baseline (ADR-066, ADR-097).
+- The headline is the residual/completeness; reconstruction pass-rate is a
+  proxy. Never a "Lore rebuilds systems" claim (ADR-081).
+
+## Rationale
+
+Reporting the residual instead of the rebuild is the whole design. It turns a
+dangerous claim (we generate systems from specs) into an honest one (this is
+how much of a system a team's recorded decisions actually pin down), which is
+exactly the corpus's own recorded frontier made empirical. It composes with
+SWE-DecisionBench without duplicating it: DecisionBench holds the corpus
+constant and varies grounding on a per-patch task (adherence lift);
+CompletenessBench holds "recorded-only" constant and measures whole-component
+completeness (the residual). Together they answer "does recorded knowledge
+help" and "how complete is it."
+
+## Alternatives
+
+- **Report reconstruction success rate as the hero number.** Rejected: it
+  reads as spec-as-source and forfeits the positioning (ADR-081), regardless
+  of internal intent.
+- **Put the generator in `rac-core` (a `rac rebuild` command).** Rejected:
+  makes Lore the assembler it is positioned beneath (ADR-081,
+  `commercial-layer-positioning`); generation is never the engine's job
+  (ADR-002).
+- **LLM-judged reconstruction similarity.** Rejected: violates the ADR-066
+  scored-path posture; executable tests are the deterministic outcome.
+
+## Accessibility
+
+Not a user interface. The bar is argument legibility: a reader can trace the
+residual number to the arms and the executable scoring without access to this
+corpus, and can see from the framing that Lore served but did not generate.
+
+## Style Guidance
+
+Every external artifact leads with residual / completeness, never
+reconstruction success. The answering agent is described as external and BYO.
+Cite the SWE-bench family as lineage without implying endorsement. Report the
+residual faithfully, including a large gap.
+
+## Open Questions
+
+- Dataset sourcing and N: how far beyond the `rac-core` dogfood MVP (OSS with
+  ADRs? synthetic?) before the result is credible.
+- Naming: keep **SWE-CompletenessBench**, or foreground recoverability
+  (SWE-ArtifactRecoverability) — settle before external publication.
+- The external-misread risk: how prominently to state the "not spec-as-source"
+  boundary in the benchmark's own local ADR.
+- Which answering agent(s) and model versions define the reference run, and
+  how the oracle ceiling is bounded fairly.
+- Whether the per-family ablation needs its own scored contract or is a
+  reported secondary analysis.
+
+## Related Requirements
+
+- rac-artifact-completeness-study
+
+## Related Decisions
+
+- adr-002
+- adr-036
+- adr-066
+- adr-081
+- adr-092
+- adr-097
+
+## Related Roadmaps
+
+- artifact-completeness-benchmark
+- decision-grounding-paper
+- external-benchmark-evidence

--- a/rac/designs/decision-grounding-thesis.md
+++ b/rac/designs/decision-grounding-thesis.md
@@ -125,11 +125,17 @@ human-ratified. That is the layer, and it is where Lore sits (ADR-081's
    feature: reproducibility, auditability, air-gap, and the "settled"
    assertion (ADR-066, ADR-034); the Sourcegraph-reversed-out-of-embeddings
    data point (ADR-081) as external corroboration.
-6. **Evaluation** — the none / RAG / rac-corpus grounding-arm study with an
-   executable task-success outcome (`rac-grounding-baseline-study`).
+6. **Evaluation** — **SWE-DecisionBench** (the published identity of the
+   `decisiongrounding` benchmark), reporting two co-primary deterministic
+   outcomes over the `no_grounding` / `naive_rag` / `rac` / `context_dump`
+   arms: structural decision-adherence and decision-conditioned executable
+   resolution (`rac-grounding-baseline-study`).
 7. **Related work** — position off Böckeler's spec-driven axis (via the Spec
-   Growth Engine); contrast agent-memory/RAG (the `rac-growth-agent-memory-
-   positioning` taxonomy) and requirements-management tools.
+   Growth Engine); place SWE-DecisionBench in the SWE-bench lineage (SWE-bench
+   resolution → SWE-ContextBench episodic context → SWE-DecisionBench
+   governing-decision adherence); contrast agent-memory/RAG (the
+   `rac-growth-agent-memory-positioning` taxonomy) and requirements-management
+   tools.
 8. **Discussion and limits** — single-corpus scope; the external-edge
    limitation; honest treatment of a null or partial result.
 

--- a/rac/designs/decision-grounding-thesis.md
+++ b/rac/designs/decision-grounding-thesis.md
@@ -1,0 +1,218 @@
+---
+schema_version: 1
+id: RAC-KWNYX97WSFBV
+type: design
+---
+# Design: Decision-Grounding Paper Thesis
+
+## Status
+
+Proposed
+
+The durable argument behind the `decision-grounding-paper` roadmap: the gap
+taxonomy, the thesis, the section outline, and a draft arXiv abstract. This
+is the paper's design, not the manuscript; the manuscript is its output and,
+being external, is referenced in prose (there is no corpus edge for an
+unpublished document — see `growth-essay-mapping`). It states the positioning
+recorded in ADR-036 and ADR-081; it does not alter it.
+
+## Context
+
+Two families of tooling now feed context to AI coding agents, and they fail
+the same way from opposite ends:
+
+- **Spec-driven development** (GitHub Spec Kit, AWS Kiro, Tessl, the Spec
+  Growth Engine, arXiv:2606.27045) couples specs to *code*. Böckeler's
+  survey separates the field into *spec-first* (specs guide an initial
+  generation, then are discarded), *spec-anchored* (specs kept in sync with
+  code), and *spec-as-source* (code generated from specs). Every point on
+  that axis is code-bound and per-repo; the spec describes a codebase, not a
+  product decision, and is ephemeral (Kiro deletes it) or generative
+  (spec-as-source inherits MDA's nondeterminism).
+- **Agent-memory / RAG** (Mem0, Zep/Graphiti, Cognee, Letta, plus rules
+  files and vector search) retrieves relevant *text*. It is nondeterministic,
+  untyped, LLM-distilled at ingest, and unable to assert "this is settled."
+
+Both miss the durable product *decision* — the why, the rejected
+alternatives, the accepted constraints — as a first-class, typed, validated,
+deterministically-retrievable artifact. The observable cost is agents
+re-litigating settled decisions and drifting from product intent. ADR-081
+records the exact open question: *"no published proof that curated decision
+context lifts agent task success."* The corpus already holds the positioning
+(ADR-081, `rac-growth-positioning`, `rac-growth-agent-memory-positioning`)
+and a deterministic evaluation (ADR-066, ADR-097). This design turns that
+into a paper.
+
+## User Need
+
+Three audiences. The **research/practitioner community** needs the missing
+layer named and located, so the field stops conflating decision knowledge
+with code specs or with fuzzy memory. **Adopters and evaluators** need
+third-party-credible evidence that deterministic decision grounding lifts
+agent outcomes — the claim ADR-081 marks unproven. The **maintainer** needs
+a citable artifact that strengthens the recorded positioning (ADR-036,
+ADR-081) without repositioning it, and that clears GATE-1.
+
+## Design
+
+### The thesis
+
+Grounding coding agents on product knowledge should be **deterministic and
+typed, not semantic and fuzzy**; the **decision record is the substrate**;
+and this layer is **orthogonal to — composes underneath — spec-driven
+development**. Lore (built on the RAC engine) is the reference
+implementation: typed artifact families, classification separated from
+validation, a validated relationship graph, git-native with no database,
+human-PR-ratified, served to agents deterministically over CLI and MCP with
+no embeddings and no LLM judge (ADR-066, ADR-034, ADR-080).
+
+### The gap taxonomy (the paper's central figure)
+
+Two axes locate the empty quadrant:
+
+- **Code-coupling** — does the artifact describe *code* (spec-driven, per
+  repo) or *product decisions* (durable, cross-repo)?
+- **Determinism** — is retrieval a *deterministic, typed* function of the
+  corpus, or a *semantic/LLM-distilled* guess?
+
+Spec-driven tools sit in `code × deterministic-ish`; agent-memory/RAG in
+`text × semantic`. The unserved quadrant is **`decisions × deterministic`**
+— durable product decisions, retrieved deterministically, typed and
+human-ratified. That is the layer, and it is where Lore sits (ADR-081's
+"deterministic source of truth for product decisions").
+
+### Draft arXiv abstract
+
+> AI coding agents accelerate implementation but repeatedly re-introduce
+> approaches their teams already rejected and drift from product intent. We
+> argue this is not a context-quantity problem but a context-*kind* problem:
+> the two dominant ways of grounding agents both omit the durable product
+> decision. Spec-driven development couples specifications to code — bound
+> to one repository, and either discarded after generation or used as a
+> nondeterministic source. Agent-memory and retrieval-augmented systems
+> distil knowledge with an LLM into a mutable store, trading determinism,
+> typing, and auditability for recall. Neither can assert that a decision is
+> settled. We name the missing layer — *deterministic, typed, human-ratified
+> decision grounding* — and locate it on a two-axis map (code-coupling ×
+> determinism) whose fourth quadrant no surveyed tool occupies. We present
+> Lore, an open-source engine that models product decisions, requirements,
+> and roadmaps as typed Markdown artifacts in git, validated deterministically
+> in CI and served to agents with no embeddings and no LLM judge. We evaluate
+> whether deterministic decision grounding improves agent task success
+> against an ungrounded and a semantic-RAG baseline on version-conditioned
+> programming tasks with executable outcomes, holding the retrieved corpus
+> constant across arms. [Result sentence — filled at Initiative 2.] The
+> contribution is the framing and the evidence, not a new paradigm: the
+> mechanisms are established (ADRs, requirements engineering, deterministic
+> IR, docs-as-code); the claim is that decision grounding is a distinct,
+> measurable, and currently unserved layer of the agent stack.
+
+### Section outline
+
+1. **Introduction** — the two failure modes (re-litigation of settled
+   decisions; drift of product intent) that neither camp addresses.
+2. **Two structural gaps** — (a) knowledge-as-code-spec loses the *why* and
+   is per-repo/ephemeral; (b) knowledge-as-embeddings loses determinism,
+   typing, and the "settled" signal.
+3. **Established foundations** — ADRs (Nygard), requirements engineering,
+   docs-as-code, deterministic IR (BM25-family), typed knowledge graphs;
+   "a machine-enforced synthesis, not a new paradigm."
+4. **Architecture** — typed artifact families; classification separate from
+   validation; the relationship graph; git-native / no database (ADR-080);
+   the human-PR-ratified trust boundary (ADR-065); deterministic serving
+   (CLI + MCP, response budget).
+5. **Determinism as the thesis** — why no-embeddings / no-LLM-judge is a
+   feature: reproducibility, auditability, air-gap, and the "settled"
+   assertion (ADR-066, ADR-034); the Sourcegraph-reversed-out-of-embeddings
+   data point (ADR-081) as external corroboration.
+6. **Evaluation** — the none / RAG / rac-corpus grounding-arm study with an
+   executable task-success outcome (`rac-grounding-baseline-study`).
+7. **Related work** — position off Böckeler's spec-driven axis (via the Spec
+   Growth Engine); contrast agent-memory/RAG (the `rac-growth-agent-memory-
+   positioning` taxonomy) and requirements-management tools.
+8. **Discussion and limits** — single-corpus scope; the external-edge
+   limitation; honest treatment of a null or partial result.
+
+## Constraints
+
+- Naming per ADR-036: "Lore (built on the RAC engine)"; state the
+  relationship once; do not reposition.
+- Consistent with the recorded no-semantic-verdict / no-database posture
+  (ADR-034, ADR-066, ADR-080) and the ADR-081 thesis.
+- The reported evaluation keeps embeddings and LLM judges out of the
+  scored/gated path (ADR-066, ADR-097); the semantic arm is comparative
+  evidence only.
+- External publication is GATE-1-blocked; nothing here is publication prose.
+
+## Rationale
+
+Leading with a general framing plus evidence — rather than a product
+description — is what separates a citable contribution from a vendor blog
+post; the Spec Growth Engine survives the same "this is just a synthesis"
+critique by owning it. RAC's advantage over that precedent is that it can
+bring an *evaluation* (the deterministic grounding eval already exists,
+ADR-066/097), addressing exactly the gap ADR-081 records. The ADR corpus
+already reads as a design-rationale section, so the paper is substantially
+pre-argued.
+
+## Alternatives
+
+- **Position-only paper (no evaluation).** Rejected as the primary plan:
+  arXiv would accept it, but it is low-impact and invites the marketing
+  critique; the evaluation is RAC's differentiator. Retained as a fallback
+  if GATE-1 or eval effort blocks the empirical version.
+- **Fold into the growth-essay series.** Rejected: the essays are a
+  personal, non-academic genre with their own bridge requirement
+  (`rac-growth-essay-bridge`); an academic paper is a distinct artifact and
+  audience.
+- **A benchmark-only release (numbers into third-party tables).** That is
+  the `external-benchmark-evidence` roadmap's job; this paper consumes its
+  output rather than replacing it.
+
+## Accessibility
+
+Not a user interface. The accessibility bar is *legibility of the argument*:
+a reader can trace every claim in the paper back, in prose, to a recorded
+decision (by ADR id) or the eval methodology, without access to this corpus.
+
+## Style Guidance
+
+Academic register, honest and non-promotional. Lore appears as a reference
+implementation and worked example, never as the subject. Cite recorded
+decisions by ADR id; cite external work (the Spec Growth Engine,
+arXiv:2606.01435, Böckeler) in prose. Report the evaluation result
+faithfully, including a null or partial outcome.
+
+## Open Questions
+
+- Venue after arXiv: which LLM4SE / agents-for-SE workshop, and on what
+  timeline relative to GATE-1.
+- Evaluation scale and task set: LongMemEval vs GitChameleon vs a bespoke
+  decision-governed set — resolved in `rac-grounding-baseline-study`.
+- Authorship and affiliation (maintainer's call), and whether an external
+  co-author strengthens credibility.
+- How to reference the manuscript from the corpus given no external-document
+  relationship type exists — prose only, or wait on that schema work.
+- Single-author position-and-evidence papers: is the empirical arm enough
+  for a peer venue, or is a larger study needed first.
+
+## Related Requirements
+
+- rac-grounding-baseline-study
+- rac-growth-positioning
+- rac-growth-agent-memory-positioning
+
+## Related Decisions
+
+- adr-034
+- adr-036
+- adr-066
+- adr-080
+- adr-081
+- adr-097
+
+## Related Roadmaps
+
+- decision-grounding-paper
+- external-benchmark-evidence
+- growth-programme

--- a/rac/requirements/rac-artifact-completeness-study.md
+++ b/rac/requirements/rac-artifact-completeness-study.md
@@ -1,0 +1,101 @@
+---
+schema_version: 1
+id: RAC-KWPC5TNY8VKA
+type: requirement
+---
+# Requirement: Artifact-Completeness Study
+
+## Status
+
+Proposed
+
+Classification: `[internal]` — the testable contract for
+**SWE-CompletenessBench**. Initiative 2 of the
+`artifact-completeness-benchmark` roadmap; the harness executes in
+`itsthelore/rac-benchmarks` (ADR-092), never in `rac-core`. Referenced in
+prose because there is no relationship type for an external-repository
+artifact.
+
+## Problem
+
+The corpus records a tacit frontier it cannot yet measure: tacit product
+knowledge is built from unrecorded observable decisions, and
+capture-at-the-moment is the one capability Lore flags as absent
+(`growth-essay-mapping`, Row 6). SWE-CompletenessBench measures it by
+reconstructing a component from its recorded artifacts and reporting the
+residual. To be credible and on-thesis it needs a testable contract: the
+residual is the reported outcome (not reconstruction success), scoring is
+deterministic and executable (no LLM judge), Lore serves but never generates,
+and the whole thing lives outside `rac-core`.
+
+## Requirements
+
+- [REQ-001] The study MUST reconstruct a target component from its recorded Lore artifact bundle using an external, bring-your-own answering agent; Lore's role is limited to serving the recorded corpus deterministically (ADR-002, ADR-036), and no generation, embedding, or LLM-judged scoring occurs inside `rac-core` (ADR-092).
+- [REQ-002] The study MUST run four arms feeding the same fixed answering agent and scaffold, varying only the knowledge source: `none`, `RAG` (semantic retrieval over the same artifacts), `rac-corpus` (deterministic Lore serving), and a full-source `oracle` ceiling.
+- [REQ-003] Scoring MUST be the target's own executable tests — deterministic, offline, no embeddings and no LLM judge in the scored path (ADR-066, ADR-097) — with a byte-stable `metrics` block and a human-gated baseline.
+- [REQ-004] The reported hero outcome MUST be the **residual** (oracle − rac): the fraction of tested behaviour recoverable from full source but not from the recorded artifacts. Reconstruction pass-rate MUST be reported as a proxy only, never as a "Lore rebuilds systems" claim (ADR-081).
+- [REQ-005] The study MUST report the grounding **lift** (rac vs none, rac vs RAG) and a **per-artifact-family ablation** (requirements vs decisions vs designs) attributing reconstruction signal.
+- [REQ-006] The benchmark's own local record MUST state the spec-as-source / codegen boundary up front (ADR-081; the `commercial-layer-positioning` discipline), so external evaluators do not misfile the study as a generation claim.
+- [REQ-007] The study MUST report its residual faithfully, including a large or inconvenient gap: a substantial residual is a valid finding about the tacit frontier, not a result to suppress.
+- [REQ-008] The harness MUST be a `rac-benchmarks` subdir on the shared family harness, driving `rac` as an external CLI with zero engine imports (ADR-097).
+
+## Acceptance Criteria
+
+- On at least the `rac-core` dogfood target, the study reports per-arm
+  reconstruction pass-rate and the residual (oracle − rac), reproducibly.
+- The `rac` arm's deterministic serving reproduces exactly on re-run; the
+  `RAG` arm reports its pinned embedding model, index build, and answering
+  agent/model version.
+- Scoring is executable tests only; no embeddings or LLM judge appears in the
+  scored path; the `metrics` block is byte-identical across runs on an
+  unchanged target.
+- The per-family ablation attributes reconstruction signal across
+  requirements / decisions / designs.
+- Nothing in `rac-core` is modified; the harness imports no engine code
+  (asserted by a test).
+- The reported artifacts lead with residual/completeness; the codegen
+  boundary is stated in the benchmark's local record.
+
+## Success Metrics
+
+- SWE-CompletenessBench produces a defensible completeness number and
+  residual for a system with a recorded Lore corpus — a measured tacit
+  frontier a reviewer would accept — composing with SWE-DecisionBench as the
+  paper's second evidence pillar.
+
+## Risks
+
+- External misread as spec-as-source. Mitigation: REQ-004/006 make the
+  residual the headline and record the codegen boundary; the agent is
+  external and BYO.
+- Thin dataset (N=1 dogfood). Mitigation: the `rac-core` dogfood is an honest
+  MVP; the roadmap sequences OSS-with-ADRs retrofit to scale it.
+- The RAG arm is a straw man. Mitigation: pin a current embedding retriever
+  and publish its configuration, mirroring `rac-grounding-baseline-study`.
+
+## Assumptions
+
+- A target with both a recorded artifact corpus and executable tests exists —
+  starting with `rac-core` itself.
+- Executable pass-rate is a defensible proxy for recoverable behaviour and
+  the residual for the tacit frontier.
+- Running the reconstruction and the RAG arm outside `rac-core` preserves the
+  engine's serve-not-generate posture (ADR-002, ADR-092).
+
+## Related Decisions
+
+- adr-002
+- adr-036
+- adr-066
+- adr-081
+- adr-092
+- adr-097
+
+## Related Roadmaps
+
+- artifact-completeness-benchmark
+- external-benchmark-evidence
+
+## Related Requirements
+
+- rac-grounding-baseline-study

--- a/rac/requirements/rac-grounding-baseline-study.md
+++ b/rac/requirements/rac-grounding-baseline-study.md
@@ -1,0 +1,99 @@
+---
+schema_version: 1
+id: RAC-KWNYXB150JEE
+type: requirement
+---
+# Requirement: Grounding Baseline Study
+
+## Status
+
+Proposed
+
+Classification: `[internal]` — the head-to-head evidence the paper needs.
+Initiative 2 of the `decision-grounding-paper` roadmap; extends the
+`external-benchmark-evidence` programme's "none / RAG / rac-corpus" arm
+design. Scopes a study, not a CI gate.
+
+## Problem
+
+ADR-081 records the open question directly: *"no published proof that
+curated decision context lifts agent task success."* The existing grounding
+eval (ADR-066, ADR-097, `rac-grounding-eval-benchmark`) proves deterministic
+*retrieval* quality on a 12-query fixture corpus against labelled
+relevant / must-not-return sets — a regression guard, not a head-to-head and
+not a task-success measure. It has no semantic/RAG arm and no downstream
+outcome. A credible paper needs a study that holds the retrieved corpus
+constant while varying only the grounding method, and measures whether the
+agent actually *does the task better* — while keeping the deterministic eval
+contract intact.
+
+## Requirements
+
+- [REQ-001] The study MUST compare at least three arms differing only in grounding: (a) none (ungrounded), (b) semantic/RAG retrieval over the same source knowledge, (c) the deterministic rac-corpus retrieval — the arm design recorded in `external-benchmark-evidence`.
+- [REQ-002] The semantic/RAG arm, and any optional LLM-judged scoring, MUST be reported as comparative evidence only and MUST NEVER enter the scored or gated path of the deterministic eval (ADR-066, ADR-097); the deterministic retrieval metrics (P@k, R@k, MRR, hard-negative violations, conformance) remain the gated contract.
+- [REQ-003] The study MUST include a DOWNSTREAM task-success outcome — the metric ADR-081 calls unproven — scored by executable tests where possible (e.g. the GitChameleon version-conditioned tasks named in `external-benchmark-evidence`) or by a pre-registered human rubric where not.
+- [REQ-004] The study MUST use a study-grade query/task set materially larger and more realistic than the current 12-query fixture set, with a declared relevant set and a declared must-not-return (supersession / rejected-approach) set, so the hard-negative head-to-head (RAC vs RAG) is measurable.
+- [REQ-005] The study MUST be deterministic and reproducible where it is gated, and every non-deterministic arm MUST pin its harness version, model version, embedding model, and index build, reported alongside results (per the `external-benchmark-evidence` reproducibility posture).
+- [REQ-006] The study MUST report its result faithfully, including a null or partial outcome: it does not assume the deterministic arm wins, and a non-lift result is a publishable finding, not a failure to suppress.
+- [REQ-007] The study MUST NOT introduce embeddings, vector search, or an LLM judge into `rac-core` itself (ADR-066, ADR-080); the semantic arm is an external comparator built in the benchmarks repository (ADR-092), not an engine feature.
+
+## Acceptance Criteria
+
+- A runnable study harness produces, for the three arms on the same source
+  knowledge, the deterministic retrieval metrics for the rac arm plus the
+  downstream task-success outcome for all arms, on the study-grade set.
+- The rac-core CI eval is unchanged: no embeddings, no LLM judge, no network
+  in its gated path; the study's semantic arm lives outside it.
+- Re-running the deterministic arm reproduces its numbers exactly; the
+  semantic arm reports its pinned model/index versions and its run-to-run
+  variance.
+- The hard-negative / supersession delta (RAC vs RAG surfacing a
+  superseded or rejected decision) is reported as a headline comparison.
+- The result is reported whichever way it falls, with the honest framing
+  REQ-006 requires.
+
+## Success Metrics
+
+- The study answers ADR-081's open question with third-party-credible
+  evidence — a measured task-success delta (in either direction) between
+  deterministic decision grounding, semantic RAG, and no grounding — on a
+  set a reviewer would accept.
+
+## Risks
+
+- The semantic arm is tuned weakly and the comparison looks like a straw
+  man. Mitigation: pin and document a competent, current embedding retriever
+  and report its configuration; invite replication via the benchmarks repo.
+- Executable task coverage is thin, weakening the downstream outcome.
+  Mitigation: REQ-003 allows a pre-registered human rubric where executable
+  scoring is unavailable, declared in advance.
+- Scope creep turns a paper study into an open-ended benchmark programme.
+  Mitigation: this requirement scopes one comparative study for the paper;
+  the broader benchmark tables stay in `external-benchmark-evidence`.
+
+## Assumptions
+
+- The `external-benchmark-evidence` "none / RAG / rac-corpus" arm and
+  GitChameleon executable scoring are a sound base to extend rather than a
+  new harness to invent.
+- A version-conditioned or decision-governed task set exists or can be
+  curated where the *right* answer depends on a recorded decision an
+  ungrounded agent would miss.
+- Running a semantic/RAG comparator outside `rac-core` (in the benchmarks
+  repository) does not compromise the engine's no-embeddings posture.
+
+## Related Decisions
+
+- adr-066
+- adr-081
+- adr-092
+- adr-097
+
+## Related Roadmaps
+
+- decision-grounding-paper
+- external-benchmark-evidence
+
+## Related Requirements
+
+- rac-grounding-eval-benchmark

--- a/rac/requirements/rac-grounding-baseline-study.md
+++ b/rac/requirements/rac-grounding-baseline-study.md
@@ -3,84 +3,100 @@ schema_version: 1
 id: RAC-KWNYXB150JEE
 type: requirement
 ---
-# Requirement: Grounding Baseline Study
+# Requirement: Grounding Study for Publication
 
 ## Status
 
 Proposed
 
-Classification: `[internal]` — the head-to-head evidence the paper needs.
-Initiative 2 of the `decision-grounding-paper` roadmap; extends the
-`external-benchmark-evidence` programme's "none / RAG / rac-corpus" arm
-design. Scopes a study, not a CI gate.
+Classification: `[internal]` — the publication-grade evidence the paper
+needs. Initiative 2 of the `decision-grounding-paper` roadmap. The multi-arm
+head-to-head **already exists** as the `decisiongrounding` benchmark in the
+`itsthelore/rac-benchmarks` repository (ADR-092); this requirement scopes the
+deltas that take it from a working benchmark to a citable study, not a new
+harness. Referenced in prose because there is no relationship type for an
+external-repository artifact (the gap recorded in `growth-essay-mapping`).
 
 ## Problem
 
-ADR-081 records the open question directly: *"no published proof that
-curated decision context lifts agent task success."* The existing grounding
-eval (ADR-066, ADR-097, `rac-grounding-eval-benchmark`) proves deterministic
-*retrieval* quality on a 12-query fixture corpus against labelled
-relevant / must-not-return sets — a regression guard, not a head-to-head and
-not a task-success measure. It has no semantic/RAG arm and no downstream
-outcome. A credible paper needs a study that holds the retrieved corpus
-constant while varying only the grounding method, and measures whether the
-agent actually *does the task better* — while keeping the deterministic eval
-contract intact.
+ADR-081 records the open question — *"no published proof that curated
+decision context lifts agent task success."* Answering it does **not** require
+building a study from scratch: `decisiongrounding` already runs the
+head-to-head this paper needs. Per its published description it compares four
+arms — `no_grounding`, `naive_rag` (Voyage embeddings + top-k), `rac` (typed
+retrieval following supersedes edges), and `context_dump` (paste everything)
+— each feeding the **same fixed answering model with the same prompt
+scaffold**, so only the grounding method varies. Its primary metric is
+**decision-adherence** (did the agent propose a prohibited or superseded
+change), scored **deterministically and structurally with no embeddings and
+no LLM judge in the scored path** (ADR-066); it sweeps corpus size
+(10/50/150/300) and includes a real-corpus pilot (PEP 386→440) with PEP/RFC
+distractor pools.
+
+What is missing for a *paper* is narrower than a new study: publication-grade
+statistical rigor, a real-corpus arm scaled beyond the pilot, and — optionally
+— a downstream executable task-success arm for external legibility. A
+construct note governs that last item: `decisiongrounding`'s adherence metric
+is the *cleaner* measure of the thesis (following settled decisions) than an
+executable task-pass rate, which conflates decision-following with unrelated
+code-correctness; executable scoring adds reviewer legibility at some
+construct-validity cost, so it is a complementary second study, not the
+primary outcome.
 
 ## Requirements
 
-- [REQ-001] The study MUST compare at least three arms differing only in grounding: (a) none (ungrounded), (b) semantic/RAG retrieval over the same source knowledge, (c) the deterministic rac-corpus retrieval — the arm design recorded in `external-benchmark-evidence`.
-- [REQ-002] The semantic/RAG arm, and any optional LLM-judged scoring, MUST be reported as comparative evidence only and MUST NEVER enter the scored or gated path of the deterministic eval (ADR-066, ADR-097); the deterministic retrieval metrics (P@k, R@k, MRR, hard-negative violations, conformance) remain the gated contract.
-- [REQ-003] The study MUST include a DOWNSTREAM task-success outcome — the metric ADR-081 calls unproven — scored by executable tests where possible (e.g. the GitChameleon version-conditioned tasks named in `external-benchmark-evidence`) or by a pre-registered human rubric where not.
-- [REQ-004] The study MUST use a study-grade query/task set materially larger and more realistic than the current 12-query fixture set, with a declared relevant set and a declared must-not-return (supersession / rejected-approach) set, so the hard-negative head-to-head (RAC vs RAG) is measurable.
-- [REQ-005] The study MUST be deterministic and reproducible where it is gated, and every non-deterministic arm MUST pin its harness version, model version, embedding model, and index build, reported alongside results (per the `external-benchmark-evidence` reproducibility posture).
-- [REQ-006] The study MUST report its result faithfully, including a null or partial outcome: it does not assume the deterministic arm wins, and a non-lift result is a publishable finding, not a failure to suppress.
-- [REQ-007] The study MUST NOT introduce embeddings, vector search, or an LLM judge into `rac-core` itself (ADR-066, ADR-080); the semantic arm is an external comparator built in the benchmarks repository (ADR-092), not an engine feature.
+- [REQ-001] The paper's evaluation MUST be the existing `decisiongrounding` multi-arm benchmark (the `no_grounding` / `naive_rag` / `rac` / `context_dump` arms over the same knowledge with a fixed answering model), extended for publication — not a re-implemented head-to-head.
+- [REQ-002] The deterministic structural adherence metric MUST remain the primary, gated outcome (ADR-066, ADR-097): the `naive_rag` (embedding) arm and any LLM-judge fallback are comparative evidence only and MUST NEVER enter the scored or gated path.
+- [REQ-003] The study MUST add publication-grade statistical rigor: a pre-registered hypothesis and analysis, paired significance testing across arms on the same scenarios (e.g. McNemar on adherence pass/fail), and reported effect sizes with confidence intervals — with the corpus-size sweep reported as a curve rather than point estimates.
+- [REQ-004] The study MUST mature the real-corpus arm beyond the PEP 386→440 pilot to a study-grade set (scaled PEP/RFC or comparable governing-decision corpora with their distractor pools), so the result generalises past the synthetic scenarios.
+- [REQ-005] The study MAY add a downstream executable task-success arm (e.g. version-conditioned tasks scored by upstream unit tests, per `external-benchmark-evidence`) as a COMPLEMENTARY external-legibility study; if added it is explicitly secondary to decision-adherence, and its executable/LLM scoring stays outside `rac-core` (ADR-092), never gating the deterministic path.
+- [REQ-006] The study MUST report its result faithfully, including a null or partial outcome: a result where `rac` beats `naive_rag` on stale/prohibited-decision adherence but not on raw task success is a publishable finding, not one to suppress.
+- [REQ-007] No embeddings, vector search, or LLM judge MAY be introduced into `rac-core` itself (ADR-066, ADR-080); the `naive_rag` and any executable/judged arm live in `rac-benchmarks` (ADR-092), which drives `rac` as an external CLI.
 
 ## Acceptance Criteria
 
-- A runnable study harness produces, for the three arms on the same source
-  knowledge, the deterministic retrieval metrics for the rac arm plus the
-  downstream task-success outcome for all arms, on the study-grade set.
-- The rac-core CI eval is unchanged: no embeddings, no LLM judge, no network
-  in its gated path; the study's semantic arm lives outside it.
-- Re-running the deterministic arm reproduces its numbers exactly; the
-  semantic arm reports its pinned model/index versions and its run-to-run
-  variance.
-- The hard-negative / supersession delta (RAC vs RAG surfacing a
-  superseded or rejected decision) is reported as a headline comparison.
-- The result is reported whichever way it falls, with the honest framing
-  REQ-006 requires.
+- The `rac` arm's deterministic adherence scoring reproduces exactly on
+  re-run; the `naive_rag` arm reports its pinned embedding model, index
+  build, answering-model version, and run-to-run variance.
+- The published result reports paired-test significance and effect sizes with
+  confidence intervals across arms, and the adherence-vs-corpus-size curve.
+- The real-corpus arm runs on a set materially larger than the PEP 386→440
+  pilot, with its distractor pool documented.
+- Any executable task-success arm is reported as a secondary study, clearly
+  distinguished from the primary adherence outcome, and built in
+  `rac-benchmarks`, not `rac-core`.
+- The `rac-core` CI grounding eval (`rac-grounding-eval-benchmark`) is
+  unchanged: no embeddings, no LLM judge, no network in its gated path.
 
 ## Success Metrics
 
-- The study answers ADR-081's open question with third-party-credible
-  evidence — a measured task-success delta (in either direction) between
-  deterministic decision grounding, semantic RAG, and no grounding — on a
-  set a reviewer would accept.
+- The paper cites a publication-grade result from `decisiongrounding` that
+  answers ADR-081's open question — a measured adherence delta (in either
+  direction) between deterministic decision grounding, semantic RAG,
+  context-dump, and no grounding — on a set a reviewer would accept.
 
 ## Risks
 
-- The semantic arm is tuned weakly and the comparison looks like a straw
-  man. Mitigation: pin and document a competent, current embedding retriever
-  and report its configuration; invite replication via the benchmarks repo.
-- Executable task coverage is thin, weakening the downstream outcome.
-  Mitigation: REQ-003 allows a pre-registered human rubric where executable
-  scoring is unavailable, declared in advance.
+- The `naive_rag` baseline looks like a straw man. Mitigation: it already uses
+  a current embedding model (Voyage) with asymmetric query/document roles;
+  publish its configuration and invite replication via `rac-benchmarks`.
+- Construct validity — adherence versus task success. Mitigation: keep
+  adherence primary (REQ-002) and treat any executable arm as a secondary,
+  clearly-labelled study (REQ-005).
 - Scope creep turns a paper study into an open-ended benchmark programme.
-  Mitigation: this requirement scopes one comparative study for the paper;
-  the broader benchmark tables stay in `external-benchmark-evidence`.
+  Mitigation: this requirement scopes the publication extension of one
+  existing benchmark; the broader external-benchmark tables stay in
+  `external-benchmark-evidence`.
 
 ## Assumptions
 
-- The `external-benchmark-evidence` "none / RAG / rac-corpus" arm and
-  GitChameleon executable scoring are a sound base to extend rather than a
-  new harness to invent.
-- A version-conditioned or decision-governed task set exists or can be
-  curated where the *right* answer depends on a recorded decision an
-  ungrounded agent would miss.
-- Running a semantic/RAG comparator outside `rac-core` (in the benchmarks
-  repository) does not compromise the engine's no-embeddings posture.
+- `decisiongrounding` is the right base to extend rather than a new harness to
+  build; its four-arm, fixed-answering-model design is sound for the claim.
+- A governing-decision corpus at study-grade scale can be curated (PEP/RFC and
+  comparable) where the correct action depends on a recorded decision an
+  ungrounded or semantically-retrieved agent would miss.
+- Running the `naive_rag` and any executable arm outside `rac-core` preserves
+  the engine's no-embeddings posture (ADR-066, ADR-080).
 
 ## Related Decisions
 

--- a/rac/requirements/rac-grounding-baseline-study.md
+++ b/rac/requirements/rac-grounding-baseline-study.md
@@ -3,7 +3,7 @@ schema_version: 1
 id: RAC-KWNYXB150JEE
 type: requirement
 ---
-# Requirement: Grounding Study for Publication
+# Requirement: SWE-DecisionBench Publication Study
 
 ## Status
 
@@ -11,92 +11,102 @@ Proposed
 
 Classification: `[internal]` — the publication-grade evidence the paper
 needs. Initiative 2 of the `decision-grounding-paper` roadmap. The multi-arm
-head-to-head **already exists** as the `decisiongrounding` benchmark in the
-`itsthelore/rac-benchmarks` repository (ADR-092); this requirement scopes the
-deltas that take it from a working benchmark to a citable study, not a new
-harness. Referenced in prose because there is no relationship type for an
+head-to-head already exists as the `decisiongrounding` implementation in
+`itsthelore/rac-benchmarks` (ADR-092), whose published dataset/paper identity
+is **SWE-DecisionBench** (the name already recorded in
+`external-benchmark-evidence`). This requirement scopes the deltas that take
+it from a working benchmark to a citable SWE-family study; it does not build a
+new harness. Referenced in prose because there is no relationship type for an
 external-repository artifact (the gap recorded in `growth-essay-mapping`).
 
 ## Problem
 
-ADR-081 records the open question — *"no published proof that curated
-decision context lifts agent task success."* Answering it does **not** require
-building a study from scratch: `decisiongrounding` already runs the
-head-to-head this paper needs. Per its published description it compares four
-arms — `no_grounding`, `naive_rag` (Voyage embeddings + top-k), `rac` (typed
-retrieval following supersedes edges), and `context_dump` (paste everything)
-— each feeding the **same fixed answering model with the same prompt
-scaffold**, so only the grounding method varies. Its primary metric is
+ADR-081 records the open question — *"no published proof that curated decision
+context lifts agent task success."* `decisiongrounding` already runs the
+head-to-head: four arms (`no_grounding`, `naive_rag` — Voyage embeddings +
+top-k, `rac` — typed retrieval following supersedes edges, and `context_dump`
+— paste everything), each feeding the **same fixed answering model with the
+same prompt scaffold**, so only grounding varies. Its primary metric is
 **decision-adherence** (did the agent propose a prohibited or superseded
-change), scored **deterministically and structurally with no embeddings and
-no LLM judge in the scored path** (ADR-066); it sweeps corpus size
-(10/50/150/300) and includes a real-corpus pilot (PEP 386→440) with PEP/RFC
-distractor pools.
+change), scored deterministically and structurally with no embeddings and no
+LLM judge (ADR-066), swept across corpus size (10/50/150/300) with a
+real-corpus pilot (PEP 386→440) and PEP/RFC distractor pools.
 
-What is missing for a *paper* is narrower than a new study: publication-grade
-statistical rigor, a real-corpus arm scaled beyond the pilot, and — optionally
-— a downstream executable task-success arm for external legibility. A
-construct note governs that last item: `decisiongrounding`'s adherence metric
-is the *cleaner* measure of the thesis (following settled decisions) than an
-executable task-pass rate, which conflates decision-following with unrelated
-code-correctness; executable scoring adds reviewer legibility at some
-construct-validity cost, so it is a complementary second study, not the
-primary outcome.
+Publishing it as **SWE-DecisionBench** — a member of the SWE-bench family —
+carries an expectation the current design does not yet fully meet: the family
+(SWE-bench, SWE-ContextBench) implies real-repository, executable
+verification, not only structural inspection of a proposed change. Earning the
+name therefore requires a second, **executable, decision-conditioned
+resolution** outcome to sit alongside adherence — both deterministic, so both
+stay ADR-066-native. What is missing for the paper is thus: the executable
+co-primary outcome, publication-grade statistical rigor, a scaled real-corpus
+arm, and explicit positioning in the SWE-bench lineage.
 
 ## Requirements
 
-- [REQ-001] The paper's evaluation MUST be the existing `decisiongrounding` multi-arm benchmark (the `no_grounding` / `naive_rag` / `rac` / `context_dump` arms over the same knowledge with a fixed answering model), extended for publication — not a re-implemented head-to-head.
-- [REQ-002] The deterministic structural adherence metric MUST remain the primary, gated outcome (ADR-066, ADR-097): the `naive_rag` (embedding) arm and any LLM-judge fallback are comparative evidence only and MUST NEVER enter the scored or gated path.
-- [REQ-003] The study MUST add publication-grade statistical rigor: a pre-registered hypothesis and analysis, paired significance testing across arms on the same scenarios (e.g. McNemar on adherence pass/fail), and reported effect sizes with confidence intervals — with the corpus-size sweep reported as a curve rather than point estimates.
-- [REQ-004] The study MUST mature the real-corpus arm beyond the PEP 386→440 pilot to a study-grade set (scaled PEP/RFC or comparable governing-decision corpora with their distractor pools), so the result generalises past the synthetic scenarios.
-- [REQ-005] The study MAY add a downstream executable task-success arm (e.g. version-conditioned tasks scored by upstream unit tests, per `external-benchmark-evidence`) as a COMPLEMENTARY external-legibility study; if added it is explicitly secondary to decision-adherence, and its executable/LLM scoring stays outside `rac-core` (ADR-092), never gating the deterministic path.
-- [REQ-006] The study MUST report its result faithfully, including a null or partial outcome: a result where `rac` beats `naive_rag` on stale/prohibited-decision adherence but not on raw task success is a publishable finding, not one to suppress.
-- [REQ-007] No embeddings, vector search, or LLM judge MAY be introduced into `rac-core` itself (ADR-066, ADR-080); the `naive_rag` and any executable/judged arm live in `rac-benchmarks` (ADR-092), which drives `rac` as an external CLI.
+- [REQ-001] The published evaluation MUST be **SWE-DecisionBench** — the published identity of the existing `decisiongrounding` multi-arm benchmark (the `no_grounding` / `naive_rag` / `rac` / `context_dump` arms over the same knowledge with a fixed answering model) — extended for publication, not a re-implemented head-to-head.
+- [REQ-002] SWE-DecisionBench MUST report two co-primary, deterministic outcomes: (a) **decision-adherence** — structural, the novel construct that distinguishes it from resolution benchmarks; and (b) **decision-conditioned resolution** — executable task success where the correct patch depends on a governing decision, scored by upstream tests. Both are deterministic and ADR-066-native (no LLM judge in the scored path).
+- [REQ-003] The executable resolution arm MUST use real-repository or version-conditioned tasks whose correct answer depends on a recorded governing decision (seeded by e.g. GitChameleon-style version-conditioned problems with executable tests), and MUST be built in `rac-benchmarks` (ADR-092), driving `rac` as an external CLI — never inside `rac-core`.
+- [REQ-004] The `naive_rag` (embedding) arm and any LLM-judge fallback MUST remain comparative evidence only and MUST NEVER enter the scored or gated path of either co-primary outcome (ADR-066, ADR-097).
+- [REQ-005] The study MUST add publication-grade statistical rigor: a pre-registered hypothesis and analysis, paired significance testing across arms on the same scenarios (e.g. McNemar) for each co-primary outcome, reported effect sizes with confidence intervals, and the corpus-size sweep reported as a curve.
+- [REQ-006] The study MUST mature the real-corpus adherence arm beyond the PEP 386→440 pilot to a study-grade set (scaled PEP/RFC or comparable governing-decision corpora with their distractor pools), so the result generalises past the synthetic scenarios.
+- [REQ-007] The paper MUST position SWE-DecisionBench explicitly in the SWE-bench lineage — SWE-bench (issue *resolution*) → SWE-ContextBench (episodic *context retrieval*, arXiv:2602.08316, the recorded neighbour) → **SWE-DecisionBench** (durable governing-*decision* adherence plus decision-conditioned resolution) — citing the family without implying endorsement or affiliation.
+- [REQ-008] The study MUST report its result faithfully, including a null or partial outcome (the recorded SWE-DecisionBench honesty rule): a result where `rac` beats `naive_rag` on stale/prohibited-decision adherence but not on raw resolution is a publishable finding, not one to suppress.
+- [REQ-009] No embeddings, vector search, or LLM judge MAY be introduced into `rac-core` itself (ADR-066, ADR-080); the `naive_rag` and the executable resolution arms live in `rac-benchmarks` (ADR-092).
 
 ## Acceptance Criteria
 
-- The `rac` arm's deterministic adherence scoring reproduces exactly on
-  re-run; the `naive_rag` arm reports its pinned embedding model, index
-  build, answering-model version, and run-to-run variance.
-- The published result reports paired-test significance and effect sizes with
-  confidence intervals across arms, and the adherence-vs-corpus-size curve.
-- The real-corpus arm runs on a set materially larger than the PEP 386→440
-  pilot, with its distractor pool documented.
-- Any executable task-success arm is reported as a secondary study, clearly
-  distinguished from the primary adherence outcome, and built in
-  `rac-benchmarks`, not `rac-core`.
+- Both co-primary outcomes are reported: structural decision-adherence and
+  executable decision-conditioned resolution, per arm, with the `rac` arm's
+  deterministic scoring reproducing exactly on re-run.
+- The executable arm runs real-repository or version-conditioned tasks scored
+  by upstream tests, built in `rac-benchmarks`, with no engine dependency.
+- Results report paired-test significance and effect sizes with confidence
+  intervals for each outcome, plus the adherence-vs-corpus-size curve.
+- The real-corpus adherence arm runs on a set materially larger than the
+  PEP 386→440 pilot, with its distractor pool documented.
+- The `naive_rag` arm reports its pinned embedding model, index build,
+  answering-model version, and run-to-run variance, and never gates either
+  outcome.
+- The paper's related-work section places SWE-DecisionBench in the
+  SWE-bench → SWE-ContextBench lineage.
 - The `rac-core` CI grounding eval (`rac-grounding-eval-benchmark`) is
   unchanged: no embeddings, no LLM judge, no network in its gated path.
 
 ## Success Metrics
 
-- The paper cites a publication-grade result from `decisiongrounding` that
-  answers ADR-081's open question — a measured adherence delta (in either
-  direction) between deterministic decision grounding, semantic RAG,
-  context-dump, and no grounding — on a set a reviewer would accept.
+- The paper cites a publication-grade SWE-DecisionBench result answering
+  ADR-081's open question — measured deltas (in either direction) between
+  deterministic decision grounding, semantic RAG, context-dump, and no
+  grounding, on both adherence and executable resolution — on a set a
+  reviewer would accept as a SWE-family benchmark.
 
 ## Risks
 
+- The SWE- name over-promises if the executable arm stays thin. Mitigation:
+  REQ-002/003 make executable resolution co-primary, not optional, so the
+  badge is earned rather than borrowed.
 - The `naive_rag` baseline looks like a straw man. Mitigation: it already uses
   a current embedding model (Voyage) with asymmetric query/document roles;
   publish its configuration and invite replication via `rac-benchmarks`.
-- Construct validity — adherence versus task success. Mitigation: keep
-  adherence primary (REQ-002) and treat any executable arm as a secondary,
-  clearly-labelled study (REQ-005).
+- Construct validity — adherence versus resolution. Mitigation: reporting both
+  as co-primary is the design response; adherence measures the thesis cleanly,
+  resolution supplies the executable rigor the family expects.
 - Scope creep turns a paper study into an open-ended benchmark programme.
-  Mitigation: this requirement scopes the publication extension of one
-  existing benchmark; the broader external-benchmark tables stay in
-  `external-benchmark-evidence`.
+  Mitigation: this requirement scopes the SWE-DecisionBench publication
+  extension of one existing benchmark; broader external-benchmark tables stay
+  in `external-benchmark-evidence`.
 
 ## Assumptions
 
-- `decisiongrounding` is the right base to extend rather than a new harness to
-  build; its four-arm, fixed-answering-model design is sound for the claim.
-- A governing-decision corpus at study-grade scale can be curated (PEP/RFC and
-  comparable) where the correct action depends on a recorded decision an
-  ungrounded or semantically-retrieved agent would miss.
-- Running the `naive_rag` and any executable arm outside `rac-core` preserves
-  the engine's no-embeddings posture (ADR-066, ADR-080).
+- `decisiongrounding` / SWE-DecisionBench is the right base to extend rather
+  than a new harness to build; its four-arm, fixed-answering-model design is
+  sound for the claim.
+- Decision-conditioned executable tasks can be sourced or curated (GitChameleon
+  version pins and comparable) where the correct patch depends on a recorded
+  decision an ungrounded or semantically-retrieved agent would miss.
+- Running the `naive_rag` and executable arms outside `rac-core` preserves the
+  engine's no-embeddings posture (ADR-066, ADR-080).
 
 ## Related Decisions
 

--- a/rac/roadmaps/future/artifact-completeness-benchmark.md
+++ b/rac/roadmaps/future/artifact-completeness-benchmark.md
@@ -1,0 +1,155 @@
+---
+schema_version: 1
+id: RAC-KWPC5P5APA9G
+type: roadmap
+---
+# Artifact-Completeness Benchmark
+
+## Status
+
+Planned
+
+Unscheduled — captured as future intent, not yet on a release. Records the
+intent to build **SWE-CompletenessBench**, a self-authored benchmark that
+measures how completely a recorded corpus specifies a system: an external
+agent reconstructs a target component from its Lore artifacts alone, and the
+*residual* — the fraction that cannot be recovered from the record — is the
+reported result. Sibling to SWE-DecisionBench (`decisiongrounding`); the
+harness executes in `itsthelore/rac-benchmarks` (ADR-092), never in
+`rac-core`. Framed as a completeness diagnostic, not a reconstruction
+scoreboard, so it stays clear of the spec-as-source line the corpus refuses
+(ADR-081: "Lore is not an SDD/codegen tool").
+
+## Context
+
+The recorded thesis is that durable, typed, human-ratified decision
+knowledge is the layer coding agents are missing — but the corpus also
+records its own frontier honestly: tacit product knowledge is built from
+*unrecorded* observable decisions, and capture-at-the-moment is the one
+capability Lore flags as absent (`growth-essay-mapping`, Row 6). No benchmark
+measures that frontier. SWE-CompletenessBench does: give an agent only a
+system's recorded artifacts and ask it to rebuild a component; whatever it
+*cannot* recover is a direct measurement of what was never written down. The
+result is a knowledge-completeness number and a residual — "the record fully
+specified X% of the observable component; (1−X) stayed tacit" — which turns
+the corpus's own honest premise into evidence.
+
+This is deliberately *not* a claim that Lore generates systems from specs.
+Lore only serves the recorded corpus deterministically (ADR-002, ADR-036); a
+bring-your-own external agent does any building, in `rac-benchmarks`. The
+residual is expected to be non-trivial — the thesis predicts an incomplete
+rebuild — so a bounded ceiling is a confirmation, not a failure.
+
+## Outcomes
+
+- A published completeness diagnostic: for a system with a recorded Lore
+  corpus, the fraction of its tested behaviour recoverable from the
+  artifacts alone, with the residual (unrecorded/tacit) gap reported as the
+  headline finding.
+- Evidence for which artifact families carry the most reconstruction signal
+  — a per-family ablation that tells teams what is worth recording.
+- A second evidence pillar for the `decision-grounding-paper`: where
+  SWE-DecisionBench measures the *lift* recorded decisions give an agent,
+  SWE-CompletenessBench measures the *completeness* of the record itself.
+
+## Initiatives
+
+### Initiative 1 — Dataset construction
+
+Assemble targets that have both a recorded artifact corpus and executable
+tests. Sequence by honesty: (a) `rac-core` dogfoods itself — rebuild a
+`rac-core` component from `rac-core`'s own `rac/` artifacts, scored by the
+engine's tests (available now, N=1); (b) retrofit open-source projects that
+carry ADRs plus tests; (c) synthetic artifact bundles for known components.
+Dataset construction, not the harness, is the make-or-break.
+
+### Initiative 2 — Harness, arms, and the residual metric
+
+A `rac-benchmarks` subdir on the shared harness (ADR-097): arms
+`none` / `RAG` / `rac-corpus`, plus a **full-source oracle** ceiling arm,
+each feeding the same external answering agent. Scoring is the target's
+executable tests — deterministic, offline, no LLM judge in the scored path
+(ADR-066). The reported hero metric is the **residual** (oracle − rac);
+reconstruction pass-rate is a proxy, not the headline.
+
+### Initiative 3 — Evidence tie-in
+
+Fold the result into the `decision-grounding-paper` as the completeness
+pillar alongside SWE-DecisionBench's adherence pillar, and into the
+`external-benchmark-evidence` programme. The residual finding is reported
+honestly whichever way it falls.
+
+## Constraints
+
+- Lore serves the corpus; it never generates. The answering agent is
+  external and bring-your-own (ADR-002, ADR-035); all building lives in
+  `rac-benchmarks`, never `rac-core` (ADR-092).
+- Scoring is deterministic and executable, no embeddings or LLM judge in the
+  scored path; byte-stable metrics; human-gated baseline (ADR-066, ADR-097).
+- The benchmark is a completeness diagnostic; the residual is the headline,
+  reconstruction pass-rate a proxy — never a "Lore rebuilds systems" claim.
+
+## Non-Goals
+
+- Positioning Lore as a spec-as-source / codegen / MDA tool (ADR-081); the
+  benchmark's own local record states the "not the assembler" discipline
+  (`commercial-layer-positioning`) up front.
+- Reconstruction success-rate as the hero number.
+- Any generation, embedding, or LLM-judged scoring inside `rac-core`
+  (ADR-066, ADR-092).
+- Duplicating SWE-DecisionBench: that measures grounding lift on a per-patch
+  task; this measures corpus completeness on a whole-component rebuild.
+
+## Success Measures
+
+- SWE-CompletenessBench reports, per arm, a reconstruction pass-rate and the
+  residual (oracle − rac) on at least the `rac-core` dogfood target, with a
+  per-artifact-family ablation.
+- The result is reproducible and deterministic where scored (ADR-066/097),
+  built entirely in `rac-benchmarks` with zero `rac-core` engine imports.
+- The residual is reported honestly, including a large or inconvenient gap.
+
+## Assumptions
+
+- Targets with both a recorded artifact corpus and executable tests can be
+  sourced — starting with `rac-core` itself.
+- Executable test pass-rate is a defensible proxy for recoverable behaviour;
+  the residual is a defensible proxy for the tacit frontier.
+- A completeness diagnostic strengthens the recorded positioning (ADR-036,
+  ADR-081) rather than straining it, because the thesis predicts a residual.
+
+## Risks
+
+- External evaluators misread "rebuild from artifacts" as a spec-as-source
+  claim (ADR-081: "evaluators misfile Lore against whichever category they
+  arrived from"). Mitigation: lead every artifact with residual/completeness,
+  keep the agent external and BYO, and record the codegen-boundary discipline
+  in the benchmark's own local ADR.
+- The dataset is too thin for a credible result (N=1). Mitigation: the
+  `rac-core` dogfood is an honest MVP; OSS-with-ADRs retrofit scales it.
+- The name reads generative. Mitigation: the completeness-forward name
+  SWE-CompletenessBench; the design records SWE-ArtifactRecoverability as an
+  alternative to settle before publication.
+
+## Related Decisions
+
+- adr-002
+- adr-036
+- adr-066
+- adr-081
+- adr-092
+- adr-097
+
+## Related Roadmaps
+
+- decision-grounding-paper
+- external-benchmark-evidence
+- growth-programme
+
+## Related Designs
+
+- artifact-completeness-diagnostic
+
+## Related Requirements
+
+- rac-artifact-completeness-study

--- a/rac/roadmaps/future/artifact-completeness-benchmark.md
+++ b/rac/roadmaps/future/artifact-completeness-benchmark.md
@@ -153,3 +153,7 @@ honestly whichever way it falls.
 ## Related Requirements
 
 - rac-artifact-completeness-study
+
+## Related Tickets
+
+- itsthelore/rac-core#299

--- a/rac/roadmaps/future/decision-grounding-paper.md
+++ b/rac/roadmaps/future/decision-grounding-paper.md
@@ -1,0 +1,155 @@
+---
+schema_version: 1
+id: RAC-KWNYX7KT1QN2
+type: roadmap
+---
+# Decision-Grounding Paper
+
+## Status
+
+Planned
+
+Unscheduled — captured as future intent, not yet on a release. **Blocked:
+GATE-1** (employer external-communications / IP review), the same gate that
+governs the growth-essay work; nothing here is published before it clears.
+This records the intent to publish an academic (arXiv, then a peer venue)
+position-and-evidence paper naming the layer the AI-coding-agent field is
+missing, with Lore (built on the RAC engine, ADR-036) as the reference
+implementation. It states positioning already recorded in ADR-036 and
+ADR-081; it does not alter it.
+
+## Context
+
+The AI-coding-agent stack has converged on two ways to give an agent
+context, and both miss the same thing from opposite sides. Spec-driven
+development tools (GitHub Spec Kit, AWS Kiro, Tessl, the Spec Growth Engine)
+couple specs to *code* — encoding what to build, but code-bound, per-repo,
+and mostly ephemeral or generative. Agent-memory and RAG systems (Mem0,
+Zep, Cognee, Letta, Cursor rules) retrieve relevant *text* — nondeterministic,
+untyped, and unable to signal "this is settled, do not re-open." Neither
+treats the durable product *decision* — the why, the rejected alternatives,
+the accepted constraints — as a first-class, typed, validated,
+deterministically-retrievable artifact.
+
+That absence is the named failure mode: agents confidently re-doing what a
+team already ruled out, because the ruling-out was never machine-legible.
+ADR-081 records the precise research gap this paper would close — *"no
+published proof that curated decision context lifts agent task success."*
+The corpus already holds the thesis (ADR-081, `rac-growth-positioning`,
+`rac-growth-agent-memory-positioning`) and a deterministic evaluation
+apparatus (ADR-066, ADR-097, `rac-grounding-eval-benchmark`); what is
+missing is a paper that frames the gap generally and brings the evidence.
+
+## Outcomes
+
+- A general, citable framing of the missing layer — *deterministic,
+  typed, human-ratified decision grounding* — with Lore as one reference
+  implementation, positioned off the spec-driven axis rather than on it.
+- Third-party-credible evidence for the claim ADR-081 flags as unproven:
+  that curated, deterministic decision context measurably improves agent
+  task outcomes over an ungrounded and a semantic-RAG baseline.
+- A published record that strengthens the recorded positioning (ADR-036,
+  ADR-081) without repositioning it.
+
+## Initiatives
+
+### Initiative 1 — The thesis and argument (`decision-grounding-thesis` design)
+
+Develop the paper's argument in the corpus: the two-axis gap taxonomy
+(code-coupling × determinism, and the empty quadrant), the synthesis of the
+recorded positioning, the section outline, and the arXiv abstract. The
+design is the durable home; the manuscript is its output.
+
+### Initiative 2 — The evaluation (`rac-grounding-baseline-study`)
+
+Scope and then run the head-to-head study the paper needs: a
+none / RAG / rac-corpus grounding-arm design with a downstream
+task-success outcome, extending the `external-benchmark-evidence` programme.
+The semantic baseline is reported as evidence, never a CI gate (ADR-066,
+ADR-097).
+
+### Initiative 3 — Clearance and submission
+
+Clear GATE-1 (external-communications / IP review), submit to arXiv
+(cs.SE), and pursue a peer venue (an LLM4SE / agents-for-software-engineering
+workshop) for citation signal. Author and affiliation are the maintainer's
+call at pickup.
+
+## Constraints
+
+- Positioning is stated, not altered: ADR-036 (Lore is the product, RAC is
+  the engine) and ADR-081 (the deterministic-source-of-truth-for-decisions
+  thesis) are the governing record; the paper cites them.
+- The reported evaluation honours the eval contract: no embeddings and no
+  LLM judge in the *scored/gated* path (ADR-066, ADR-097); any semantic or
+  LLM-judged arm is comparative evidence only, version-pinned, never a gate.
+- No new engine scope: this is a positioning-and-evidence effort, not a
+  product feature; it adds no CLI, schema, or contract behaviour.
+- External publication waits on GATE-1.
+
+## Non-Goals
+
+- Repositioning Lore or altering ADR-036 / ADR-081.
+- A marketing paper: Lore is a reference implementation and worked example,
+  not the subject; the contribution is the framing plus the evidence.
+- Embeddings, vector-RAG, or an LLM judge anywhere in the scored eval gate
+  (ADR-066) — the semantic arm is a reported baseline only.
+- Folding into the growth-essay series (`growth-essay-mapping`): that is a
+  personal, non-academic genre with its own GATE-1 track; this is distinct.
+
+## Success Measures
+
+- The thesis design and the study requirement pass `rac validate`,
+  `rac relationships --validate`, and `rac review` with no priority 1–2
+  findings, so the paper's own argument clears the corpus gates it describes.
+- The evaluation produces a defensible head-to-head result (RAC vs RAG vs
+  none) on a study-grade query set with a downstream task-success outcome —
+  or records honestly that the result did not support the claim.
+- A submitted preprint that a reader can trace back, in prose, to the
+  recorded decisions and the eval methodology.
+
+## Assumptions
+
+- GATE-1 can be cleared for an academic publication as it is anticipated
+  for the essays; the timeline is external and unscheduled here.
+- The `external-benchmark-evidence` "none / RAG / rac-corpus" arm and the
+  GitChameleon executable-scoring skeleton are the right experimental base
+  to extend, rather than a new harness.
+- Position-and-evidence papers of this shape are acceptable on arXiv cs.SE
+  (the Spec Growth Engine, arXiv:2606.27045, is a recent single-author
+  precedent); peer-venue acceptance is a separate, later bar.
+
+## Risks
+
+- Reads as vendor marketing rather than a contribution. Mitigation: lead
+  with the general framing and the evaluation; Lore is the worked example,
+  not the pitch (the Non-Goals pin this).
+- The evaluation fails to show a task-success lift. Mitigation: the study
+  is framed to report the honest result; a null result still advances the
+  question ADR-081 says is open, and the deterministic-retrieval regression
+  evidence stands regardless.
+- The paper cannot be a validated corpus edge — there is no relationship
+  type for external/unpublished documents (recorded in `growth-essay-mapping`
+  and `rac-growth-essay-bridge`). Mitigation: cite the manuscript and the
+  preprints in prose; keep the durable argument in the design artifact.
+
+## Related Decisions
+
+- adr-036
+- adr-066
+- adr-081
+- adr-097
+
+## Related Roadmaps
+
+- growth-programme
+- external-benchmark-evidence
+- commercial-layer-positioning
+
+## Related Designs
+
+- decision-grounding-thesis
+
+## Related Requirements
+
+- rac-grounding-baseline-study

--- a/rac/roadmaps/future/decision-grounding-paper.md
+++ b/rac/roadmaps/future/decision-grounding-paper.md
@@ -62,9 +62,11 @@ design is the durable home; the manuscript is its output.
 
 ### Initiative 2 — The evaluation (`rac-grounding-baseline-study`)
 
-Scope and then run the head-to-head study the paper needs: a
-none / RAG / rac-corpus grounding-arm design with a downstream
-task-success outcome, extending the `external-benchmark-evidence` programme.
+Mature the existing `decisiongrounding` head-to-head — published as
+**SWE-DecisionBench** — into a citable SWE-family study: two co-primary
+deterministic outcomes (decision-adherence and decision-conditioned
+executable resolution) across the `no_grounding` / `naive_rag` / `rac` /
+`context_dump` arms, extending the `external-benchmark-evidence` programme.
 The semantic baseline is reported as evidence, never a CI gate (ADR-066,
 ADR-097).
 

--- a/rac/roadmaps/future/decision-grounding-paper.md
+++ b/rac/roadmaps/future/decision-grounding-paper.md
@@ -155,3 +155,7 @@ call at pickup.
 ## Related Requirements
 
 - rac-grounding-baseline-study
+
+## Related Tickets
+
+- itsthelore/rac-core#293


### PR DESCRIPTION
# Summary

Implements two thematically-linked corpus programmes (10 commits, 6 new artifacts, corpus only — no engine code changes): the **decision-grounding paper** and its two benchmark evidence pillars. Records intent, contracts, and acceptance criteria; execution lives in the epics.

Adds:
- The `decision-grounding-paper` programme — a roadmap, the `decision-grounding-thesis` design (gap taxonomy, draft arXiv abstract, section outline), and the `rac-grounding-baseline-study` requirement, reconciled to the existing `decisiongrounding` benchmark and rebranded to **SWE-DecisionBench** with a co-primary executable arm.
- The `artifact-completeness-benchmark` programme — a roadmap, the `artifact-completeness-diagnostic` design, and the `rac-artifact-completeness-study` requirement: **SWE-CompletenessBench**, the sibling completeness diagnostic whose hero metric is the residual (tacit) gap.
- Two ADR-093 `## Related Tickets` bridges to the execution epics #293 and #299.

# Roadmap / ADR Trace

Roadmaps (new in this PR, both `future/`, Unscheduled):
- `rac/roadmaps/future/decision-grounding-paper.md` — epic #293 — the arXiv position-and-evidence paper naming the deterministic decision-grounding layer; blocked on GATE-1 for publication.
- `rac/roadmaps/future/artifact-completeness-benchmark.md` — epic #299 — SWE-CompletenessBench, the recorded-knowledge completeness diagnostic.

Relevant ADRs: the programmes state and cite ADR-036 (identity), ADR-081 (competitive positioning; "Lore is not an SDD/codegen tool"), ADR-066/097 (deterministic eval, no embeddings/LLM judge in the scored path), ADR-092 (benchmarks live in `rac-benchmarks`), ADR-002/034/080 — none is contradicted. Positioning is stated, not altered.

# Scope

## Included
- decision-grounding-paper: the thesis (code-coupling × determinism gap taxonomy, the empty `decisions × deterministic` quadrant), a draft arXiv abstract and 8-section outline, and the SWE-DecisionBench study contract — reconciled to name the existing `decisiongrounding` benchmark as its implementation, rebranded to SWE-DecisionBench, with decision-adherence and decision-conditioned executable resolution as co-primary deterministic outcomes, positioned in the SWE-bench → SWE-ContextBench lineage.
- artifact-completeness-benchmark: SWE-CompletenessBench — an external agent reconstructs a component from its Lore artifacts alone; the residual (oracle − rac) is the reported hero metric = the measured tacit frontier the corpus already names (`growth-essay-mapping`, Row 6). Arms none/RAG/rac + full-source oracle; executable deterministic scoring; per-artifact-family ablation.
- Two `## Related Tickets` bridges (#293, #299).

## Excluded
- No engine code — corpus-only; both benchmarks execute in `itsthelore/rac-benchmarks` (ADR-092), never in `rac-core`.
- No spec-as-source / codegen claim: Lore serves the corpus and never generates; the completeness benchmark leads with the residual, never a reconstruction success-rate (ADR-081).
- No embeddings, vector search, or LLM judge in the scored path of either benchmark (ADR-066/097); the semantic/RAG arms live in `rac-benchmarks`.
- No repositioning of Lore or alteration of ADR-036/081.
- External publication of the paper waits on GATE-1 (#296).

# Product / Architecture Decisions

- The SWE-DecisionBench study is a reconciliation, not a new build: the four-arm head-to-head (`no_grounding`/`naive_rag`/`rac`/`context_dump`) already exists as `decisiongrounding`; this PR names it, rebrands it, and scopes the publication-grade deltas.
- SWE-CompletenessBench is named completeness-forward (not "RebuildFromArtifact") specifically so the verb does not imply codegen — the residual/completeness framing is what keeps it clear of the spec-as-source lane ADR-081 refuses.
- The two benchmarks are complementary: DecisionBench measures grounding *lift* on a per-patch task (adherence/resolution); CompletenessBench measures corpus *completeness* on a whole-component rebuild (the residual). They are the paper's two evidence pillars.
- Both benchmarks stay out of `rac-core` (ADR-092), keeping embeddings and any LLM-judged scoring out of the engine.

# User-Facing Contract

Corpus-only change: no CLI, JSON, schema, or exit-code behavior changes. The contracts the requirements specify (the SWE-DecisionBench study, the SWE-CompletenessBench harness and residual metric) ship later, in `rac-benchmarks`, gated by the acceptance criteria recorded here.

# Verification

## Ran
- `rac validate rac/` — exit 0 (381 artifacts valid, 0 invalid, OKF conformant).
- `rac relationships rac/ --validate` — 2,230 relationships, 0 issues.
- `rac review rac/` — no priority 1–2 findings.
- `rac resolve` on all new ids and cross-linked stems (decision-grounding-paper, decision-grounding-thesis, rac-grounding-baseline-study, artifact-completeness-benchmark, artifact-completeness-diagnostic, rac-artifact-completeness-study) at their paths.

## Covered
- All Related entries resolve (lowercase adr-NNN aliases; roadmap/design/requirement stems); the #293 and #299 ticket bridges format-lint clean.
- Commit identity verified on all ten commits: maintainer on both author and committer, no tool attribution.
- The branch was rebased onto current `main` after the `lore-at-team-scale` work merged (ADRs 098/099); the ten commits are disjoint from that work, so the rebase was clean.

# Review Path

1. `rac/roadmaps/future/decision-grounding-paper.md` + `rac/designs/decision-grounding-thesis.md` + `rac/requirements/rac-grounding-baseline-study.md` — the paper thesis, abstract, and the SWE-DecisionBench study contract.
2. `rac/roadmaps/future/artifact-completeness-benchmark.md` + `rac/designs/artifact-completeness-diagnostic.md` + `rac/requirements/rac-artifact-completeness-study.md` — SWE-CompletenessBench; check the completeness-diagnostic framing and the spec-as-source guardrail.

# Notes For Reviewer

- Both programmes are corpus intent + contracts; the benchmarks themselves are built in `rac-benchmarks` (there is an existing `decisiongrounding` implementation and a `publish-swe-decisionbench` roadmap over there). This session's scope is `rac-core`, so those references are prose.
- The dataset is the real open work for SWE-CompletenessBench (#300): the honest MVP is `rac-core` dogfooding itself — rebuilding a `rac-core` component from its own `rac/` corpus, scored by the engine's tests.
- Epics #293 and #299 already exist with natively-linked sub-issues; their blob/main intent links resolve once this merges.
- This repo rebase-merges (squash disabled); the PR title becomes the lead commit subject.

# Implementation Process

Implemented with AI assistance under the roadmap contract; final scope, framing (completeness diagnostic, not spec-as-source), naming, and acceptance decisions were made by the maintainer.