### PR TITLE
feat(find): add a tag search tier and --tag facet [roadmap:candidate-discovery]

### DIFF
--- a/.cursor/rules
+++ b/.cursor/rules
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: ffb0d12b8aaadcab7cc80995e6f52cb187038eca1e567d12ef49f606c7ff5b14) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: de97a0a6fdfca63fc7f2327e65f65ee83645d0313dbd3032db38ca0568a5813e) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -81,4 +81,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KWV0HZ2SSGE2** — ADR-101: Org-Wide Documentation Site Amends Docs Hosting and Repository Topology _(Product)_
 - **RAC-KWV63BR8AW71** — ADR-102: Org-Site Brand Direction — Light, Restrained, Site Rhymes With Product UI _(Product)_
 - **RAC-KWY0SHYCVY2D** — ADR-108: Term-Range-Partitioned Parallel Merge for the Cold Build _(Architecture)_
+- **RAC-KWY7886GSEE5** — ADR-109: Tag Search Tier and Tag Facet _(Technical)_
 <!-- END RAC MANAGED BLOCK -->

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: ffb0d12b8aaadcab7cc80995e6f52cb187038eca1e567d12ef49f606c7ff5b14) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: de97a0a6fdfca63fc7f2327e65f65ee83645d0313dbd3032db38ca0568a5813e) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -81,4 +81,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KWV0HZ2SSGE2** — ADR-101: Org-Wide Documentation Site Amends Docs Hosting and Repository Topology _(Product)_
 - **RAC-KWV63BR8AW71** — ADR-102: Org-Site Brand Direction — Light, Restrained, Site Rhymes With Product UI _(Product)_
 - **RAC-KWY0SHYCVY2D** — ADR-108: Term-Range-Partitioned Parallel Merge for the Cold Build _(Architecture)_
+- **RAC-KWY7886GSEE5** — ADR-109: Tag Search Tier and Tag Facet _(Technical)_
 <!-- END RAC MANAGED BLOCK -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: ffb0d12b8aaadcab7cc80995e6f52cb187038eca1e567d12ef49f606c7ff5b14) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: de97a0a6fdfca63fc7f2327e65f65ee83645d0313dbd3032db38ca0568a5813e) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -81,4 +81,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KWV0HZ2SSGE2** — ADR-101: Org-Wide Documentation Site Amends Docs Hosting and Repository Topology _(Product)_
 - **RAC-KWV63BR8AW71** — ADR-102: Org-Site Brand Direction — Light, Restrained, Site Rhymes With Product UI _(Product)_
 - **RAC-KWY0SHYCVY2D** — ADR-108: Term-Range-Partitioned Parallel Merge for the Cold Build _(Architecture)_
+- **RAC-KWY7886GSEE5** — ADR-109: Tag Search Tier and Tag Facet _(Technical)_
 <!-- END RAC MANAGED BLOCK -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ to the corpus artifact and they load through the imports below.
 - Previous series: `rac/roadmaps/v0.21.x-editor/` (complete)
 - Decisions (ADRs): `rac/decisions/`
 
-<!-- BEGIN RAC MANAGED BLOCK (digest: ffb0d12b8aaadcab7cc80995e6f52cb187038eca1e567d12ef49f606c7ff5b14) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: de97a0a6fdfca63fc7f2327e65f65ee83645d0313dbd3032db38ca0568a5813e) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -106,4 +106,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KWV0HZ2SSGE2** — ADR-101: Org-Wide Documentation Site Amends Docs Hosting and Repository Topology _(Product)_
 - **RAC-KWV63BR8AW71** — ADR-102: Org-Site Brand Direction — Light, Restrained, Site Rhymes With Product UI _(Product)_
 - **RAC-KWY0SHYCVY2D** — ADR-108: Term-Range-Partitioned Parallel Merge for the Cold Build _(Architecture)_
+- **RAC-KWY7886GSEE5** — ADR-109: Tag Search Tier and Tag Facet _(Technical)_
 <!-- END RAC MANAGED BLOCK -->

--- a/rac/decisions/adr-109-tag-search-tier-and-facet.md
+++ b/rac/decisions/adr-109-tag-search-tier-and-facet.md
@@ -1,0 +1,125 @@
+---
+schema_version: 1
+id: RAC-KWY7886GSEE5
+type: decision
+---
+# ADR-109: Tag Search Tier and Tag Facet
+
+## Context
+
+Frontmatter `tags` are a validated field (a list of non-empty strings) that
+authors already write, but they are invisible to retrieval: the search field
+set is `{id, title, path, heading, body}` only, tags never enter the token
+vectors or the persisted index, and there is no way to filter by tag. The
+first benchmark run put candidate discovery under scrutiny, and this is a
+concrete discovery-quality gap — a curated topical label the engine ignores.
+
+ADR-038 established the precedent and the boundary: a lexical body tier was
+added by decision, and "no embeddings, semantic scoring, stemming, or synonym
+expansion in Core — ever." A tag tier sits squarely inside that
+deterministic-lexical envelope. The tokens the store persists are a
+byte-parity contract (ADR-104), so making tags searchable is also a store
+format change, not only a tokenizer change.
+
+## Decision
+
+`tags` become a searchable lexical field and a filter facet.
+
+- **Tier.** `tags` is a metadata match tier at rank 2, between title and path:
+  a curated tag outranks an incidental path token but not the artifact's own
+  title. Like id/title/path it carries no snippet (ADR-038). Tag strings are
+  tokenised by the same ADR-037 rule as every field — a multi-word tag
+  `data-model` yields `data`/`model` — so a query term matches a tag uniformly,
+  with no special matcher.
+- **Ranking.** The tags field gets a BM25F boost of 2.5 (above path's 2.0,
+  below title's 3.0), the graded contribution that is the real ranking lever
+  (ADR-078). The boost value, not the field's position in the field list, sets
+  the rank; `tags` is appended last in the field list so the existing five
+  fields keep their exact float-summation order and an untagged artifact scores
+  byte-identically.
+- **Facet.** A `--tag` flag on `rac find` (repeatable) and a `tags` argument on
+  the `search_artifacts` tool constrain the matched set to artifacts carrying
+  every requested tag. The facet matches the **raw whole tag, casefolded,
+  exactly** — `--tag data-model` matches only that tag, never the token
+  `model` — a deliberately different mechanism from the tokenised tier. AND
+  semantics across repeated tags, like the query's term AND. The facet is a
+  pre-scoring constraint applied alongside the type filter, so corpus-wide BM25
+  statistics (IDF, mean field length) stay corpus-global. `rac find` and
+  `search_artifacts` serve it identically (ADR-031).
+- **Persistence and format.** The tags field vector is persisted like every
+  other field; the raw tag strings are persisted in the `entries.seg` identity
+  block so the facet can match whole tags reconstructed from the store. This
+  bumps the segment format version (3→4) and the cache bundle version ("2"→"3");
+  an older store fails the version gates closed and is rebuilt. The store's
+  scoring fingerprint already changes with the new boost, a third independent
+  guard. Index-served output stays byte-identical to a fresh walk-and-parse
+  build, worker-count invariant, re-proven across the bump.
+- **JSON contract.** Tags are surfaced additively on a *search result*, emitted
+  only when non-empty, so an untagged hit is byte-identical to the pre-tags
+  shape (ADR-007). The identity-only `rac index` manifest is unchanged.
+- **No semantics.** No embeddings, semantic scoring, stemming, or synonym
+  expansion — the tier is a deterministic lexical extension (ADR-038, ADR-066).
+
+## Consequences
+
+### Positive
+
+- The curated topical signal authors already record becomes findable and
+  filterable, improving candidate discovery without widening it semantically.
+- One mechanism per need: tokenised matching for the tier, whole-tag exact
+  matching for the facet — each explainable and deterministic.
+
+### Negative
+
+- A persisted-store format bump: the byte-parity gate must be re-proven across
+  the new field, and older stores rebuild once. Bounded — a rebuild is a
+  latency cost, never an answer change (ADR-104).
+- The tier renumber shifts the `evidence.tier` integer for path/heading/body
+  matches by one in `--explain`/tool output; the fused result *order* is
+  unchanged (BM25F-driven). The evidence-bearing fixtures are regenerated
+  deliberately.
+
+## Status
+
+Accepted
+
+## Category
+
+Technical
+
+## Alternatives Considered
+
+### A tag facet only, no tier
+
+A filter without a tier would let a user narrow by tag but never *rank* on one,
+so a query whose only signal is a tag would miss the artifact entirely.
+Rejected: tags are a genuine relevance signal, not only a filter axis.
+
+### Match the facet on tokenised tags
+
+Filtering on tokenised tags would make `--tag model` match `data-model`,
+conflating the facet with the tier and surprising a user who asked for a
+specific label. Rejected: the facet matches whole tags exactly; the tier does
+the tokenised matching.
+
+### Embedding or semantic tag expansion
+
+Rejected on ADR-038 and ADR-066: no embeddings or semantic scoring in Core. The
+tier is lexical only.
+
+## Relationship to Other Decisions
+
+- ADR-037 (RAC-KTXTAF6ZKDK8): tags tokenise by the same token-boundary rule.
+- ADR-038 (RAC-KTXTAG63E89H): extends the lexical tier ladder; re-affirms no
+  embeddings/semantic scoring.
+- ADR-078 (RAC-KVSQ24G2H2D6): the tags BM25F boost is the graded ranking lever.
+- ADR-104 (RAC-KWS7QCT10Q5A): the persisted store the tags field and format bump
+  extend; the byte-parity gate holds.
+- ADR-007 (RAC-KTQ63DPYKJF4): tags are additive in search results; the manifest
+  contract is unchanged.
+- ADR-031 (RAC-KTW0M81B0GBB): CLI and MCP serve the facet identically.
+- ADR-066 (RAC-KV6KFCC8MHTM): the deterministic, embedding-free retrieval line.
+
+## Related Roadmaps
+
+- candidate-discovery

--- a/rac/roadmaps/candidate-discovery.md
+++ b/rac/roadmaps/candidate-discovery.md
@@ -1,0 +1,79 @@
+---
+schema_version: 1
+id: RAC-KWY786B4XMZE
+type: roadmap
+---
+# Candidate Discovery
+
+## Status
+
+Planned
+
+Captures the candidate-discovery entry-point work surfaced by the first
+benchmark run: the path a query takes to find candidate artifacts before the
+typed graph. The persistent inverted index (adopted via the rebuild-scale
+work) made warm retrieval scale-invariant; this roadmap tracks the discovery
+*quality* and *reach* gaps that remain.
+
+## Context
+
+The benchmark showed the typed graph layers hold up but the entry point into
+them was the scaling bottleneck. Adopting the persistent memory-mapped index
+made candidate discovery bound by query selectivity rather than corpus size —
+deterministic and lexical, no embeddings (ADR-037/038/066). Two discovery gaps
+remain from that analysis: frontmatter `tags` are parsed and validated but
+invisible to search (no tag tier, no tag filter), and the postings-served fast
+path is opt-in and serves only the compacted base. This roadmap records those
+as scheduled work rather than latent gaps.
+
+## Outcomes
+
+- Frontmatter `tags` are a first-class part of discovery: a query term matches
+  an artifact's tags, and a `--tag` facet narrows results to artifacts carrying
+  a tag — the curated topical signal authors already write becomes findable.
+- Discovery stays deterministic and lexical end to end: every new signal is a
+  BM25F/tier extension, never an embedding or semantic score (ADR-038/066).
+
+## Initiatives
+
+- Tag search tier and tag facet: make `tags` a searchable lexical field (a
+  metadata tier between title and path, ADR-037 tokenisation, a BM25F boost)
+  and add a `--tag` / `tags` facet with AND semantics to `rac find` and the
+  `search_artifacts` tool. Ships behind a persisted-store format bump with the
+  byte-parity gate re-proven (ADR-109).
+- (Deferred, tracked elsewhere) Making the postings-served fast path the
+  reachable default for one-shot CLI queries, and folding delta-window postings
+  into discovery so edited corpora keep the fast path — recorded in the
+  single-node-scale residuals, not this item.
+
+## Success Measures
+
+- A query term present only in an artifact's tags retrieves it; a `--tag`
+  filter constrains the result set to artifacts carrying every requested tag,
+  case-insensitively; both served byte-identically whether index-on or
+  index-off.
+- Tag tokens do not leak into other tiers (a tag-only term surfaces no
+  heading/body snippet), and untagged corpora are byte-identical to the
+  pre-tags output.
+
+## Assumptions
+
+- `tags` remain a validated frontmatter list of non-empty strings; the tag
+  facet matches whole tags, the tier matches tokenised tags.
+- The persisted index remains a disposable derived structure; a format bump is
+  a rebuild cost, never an answer change (ADR-104).
+
+## Risks
+
+- The tags field is persisted in the index, so the tier/facet ships with a
+  store format bump; the byte-parity gate (store == fresh build, worker-count
+  invariant) is the tripwire and must be re-proven, not assumed, across the
+  bump.
+
+## Related Decisions
+
+- RAC-KWY7886GSEE5
+
+## Related Roadmaps
+
+- single-node-scale-residuals

--- a/src/rac/cli.py
+++ b/src/rac/cli.py
@@ -1047,6 +1047,7 @@ def cmd_find(args: argparse.Namespace) -> int:
             args.query,
             artifact_type=args.type,
             recursive=not args.top_level,
+            tags=args.tags,
         )
     # Freshness phase 1 (ADR-045): join git-derived staleness onto matches after
     # ranking, so the matched set and order are unchanged (REQ-005) and the fields
@@ -2159,6 +2160,16 @@ def build_parser() -> argparse.ArgumentParser:
         help=(
             "Only live decisions (Accepted, non-retired) — the 'what did we "
             "decide about X / is X ruled out' query (ADR-067)."
+        ),
+    )
+    p_find.add_argument(
+        "--tag",
+        action="append",
+        dest="tags",
+        metavar="TAG",
+        help=(
+            "Only match artifacts carrying this frontmatter tag (repeatable; all "
+            "required). Narrows the query by tag (ADR-109)."
         ),
     )
     p_find.add_argument(

--- a/src/rac/mcp/server.py
+++ b/src/rac/mcp/server.py
@@ -520,7 +520,7 @@ def build_server(
     ) -> str:
         # ``tags`` only rides the audit args when supplied, so a plain query's
         # recorded shape is byte-identical to before (additive, ADR-007/ADR-109).
-        args = {"query": query, "type": type}
+        args: dict[str, str | list[str] | None] = {"query": query, "type": type}
         if tags:
             args["tags"] = tags
         return observed(

--- a/src/rac/mcp/server.py
+++ b/src/rac/mcp/server.py
@@ -146,9 +146,10 @@ DESC_SEARCH_ARTIFACTS = (
     "decisions (ADRs), designs, roadmaps, and prompts — by keyword. Call this "
     "before designing or implementing anything that an existing requirement or "
     "prior decision might cover, and whenever the user mentions a feature area, "
-    "so recorded decisions are respected instead of rediscovered. Returns "
-    "matching artifact IDs, types, titles, and paths; use get_artifact to read "
-    "a match."
+    "so recorded decisions are respected instead of rediscovered. Optionally "
+    "pass `tags` to narrow the query to artifacts carrying every given "
+    "frontmatter tag. Returns matching artifact IDs, types, titles, and paths "
+    "(plus their tags when tagged); use get_artifact to read a match."
 )
 
 DESC_GET_RELATED = (
@@ -271,6 +272,7 @@ def _search_artifacts(
     artifact_type: str | None,
     budget: int,
     reader: FreshnessTracker | None = None,
+    tags: list[str] | None = None,
 ) -> str:
     if reader is not None:
         derived = reader.read_model()
@@ -278,7 +280,7 @@ def _search_artifacts(
             # Served from the memory-mapped base (the delta is empty): the postings
             # fast path touches only the query terms' prefix ranges and the matched
             # docs' rows, byte-identical to a full-corpus walk (ADR-104).
-            result = derived.search(query, artifact_type=artifact_type)
+            result = derived.search(query, artifact_type=artifact_type, tags=tags)
         else:
             # A non-empty delta serves from the re-derived in-memory snapshot; its
             # search is the whole-corpus scan, correct and already resident.
@@ -287,10 +289,11 @@ def _search_artifacts(
                 query,
                 artifact_type=artifact_type,
                 field_tokens_by_path=derived.field_tokens_by_path,
+                tags=tags,
             )
     else:
         entries = build_repository_index(root, recursive=True).artifacts
-        result = search_index(entries, query, artifact_type=artifact_type)
+        result = search_index(entries, query, artifact_type=artifact_type, tags=tags)
     # Freshness phase 1 (ADR-045): join git-derived staleness after ranking, so
     # search order is unchanged and the fields degrade to null outside git.
     annotate_search_recency(result.matches, root)
@@ -512,11 +515,18 @@ def build_server(
         )
 
     @server.tool(name="search_artifacts", description=DESC_SEARCH_ARTIFACTS)
-    def search_artifacts(query: str, ctx: Context, type: str | None = None) -> str:
+    def search_artifacts(
+        query: str, ctx: Context, type: str | None = None, tags: list[str] | None = None
+    ) -> str:
+        # ``tags`` only rides the audit args when supplied, so a plain query's
+        # recorded shape is byte-identical to before (additive, ADR-007/ADR-109).
+        args = {"query": query, "type": type}
+        if tags:
+            args["tags"] = tags
         return observed(
             "search_artifacts",
-            {"query": query, "type": type},
-            lambda: _search_artifacts(root, query, type, budget, reader),
+            args,
+            lambda: _search_artifacts(root, query, type, budget, reader, tags),
             _request_principal(ctx),
         )
 

--- a/src/rac/services/derived_cache.py
+++ b/src/rac/services/derived_cache.py
@@ -73,7 +73,9 @@ from rac.services.scope_paths import repository_root
 # JSON blob) but not the bundle shape, so the version stays "2"; the encoding is
 # versioned independently by the store's own segment-format and layout versions,
 # and an old JSON blob is simply never opened as a store (a miss).
-SCHEMA_VERSION = "2"
+# Bumped to "3" by the tags tier (ADR-109): the store's bundle version, so a
+# store built before the tags field fails the bundle-version gate and rebuilds.
+SCHEMA_VERSION = "3"
 
 _DECISION_TYPE = "decision"
 

--- a/src/rac/services/index.py
+++ b/src/rac/services/index.py
@@ -50,6 +50,10 @@ class IndexEntry:
     # additive): the deterministic graph signal the relevance ranker fuses
     # (ADR-078). Not serialized — the index JSON contract is unchanged.
     inbound_count: int = 0
+    # Frontmatter tags (ADR-109, additive): the tags search tier and the `--tag`
+    # facet read from here. Not serialized in the manifest to_dict — the index
+    # JSON contract stays identity-only, same as search_sections/inbound_count.
+    tags: list[str] = field(default_factory=list)
 
     def to_dict(self) -> dict:
         return {
@@ -130,6 +134,7 @@ def index_from_corpus(
                 aliases=artifact_identifiers(product, spec, str(path)),
                 search_sections=product.search_sections,
                 inbound_count=inbound.get(str(path), 0),
+                tags=list(product.metadata.tags) if product.metadata else [],
             )
         )
     return RepositoryIndex(directory=directory, recursive=recursive, artifacts=artifacts)

--- a/src/rac/services/index_format.py
+++ b/src/rac/services/index_format.py
@@ -38,7 +38,10 @@ SEGMENT_MAGIC = b"RACIDX01"
 # resolve an id in O(lookup) instead of reconstructing every identity row: a
 # store written before the bump lacks those files and fails this gate closed, so
 # the point-resolution fast path never reads a half-old layout.
-SEGMENT_FORMAT_VERSION = 3
+# Bumped to 4 by the tags tier (ADR-109): entries.seg rows carry a raw-tags list
+# and tokens.seg/header gain a 6th field vector, so a v3 store fails this gate
+# closed and is rebuilt fresh rather than misread with the wrong field count.
+SEGMENT_FORMAT_VERSION = 4
 
 _U32 = struct.Struct("<I")
 _U64 = struct.Struct("<Q")

--- a/src/rac/services/index_store.py
+++ b/src/rac/services/index_store.py
@@ -70,6 +70,7 @@ from rac.services.resolve import (
     SearchableArtifact,
     SearchResult,
     _bm25f_scored,
+    _entry_has_tags,
     _Match,
     _match_entry,
     _rank_and_build,
@@ -82,7 +83,9 @@ from rac.services.resolve import (
 # order; the fold feeds them back to the shared scorer in the same order, so the
 # float summation order — the parity-critical one — is preserved.
 FIELDS: tuple[str, ...] = tuple(_FIELD_BOOSTS)
-assert FIELDS == ("id", "title", "path", "heading", "body"), "field order is a parity contract"
+assert FIELDS == ("id", "title", "path", "heading", "body", "tags"), (
+    "field order is a parity contract"
+)
 
 # On-disk layout root and version. A layout bump lands in a new subdirectory, so
 # stores from an older layout are simply never found (a miss) — never rehydrated.
@@ -216,6 +219,10 @@ def _iter_segment_files(
         row.opt_text(entry.title)
         row.text(entry.path)
         row.text_list(list(entry.aliases))
+        # Raw tags in the identity block (ADR-109) so the `--tag` facet matches
+        # whole tags reconstructed from the store; placed after aliases and before
+        # inbound so entry_path (which stops at path) is untouched.
+        row.text_list(list(entry.tags))
         row.u32(entry.inbound_count)
         for value in lengths:
             row.u32(value)
@@ -543,7 +550,10 @@ class MmapIndexReader:
         title = reader.opt_text()
         path = reader.text()
         aliases = reader.text_list()
-        return IndexEntry(id=entry_id, type=entry_type, title=title, path=path, aliases=aliases)
+        tags = reader.text_list()
+        return IndexEntry(
+            id=entry_id, type=entry_type, title=title, path=path, aliases=aliases, tags=tags
+        )
 
     def full_entry(self, docid: int) -> IndexEntry:
         """The full index row: identity plus searchable sections and inbound count."""
@@ -553,6 +563,7 @@ class MmapIndexReader:
         title = reader.opt_text()
         path = reader.text()
         aliases = reader.text_list()
+        tags = reader.text_list()
         inbound = reader.u32()
         sections = self._read_sections(docid)
         return IndexEntry(
@@ -563,6 +574,7 @@ class MmapIndexReader:
             aliases=aliases,
             search_sections=sections,
             inbound_count=inbound,
+            tags=tags,
         )
 
     def _read_sections(self, docid: int) -> list[SearchSection]:
@@ -585,7 +597,8 @@ class MmapIndexReader:
         reader.text()
         reader.opt_text()
         reader.text()
-        reader.text_list()
+        reader.text_list()  # aliases
+        reader.text_list()  # tags
         reader.u32()  # inbound
         lengths = [reader.u32() for _ in FIELDS]
         return lengths[FIELDS.index(field_name)]
@@ -990,7 +1003,13 @@ class Fold:
 
     # --- postings-served search (ADR-104; ADR-078 scoring unchanged) -----------
 
-    def search(self, query: str, artifact_type: str | None = None) -> SearchResult:
+    def search(
+        self,
+        query: str,
+        artifact_type: str | None = None,
+        *,
+        tags: Sequence[str] | None = None,
+    ) -> SearchResult:
         """`rac find` search served from the postings, byte-identical to a walk.
 
         Reproduces :func:`resolve.search_index` without materialising the whole
@@ -1000,16 +1019,21 @@ class Fold:
         header, ``df`` from the prefix ranges — carry the non-matching corpus's
         contribution without touching its rows. Matching, snippet selection, and
         the fused BM25F+RRF ranking all run through the shared scoring code on
-        inputs value-identical to the fresh walk, so the emitted bytes match.
+        inputs value-identical to the fresh walk, so the emitted bytes match. The
+        ``tags`` facet narrows the candidates to those carrying every tag, exactly
+        as the fresh path does (ADR-109).
         """
         terms = tokenize(query)
         if not terms:
             return SearchResult(query=query, artifact_type=artifact_type, matches=[])
+        tag_filter = frozenset(t.casefold() for t in tags) if tags else frozenset()
         matched: list[tuple[SearchableArtifact, _Match]] = []
         field_tokens_by_path: dict[str, dict[str, list[str]]] = {}
         for docid in sorted(self.candidate_docids(terms)):
             entry = self.base.full_entry(docid)
             if artifact_type is not None and entry.type != artifact_type:
+                continue
+            if tag_filter and not _entry_has_tags(entry, tag_filter):
                 continue
             entry_tokens = _tokenize_entry(entry)
             match = _match_entry(entry_tokens, terms)
@@ -1117,16 +1141,23 @@ class ReadModelView:
             for row in self._fold.scope_rows_raw()
         ]
 
-    def search(self, query: str, artifact_type: str | None = None) -> SearchResult:
+    def search(
+        self,
+        query: str,
+        artifact_type: str | None = None,
+        *,
+        tags: Sequence[str] | None = None,
+    ) -> SearchResult:
         """Postings-served `rac find` search — byte-identical to ``search_index``.
 
         The store fast path a search-shaped tool takes when the read-model is
         served from the memory-mapped base (the delta is empty): it touches only
         the query terms' prefix ranges and the matched docs' rows, never the whole
         corpus, while producing the same ordered matches, ``match_count``, and
-        evidence a fresh whole-corpus walk would.
+        evidence a fresh whole-corpus walk would. ``tags`` narrows to artifacts
+        carrying every requested tag (ADR-109).
         """
-        return self._fold.search(query, artifact_type=artifact_type)
+        return self._fold.search(query, artifact_type=artifact_type, tags=tags)
 
     def resolve(self, artifact_id: str) -> ResolutionResult:
         """Point resolution over the persisted alias map — byte-identical to a walk.

--- a/src/rac/services/repository.py
+++ b/src/rac/services/repository.py
@@ -77,6 +77,10 @@ class Artifact:
     # (ADR-078); carried so a repository-model search ranks like every other
     # surface. Not part of any JSON contract.
     inbound_count: int = 0
+    # Frontmatter tags (ADR-109): carried so a repository-model search matches
+    # the tags tier and the `--tag` facet like every other surface. Not part of
+    # any JSON contract.
+    tags: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -241,6 +245,7 @@ def repository_from_corpus(
             missing_recommended=missing_by_path.get(entry.path, ()),
             search_sections=tuple(entry.search_sections),
             inbound_count=entry.inbound_count,
+            tags=tuple(entry.tags),
         )
         for entry in index.artifacts
     ]

--- a/src/rac/services/resolve.py
+++ b/src/rac/services/resolve.py
@@ -64,21 +64,27 @@ class SearchableArtifact(Protocol):
     def search_sections(self) -> Sequence[SearchSection]: ...
     @property
     def inbound_count(self) -> int: ...
+    @property
+    def tags(self) -> Sequence[str]: ...
 
 
-# Match-field priority for search ordering (lower ranks first); the ladder
-# pinned by ADR-037/ADR-038: id, then title, then path, then heading, then body.
+# Match-field priority for search ordering (lower ranks first); the ladder pinned
+# by ADR-037/ADR-038 and extended by ADR-109 with a tags tier between title and
+# path: id, title, tags, path, heading, body. A curated tag outranks an
+# incidental path token but not the artifact's own title.
 _RANK_ID = 0
 _RANK_TITLE = 1
-_RANK_PATH = 2
-_RANK_HEADING = 3
-_RANK_BODY = 4
+_RANK_TAGS = 2
+_RANK_PATH = 3
+_RANK_HEADING = 4
+_RANK_BODY = 5
 
 # Tier number -> field name, the projection ADR-037's ladder exposes as match
 # evidence (WS2 explainable retrieval): the winning rank named, no new compute.
 _RANK_NAMES: dict[int, str] = {
     _RANK_ID: "id",
     _RANK_TITLE: "title",
+    _RANK_TAGS: "tags",
     _RANK_PATH: "path",
     _RANK_HEADING: "heading",
     _RANK_BODY: "body",
@@ -143,6 +149,12 @@ class ResolvedArtifact:
     # for search until a surface enriches it, and absent from ``to_dict`` then, so
     # the pre-freshness shape is byte-identical (ADR-007).
     recency: dict | None = None
+    # Frontmatter tags (ADR-109, additive): surfaced on a *search* hit so a caller
+    # sees why it matched and what else the artifact carries. Emitted from
+    # ``to_dict`` only when non-empty, so an untagged hit is byte-identical to the
+    # pre-tags shape (ADR-007); the identity-only ``rac index`` manifest is
+    # unchanged.
+    tags: list[str] = field(default_factory=list)
 
     def to_dict(self, *, include_evidence: bool = True) -> dict:
         payload: dict[str, Any] = {
@@ -159,6 +171,8 @@ class ResolvedArtifact:
             payload["evidence"] = self.evidence
         if self.recency is not None:
             payload["recency"] = self.recency
+        if self.tags:
+            payload["tags"] = self.tags
         return payload
 
     @classmethod
@@ -178,6 +192,7 @@ class ResolvedArtifact:
             section=section,
             snippet=snippet,
             evidence=evidence,
+            tags=list(getattr(entry, "tags", ())),
         )
 
 
@@ -403,6 +418,11 @@ def _tokenize_entry(entry: SearchableArtifact) -> _EntryTokens:
     fields = {
         "id": _id_tokens(entry),
         "title": tokenize(entry.title or ""),
+        # Tags tokenise by the same ADR-037 rule as every field: a multi-word tag
+        # like ``data-model`` yields ``data``/``model``, so a query term matches a
+        # tag uniformly (ADR-109). The facet (``_entry_has_tags``) matches the raw
+        # whole tag instead — a deliberately different mechanism.
+        "tags": [token for tag in getattr(entry, "tags", ()) for token in tokenize(tag)],
         "path": tokenize(entry.path),
         "heading": heading_tokens,
         "body": body_tokens,
@@ -475,6 +495,7 @@ def _match_body(
 _TIERS: tuple[tuple[int, _TierMatcher], ...] = (
     (_RANK_ID, _match_field("id")),
     (_RANK_TITLE, _match_field("title")),
+    (_RANK_TAGS, _match_field("tags")),
     (_RANK_PATH, _match_field("path")),
     (_RANK_HEADING, _match_headings),
     (_RANK_BODY, _match_body),
@@ -531,16 +552,19 @@ def find_artifacts(
     query: str,
     artifact_type: str | None = None,
     recursive: bool = True,
+    *,
+    tags: Sequence[str] | None = None,
 ) -> SearchResult:
-    """Search artifacts under ``directory`` by id, title, path, heading, or body.
+    """Search artifacts under ``directory`` by id, title, tags, path, heading, or body.
 
     Deterministic and explainable (no ranking heuristics): token-boundary
-    matching (ADR-037), the five-tier ladder with body text (ADR-038), results
-    ordered by match-field priority then sorted path. An empty result is a
-    valid outcome, not an error.
+    matching (ADR-037), the tiered ladder with a tags tier and body text
+    (ADR-038/ADR-109), results ordered by match-field priority then sorted path.
+    ``tags`` narrows the matched set to artifacts carrying every requested tag
+    (the ``--tag`` facet). An empty result is a valid outcome, not an error.
     """
     entries = build_repository_index(directory, recursive=recursive).artifacts
-    return search_index(entries, query, artifact_type=artifact_type)
+    return search_index(entries, query, artifact_type=artifact_type, tags=tags)
 
 
 # --- Live decision query (v0.21.16, ADR-067) ---------------------------------
@@ -640,13 +664,19 @@ _GRAPH_WEIGHT = 0.5
 _BM25_K1 = 1.2  # term-frequency saturation.
 _BM25_B = 0.75  # field-length normalisation strength.
 # Field boosts mirror the old tier order (id/title heaviest, body lightest),
-# turning the hard tier cutoff into a graded BM25F contribution.
+# turning the hard tier cutoff into a graded BM25F contribution. ``tags`` is
+# appended LAST, not at its tier position (rank 2), so the original five fields
+# keep their exact float-summation order — the parity-critical one the store
+# depends on (ADR-109); an untagged artifact adds a ``+0.0`` tags term, leaving
+# its score byte-identical. The boost value (2.5, above path, below title), not
+# the dict position, is the BM25F ranking lever.
 _FIELD_BOOSTS: dict[str, float] = {
     "id": 4.0,
     "title": 3.0,
     "path": 2.0,
     "heading": 1.5,
     "body": 1.0,
+    "tags": 2.5,
 }
 
 
@@ -784,12 +814,23 @@ def _competition_ranks(scores: dict[str, float]) -> dict[str, int]:
     return ranks
 
 
+def _entry_has_tags(entry: SearchableArtifact, wanted: frozenset[str]) -> bool:
+    """Whether ``entry`` carries every tag in ``wanted`` (the ``--tag`` facet).
+
+    Exact whole-tag match, casefolded (tags are case-insensitive labels, ADR-109):
+    ``--tag data-model`` matches only that tag, never the token ``model``. AND
+    across the requested set — a narrowing filter, like the query's term AND.
+    """
+    return wanted <= {tag.casefold() for tag in getattr(entry, "tags", ())}
+
+
 def search_index(
     entries: Sequence[SearchableArtifact],
     query: str,
     artifact_type: str | None = None,
     *,
     field_tokens_by_path: dict[str, dict[str, list[str]]] | None = None,
+    tags: Sequence[str] | None = None,
 ) -> SearchResult:
     """Search already-discovered entries with `rac find` semantics (v0.8.1).
 
@@ -807,6 +848,10 @@ def search_index(
     to computing it fresh — only the per-call re-tokenisation is skipped.
     """
     terms = tokenize(query)
+    # The tag facet is a pre-scoring constraint applied alongside the type filter,
+    # so surviving results rank among themselves while corpus-wide BM25 stats stay
+    # corpus-global (IDF unchanged, ADR-109). Empty/None means no facet.
+    tag_filter = frozenset(t.casefold() for t in tags) if tags else frozenset()
     matched: list[tuple[SearchableArtifact, _Match]] = []
     # Field vectors of the entries the matcher tokenised this call, reused below
     # for the corpus statistics so each entry is tokenised at most once.
@@ -814,6 +859,8 @@ def search_index(
     if terms:  # an all-punctuation query tokenizes to nothing: no matches.
         for entry in entries:
             if artifact_type is not None and entry.type != artifact_type:
+                continue
+            if tag_filter and not _entry_has_tags(entry, tag_filter):
                 continue
             entry_tokens = _tokenize_entry(entry)
             matched_field_tokens[entry.path] = entry_tokens.fields

--- a/tests/golden/find_explain_json.txt
+++ b/tests/golden/find_explain_json.txt
@@ -36,7 +36,7 @@
         "terms": [
           "markdown"
         ],
-        "tier": 4,
+        "tier": 5,
         "score": 0.024326,
         "components": {
           "bm25": 0.105266,

--- a/tests/test_b1_read_model.py
+++ b/tests/test_b1_read_model.py
@@ -223,8 +223,8 @@ def test_extended_bundle_round_trips_losslessly(tmp_path):
 
 
 def test_schema_version_was_bumped_by_adr_100():
-    # ADR-103 extended the cached bundle, so the schema version moved off "1".
-    assert derived_cache.SCHEMA_VERSION == "2"
+    # ADR-103 moved it off "1"; ADR-109 (the tags field) bumped it to "3".
+    assert derived_cache.SCHEMA_VERSION == "3"
 
 
 def test_old_version_cache_file_is_a_miss_never_rehydrated(tmp_path):
@@ -233,7 +233,7 @@ def test_old_version_cache_file_is_a_miss_never_rehydrated(tmp_path):
     cache_file = next((tmp_path / "cache").glob("*.json"))
 
     obj = json.loads(cache_file.read_text(encoding="utf-8"))
-    assert obj["schema_version"] == "2"
+    assert obj["schema_version"] == "3"
 
     # The version gate rejects an old-shape file outright — from_json_obj raises,
     # which the reader treats as a miss (never a rehydration into the new shape).
@@ -247,4 +247,4 @@ def test_old_version_cache_file_is_a_miss_never_rehydrated(tmp_path):
     cache_file.write_text(json.dumps(stale), encoding="utf-8")
     rebuilt = cache.load_or_build(CORPUS)
     assert rebuilt == fresh == build_derived_index(CORPUS)
-    assert json.loads(cache_file.read_text(encoding="utf-8"))["schema_version"] == "2"
+    assert json.loads(cache_file.read_text(encoding="utf-8"))["schema_version"] == "3"

--- a/tests/test_b2_index_store.py
+++ b/tests/test_b2_index_store.py
@@ -84,9 +84,11 @@ def _decision(
     body: str = "alpha beta gamma",
     scope: str | None = None,
     related: tuple[str, ...] = (),
+    tags: tuple[str, ...] = (),
 ) -> str:
+    tags_line = f"tags: [{', '.join(tags)}]\n" if tags else ""
     text = (
-        f"---\nschema_version: 1\nid: {ident}\ntype: decision\n---\n"
+        f"---\nschema_version: 1\nid: {ident}\ntype: decision\n{tags_line}---\n"
         f"# {title}\n\n## Status\n\n{status}\n\n## Category\n\nArchitecture\n\n"
         f"## Context\n\n{body}\n\n## Decision\n\nD.\n\n## Consequences\n\nE.\n"
     )
@@ -228,6 +230,39 @@ def test_view_equals_fresh_build_not_self_round_trip(tmp_path):
     root = _corpus(tmp_path / "corpus")
     cache = DerivedIndexCache(tmp_path / "cache")
     assert cache.load_or_build(str(root)) == build_derived_index(str(root))
+
+
+def test_tags_survive_store_round_trip_and_facet_matches_fresh(tmp_path):
+    # ADR-109: the store persists the tags field and the raw tags, so an
+    # index-served tag tier hit and `--tag` facet are byte-identical to a fresh
+    # walk. The store view must equal a fresh build with tagged artifacts.
+    root = tmp_path / "corpus"
+    root.mkdir(parents=True)
+    (root / "a.md").write_text(
+        _decision(_D1, "Alpha", body="shared body", tags=("security", "data-model")),
+        encoding="utf-8",
+    )
+    (root / "b.md").write_text(
+        _decision(_D2, "Beta", body="shared body", tags=("performance",)), encoding="utf-8"
+    )
+    cache = DerivedIndexCache(tmp_path / "cache")
+    assert cache.load_or_build(str(root)) == build_derived_index(str(root))
+
+    fold, _entries, _ftbp = _fold_for(tmp_path, root)
+    # Tag-tier term served from the postings equals the fresh walk.
+    assert [m.id for m in fold.search("security").matches] == [
+        m.id for m in search_index(build_repository_index(str(root)).artifacts, "security").matches
+    ]
+    # `--tag` facet served from the store equals the fresh walk (AND, casefold).
+    store_ids = [m.to_dict() for m in fold.search("shared", tags=["SECURITY"]).matches]
+    fresh_ids = [
+        m.to_dict()
+        for m in search_index(
+            build_repository_index(str(root)).artifacts, "shared", tags=["SECURITY"]
+        ).matches
+    ]
+    assert store_ids == fresh_ids
+    assert len(store_ids) == 1
 
 
 # =============================================================================

--- a/tests/test_b5_scale_hardening.py
+++ b/tests/test_b5_scale_hardening.py
@@ -47,7 +47,7 @@ from rac.services.freshness import FreshnessTracker
 from rac.services.index_store import open_read_model, store_dir, write_store
 from rac.services.parallel_build import build_derived_index_parallel
 
-_BUNDLE_VERSION = "2"
+_BUNDLE_VERSION = "3"
 
 
 def _decision(i: int, *, title: str | None = None, body: str = "alpha beta gamma") -> str:

--- a/tests/test_char_mcp.py
+++ b/tests/test_char_mcp.py
@@ -356,4 +356,4 @@ def test_cache_file_named_by_corpus_hash_carries_schema_version(tmp_path):
     expected = cache_dir / f"{corpus_content_hash(CORPUS)}.json"
     assert expected.exists()
     obj = json.loads(expected.read_text(encoding="utf-8"))
-    assert obj["schema_version"] == derived_cache.SCHEMA_VERSION == "2"
+    assert obj["schema_version"] == derived_cache.SCHEMA_VERSION == "3"

--- a/tests/test_explain.py
+++ b/tests/test_explain.py
@@ -88,21 +88,22 @@ def test_path_tier_evidence(tmp_path):
     assert _tier_evidence(_evidence_for(_corpus(tmp_path), "catalog")) == {
         "field": "path",
         "terms": ["catalog"],
-        "tier": 2,
+        # tier 3: the tags tier (ADR-109) sits at rank 2, shifting path down one.
+        "tier": 3,
     }
 
 
 def test_heading_tier_evidence(tmp_path):
     # "eviction" appears only in the "Eviction Heuristics" section heading.
     ev = _evidence_for(_corpus(tmp_path), "eviction")
-    assert ev["field"] == "heading" and ev["tier"] == 3
+    assert ev["field"] == "heading" and ev["tier"] == 4
     assert ev["terms"] == ["eviction"]
 
 
 def test_body_tier_evidence(tmp_path):
     # "mitochondria" appears only in the Context body line.
     ev = _evidence_for(_corpus(tmp_path), "mitochondria")
-    assert ev["field"] == "body" and ev["tier"] == 4
+    assert ev["field"] == "body" and ev["tier"] == 5
     assert ev["terms"] == ["mitochondria"]
 
 

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -589,3 +589,117 @@ def test_ranking_is_byte_stable_across_runs(tmp_path):
     a = find_artifacts(str(tmp_path), "alpha").to_dict()
     b = find_artifacts(str(tmp_path), "alpha").to_dict()
     assert json.dumps(a) == json.dumps(b)
+
+
+# --- Tag search tier + facet (ADR-109) ---------------------------------------
+
+_TAGGED_A = """---
+schema_version: 1
+id: RAC-01JY4M8X2QA1
+type: decision
+tags: [security, data-model]
+---
+# Alpha Decision
+
+## Context
+
+shared body text
+
+## Decision
+
+d
+
+## Consequences
+
+e
+"""
+
+_TAGGED_B = """---
+schema_version: 1
+id: RAC-01JY4M8X2QB2
+type: decision
+tags: [performance]
+---
+# Beta Decision
+
+## Context
+
+shared body text
+
+## Decision
+
+d
+
+## Consequences
+
+e
+"""
+
+
+@pytest.fixture
+def tagged_repo(tmp_path):
+    (tmp_path / "a.md").write_text(_TAGGED_A, encoding="utf-8")
+    (tmp_path / "b.md").write_text(_TAGGED_B, encoding="utf-8")
+    return tmp_path
+
+
+def test_tag_term_matches_via_tags_tier(tagged_repo):
+    # A query term present only in a tag retrieves the artifact through the tags
+    # tier at rank 2, and the tags are surfaced additively on the result.
+    result = find_artifacts(str(tagged_repo), "security")
+    assert result.match_count == 1
+    match = result.matches[0]
+    assert match.id == "RAC-01JY4M8X2QA1"
+    assert match.evidence["field"] == "tags"
+    assert match.evidence["tier"] == 2
+    assert match.to_dict()["tags"] == ["security", "data-model"]
+
+
+def test_multiword_tag_tokenizes_like_other_fields(tagged_repo):
+    # `data-model` tokenizes to data/model (ADR-037), so `model` hits via tags.
+    assert find_artifacts(str(tagged_repo), "model").match_count == 1
+
+
+def test_term_absent_from_tags_does_not_match(tagged_repo):
+    assert find_artifacts(str(tagged_repo), "nonesuch").match_count == 0
+
+
+def test_tag_match_is_metadata_no_snippet(tagged_repo):
+    # A tags hit carries no section/snippet — a metadata tier like id/title/path.
+    match = find_artifacts(str(tagged_repo), "security").matches[0]
+    assert match.section is None
+    assert match.snippet is None
+
+
+def test_untagged_result_omits_tags_key(repo):
+    # An untagged artifact's search result is byte-identical to the pre-tags shape.
+    match = find_artifacts(str(repo), "canonical source").matches[0]
+    assert "tags" not in match.to_dict()
+
+
+def test_tag_facet_narrows_matched_set(tagged_repo):
+    # Both artifacts share the body term; the facet narrows to the tag carrier.
+    assert find_artifacts(str(tagged_repo), "shared").match_count == 2
+    assert find_artifacts(str(tagged_repo), "shared", tags=["security"]).match_count == 1
+    assert find_artifacts(str(tagged_repo), "shared", tags=["performance"]).match_count == 1
+
+
+def test_tag_facet_is_and_across_tags(tagged_repo):
+    both = find_artifacts(str(tagged_repo), "shared", tags=["security", "data-model"])
+    assert both.match_count == 1
+    disjoint = find_artifacts(str(tagged_repo), "shared", tags=["security", "performance"])
+    assert disjoint.match_count == 0
+
+
+def test_tag_facet_is_casefolded_exact_whole_tag(tagged_repo):
+    # Case-insensitive whole-tag match: `SECURITY` hits, but the token `model`
+    # (a tier token of `data-model`, not a whole tag) does not filter through.
+    assert find_artifacts(str(tagged_repo), "shared", tags=["SECURITY"]).match_count == 1
+    assert find_artifacts(str(tagged_repo), "shared", tags=["model"]).match_count == 0
+
+
+def test_cli_tag_flag_narrows_find(tagged_repo, capsys):
+    rc = main(["find", "shared", str(tagged_repo), "--tag", "security", "--json"])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert [m["id"] for m in out["matches"]] == ["RAC-01JY4M8X2QA1"]


### PR DESCRIPTION
# Summary

Implements `rac/roadmaps/candidate-discovery.md` — the first candidate-discovery gap the benchmark surfaced. Frontmatter `tags` were parsed and validated but invisible to retrieval: the search field set was `{id, title, path, heading, body}` and there was no way to filter by tag. This makes `tags` a searchable lexical field and adds a `--tag` facet — deterministic and lexical throughout, no embeddings (ADR-037/038/066).

Adds:
- A `tags` search tier: a query term matches an artifact's tags (a metadata tier at rank 2, tokenised by the ADR-037 rule, BM25F boost 2.5).
- A `--tag` facet on `rac find` and a `tags` argument on the `search_artifacts` MCP tool: narrows results to artifacts carrying every requested tag.
- ADR-109, the `candidate-discovery` roadmap, and tier/facet/store-parity tests.

# Roadmap / ADR Trace

Roadmap:
- `rac/roadmaps/candidate-discovery.md`

Relevant ADRs:
- `rac/decisions/adr-109-tag-search-tier-and-facet.md`

# Scope

## Included
- `tags` searchable tier: `IndexEntry.tags` (from `product.metadata.tags`), a metadata tier at rank 2 between title and path, tokenised like every field (`data-model` becomes `data`/`model`), BM25F boost 2.5. The boost is appended last in the field list so the existing five fields keep their exact float-summation order and an untagged artifact scores byte-identically.
- `--tag` / `tags` facet: raw whole-tag, casefolded, exact match, AND semantics across repeated tags; served identically by `rac find` and `search_artifacts`. Applied as a pre-scoring constraint alongside the type filter, so corpus-wide BM25 statistics stay corpus-global.
- Persisted store: the tags field vector rides the existing per-field persistence; the raw tags are stored in the `entries.seg` identity block for the facet. Segment format version 3 to 4 and cache bundle version "2" to "3"; an older store fails the version gates closed and rebuilds.
- Tags surfaced additively on a search result (emitted only when non-empty); the identity-only `rac index` manifest is unchanged.

## Excluded
- Semantic / embedding / stemming / synonym expansion on tags — categorically out of scope (ADR-038, ADR-066).
- The tag tier over a non-empty delta window relies on the same base/delta seam as the rest of postings-served search; no new delta behaviour is added here.
- Making the postings-served fast path the reachable default for one-shot `rac find`, and folding delta-window postings into discovery — separate, recorded in the single-node-scale residuals, not this PR.

# Product / Architecture Decisions
- Two mechanisms, one need each: the **tier** matches tokenised tags (so `model` finds `data-model`), the **facet** matches whole tags exactly (so `--tag data-model` matches only that label, never `model`).
- The tier renumber (`tags` at rank 2) shifts the `evidence.tier` integer for path/heading/body matches by one in the `--explain`/tool output; the fused result *order* is unchanged (BM25F-driven, ADR-078). Documented in ADR-109.
- The tags field is persisted, so the feature ships with a store format bump; the byte-parity gate (store equals a fresh build, worker-count invariant) is re-proven across it rather than assumed.

# User-Facing Contract

## CLI
`rac find QUERY --tag TAG [--tag TAG ...]` — narrows the query to artifacts carrying every given frontmatter tag. Repeatable; AND semantics; case-insensitive whole-tag match.

## MCP
`search_artifacts(query, type=None, tags=None)` — `tags` narrows identically; it rides the audit args only when supplied, so a plain query's recorded shape is byte-identical (additive, ADR-007).

## JSON / Human Output
A search result gains a `tags` field, emitted only when the artifact is tagged — an untagged hit is byte-identical to the pre-tags shape. The `rac index` manifest is unchanged. Default `rac find` JSON (no `--explain`) is unchanged except the additive `tags` on tagged hits.

## Exit Codes
Unchanged.

# Verification

## Ran
- `python -m pytest` — full suite, twice from clean: 2138 passed.
- `ruff check` and `mypy` on the changed modules: clean.
- `rac validate rac/` gives 402 valid, 0 invalid; `rac relationships rac/ --validate` gives 2339 checked, 0 issues; `rac review rac/` no priority 1–2.
- End-to-end: `rac find shared DIR --tag security --json` returns only the tagged artifact, with its tags surfaced.

## Covered
- Tier: a term only in a tag matches at `evidence.tier == 2` with `field == "tags"`; a multi-word tag tokenises (`model` hits `data-model`); a term absent from tags does not match; a tags hit carries no section/snippet (metadata tier); an untagged result omits the `tags` key.
- Facet: `--tag` narrows with AND across tags, casefolded, whole-tag exact (`SECURITY` hits, the token `model` does not); the CLI flag narrows `rac find`.
- Store parity: a tagged corpus's store view equals a fresh `build_derived_index`; the tag tier and `--tag` facet served from the postings store are byte-identical to the fresh walk; `workers=1` vs `workers=4` segment hashes hold across the format bump.
- Regenerated the `find_explain_json` golden — the diff is exactly the `tier: 4 to 5` shift on the body match; pinned schema/bundle versions bumped "2" to "3".

# Review Path
1. `rac/decisions/adr-109-tag-search-tier-and-facet.md` — the decision and its boundaries.
2. `src/rac/services/resolve.py` + `src/rac/services/index.py` — the tier, boost, tokenisation, `IndexEntry.tags`, the facet helper, and result surfacing.
3. `src/rac/services/index_store.py` / `index_format.py` / `derived_cache.py` — the format bump and raw-tag persistence.
4. `src/rac/cli.py` + `src/rac/mcp/server.py` — the `--tag` / `tags` surfaces.
5. `tests/test_resolve.py`, `tests/test_b2_index_store.py` — tier, facet, and store parity.

# Notes For Reviewer
- The riskiest change is the store format bump: `FIELDS`'s parity assertion, the `entries.seg` writer and its three readers, and the two version constants must move together. The gate is store equals a fresh build with tagged artifacts, re-proven in `test_b2_index_store`.
- Branched off the merged rebuild-scale work (#329) and rebased onto `main`.

# Implementation Process
Implemented with AI assistance under the roadmap contract; final scope, review, and acceptance decisions were made by the maintainer.