### PR TITLE
docs(design): capture net-new adoption opportunities as designs [roadmap:growth-programme]

### DIFF
--- a/rac/designs/adoption-opportunity-survey.md
+++ b/rac/designs/adoption-opportunity-survey.md
@@ -1,0 +1,270 @@
+---
+schema_version: 1
+id: RAC-KWQAJG8WDSN1
+type: design
+---
+# Adoption Opportunity Survey
+
+## Status
+
+Proposed
+
+Exploratory — this records the output of a grounded adoption-opportunity
+discovery pass so the reasoning lives in the corpus, not a session's scratch
+space (ADR-047). It is not an accepted build. It surveys net-new adoption
+levers, states each one's honest overlap with already-recorded work, and
+leaves a recommended priority order rather than a closed decision. It states
+positioning already recorded in ADR-036 and ADR-081; it does not alter it.
+
+## Context
+
+The prompt behind this survey was "review the codebase and identify 10x
+products and features that would increase adoption." Run naively, that prompt
+re-discovers work already planned or already shipping — because it has no step
+that grounds each idea against the record first. So this survey did the
+grounding first, and the honest headline is: **most of the obvious adoption
+space is already recorded.** The roadmap and ADRs already own activation (the
+`<5min` / `<30s` cold-start contract, `rac quickstart`, zero-config
+`pipx`/`uv` install, the demo GIF — `rac-growth-adoption`, ADR-044),
+positioning (`rac-growth-positioning`, the `decision-grounding-paper`),
+capture surfaces (`lore-slack-bot`, `lore-overlay`, the agent-interview skill
+and `/intake` action in `lore-frontend-optionality` Thread E), distribution
+and CI reach (SARIF, `ci-report-formats`, `agnostic-surfaces`, `rac-editors`,
+`oci-image`, `integration-recipe-factory`), RAG and enterprise
+(`corpus-export-to-rag-backends`, `corpus-sync`, `lore-at-team-scale`,
+`lore-supermemory-grounding`), and ecosystem (`rac-growth-extensibility`,
+`rac-growth-ecosystem-list`, `artifact-family-factory`).
+
+The single most important finding is a meta-one: `lore-frontend-optionality`
+already concluded that the highest-leverage move is **distribution of the MCP
+surface Lore already ships** (Thread D), and it sits there as an unbuilt Open
+Question. The biggest lever is not undiscovered; it is un-scheduled.
+
+What remains after grounding is a short, honest set of net-new levers,
+recorded here so a future session inherits both the map and the ideas.
+
+## User Need
+
+- The **maintainer** deciding where the next unit of adoption effort buys the
+  most, given how much is already recorded.
+- **Future sessions**, which need the "already decided / already shipping" map
+  as much as the ideas — the grounding step is what stops the next discovery
+  pass from re-proposing (or re-building) settled work, the exact failure that
+  produced a duplicated `freshness-and-drift-detection` build in the session
+  that authored this survey.
+- **Contributors** looking for a well-scoped, net-new place to help.
+
+## Design
+
+Five opportunities survived grounding. Each is stated as a card: the thesis,
+the adoption lever and the mechanism that moves it, the evidence and the
+net-new check against the record, a rough effort/risk, and the smallest proof
+that would validate or kill it. They are ordered by (impact × confidence) ÷
+effort.
+
+### Opportunity 1 — Decisions-on-PR surfacing *(the recommendation)*
+
+- **Thesis.** A PR that edits governed code gets one comment naming the
+  decisions that govern it — "this touches code governed by ADR-081:
+  [one-line summary] — still current?" — so the record surfaces at the moment
+  a human or agent would otherwise ignore it.
+- **Lever + mechanism.** Distribution *and* retention. It is visible on every
+  PR in every adopting repo (passive proof the tool is working), and it
+  delivers Lore's core payoff — stop re-doing what was ruled out — at the
+  decision point rather than buried in a corpus.
+- **Evidence / net-new.** It rides two just-shipped capabilities: the
+  `rac decisions` path→decisions lookup and the `## Applies To` scope
+  (`decision-to-code-proximity`, `code-scope-consumption`). Today no PR
+  surface does this — the shipped CI actions surface *validation and
+  relationship errors* as annotations, never the governing decisions for the
+  code under review. It is on-thesis with ADR-067 (post-edit context supply,
+  not pre-edit interception) and ADR-034 (report the decisions as facts, never
+  a verdict).
+- **Effort / risk.** Low–medium: a CI action that runs `rac decisions` over a
+  PR's changed paths and posts one deduplicated comment. The hardest unknown
+  is relevance tuning — an over-eager comment trains reviewers to ignore it
+  (the same over-flagging lesson `freshness-and-drift-detection` records).
+- **Smallest proof.** Run `rac decisions` over the changed paths of five recent
+  real PRs in this repo and eyeball whether the surfaced decisions would have
+  genuinely helped the reviewer.
+
+### Opportunity 2 — Corpus status badge for adopters' READMEs
+
+- **Thesis.** A shields-style badge — `Lore · 42 decisions · validated` — that
+  an *adopting* repo displays in its README, generated from the corpus.
+- **Lever + mechanism.** Distribution / virality — the classic open-source
+  badge loop (build and coverage badges): every adopter's README becomes
+  passive social proof and a link back.
+- **Evidence / net-new.** The underlying counts already exist
+  (`rac portfolio` / `rac review`). This is distinct from RAC's *own* CI and
+  coverage badges (`rac-trust-transparency` FR-6/FR-7), which sign this
+  repository's build — not a feature adopters render for their corpus.
+- **Effort / risk.** Near-zero: a shields-compatible JSON shape plus a
+  documented snippet. Risk: a stale or misleading badge; mitigated by deriving
+  it live from the corpus, never a stored value (ADR-045 posture).
+- **Smallest proof.** Emit the shields JSON for this corpus, render one badge,
+  place it in the README, and judge whether it reads as credible.
+
+### Opportunity 3 — Graduate MCP grounding distribution *(schedule the record's own #1)*
+
+- **Thesis.** `rac mcp init` writes the host snippet (`.mcp.json` for Claude
+  Code, the Cursor/Codex equivalents), and `lore` is listed in the MCP
+  registries, so any team plugs the flagship surface in without hand-wiring.
+- **Lever + mechanism.** Distribution — the record argues MCP is a
+  cross-vendor standard at scale; registration is the cheapest path to the
+  largest strategic payoff and reinforces the authority-of-record identity.
+- **Net-new check.** This is **already recorded** as `lore-frontend-optionality`
+  Thread D plus an Open Question — it is not a discovery. It is included here
+  only to flag that the record's own top-ranked lever is unbuilt; the honest
+  action is to graduate it to a roadmap item, not to re-derive it.
+- **Effort / risk.** Low. The risk is coordination, not build (see Open
+  Questions on parallel threads).
+- **Smallest proof.** Ship the `rac mcp init` snippet for one host and submit
+  one registry listing; measure installs.
+
+### Opportunity 4 — Zero-install evaluator playground
+
+- **Thesis.** An evaluator writes or pastes a decision and instantly sees it
+  validated and classified, with a shareable permalink, without installing
+  anything.
+- **Lever + mechanism.** Activation — it removes the install barrier entirely.
+  `rac-growth-adoption` optimizes the install *path* (five-minute cold start)
+  but never eliminates it; every minute before first value still loses
+  evaluators. A shareable permalink adds a distribution loop.
+- **Net-new check.** Distinct from `rac-localview` (a *local* single-file
+  viewer) and the Thread E capture *form* (for authors getting knowledge in).
+  A public *evaluator* surface is not recorded — net-new, but adjacent.
+- **Effort / risk.** High, and the reason it ranks below the cheap wins. The
+  engine is Python; a browser surface needs either a hosted `rac` endpoint or a
+  Pyodide/WASM build. It must stay a thin client over the contract (ADR-063)
+  and never a content store (ADR-024) — the pasted text is ephemeral.
+- **Smallest proof.** A hosted endpoint that runs `rac validate -` /
+  `rac inspect` on pasted text behind a trivial page; measure paste→result
+  completion.
+
+### Opportunity 5 — Shareable public decision pages *(recorded honestly as an overlap)*
+
+- **Thesis.** Render a decision as a clean, linkable, embeddable public page —
+  a distribution surface, not a capture one.
+- **Net-new check.** This substantially overlaps `rac-localview` (local HTML
+  export) and the docs site. The genuinely net-new sliver — hosted,
+  embeddable, public decision permalinks as distribution — is thin enough that
+  it is better folded into Opportunity 1 (a PR comment links a rendered
+  decision) or Opportunity 4 (the playground's permalink) than pursued
+  standalone. Recorded here for completeness, not ranked.
+
+### Recommended priority order
+
+1. **Decisions-on-PR surfacing (1)** — best leverage-per-build, genuinely
+   net-new, and the most on-thesis idea available; it makes the core promise
+   visible at the decision point and compounds capability shipped this week.
+2. **Corpus status badge (2)** — the near-zero-effort quick win; a cheap
+   distribution loop over output that already exists.
+3. **Graduate MCP distribution (3)** — the record's own #1 lever, sitting
+   unbuilt; schedule it rather than re-discover it.
+4. **Evaluator playground (4)** — the highest-ceiling activation lever, but a
+   real build with a hosting question to settle first.
+5. **Public decision pages (5)** — fold into 1 or 4; do not build standalone.
+
+## Constraints
+
+- **Thin clients over the contract (ADR-063).** Every surface here consumes the
+  published CLI/JSON/MCP output; none reimplements the engine. The badge, the
+  PR comment, and the playground all read `rac`'s existing output.
+- **RAC is not a content store (ADR-024).** The playground's pasted text and
+  the badge's counts are ephemeral projections; artifacts stay on disk.
+- **Facts, not verdicts (ADR-034); post-edit, not interception (ADR-067).** The
+  PR comment names governing decisions and recommends review; it never blocks
+  an edit or renders a judgement, and it augments the human PR trust boundary
+  (ADR-065) rather than replacing it.
+- **Additive contracts only (ADR-007).** Any new JSON (a shields shape, a
+  playground response) is additive; `schema_version` is unchanged.
+- **Brand and topology (ADR-068).** Installed surfaces (a hosted playground, a
+  badge service) are `lore-*` products; engine affordances (`rac mcp init`, a
+  `rac decisions --changed` mode) are `rac-*`.
+- **Positioning is stated, not altered (ADR-036, ADR-081).** None of these
+  repositions Lore or proposes the spec-as-source / codegen direction ADR-081
+  refuses.
+
+## Rationale
+
+Two lines of reasoning shaped the ranking. First, **grounding before ideation
+is the whole method** — it is what let this survey report five net-new items
+honestly instead of ten padded ones, and it is exactly the step the original
+prompt lacked. Second, **distribution of existing surfaces beats new builds**,
+the same conclusion `lore-frontend-optionality` reached: the two cheapest wins
+(the PR comment and the badge) turn output Lore already produces into reach,
+and they compound capability that already shipped. A new build (the playground)
+earns a lower rank precisely because its value is real but conditional on a
+hosting decision.
+
+## Alternatives
+
+Deliberately excluded as re-discoveries — grounding is what kept them out:
+
+- **MCP-as-frontend / grounding distribution** — recorded
+  (`lore-frontend-optionality` Thread D); surfaced above only as "schedule it."
+- **Any capture or non-technical authoring surface** — recorded (Thread E:
+  agent-interview skill, `/intake` action, guided web-capture form).
+- **A homegrown editor** — explicitly rejected (`lore-frontend-optionality`
+  Thread B) on build/maintenance cost and the git-source-of-truth identity.
+- **Semantic / RAG recall** — recorded (`corpus-export-to-rag-backends`,
+  `lore-supermemory-grounding`).
+- **Benchmarks and the paper** — recorded (`external-benchmark-evidence`,
+  `decision-grounding-paper`, `artifact-completeness-benchmark`).
+- **Enterprise / team scale** — shipped (`lore-at-team-scale`).
+- **Editor / OCI / GitLab reach** — recorded (`rac-editors-buildout`,
+  `oci-image`, `ci-report-formats`).
+
+## Accessibility
+
+Not a user interface. The bar is legibility of the analysis: each opportunity
+traces its net-new claim to the record it was checked against (by roadmap
+codename, design, or ADR id), so a reader can verify the grounding without
+re-running the pass. Any surface that graduates from here inherits the
+recorded accessibility constraints of its kind — keyboard-first parity for a
+viewer (ADR-028), provenance legibility for a grounding surface.
+
+## Style Guidance
+
+Honest, non-promotional register — no "revolutionary" or "blazing." An
+opportunity earns its rank with evidence and a falsifiable smallest-proof, and
+overlaps with recorded work are stated plainly (Opportunity 3 and 5 lead with
+their overlap). Cite recorded decisions by ADR id and related work by codename.
+
+## Open Questions
+
+- Should any of Opportunities 1–4 graduate to a `future/` roadmap item now, or
+  stay recorded here until a build is scheduled?
+- For the **playground (4)**: hosted `rac` endpoint or a Pyodide/WASM build,
+  and where does it live under the `lore-*` brand (ADR-068)?
+- For the **badge (2)**: is a static shields JSON shape enough, or is a small
+  hosted endpoint warranted, and how is staleness communicated?
+- **Coordination.** This repository has heavy parallel-agent activity; before
+  any of these is built, re-run the claim check (open PRs, active branches) so
+  a graduated item is not drafted twice — the discipline this survey exists to
+  encode.
+
+## Related Decisions
+
+- adr-007
+- adr-024
+- adr-034
+- adr-036
+- adr-045
+- adr-063
+- adr-065
+- adr-067
+- adr-068
+- adr-081
+
+## Related Roadmaps
+
+- growth-programme
+- decision-to-code-proximity
+- integration-recipe-factory
+
+## Related Requirements
+
+- rac-growth-adoption
+- rac-growth-positioning

--- a/rac/designs/adoption-opportunity-survey.md
+++ b/rac/designs/adoption-opportunity-survey.md
@@ -56,115 +56,41 @@ recorded here so a future session inherits both the map and the ideas.
 
 ## Design
 
-Five opportunities survived grounding. Each is stated as a card: the thesis,
-the adoption lever and the mechanism that moves it, the evidence and the
-net-new check against the record, a rough effort/risk, and the smallest proof
-that would validate or kill it. They are ordered by (impact × confidence) ÷
-effort.
+Grounding left a short, honest set of net-new levers. Each is recorded as its
+own design for independent consideration; this survey is the **index** — it
+holds the grounding, the already-decided map, and the priority order that are
+*about the set*, not any single opportunity. Ordered by
+(impact × confidence) ÷ effort:
 
-### Opportunity 1 — Decisions-on-PR surfacing *(the recommendation)*
+1. **Decisions-on-PR surfacing** (`pr-decision-surfacing`) — *the
+   recommendation*. A PR that edits governed code gets one comment naming the
+   decisions that govern it, at the moment a reviewer or agent would otherwise
+   ignore them. Distribution + retention; rides the just-shipped `rac decisions`
+   / `## Applies To` lookup (`decision-to-code-proximity`). Cheap, net-new, and
+   the most on-thesis idea in the set.
+2. **Corpus status badge** (`corpus-status-badge`) — *the cheapest win*. A
+   shields-style `Lore · N decisions · validated` badge an adopting repo renders
+   from its corpus; a distribution loop over counts `rac` already emits. Distinct
+   from RAC's own CI/coverage badges (`rac-trust-transparency` FR-6/FR-7).
+3. **MCP registration helper** (`mcp-registration-helper`) — *scheduling the
+   record's own #1*. `lore-frontend-optionality` Thread D already ranked MCP
+   distribution first and left the mechanism (`rac mcp init` + registry listings)
+   as an open question; that design answers it. Not a re-discovery — the
+   scheduling of an already-recorded conclusion.
+4. **Evaluator playground** (`evaluator-playground`) — *the highest ceiling, a
+   real build*. A zero-install, paste-a-decision-see-it-validated surface that
+   removes the install barrier `rac-growth-adoption` only shortens; gated on a
+   hosting decision (hosted `rac` endpoint vs. Pyodide/WASM).
 
-- **Thesis.** A PR that edits governed code gets one comment naming the
-  decisions that govern it — "this touches code governed by ADR-081:
-  [one-line summary] — still current?" — so the record surfaces at the moment
-  a human or agent would otherwise ignore it.
-- **Lever + mechanism.** Distribution *and* retention. It is visible on every
-  PR in every adopting repo (passive proof the tool is working), and it
-  delivers Lore's core payoff — stop re-doing what was ruled out — at the
-  decision point rather than buried in a corpus.
-- **Evidence / net-new.** It rides two just-shipped capabilities: the
-  `rac decisions` path→decisions lookup and the `## Applies To` scope
-  (`decision-to-code-proximity`, `code-scope-consumption`). Today no PR
-  surface does this — the shipped CI actions surface *validation and
-  relationship errors* as annotations, never the governing decisions for the
-  code under review. It is on-thesis with ADR-067 (post-edit context supply,
-  not pre-edit interception) and ADR-034 (report the decisions as facts, never
-  a verdict).
-- **Effort / risk.** Low–medium: a CI action that runs `rac decisions` over a
-  PR's changed paths and posts one deduplicated comment. The hardest unknown
-  is relevance tuning — an over-eager comment trains reviewers to ignore it
-  (the same over-flagging lesson `freshness-and-drift-detection` records).
-- **Smallest proof.** Run `rac decisions` over the changed paths of five recent
-  real PRs in this repo and eyeball whether the surfaced decisions would have
-  genuinely helped the reviewer.
+**Opportunity 5 — shareable public decision pages is deliberately not a separate
+design.** Its own analysis concludes "fold in": a rendered, shareable decision
+page rides the PR comment (design 1 links one) and the playground permalink
+(design 4), rather than standing alone. Recorded here so the idea is not lost,
+not as its own artifact.
 
-### Opportunity 2 — Corpus status badge for adopters' READMEs
-
-- **Thesis.** A shields-style badge — `Lore · 42 decisions · validated` — that
-  an *adopting* repo displays in its README, generated from the corpus.
-- **Lever + mechanism.** Distribution / virality — the classic open-source
-  badge loop (build and coverage badges): every adopter's README becomes
-  passive social proof and a link back.
-- **Evidence / net-new.** The underlying counts already exist
-  (`rac portfolio` / `rac review`). This is distinct from RAC's *own* CI and
-  coverage badges (`rac-trust-transparency` FR-6/FR-7), which sign this
-  repository's build — not a feature adopters render for their corpus.
-- **Effort / risk.** Near-zero: a shields-compatible JSON shape plus a
-  documented snippet. Risk: a stale or misleading badge; mitigated by deriving
-  it live from the corpus, never a stored value (ADR-045 posture).
-- **Smallest proof.** Emit the shields JSON for this corpus, render one badge,
-  place it in the README, and judge whether it reads as credible.
-
-### Opportunity 3 — Graduate MCP grounding distribution *(schedule the record's own #1)*
-
-- **Thesis.** `rac mcp init` writes the host snippet (`.mcp.json` for Claude
-  Code, the Cursor/Codex equivalents), and `lore` is listed in the MCP
-  registries, so any team plugs the flagship surface in without hand-wiring.
-- **Lever + mechanism.** Distribution — the record argues MCP is a
-  cross-vendor standard at scale; registration is the cheapest path to the
-  largest strategic payoff and reinforces the authority-of-record identity.
-- **Net-new check.** This is **already recorded** as `lore-frontend-optionality`
-  Thread D plus an Open Question — it is not a discovery. It is included here
-  only to flag that the record's own top-ranked lever is unbuilt; the honest
-  action is to graduate it to a roadmap item, not to re-derive it.
-- **Effort / risk.** Low. The risk is coordination, not build (see Open
-  Questions on parallel threads).
-- **Smallest proof.** Ship the `rac mcp init` snippet for one host and submit
-  one registry listing; measure installs.
-
-### Opportunity 4 — Zero-install evaluator playground
-
-- **Thesis.** An evaluator writes or pastes a decision and instantly sees it
-  validated and classified, with a shareable permalink, without installing
-  anything.
-- **Lever + mechanism.** Activation — it removes the install barrier entirely.
-  `rac-growth-adoption` optimizes the install *path* (five-minute cold start)
-  but never eliminates it; every minute before first value still loses
-  evaluators. A shareable permalink adds a distribution loop.
-- **Net-new check.** Distinct from `rac-localview` (a *local* single-file
-  viewer) and the Thread E capture *form* (for authors getting knowledge in).
-  A public *evaluator* surface is not recorded — net-new, but adjacent.
-- **Effort / risk.** High, and the reason it ranks below the cheap wins. The
-  engine is Python; a browser surface needs either a hosted `rac` endpoint or a
-  Pyodide/WASM build. It must stay a thin client over the contract (ADR-063)
-  and never a content store (ADR-024) — the pasted text is ephemeral.
-- **Smallest proof.** A hosted endpoint that runs `rac validate -` /
-  `rac inspect` on pasted text behind a trivial page; measure paste→result
-  completion.
-
-### Opportunity 5 — Shareable public decision pages *(recorded honestly as an overlap)*
-
-- **Thesis.** Render a decision as a clean, linkable, embeddable public page —
-  a distribution surface, not a capture one.
-- **Net-new check.** This substantially overlaps `rac-localview` (local HTML
-  export) and the docs site. The genuinely net-new sliver — hosted,
-  embeddable, public decision permalinks as distribution — is thin enough that
-  it is better folded into Opportunity 1 (a PR comment links a rendered
-  decision) or Opportunity 4 (the playground's permalink) than pursued
-  standalone. Recorded here for completeness, not ranked.
-
-### Recommended priority order
-
-1. **Decisions-on-PR surfacing (1)** — best leverage-per-build, genuinely
-   net-new, and the most on-thesis idea available; it makes the core promise
-   visible at the decision point and compounds capability shipped this week.
-2. **Corpus status badge (2)** — the near-zero-effort quick win; a cheap
-   distribution loop over output that already exists.
-3. **Graduate MCP distribution (3)** — the record's own #1 lever, sitting
-   unbuilt; schedule it rather than re-discover it.
-4. **Evaluator playground (4)** — the highest-ceiling activation lever, but a
-   real build with a hosting question to settle first.
-5. **Public decision pages (5)** — fold into 1 or 4; do not build standalone.
+The order above is the recommendation: do the two cheap distribution wins (1, 2)
+first, schedule the record's top lever (3), and sequence the higher-ceiling build
+(4) after its hosting question is settled.
 
 ## Constraints
 

--- a/rac/designs/corpus-status-badge.md
+++ b/rac/designs/corpus-status-badge.md
@@ -1,0 +1,120 @@
+---
+schema_version: 1
+id: RAC-KWQAZW678TP3
+type: design
+---
+# Corpus Status Badge
+
+## Status
+
+Proposed
+
+Exploratory — Opportunity 2 of `adoption-opportunity-survey`, split out for
+independent consideration. The cheapest net-new distribution lever. Not an
+accepted build.
+
+## Context
+
+Open-source developer tools spread partly through the README badge loop: a
+coverage or build badge in one project's README is passive social proof and a
+link back, seen by everyone who visits. Lore produces the numbers such a badge
+would show — artifact counts, validation state, health — via `rac portfolio`
+and `rac review`, but exposes no badge an *adopting* repository can render for
+its own corpus. This is distinct from RAC's own CI and coverage badges
+(`rac-trust-transparency` FR-6/FR-7), which sign this repository's build, not a
+feature an adopter displays.
+
+## User Need
+
+- An **adopting team** wants a small, credible signal in their README that they
+  keep decisions as code and that the corpus validates — a trust marker for
+  their own readers.
+- **Lore** wants each adopter's README to become a passive link back — the
+  distribution loop the CLI has no equivalent of today.
+
+## Design
+
+A shields.io-compatible endpoint shape emitted from the corpus — a minimal JSON
+(`{ schemaVersion, label, message, color }`) that renders as
+`Lore · 42 decisions · validated`. Two delivery options:
+
+1. **Static** — `rac badge --json` (or a documented projection of
+   `rac portfolio --json`) that a repo writes to a file its README references,
+   refreshed in CI. Zero hosted infrastructure.
+2. **Endpoint** — a small `lore-*` service that reads a public corpus and serves
+   the shields JSON live, so the badge is always current without a commit.
+
+Both derive the message live from the corpus (counts, valid/invalid, health)
+and never store a value (the ADR-045 derive-not-store posture). The message is
+data, not a verdict (ADR-034): it reports "42 decisions, validated," not "good."
+
+## Constraints
+
+- **Thin client over the contract (ADR-063), additive (ADR-007).** The badge
+  reads `rac portfolio` / `rac review` output; a `rac badge` mode is an additive
+  projection, `schema_version` unchanged.
+- **Derive, never store (ADR-045 posture).** A stale badge is worse than none;
+  the value is computed from the current corpus each time, and CI (static
+  option) or the endpoint (hosted option) keeps it fresh.
+- **Facts, not verdicts (ADR-034).** The badge states counts and validation
+  state; it makes no quality claim.
+- **Brand/topology (ADR-068).** `rac badge` is an engine affordance; a hosted
+  endpoint is a `lore-*` product.
+
+## Rationale
+
+Near-zero build over output that already exists, and the highest-reach-per-effort
+option in the survey: every adopter's README becomes a passive advertisement and
+a trust marker at once. It reinforces the recorded identity (a corpus that
+validates deterministically) rather than adding a new category.
+
+## Alternatives
+
+- **A dashboard instead of a badge.** Higher effort, lower reach; a badge is the
+  proven, glanceable distribution unit. A richer view already exists as
+  `rac-localview` / the Explorer.
+- **Reuse RAC's own CI badge pattern.** Rejected: those sign this repo's build,
+  not an adopter's corpus; conflating them would misrepresent what the badge
+  attests.
+- **A hosted-only endpoint.** Rejected as the sole path: it forces
+  infrastructure for what a static CI-refreshed file already delivers; offer the
+  static shape first, the endpoint as an option.
+
+## Accessibility
+
+Badges must not encode meaning in colour alone: the message text
+("42 decisions · validated") carries the information; colour is redundant
+reinforcement, and a non-colour reading is complete.
+
+## Style Guidance
+
+Match the shields.io convention (label · message · colour). Keep the message
+factual and short; no promotional adjectives. Use the `lore` mark consistent
+with ADR-036 naming.
+
+## Open Questions
+
+- Is the static `rac badge --json` shape sufficient, or is a hosted endpoint
+  warranted for always-current badges without a commit?
+- What exactly does the message show — decision count, total artifacts,
+  validation state, health score — and how is "validated" defined for a corpus
+  with advisory-only findings?
+- How is staleness communicated in the static option if a repo forgets to
+  refresh the badge in CI?
+
+## Related Decisions
+
+- adr-007
+- adr-034
+- adr-036
+- adr-045
+- adr-063
+- adr-068
+
+## Related Roadmaps
+
+- growth-programme
+
+## Related Requirements
+
+- rac-growth-adoption

--- a/rac/designs/evaluator-playground.md
+++ b/rac/designs/evaluator-playground.md
@@ -1,0 +1,121 @@
+---
+schema_version: 1
+id: RAC-KWQAZZPA101N
+type: design
+---
+# Zero-Install Evaluator Playground
+
+## Status
+
+Proposed
+
+Exploratory — Opportunity 4 of `adoption-opportunity-survey`. The highest-ceiling
+activation lever, and a real build gated on a hosting decision, so it ranks
+below the cheap distribution wins. Not an accepted build.
+
+## Context
+
+`rac-growth-adoption` optimises the *install path* — a sub-five-minute,
+zero-config cold start — but it never removes the install itself, and every
+minute before first value loses evaluators. An evaluator who has not yet decided
+to install anything has no way to see Lore work. Competing developer tools that
+win on adoption ship a zero-install "try it in the browser" surface;
+`rac-localview` is a *local* viewer and the capture form
+(`lore-frontend-optionality` Thread E) is for *authors*, so a public *evaluator*
+surface is not covered.
+
+## User Need
+
+- An **evaluator** wants to write or paste a decision and instantly see it
+  validated and classified — the "what does this tool actually do" moment —
+  without installing, configuring, or signing up.
+- A **sharer** wants a permalink to the result to send to a colleague — the
+  distribution loop that absorbs the survey's Opportunity 5.
+
+## Design
+
+A minimal public page: paste or type an artifact, and it runs the real engine
+surfaces — `rac validate`, `rac inspect` (classification), and a small
+relationship view — showing the exact output the CLI produces, with a shareable
+permalink to the input+result. Two engine-delivery options, both keeping the
+engine as the single source of truth:
+
+1. **Hosted `rac` endpoint** — a thin `lore-*` service that runs `rac validate
+   -` / `rac inspect` on submitted text and returns the JSON the page renders.
+   The pasted text is ephemeral; nothing is stored beyond an optional
+   short-lived permalink (ADR-024 — not a content store).
+2. **Pyodide / WASM** — the engine (or the thin TS client over the contract,
+   ADR-063) runs in the browser, no server round-trip.
+
+Either way the page is a thin client over the published contract; it
+reimplements no engine logic (ADR-063) and renders the same bytes the CLI does.
+
+## Constraints
+
+- **Thin client over the contract (ADR-063).** The playground calls `rac`
+  surfaces; it never re-derives validation or classification.
+- **Not a content store (ADR-024).** Pasted text is ephemeral; a permalink, if
+  offered, stores the minimal input+result for sharing, not a corpus.
+- **Facts, not verdicts (ADR-034).** It shows validation output and
+  classification, never a quality score of the user's decision.
+- **Brand/topology (ADR-068).** A hosted playground is a `lore-*` product; any
+  engine change to support a browser build is `rac-*` and additive (ADR-007).
+
+## Rationale
+
+It attacks the one activation cost the recorded work leaves standing — the
+install itself — and adds a distribution loop via shareable permalinks. It ranks
+below the badge and PR-comment because it is a genuine build with an unsettled
+hosting model, not a projection of existing output; but its ceiling (converting
+evaluators who would never install a CLI) is the highest of the set.
+
+## Alternatives
+
+- **A recorded demo GIF only.** Already planned (`growth-demo-gif`); it shows the
+  loop but the evaluator cannot *try* it — passive, not hands-on.
+- **Ship the desktop/live viewer instead.** Different audience (a viewer for an
+  existing corpus vs. a try-it surface for a newcomer); complementary, not a
+  substitute.
+- **Do nothing.** Acceptable only if the install path is judged low enough
+  friction; the survey's bet is that removing the install entirely is a distinct,
+  higher-ceiling lever.
+
+## Accessibility
+
+Keyboard-first and screen-reader legible: the paste area, the run action, and the
+result must be reachable and announced without a pointer, matching the
+Explorer's keyboard-first conventions (ADR-028). Output preserves provenance —
+verbatim engine output distinct from any explanatory chrome.
+
+## Style Guidance
+
+Minimal and honest — the page shows the real CLI output, not a prettified
+reinterpretation. No marketing chrome around the result; the determinism *is*
+the pitch. Name the surface under the `lore` brand (ADR-036).
+
+## Open Questions
+
+- Hosted `rac` endpoint or Pyodide/WASM — which delivery model, given the engine
+  is Python and the TS client is a thin contract consumer (ADR-063)?
+- Does a shareable permalink require any persistence, and if so what is the
+  minimal, non-content-store shape (ADR-024) and its retention?
+- Where does it live under the `lore-*` brand (ADR-068), and does it reuse
+  `rac-localview` rendering or stand alone?
+
+## Related Decisions
+
+- adr-007
+- adr-024
+- adr-028
+- adr-034
+- adr-036
+- adr-063
+- adr-068
+
+## Related Roadmaps
+
+- growth-programme
+
+## Related Requirements
+
+- rac-growth-adoption

--- a/rac/designs/mcp-registration-helper.md
+++ b/rac/designs/mcp-registration-helper.md
@@ -1,0 +1,114 @@
+---
+schema_version: 1
+id: RAC-KWQAZXY975K3
+type: design
+---
+# MCP Registration Helper
+
+## Status
+
+Proposed
+
+Exploratory — Opportunity 3 of `adoption-opportunity-survey`. This is **not** a
+new direction: `lore-frontend-optionality` (Thread D) already concluded that
+distributing the MCP surface Lore ships is the highest-leverage move, and left
+the *mechanism* — "should Lore ship a documented snippet or a `rac mcp init`
+helper per host?" — as an Open Question. This design answers that mechanism
+question so the recorded #1 lever can graduate from an open question to a
+buildable item. It does not re-argue Thread D's conclusion.
+
+## Context
+
+`rac mcp` is a read-only stdio MCP server (ADR-029, ADR-030) that plugs into
+every MCP host (Claude Code, Cursor, Codex, and peers) at child-process
+latency. The barrier to that distribution is not capability — it is the
+per-host wiring a team must hand-author (`.mcp.json` and each host's
+equivalent) and the fact that `lore` is not listed where users discover MCP
+servers. Thread D named this; nothing yet closes it.
+
+## User Need
+
+- A **team** adopting Lore for agent grounding wants to point every agent at the
+  committed server in one step, without learning each host's config dialect.
+- A **user browsing an MCP registry** should be able to find and install `lore`
+  the way they find any other server — the discovery half of distribution.
+
+## Design
+
+Two complementary pieces:
+
+1. **`rac mcp init [--host <host>]`** — an engine affordance that writes (or
+   prints) the correct registration snippet for a host: the project-scoped
+   `.mcp.json` block for Claude Code, and the documented equivalents for Cursor,
+   Codex, and peers. It writes only registration config pointing at
+   `rac mcp`; it introduces no new server capability and no write surface (the
+   MCP surface stays read-only, ADR-029/030). Idempotent and additive.
+2. **Registry listings** — publish `lore` in the MCP registries with a
+   maintained `server.json`-style manifest, so discovery works without knowing
+   the project exists.
+
+## Constraints
+
+- **Read-only, tools-only MCP (ADR-029, ADR-030).** This is distribution of the
+  existing surface, never new write capability.
+- **Thin config over the contract (ADR-063), additive (ADR-007).** `rac mcp
+  init` emits registration config; it changes no engine behaviour and no
+  existing output.
+- **Brand/topology (ADR-068).** `rac mcp init` is an engine affordance (`rac-*`);
+  a registry listing is a distribution artifact for the `lore` product.
+- **Positioning stated, not altered (ADR-036).** Grounding-as-authority is the
+  recorded identity; this distributes it, it does not reposition.
+
+## Rationale
+
+Thread D ranks this the cheapest path to the largest strategic payoff, and the
+survey confirms it is the record's own #1 lever sitting unbuilt. The mechanism
+is small (a snippet generator plus listings), reuses a shipped surface, and
+compounds every other adoption lever — an agent that has `lore` registered is
+an agent that can be grounded.
+
+## Alternatives
+
+- **Documentation only (no `rac mcp init`).** A per-host doc snippet is the
+  minimum; the helper removes the copy-paste-and-adapt step. Ship the docs
+  regardless; the helper is the affordance that makes it one command.
+- **A new "installer" product.** Over-built: registration is config, not a
+  product; the engine affordance plus registry listings suffice.
+- **Leave it in Thread D as an open question.** The status quo — which is
+  precisely why the record's top lever is unbuilt.
+
+## Accessibility
+
+`rac mcp init` output is plain text config a user can inspect before applying;
+it never writes silently without showing what it wrote. Registry listings
+follow each registry's accessibility conventions.
+
+## Style Guidance
+
+Neutral, factual snippets that match each host's documented format exactly.
+Name the surface `lore` (ADR-036). No promotional framing in registry copy —
+state what the server does (read-only decision grounding) and what it does not.
+
+## Open Questions
+
+- Which hosts does `rac mcp init` cover first (Claude Code project scope is the
+  established pattern; Cursor and Codex next), and does it write files or only
+  print?
+- Which MCP registries are worth listing in, and who maintains the manifest as
+  the surface evolves?
+- Should this graduate to a `future/` roadmap item on its own, or ride the
+  `agnostic-surfaces` / distribution track?
+
+## Related Decisions
+
+- adr-007
+- adr-029
+- adr-030
+- adr-036
+- adr-063
+- adr-068
+
+## Related Roadmaps
+
+- growth-programme
+- agnostic-surfaces

--- a/rac/designs/pr-decision-surfacing.md
+++ b/rac/designs/pr-decision-surfacing.md
@@ -1,0 +1,140 @@
+---
+schema_version: 1
+id: RAC-KWQAZTC4EWBF
+type: design
+---
+# Decisions-on-PR Surfacing
+
+## Status
+
+Proposed
+
+Exploratory — the top-ranked net-new adoption lever from
+`adoption-opportunity-survey` (Opportunity 1), split out for independent
+consideration. Not an accepted build. It states positioning recorded in
+ADR-036 and ADR-081 and honours ADR-034/ADR-067; it does not alter them.
+
+## Context
+
+Lore's core promise is that a coding agent — or a human reviewer — stops
+re-doing what a team already ruled out. Today that value is realised only if
+someone thinks to query the corpus. At the one moment it matters most — a pull
+request editing code a decision governs — nothing surfaces the governing
+decision. The shipped CI actions annotate *validation and relationship errors*
+("your corpus is malformed"), never *the decisions that govern the code under
+review*.
+
+Two capabilities that just shipped make this cheap: the `rac decisions`
+path→decisions lookup and the `## Applies To` code-scope declaration
+(`decision-to-code-proximity`, mechanism recorded in `code-scope-consumption`).
+The lookup answers "which live decisions govern this path" deterministically;
+a PR knows its changed paths; the join is a comment.
+
+## User Need
+
+- **Reviewers and agents on a PR** need the governing decisions for the code
+  they are changing, in context, without leaving the review — so a settled
+  constraint is seen before it is violated, not after.
+- **Evaluators and teammates** watching the repo see, on every PR, that Lore is
+  doing something useful — passive proof and a link back (the distribution
+  half of the lever).
+
+## Design
+
+A CI action (a `lore-*` GitHub Action per ADR-068, or a documented recipe over
+the existing `rac` CLI) that, on a pull request:
+
+1. Computes the PR's changed paths.
+2. Runs `rac decisions <path>` for each (the same service the CLI and the sixth
+   MCP tool already use), collecting the live decisions whose `## Applies To`
+   scope covers a changed path.
+3. Posts **one** deduplicated comment naming each governing decision by id and
+   title, with a one-line summary and a "still current? — review recommended"
+   prompt, plus a link to the decision. Re-runs update the same comment rather
+   than stacking.
+
+The comment reports the decisions as **facts** — "this PR touches code governed
+by ADR-081" — never a verdict on the change and never a merge gate (ADR-034).
+It is post-edit context supply, not pre-edit interception (ADR-067). Where a
+governed decision has also drifted (the `suspect-artifact` signal,
+`freshness-and-drift-detection`), the comment may note it — the two compose.
+
+This also absorbs Opportunity 5 of the survey (public decision pages): the
+comment links a rendered, shareable view of each cited decision, so the
+"shareable decision page" idea rides here rather than as a standalone surface.
+
+## Constraints
+
+- **Thin client over the contract (ADR-063).** The action shells to `rac
+  decisions --json`; it re-derives nothing. A `rac decisions --changed`
+  convenience mode (diff-aware) would be an additive engine affordance
+  (ADR-007), never new engine logic.
+- **Facts, not verdicts (ADR-034); post-edit, not interception (ADR-067).** No
+  merge gate ships here; the human PR review stays the trust boundary
+  (ADR-065).
+- **Advisory quality is the risk, not correctness.** An over-eager comment
+  trains reviewers to ignore it — the same over-flagging lesson
+  `freshness-and-drift-detection` records. Scope to live decisions with a
+  matching declared `## Applies To`; keep the comment terse.
+- **Brand/topology (ADR-068).** The Action is a `lore-*` product; any engine
+  convenience mode is `rac-*`.
+
+## Rationale
+
+Best leverage-per-build of the surveyed options: it reuses output `rac` already
+produces, compounds capability that shipped this week, and puts Lore's core
+promise where it is felt — the review. It is on-thesis rather than a new
+category, so it strengthens the recorded positioning (ADR-036, ADR-081) instead
+of straining it.
+
+## Alternatives
+
+- **A pre-merge gate that blocks PRs touching governed-but-drifted code.**
+  Rejected for this phase: gating is post-advisory territory (ADR-075) and
+  cuts against ADR-034/ADR-067; advisory-first proves signal quality before any
+  gate, exactly as the drift work sequenced it.
+- **Surface it only in the IDE (extension), not the PR.** Complementary, not a
+  replacement — the PR is where cross-team review and the distribution loop
+  live; the extension is the single-author surface.
+- **Do nothing / rely on the agent to query.** The status quo; the value stays
+  invisible at the decision point, which is the gap this closes.
+
+## Accessibility
+
+The comment is plain Markdown: decision id, title, one-line summary, link.
+Provenance stays legible — the verbatim, id-addressed decision text is distinct
+from the one-line summary, and the summary never restates a decision as a
+verdict.
+
+## Style Guidance
+
+Terse and factual. Lead with the decision id and title; one line of summary;
+"review recommended," never "you must." No promotional language. Cite decisions
+by id.
+
+## Open Questions
+
+- Ship as a first-party `lore-*` Action, or a documented recipe in
+  `integration-recipe-factory` over `rac decisions` that any CI can adopt?
+- Is a `rac decisions --changed <base>..<head>` diff-aware mode worth adding to
+  the engine, or does the Action compute changed paths itself and call
+  `rac decisions` per path?
+- How is comment noise tuned — a per-run cap, a relevance threshold, or
+  collapsing to "N governing decisions" with a details expander?
+
+## Related Decisions
+
+- adr-007
+- adr-034
+- adr-063
+- adr-065
+- adr-067
+- adr-068
+- adr-081
+
+## Related Roadmaps
+
+- growth-programme
+- decision-to-code-proximity
+- freshness-and-drift-detection
+- integration-recipe-factory

--- a/rac/roadmaps/future/decisions-on-pr.md
+++ b/rac/roadmaps/future/decisions-on-pr.md
@@ -1,0 +1,122 @@
+---
+schema_version: 1
+id: RAC-KWQCQEMSM601
+type: roadmap
+---
+# Decisions on Pull Requests
+
+## Status
+
+Planned
+
+Unscheduled — captured as future intent, not yet on a release. The graduation of
+the top-ranked net-new adoption lever from `adoption-opportunity-survey`
+(Opportunity 1); the implementation contract — the *how* — lives in the
+`pr-decision-surfacing` design. This records the *what and why* so the work has
+a tracked home; it states positioning already recorded in ADR-036 and ADR-081
+and honours ADR-034/ADR-067, and does not alter them.
+
+## Context
+
+Lore's core promise — a coding agent or reviewer stops re-doing what a team
+already ruled out — is realised today only if someone thinks to query the
+corpus. At the moment it matters most, a pull request editing code a decision
+governs, nothing surfaces the governing decision; the shipped CI actions
+annotate corpus *errors*, never the *decisions that govern the code under
+review*. Two capabilities that just shipped make closing this cheap: the
+`rac decisions` path→decisions lookup and the `## Applies To` code-scope
+declaration (`decision-to-code-proximity`). This roadmap turns that into a
+visible surface at the review — an adoption lever (visible on every PR in every
+adopting repo) that is also on-thesis (the promise, delivered where it is felt).
+
+## Outcomes
+
+- A pull request that edits governed code carries one advisory comment naming
+  the live decisions that govern the changed paths — id, title, a one-line
+  summary, and a "review recommended" prompt — so a settled constraint is seen
+  before it is violated.
+- The surface is advisory and post-edit: it reports decisions as facts, never a
+  verdict or a merge gate (ADR-034, ADR-067); the human PR review stays the
+  trust boundary (ADR-065).
+- Every adopting repo's PRs become passive proof the tool is working — the
+  distribution loop the CLI has no equivalent of today.
+
+## Initiatives
+
+### Initiative 1 — Diff-aware path→decisions surfacing
+
+Compute a PR's changed paths and collect, per path, the live decisions whose
+declared `## Applies To` scope covers it — reusing the `rac decisions` service
+(no new engine logic). Decide whether the engine gains a `rac decisions
+--changed <base>..<head>` convenience mode (additive, ADR-007) or the surface
+computes changed paths itself.
+
+### Initiative 2 — The PR comment surface
+
+A `lore-*` GitHub Action (or a documented `integration-recipe-factory` recipe
+any CI can adopt) that posts one deduplicated comment and updates it in place on
+re-runs. Facts only; links each cited decision to a rendered, shareable view —
+which absorbs the survey's "public decision pages" idea rather than building it
+standalone.
+
+### Initiative 3 — Advisory quality
+
+Tune relevance so the comment stays trusted: scope to live decisions with a
+matching declared scope, keep it terse, and guard against the over-flagging the
+`freshness-and-drift-detection` work records. Compose with the drift signal —
+a governed decision that is also suspect can be noted.
+
+## Success Measures
+
+- On a PR touching a path with a governing decision, the comment appears, names
+  the decision by id, and recommends review; on a PR touching nothing governed,
+  no comment appears.
+- The surface never changes a PR's merge status (advisory only; ADR-034,
+  ADR-067, ADR-075).
+- The comment is reproducible from the corpus and the changed paths — a pure
+  function of `rac decisions` output, no wall-clock or model input.
+- `rac validate rac/`, `rac relationships rac/ --validate`, and `rac review
+  rac/` stay clean.
+
+## Assumptions
+
+- `decision-to-code-proximity` has shipped `rac decisions` and the `## Applies
+  To` scope (it has), so this is a surface over existing capability, not new
+  engine logic.
+- Teams that adopt Lore run CI on their PRs, so a CI-hosted comment reaches the
+  review.
+
+## Risks
+
+- Over-flagging trains reviewers to ignore the comment (the recorded
+  freshness-and-drift lesson). Mitigation: scope tightly to declared governing
+  decisions; keep the comment terse; advisory-first.
+- Read as a gate rather than context. Mitigation: facts-only wording, no merge
+  status change, "review recommended" never "you must" (ADR-034, ADR-067).
+- Parallel-thread duplication in this repository. Mitigation: re-run the claim
+  check (open PRs, active branches) before build, per the survey's discipline.
+
+## Related Decisions
+
+- adr-007
+- adr-034
+- adr-063
+- adr-065
+- adr-067
+- adr-068
+- adr-081
+
+## Related Roadmaps
+
+- growth-programme
+- decision-to-code-proximity
+- freshness-and-drift-detection
+- integration-recipe-factory
+
+## Related Designs
+
+- pr-decision-surfacing
+
+## Related Requirements
+
+- rac-growth-adoption


### PR DESCRIPTION
# Summary

Corpus-only (no engine changes). Records the output of a **grounded** adoption-opportunity discovery pass as durable artifacts (ADR-047), under the `growth-programme` (#230). The discovery was run record-first, so nothing here re-proposes work already planned or shipping.

Adds:
- `adoption-opportunity-survey` — the grounded **index**: the already-decided/shipping map, the priority order, and the coordination note.
- Four per-opportunity **designs**: `pr-decision-surfacing`, `corpus-status-badge`, `mcp-registration-helper`, `evaluator-playground`.
- One **`future/` roadmap**, `decisions-on-pr`, graduating the top pick so it has a tracked execution home (references the design, clearing its orphan).

# Roadmap / ADR Trace

Roadmaps: `rac/roadmaps/future/decisions-on-pr.md` (new, Unscheduled); relates to `growth-programme`, `decision-to-code-proximity`, `freshness-and-drift-detection`, `integration-recipe-factory`.
Designs: the survey + four opportunity designs under `rac/designs/`.
Relevant ADRs (stated, not altered): ADR-036/ADR-081 (positioning), ADR-034 (facts not verdicts), ADR-067 (post-edit context supply), ADR-063 (thin clients), ADR-024 (not a content store), ADR-045 (derive from git), ADR-029/030 (read-only MCP), ADR-068 (brand/topology), ADR-007 (additive), ADR-047 (durable thinking in the corpus).

# Scope

## Included
- The grounded survey (Context = the "already decided" map; Alternatives = the re-discoveries deliberately excluded).
- Four standalone designs, each net-new-checked against the record.
- The `decisions-on-pr` future roadmap (the top pick's what/why; the design is its how).

## Excluded
- **No engine code, no build.** These are proposals; each design stops at mechanism + smallest-proof.
- Re-discoveries: MCP-as-frontend (recorded, `lore-frontend-optionality` Thread D), capture surfaces (Thread E), a homegrown editor (rejected, Thread B), semantic/RAG recall, benchmarks/paper, enterprise scale, editor/OCI/GitLab reach — all already recorded; grounding kept them out.
- **Opportunity 5 (public decision pages)** is deliberately *not* a separate artifact — its own analysis folds it into designs 1 and 4.

# Product / Architecture Decisions

- **Grounding before ideation** is the method: the survey reports five net-new levers honestly rather than ten padded ones, because each was diffed against the roadmap, ADRs, and in-flight PRs/branches first.
- **`mcp-registration-helper` is not a re-discovery** of `lore-frontend-optionality` Thread D — it answers the *open mechanism question* Thread D left (`rac mcp init` + registry listings), graduating the record's own #1 lever.
- **Everything stays on-thesis:** every proposed surface is a thin client over the published contract (ADR-063), reports facts not verdicts (ADR-034), is post-edit not interception (ADR-067), and installed surfaces are `lore-*` while engine affordances are `rac-*` (ADR-068). No repositioning (ADR-036/081).
- **`design`→`design` edges aren't supported**, so cross-references between these designs live in prose; the roadmap→design edge (`decisions-on-pr` → `pr-decision-surfacing`) is the one formal link, and it clears the top pick's orphan.

# User-Facing Contract

None. Corpus-only: no CLI, JSON, schema, or exit-code change. The contracts the designs sketch (a PR-comment Action, a shields badge, `rac mcp init`, a playground) ship later, if graduated, under their own decisions.

# Verification

## Ran
- `rac validate rac/` → exit 0.
- `rac relationships rac/ --validate` → 2,294 checked, **0 issues**.
- `rac review rac/` → exit 0 (no priority 1-2).
- `rac doctor rac/` confirms `pr-decision-surfacing` is no longer orphaned (the roadmap references it).

## Covered
- All five artifacts validate against the design/roadmap schemas.
- Every `## Related` edge resolves (ADR ids, roadmap/design/requirement stems).
- Commit identity: maintainer on author and committer across all three commits; no tool attribution.

# Review Path

1. `rac/designs/adoption-opportunity-survey.md` — the grounded index; check the "already decided" map and the honesty of the net-new claims.
2. `rac/designs/pr-decision-surfacing.md` — the top pick (also absorbs Opportunity 5).
3. `rac/designs/corpus-status-badge.md`, `rac/designs/mcp-registration-helper.md`, `rac/designs/evaluator-playground.md`.
4. `rac/roadmaps/future/decisions-on-pr.md` — the graduated what/why.

# Notes For Reviewer

- This repo has heavy parallel-agent activity and `main` moved several times during authoring; I claim-checked (open PRs + ~28 active branches) before writing and rebased onto current `main`. The survey bakes a "re-run the claim check before building any of these" note into its Open Questions for that reason.
- The three other designs (`corpus-status-badge`, `mcp-registration-helper`, `evaluator-playground`) are intentionally left as exploratory orphans until/unless they graduate to their own roadmap items — a `doctor` warning, not a gate.

# Implementation Process

Produced by a grounded discovery pass under the roadmap contract; final scope, framing (net-new vs. recorded), and the design/roadmap split were the maintainer's calls.