### PR TITLE
docs(recipes): integration recipe factory + first three harness recipes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,18 @@ as candidate relationships.
   (ADR-087). It is warning-only (always exits `0`) and silent outside git or where
   history cannot answer. `rac review` surfaces the same finding beside its
   write-cadence advisory.
+- **A template and gate for harness integration recipes.** Connecting a coding
+  agent to RAC is documentation, not engine work — the same push
+  (`rac export --agent-rules`) / pull (`lore` MCP) / post-edit-enforcement shape
+  each time. A new [`examples/_recipe-template/`](examples/_recipe-template/) plus
+  an [authoring guide](docs/integration-recipes.md) capture that shape (the README
+  skeleton, the `lore` invocation in JSON/TOML/YAML, and the `examples/guide/`
+  verify close), so a contributor produces a consistent `examples/<client>/` recipe
+  by filling the template — with a fixed enforcement section that never drifts into
+  pre-edit interception (ADR-067) and zero `rac-core` engine diff. A recipe is
+  listed in [`docs/ecosystem.md`](docs/ecosystem.md) only after it is smoke-tested
+  against a released engine; until then it ships carrying a
+  `verify against <client> <version>` marker and stays off the table.
 
 ## 2026.06.5 — the "rename" release
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,7 +108,12 @@ as candidate relationships.
   pre-edit interception (ADR-067) and zero `rac-core` engine diff. A recipe is
   listed in [`docs/ecosystem.md`](docs/ecosystem.md) only after it is smoke-tested
   against a released engine; until then it ships carrying a
-  `verify against <client> <version>` marker and stays off the table.
+  `verify against <client> <version>` marker and stays off the table. Ships with
+  the first three recipes authored from the template —
+  [`examples/windsurf/`](examples/windsurf/README.md),
+  [`examples/cline/`](examples/cline/README.md), and
+  [`examples/zed/`](examples/zed/README.md) — each documented but not yet verified,
+  so they carry the marker and are not listed in `docs/ecosystem.md`.
 
 ## 2026.06.5 — the "rename" release
 

--- a/docs/ecosystem.md
+++ b/docs/ecosystem.md
@@ -30,3 +30,14 @@ An entry is one row in the table above. The criteria:
 Entries are added by a pull request changing the single table row.
 The project's contribution policy is pending; until it is published,
 external additions cannot yet be accepted.
+
+### Harness integration recipes
+
+A harness integration (a worked `examples/<client>/` setup connecting a
+coding agent to RAC) follows a template and a verification gate — see the
+[integration recipes authoring guide](integration-recipes.md). A recipe is
+listed here **only after it is smoke-tested against a released engine
+version** by running the grounding demo ([`examples/guide/`](https://github.com/itsthelore/rac-core/blob/main/examples/guide/demo.md))
+with the harness connected. Until then it ships as documentation carrying a
+`verify against <client> <version>` marker and stays off this table — the
+real-and-verified rule made a precondition of the row, not a courtesy.

--- a/docs/integration-recipes.md
+++ b/docs/integration-recipes.md
@@ -1,0 +1,132 @@
+# Integration recipes — authoring guide
+
+RAC meets a coding agent on two surfaces it does not own: a generated
+agent-instructions file the agent reads (the **push**), and the `lore` MCP server
+the agent connects to for live retrieval (the **pull**). Because both are standard
+surfaces, connecting a new harness is **documentation, not engine work** — a worked
+`examples/<client>/` setup plus a row in [`docs/ecosystem.md`](ecosystem.md).
+
+This guide is the authoring contract for those recipes. The shapes recur — the same
+`lore` invocation in three config dialects, the same push/pull/enforcement README
+structure, the same "verify with the grounding demo" close — so a new recipe is
+filling a template, not reverse-engineering an existing one. Every recipe adds
+**zero `rac-core` engine diff**: it consumes only the two stable surfaces (the
+export and the MCP server) as additive contracts (ADR-007, ADR-008, ADR-063), and
+stores and serves nothing new (ADR-024).
+
+## The template
+
+Copy [`examples/_recipe-template/`](../examples/_recipe-template/) to
+`examples/<client>/` and fill it in. It carries the README skeleton and the `lore`
+invocation in all three config dialects; the inline HTML comments tell you what to
+replace and what to leave alone. You should be able to produce a complete,
+structurally consistent recipe from the template and this checklist **without
+opening another recipe** — the same way `rac new` makes an artifact from its
+template (ADR-021).
+
+## The recurring shape
+
+A recipe README has these parts, in this order:
+
+1. **Title and framing** — `# RAC with <Client>`, then one line naming the two
+   surfaces (the context file the client reads, and the `lore` MCP server).
+2. **Prerequisites** — `pip install rac-core` and a corpus under `rac/`.
+3. **Context file (the push)** — `rac export rac/ --agent-rules`, and which
+   generated file this client reads (`AGENTS.md` is the glob-free default;
+   `CLAUDE.md` and `.github/copilot-instructions.md` are the other targets).
+4. **The `lore` MCP server (the pull)** — the config path for this client and the
+   server invocation in the client's dialect (below). Name the five read-only
+   tools and note the server re-reads the corpus per call and never writes.
+5. **Enforcement is separate** — the fixed ADR-067 paragraph (below). Do not
+   reword it.
+6. **Verify it** — the grounding demo, [`examples/guide/`](../examples/guide/demo.md).
+7. **Summary** — the three-row table (context file, `lore` MCP, CI gate).
+
+### The `lore` invocation, in three dialects
+
+Every recipe runs the same server — `rac mcp --root .` — expressed in whichever
+config dialect the harness uses. Keep only the one your harness reads.
+
+```json
+{ "mcpServers": { "lore": { "command": "rac", "args": ["mcp", "--root", "."] } } }
+```
+
+```toml
+[mcp_servers.lore]
+command = "rac"
+args = ["mcp", "--root", "."]
+```
+
+```yaml
+mcpServers:
+  lore:
+    command: rac
+    args: [mcp, --root, .]
+```
+
+Use a project-scoped config path (commit it to share with the team); for a global
+config, use an absolute `--root` path.
+
+### The enforcement section is fixed (ADR-067)
+
+Every recipe's enforcement section describes **context-supply plus post-edit CI
+only** — never a pre-edit interception hook — restated identically so the boundary
+never drifts. Copy this paragraph verbatim, swapping only the client name:
+
+> RAC supplies context and enforces *after* the edit (ADR-067). There is no
+> platform API to veto a `<Client>` agent edit before it lands, so `<Client>`
+> relies on the post-edit guard: `rac validate` / `rac relationships --validate`
+> and the GitHub Action / pre-merge gate, the same as any contributor.
+
+A harness that offers a pre-edit hook is tempting to describe as enforcement — do
+not. The single exception is Claude Code's pre-edit veto, which is
+Claude-Code-specific and documented only in [`examples/claude-code/`](../examples/claude-code/README.md);
+every other recipe points readers there rather than describing a hook of its own.
+
+## Authoring checklist
+
+- [ ] Copied `examples/_recipe-template/` to `examples/<client>/` and removed every
+      `<PLACEHOLDER>` and HTML comment.
+- [ ] Section 1 names `rac export rac/ --agent-rules` and the exact context file
+      this client reads.
+- [ ] Section 2 shows the one config dialect and path this client uses, and names
+      the five read-only tools.
+- [ ] Section 3 is the fixed ADR-067 paragraph, client name swapped, nothing else
+      changed — no pre-edit hook described.
+- [ ] The "Verify it" close points at [`examples/guide/`](../examples/guide/demo.md).
+- [ ] The recipe adds **no** `rac-core` source diff (documentation only).
+- [ ] The recipe carries the `verify against <client> <version>` marker and is
+      **not** yet added to `docs/ecosystem.md` (see the verification gate below).
+
+## The verification gate
+
+A recipe that is *written* is not yet a recipe that is *proven*. The line between
+"documented" and "verified against a released engine" is hard and explicit, so a
+reader can trust every harness [`docs/ecosystem.md`](ecosystem.md) lists.
+
+- **Documented (unverified).** A freshly authored recipe ships carrying the
+  `verify against <client> <version>` marker (the convention already used in
+  [`docs/mcp.md`](mcp.md)) and **stays off** the `docs/ecosystem.md` table. It is
+  useful documentation; it makes no verified-integration claim.
+- **Verified.** Smoke-test the recipe against a **released** `rac-core` version by
+  running the grounding demo ([`examples/guide/`](../examples/guide/demo.md)) with
+  the harness connected over the recipe's config — the same engine behaviour every
+  recipe is proven against. Only then remove the marker and add a
+  `docs/ecosystem.md` row, dated against the version it was smoke-tested on.
+
+Each `docs/ecosystem.md` row is **real and verified** — a named harness, a verified
+recipe, dated against its engine version — with no row added before smoke-test.
+This keeps the ecosystem table trustworthy and stops it drifting into a vague
+"works with any MCP client" claim. The gate is documentation and process
+discipline over the existing surfaces; it requires no engine change.
+
+## Related
+
+- [`docs/ecosystem.md`](ecosystem.md) — the verified-integration table these
+  recipes graduate into.
+- [`docs/mcp.md`](mcp.md) — per-client MCP setup and the `verify against` marker
+  convention.
+- Existing recipes to model against once you have the shape:
+  [`examples/cursor/`](../examples/cursor/README.md),
+  [`examples/codex/`](../examples/codex/README.md),
+  [`examples/copilot/`](../examples/copilot/README.md).

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -21,6 +21,11 @@ Replace `/path/to/your/repo` with the absolute path to the directory that
 contains your RAC artifacts (or the `rac/` subdirectory within it). Use the
 path you would pass to `rac validate`.
 
+> Adding a client that is not listed here? Every harness connects on the same two
+> surfaces (the generated agent-instructions file and the `lore` MCP server), so a
+> new integration is a documented recipe, not engine work — follow the
+> [integration recipes authoring guide](integration-recipes.md).
+
 ### Claude Code
 
 **Command form** (adds the server to your Claude Code session):

--- a/examples/_recipe-template/README.md
+++ b/examples/_recipe-template/README.md
@@ -1,0 +1,99 @@
+<!--
+RECIPE TEMPLATE — copy this directory to examples/<client>/ and fill it in.
+
+How to author a new harness recipe from this template alone (no need to read an
+existing recipe): see docs/integration-recipes.md for the full checklist. Replace
+every <PLACEHOLDER>, keep the three numbered sections and the "Verify it" close in
+this order, and delete the config dialect(s) your harness does not use. Do NOT
+change the wording of section 3 (Enforcement) — it is fixed by ADR-067 so the
+boundary reads identically across every recipe. Delete these HTML comments as you
+go; a finished recipe carries none of them.
+-->
+# RAC with <Client>
+
+[<Client>](<client-url>) consumes RAC on two surfaces — a generated context file
+<Client> reads, and the `lore` MCP server it connects to. A stranger can reproduce
+this from the file alone.
+
+## Prerequisites
+
+```bash
+pip install rac-core   # the `rac` CLI and the `lore` MCP server
+```
+
+A repository with a RAC corpus under `rac/` (run `rac quickstart`, or use this
+repository's own `rac/`).
+
+## 1. Context file (the push)
+
+```bash
+rac export rac/ --agent-rules
+```
+
+This writes several agent-context files; <Client> reads **`<CONTEXT-FILE>`**
+<!-- e.g. AGENTS.md (the glob-free default), CLAUDE.md, or .github/copilot-instructions.md -->
+as plain instructions. The managed block keeps your own content intact; re-run on
+change (`rac export rac/ --agent-rules --check` fails CI on drift).
+
+## 2. The `lore` MCP server (the pull)
+
+Add **`<CONFIG-PATH>`** <!-- e.g. .cursor/mcp.json, ~/.codex/config.toml --> with the
+`lore` server invocation (a sample is in [`<SAMPLE-FILE>`](<SAMPLE-FILE>)):
+
+<!-- Keep only the dialect your harness uses; delete the others. -->
+```json
+{
+  "mcpServers": {
+    "lore": { "command": "rac", "args": ["mcp", "--root", "."] }
+  }
+}
+```
+
+```toml
+[mcp_servers.lore]
+command = "rac"
+args = ["mcp", "--root", "."]
+```
+
+```yaml
+mcpServers:
+  lore:
+    command: rac
+    args: [mcp, --root, .]
+```
+
+- **Project:** commit `<CONFIG-PATH>` to share it with the team.
+- **Global:** `<GLOBAL-CONFIG-PATH>` — use an absolute `--root` path.
+
+It exposes the five read-only `lore` tools (`get_summary`, `search_artifacts`,
+`get_artifact`, `get_related`, `find_decisions`); the server re-reads the corpus on
+every call and never writes to the repo.
+
+## 3. Enforcement is separate, and <Client>-agnostic
+
+<!-- FIXED WORDING (ADR-067). Only swap <Client> for the harness name; change nothing
+else in this section so the boundary reads identically across every recipe. -->
+RAC supplies context and enforces *after* the edit (ADR-067). There is no platform
+API to veto a <Client> agent edit before it lands, so <Client> relies on the
+post-edit guard: `rac validate` / `rac relationships --validate` and the GitHub
+Action / pre-merge gate, the same as any contributor. (A pre-edit veto is
+Claude-Code-specific — see [`examples/claude-code/`](../claude-code/README.md).)
+
+## Verify it
+
+Run the bundled grounding demo — same task twice, once unconnected and once with
+`lore` connected — and watch the connected run respect a recorded decision the
+unconnected run violates: [`examples/guide/`](../guide/demo.md).
+
+## Summary
+
+| Surface | Command | What <Client> does with it |
+| --- | --- | --- |
+| `<CONTEXT-FILE>` | `rac export rac/ --agent-rules` | Reads it as project instructions |
+| `lore` MCP | `<CONFIG-PATH>` → `rac mcp --root .` | Calls `find_decisions` / `get_related` on demand |
+| CI gate | `rac validate` · `rac relationships --validate` | Enforces on every PR |
+
+<!-- Before this recipe is listed in docs/ecosystem.md it MUST be smoke-tested against
+a released rac-core version (docs/integration-recipes.md, the verification gate).
+Until then, keep the marker below and stay off the ecosystem table. -->
+<!-- TODO: verify against <Client> <version> before listing in docs/ecosystem.md -->

--- a/examples/_recipe-template/config.example.toml
+++ b/examples/_recipe-template/config.example.toml
@@ -1,0 +1,5 @@
+# The same `lore` server invocation as the JSON and YAML dialects, in TOML.
+# Some harnesses (e.g. OpenAI Codex) namespace MCP servers under `mcp_servers`.
+[mcp_servers.lore]
+command = "rac"
+args = ["mcp", "--root", "."]

--- a/examples/_recipe-template/mcp.example.json
+++ b/examples/_recipe-template/mcp.example.json
@@ -1,0 +1,5 @@
+{
+  "mcpServers": {
+    "lore": { "command": "rac", "args": ["mcp", "--root", "."] }
+  }
+}

--- a/examples/_recipe-template/mcp.example.yaml
+++ b/examples/_recipe-template/mcp.example.yaml
@@ -1,0 +1,5 @@
+# The same `lore` server invocation as the JSON and TOML dialects, in YAML.
+mcpServers:
+  lore:
+    command: rac
+    args: [mcp, --root, .]

--- a/examples/cline/README.md
+++ b/examples/cline/README.md
@@ -1,0 +1,84 @@
+# RAC with Cline
+
+[Cline](https://cline.bot) consumes RAC on two surfaces — a rules file Cline reads,
+and the `lore` MCP server it connects to. A stranger can reproduce this from the
+file alone.
+
+## Prerequisites
+
+```bash
+pip install rac-core   # the `rac` CLI and the `lore` MCP server
+```
+
+A repository with a RAC corpus under `rac/` (run `rac quickstart`, or use this
+repository's own `rac/`).
+
+## 1. Context (the push)
+
+```bash
+rac export rac/ --agent-rules
+```
+
+This writes `AGENTS.md` and friends — but Cline reads its own rules format
+(`.clinerules`), not `AGENTS.md`, so the durable grounding for Cline comes through
+the `lore` MCP server in section 2. Add a short rule that points Cline at it —
+create **`.clinerules`** (a file, or `.clinerules/rac.md` in the directory form) in
+the repo root:
+
+```md
+# Recorded decisions (RAC)
+
+This repository records product decisions as RAC artifacts under `rac/`. Before
+designing or changing anything a decision might cover, query the `lore` MCP tools
+(`search_artifacts`, `find_decisions`, `get_related`) and follow what they return;
+cite decisions by ID. Recorded decisions take precedence over conventions inferred
+from the code.
+```
+
+The rule is a pointer; the substance is served live by `lore` (section 2), so it
+never drifts out of date. (`rac export rac/ --agent-rules --check` still keeps the
+generated `AGENTS.md` honest for any tool that does read it.)
+
+## 2. The `lore` MCP server (the pull)
+
+Open Cline's **MCP Servers** panel → **Configure MCP Servers** to edit
+`cline_mcp_settings.json`, and add the `lore` server (a sample is in
+[`cline_mcp_settings.example.json`](cline_mcp_settings.example.json)):
+
+```json
+{
+  "mcpServers": {
+    "lore": { "command": "rac", "args": ["mcp", "--root", "."] }
+  }
+}
+```
+
+Cline runs the server over stdio; use an absolute `--root` path (the directory you
+would pass to `rac validate`). The server appears in the MCP Servers panel with its
+tool list once live. It exposes the five read-only `lore` tools (`get_summary`,
+`search_artifacts`, `get_artifact`, `get_related`, `find_decisions`); the server
+re-reads the corpus on every call and never writes to the repo.
+
+## 3. Enforcement is separate, and Cline-agnostic
+
+RAC supplies context and enforces *after* the edit (ADR-067). There is no platform
+API to veto a Cline agent edit before it lands, so Cline relies on the post-edit
+guard: `rac validate` / `rac relationships --validate` and the GitHub Action /
+pre-merge gate, the same as any contributor. (A pre-edit veto is
+Claude-Code-specific — see [`examples/claude-code/`](../claude-code/README.md).)
+
+## Verify it
+
+Run the bundled grounding demo — same task twice, once unconnected and once with
+`lore` connected — and watch the connected run respect a recorded decision the
+unconnected run violates: [`examples/guide/`](../guide/demo.md).
+
+## Summary
+
+| Surface | Command | What Cline does with it |
+| --- | --- | --- |
+| `.clinerules` | (hand-written pointer) | Reads it as project rules |
+| `lore` MCP | `cline_mcp_settings.json` → `rac mcp --root <abs>` | Calls `find_decisions` / `get_related` on demand |
+| CI gate | `rac validate` · `rac relationships --validate` | Enforces on every PR |
+
+<!-- TODO: verify against Cline <version> before listing in docs/ecosystem.md -->

--- a/examples/cline/README.md
+++ b/examples/cline/README.md
@@ -81,4 +81,15 @@ unconnected run violates: [`examples/guide/`](../guide/demo.md).
 | `lore` MCP | `cline_mcp_settings.json` → `rac mcp --root <abs>` | Calls `find_decisions` / `get_related` on demand |
 | CI gate | `rac validate` · `rac relationships --validate` | Enforces on every PR |
 
+## Verification status
+
+- **Engine half — mechanically verified (2026-07-04).** The `rac mcp` invocation
+  this recipe prescribes was smoke-tested over stdio against `examples/guide/`: the
+  five `lore` tools respond and `search_artifacts` / `get_artifact` / `get_related`
+  return the grounding decision. This is the RAC-owned half every recipe shares.
+- **Harness half — not yet verified.** Running the grounding demo *through Cline
+  itself* (config parsing plus a live agent) needs the released app and an API key
+  — a human/CI step. Until it is done, this recipe keeps the `verify against`
+  marker below and stays out of [`docs/ecosystem.md`](../../docs/ecosystem.md).
+
 <!-- TODO: verify against Cline <version> before listing in docs/ecosystem.md -->

--- a/examples/cline/cline_mcp_settings.example.json
+++ b/examples/cline/cline_mcp_settings.example.json
@@ -1,0 +1,5 @@
+{
+  "mcpServers": {
+    "lore": { "command": "rac", "args": ["mcp", "--root", "."] }
+  }
+}

--- a/examples/windsurf/README.md
+++ b/examples/windsurf/README.md
@@ -80,4 +80,15 @@ unconnected run violates: [`examples/guide/`](../guide/demo.md).
 | `lore` MCP | `~/.codeium/windsurf/mcp_config.json` → `rac mcp --root <abs>` | Calls `find_decisions` / `get_related` on demand |
 | CI gate | `rac validate` · `rac relationships --validate` | Enforces on every PR |
 
+## Verification status
+
+- **Engine half — mechanically verified (2026-07-04).** The `rac mcp` invocation
+  this recipe prescribes was smoke-tested over stdio against `examples/guide/`: the
+  five `lore` tools respond and `search_artifacts` / `get_artifact` / `get_related`
+  return the grounding decision. This is the RAC-owned half every recipe shares.
+- **Harness half — not yet verified.** Running the grounding demo *through Windsurf
+  itself* (config parsing plus a live agent) needs the released app and an API key
+  — a human/CI step. Until it is done, this recipe keeps the `verify against`
+  marker below and stays out of [`docs/ecosystem.md`](../../docs/ecosystem.md).
+
 <!-- TODO: verify against Windsurf <version> before listing in docs/ecosystem.md -->

--- a/examples/windsurf/README.md
+++ b/examples/windsurf/README.md
@@ -1,0 +1,83 @@
+# RAC with Windsurf
+
+[Windsurf](https://windsurf.com) consumes RAC on two surfaces — a rules file
+Cascade reads, and the `lore` MCP server it connects to. A stranger can reproduce
+this from the file alone.
+
+## Prerequisites
+
+```bash
+pip install rac-core   # the `rac` CLI and the `lore` MCP server
+```
+
+A repository with a RAC corpus under `rac/` (run `rac quickstart`, or use this
+repository's own `rac/`).
+
+## 1. Context (the push)
+
+```bash
+rac export rac/ --agent-rules
+```
+
+This writes `AGENTS.md` and friends — but Windsurf reads its own rules format
+(`.windsurf/rules/*.md`), not `AGENTS.md`, so the durable grounding for Windsurf
+comes through the `lore` MCP server in section 2. Add a short rule that points
+Cascade at it — create **`.windsurf/rules/rac.md`**:
+
+```md
+# Recorded decisions (RAC)
+
+This repository records product decisions as RAC artifacts under `rac/`. Before
+designing or changing anything a decision might cover, query the `lore` MCP tools
+(`search_artifacts`, `find_decisions`, `get_related`) and follow what they return;
+cite decisions by ID. Recorded decisions take precedence over conventions inferred
+from the code.
+```
+
+The rule is a pointer; the substance is served live by `lore` (section 2), so it
+never drifts out of date. (`rac export rac/ --agent-rules --check` still keeps the
+generated `AGENTS.md` honest for any tool that does read it.)
+
+## 2. The `lore` MCP server (the pull)
+
+Add the `lore` server to Windsurf's MCP config at
+**`~/.codeium/windsurf/mcp_config.json`** (a sample is in
+[`mcp_config.example.json`](mcp_config.example.json)):
+
+```json
+{
+  "mcpServers": {
+    "lore": { "command": "rac", "args": ["mcp", "--root", "."] }
+  }
+}
+```
+
+The config is global, so use an absolute `--root` path (the directory you would
+pass to `rac validate`). Refresh servers in Cascade's MCP panel after saving. It
+exposes the five read-only `lore` tools (`get_summary`, `search_artifacts`,
+`get_artifact`, `get_related`, `find_decisions`); the server re-reads the corpus on
+every call and never writes to the repo.
+
+## 3. Enforcement is separate, and Windsurf-agnostic
+
+RAC supplies context and enforces *after* the edit (ADR-067). There is no platform
+API to veto a Windsurf agent edit before it lands, so Windsurf relies on the
+post-edit guard: `rac validate` / `rac relationships --validate` and the GitHub
+Action / pre-merge gate, the same as any contributor. (A pre-edit veto is
+Claude-Code-specific — see [`examples/claude-code/`](../claude-code/README.md).)
+
+## Verify it
+
+Run the bundled grounding demo — same task twice, once unconnected and once with
+`lore` connected — and watch the connected run respect a recorded decision the
+unconnected run violates: [`examples/guide/`](../guide/demo.md).
+
+## Summary
+
+| Surface | Command | What Windsurf does with it |
+| --- | --- | --- |
+| `.windsurf/rules/rac.md` | (hand-written pointer) | Reads it as an always-on rule |
+| `lore` MCP | `~/.codeium/windsurf/mcp_config.json` → `rac mcp --root <abs>` | Calls `find_decisions` / `get_related` on demand |
+| CI gate | `rac validate` · `rac relationships --validate` | Enforces on every PR |
+
+<!-- TODO: verify against Windsurf <version> before listing in docs/ecosystem.md -->

--- a/examples/windsurf/mcp_config.example.json
+++ b/examples/windsurf/mcp_config.example.json
@@ -1,0 +1,5 @@
+{
+  "mcpServers": {
+    "lore": { "command": "rac", "args": ["mcp", "--root", "."] }
+  }
+}

--- a/examples/zed/README.md
+++ b/examples/zed/README.md
@@ -75,4 +75,15 @@ unconnected run violates: [`examples/guide/`](../guide/demo.md).
 | `lore` MCP | `settings.json` → `context_servers.lore` | Calls `find_decisions` / `get_related` on demand |
 | CI gate | `rac validate` · `rac relationships --validate` | Enforces on every PR |
 
+## Verification status
+
+- **Engine half — mechanically verified (2026-07-04).** The `rac mcp` invocation
+  this recipe prescribes was smoke-tested over stdio against `examples/guide/`: the
+  five `lore` tools respond and `search_artifacts` / `get_artifact` / `get_related`
+  return the grounding decision. This is the RAC-owned half every recipe shares.
+- **Harness half — not yet verified.** Running the grounding demo *through Zed
+  itself* (config parsing plus a live agent) needs the released app and an API key
+  — a human/CI step. Until it is done, this recipe keeps the `verify against`
+  marker below and stays out of [`docs/ecosystem.md`](../../docs/ecosystem.md).
+
 <!-- TODO: verify against Zed <version> before listing in docs/ecosystem.md -->

--- a/examples/zed/README.md
+++ b/examples/zed/README.md
@@ -1,0 +1,78 @@
+# RAC with Zed
+
+[Zed](https://zed.dev) consumes RAC on two surfaces — a generated context file Zed
+reads, and the `lore` MCP server it connects to. A stranger can reproduce this from
+the file alone.
+
+## Prerequisites
+
+```bash
+pip install rac-core   # the `rac` CLI and the `lore` MCP server
+```
+
+A repository with a RAC corpus under `rac/` (run `rac quickstart`, or use this
+repository's own `rac/`).
+
+## 1. Context file (the push)
+
+```bash
+rac export rac/ --agent-rules
+```
+
+This writes several agent-context files; Zed reads **`AGENTS.md`** at the project
+root as agent **Instructions** (Zed's always-on rules are its Instructions, which
+include a project `AGENTS.md`). No extra step — the recorded decisions reach Zed's
+Agent Panel as instructions. The managed block keeps your own content intact;
+re-run on change (`rac export rac/ --agent-rules --check` fails CI on drift).
+
+## 2. The `lore` MCP server (the pull)
+
+Zed keys MCP servers under **`context_servers`** (not `mcpServers`), added at the
+top level of `settings.json` (a sample is in
+[`settings.example.json`](settings.example.json)):
+
+```json
+{
+  "context_servers": {
+    "lore": {
+      "source": "custom",
+      "command": "rac",
+      "args": ["mcp", "--root", "."],
+      "env": {}
+    }
+  }
+}
+```
+
+- **Project:** `.zed/settings.json` in the repo root (commit it to share with the
+  team).
+- **Global:** your user `settings.json` — use an absolute `--root` path.
+
+Zed restarts the server process on save (no editor restart). It exposes the five
+read-only `lore` tools (`get_summary`, `search_artifacts`, `get_artifact`,
+`get_related`, `find_decisions`); the server re-reads the corpus on every call and
+never writes to the repo.
+
+## 3. Enforcement is separate, and Zed-agnostic
+
+RAC supplies context and enforces *after* the edit (ADR-067). There is no platform
+API to veto a Zed agent edit before it lands, so Zed relies on the post-edit guard:
+`rac validate` / `rac relationships --validate` and the GitHub Action / pre-merge
+gate, the same as any contributor. (A pre-edit veto is Claude-Code-specific — see
+[`examples/claude-code/`](../claude-code/README.md).)
+
+## Verify it
+
+Run the bundled grounding demo — same task twice, once unconnected and once with
+`lore` connected — and watch the connected run respect a recorded decision the
+unconnected run violates: [`examples/guide/`](../guide/demo.md).
+
+## Summary
+
+| Surface | Command | What Zed does with it |
+| --- | --- | --- |
+| `AGENTS.md` | `rac export rac/ --agent-rules` | Reads it as agent Instructions |
+| `lore` MCP | `settings.json` → `context_servers.lore` | Calls `find_decisions` / `get_related` on demand |
+| CI gate | `rac validate` · `rac relationships --validate` | Enforces on every PR |
+
+<!-- TODO: verify against Zed <version> before listing in docs/ecosystem.md -->

--- a/examples/zed/settings.example.json
+++ b/examples/zed/settings.example.json
@@ -1,0 +1,10 @@
+{
+  "context_servers": {
+    "lore": {
+      "source": "custom",
+      "command": "rac",
+      "args": ["mcp", "--root", "."],
+      "env": {}
+    }
+  }
+}

--- a/rac/requirements/rac-recipe-authoring-contract.md
+++ b/rac/requirements/rac-recipe-authoring-contract.md
@@ -7,7 +7,7 @@ type: requirement
 
 ## Status
 
-Proposed
+Accepted
 
 Classification: `[internal]` — a contributor-facing authoring contract, not
 a CLI behaviour. Initiative 1 of the `integration-recipe-factory` roadmap.

--- a/rac/requirements/rac-recipe-verification-gate.md
+++ b/rac/requirements/rac-recipe-verification-gate.md
@@ -7,7 +7,7 @@ type: requirement
 
 ## Status
 
-Proposed
+Accepted
 
 Classification: `[internal]` — governs when a recipe becomes a listed,
 verified integration. Initiative 3 of the `integration-recipe-factory`


### PR DESCRIPTION
Takes **`integration-recipe-factory`** (rank-6 Tranche A of `deterministic-substrate`, #248) into build. Ships the authoring contract, the verification gate, **and the first three recipes authored from the template**. Implements `rac-recipe-authoring-contract` and `rac-recipe-verification-gate` (both Accepted here). **Zero `rac-core` engine diff** — every change is documentation.

## Why

Connecting a coding agent to RAC is documentation, not engine work: every harness meets RAC on the same two surfaces — the generated agent-instructions file (the push) and the `lore` MCP server (the pull) — with the same post-edit enforcement boundary (ADR-067). Recipes were added ad hoc, risking structural drift (most dangerously into describing a pre-edit hook as enforcement). This names the recurring shape and proves it with three real recipes.

## What

**Initiative 1 — authoring template + contract** (`rac-recipe-authoring-contract`):
- **`examples/_recipe-template/`** — a copyable skeleton (README with the fixed push/pull/enforcement/verify structure + the `lore` invocation in JSON/TOML/YAML).
- **`docs/integration-recipes.md`** — the authoring guide: the recurring shape, the three dialects, the **fixed ADR-067 enforcement paragraph**, and a checklist. Fill the template → a consistent per-client `examples/` recipe without reading another (ADR-021).

**Initiative 3 — verification gate** (`rac-recipe-verification-gate`):
- A recipe reaches `docs/ecosystem.md` **only after** smoke-testing against a **released** engine via the `examples/guide/` demo; until then it carries a verify-against-client-version marker and stays off the table. Wired into `docs/ecosystem.md` and `docs/mcp.md`.

**First three recipes** (Initiative 2 — proving the template; config surfaces confirmed against current vendor docs):
- **`examples/zed/`** — the clean case: Zed reads the generated `AGENTS.md` natively (its Instructions), and connects `lore` via `settings.json` → `context_servers`.
- **`examples/windsurf/`** — Windsurf reads `.windsurf/rules/*.md` (not AGENTS.md), so the push is a short pointer rule and the `lore` MCP pull (`~/.codeium/windsurf/mcp_config.json`) carries the live grounding.
- **`examples/cline/`** — same bridge pattern: `.clinerules` pointer + `lore` via `cline_mcp_settings.json`.
- All three are **documented, not yet verified** — they carry the verify-against-client-version marker and are **not** listed in `docs/ecosystem.md`, exactly as the gate requires.

## Boundary & scope

- Recipes consume only the two stable surfaces (`rac export --agent-rules`, the `lore` MCP server) as additive contracts (ADR-007/008/063); no engine code, no new served surface (ADR-024). Verified: no `src/` diff.
- Enforcement is context-supply + post-edit CI only (ADR-067/065), fixed wording across every recipe; the one pre-edit veto (Claude Code) stays documented only in its own recipe.
- Follow-ups: verifying these three against a released engine (then adding their ecosystem rows), and Initiative 2's fuller prioritised backlog.

## Verification

- `rac validate rac/` / `rac relationships --validate` / `rac review` (no priority 1–2) / agent-rules drift check all clean.
- Full test battery green (1878 passed). New `examples/` dirs are gated by no test (only `examples/guide/` is dogfood-gated); the three MCP config samples parse as valid JSON.
- Harness config surfaces confirmed against current vendor documentation (Windsurf `mcp_config.json`; Cline `cline_mcp_settings.json`; Zed `context_servers`).