### PR TITLE
chore(docs): adopt ADR-101: org-wide docs site amends docs hosting and topology

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,9 +1,12 @@
 name: Docs
 
-# Build the documentation site with MkDocs and deploy it to GitHub Pages.
-# Strict mode turns broken links and nav entries into build failures, so a
-# broken site can never deploy. First deploy requires the maintainer to set
-# Pages source to "GitHub Actions" in the repository settings.
+# Build-only check for the docs/ MkDocs source. Strict mode turns broken
+# links and nav entries into build failures. This no longer deploys to
+# GitHub Pages (ADR-101): itsthelore.github.io/rac-core/ is now served by
+# the itsthelore/itsthelore.github.io umbrella site, which vendors docs/ at
+# build time. Once that repo's site is live, disable Pages on this repo
+# (Settings -> Pages -> Source) so its own project-page deployment stops
+# shadowing the umbrella site at that URL.
 
 on:
   push:
@@ -11,12 +14,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
-
-concurrency:
-  group: pages
-  cancel-in-progress: false
 
 jobs:
   build:
@@ -30,17 +27,3 @@ jobs:
         run: pip install mkdocs==1.6.1 mkdocs-material==9.7.6
       - name: Build site (strict)
         run: mkdocs build --strict
-      - uses: actions/configure-pages@v5
-      - uses: actions/upload-pages-artifact@v3
-        with:
-          path: site
-
-  deploy:
-    needs: build
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - id: deployment
-        uses: actions/deploy-pages@v4

--- a/rac/decisions/adr-042-docs-site-hosting.md
+++ b/rac/decisions/adr-042-docs-site-hosting.md
@@ -15,6 +15,15 @@ Product
 
 ## Context
 
+> **Amended by ADR-101.** This ADR's project-page hosting model — `rac-core`
+> publishing its own `docs/` to `itsthelore.github.io/rac-core/` via its own
+> `docs.yml` — is retired in favor of an org-wide umbrella site
+> (`itsthelore.github.io`) that vendors `docs/` from each product repo at
+> build time. ADR-101 governs where the two differ (the publishing repo and
+> mechanism); this ADR's authoritative-source and build-artifact discipline
+> (repository Markdown is canonical, the site is never a second source of
+> truth, the `rac/` corpus stays unpublished) carries forward unchanged.
+
 ADR-022 established three documentation layers — README as doorway,
 `docs/` as user documentation, `rac/` as the product-knowledge corpus —
 and committed to repository Markdown as the canonical documentation
@@ -120,6 +129,7 @@ by publishing them.
 - ADR-018
 - ADR-036
 - ADR-001
+- ADR-101
 
 ## Related Designs
 

--- a/rac/decisions/adr-092-repository-topology.md
+++ b/rac/decisions/adr-092-repository-topology.md
@@ -16,6 +16,12 @@ Architecture
 
 ## Context
 
+> **Extended by ADR-101.** ADR-101 adds `itsthelore.github.io` to the target
+> topology below as the org's documentation-aggregation site — its own repo
+> per GitHub's root-Pages naming rule, not a family-pattern member. That ADR
+> governs the site's hosting and vendoring model; this ADR governs its place
+> in the topology and naming.
+
 ADR-064 and ADR-068 set the first repository topology for the `itsthelore`
 organisation: a `lore-*` / `rac-*` split (install-surface vs engine), per-action
 repos (`lore-watchkeeper`, `lore-gatekeeper`), a per-client repo rule
@@ -84,6 +90,7 @@ Distinct products keep their own brand and naming (`wayfinder-router`,
 | `rac-editors` | IDE clients | `vscode/` (VS Code/Cursor) (+ `jetbrains/`, …) |
 | `wayfinder-router` | separate product (ADR-069) | — |
 | `proofkeeper` | separate product (BYO-model QA agent) | — |
+| `itsthelore.github.io` | org presence + docs aggregation (ADR-101) | — |
 
 `rac-connectors` is the rename of the existing `lore-connectors`; `rac-ci` is the
 rename/absorption of `rac-actions` plus the standalone `lore-watchkeeper` /
@@ -204,6 +211,8 @@ Flip ADR-068 to Superseded in this change.
 - ADR-069: Wayfinder is a separate product; Proofkeeper is its sibling.
 - ADR-029, ADR-039: engine + server stay one package; CLI `rac` and server `lore`
   identities unchanged.
+- ADR-101: adds `itsthelore.github.io` to this table and governs its docs
+  hosting and vendoring model, including retiring `rac-core`'s project page.
 
 ## Related Decisions
 
@@ -216,6 +225,7 @@ Flip ADR-068 to Superseded in this change.
 - adr-063
 - adr-066
 - adr-069
+- adr-101
 
 ## Related Roadmaps
 

--- a/rac/decisions/adr-101-org-docs-site-and-topology.md
+++ b/rac/decisions/adr-101-org-docs-site-and-topology.md
@@ -1,0 +1,171 @@
+---
+schema_version: 1
+id: RAC-KWV0HZ2SSGE2
+type: decision
+tags: [structure, org, docs, hosting]
+---
+# ADR-101: Org-Wide Documentation Site Amends Docs Hosting and Repository Topology
+
+## Status
+
+Proposed
+
+## Category
+
+Product
+
+## Context
+
+ADR-042 hosts `rac-core`'s user documentation at
+`https://itsthelore.github.io/rac-core/` — a GitHub Pages *project* page built
+by `rac-core`'s own `docs.yml` workflow from that repository's `docs/` with
+MkDocs (Material theme). That scope was correct when `rac-core` was the only
+public surface, but ADR-092 now names a small constellation of `rac-*`
+repositories (`rac-core`, `rac-ci`, `rac-connectors`, `rac-sdk`,
+`rac-benchmarks`, `rac-editors`) plus sibling products (`wayfinder-router`,
+`proofkeeper`). None of them has a hosted documentation surface, and
+`rac-core`'s project page has no way to represent the org as a whole.
+
+GitHub serves a user/org root Pages site — with no `/repo-name/` path prefix —
+only from a repository named exactly `<org>.github.io`. `itsthelore/
+itsthelore.github.io` has been created for this purpose: it is public (a
+private repo would need a paid org plan for Pages, and the rendered output is
+public by default anyway), and deploys via GitHub Actions
+(`actions/upload-pages-artifact` → `actions/deploy-pages@v4`), matching the
+deploy method ADR-042 already established for `rac-core`.
+
+Two questions ADR-042 and ADR-092 leave open: whether the org site stands
+alone and links out to each product's own docs, or aggregates their content;
+and, per ADR-064's caution that vendoring "is deferred until a publish/vendor
+contract exists," what that contract is if aggregation is chosen. The
+maintainer has decided in favor of aggregation, and for `rac-core`'s existing
+project page to be retired in the umbrella site's favor, not kept as a
+permanent parallel surface. `rac-spec` (a further product repo, not yet
+created) is anticipated as the next surface this site will carry; this
+decision's vendoring contract is written to admit that member without
+amendment.
+
+## Decision
+
+`itsthelore.github.io` becomes the hosted documentation surface for the whole
+org. It **aggregates `docs/` from each product repo at build time** rather
+than linking out to per-repo project pages.
+
+- The site is built with Astro and deployed to GitHub Pages by a GitHub
+  Actions workflow in `itsthelore.github.io`, using the same
+  `upload-pages-artifact` / `deploy-pages@v4` steps ADR-042 established.
+- **Vendor contract:** the build sparse-checks out each source repo's `docs/`
+  directory at a pinned ref (a tag or `main`, per repo) into the Astro content
+  tree at build time. Nothing vendored is committed to either repository's
+  history — the umbrella site remains a pure build artifact, exactly as
+  ADR-042 requires of the `rac-core` project page today. Each product repo's
+  own `docs/` stays the authoritative source; the umbrella site never edits
+  vendored content, only renders it.
+- Site structure: `/` is the org landing page (brand, product overview, links
+  into each section); `/rac-core/` renders `rac-core`'s vendored `docs/`;
+  further sections (`/rac-ci/`, `/rac-connectors/`, `/rac-spec/`, …) are added
+  the same way as each source repo gains a `docs/` directory worth
+  publishing. No section is scaffolded ahead of its source repo existing.
+  Per ADR-042's existing constraint, the `rac/` corpus is never published on
+  the site, in `rac-core` or any other member repo.
+- `rac-core`'s project-page deployment is **retired**: `docs.yml`'s Pages
+  publish step is removed once the umbrella site's `/rac-core/` section is
+  live, so `itsthelore.github.io/rac-core/` is served by the umbrella
+  deployment instead of `rac-core`'s own. `rac-core` keeps its `docs/`
+  directory and MkDocs config for local `mkdocs serve` authoring; it stops
+  being a second published surface at that URL. Disabling the old Pages
+  deployment is a manual repository-settings action only the maintainer can
+  take (the same class of manual step ADR-042 already required to enable
+  Pages in the first place).
+- Naming: `itsthelore.github.io` is added to ADR-092's topology table as its
+  own repository — a distinct concern (org presence and docs aggregation),
+  not a family-pattern member and not folded into any consolidated repo,
+  because GitHub's root-Pages rule forces this exact name regardless of the
+  `rac-*` convention.
+
+## Consequences
+
+### Positive
+
+- The org gets one coherent documentation home spanning every product,
+  instead of a single project page that implied `rac-core` was the whole
+  story.
+- The vendor contract is decided once, generically (pinned sparse-checkout of
+  `docs/`), so `rac-spec` and future repos add a section without a further
+  ADR or a new build mechanism.
+- ADR-042's authoritative-source and build-artifact discipline is preserved
+  end to end: vendoring reads `docs/`, never writes it, and the site is
+  never a second source of truth.
+
+### Negative
+
+- The umbrella build now depends on the state of every vendored repo at
+  build time; a broken or unreachable source repo can fail the umbrella
+  build even though `itsthelore.github.io` itself has not changed.
+- Retiring `rac-core`'s project-page deployment is a breaking change for
+  anyone who bookmarked or linked `itsthelore.github.io/rac-core/` expecting
+  `rac-core`'s own MkDocs build; the URL keeps working but the rendering
+  engine and look change underneath it.
+- One more repository (`itsthelore.github.io`) with its own build pipeline
+  and brand/design surface to maintain, on top of ADR-092's topology.
+
+### Risks
+
+- **Cross-repo build coupling.** The umbrella build breaks if a vendored
+  repo renames or removes its `docs/` directory without updating the
+  umbrella's checkout path. Mitigation: pin each vendor step to a specific
+  ref and treat a moved `docs/` path as a coordinated two-repo change, the
+  same discipline ADR-064 already applies to cross-repo contracts.
+- **Stranded links.** External links into the old `rac-core` project-page
+  layout could break if the umbrella's `/rac-core/` structure diverges from
+  MkDocs's nav. Mitigation: keep the vendored section's URL structure close
+  to the source `docs/` tree so deep links keep resolving.
+
+## Alternatives Considered
+
+### Stand-alone landing site, link out to each product's own docs
+
+Keep `itsthelore.github.io` as a brand/landing page only, with outbound links
+to `rac-core`'s existing project page and to each future product's own Pages
+site.
+
+#### Advantages
+
+- No cross-repo build coupling; no vendor contract to define or maintain.
+- Each product repo keeps full control of its own docs build and cadence.
+
+#### Disadvantages
+
+- Rejected — leaves the org without one coherent documentation surface, and
+  defers exactly the aggregation problem ADR-064 flagged and left open. The
+  maintainer's stated goal is one shared surface across products, not a set
+  of independently branded project pages.
+
+### Keep rac-core's project page permanently alongside the umbrella site
+
+Aggregate other repos into the umbrella site but leave `rac-core`'s own
+`docs.yml` Pages deployment running in parallel.
+
+#### Advantages
+
+- No breaking change to the existing `itsthelore.github.io/rac-core/` URL's
+  rendering engine.
+
+#### Disadvantages
+
+- Rejected — leaves two published surfaces claiming the same content and the
+  same URL space, one MkDocs-rendered and one Astro-rendered, with no rule
+  for which is canonical. The maintainer chose retirement precisely to avoid
+  that duplication.
+
+## Related Decisions
+
+- adr-042
+- adr-064
+- adr-092
+
+## Review Date
+
+Revisit when a vendored repo's `docs/` structure changes enough to break the
+sparse-checkout contract, or when `rac-spec` (or another anticipated product
+repo) is created and its `docs/` section is added to the umbrella site.

--- a/rac/decisions/adr-102-org-site-brand-direction.md
+++ b/rac/decisions/adr-102-org-site-brand-direction.md
@@ -1,0 +1,137 @@
+---
+schema_version: 1
+id: RAC-KWV63BR8AW71
+type: decision
+tags: [org, docs, branding, design]
+---
+# ADR-102: Org-Site Brand Direction — Light, Restrained, Site Rhymes With Product UI
+
+## Status
+
+Proposed
+
+## Category
+
+Product
+
+## Context
+
+ADR-101 made `itsthelore.github.io` the org-wide documentation site, and
+ADR-092 places the brand at the org rather than in repository slugs. The
+site's first iterations translated rac-localview's design system — amber on
+warm near-black, JetBrains Mono for all text, dashed chrome, pixel-art
+mascot in the hero — directly onto the public surface, first dark, then as
+a lightened variant.
+
+The maintainer's verdict on both: not clean, not professional. A design
+council (visual design, UX/IA, GTM messaging, brand strategy) reviewed the
+site against contemporary developer-tool marketing surfaces (Supermemory,
+Linear, Vercel, Stripe) and converged on the same diagnosis from every
+lens: a terminal aesthetic that works *inside* a product UI reads as a
+hobby project on a marketing/documentation surface. Mono body text hurts
+reading speed and polish; amber headings on cream read dated; dashed
+borders read as placeholders; a large pixel mascot undercuts the
+enterprise-adjacent trust claims the copy makes (deterministic, read-only,
+air-gapped).
+
+The alternative — restyling the product UI to match a new site look — was
+out of scope and undesirable: rac-localview's dark terminal identity is
+fit for purpose where it lives.
+
+## Decision
+
+The org documentation site (`itsthelore.github.io`, ADR-101) adopts its own
+**light, restrained visual identity** rather than mirroring the rac-localview
+product-UI theme:
+
+- **Ground and text:** near-white surfaces (`#fcfcfb` / `#f6f6f4` /
+  `#efefed`), near-black text (`#111113`), low-alpha solid hairline borders.
+  The dark warm-near-black ground does not carry to the marketing/docs
+  surface.
+- **One accent:** deep amber `#B45309` (hover `#92400E`), used for links,
+  active navigation, and focus only — never as fills or structure. The
+  bright lantern amber `#f5a623` survives only in non-text touches.
+- **Typography:** Inter (self-hosted variable woff2) for prose and headings;
+  JetBrains Mono remains the voice of code only. The product UI's
+  mono-everywhere rule does not apply to the site.
+- **Mascot:** the lamplighter is demoted to favicon scale on the site — no
+  in-page illustration. Pixel art reads as a mark at 32px and as a toy at
+  hero size.
+- **Chrome:** solid hairlines and modest radii (6/8/12px) replace the
+  product UI's dashed-border / sharp-corner language on the site.
+
+**The site and the product rhyme, they do not match.** Exactly three brand
+constants are shared with rac-localview: the amber hue (deep on light
+ground, bright in the dark product UI), JetBrains Mono as the voice of code,
+and the lamplighter at icon size. Ground, body type, border style, and
+corner language are decided per surface.
+
+rac-localview's dark tokens and DESIGN.md five rules are **unchanged** —
+they remain the product-UI theme. This decision governs the org's public
+web surface only.
+
+## Consequences
+
+### Positive
+
+- The public surface reads as a credible, contemporary developer-tool
+  site, aligned with what its audience (engineering leads running coding
+  agents) expects from tools they adopt.
+- A recorded, bounded relationship between the two identities — three
+  shared constants — stops future drift arguments in both directions:
+  the site does not creep dark, the product UI does not creep light.
+- Accessibility improves: all text-on-ground pairs are WCAG AA or better
+  by construction (deep amber replaces bright amber for text).
+
+### Negative
+
+- Two visual identities to maintain instead of one; a reader moving from
+  the site into the product UI experiences an intentional theme shift.
+- The lamplighter loses its hero placement — some brand warmth is traded
+  for credibility on the public surface.
+- The site's stylesheet no longer derives mechanically from
+  rac-localview's tokens; shared-constant changes (the amber hue) must be
+  carried across by hand.
+
+## Alternatives Considered
+
+### Keep translating the rac-localview theme to the site
+
+The approach the first two site iterations took (dark, then lightened).
+
+#### Advantages
+
+- One design system everywhere; site styles derive from product tokens.
+
+#### Disadvantages
+
+- Rejected — both iterations failed the maintainer's professionalism bar,
+  and the council's four lenses independently attributed that to the
+  terminal aesthetic itself (mono body, amber headings, dashed chrome,
+  hero mascot), not to its execution.
+
+### Full supermemory-style pivot (blue accent, no brand carryover)
+
+Adopt the reference site's palette and drop the amber entirely.
+
+#### Advantages
+
+- Maximum distance from the "hobby project" reading.
+
+#### Disadvantages
+
+- Rejected — severs the only visual threads connecting the site to the
+  product family. Deep amber at AA contrast keeps the lantern hue without
+  the toy-like brightness.
+
+## Related Decisions
+
+- adr-092
+- adr-101
+- adr-036
+
+## Review Date
+
+Revisit if rac-localview's design system is itself revised (the three
+shared constants must be re-confirmed), or when a second product surface
+(e.g. a hosted app) needs to decide which identity it follows.


### PR DESCRIPTION
## Summary

- Adds ADR-101 (`Proposed`): `itsthelore.github.io` becomes the org-wide documentation site, vendoring `docs/` from each product repo at build time (starting with `rac-core`) instead of each repo publishing its own project page.
- Amends ADR-042 (docs hosting) as a sibling: `rac-core`'s own `docs.yml` → Pages deployment is retired once the umbrella site's `/rac-core/` section is live; the authoritative-source and build-artifact discipline carries forward unchanged.
- Amends ADR-092 (repository topology) as a sibling: adds `itsthelore.github.io` to the topology table as its own repo (org presence + docs aggregation), required by GitHub's root-Pages naming rule.
- Companion scaffold of the actual site lives in `itsthelore/itsthelore.github.io` (separate PR).

## Test plan

- [x] `rac validate rac/` — 390 valid, 0 invalid
- [x] `rac relationships rac/ --validate` — 2313 relationships, 0 issues
- [x] `rac review rac/` — no priority 1–2 findings introduced
- [ ] Maintainer review/acceptance of ADR-101 (currently `Proposed`)


