### PR TITLE
feat(find): surface git-derived recency on find and search read surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,16 @@ as candidate relationships.
   guessed; Notion database CSVs are reported and skipped (rows arrive as their
   own pages); a Roam JSON graph is flattened to outliner Markdown per page
   (ADR-079).
+- **Freshness on the surfaces where you pick artifacts.** `rac find` results and
+  the MCP `search_artifacts` tool now carry a git-derived `recency` object per
+  match — `last_committed`, `age_days`, and a `stale` flag — so you can see which
+  result has decayed without opening it. `stale` is `true` once an artifact's age
+  exceeds a freshness threshold (default 180 days; set `freshness.stale_after_days`
+  in `.rac/config.yaml` to change it). In the human `rac find` output a stale match
+  is flagged inline with `⚠ stale (Nd)`. It is advisory data beside its date, never
+  a correctness verdict, and it never changes which artifacts match or their order;
+  outside a git repository the fields degrade to `null`. Derived from git, never a
+  stored frontmatter date (ADR-045).
 
 ## 2026.06.5 — the "rename" release
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1291,6 +1291,25 @@ score and its components (`bm25`, `lexical_rank`, `graph_rank`, `inbound`), so a
 caller can see why one result outranks another. It is additive: the default
 output (without `--explain`) is unchanged, and `schema_version` stays `1`.
 
+Each match also carries a **`recency`** object — git-derived freshness so you
+can see which result has decayed without opening it (ADR-045). `last_committed`
+is the ISO date of the file's most recent commit; `age_days` is its age in whole
+days; `stale` is `true` when that age exceeds the freshness threshold. The
+threshold defaults to **180 days** and is configurable per repository in
+`.rac/config.yaml`:
+
+```yaml
+freshness:
+  stale_after_days: 90
+```
+
+The indicator is data beside its date, never a correctness verdict — a stale
+artifact may be perfectly correct, just untouched. Recency never changes which
+artifacts match or their order (ranking is unaffected). Outside a git
+repository, or for an untracked file, the three fields degrade to `null` rather
+than a fabricated date; in the human output a stale match is flagged inline with
+`⚠ stale (Nd)`.
+
 ```bash
 rac find markdown rac/
 rac find explorer rac/ --type decision
@@ -1309,7 +1328,12 @@ rac find markdown rac/ --explain        # show the relevance-score breakdown
       "id": "RAC-01JY4M8X2QZ7",
       "type": "decision",
       "title": "Markdown Is the Canonical Source Format",
-      "path": "rac/decisions/markdown-first.md"
+      "path": "rac/decisions/markdown-first.md",
+      "recency": {
+        "last_committed": "2026-01-04T12:00:00+00:00",
+        "age_days": 181,
+        "stale": true
+      }
     }
   ]
 }

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -155,6 +155,16 @@ returns immediate neighbours only, while `depth>1` additionally returns a
 roadmap depends on. The walk is bounded (depth, frontier, visited-set, and a work
 budget) and deterministic; a truncation marker is set if any cap stops it.
 
+Each `search_artifacts` match carries an additive **`recency`** object —
+`last_committed`, `age_days`, and a `stale` flag derived from git history
+(ADR-045) — so an agent choosing between results can see which artifact has
+decayed without a follow-up `get_artifact`. `stale` is `true` once a file's age
+exceeds the freshness threshold (default 180 days, set per repository under
+`freshness.stale_after_days` in `.rac/config.yaml`). It is advisory data beside
+its date, never a correctness verdict, and never changes which artifacts match or
+their order; outside git the fields degrade to `null`. The join respects the
+response budget — matches truncate whole, exactly as before.
+
 The tool descriptions contain the trigger language; well-tuned agents call them
 without being told to.
 

--- a/rac/requirements/rac-freshness-read-surfaces.md
+++ b/rac/requirements/rac-freshness-read-surfaces.md
@@ -7,7 +7,7 @@ type: requirement
 
 ## Status
 
-Proposed
+Accepted
 
 Classification: `[internal]` — staleness visible where artifacts are
 picked. Initiative 1 (phase 1) of the `freshness-and-drift-detection`

--- a/src/rac/cli.py
+++ b/src/rac/cli.py
@@ -1021,6 +1021,12 @@ def cmd_find(args: argparse.Namespace) -> int:
             artifact_type=args.type,
             recursive=not args.top_level,
         )
+    # Freshness phase 1 (ADR-045): join git-derived staleness onto matches after
+    # ranking, so the matched set and order are unchanged (REQ-005) and the fields
+    # degrade to null outside git (REQ-003).
+    from rac.services.recency import annotate_search_recency
+
+    annotate_search_recency(result.matches, args.directory)
     if args.json:
         print(outputs.render_find_json(result, explain=args.explain))
     else:

--- a/src/rac/mcp/server.py
+++ b/src/rac/mcp/server.py
@@ -67,7 +67,7 @@ from rac.services.agent_rules import artifact_status
 from rac.services.derived_cache import DerivedIndexCache
 from rac.services.index import IndexEntry, build_repository_index, index_from_corpus
 from rac.services.portfolio import build_portfolio_summary
-from rac.services.recency import artifact_provenance
+from rac.services.recency import annotate_search_recency, artifact_provenance
 from rac.services.relationships import (
     incoming_references,
     neighborhood,
@@ -259,6 +259,9 @@ def _search_artifacts(
     else:
         entries = build_repository_index(root, recursive=True).artifacts
         result = search_index(entries, query, artifact_type=artifact_type)
+    # Freshness phase 1 (ADR-045): join git-derived staleness after ranking, so
+    # search order is unchanged and the fields degrade to null outside git.
+    annotate_search_recency(result.matches, root)
     return serialize(result.to_dict(), budget)
 
 

--- a/src/rac/output/human.py
+++ b/src/rac/output/human.py
@@ -1042,7 +1042,16 @@ def render_find_human(result: SearchResult, *, explain: bool = False) -> str:
     indent = f"{' ' * id_w}  {' ' * type_w}  "
     lines: list[str] = []
     for m in result.matches:
-        lines.append(f"{m.id:<{id_w}}  {m.type:<{type_w}}  {m.title or '—'}")
+        row = f"{m.id:<{id_w}}  {m.type:<{type_w}}  {m.title or '—'}"
+        # Staleness marker (ADR-045): a match whose file has not been committed
+        # within the freshness window is flagged inline. It is an advisory
+        # signal read off git recency, never a validation error — fresh matches
+        # render exactly as before (REQ-004). Absent when recency is unresolved
+        # (e.g. outside a git repository).
+        if m.recency and m.recency.get("stale"):
+            age = m.recency.get("age_days")
+            row += _yellow(f"  ⚠ stale ({age}d)" if age is not None else "  ⚠ stale")
+        lines.append(row)
         # Heading/body matches carry a snippet; show the matched section and line
         # indented under the row so an agent or reader can triage without opening
         # the file (ADR-038). Metadata matches have no snippet and stay one line.

--- a/src/rac/services/recency.py
+++ b/src/rac/services/recency.py
@@ -19,13 +19,17 @@ cadence nudge, v0.13.3) stay inside ADR-017.
 from __future__ import annotations
 
 import subprocess
+from collections.abc import Iterable
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
+
+import yaml
 
 from rac.core.markdown import parse
 from rac.services.agent_rules import artifact_status
 from rac.services.index import build_repository_index
+from rac.services.init import find_config_file
 
 # Field separator for combined ``git log --format`` records. The unit-separator
 # control byte never appears in a commit date, author name, or email, so a
@@ -322,3 +326,126 @@ def artifact_provenance(directory: str, path: str) -> ArtifactProvenance:
         first_author=first_author,
         status_history=_status_history(repo_root, path),
     )
+
+
+# --- Staleness indicator (freshness-and-drift phase 1, ADR-045) ---------------
+#
+# A documented, deterministic function of an artifact's last-committed age
+# against a configurable threshold, reported as data beside its date — never a
+# score or verdict (ADR-034). The last-committed date is the git fact (stable for
+# a fixed git state); the derived ``age_days`` / ``stale`` are relative to a
+# reference time (``now`` by default, injectable so tests stay deterministic).
+
+# The documented default: an artifact untouched for this many days reads "stale".
+DEFAULT_STALE_AFTER_DAYS = 180
+
+
+@dataclass(frozen=True)
+class Staleness:
+    """One artifact's freshness: its last-committed date and derived indicator."""
+
+    last_committed: datetime | None
+    age_days: int | None
+    stale: bool | None
+
+    def to_dict(self) -> dict:
+        return {
+            "last_committed": self.last_committed.isoformat() if self.last_committed else None,
+            "age_days": self.age_days,
+            "stale": self.stale,
+        }
+
+
+def staleness(
+    last_committed: datetime | None,
+    *,
+    threshold_days: int = DEFAULT_STALE_AFTER_DAYS,
+    reference: datetime | None = None,
+) -> Staleness:
+    """The staleness of one last-committed date against ``threshold_days``.
+
+    ``age_days`` is whole days between ``reference`` (default: now, UTC) and
+    ``last_committed``; ``stale`` is ``age_days > threshold_days``. An unknown
+    date (outside git, untracked) yields all-``None`` — never a fabricated date
+    (ADR-045 degrade posture). Passing ``reference`` makes the result
+    deterministic for tests.
+    """
+    if last_committed is None:
+        return Staleness(None, None, None)
+    if reference is None:
+        reference = datetime.now(UTC)
+    age_days = (reference - last_committed).days
+    return Staleness(
+        last_committed=last_committed, age_days=age_days, stale=age_days > threshold_days
+    )
+
+
+def load_freshness_threshold(directory: str) -> int:
+    """The ``freshness.stale_after_days`` from the nearest ``.rac/config.yaml``.
+
+    Discovery reuses the shared ``.rac/config.yaml`` walk (:func:`find_config_file`).
+    Defaults to :data:`DEFAULT_STALE_AFTER_DAYS` when there is no config file, no
+    ``freshness`` stanza, or the value is not a positive integer — the config is
+    advisory, so a malformed value degrades to the default rather than raising.
+    """
+    config_path = find_config_file(directory)
+    if config_path is None:
+        return DEFAULT_STALE_AFTER_DAYS
+    try:
+        data = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError):
+        return DEFAULT_STALE_AFTER_DAYS
+    section = data.get("freshness") if isinstance(data, dict) else None
+    value = section.get("stale_after_days") if isinstance(section, dict) else None
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        return DEFAULT_STALE_AFTER_DAYS
+    return value
+
+
+def recency_for_paths(
+    directory: str,
+    paths: Iterable[str],
+    *,
+    threshold_days: int = DEFAULT_STALE_AFTER_DAYS,
+    reference: datetime | None = None,
+) -> dict[str, Staleness]:
+    """Git-derived staleness for each of ``paths`` (the read-surface join).
+
+    One git boundary, reused (ADR-045): last-committed per path, then the
+    staleness indicator. Outside a repository every path maps to an unknown
+    :class:`Staleness` — no exception crosses the boundary (REQ-003).
+    """
+    if reference is None:
+        reference = datetime.now(UTC)
+    repo_root = _repository_root(directory)
+    result: dict[str, Staleness] = {}
+    for path in paths:
+        last = _last_committed(repo_root, path) if repo_root is not None else None
+        result[path] = staleness(last, threshold_days=threshold_days, reference=reference)
+    return result
+
+
+def annotate_search_recency(
+    matches: list,
+    directory: str,
+    *,
+    threshold_days: int | None = None,
+    reference: datetime | None = None,
+) -> None:
+    """Join git-derived staleness onto search matches (the read-surface enrichment).
+
+    Sets each match's ``recency`` dict in place, computed *after* ranking so the
+    matched set and order are untouched (REQ-005). The threshold defaults to the
+    corpus's ``freshness`` config (else 180 days). Duck-typed on ``.path`` /
+    ``.recency`` to avoid coupling recency to the resolver.
+    """
+    if not matches:
+        return
+    threshold = (
+        threshold_days if threshold_days is not None else load_freshness_threshold(directory)
+    )
+    by_path = recency_for_paths(
+        directory, [m.path for m in matches], threshold_days=threshold, reference=reference
+    )
+    for match in matches:
+        match.recency = by_path[match.path].to_dict()

--- a/src/rac/services/resolve.py
+++ b/src/rac/services/resolve.py
@@ -132,6 +132,12 @@ class ResolvedArtifact:
     # is unchanged. Always set for a search match; the gate it answers to is
     # ``include_evidence`` so the CLI's default ``rac find`` JSON stays byte-stable.
     evidence: dict | None = None
+    # Git-derived staleness (freshness phase 1, additive): last-committed date
+    # plus the staleness indicator, joined by the read surface *after* ranking so
+    # matching and order are unchanged (ADR-045, ADR-078). None for resolution and
+    # for search until a surface enriches it, and absent from ``to_dict`` then, so
+    # the pre-freshness shape is byte-identical (ADR-007).
+    recency: dict | None = None
 
     def to_dict(self, *, include_evidence: bool = True) -> dict:
         payload: dict[str, Any] = {
@@ -146,6 +152,8 @@ class ResolvedArtifact:
             payload["snippet"] = self.snippet
         if include_evidence and self.evidence is not None:
             payload["evidence"] = self.evidence
+        if self.recency is not None:
+            payload["recency"] = self.recency
         return payload
 
     @classmethod

--- a/tests/test_explain.py
+++ b/tests/test_explain.py
@@ -18,6 +18,7 @@ from rac import cli
 from rac.mcp.server import build_server
 from rac.output import json as json_output
 from rac.services.index import build_repository_index
+from rac.services.recency import annotate_search_recency
 from rac.services.resolve import find_artifacts, search_index
 
 # One decision authored so each query term is unique to one match tier. The
@@ -169,11 +170,18 @@ def test_mcp_search_payload_equals_find_explain_json(tmp_path):
     server = build_server(root)
     contents, _ = asyncio.run(server.call_tool("search_artifacts", {"query": "photosynthesis"}))
     mcp_payload = json.loads(contents[0].text)
-    cli_payload = json.loads(
-        json_output.render_find_json(find_artifacts(root, "photosynthesis"), explain=True)
-    )
+    # `rac find --explain --json` joins git-derived recency the same way the MCP
+    # surface does (freshness-and-drift phase 1); annotate the CLI side to keep
+    # the one-source-of-truth equality exact. Both are computed from the same git
+    # state at the same instant, so the (volatile) values stay equal by
+    # construction — outside git, both degrade to the same null recency block.
+    cli_result = find_artifacts(root, "photosynthesis")
+    annotate_search_recency(cli_result.matches, root)
+    cli_payload = json.loads(json_output.render_find_json(cli_result, explain=True))
     assert mcp_payload == cli_payload
     assert mcp_payload["matches"][0]["evidence"]["field"] == "title"
+    # Recency rides additively on the surface payload (null outside git, REQ-003).
+    assert set(mcp_payload["matches"][0]["recency"]) == {"last_committed", "age_days", "stale"}
 
 
 # --- CLI --explain faces (REQ-004, REQ-006) ----------------------------------

--- a/tests/test_golden.py
+++ b/tests/test_golden.py
@@ -14,7 +14,9 @@ then commit the diff.
 
 from __future__ import annotations
 
+import json
 import os
+import re
 from pathlib import Path
 
 import pytest
@@ -23,6 +25,29 @@ from rac.cli import main
 
 REPO_ROOT = Path(__file__).parent.parent
 GOLDEN_DIR = Path(__file__).parent / "golden"
+
+# Find output carries a git-derived `recency` object per match (freshness-and-
+# drift phase 1). Its `age_days`/`stale` are wall-clock-relative, so leaving them
+# in a byte-pinned golden would make it time-fragile. REQ-006's remedy is to
+# exclude the git-derived fields from the byte-pinned goldens; the recency
+# contract itself is pinned deterministically, against controlled git state, in
+# tests/test_recency.py. These are the find cases whose output embeds it.
+_FIND_JSON_CASES = {"find_json", "find_explain_json"}
+_FIND_HUMAN_CASES = {"find_human"}
+_STALE_MARKER_RE = re.compile(r" ⚠ stale \(\d+d\)")
+
+
+def _strip_git_derived_recency(out: str, name: str) -> str:
+    """Excise the git-derived recency fields so the golden stays time-stable."""
+    if name in _FIND_JSON_CASES:
+        data = json.loads(out)
+        for match in data.get("matches", []):
+            match.pop("recency", None)
+        return json.dumps(data, indent=2) + "\n"
+    if name in _FIND_HUMAN_CASES:
+        return _STALE_MARKER_RE.sub("", out)
+    return out
+
 
 # (name, argv, expected exit code). Paths are relative to the repository root
 # (the tests chdir there) so golden files stay machine-independent.
@@ -132,7 +157,7 @@ def test_golden(name, argv, expected_rc, capsys, monkeypatch):
     monkeypatch.setenv("XDG_STATE_HOME", "tests/fixtures/telemetry/state")
 
     rc = main(argv)
-    out = capsys.readouterr().out
+    out = _strip_git_derived_recency(capsys.readouterr().out, name)
 
     golden = GOLDEN_DIR / f"{name}.txt"
     if os.environ.get("RAC_UPDATE_GOLDEN") == "1":

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -28,6 +28,7 @@ from rac.mcp.budget import (
 from rac.mcp.server import build_server
 from rac.output import json as json_output
 from rac.services.portfolio import build_portfolio_summary
+from rac.services.recency import annotate_search_recency
 from rac.services.resolve import find_artifacts, find_decisions, resolve_artifact
 
 CORPUS = fixture_path("mcp", "corpus")
@@ -45,6 +46,19 @@ def call(root: str, tool: str, args: dict, budget: int = DEFAULT_BUDGET) -> dict
     contents, _structured = asyncio.run(server.call_tool(tool, args))
     assert len(contents) == 1
     return json.loads(contents[0].text)
+
+
+def find_like_cli(root: str, query: str) -> dict:
+    """The `rac find --explain --json` payload, recency joined as `cmd_find` does.
+
+    The read surfaces (MCP `search_artifacts` and `rac find`) both annotate
+    git-derived recency post-ranking (freshness-and-drift phase 1). Mirroring
+    that here keeps the one-source-of-truth equivalence exact against the MCP
+    surface — both sides read the same git state at the same instant.
+    """
+    result = find_artifacts(root, query)
+    annotate_search_recency(result.matches, root)
+    return json.loads(json_output.render_find_json(result, explain=True))
 
 
 # --- get_artifact ------------------------------------------------------------
@@ -133,9 +147,20 @@ def test_search_artifacts_shape_and_order():
     assert payload["match_count"] == 3
     for match in payload["matches"]:
         # WS2: search results carry an additive `evidence` object (always present),
-        # now also carrying the ADR-078 relevance-score components.
-        assert list(match) == ["id", "type", "title", "path", "evidence"]
+        # now also carrying the ADR-078 relevance-score components. Freshness phase
+        # 1 adds a second additive object, `recency`, last (ADR-007). Both trail the
+        # metadata quartet.
+        assert list(match) == ["id", "type", "title", "path", "evidence", "recency"]
         assert set(match["evidence"]) == {"field", "terms", "tier", "score", "components"}
+        # The fixture is git-tracked, so recency populates from real history; pin
+        # its shape (string-or-null date, int-or-null age, bool-or-null flag),
+        # never the volatile values (the `provenance` precedent, REQ-006).
+        assert set(match["recency"]) == {"last_committed", "age_days", "stale"}
+        assert match["recency"]["last_committed"] is None or isinstance(
+            match["recency"]["last_committed"], str
+        )
+        assert match["recency"]["age_days"] is None or isinstance(match["recency"]["age_days"], int)
+        assert match["recency"]["stale"] is None or isinstance(match["recency"]["stale"], bool)
     assert "truncated" not in payload
 
 
@@ -148,11 +173,8 @@ def test_search_artifacts_type_filter():
 def test_search_artifacts_matches_cli_find_json():
     payload = call(CORPUS, "search_artifacts", {"query": "messaging"})
     # MCP search always carries evidence; the equal CLI face is `--explain --json`
-    # (REQ-004, one source of truth).
-    cli = json.loads(
-        json_output.render_find_json(find_artifacts(CORPUS, "messaging"), explain=True)
-    )
-    assert payload == cli
+    # (REQ-004, one source of truth). Both surfaces join recency identically.
+    assert payload == find_like_cli(CORPUS, "messaging")
 
 
 def test_search_artifacts_empty_result_is_not_an_error():
@@ -172,8 +194,7 @@ def test_search_artifacts_body_match_carries_snippet():
     assert match["id"] == REQ
     assert match["section"] == "Problem"
     assert match["snippet"] == "Services are tightly coupled."
-    cli = json.loads(json_output.render_find_json(find_artifacts(CORPUS, "tightly"), explain=True))
-    assert payload == cli
+    assert payload == find_like_cli(CORPUS, "tightly")
 
 
 def test_search_artifacts_metadata_match_omits_snippet_fields():
@@ -181,8 +202,9 @@ def test_search_artifacts_metadata_match_omits_snippet_fields():
     # (ADR-007): no section/snippet keys appear.
     payload = call(CORPUS, "search_artifacts", {"query": "decoupled", "type": "requirement"})
     assert [m["id"] for m in payload["matches"]] == [REQ]
-    # No section/snippet on a metadata match; `evidence` is still additive.
-    assert list(payload["matches"][0]) == ["id", "type", "title", "path", "evidence"]
+    # No section/snippet on a metadata match; `evidence` and `recency` are the
+    # additive trailers (ADR-007), never the per-match snippet fields.
+    assert list(payload["matches"][0]) == ["id", "type", "title", "path", "evidence", "recency"]
     evidence = payload["matches"][0]["evidence"]
     assert {k: evidence[k] for k in ("field", "terms", "tier")} == {
         "field": "title",

--- a/tests/test_recency.py
+++ b/tests/test_recency.py
@@ -8,12 +8,27 @@ uncommitted files, never raising.
 
 from __future__ import annotations
 
+import asyncio
+import json
 import os
 import subprocess
-from datetime import datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
-from rac.services.recency import artifact_recency
+from rac import cli
+from rac.mcp.server import build_server
+from rac.output import human as human_output
+from rac.output import json as json_output
+from rac.services.recency import (
+    DEFAULT_STALE_AFTER_DAYS,
+    Staleness,
+    annotate_search_recency,
+    artifact_recency,
+    load_freshness_threshold,
+    recency_for_paths,
+    staleness,
+)
+from rac.services.resolve import find_artifacts
 
 _REQUIREMENT = "# {title}\n\n## Problem\n\np\n\n## Requirements\n\n[REQ-001] x\n"
 _DECISION = "# {title}\n\n## Context\n\nc\n\n## Decision\n\nd\n\n## Consequences\n\nk\n"
@@ -144,3 +159,237 @@ def test_recency_to_dict_shape(tmp_path):
     assert payload["by_type"]["requirement"] == "2026-01-01T12:00:00+00:00"
     assert payload["artifacts"][0]["type"] == "requirement"
     assert payload["artifacts"][0]["last_committed"] == "2026-01-01T12:00:00+00:00"
+
+
+# --- staleness indicator (freshness-and-drift phase 1, REQ-004) --------------
+#
+# ``staleness`` is a deterministic function of a last-committed date against a
+# threshold. The ``reference`` parameter pins "now" so the derived age and flag
+# are exact — no wall-clock dependence in these assertions.
+
+_REF = datetime(2026, 7, 1, 12, 0, 0, tzinfo=UTC)
+
+
+def test_staleness_unknown_date_is_all_none():
+    # Outside git / untracked: no date, so no derived age or flag — never a
+    # fabricated date (REQ-003, ADR-045 posture).
+    result = staleness(None, reference=_REF)
+    assert result == Staleness(None, None, None)
+    assert result.to_dict() == {"last_committed": None, "age_days": None, "stale": None}
+
+
+def test_staleness_fresh_below_threshold():
+    committed = _REF - timedelta(days=100)
+    result = staleness(committed, threshold_days=180, reference=_REF)
+    assert result.age_days == 100
+    assert result.stale is False
+    assert result.last_committed == committed
+
+
+def test_staleness_stale_above_threshold():
+    result = staleness(_REF - timedelta(days=181), threshold_days=180, reference=_REF)
+    assert result.age_days == 181
+    assert result.stale is True
+
+
+def test_staleness_boundary_is_not_stale_at_exactly_threshold():
+    # ``stale`` is age > threshold, so an artifact exactly at the threshold is
+    # still fresh — the boundary is documented and deterministic (REQ-004).
+    result = staleness(_REF - timedelta(days=180), threshold_days=180, reference=_REF)
+    assert result.age_days == 180
+    assert result.stale is False
+
+
+def test_staleness_respects_custom_threshold():
+    committed = _REF - timedelta(days=45)
+    assert staleness(committed, threshold_days=30, reference=_REF).stale is True
+    assert staleness(committed, threshold_days=90, reference=_REF).stale is False
+
+
+def test_staleness_default_threshold_is_180():
+    assert DEFAULT_STALE_AFTER_DAYS == 180
+    assert staleness(_REF - timedelta(days=179), reference=_REF).stale is False
+    assert staleness(_REF - timedelta(days=181), reference=_REF).stale is True
+
+
+def test_staleness_to_dict_serialises_date():
+    committed = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+    payload = staleness(committed, threshold_days=180, reference=_REF).to_dict()
+    assert payload == {
+        "last_committed": "2026-01-01T12:00:00+00:00",
+        "age_days": 181,
+        "stale": True,
+    }
+
+
+# --- freshness threshold config (REQ-004) ------------------------------------
+
+
+def _write_config(tmp_path: Path, body: str) -> None:
+    config_dir = tmp_path / ".rac"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    (config_dir / "config.yaml").write_text(body, encoding="utf-8")
+
+
+def test_threshold_defaults_when_no_config(tmp_path):
+    assert load_freshness_threshold(str(tmp_path)) == DEFAULT_STALE_AFTER_DAYS
+
+
+def test_threshold_reads_freshness_stanza(tmp_path):
+    _write_config(tmp_path, "repository_key: acme\nfreshness:\n  stale_after_days: 30\n")
+    assert load_freshness_threshold(str(tmp_path)) == 30
+
+
+def test_threshold_found_from_subdirectory(tmp_path):
+    _write_config(tmp_path, "freshness:\n  stale_after_days: 45\n")
+    sub = tmp_path / "rac" / "requirements"
+    sub.mkdir(parents=True)
+    assert load_freshness_threshold(str(sub)) == 45
+
+
+def test_threshold_defaults_without_freshness_stanza(tmp_path):
+    _write_config(tmp_path, "repository_key: acme\n")
+    assert load_freshness_threshold(str(tmp_path)) == DEFAULT_STALE_AFTER_DAYS
+
+
+def test_threshold_defaults_on_non_positive_or_wrong_type(tmp_path):
+    for body in (
+        "freshness:\n  stale_after_days: 0\n",
+        "freshness:\n  stale_after_days: -5\n",
+        "freshness:\n  stale_after_days: soon\n",
+        "freshness:\n  stale_after_days: true\n",  # bool is not a day count
+        "freshness: not-a-mapping\n",
+    ):
+        _write_config(tmp_path, body)
+        assert load_freshness_threshold(str(tmp_path)) == DEFAULT_STALE_AFTER_DAYS
+
+
+def test_threshold_defaults_on_malformed_yaml(tmp_path):
+    _write_config(tmp_path, "freshness: [unterminated\n")
+    assert load_freshness_threshold(str(tmp_path)) == DEFAULT_STALE_AFTER_DAYS
+
+
+# --- recency_for_paths / annotate (REQ-001, REQ-003, REQ-005) ----------------
+
+
+def _ancient_and_fresh(tmp_path: Path) -> tuple[str, str]:
+    """A git repo with one ancient artifact and one committed just now.
+
+    Returns the two artifact paths. The ancient one is decades old, so it is
+    ``stale`` against any sane threshold regardless of wall-clock; the fresh one
+    is committed at real "now" (age 0), so it is never stale.
+    """
+    _init(tmp_path)
+    corpus = tmp_path / "rac" / "requirements"
+    corpus.mkdir(parents=True)
+    ancient = corpus / "ancient.md"
+    fresh = corpus / "fresh.md"
+    ancient.write_text(_REQUIREMENT.format(title="Ancient Widget"), encoding="utf-8")
+    _git(tmp_path, "add", ".")
+    _git(tmp_path, "commit", "--quiet", "-m", "ancient", when="2000-01-01T00:00:00+00:00")
+    fresh.write_text(_REQUIREMENT.format(title="Fresh Widget"), encoding="utf-8")
+    _git(tmp_path, "add", ".")
+    _git(tmp_path, "commit", "--quiet", "-m", "fresh")
+    return str(ancient), str(fresh)
+
+
+def test_recency_for_paths_exact_age_with_reference(tmp_path):
+    _init(tmp_path)
+    corpus = tmp_path / "rac" / "requirements"
+    corpus.mkdir(parents=True)
+    (corpus / "a.md").write_text(_REQUIREMENT.format(title="A"), encoding="utf-8")
+    _git(tmp_path, "add", ".")
+    _git(tmp_path, "commit", "--quiet", "-m", "init", when="2026-01-01T00:00:00+00:00")
+
+    path = str(corpus / "a.md")
+    reference = datetime(2026, 7, 1, 0, 0, 0, tzinfo=UTC)
+    result = recency_for_paths(str(tmp_path), [path], threshold_days=180, reference=reference)
+    assert result[path].age_days == 181
+    assert result[path].stale is True
+
+
+def test_recency_for_paths_outside_git_is_unknown(tmp_path):
+    corpus = tmp_path / "rac" / "requirements"
+    corpus.mkdir(parents=True)
+    (corpus / "a.md").write_text(_REQUIREMENT.format(title="A"), encoding="utf-8")
+    path = str(corpus / "a.md")
+    result = recency_for_paths(str(tmp_path), [path])
+    assert result[path] == Staleness(None, None, None)
+
+
+def test_annotate_search_recency_is_noop_on_empty():
+    # Guard the degenerate case: no matches, no git calls, no error.
+    assert annotate_search_recency([], "/nonexistent") is None
+
+
+def test_annotate_search_recency_joins_stale_flag(tmp_path):
+    _ancient_and_fresh(tmp_path)
+    result = find_artifacts(str(tmp_path), "widget")
+    annotate_search_recency(result.matches, str(tmp_path))
+    by_title = {m.title: m.recency for m in result.matches}
+    assert by_title["Ancient Widget"]["stale"] is True
+    assert by_title["Fresh Widget"]["stale"] is False
+    # last_committed is the git fact; both are present strings.
+    assert by_title["Ancient Widget"]["last_committed"].startswith("2000-01-01")
+
+
+def test_annotate_search_recency_threshold_override(tmp_path):
+    # A tiny threshold with a far-future reference flips even the fresh file to
+    # stale — the join honours the passed threshold, not just the config default.
+    _ancient_and_fresh(tmp_path)
+    result = find_artifacts(str(tmp_path), "widget")
+    reference = datetime(2030, 1, 1, tzinfo=UTC)
+    annotate_search_recency(result.matches, str(tmp_path), threshold_days=1, reference=reference)
+    assert all(m.recency["stale"] is True for m in result.matches)
+
+
+# --- read surfaces: find JSON / human / MCP search (REQ-001, REQ-006) --------
+
+
+def test_find_json_carries_recency_stale_flags(tmp_path):
+    ancient, fresh = _ancient_and_fresh(tmp_path)
+    result = find_artifacts(str(tmp_path), "widget")
+    annotate_search_recency(result.matches, str(tmp_path))
+    payload = json.loads(json_output.render_find_json(result))
+    by_path = {m["path"]: m["recency"] for m in payload["matches"]}
+    assert by_path[ancient]["stale"] is True
+    assert by_path[fresh]["stale"] is False
+    # Additive: schema_version is unchanged and recency sits beside the metadata.
+    assert payload["schema_version"] == "1"
+
+
+def test_find_human_marks_only_stale_matches(tmp_path):
+    _ancient_and_fresh(tmp_path)
+    result = find_artifacts(str(tmp_path), "widget")
+    annotate_search_recency(result.matches, str(tmp_path))
+    rendered = human_output.render_find_human(result)
+    # The ancient match carries the inline marker; the fresh one does not.
+    ancient_line = next(line for line in rendered.splitlines() if "Ancient Widget" in line)
+    fresh_line = next(line for line in rendered.splitlines() if "Fresh Widget" in line)
+    assert "stale" in ancient_line
+    assert "stale" not in fresh_line
+
+
+def test_mcp_search_carries_recency_within_budget(tmp_path):
+    _ancient_and_fresh(tmp_path)
+    server = build_server(str(tmp_path))
+    contents, _ = asyncio.run(server.call_tool("search_artifacts", {"query": "widget"}))
+    payload = json.loads(contents[0].text)
+    assert payload["match_count"] == 2
+    assert "truncated" not in payload  # REQ-007: budget unaffected on a small corpus
+    for match in payload["matches"]:
+        assert set(match["recency"]) == {"last_committed", "age_days", "stale"}
+
+
+def test_cli_find_wires_recency_end_to_end(tmp_path, capsys):
+    # Through the real `rac find` command (not a manual annotate): the JSON face
+    # carries recency, and the human face flags the ancient match inline.
+    ancient, _fresh = _ancient_and_fresh(tmp_path)
+    cli.main(["find", "widget", str(tmp_path), "--json"])
+    payload = json.loads(capsys.readouterr().out)
+    by_path = {m["path"]: m["recency"] for m in payload["matches"]}
+    assert by_path[ancient]["stale"] is True
+
+    cli.main(["find", "widget", str(tmp_path)])
+    human = capsys.readouterr().out
+    assert "stale" in next(line for line in human.splitlines() if "Ancient Widget" in line)


### PR DESCRIPTION
Initiative 1 (PR-1) of the **freshness-and-drift-detection** roadmap — issue #278. Implements the `rac-freshness-read-surfaces` requirement (flipped to Accepted here).

## Why

Recency already exists in the engine (ADR-045) and on the MCP `get_artifact` response, but the surfaces where readers and agents actually *pick* artifacts — `rac find` and MCP `search_artifacts` — showed nothing about age. A five-year-old artifact and one touched yesterday looked identical in a result list. This makes decay visible exactly where selection happens.

## What

- **New staleness helper over the existing git recency boundary** (`recency.py`): last-committed date, whole-day `age_days` against a configurable threshold, and a `stale` flag. The reference time is injectable so the derived age/flag are deterministic in tests; no new git touchpoint and no git library (ADR-045).
- **Configurable threshold** — default **180 days**, read from a `freshness.stale_after_days` stanza in the shared `.rac/config.yaml` (reuses the existing config-discovery walk). A malformed or non-positive value degrades to the default.
- **`rac find` (JSON + human) and MCP `search_artifacts`** join recency onto each match **after ranking**, so the matched set and order are byte-for-byte identical to before (the ADR-078 contract and its goldens are untouched). The human find output flags a stale match inline with `⚠ stale (Nd)`.
- Additive per ADR-007 (`schema_version` unchanged); degrades to `null` outside git or for untracked files, never a fabricated date (ADR-045). Never a verdict — data beside its date (ADR-034).

## Golden stability

Per the requirement's golden-stability constraint (REQ-006), the byte-pinned find goldens **exclude** the git-derived fields (their `age_days`/`stale` are wall-clock-relative); the recency contract itself is pinned deterministically against controlled-git fixtures in `tests/test_recency.py`. The MCP shape/equivalence tests acknowledge the additive `recency` object the way the existing `provenance` addition did.

## Tests

- Unit: `staleness()` (exact age via injected reference, threshold boundary, unknown-date degrade), `.rac/config.yaml` threshold (default / override / malformed / non-positive), `recency_for_paths`, `annotate_search_recency`.
- Surface: controlled-git fixtures pin the find JSON/human and MCP search join end-to-end, including the CLI `rac find` path and the response-budget invariant (REQ-007).
- Full battery green; `rac validate` / `rac relationships --validate` / `rac review` (no priority 1–2) / agent-rules drift check all clean.

## Scope

Read-surface visibility only. The advisory `suspect-artifact` drift finding is PR-2 (#279); retrieval bias from recency is a later, separately scoped phase.