### PR TITLE
feat(doctor): git-native suspect-artifact drift finding

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -102,7 +102,7 @@ jobs:
           - name: review
             paths: "tests/test_review.py tests/test_cadence.py"
           - name: doctor
-            paths: "tests/test_doctor.py tests/test_links.py"
+            paths: "tests/test_doctor.py tests/test_links.py tests/test_drift.py"
           - name: coverage-report
             paths: "tests/test_coverage.py"
           - name: usage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,17 @@ as candidate relationships.
   a correctness verdict, and it never changes which artifacts match or their order;
   outside a git repository the fields degrade to `null`. Derived from git, never a
   stored frontmatter date (ADR-045).
+- **`rac doctor` flags suspect-artifact drift.** A new advisory `suspect-artifact`
+  finding surfaces the git-native "suspect link": a referring artifact whose
+  resolved relationship target was committed **more recently** than the referrer
+  itself, so the reference may no longer reflect the target. It names the newer
+  target and both commit dates as facts and recommends review — never a verdict,
+  never an auto-fix (ADR-034). Derived purely from git history and the validated
+  relationship graph (ADR-045, ADR-074); only declared, resolvable references
+  participate, so external references (tickets, `verified by`) are excluded
+  (ADR-087). It is warning-only (always exits `0`) and silent outside git or where
+  history cannot answer. `rac review` surfaces the same finding beside its
+  write-cadence advisory.
 
 ## 2026.06.5 — the "rename" release
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -422,6 +422,12 @@ so it is safe in CI; it needs git history and is silent outside a git repository
 or on an empty corpus. The framing is capture cadence, not work tracking
 (ADR-017).
 
+Review also surfaces the advisory **`suspect-artifact` drift** finding — the same
+git-native signal `rac doctor` reports, beside the cadence nudge: a referring
+artifact whose resolved relationship target was committed more recently than it
+was. It is advisory (never changes the exit code) and silent outside git. See the
+[`doctor` section](#suspect-artifact) for the full definition.
+
 ## doctor
 
 One front door for **corpus health**. `rac doctor` runs validation and
@@ -452,6 +458,7 @@ ones are advisory and exit `0`):
 | `high-fan-out-hub` | warning | more resolved edges than `--hub-threshold` |
 | `injection-style-content` | warning | instruction-like content flagged for review |
 | `unlinked-reference` | warning | the body names another artifact with no declared edge |
+| `suspect-artifact` | warning | a resolved reference target changed after this artifact did |
 
 ### unlinked-reference
 
@@ -471,6 +478,24 @@ alias**. The `## Related` sections themselves, fenced code blocks, and
 self-references are excluded; title and free-text matching are out of scope. To
 promote a suggestion, add its line (for example `- adr-074`) under the named
 `## Related <Type>` section.
+
+### suspect-artifact
+
+A target artifact can change while everything referencing it stays untouched, so
+the reference silently goes stale. `suspect-artifact` is the git-native equivalent
+of the "suspect link" enterprise review tools surface: for every **resolved**
+relationship edge, it compares git's last-committed date of the target against the
+referrer's, and flags the referrer when the target changed **more recently**. The
+finding names the newer target and both commit dates as facts and recommends
+review — never a correctness verdict, and never an auto-fix (ADR-034).
+
+It is derived purely from git history and the validated relationship graph
+(ADR-045, ADR-074): only declared, resolvable references participate, so external
+references (tickets, `verified by`) are excluded (ADR-087). It is advisory (always
+exits `0`) and degrades to nothing outside a git repository or where history
+cannot answer (shallow clones, untracked files). `rac review` surfaces the same
+finding through its advisory channel. To clear one, review the referrer and commit
+any update it needs — a newer commit on the referrer resolves the finding.
 
 ## coverage
 

--- a/rac/requirements/rac-drift-advisory-finding.md
+++ b/rac/requirements/rac-drift-advisory-finding.md
@@ -7,7 +7,7 @@ type: requirement
 
 ## Status
 
-Proposed
+Accepted
 
 Classification: `[internal]` — the git-native suspect link. Initiative 2
 (phase 1) of the `freshness-and-drift-detection` roadmap.

--- a/src/rac/output/human.py
+++ b/src/rac/output/human.py
@@ -73,6 +73,7 @@ from rac.services.review import (
     PRIORITY_INVALID_ARTIFACT,
     PRIORITY_MISSING_RECOMMENDED,
     PRIORITY_STALE_CORPUS,
+    PRIORITY_SUSPECT_DRIFT,
     PRIORITY_UNKNOWN_ARTIFACT,
     ReviewReport,
 )
@@ -801,6 +802,7 @@ _PRIORITY_LABELS = {
     PRIORITY_UNKNOWN_ARTIFACT: "Unrecognized artifacts",
     PRIORITY_MISSING_RECOMMENDED: "Missing recommended information",
     PRIORITY_STALE_CORPUS: "Write cadence",
+    PRIORITY_SUSPECT_DRIFT: "Possible drift (review recommended)",
 }
 
 

--- a/src/rac/services/doctor.py
+++ b/src/rac/services/doctor.py
@@ -36,6 +36,7 @@ from typing import Any
 
 from rac.core.artifacts import spec_for
 from rac.core.corpus import CorpusCache, CorpusEntry
+from rac.services.drift import CODE_SUSPECT_ARTIFACT, drift_problem, suspect_drift
 from rac.services.links import detect_unlinked_references
 from rac.services.relationships import (
     ISSUE_DUPLICATE_IDENTIFIER,
@@ -64,6 +65,9 @@ CODE_ORPHANED_ARTIFACT = "orphaned-artifact"
 CODE_HIGH_FAN_OUT_HUB = "high-fan-out-hub"
 CODE_INJECTION_CONTENT = "injection-style-content"
 CODE_UNLINKED_REFERENCE = "unlinked-reference"
+# The git-native suspect-link finding (freshness-and-drift phase 1) is owned by
+# `rac.services.drift` (imported above as CODE_SUSPECT_ARTIFACT); `rac review`
+# consumes the same primitive, so the two surfaces cannot drift apart.
 
 # Heuristic injection-style idioms (REQ-005): instruction overrides, role/system
 # impersonation, concealment from the user, and steering away from recorded
@@ -170,7 +174,7 @@ def diagnose(
 ) -> DoctorReport:
     """Run validation, relationship integrity, and the two new checks in one pass.
 
-    All four phases share one per-invocation :class:`CorpusCache` (WS8), so each
+    The phases share one per-invocation :class:`CorpusCache` (WS8), so each
     artifact is parsed once for the whole run rather than re-parsed by the
     validation, relationship, and degree/injection phases independently. The
     short-circuit is a performance path only — the report is byte-identical to a
@@ -184,6 +188,7 @@ def diagnose(
     findings.extend(_degree_findings(entries, hub_threshold))
     findings.extend(_injection_findings(entries))
     findings.extend(_unlinked_reference_findings(directory, entries, recursive))
+    findings.extend(_suspect_artifact_findings(directory, entries))
     # Deterministic order: errors before warnings, then path, code, problem.
     findings.sort(key=lambda f: (_SEVERITY_RANK[f.severity], f.path, f.code, f.problem))
     return DoctorReport(directory=directory, hub_threshold=hub_threshold, findings=findings)
@@ -336,6 +341,32 @@ def _unlinked_reference_findings(
                     f"Add `{ref.suggested_line}` under `## {ref.related_section}` "
                     "if the link is intended — a suggestion to review; RAC writes "
                     "no edge (ADR-082)."
+                ),
+            )
+        )
+    return findings
+
+
+def _suspect_artifact_findings(directory: str, entries: list[CorpusEntry]) -> list[DoctorFinding]:
+    """Suspect-link drift: a referrer whose resolved target changed more recently.
+
+    Reuses the shared drift primitive (git recency over the validated relationship
+    graph). Advisory WARNINGs only — they name the newer target and both commit
+    dates as facts and recommend review, never a verdict or an auto-fix (REQ-004,
+    ADR-034). Empty outside git or for artifacts whose only references are external
+    (REQ-003, REQ-005), so warning-only runs still exit 0 (REQ-002).
+    """
+    findings: list[DoctorFinding] = []
+    for record in suspect_drift(directory, entries):
+        findings.append(
+            DoctorFinding(
+                path=record.source_path,
+                code=CODE_SUSPECT_ARTIFACT,
+                severity=SEVERITY_WARNING,
+                problem=drift_problem(record),
+                fix=(
+                    "Review whether this artifact still reflects the newer target and "
+                    "update it if needed. Advisory only — RAC changes nothing (ADR-034)."
                 ),
             )
         )

--- a/src/rac/services/drift.py
+++ b/src/rac/services/drift.py
@@ -1,0 +1,111 @@
+"""Git-native suspect-artifact drift detection (freshness-and-drift phase 1).
+
+A target artifact can change while everything referencing it stays untouched.
+The corpus already holds both halves of the evidence — the validated
+relationship graph (ADR-074) and git's commit dates (ADR-045) — but emits no
+signal. This module joins the two into a deterministic, git-native equivalent of
+the "suspect link" enterprise review tools surface: a referring artifact whose
+resolved relationship target was committed *after* the referrer itself last
+changed, so the reference may no longer reflect the target.
+
+The computation is a pure function of git state and the resolved graph — no
+wall-clock input — so a fixed git history yields byte-identical records across
+runs (the golden-stability property the requirement leans on). It is advisory
+only: it names facts (the newer target, both commit dates), never a correctness
+verdict and never an auto-fix (ADR-034). Two consumers wrap the same records into
+their own finding shapes — ``rac doctor`` and ``rac review`` — so the signal has
+one source of truth.
+
+Scope (REQ-003): only declared, resolvable artifact references participate.
+External-reference sections (related tickets, verified by) resolve to no in-corpus
+artifact by design (ADR-087), so they carry no ``resolved_path`` and are excluded
+without a special case. Outside git, or where history cannot answer, every date is
+``None`` and the result is empty — the ADR-045 degrade posture (REQ-005).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from rac.core.corpus import CorpusEntry
+from rac.services.recency import last_committed_for_paths
+from rac.services.relationships import relationships_from_corpus
+
+# Stable finding code, shared by every surface that reports drift (ADR-007). The
+# name is deliberately artifact-scoped, not link-scoped: phase 2 extends the same
+# code to code-scope drift once declared scopes exist, without a rename (REQ-007).
+CODE_SUSPECT_ARTIFACT = "suspect-artifact"
+
+
+@dataclass(frozen=True)
+class DriftRecord:
+    """One suspect edge: a referrer whose resolved target changed more recently.
+
+    ``target_ref`` is the reference text as declared (the source of truth,
+    ADR-016); ``source_committed`` / ``target_committed`` are the evidencing
+    git commit times, both known (a ``None`` on either side is not drift).
+    """
+
+    source_path: str
+    target_path: str
+    target_ref: str
+    source_committed: datetime
+    target_committed: datetime
+
+
+def suspect_drift(directory: str, entries: list[CorpusEntry]) -> list[DriftRecord]:
+    """Resolved relationship edges whose target was committed after the referrer.
+
+    Deterministic and offline: reads the resolved graph (ADR-074) and one
+    last-committed date per involved artifact (ADR-045), then keeps the edges
+    where the target's date is strictly newer than the source's. Deduplicated per
+    ``(source, target)`` pair — a source that references the same target in two
+    sections yields one record — and sorted for a stable order. Empty outside git
+    or when no reference resolves (REQ-003, REQ-005).
+    """
+    resolved = [rel for rel in relationships_from_corpus(entries) if rel.resolved_path is not None]
+    if not resolved:
+        return []
+
+    involved: set[str] = set()
+    for rel in resolved:
+        involved.add(rel.source_path)
+        involved.add(rel.resolved_path)  # type: ignore[arg-type]  # filtered non-None above
+    committed = last_committed_for_paths(directory, involved)
+
+    records: list[DriftRecord] = []
+    seen: set[tuple[str, str]] = set()
+    for rel in resolved:
+        target_path = rel.resolved_path
+        assert target_path is not None  # filtered above
+        source_when = committed.get(rel.source_path)
+        target_when = committed.get(target_path)
+        if source_when is None or target_when is None:
+            continue  # untracked / outside git — degrade to no finding (REQ-005)
+        if target_when <= source_when:
+            continue  # referrer is as new as its target — not suspect
+        key = (rel.source_path, target_path)
+        if key in seen:
+            continue
+        seen.add(key)
+        records.append(
+            DriftRecord(
+                source_path=rel.source_path,
+                target_path=target_path,
+                target_ref=rel.target,
+                source_committed=source_when,
+                target_committed=target_when,
+            )
+        )
+    records.sort(key=lambda d: (d.source_path, d.target_path))
+    return records
+
+
+def drift_problem(record: DriftRecord) -> str:
+    """The shared human-readable finding text: facts only, review recommended."""
+    return (
+        f"references {record.target_ref} which changed more recently "
+        f"(target last committed {record.target_committed.isoformat()}, "
+        f"this artifact {record.source_committed.isoformat()}) — review recommended"
+    )

--- a/src/rac/services/recency.py
+++ b/src/rac/services/recency.py
@@ -402,6 +402,20 @@ def load_freshness_threshold(directory: str) -> int:
     return value
 
 
+def last_committed_for_paths(directory: str, paths: Iterable[str]) -> dict[str, datetime | None]:
+    """Git last-committed time for each of ``paths`` (the raw recency primitive).
+
+    One git boundary (ADR-045): the most-recent commit time per path, or ``None``
+    for an untracked path or when ``directory`` is not a repository — no exception
+    crosses the boundary (REQ-005). Drift detection compares these dates directly;
+    the staleness join layers a threshold on top of the same values.
+    """
+    repo_root = _repository_root(directory)
+    if repo_root is None:
+        return {path: None for path in paths}
+    return {path: _last_committed(repo_root, path) for path in paths}
+
+
 def recency_for_paths(
     directory: str,
     paths: Iterable[str],
@@ -417,12 +431,11 @@ def recency_for_paths(
     """
     if reference is None:
         reference = datetime.now(UTC)
-    repo_root = _repository_root(directory)
-    result: dict[str, Staleness] = {}
-    for path in paths:
-        last = _last_committed(repo_root, path) if repo_root is not None else None
-        result[path] = staleness(last, threshold_days=threshold_days, reference=reference)
-    return result
+    last_by_path = last_committed_for_paths(directory, paths)
+    return {
+        path: staleness(last, threshold_days=threshold_days, reference=reference)
+        for path, last in last_by_path.items()
+    }
 
 
 def annotate_search_recency(

--- a/src/rac/services/review.py
+++ b/src/rac/services/review.py
@@ -25,6 +25,9 @@ from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
+from rac.core.corpus import CorpusCache
+
+from .drift import CODE_SUSPECT_ARTIFACT, drift_problem, suspect_drift
 from .portfolio import (
     ATTENTION_BROKEN_RELATIONSHIP,
     ATTENTION_INVALID,
@@ -41,9 +44,15 @@ PRIORITY_UNKNOWN_ARTIFACT = 3
 PRIORITY_MISSING_RECOMMENDED = 4
 # Write-cadence nudge (v0.13.3): below every other finding, never fails review.
 PRIORITY_STALE_CORPUS = 5
+# Suspect-artifact drift (freshness-and-drift phase 1): a git-native advisory that
+# sits beside the cadence nudge — advisory only, never fails review (REQ-002).
+PRIORITY_SUSPECT_DRIFT = 6
 
 REVIEW_UNKNOWN_ARTIFACT = "unknown-artifact"
 REVIEW_STALE_CORPUS = "stale-corpus"
+# The stable drift code is owned by `rac.services.drift`; re-exported here under
+# the review namespace so both surfaces report the identical code (ADR-007).
+REVIEW_SUSPECT_ARTIFACT = CODE_SUSPECT_ARTIFACT
 
 # Default cadence window when `--stale-after` is given without a value: two
 # weeks (v0.13.3).
@@ -72,6 +81,9 @@ _IMPACT = {
     REVIEW_UNKNOWN_ARTIFACT: "No schema matched, so required structure cannot be checked.",
     REVIEW_STALE_CORPUS: (
         "The write habit has stalled; product knowledge stops reflecting the work."
+    ),
+    REVIEW_SUSPECT_ARTIFACT: (
+        "A referenced artifact changed after this one did, so the reference may be stale."
     ),
 }
 
@@ -190,12 +202,41 @@ def build_review(
     """
     portfolio = build_portfolio_summary(directory, recursive=recursive)
     report = review_from_portfolio(directory, portfolio, recursive=recursive)
+    advisories: list[ReviewIssue] = list(_drift_findings(directory, recursive))
     if stale_after_days is not None:
         finding = _cadence_finding(directory, recursive, stale_after_days, now=now)
         if finding is not None:
-            report.issues.append(finding)
-            report.issues.sort(key=lambda i: (i.priority, i.path, i.code))
+            advisories.append(finding)
+    if advisories:
+        report.issues.extend(advisories)
+        report.issues.sort(key=lambda i: (i.priority, i.path, i.code))
     return report
+
+
+def _drift_findings(directory: str, recursive: bool) -> list[ReviewIssue]:
+    """Suspect-artifact drift advisories, beside the cadence nudge (REQ-002).
+
+    Surfaces the same git-native signal ``rac doctor`` reports, through review's
+    advisory channel: one finding per referrer whose resolved target changed more
+    recently. Advisory only (priority below every blocking finding), so it never
+    changes the review verdict; empty outside git or with no drift (REQ-005).
+    """
+    entries = CorpusCache().collect(directory, recursive=recursive)
+    issues: list[ReviewIssue] = []
+    for record in suspect_drift(directory, entries):
+        issues.append(
+            ReviewIssue(
+                priority=PRIORITY_SUSPECT_DRIFT,
+                severity="warning",
+                path=record.source_path,
+                identifier=Path(record.source_path).stem,
+                code=REVIEW_SUSPECT_ARTIFACT,
+                message=drift_problem(record),
+                action="Run: rac doctor " + directory,
+                impact=impact_for(REVIEW_SUSPECT_ARTIFACT),
+            )
+        )
+    return issues
 
 
 def _cadence_finding(

--- a/tests/test_drift.py
+++ b/tests/test_drift.py
@@ -1,0 +1,242 @@
+"""Suspect-artifact drift detection (freshness-and-drift phase 1).
+
+Each test builds a throwaway git repository under ``tmp_path`` with controlled
+commit times, so the suspect signal is a deterministic function of git state —
+byte-identical across runs (REQ-006) and independent of the wall clock. Drift is
+advisory: it names facts and recommends review, never a verdict, and degrades to
+nothing outside git (REQ-004, REQ-005).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+from rac.core.corpus import CorpusCache
+from rac.services.doctor import diagnose, render_doctor_json
+from rac.services.drift import CODE_SUSPECT_ARTIFACT, suspect_drift
+from rac.services.review import PRIORITY_SUSPECT_DRIFT, build_review
+from rac.services.review import REVIEW_SUSPECT_ARTIFACT as REVIEW_CODE
+
+# A decision that references a requirement (a resolvable in-corpus edge) and a
+# decision whose only reference is an external ticket (never resolves, ADR-087).
+_REQ = (
+    "---\nschema_version: 1\nid: {id}\ntype: requirement\n---\n# {t}\n\n"
+    "## Problem\n\np\n\n## Requirements\n\n[REQ-001] x\n"
+)
+_DEC = (
+    "---\nschema_version: 1\nid: {id}\ntype: decision\n---\n# {t}\n\n## Status\n\n"
+    "Accepted\n\n## Context\n\nc\n\n## Decision\n\nd\n\n## Consequences\n\nk\n\n"
+    "## Related Requirements\n\n- {ref}\n"
+)
+_DEC_TICKET = (
+    "---\nschema_version: 1\nid: {id}\ntype: decision\n---\n# {t}\n\n## Status\n\n"
+    "Accepted\n\n## Context\n\nc\n\n## Decision\n\nd\n\n## Consequences\n\nk\n\n"
+    "## Related Tickets\n\n- {ref}\n"
+)
+
+_RID = "RAC-AAAAAAAAAAA1"
+_DID = "RAC-BBBBBBBBBBB2"
+
+
+def _git(repo: Path, *args: str, when: str | None = None) -> None:
+    env = dict(os.environ)
+    if when is not None:
+        env["GIT_AUTHOR_DATE"] = when
+        env["GIT_COMMITTER_DATE"] = when
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=Test",
+            "-c",
+            "user.email=test@example.com",
+            "-c",
+            "commit.gpgsign=false",
+            *args,
+        ],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        env=env,
+    )
+
+
+def _init(repo: Path) -> None:
+    _git(repo, "init", "--quiet", "--initial-branch=main")
+
+
+def _corpus(tmp_path: Path) -> Path:
+    """A repo where a decision references a requirement; both committed together."""
+    _init(tmp_path)
+    corpus = tmp_path / "rac"
+    corpus.mkdir(parents=True)
+    (corpus / "dec.md").write_text(_DEC.format(id=_DID, t="Dec", ref=_RID), encoding="utf-8")
+    (corpus / "req.md").write_text(_REQ.format(id=_RID, t="Req"), encoding="utf-8")
+    _git(tmp_path, "add", ".")
+    _git(tmp_path, "commit", "--quiet", "-m", "init", when="2026-01-01T00:00:00+00:00")
+    return corpus
+
+
+def _touch(tmp_path: Path, rel: str, body: str, when: str) -> None:
+    (tmp_path / "rac" / rel).write_text(body, encoding="utf-8")
+    _git(tmp_path, "add", ".")
+    _git(tmp_path, "commit", "--quiet", "-m", f"touch {rel}", when=when)
+
+
+# --- primitive (REQ-001, REQ-003, REQ-005) -----------------------------------
+
+
+def _entries(tmp_path: Path) -> list:
+    return CorpusCache().collect(str(tmp_path))
+
+
+def test_target_newer_than_referrer_is_suspect(tmp_path):
+    _corpus(tmp_path)
+    _touch(tmp_path, "req.md", _REQ.format(id=_RID, t="Req v2"), "2026-06-01T00:00:00+00:00")
+    records = suspect_drift(str(tmp_path), _entries(tmp_path))
+    assert len(records) == 1
+    record = records[0]
+    assert Path(record.source_path).name == "dec.md"
+    assert Path(record.target_path).name == "req.md"
+    assert record.target_ref == _RID
+    assert record.target_committed > record.source_committed
+
+
+def test_referrer_newer_than_target_is_not_suspect(tmp_path):
+    _corpus(tmp_path)
+    _touch(
+        tmp_path, "dec.md", _DEC.format(id=_DID, t="Dec v2", ref=_RID), "2026-06-01T00:00:00+00:00"
+    )
+    assert suspect_drift(str(tmp_path), _entries(tmp_path)) == []
+
+
+def test_touching_referrer_clears_the_finding(tmp_path):
+    _corpus(tmp_path)
+    _touch(tmp_path, "req.md", _REQ.format(id=_RID, t="Req v2"), "2026-06-01T00:00:00+00:00")
+    assert len(suspect_drift(str(tmp_path), _entries(tmp_path))) == 1
+    # Committing a newer change to the referrer clears it (Acceptance criterion).
+    _touch(
+        tmp_path, "dec.md", _DEC.format(id=_DID, t="Dec v2", ref=_RID), "2026-07-01T00:00:00+00:00"
+    )
+    assert suspect_drift(str(tmp_path), _entries(tmp_path)) == []
+
+
+def test_equal_commit_time_is_not_suspect(tmp_path):
+    # Committed together (identical time): the referrer is as new as its target.
+    _corpus(tmp_path)
+    assert suspect_drift(str(tmp_path), _entries(tmp_path)) == []
+
+
+def test_external_only_reference_never_drifts(tmp_path):
+    # A decision whose only reference is an external ticket (ADR-087). It resolves
+    # to no in-corpus artifact, so it cannot be a suspect edge (REQ-003), even
+    # after any amount of unrelated churn.
+    _init(tmp_path)
+    corpus = tmp_path / "rac"
+    corpus.mkdir(parents=True)
+    (corpus / "dec.md").write_text(
+        _DEC_TICKET.format(id=_DID, t="Dec", ref="PROJ-42"), encoding="utf-8"
+    )
+    (corpus / "req.md").write_text(_REQ.format(id=_RID, t="Req"), encoding="utf-8")
+    _git(tmp_path, "add", ".")
+    _git(tmp_path, "commit", "--quiet", "-m", "init", when="2026-01-01T00:00:00+00:00")
+    _touch(tmp_path, "req.md", _REQ.format(id=_RID, t="Req v2"), "2026-06-01T00:00:00+00:00")
+    assert suspect_drift(str(tmp_path), _entries(tmp_path)) == []
+
+
+def test_duplicate_edge_yields_one_record(tmp_path):
+    # A decision that references the same requirement in two sections yields a
+    # single deduplicated record.
+    _init(tmp_path)
+    corpus = tmp_path / "rac"
+    corpus.mkdir(parents=True)
+    dec = (
+        f"---\nschema_version: 1\nid: {_DID}\ntype: decision\n---\n# Dec\n\n## Status\n\n"
+        "Accepted\n\n## Context\n\nc\n\n## Decision\n\nd\n\n## Consequences\n\nk\n\n"
+        f"## Related Requirements\n\n- {_RID}\n\n## Supersedes\n\n- {_RID}\n"
+    )
+    (corpus / "dec.md").write_text(dec, encoding="utf-8")
+    (corpus / "req.md").write_text(_REQ.format(id=_RID, t="Req"), encoding="utf-8")
+    _git(tmp_path, "add", ".")
+    _git(tmp_path, "commit", "--quiet", "-m", "init", when="2026-01-01T00:00:00+00:00")
+    _touch(tmp_path, "req.md", _REQ.format(id=_RID, t="Req v2"), "2026-06-01T00:00:00+00:00")
+    assert len(suspect_drift(str(tmp_path), _entries(tmp_path))) == 1
+
+
+def test_outside_git_yields_no_findings(tmp_path):
+    # No `git init`: a plain directory. Degrade to nothing, never an error (REQ-005).
+    corpus = tmp_path / "rac"
+    corpus.mkdir(parents=True)
+    (corpus / "dec.md").write_text(_DEC.format(id=_DID, t="Dec", ref=_RID), encoding="utf-8")
+    (corpus / "req.md").write_text(_REQ.format(id=_RID, t="Req"), encoding="utf-8")
+    assert suspect_drift(str(tmp_path), _entries(tmp_path)) == []
+
+
+def test_records_are_byte_stable_across_runs(tmp_path):
+    _corpus(tmp_path)
+    _touch(tmp_path, "req.md", _REQ.format(id=_RID, t="Req v2"), "2026-06-01T00:00:00+00:00")
+    a = render_doctor_json(diagnose(str(tmp_path)))
+    b = render_doctor_json(diagnose(str(tmp_path)))
+    assert a == b
+
+
+# --- rac doctor surface (REQ-001, REQ-002, REQ-004) --------------------------
+
+
+def test_doctor_emits_advisory_warning_and_exits_zero(tmp_path):
+    _corpus(tmp_path)
+    _touch(tmp_path, "req.md", _REQ.format(id=_RID, t="Req v2"), "2026-06-01T00:00:00+00:00")
+    report = diagnose(str(tmp_path))
+    suspects = [f for f in report.findings if f.code == CODE_SUSPECT_ARTIFACT]
+    assert len(suspects) == 1
+    finding = suspects[0]
+    assert finding.severity == "warning"
+    assert Path(finding.path).name == "dec.md"
+    # Names the newer target and both dates as facts, recommends review (REQ-004).
+    assert _RID in finding.problem
+    assert "2026-06-01T00:00:00+00:00" in finding.problem
+    assert "2026-01-01T00:00:00+00:00" in finding.problem
+    assert "review recommended" in finding.problem
+    assert "Advisory only" in finding.fix
+    # Warning-only run exits zero (REQ-002).
+    assert report.ok
+    assert report.error_count == 0
+
+
+def test_doctor_no_drift_when_nothing_changed(tmp_path):
+    _corpus(tmp_path)
+    report = diagnose(str(tmp_path))
+    assert [f for f in report.findings if f.code == CODE_SUSPECT_ARTIFACT] == []
+
+
+# --- rac review advisory channel (REQ-002) -----------------------------------
+
+
+def test_review_surfaces_drift_as_advisory(tmp_path):
+    _corpus(tmp_path)
+    _touch(tmp_path, "req.md", _REQ.format(id=_RID, t="Req v2"), "2026-06-01T00:00:00+00:00")
+    report = build_review(str(tmp_path))
+    drift = [i for i in report.issues if i.code == REVIEW_CODE]
+    assert len(drift) == 1
+    issue = drift[0]
+    assert issue.priority == PRIORITY_SUSPECT_DRIFT
+    assert issue.severity == "warning"
+    assert _RID in issue.message
+    # Advisory only: it never fails the review (no priority 1-2 finding).
+    assert report.ok
+
+
+def test_review_drift_and_doctor_report_the_same_code(tmp_path):
+    # One source of truth: both surfaces use the drift primitive's stable code.
+    assert REVIEW_CODE == CODE_SUSPECT_ARTIFACT
+
+
+def test_review_human_labels_the_drift_group(tmp_path):
+    from rac.output.human import render_review_human
+
+    _corpus(tmp_path)
+    _touch(tmp_path, "req.md", _REQ.format(id=_RID, t="Req v2"), "2026-06-01T00:00:00+00:00")
+    rendered = render_review_human(build_review(str(tmp_path)))
+    assert "Possible drift" in rendered


### PR DESCRIPTION
Initiative 2 (PR-2) of the **freshness-and-drift-detection** roadmap — issue #279. Implements the `rac-drift-advisory-finding` requirement (flipped to Accepted here). Completes phase 1, following #306.

## Why

A target artifact can change while everything referencing it stays untouched — the reference silently goes stale. The corpus already holds both halves of the evidence (the validated relationship graph and git's commit dates) but emitted no signal. This is the git-native equivalent of the "suspect link" enterprise review tools surface.

## What

- **New shared drift primitive** (`rac.services.drift`): for every **resolved** relationship edge, compare git's last-committed date of the target against the referrer's, and flag the referrer when the target changed **more recently**. It is a pure function of git state (no wall-clock input), so a fixed history yields **byte-identical** records — the golden-stability property the requirement leans on.
- **`rac doctor`** gains a warning-severity **`suspect-artifact`** finding that names the newer target and both commit dates as facts and recommends review — never a verdict, never an auto-fix (ADR-034).
- **`rac review`** surfaces the same finding through its advisory channel, beside the write-cadence nudge, at its own priority below every blocking finding — so it never changes the review verdict.
- Scoped to **declared, resolvable** references only, so external references (tickets, `verified by`) are excluded (ADR-087). Warning-only — `rac doctor` still exits `0` (REQ-002). Degrades to nothing outside git or where history cannot answer (shallow clones, untracked files; REQ-005). One shared stable code across both surfaces, so they cannot drift apart.

## Golden stability (REQ-006)

The finding is a deterministic function of git state, and the byte-pinned doctor/review golden fixtures declare no resolvable cross-references, so no drift finding appears in any uncontrolled-git golden — the existing golden suite passes unchanged. Drift behaviour is pinned against controlled-history fixtures in `tests/test_drift.py`.

## Tests

- Primitive: target-newer is suspect; referrer-newer and equal-time are not; touching the referrer clears it; external-only never drifts; duplicate edge dedups; byte-stable across runs; no-git yields zero findings and zero errors.
- Surfaces: `rac doctor` warning + exit 0 with the target/dates/review-recommended text; `rac review` advisory at its own priority; both report the identical code; human render labels the drift group.
- Full battery green (1878 passed); `rac validate` / `rac relationships --validate` / `rac review` (no priority 1–2) / agent-rules drift check all clean.

## Note on volume

On the live rac-core corpus this surfaces ~129 advisories today — mostly artifacts whose shared targets (e.g. an ADR or a growth-requirement) were touched in recent batch corpus edits. That is the "real findings in hand" the requirement's Assumptions anticipate for phase-1 tuning; it is advisory (doctor exits 0, review stays clean) and filterable by the stable code. Finer "meaningful change" scoping is explicitly deferred within phase 1.

## Scope

Advisory only — no CI-failing gate ships this phase (REQ-007). The finding shape admits additive extension to code-scope drift once `decision-to-code-proximity`'s declared scopes exist, without renaming the stable code.