### PR TITLE
feat(find): reuse the persistent store for rac find --cache [roadmap:candidate-discovery]

### DIFF
--- a/.cursor/rules
+++ b/.cursor/rules
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: de97a0a6fdfca63fc7f2327e65f65ee83645d0313dbd3032db38ca0568a5813e) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: 3d79e93ec7ce3f503bab797a7d7204d82b9bf4f8877d825ec7e89c6c79251b5c) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -82,4 +82,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KWV63BR8AW71** — ADR-102: Org-Site Brand Direction — Light, Restrained, Site Rhymes With Product UI _(Product)_
 - **RAC-KWY0SHYCVY2D** — ADR-108: Term-Range-Partitioned Parallel Merge for the Cold Build _(Architecture)_
 - **RAC-KWY7886GSEE5** — ADR-109: Tag Search Tier and Tag Facet _(Technical)_
+- **RAC-KWYEHJXR0M3G** — ADR-110: One-Shot `rac find --cache` Reuses the Persistent Store _(Technical)_
 <!-- END RAC MANAGED BLOCK -->

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: de97a0a6fdfca63fc7f2327e65f65ee83645d0313dbd3032db38ca0568a5813e) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: 3d79e93ec7ce3f503bab797a7d7204d82b9bf4f8877d825ec7e89c6c79251b5c) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -82,4 +82,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KWV63BR8AW71** — ADR-102: Org-Site Brand Direction — Light, Restrained, Site Rhymes With Product UI _(Product)_
 - **RAC-KWY0SHYCVY2D** — ADR-108: Term-Range-Partitioned Parallel Merge for the Cold Build _(Architecture)_
 - **RAC-KWY7886GSEE5** — ADR-109: Tag Search Tier and Tag Facet _(Technical)_
+- **RAC-KWYEHJXR0M3G** — ADR-110: One-Shot `rac find --cache` Reuses the Persistent Store _(Technical)_
 <!-- END RAC MANAGED BLOCK -->

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -96,7 +96,7 @@ jobs:
           - name: relationships
             paths: "tests/test_relationships.py tests/test_relationships_cmd.py tests/test_relationship_validation.py tests/test_relationship_graph.py tests/test_lifecycle_status.py tests/test_rename.py"
           - name: resolve
-            paths: "tests/test_resolve.py tests/test_find_decisions.py tests/test_scope.py tests/test_explain.py tests/test_selective_retrieval.py"
+            paths: "tests/test_resolve.py tests/test_find_decisions.py tests/test_scope.py tests/test_explain.py tests/test_selective_retrieval.py tests/test_find_cache.py"
           - name: eval
             paths: "tests/test_eval.py"
           - name: review

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: de97a0a6fdfca63fc7f2327e65f65ee83645d0313dbd3032db38ca0568a5813e) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: 3d79e93ec7ce3f503bab797a7d7204d82b9bf4f8877d825ec7e89c6c79251b5c) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -82,4 +82,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KWV63BR8AW71** — ADR-102: Org-Site Brand Direction — Light, Restrained, Site Rhymes With Product UI _(Product)_
 - **RAC-KWY0SHYCVY2D** — ADR-108: Term-Range-Partitioned Parallel Merge for the Cold Build _(Architecture)_
 - **RAC-KWY7886GSEE5** — ADR-109: Tag Search Tier and Tag Facet _(Technical)_
+- **RAC-KWYEHJXR0M3G** — ADR-110: One-Shot `rac find --cache` Reuses the Persistent Store _(Technical)_
 <!-- END RAC MANAGED BLOCK -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ to the corpus artifact and they load through the imports below.
 - Previous series: `rac/roadmaps/v0.21.x-editor/` (complete)
 - Decisions (ADRs): `rac/decisions/`
 
-<!-- BEGIN RAC MANAGED BLOCK (digest: de97a0a6fdfca63fc7f2327e65f65ee83645d0313dbd3032db38ca0568a5813e) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: 3d79e93ec7ce3f503bab797a7d7204d82b9bf4f8877d825ec7e89c6c79251b5c) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -107,4 +107,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KWV63BR8AW71** — ADR-102: Org-Site Brand Direction — Light, Restrained, Site Rhymes With Product UI _(Product)_
 - **RAC-KWY0SHYCVY2D** — ADR-108: Term-Range-Partitioned Parallel Merge for the Cold Build _(Architecture)_
 - **RAC-KWY7886GSEE5** — ADR-109: Tag Search Tier and Tag Facet _(Technical)_
+- **RAC-KWYEHJXR0M3G** — ADR-110: One-Shot `rac find --cache` Reuses the Persistent Store _(Technical)_
 <!-- END RAC MANAGED BLOCK -->

--- a/rac/decisions/adr-110-one-shot-find-store-reuse.md
+++ b/rac/decisions/adr-110-one-shot-find-store-reuse.md
@@ -1,0 +1,127 @@
+---
+schema_version: 1
+id: RAC-KWYEHJXR0M3G
+type: decision
+---
+# ADR-110: One-Shot `rac find --cache` Reuses the Persistent Store
+
+## Context
+
+The persistent memory-mapped index store (ADR-104) makes candidate discovery
+scale-invariant, but it has been reachable only through the long-lived MCP
+server (`rac mcp --cache`), which holds the store open and watches the corpus
+with filesystem events (ADR-105). The benchmark that drives candidate discovery
+invokes `rac find` as a one-shot CLI process per query, and that path has no
+store reuse: `cmd_find` walks, parses, and rebuilds the relationship graph on
+every invocation — exactly the entry-point cost the store exists to remove.
+
+A one-shot process cannot hold the store open or use the event watcher, but the
+store is content-addressed on disk and shared across processes, so a first
+invocation can build and write it and every later invocation against the
+unchanged corpus can serve from it. The seam already exists:
+`DerivedIndexCache.load_or_build` opens the store on a warm hit and builds
+fresh + writes it on a cold miss, and the serving paths already branch on the
+returned read-model type.
+
+## Decision
+
+`rac find` gains an opt-in `--cache` flag that serves the query from the
+persistent index store via `DerivedIndexCache.load_or_build`, byte-identical to
+the uncached walk.
+
+- **Opt-in, default unchanged.** `--cache` is off by default; without it
+  `rac find` walks and parses exactly as before (ADR-104's opt-in posture, the
+  same shape as `rac mcp --cache` and `rac validate --cache`). The store is
+  disposable and content-addressed under `$XDG_CACHE_HOME` (`RAC_CACHE_DIR`
+  overrides); deleting it costs only latency.
+- **Byte-parity.** The cached result is the same `SearchResult` the walk
+  produces — search, the `--decisions` live query, `--type`, the `--tag` facet,
+  and `--explain` evidence are all served through the read-model exactly as
+  `mcp/server.py` serves them (a `ReadModelView` postings fast path on a warm
+  hit, `search_index` / `find_decisions_in` over a fresh `DerivedIndex` on a
+  cold miss). Recency annotation is unchanged — it is joined per-match from git
+  after ranking (ADR-045), independent of how the matches were produced.
+- **Cross-process reuse.** The first `--cache` invocation against a corpus
+  builds fresh and writes the store; every later one-shot process against the
+  unchanged corpus serves from the memory-mapped store with no walk, parse, or
+  graph rebuild. This is the aggregate win for a benchmark or agent that issues
+  many one-shot queries against a stable corpus.
+
+### The two honest costs
+
+- **The O(n) hash floor stands.** `load_or_build` recomputes the corpus content
+  hash on every call to detect change before reusing anything, reading every
+  file's bytes. A warm one-shot therefore still pays O(n) *hashing* — it skips
+  the far more expensive parse, derive, and re-tokenisation, not the hash. Only
+  the long-lived server escapes the hash via the event watcher (ADR-105); a
+  one-shot cannot, by construction.
+- **A cold run is slower than the plain walk.** The miss path forks workers and
+  writes the store, heavier than the current single-process build. A genuine
+  single query with no follow-up is net-negative; the fork and write only
+  amortise across later warm invocations. This is why `--cache` is opt-in rather
+  than the default.
+
+## Consequences
+
+### Positive
+
+- One-shot `rac find` becomes bound by query selectivity, not corpus size, on
+  the warm path — the entry-point fix reaches the CLI, not only the server.
+- No new machinery: the flag is a thin consumer of the existing store, cache,
+  and read-model, and inherits their byte-parity guarantees.
+
+### Negative
+
+- A second reuse surface for the store means the store's freshness and
+  disposability contracts now matter to a short-lived process too; the O(n) hash
+  floor and the cold-run penalty are real and recorded here so the flag is used
+  where it pays (repeated queries against a stable corpus), not blindly.
+
+## Status
+
+Accepted
+
+## Category
+
+Technical
+
+## Alternatives Considered
+
+### Make `--cache` the default for `rac find`
+
+Default reuse would speed a benchmark's plain `rac find` without a harness
+change, but it slows a genuine single one-shot (the cold fork + write) and
+amends ADR-104's opt-in-defaults-unchanged posture. Rejected in favour of an
+opt-in flag; the default walk path stays byte-for-byte unchanged.
+
+### Share the server's event-watched freshness with the CLI
+
+The watcher (ADR-105) that lets the server skip the per-call hash needs a
+persistent process to hold the state and receive events. A one-shot CLI has no
+such process, so it cannot avoid the hash. Rejected as inapplicable; the O(n)
+hash floor is accepted and documented instead.
+
+### A per-invocation stat-only changeset scan
+
+Detecting change by stat instead of hashing the bytes would lower the floor, but
+it is still O(files) and is the same unshipped residual the single-node-scale
+work records; not in scope for this flag.
+
+## Relationship to Other Decisions
+
+- ADR-104 (RAC-KWS7QCT10Q5A): extends the persistent store to a one-shot CLI
+  surface; inherits its content-addressing, disposability, and byte-parity.
+- ADR-099 (RAC-KWMZ3MR9DZ09): the derived cache whose `load_or_build` seam the
+  flag consumes directly.
+- ADR-105 (RAC-KWSDFYW7PCW6): the event-watched freshness a one-shot cannot use,
+  which is why the O(n) hash floor stands.
+- ADR-106 (RAC-KWSH9J2S7QB1): the precedent — `rac validate --cache` introduced
+  opt-in store reuse to a CLI command as its own decision.
+- ADR-031 (RAC-KTW0M81B0GBB): the CLI and the MCP tool serve the same result
+  from the same read-model.
+- ADR-045 (RAC-KV2E5B1122YN): recency stays a git-per-match join after ranking,
+  unaffected by the search path.
+
+## Related Roadmaps
+
+- candidate-discovery

--- a/rac/roadmaps/candidate-discovery.md
+++ b/rac/roadmaps/candidate-discovery.md
@@ -41,10 +41,15 @@ as scheduled work rather than latent gaps.
   and add a `--tag` / `tags` facet with AND semantics to `rac find` and the
   `search_artifacts` tool. Ships behind a persisted-store format bump with the
   byte-parity gate re-proven (ADR-109).
-- (Deferred, tracked elsewhere) Making the postings-served fast path the
-  reachable default for one-shot CLI queries, and folding delta-window postings
-  into discovery so edited corpora keep the fast path — recorded in the
-  single-node-scale residuals, not this item.
+- One-shot CLI store reuse: an opt-in `rac find --cache` that serves the query
+  from the persistent index store (ADR-104) via `load_or_build` instead of a
+  fresh walk, so a benchmark or agent issuing many one-shot queries against a
+  stable corpus skips the parse and graph rebuild on every warm invocation.
+  Byte-identical to the uncached walk (ADR-110).
+- (Deferred, tracked elsewhere) Folding delta-window postings into discovery so
+  edited corpora keep the fast path before compaction, and lowering the one-shot
+  freshness cost below the O(n) byte-hash floor (a stat/fsmonitor fast path) —
+  recorded in the single-node-scale residuals, not this item.
 
 ## Success Measures
 
@@ -55,6 +60,9 @@ as scheduled work rather than latent gaps.
 - Tag tokens do not leak into other tiers (a tag-only term surfaces no
   heading/body snippet), and untagged corpora are byte-identical to the
   pre-tags output.
+- `rac find --cache` returns byte-identical output to `rac find` for search,
+  the `--decisions` query, `--type`, `--tag`, and `--explain`, cold and warm;
+  the warm run serves from the store without re-parsing.
 
 ## Assumptions
 

--- a/src/rac/cli.py
+++ b/src/rac/cli.py
@@ -151,6 +151,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     from rac.services.note_ingest import VaultIngestResult
+    from rac.services.resolve import SearchResult
 
 EXIT_OK = 0
 EXIT_VALIDATION_FAILED = 1
@@ -1026,12 +1027,52 @@ def cmd_resolve(args: argparse.Namespace) -> int:
     return EXIT_OK if result.outcome == OUTCOME_RESOLVED else EXIT_VALIDATION_FAILED
 
 
+def _find_from_store(args: argparse.Namespace) -> SearchResult:
+    """Serve `rac find --cache` from the persistent index store (ADR-110).
+
+    Reuses ``DerivedIndexCache.load_or_build``: a warm run against an unchanged
+    corpus serves from the memory-mapped store with no walk/parse/graph rebuild;
+    a cold run builds fresh and writes the store for the next invocation. The
+    result is byte-identical to the uncached walk — the store fast path and the
+    fresh build are branched exactly as ``mcp/server.py`` does (ADR-104 parity).
+    When the store cannot be written, ``load_or_build`` returns a fresh
+    ``DerivedIndex`` and the ``else`` branches handle it.
+    """
+    from rac.services.derived_cache import DerivedIndexCache
+    from rac.services.index_store import ReadModelView
+    from rac.services.resolve import find_decisions_in, search_index
+
+    view = DerivedIndexCache().load_or_build(args.directory, recursive=not args.top_level)
+    if args.decisions:
+        if isinstance(view, ReadModelView):
+            return view.find_decisions(args.query)
+        return find_decisions_in(
+            view.index_entries,
+            view.live_decision_paths,
+            args.query,
+            field_tokens_by_path=view.field_tokens_by_path,
+        )
+    if isinstance(view, ReadModelView):
+        return view.search(args.query, artifact_type=args.type, tags=args.tags)
+    return search_index(
+        view.index_entries,
+        args.query,
+        artifact_type=args.type,
+        tags=args.tags,
+        field_tokens_by_path=view.field_tokens_by_path,
+    )
+
+
 def cmd_find(args: argparse.Namespace) -> int:
     from rac.services.resolve import find_artifacts, find_decisions
 
     if not Path(args.directory).is_dir():
         _usage_error(f"not a directory: {args.directory}")
-    if args.decisions:
+    if args.cache:
+        # Opt-in store reuse (ADR-110): serve from the persistent index store
+        # instead of a fresh walk, byte-identical to the uncached path below.
+        result = _find_from_store(args)
+    elif args.decisions:
         # `--decisions` is the live decision query (ADR-067): it implies the
         # decision type filter *and* restricts to live (Accepted, non-retired)
         # decisions — the deterministic "what did we decide about X" retrieval.
@@ -2170,6 +2211,16 @@ def build_parser() -> argparse.ArgumentParser:
         help=(
             "Only match artifacts carrying this frontmatter tag (repeatable; all "
             "required). Narrows the query by tag (ADR-109)."
+        ),
+    )
+    p_find.add_argument(
+        "--cache",
+        action="store_true",
+        help=(
+            "Reuse the persistent index store across runs for large corpora, "
+            "skipping the walk and parse on an unchanged corpus; disposable and "
+            "byte-identical to the uncached run (off by default, RAC_CACHE_DIR / "
+            "$XDG_CACHE_HOME, ADR-110)."
         ),
     )
     p_find.add_argument(

--- a/tests/test_find_cache.py
+++ b/tests/test_find_cache.py
@@ -1,0 +1,96 @@
+"""`rac find --cache` byte-parity with the uncached walk (ADR-110).
+
+One-shot `rac find --cache` serves from the persistent index store instead of a
+fresh walk. The contract is that its output is byte-identical to the uncached
+`rac find` for every mode, cold (store just written) and warm (store reused),
+and that a cold run writes the store for the next invocation. When the store
+cannot be written, `load_or_build` returns a fresh `DerivedIndex` and the CLI
+serves from that — still byte-identical.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+
+import pytest
+
+from rac.cli import main
+
+
+def _decision(ident: str, title: str, *, tags: str, body: str) -> str:
+    return (
+        f"---\nschema_version: 1\nid: {ident}\ntype: decision\ntags: {tags}\n---\n"
+        f"# {title}\n\n## Status\n\nAccepted\n\n## Category\n\nArchitecture\n\n"
+        f"## Context\n\n{body}\n\n## Decision\n\nD.\n\n## Consequences\n\nE.\n"
+    )
+
+
+@pytest.fixture
+def corpus(tmp_path, monkeypatch):
+    (tmp_path / "a.md").write_text(
+        _decision("RAC-01JY4M8X2QA1", "Alpha", tags="[security, data-model]", body="shared alpha"),
+        encoding="utf-8",
+    )
+    (tmp_path / "b.md").write_text(
+        _decision("RAC-01JY4M8X2QB2", "Beta", tags="[performance]", body="shared beta"),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("RAC_CACHE_DIR", str(tmp_path / "cache"))
+    return tmp_path
+
+
+def _run(argv: list[str]) -> tuple[int, str]:
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        rc = main(argv)
+    return rc, buf.getvalue()
+
+
+@pytest.mark.parametrize(
+    "extra",
+    [
+        pytest.param([], id="search"),
+        pytest.param(["--type", "decision"], id="type"),
+        pytest.param(["--tag", "security"], id="tag"),
+        pytest.param(["--explain"], id="explain"),
+        pytest.param(["--decisions"], id="decisions"),
+    ],
+)
+def test_find_cache_is_byte_identical_to_the_walk(corpus, extra):
+    base = ["find", "shared", str(corpus), "--json"]
+    rc_walk, walk = _run(base + extra)
+    rc_cold, cold = _run(base + ["--cache"] + extra)  # cold miss: builds + writes the store
+    rc_warm, warm = _run(base + ["--cache"] + extra)  # warm hit: served from the store
+    assert rc_walk == rc_cold == rc_warm == 0
+    assert walk == cold, "cached (cold) output must equal the uncached walk"
+    assert cold == warm, "warm store-served output must equal the cold run"
+
+
+def test_cold_cache_run_writes_the_store(corpus):
+    from rac.services.index_store import store_root
+
+    _run(["find", "shared", str(corpus), "--json", "--cache"])
+    root = store_root(corpus / "cache")
+    assert root.exists() and any(root.iterdir()), "a cold --cache run must persist the store"
+
+
+def test_cache_falls_back_to_fresh_when_store_unwritable(corpus, monkeypatch):
+    # When the store can't be written, load_or_build returns a fresh DerivedIndex
+    # and the CLI serves from that — output must still equal the walk.
+    from rac.services.derived_cache import DerivedIndexCache
+
+    monkeypatch.setattr(DerivedIndexCache, "_write_store", lambda self, h, d: False)
+    rc_walk, walk = _run(["find", "shared", str(corpus), "--json"])
+    rc_cache, cached = _run(["find", "shared", str(corpus), "--json", "--cache"])
+    assert rc_walk == rc_cache == 0
+    assert walk == cached
+
+
+def test_top_level_composes_with_cache(corpus):
+    # --cache honours --top-level (its own content-hash / store); still identical.
+    base = ["find", "shared", str(corpus), "--json", "--top-level"]
+    rc_walk, walk = _run(base)
+    rc_cache, cached = _run(base + ["--cache"])
+    assert rc_walk == rc_cache == 0
+    assert walk == cached


### PR DESCRIPTION
# Summary

Implements `rac/roadmaps/candidate-discovery.md` — the one-shot CLI store reuse. The benchmark drives `rac find` as a one-shot process per query, and that path re-walked, re-parsed, and rebuilt the relationship graph on every invocation (the entry-point cost). The persistent index store (ADR-104) that fixes this was reachable only through the long-lived MCP server. This adds an opt-in `--cache` that serves `rac find` from that store, byte-identical to the uncached walk.

Adds:
- `rac find --cache`: a warm run against an unchanged corpus serves from the memory-mapped store (no walk/parse/graph rebuild); a cold run builds fresh and writes the store for the next invocation.
- ADR-110 and the delivered-initiative update to the candidate-discovery roadmap.
- CLI byte-parity tests across every find mode.

Stacked on PR #330 (the tag work), because the cached path threads the `--tag` facet; this PR's diff is store-reuse-only and retargets to `main` when #330 merges.

# Roadmap / ADR Trace

Roadmap:
- `rac/roadmaps/candidate-discovery.md`

Relevant ADRs:
- `rac/decisions/adr-110-one-shot-find-store-reuse.md`

# Scope

## Included
- `--cache` flag on `rac find` (opt-in, off by default), and a `_find_from_store` seam in `cmd_find` that calls `DerivedIndexCache.load_or_build` and branches on the read-model type exactly as `mcp/server.py` does: `ReadModelView.search` / `.find_decisions` on a warm hit, `search_index` / `find_decisions_in` over a fresh `DerivedIndex` on a cold miss.
- Every find mode served from the store: search, `--decisions`, `--type`, `--tag`, `--explain` — all byte-identical to the walk. `--cache` composes with `--top-level` (its own content-hash and store).
- The store-unwritable fallback: `load_or_build` returns a fresh `DerivedIndex`, and the CLI serves from it (still identical).

## Excluded
- Default-on reuse: rejected in ADR-110; the cold run is slower (fork + write), so a genuine single one-shot is net-negative. The default walk path is byte-for-byte unchanged.
- Lowering the O(n) hash floor for one-shot processes (a stat/fsmonitor changeset scan), and folding delta-window postings into discovery — deferred residuals, not this PR.
- `rac resolve` / `rac decisions-for` reuse — scoped to `find` (the benchmark's command) for now; the same seam would extend to them.

# Product / Architecture Decisions
- **Opt-in.** Mirrors `rac mcp --cache` and `rac validate --cache` (ADR-104 posture); default `rac find` is unchanged.
- **Two honest costs (recorded in ADR-110).** A warm one-shot still pays the O(n) byte-hash floor — `load_or_build` re-hashes every file to detect change before reusing anything, so it skips the expensive parse/derive, not the hash; only the persistent server escapes it via the event watcher (ADR-105), which a one-shot has no process to hold. And a cold run is slower than the plain walk, so the fork + write only amortise across later warm invocations against a stable corpus.
- **Recency untouched.** Staleness is joined per-match from git after ranking (ADR-045), independent of the search path, so the cached result annotates identically.

# User-Facing Contract

## CLI
`rac find QUERY [DIR] --cache` — serves the query from the persistent index store, skipping the walk/parse on an unchanged corpus; disposable and byte-identical to the uncached run (off by default; `RAC_CACHE_DIR` / `$XDG_CACHE_HOME`). Composes with `--type`, `--tag`, `--decisions`, `--explain`, `--top-level`.

## Human / JSON Output
Byte-identical to `rac find` without `--cache` for every mode. The default (no-`--cache`) path is unchanged.

## Exit Codes
Unchanged.

# Verification

## Ran
- `python -m pytest` — full suite, twice from clean: 2146 passed.
- `ruff check` and full-tree `mypy src/`: clean.
- `rac validate rac/` gives 403 valid, 0 invalid; `rac relationships rac/ --validate` gives 2340 checked, 0 issues; `rac review rac/` no priority 1–2.
- End-to-end: `rac find shared DIR --cache --json` cold then warm returns identical output, and the store directory is written after the cold run.

## Covered
- `tests/test_find_cache.py`: `rac find --cache` output equals the uncached `rac find` for search, `--decisions`, `--type`, `--tag`, and `--explain` — cold (store just written) and warm (store reused); a cold run persists the store; the store-unwritable fallback stays identical; `--top-level` composes.
- Registered the new test file in the resolve CI battery (ADR-027 `test_ci_batteries` guard).

# Review Path
1. `rac/decisions/adr-110-one-shot-find-store-reuse.md` — the decision and the two recorded costs.
2. `src/rac/cli.py` — the `--cache` flag on `p_find` and the `_find_from_store` seam in `cmd_find`.
3. `tests/test_find_cache.py` — the byte-parity matrix.

# Notes For Reviewer
- No service code changed — the CLI is a thin new consumer of the existing store, cache, and read-model, so it inherits their byte-parity guarantees; the reused functions (`load_or_build`, `ReadModelView.search`/`.find_decisions`, `search_index`, `find_decisions_in`) are untouched.
- Stacked on `claude/candidate-discovery-tags` (#330); base retargets to `main` on merge.

# Implementation Process
Implemented with AI assistance under the roadmap contract; final scope, review, and acceptance decisions were made by the maintainer.