### PR TITLE
docs(roadmap): mark Tranche A roadmaps Achieved (housekeeping)

### DIFF
--- a/rac/roadmaps/integration-recipe-factory.md
+++ b/rac/roadmaps/integration-recipe-factory.md
@@ -7,18 +7,19 @@ type: roadmap
 
 ## Status
 
-Planned
+Achieved
 
-Prioritised as the rank-6 Tranche A item of the deterministic-substrate
-programme, graduated out of `future/` alongside `lean-context-delivery` now
-the programme's rank 1–4 items are live. This is the *harness* half of the
-integration story; the *backend/RAG* half lives in
-`corpus-export-to-rag-backends`, and the positioning/ecosystem framing in
-`growth-programme`. It adds no engine code — every recipe is a
-documentation unit. The programme's boundary constraint is carried verbatim:
-**every recipe is context-supply and post-edit CI enforcement (ADR-067),
-never pre-edit interception.** Execution is tracked in GitHub (ADR-093): the
-epic in `## Related Tickets` carries ordering and task state.
+Delivered across all three initiatives (PRs #309, #310): the recipe authoring
+template and contract, the verification gate, and the prioritised harness
+backlog — proven with four recipes authored from the template (Zed, Windsurf,
+Cline, opencode), each engine-half smoke-tested and carrying its
+`verify against` marker until harness-connected verification. Zero engine diff,
+as designed — every recipe is a documentation unit. The programme's boundary
+constraint held throughout: **every recipe is context-supply and post-edit CI
+enforcement (ADR-067), never pre-edit interception.** Was the rank-6 Tranche A
+item of the deterministic-substrate programme (the *harness* half of the
+integration story, beside `corpus-export-to-rag-backends`); execution tracked in
+GitHub (ADR-093).
 
 ## Context
 

--- a/rac/roadmaps/lean-context-delivery.md
+++ b/rac/roadmaps/lean-context-delivery.md
@@ -7,15 +7,16 @@ type: roadmap
 
 ## Status
 
-Planned
+Achieved
 
-Prioritised as the rank-9 Tranche A item of the deterministic-substrate
-programme, graduated out of `future/` alongside `integration-recipe-factory`
-now the programme's rank 1–4 items are live. Its concrete accounting method
-is recorded in the `lean-context-delivery-measurement` design; leanness is
-made a measured, regression-checked property here, never a semantic
-compression (ADR-066). Execution is tracked in GitHub (ADR-093): the epic in
-`## Related Tickets` carries ordering and task state.
+Delivered across all three initiatives (PR #311): the measured,
+regression-checked MCP surface budget (`rac/mcp/surface.py` — standing surface
+~915 tokens under a 1000 budget), the selective-on-demand retrieval guarantee
+asserted in the suite, and the CLI-first delivery path documented in
+`docs/context-cost.md`. Leanness is made a measured property, never a semantic
+compression (ADR-066); the accounting method is recorded in the
+`lean-context-delivery-measurement` design. Was the rank-9 Tranche A item of the
+deterministic-substrate programme; execution tracked in GitHub (ADR-093).
 
 ## Context
 


### PR DESCRIPTION
Housekeeping: the corpus roadmap statuses had fallen behind the delivered reality. Both `deterministic-substrate` Tranche A roadmaps are fully shipped, so this flips them to the **Achieved** terminal status (ADR-061) with a delivery note.

## What

- **`integration-recipe-factory`** → Achieved. Delivered across #309/#310: the recipe authoring template + contract, the verification gate, and the prioritised harness backlog, proven with four recipes (Zed, Windsurf, Cline, opencode). Zero engine diff.
- **`lean-context-delivery`** → Achieved. Delivered across #311: the measured/regression-checked MCP surface budget, the selective-retrieval guarantee, and the CLI-first delivery docs.

`freshness-and-drift-detection` is deliberately **left non-terminal** — phase 1 shipped (#278/#279), but its CI-gate and retrieval-bias phases remain fenced and unscheduled.

## Scope

- Corpus status flips only — no code, no behaviour change. The delivery notes preserve each roadmap's durable constraint framing (ADR-067 for recipes, ADR-066 for lean).
- `rac validate` / `rac relationships --validate` / `rac review` (no priority 1–2) / agent-rules drift check all clean; dogfood + stats suites green.

## Companion (not in this PR)

The `deterministic-substrate` execution epic (#248) still shows these Tranche A boxes unchecked; I'll tick them directly on the issue (a GitHub edit, not a corpus change) so the epic matches. With these two Achieved and `decision-to-code-proximity` already done, **Tranche A is cleared** except the fenced freshness later-phases.