### PR TITLE
feat(mcp): lean-context-delivery — measured surface budget, selective retrieval, CLI-first path

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -96,7 +96,7 @@ jobs:
           - name: relationships
             paths: "tests/test_relationships.py tests/test_relationships_cmd.py tests/test_relationship_validation.py tests/test_relationship_graph.py tests/test_lifecycle_status.py tests/test_rename.py"
           - name: resolve
-            paths: "tests/test_resolve.py tests/test_find_decisions.py tests/test_scope.py tests/test_explain.py"
+            paths: "tests/test_resolve.py tests/test_find_decisions.py tests/test_scope.py tests/test_explain.py tests/test_selective_retrieval.py"
           - name: eval
             paths: "tests/test_eval.py"
           - name: review

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,7 +92,7 @@ jobs:
           - name: explorer
             paths: "tests/test_explorer_adapter.py tests/test_explorer_app.py tests/test_explorer_cli.py tests/test_explorer_commands.py tests/test_explorer_editor.py tests/test_explorer_isolation.py tests/test_explorer_workspace.py"
           - name: mcp
-            paths: "tests/test_mcp_server.py tests/test_mcp_tools.py tests/test_mcp_isolation.py tests/test_mcp_telemetry.py tests/test_mcp_ping.py tests/test_mcp_audit.py tests/test_mcp_http.py tests/test_derived_cache.py"
+            paths: "tests/test_mcp_server.py tests/test_mcp_tools.py tests/test_mcp_isolation.py tests/test_mcp_telemetry.py tests/test_mcp_ping.py tests/test_mcp_audit.py tests/test_mcp_http.py tests/test_derived_cache.py tests/test_mcp_surface_budget.py"
           - name: relationships
             paths: "tests/test_relationships.py tests/test_relationships_cmd.py tests/test_relationship_validation.py tests/test_relationship_graph.py tests/test_lifecycle_status.py tests/test_rename.py"
           - name: resolve

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,17 @@ as candidate relationships.
   guide also carries a dated, adoption-ordered **harness backlog** — honest about
   what is shipped, drafted, or a candidate, and about which candidates are
   superseded (Gemini CLI is being wound down; Roo Code is archived).
+- **The MCP surface is measured and budgeted.** A knowledge server justifies
+  itself only if it stays lean, so the agent-facing footprint — the five tool
+  descriptions and their JSON schemas a client pays for every session — is now a
+  regression-checked property. A deterministic, offline token count (no model, no
+  network — ADR-066) holds the standing surface under a stated budget: today it
+  measures ~915 tokens against a 1000 budget (for context, comparable MCP servers
+  have been cited around 23k), so a description or schema edit that inflates the
+  surface fails CI rather than quietly taxing every session. Raising the budget
+  needs explicit justification and is itself capped; a representative response is
+  budgeted too. The served five-tool surface is unchanged — this measures, it does
+  not shrink (ADR-033).
 
 ## 2026.06.5 — the "rename" release
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,17 @@ as candidate relationships.
   needs explicit justification and is itself capped; a representative response is
   budgeted too. The served five-tool surface is unchanged — this measures, it does
   not shrink (ADR-033).
+- **Lean context delivery documented.** A new
+  [Context Cost](docs/context-cost.md) guide explains how Lore keeps the agent-
+  facing footprint small: the measured MCP budget, **selective on-demand retrieval
+  by default** (search and lookup return the relevant artifacts, never the whole
+  corpus — the antidote to context rot; bulk delivery is an explicit `rac export`,
+  not a default), and the **CLI as a first-class, lowest-tax delivery path**
+  (`find` / `resolve` / `relationships` ground an agent with zero standing token
+  cost, with when-to-use-which guidance against the MCP server — both stay
+  supported, neither is deprecated). Selectivity is by scoping, never by lossy
+  compression (ADR-066); the selective-by-default guarantee is now asserted in the
+  test suite.
 
 ## 2026.06.5 — the "rename" release
 

--- a/docs/context-cost.md
+++ b/docs/context-cost.md
@@ -1,0 +1,87 @@
+# Context cost & lean delivery
+
+A knowledge server justifies itself only if it stays lean — otherwise it becomes
+the noise it was meant to cure. Two findings shape how Lore delivers knowledge to
+an agent:
+
+- **Context rot.** Every frontier model degrades as input grows, well before the
+  window fills — so dumping a corpus at an agent *actively worsens* output.
+- **The MCP "context tax."** A tool surface spends token real estate on
+  descriptions and schemas before it answers anything; oversized surfaces have
+  been cited around ~23k tokens.
+
+Lore's answer is three deliberate properties: a **measured, budgeted** tool
+surface, **selective on-demand** retrieval by default, and a **CLI delivery path**
+that spends no standing tokens at all. None of them uses AI summarisation or
+compression — payloads stay small because they are *scoped*, not lossily shrunk
+(ADR-066).
+
+## 1. The MCP surface is measured and budgeted
+
+The standing cost of the MCP server — the five tool descriptions and their JSON
+schemas a client loads every session — is measured deterministically and offline
+(no model, no network) and held under a budget as a regression check. Today it
+measures ~915 tokens against a 1000 budget — roughly 25× under the ~23k figure the
+context-tax critique cited. A description or schema edit that inflates the surface
+fails CI rather than quietly taxing every session (see the
+[`rac-mcp-surface-budget`](https://github.com/itsthelore/rac-core/blob/main/rac/requirements/rac-mcp-surface-budget.md)
+requirement and `rac/mcp/surface.py`).
+
+## 2. Retrieval is selective and on-demand by default
+
+Both delivery surfaces return the **relevant** artifacts for a query, never the
+whole corpus:
+
+- `search_artifacts` / `rac find` return the matches for a query — a small, scoped
+  result set, ranked and bounded by the response budget (ADR-033).
+- `get_artifact` / `rac resolve` return **one** artifact by id.
+- `get_related` / `rac relationships` return an artifact's immediate neighbours,
+  not a transitive dump.
+
+This is the antidote to context rot: an agent receives small, relevant payloads by
+construction, and pulls more only when it asks. **Bulk, whole-corpus delivery is an
+explicit, opt-in action** — `rac export` — never a retrieval default. No default
+path hands an agent the entire corpus; it must request it.
+
+## 3. The CLI is a first-class, lowest-tax delivery path
+
+The MCP server is not the only way to ground an agent, and it is not always the
+leanest. A CLI spends **no** standing token tax — it costs nothing until invoked —
+which is why the context-tax critique steers toward CLI utilities. Lore's
+CLI-first posture (ADR-005) makes this a supported choice, not an afterthought:
+`find`, `resolve`, and `relationships` deliver the same grounding the MCP tools do.
+
+Ground an agent through the CLI by having it shell out and read JSON:
+
+```bash
+# What did we already decide about deleting users?
+rac find "delete user" rac/ --json
+
+# Read the specific decision the search surfaced.
+rac resolve RAC-01JY4M8X2QZ7 rac/ --json
+
+# Which recorded decisions govern the file I'm about to edit?
+rac decisions-for src/users/repository.py rac/ --json
+
+# What else would this change affect?
+rac relationships rac/ --json
+```
+
+Each returns a small, scoped, JSON payload the agent can act on — the same
+selective-by-default retrieval as the MCP path, with zero standing surface cost.
+
+### When to use which
+
+Both surfaces are first-class and supported; the choice is a context-cost
+trade-off, not a deprecation.
+
+| Prefer the **CLI path** when… | Prefer the **MCP server** when… |
+| --- | --- |
+| The agent can shell out (CI jobs, scripted agents, terminal tools) | The agent calls tools autonomously mid-conversation |
+| You want zero standing token cost — nothing is paid until a command runs | You want the model to decide *when* to retrieve, from the tool descriptions alone |
+| Grounding is a discrete step in a pipeline | Grounding is interactive and continuous |
+
+The MCP server stays fully documented and supported — see
+[MCP Server](mcp.md). The CLI commands are in the [CLI Reference](cli.md). Use
+whichever spends the context you can afford; neither is deprecated in favour of the
+other.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,7 @@ nav:
   - MCP Server: mcp.md
   - Shared Server: shared-server.md
   - CLI Reference: cli.md
+  - Context Cost: context-cost.md
   - Watchkeeper: watchkeeper.md
   - Artifacts: artifacts.md
   - Relationships: relationships.md

--- a/rac/designs/lean-context-delivery-measurement.md
+++ b/rac/designs/lean-context-delivery-measurement.md
@@ -7,11 +7,13 @@ type: design
 
 ## Status
 
-Proposed
+Accepted
 
 The concrete accounting method behind `lean-context-delivery` Initiative 1 —
 input to the implementation, not a substitute for the acceptance criteria in
-`rac-mcp-surface-budget`. The Open Questions below are the pickup agenda.
+`rac-mcp-surface-budget`. Implemented in `rac/mcp/surface.py` and checked by
+`tests/test_mcp_surface_budget.py`; the Open Questions below are now resolved and
+recorded there.
 
 ## Context
 
@@ -105,14 +107,27 @@ adjacent, so a change to either is reviewed together.
 
 ## Open Questions
 
-- The exact tokenisation rule to standardise on for the offline count, and how
-  to keep it stable if the surface's serialization changes.
-- The initial budget value and how much headroom to leave above today's
-  measured surface.
-- Whether the "typical response" should be a single representative page or a
-  small basket of queries averaged, and how to pin it against corpus growth.
-- Whether the standing cost (descriptions + schemas) and the per-call cost
-  (typical response) get separate budgets or one combined ceiling.
+All four are now resolved and encoded in `rac/mcp/surface.py`:
+
+- **Tokenisation rule** → a dependency-free deterministic count: word runs
+  (alphanumeric) and each standalone punctuation character count as one token
+  (regex `[A-Za-z0-9]+|[^\sA-Za-z0-9]`). A real model tokenizer would tie the
+  number to a model vocabulary and add a dependency, against the offline/lean
+  posture (ADR-066); the design's own Rationale accepts a faithful-enough proxy,
+  and this is it. Stable across serialization changes because it counts the
+  serialized bytes as advertised, not a model's view of them.
+- **Initial budget + headroom** → the standing surface measures ~915 tokens
+  today; the enforced budget is **1000**. It may be raised only with explicit
+  approval and written justification, up to a hard cap of **1250** (a test pins
+  that the budget constant itself stays within the cap, so a bump is never
+  silent).
+- **Typical response** → a small fixed basket — a representative
+  `search_artifacts` page and a `get_artifact` payload — measured over the pinned
+  `examples/guide` corpus, each held under a per-call ceiling.
+- **Separate vs combined budgets** → **separate**: a corpus-independent standing
+  budget (descriptions + schemas, the headline context-tax number) and a per-call
+  budget over the fixture basket. They catch different regressions — surface bloat
+  versus response-serialization bloat.
 
 ## Related Requirements
 

--- a/rac/requirements/rac-cli-first-delivery.md
+++ b/rac/requirements/rac-cli-first-delivery.md
@@ -7,7 +7,7 @@ type: requirement
 
 ## Status
 
-Proposed
+Accepted
 
 Classification: `[external]` — a user-facing, documented delivery path.
 Initiative 3 of the `lean-context-delivery` roadmap.

--- a/rac/requirements/rac-mcp-surface-budget.md
+++ b/rac/requirements/rac-mcp-surface-budget.md
@@ -7,7 +7,7 @@ type: requirement
 
 ## Status
 
-Proposed
+Accepted
 
 Classification: `[internal]` — a measured, regression-checked property of the
 agent-facing surface. Initiative 1 of the `lean-context-delivery` roadmap.

--- a/rac/requirements/rac-selective-retrieval-default.md
+++ b/rac/requirements/rac-selective-retrieval-default.md
@@ -7,7 +7,7 @@ type: requirement
 
 ## Status
 
-Proposed
+Accepted
 
 Classification: `[internal]` — a default-behaviour guarantee for the retrieval
 path. Initiative 2 of the `lean-context-delivery` roadmap.

--- a/src/rac/mcp/surface.py
+++ b/src/rac/mcp/surface.py
@@ -1,0 +1,120 @@
+"""Measured MCP surface budget (lean-context-delivery, Initiative 1).
+
+A knowledge server justifies itself only if it stays lean; otherwise it becomes
+the "context tax" it was meant to cure. ADR-033 records the instinct as a
+response budget, but nothing measured the *standing* agent-facing footprint — the
+tool descriptions and JSON schemas a client pays for every session — so drift was
+invisible: a description edit or a new field could inflate the surface with no
+signal.
+
+This module measures that footprint deterministically and offline (ADR-066): no
+model, no network. A fixed input yields a fixed integer via one stated
+tokenisation rule, so the number is reproducible from the inputs alone and can be
+held to a budget as a regression check (`tests/test_mcp_surface_budget.py`). It
+counts the existing five-tool surface exactly as served — it adds no tool, removes
+none, and compresses nothing (REQ-004).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from typing import Any
+
+# --- The stated tokenisation rule (REQ-002) ----------------------------------
+#
+# Word runs (alphanumeric) and each standalone non-space, non-alphanumeric
+# character (punctuation) count as one token. Dependency-free and deterministic —
+# reproducible from the input alone. A real model tokenizer (e.g. tiktoken) would
+# tie the number to a model's vocabulary and add a dependency, against the lean,
+# offline posture (ADR-066); the design accepts a faithful-enough proxy, and this
+# is it. Underscores split words (they are punctuation here), which is fine: the
+# rule only has to be fixed and stated, not match any one model.
+_TOKEN = re.compile(r"[A-Za-z0-9]+|[^\sA-Za-z0-9]")
+
+
+def approx_tokens(text: str) -> int:
+    """The deterministic, offline token count of ``text`` (the stated rule)."""
+    return len(_TOKEN.findall(text))
+
+
+# --- Budgets (kept beside the check; a change here is reviewed with it) -------
+#
+# The enforced ceiling on the standing surface (descriptions + schemas), in
+# tokens. Measured surface today is ~915; the budget holds it under 1000. Raising
+# it is a reviewed edit that MUST carry justification, and it may not exceed the
+# hard cap below without a deeper reconsideration (a test pins that the budget
+# itself stays within the cap).
+STANDING_BUDGET_TOKENS = 1000
+# The absolute cap on the budget constant itself: the standing budget may be
+# raised — with explicit approval and written justification — up to here, and
+# never silently past it.
+STANDING_BUDGET_HARD_CAP = 1250
+# The per-call response ceiling over the pinned fixture basket, in tokens. It
+# catches serialization field-bloat in a typical response that sits below
+# ADR-033's serve-time truncation cap; the two are complementary (REQ-005).
+PER_CALL_BUDGET_TOKENS = 1400
+
+
+@dataclass(frozen=True)
+class ToolCost:
+    """One tool's standing token cost: its description and its JSON schema."""
+
+    name: str
+    description_tokens: int
+    schema_tokens: int
+
+    @property
+    def total(self) -> int:
+        return self.description_tokens + self.schema_tokens
+
+
+@dataclass(frozen=True)
+class SurfaceMeasurement:
+    """The standing token cost of the served tool surface, per tool and summed."""
+
+    tools: tuple[ToolCost, ...]
+
+    @property
+    def standing_tokens(self) -> int:
+        return sum(t.total for t in self.tools)
+
+    @property
+    def description_tokens(self) -> int:
+        return sum(t.description_tokens for t in self.tools)
+
+    @property
+    def schema_tokens(self) -> int:
+        return sum(t.schema_tokens for t in self.tools)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "standing_tokens": self.standing_tokens,
+            "description_tokens": self.description_tokens,
+            "schema_tokens": self.schema_tokens,
+            "budget": STANDING_BUDGET_TOKENS,
+            "tools": [
+                {"name": t.name, "description": t.description_tokens, "schema": t.schema_tokens}
+                for t in self.tools
+            ],
+        }
+
+
+async def measure_surface(server: Any) -> SurfaceMeasurement:
+    """The standing token cost of ``server``'s tool surface (descriptions + schemas).
+
+    Corpus-independent: it counts the served tool descriptions and their JSON
+    schemas exactly as advertised to a client, over the stated tokenisation rule.
+    Tools are sorted by name so the measurement is order-stable.
+    """
+    tools = await server.list_tools()
+    costs = tuple(
+        ToolCost(
+            name=tool.name,
+            description_tokens=approx_tokens(tool.description or ""),
+            schema_tokens=approx_tokens(json.dumps(tool.inputSchema, sort_keys=True)),
+        )
+        for tool in sorted(tools, key=lambda t: t.name)
+    )
+    return SurfaceMeasurement(tools=costs)

--- a/tests/test_mcp_surface_budget.py
+++ b/tests/test_mcp_surface_budget.py
@@ -1,0 +1,113 @@
+"""Measured MCP surface budget (lean-context-delivery Init 1, ADR-033 / ADR-066).
+
+The agent-facing footprint is a regression-checked property, not silent drift: a
+deterministic, offline token count of the five-tool surface (descriptions +
+schemas) held under a stated budget, plus a per-call response ceiling over a
+pinned fixture. No model, no network — the same input yields the same integer, so
+a description or schema that inflates past the budget fails here rather than
+quietly taxing every session.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from conftest import fixture_path
+
+from rac.mcp.server import build_server
+from rac.mcp.surface import (
+    PER_CALL_BUDGET_TOKENS,
+    STANDING_BUDGET_HARD_CAP,
+    STANDING_BUDGET_TOKENS,
+    approx_tokens,
+    measure_surface,
+)
+
+# Two independent corpora: the standing surface (descriptions + schemas) must be
+# identical over both, proving it is corpus-independent. The per-call basket runs
+# over the grounding-demo corpus so the representative response is meaningful.
+MCP_CORPUS = fixture_path("mcp", "corpus")
+GUIDE_CORPUS = str(Path(__file__).parent.parent / "examples" / "guide")
+DECISION = "GUIDE-KTW9YBDWDBFM"  # ADR-001, the grounding decision
+
+
+def _measure(root: str):
+    return asyncio.run(measure_surface(build_server(root)))
+
+
+def _response(root: str, tool: str, args: dict) -> str:
+    async def call() -> str:
+        contents, _ = await build_server(root).call_tool(tool, args)
+        return contents[0].text
+
+    return asyncio.run(call())
+
+
+# --- the tokenisation rule (REQ-002) -----------------------------------------
+
+
+def test_token_rule_is_the_stated_deterministic_count():
+    # Word runs and standalone punctuation each count once; whitespace is skipped.
+    assert approx_tokens("") == 0
+    assert approx_tokens("hello world") == 2
+    assert approx_tokens("a, b.") == 4  # a , b .
+    # Underscores split words (they are punctuation under the rule) — pinned so
+    # the behaviour is explicit, since tool names carry them.
+    assert approx_tokens("get_artifact") == 3  # get _ artifact
+
+
+# --- standing surface budget (REQ-001, REQ-003, REQ-004) ---------------------
+
+
+def test_standing_surface_is_within_budget():
+    measurement = _measure(MCP_CORPUS)
+    assert measurement.standing_tokens <= STANDING_BUDGET_TOKENS, (
+        f"MCP standing surface is {measurement.standing_tokens} tokens, over the "
+        f"{STANDING_BUDGET_TOKENS} budget. Trim a tool description or schema, or "
+        f"raise the budget (with justification, up to {STANDING_BUDGET_HARD_CAP}) "
+        "beside the constant in rac/mcp/surface.py."
+    )
+
+
+def test_surface_is_the_five_tool_surface_unchanged():
+    # The measurement counts the served surface; it adds no tool and removes none.
+    measurement = _measure(MCP_CORPUS)
+    assert len(measurement.tools) == 5
+    assert {t.name for t in measurement.tools} == {
+        "get_summary",
+        "search_artifacts",
+        "get_artifact",
+        "get_related",
+        "find_decisions",
+    }
+
+
+def test_standing_surface_is_corpus_independent():
+    # Descriptions + schemas do not depend on the corpus, so the standing number
+    # is a stable property of the server, not of any one repository.
+    assert _measure(MCP_CORPUS).standing_tokens == _measure(GUIDE_CORPUS).standing_tokens
+
+
+def test_measurement_is_deterministic():
+    # Same input, same integer — no model, no network (REQ-002).
+    assert _measure(MCP_CORPUS).standing_tokens == _measure(MCP_CORPUS).standing_tokens
+
+
+def test_budget_stays_within_its_hard_cap():
+    # The budget may be raised with review, but never silently past the cap: going
+    # above 1250 is a deliberate change to the cap itself, not a quiet bump.
+    assert STANDING_BUDGET_TOKENS <= STANDING_BUDGET_HARD_CAP
+
+
+# --- per-call response budget (REQ-005) --------------------------------------
+
+
+def test_typical_responses_are_within_the_per_call_budget():
+    # A representative search page and a representative get_artifact payload over
+    # the pinned fixture stay under the per-call ceiling. This catches
+    # serialization field-bloat below ADR-033's serve-time truncation.
+    search = _response(GUIDE_CORPUS, "search_artifacts", {"query": "delete user"})
+    artifact = _response(GUIDE_CORPUS, "get_artifact", {"id": DECISION})
+    assert approx_tokens(search) <= PER_CALL_BUDGET_TOKENS
+    assert approx_tokens(artifact) <= PER_CALL_BUDGET_TOKENS

--- a/tests/test_selective_retrieval.py
+++ b/tests/test_selective_retrieval.py
@@ -1,0 +1,64 @@
+"""Selective on-demand retrieval by default (lean-context-delivery Init 2).
+
+The default retrieval path returns the *relevant* artifacts for a query — never
+the whole corpus — so an agent receives small, scoped payloads by construction,
+the antidote to context rot. Bulk, whole-corpus delivery is an explicit action
+(`rac export`), not a retrieval default (REQ-001, REQ-004). Selectivity is by
+scoping, not by lossy compression (ADR-066).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+from conftest import fixture_path
+
+from rac.mcp.server import build_server
+from rac.services.index import build_repository_index
+from rac.services.resolve import find_artifacts
+
+CORPUS = fixture_path("mcp", "corpus")
+DECISION = "RAC-MCPDEC000001"
+
+
+def _total_artifacts() -> int:
+    return len([e for e in build_repository_index(CORPUS).artifacts if e.type != "unknown"])
+
+
+def _call(tool: str, args: dict) -> str:
+    async def go() -> str:
+        contents, _ = await build_server(CORPUS).call_tool(tool, args)
+        return contents[0].text
+
+    return asyncio.run(go())
+
+
+def test_cli_find_returns_a_relevant_subset_not_the_whole_corpus():
+    total = _total_artifacts()
+    assert total >= 3  # a corpus big enough for "subset" to mean something
+    result = find_artifacts(CORPUS, "messaging")
+    assert 0 < result.match_count < total
+
+
+def test_mcp_search_is_selective_by_default():
+    total = _total_artifacts()
+    payload = json.loads(_call("search_artifacts", {"query": "messaging"}))
+    assert 0 < payload["match_count"] < total
+
+
+def test_lookup_returns_one_artifact_not_a_dump():
+    # get_artifact is a scoped, on-demand lookup: one artifact by id, never the
+    # corpus. The response is a single object keyed to the requested id.
+    payload = json.loads(_call("get_artifact", {"id": DECISION}))
+    assert payload["id"] == DECISION
+    assert "error" not in payload
+
+
+def test_no_retrieval_tool_returns_the_whole_corpus():
+    # None of the retrieval surfaces hands back every artifact for a typical call:
+    # search is a subset, lookup is one. The whole-corpus payload is only ever an
+    # explicit `rac export`, never a default here.
+    total = _total_artifacts()
+    search = json.loads(_call("search_artifacts", {"query": "messaging"}))
+    assert search["match_count"] < total


### PR DESCRIPTION
Delivers **all three initiatives** of `lean-context-delivery` (rank-9 Tranche A of `deterministic-substrate`, #248). Implements `rac-mcp-surface-budget`, `rac-selective-retrieval-default`, and `rac-cli-first-delivery`, and resolves the `lean-context-delivery-measurement` design's open questions — all flipped to Accepted.

## Why

A knowledge server justifies itself only if it stays lean — otherwise it becomes the "context tax" it was meant to cure. Two research findings drive this: **context rot** (every frontier model degrades as input grows, so dumping a corpus worsens output) and the **MCP context tax** (tool surfaces spend token real estate before answering; comparable servers cited around ~23k tokens).

## Initiative 1 — Measure and bound the MCP surface

- **`rac/mcp/surface.py`** — deterministic, offline token measurement (no model, no network; ADR-066) of the standing surface (5 tool descriptions + schemas), via a stated dependency-free tokenisation rule. Counts the served surface exactly — adds/removes/compresses nothing.
- **`tests/test_mcp_surface_budget.py`** — regression check.

| Measured today | Budget |
|---|---|
| **Standing surface: 915 tokens** (542 desc + 373 schema) | **1000** |
| `search_artifacts` page 1110 · `get_artifact` 870 | per-call ceiling 1400 |

~25× under the ~23k figure the critique cited — a guardrail on an already-lean surface. Standing budget **1000**, raisable only with explicit justification up to a **hard-capped 1250** (a test pins the budget stays within the cap — no silent bumps).

## Initiative 2 — Selective, on-demand retrieval by default

- **`tests/test_selective_retrieval.py`** — pins the guarantee: `search`/`find` return a relevant *subset*, `get_artifact`/`resolve` return *one* artifact, no retrieval tool hands back the whole corpus. Bulk delivery is an explicit `rac export`, never a default (REQ-001/004). Confirms an existing property — no retrieval behaviour changes.

## Initiative 3 — CLI-first delivery as a first-class option

- **`docs/context-cost.md`** (new, in the nav) — the consolidated guide: the measured budget, selective-by-default retrieval, and the CLI (`find`/`resolve`/`relationships`) as a **zero-standing-tax** way to ground an agent, with a worked example and **when-to-use-which** guidance against the MCP server. Both surfaces stay first-class; neither is deprecated (ADR-005).

## Verification

- 11 new tests across two batteries (`mcp`, `resolve`); full battery green (**1889 passed**).
- `rac validate` / `rac relationships --validate` / `rac review` (no priority 1–2) / agent-rules drift check all clean.
- CLI examples in the guide verified against the live commands.
- No engine behaviour changed — the served surface and retrieval paths are identical; this measures, documents, and guarantees them.