### PR TITLE
docs(recipes): harness backlog + opencode recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,7 +113,10 @@ as candidate relationships.
   [`examples/windsurf/`](examples/windsurf/README.md),
   [`examples/cline/`](examples/cline/README.md), and
   [`examples/zed/`](examples/zed/README.md) — each documented but not yet verified,
-  so they carry the marker and are not listed in `docs/ecosystem.md`.
+  so they carry the marker and are not listed in `docs/ecosystem.md`. The guide
+  also carries a dated, adoption-ordered **harness backlog** — honest about what is
+  shipped, drafted, or a candidate, and about which candidates are superseded
+  (Gemini CLI is being wound down; Roo Code is archived).
 
 ## 2026.06.5 — the "rename" release
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,14 +109,15 @@ as candidate relationships.
   listed in [`docs/ecosystem.md`](docs/ecosystem.md) only after it is smoke-tested
   against a released engine; until then it ships carrying a
   `verify against <client> <version>` marker and stays off the table. Ships with
-  the first three recipes authored from the template —
+  the first four recipes authored from the template —
   [`examples/windsurf/`](examples/windsurf/README.md),
-  [`examples/cline/`](examples/cline/README.md), and
-  [`examples/zed/`](examples/zed/README.md) — each documented but not yet verified,
-  so they carry the marker and are not listed in `docs/ecosystem.md`. The guide
-  also carries a dated, adoption-ordered **harness backlog** — honest about what is
-  shipped, drafted, or a candidate, and about which candidates are superseded
-  (Gemini CLI is being wound down; Roo Code is archived).
+  [`examples/cline/`](examples/cline/README.md),
+  [`examples/zed/`](examples/zed/README.md), and
+  [`examples/opencode/`](examples/opencode/README.md) — each documented but not yet
+  verified, so they carry the marker and are not listed in `docs/ecosystem.md`. The
+  guide also carries a dated, adoption-ordered **harness backlog** — honest about
+  what is shipped, drafted, or a candidate, and about which candidates are
+  superseded (Gemini CLI is being wound down; Roo Code is archived).
 
 ## 2026.06.5 — the "rename" release
 

--- a/docs/integration-recipes.md
+++ b/docs/integration-recipes.md
@@ -120,6 +120,46 @@ This keeps the ecosystem table trustworthy and stops it drifting into a vague
 "works with any MCP client" claim. The gate is documentation and process
 discipline over the existing surfaces; it requires no engine change.
 
+## Harness backlog
+
+The harnesses worth a recipe, ordered by adoption signal — not completeness
+(chasing every MCP client is unbounded). The list is honest about what is
+*shipped*, *drafted*, or a *candidate*, and it is **dated**, because the landscape
+moves fast: a harness can be archived or superseded between releases, so re-check
+before starting one. Priority follows real adoption, not this table's row order.
+
+_Last reviewed: 2026-07-04._
+
+| Harness | Status | Notes |
+| --- | --- | --- |
+| Claude Code | Verified — listed | [`examples/claude-code/`](../examples/claude-code/README.md); reads `CLAUDE.md`, plus the skill and the pre-edit veto hook |
+| Cursor | Verified — listed | [`examples/cursor/`](../examples/cursor/README.md); reads `AGENTS.md` |
+| GitHub Copilot | Verified — listed | [`examples/copilot/`](../examples/copilot/README.md); reads `.github/copilot-instructions.md` |
+| OpenAI Codex | Verified — listed | [`examples/codex/`](../examples/codex/README.md); reads `AGENTS.md` |
+| Amp | Verified — listed | [`examples/amp/`](../examples/amp/README.md); reads `AGENTS.md` |
+| Omnigent | Documented | [`examples/omnigent/`](../examples/omnigent/README.md); in `docs/mcp.md`, not yet an ecosystem row |
+| Zed | Drafted — unverified | [`examples/zed/`](../examples/zed/README.md); reads `AGENTS.md` natively (clean); engine half smoke-tested |
+| Windsurf | Drafted — unverified | [`examples/windsurf/`](../examples/windsurf/README.md); own rules file + MCP pull |
+| Cline | Drafted — unverified | [`examples/cline/`](../examples/cline/README.md); own rules file + MCP pull |
+| opencode | Candidate — high | Most-starred open-source agent (2026); `AGENTS.md`-native + MCP — a clean recipe like Zed |
+| Goose | Candidate | Block's MCP-native agent; instruction surface to confirm on authoring |
+| Continue | Candidate | Open-source, VS Code + JetBrains; MCP + a rules file |
+| Kilo Code | Candidate | VS Code agent; MCP; the migration target for former Roo Code users |
+| JetBrains AI | Candidate | JetBrains IDE assistant; MCP + a guidelines file |
+
+**Superseded / not worth a recipe (as of 2026-07-04):**
+
+- **Gemini CLI** — Google is winding down request serving (mid-2026) in favour of
+  the closed-source **Antigravity CLI**; hold until the successor's integration
+  surfaces settle before drafting one.
+- **Roo Code** — archived and read-only (final release May 2026). Do not start a
+  recipe; its users are migrating to Cline or Kilo Code, both already listed above.
+
+To pick up a candidate: follow [the template](#the-template), draft
+`examples/<client>/`, ship it with its `verify against <client> <version>` marker,
+and move it to *Drafted* here. It reaches *Verified — listed* only after the
+harness-connected smoke test clears [the verification gate](#the-verification-gate).
+
 ## Related
 
 - [`docs/ecosystem.md`](ecosystem.md) — the verified-integration table these

--- a/docs/integration-recipes.md
+++ b/docs/integration-recipes.md
@@ -141,7 +141,7 @@ _Last reviewed: 2026-07-04._
 | Zed | Drafted — unverified | [`examples/zed/`](../examples/zed/README.md); reads `AGENTS.md` natively (clean); engine half smoke-tested |
 | Windsurf | Drafted — unverified | [`examples/windsurf/`](../examples/windsurf/README.md); own rules file + MCP pull |
 | Cline | Drafted — unverified | [`examples/cline/`](../examples/cline/README.md); own rules file + MCP pull |
-| opencode | Candidate — high | Most-starred open-source agent (2026); `AGENTS.md`-native + MCP — a clean recipe like Zed |
+| opencode | Drafted — unverified | [`examples/opencode/`](../examples/opencode/README.md); reads `AGENTS.md` natively (clean); engine half smoke-tested |
 | Goose | Candidate | Block's MCP-native agent; instruction surface to confirm on authoring |
 | Continue | Candidate | Open-source, VS Code + JetBrains; MCP + a rules file |
 | Kilo Code | Candidate | VS Code agent; MCP; the migration target for former Roo Code users |

--- a/examples/opencode/README.md
+++ b/examples/opencode/README.md
@@ -1,0 +1,89 @@
+# RAC with opencode
+
+[opencode](https://opencode.ai) consumes RAC on two surfaces — a generated context
+file opencode reads, and the `lore` MCP server it connects to. A stranger can
+reproduce this from the file alone.
+
+## Prerequisites
+
+```bash
+pip install rac-core   # the `rac` CLI and the `lore` MCP server
+```
+
+A repository with a RAC corpus under `rac/` (run `rac quickstart`, or use this
+repository's own `rac/`).
+
+## 1. Context file (the push)
+
+```bash
+rac export rac/ --agent-rules
+```
+
+This writes several agent-context files; opencode reads **`AGENTS.md`** at the
+project root natively as its instructions. No extra step — the recorded decisions
+reach opencode's agent as instructions. The managed block keeps your own content
+intact; re-run on change (`rac export rac/ --agent-rules --check` fails CI on
+drift).
+
+## 2. The `lore` MCP server (the pull)
+
+opencode keys MCP servers under an **`mcp`** block, with a local (stdio) server
+given as a `command` **array**. Add it to `opencode.json` in the repo root (a
+sample is in [`opencode.example.json`](opencode.example.json)):
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "lore": {
+      "type": "local",
+      "command": ["rac", "mcp", "--root", "."],
+      "enabled": true
+    }
+  }
+}
+```
+
+- **Project:** `opencode.json` in the repo root (commit it to share with the team).
+- **Global:** `~/.config/opencode/opencode.json` — use an absolute `--root` path.
+- Or run `opencode mcp add` and follow the prompts; `opencode mcp list` shows the
+  server and its connection status.
+
+It exposes the five read-only `lore` tools (`get_summary`, `search_artifacts`,
+`get_artifact`, `get_related`, `find_decisions`); the server re-reads the corpus on
+every call and never writes to the repo.
+
+## 3. Enforcement is separate, and opencode-agnostic
+
+RAC supplies context and enforces *after* the edit (ADR-067). There is no platform
+API to veto an opencode agent edit before it lands, so opencode relies on the
+post-edit guard: `rac validate` / `rac relationships --validate` and the GitHub
+Action / pre-merge gate, the same as any contributor. (A pre-edit veto is
+Claude-Code-specific — see [`examples/claude-code/`](../claude-code/README.md).)
+
+## Verify it
+
+Run the bundled grounding demo — same task twice, once unconnected and once with
+`lore` connected — and watch the connected run respect a recorded decision the
+unconnected run violates: [`examples/guide/`](../guide/demo.md).
+
+## Summary
+
+| Surface | Command | What opencode does with it |
+| --- | --- | --- |
+| `AGENTS.md` | `rac export rac/ --agent-rules` | Reads it as instructions |
+| `lore` MCP | `opencode.json` → `mcp.lore` (`rac mcp --root .`) | Calls `find_decisions` / `get_related` on demand |
+| CI gate | `rac validate` · `rac relationships --validate` | Enforces on every PR |
+
+## Verification status
+
+- **Engine half — mechanically verified (2026-07-04).** The `rac mcp` invocation
+  this recipe prescribes was smoke-tested over stdio against `examples/guide/`: the
+  five `lore` tools respond and `search_artifacts` / `get_artifact` / `get_related`
+  return the grounding decision. This is the RAC-owned half every recipe shares.
+- **Harness half — not yet verified.** Running the grounding demo *through opencode
+  itself* (config parsing plus a live agent) needs the released client and an API
+  key — a human/CI step. Until it is done, this recipe keeps the `verify against`
+  marker below and stays out of [`docs/ecosystem.md`](../../docs/ecosystem.md).
+
+<!-- TODO: verify against opencode <version> before listing in docs/ecosystem.md -->

--- a/examples/opencode/opencode.example.json
+++ b/examples/opencode/opencode.example.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "lore": {
+      "type": "local",
+      "command": ["rac", "mcp", "--root", "."],
+      "enabled": true
+    }
+  }
+}


### PR DESCRIPTION
Initiative 2 of `integration-recipe-factory` (#248): the prioritised harness backlog **and the first candidate picked up from it** — the opencode recipe. Follows the template + gate + first three recipes (#309). **Zero engine diff** — documentation only.

## The harness backlog

A dated, adoption-ordered backlog in `docs/integration-recipes.md` — the full integration landscape in one honest table (verified-listed → drafted-unverified → candidate). Priority follows real adoption, not completeness; the list is explicitly non-exhaustive and re-checkable.

It already earned its keep: two candidates the roadmap itself named have since lapsed, recorded as **superseded** rather than sending someone to write a dead recipe —
- **Gemini CLI** — Google is winding it down (mid-2026) for the closed-source Antigravity CLI; hold.
- **Roo Code** — archived / read-only since May 2026; users migrating to Cline / Kilo Code.

## The opencode recipe (first candidate → drafted)

`examples/opencode/` — opencode is the most-starred open-source agent (2026) and reads the generated **`AGENTS.md`** natively, so it's a clean recipe like Zed. The `lore` server connects via `opencode.json`'s `mcp` block (a local stdio `command` array with a schema URL — its own dialect). Authored from the template; the backlog row moves opencode **Candidate → Drafted** (Goose becomes the new top candidate).

Like the other drafted recipes, it carries the **engine-half mechanical-verification note** (the `rac mcp` invocation was smoke-tested over stdio) and the `verify against opencode <version>` marker, and stays **off `docs/ecosystem.md`** until the harness-connected step clears the gate.

## Scope & verification

- Documentation only — no engine diff, no corpus/requirement change.
- `rac validate rac/` clean; the `opencode.json` sample parses as valid JSON; no test surface touched.

With this, `integration-recipe-factory` has delivered all three initiatives plus four recipes (Zed, Windsurf, Cline, opencode). The remaining follow-up is the human/CI harness-connected verification for any of the four.