### PR TITLE
refactor(relationships): resolve the graph once across the derived build [roadmap:rebuild-scale]

### DIFF
--- a/src/rac/services/derived_cache.py
+++ b/src/rac/services/derived_cache.py
@@ -48,6 +48,7 @@ from rac.services.relationships import (
     Relationship,
     inbound_counts_from_relationships,
     relationships_from_corpus,
+    resolution_index_from_entries,
 )
 from rac.services.resolve import field_tokens_for_entries, live_decision_paths
 
@@ -253,7 +254,12 @@ def build_derived_index_from_entries(
     ``walk_corpus`` would yield. Every derived structure is a pure function of the
     snapshot, so identical entries in identical order give identical bytes.
     """
-    rels = relationships_from_corpus(entries)
+    # Resolve the reference graph once and share the index across every consumer
+    # that would otherwise rebuild it (relationships, the portfolio's summary, and
+    # its relationship validation) — byte-identical, since the index is a pure
+    # function of the snapshot. The cold build resolved it three times before.
+    resolution_index = resolution_index_from_entries(entries)
+    rels = relationships_from_corpus(entries, resolution_index=resolution_index)
     inbound = inbound_counts_from_relationships(rels)
     index = index_from_corpus(directory, entries, recursive=recursive, inbound=inbound)
     return DerivedIndex(
@@ -261,7 +267,9 @@ def build_derived_index_from_entries(
         relationships=rels,
         field_tokens_by_path=field_tokens_for_entries(index.artifacts),
         live_decision_paths=live_decision_paths(entries),
-        portfolio_summary=portfolio_from_corpus(directory, entries, recursive=recursive).to_dict(),
+        portfolio_summary=portfolio_from_corpus(
+            directory, entries, recursive=recursive, resolution_index=resolution_index
+        ).to_dict(),
         scope_rows=_scope_rows_from_corpus(entries),
     )
 

--- a/src/rac/services/portfolio.py
+++ b/src/rac/services/portfolio.py
@@ -39,6 +39,8 @@ from .relationships import (
     ISSUE_TARGET_AMBIGUOUS,
     ISSUE_TARGET_NOT_FOUND,
     RelationshipSummary,
+    ResolutionIndex,
+    resolution_index_from_entries,
     summary_from_corpus,
     validation_from_corpus,
 )
@@ -175,13 +177,23 @@ def build_portfolio_summary(directory: str, recursive: bool = True) -> Portfolio
 
 
 def portfolio_from_corpus(
-    directory: str, entries: list[CorpusEntry], recursive: bool = True
+    directory: str,
+    entries: list[CorpusEntry],
+    recursive: bool = True,
+    *,
+    resolution_index: ResolutionIndex | None = None,
 ) -> PortfolioSummary:
     """Summarize an already-walked corpus snapshot (v0.8.0).
 
     Same result as :func:`build_portfolio_summary`. The snapshot also feeds
-    the relationship summary, so a portfolio costs one walk instead of two.
+    the relationship summary, so a portfolio costs one walk instead of two. A
+    prebuilt ``resolution_index`` (from the derived build) is shared across the
+    relationship summary and validation rather than each rebuilding it — the
+    portfolio dict is byte-identical either way; it is built once here if not
+    supplied.
     """
+    if resolution_index is None:
+        resolution_index = resolution_index_from_entries(entries)
 
     # Repository-wide severity overrides (ADR-053): review/portfolio/watchkeeper
     # honour the same .rac/config.yaml policy as `rac validate`.
@@ -258,10 +270,12 @@ def portfolio_from_corpus(
     # --- relationship summary ------------------------------------------------
     # Reuses the snapshot (no second walk); per-reference issues become
     # attention items so broken references are surfaced, not just counted.
-    rel_summary = summary_from_corpus(entries)
+    rel_summary = summary_from_corpus(entries, resolution_index=resolution_index)
     # The full relationship-validation gate (additive, v0.16.0): same verdict as
     # `rac relationships --validate`, over the same snapshot (no extra walk).
-    relationships_ok = validation_from_corpus(directory, entries, recursive=recursive).ok
+    relationships_ok = validation_from_corpus(
+        directory, entries, recursive=recursive, resolution_index=resolution_index
+    ).ok
     for issue in rel_summary.issues:
         source = issue.source_path or ""
         label = (issue.relationship or "").replace("_", " ").title()

--- a/src/rac/services/relationships.py
+++ b/src/rac/services/relationships.py
@@ -372,6 +372,9 @@ def _entry_items(
 
 # Identifier index: {casefold(ident) -> [(path, display_ident), ...]}
 _IdentIndex = dict[str, list[tuple[str, str]]]
+# Public alias for the reference-resolution index, so a caller can build it once
+# and share it across the consumers that would otherwise each rebuild it.
+ResolutionIndex = _IdentIndex
 
 
 def _build_identifier_index(
@@ -404,6 +407,18 @@ def build_resolution_index(
         for ident in artifact_identifiers(product, spec, path):
             index.setdefault(ident.casefold(), []).append((path, ident))
     return index
+
+
+def resolution_index_from_entries(entries: list[CorpusEntry]) -> ResolutionIndex:
+    """The reference-resolution index for a snapshot, to build once and share.
+
+    A pure, deterministic function of the snapshot's items. Passing the result
+    into ``relationships_from_corpus``, ``summary_from_corpus``, and
+    ``validation_from_corpus`` lets a derived build resolve over one index rather
+    than each consumer rebuilding an identical one — byte-identical output, since
+    the index is the same object every consumer would otherwise construct.
+    """
+    return build_resolution_index(_entry_items(entries))
 
 
 def _resolve_references(
@@ -585,6 +600,8 @@ def _validate(
     directory: str,
     items: list[tuple[str, Product, ArtifactSpec | None]],
     recursive: bool,
+    *,
+    resolution_index: ResolutionIndex | None = None,
 ) -> RelationshipValidation:
     index = _build_identifier_index(items)
 
@@ -614,7 +631,8 @@ def _validate(
                 )
             )
 
-    resolution_index = build_resolution_index(items)
+    if resolution_index is None:
+        resolution_index = build_resolution_index(items)
     by_path = {path: (product, spec) for path, product, spec in items}
 
     def _resolved(ref: str, source_path: str) -> str | None:
@@ -720,14 +738,19 @@ def validate_relationships(
 
 
 def validation_from_corpus(
-    directory: str, entries: list[CorpusEntry], recursive: bool = True
+    directory: str,
+    entries: list[CorpusEntry],
+    recursive: bool = True,
+    *,
+    resolution_index: ResolutionIndex | None = None,
 ) -> RelationshipValidation:
     """Validate relationships in an already-walked corpus snapshot (v0.8.0).
 
     Same result as :func:`validate_relationships`; the snapshot lets one walk
-    feed several analyses (repository model, future incremental refresh).
+    feed several analyses (repository model, future incremental refresh). A
+    prebuilt ``resolution_index`` is used when supplied (byte-identical output).
     """
-    return _validate(directory, _entry_items(entries), recursive)
+    return _validate(directory, _entry_items(entries), recursive, resolution_index=resolution_index)
 
 
 def validate_relationships_file(path: str) -> RelationshipValidation:
@@ -834,20 +857,27 @@ def summarize_relationships(directory: str, recursive: bool = True) -> Relations
     return _summarize(_corpus_items(directory, recursive))
 
 
-def summary_from_corpus(entries: list[CorpusEntry]) -> RelationshipSummary:
+def summary_from_corpus(
+    entries: list[CorpusEntry], *, resolution_index: ResolutionIndex | None = None
+) -> RelationshipSummary:
     """Aggregate relationship health for an already-walked snapshot (v0.8.0).
 
     Same result as :func:`summarize_relationships`; the snapshot lets one walk
-    feed several analyses (repository model, future incremental refresh).
+    feed several analyses (repository model, future incremental refresh). A
+    prebuilt ``resolution_index`` is used when supplied (byte-identical output).
     """
-    return _summarize(_entry_items(entries))
+    return _summarize(_entry_items(entries), resolution_index=resolution_index)
 
 
-def _summarize(items: list[tuple[str, Product, ArtifactSpec | None]]) -> RelationshipSummary:
+def _summarize(
+    items: list[tuple[str, Product, ArtifactSpec | None]],
+    *,
+    resolution_index: ResolutionIndex | None = None,
+) -> RelationshipSummary:
     if not items:
         return RelationshipSummary(total=0, valid=0, broken=0, orphaned=0, coverage=1.0)
 
-    index = build_resolution_index(items)
+    index = resolution_index if resolution_index is not None else build_resolution_index(items)
     checked, ref_issues, resolved_targets = _resolve_references(items, index)
 
     broken = len(ref_issues)
@@ -902,15 +932,19 @@ class Relationship:
     issue: str | None
 
 
-def relationships_from_corpus(entries: list[CorpusEntry]) -> list[Relationship]:
+def relationships_from_corpus(
+    entries: list[CorpusEntry], *, resolution_index: ResolutionIndex | None = None
+) -> list[Relationship]:
     """Every declared reference in a corpus snapshot as :class:`Relationship`.
 
     Ordering is deterministic: source artifacts in snapshot (sorted path)
     order, sections in each artifact's own schema order, references in
-    declaration order — matching ``_resolve_references``.
+    declaration order — matching ``_resolve_references``. A prebuilt
+    ``resolution_index`` (from :func:`resolution_index_from_entries`) is used when
+    supplied, so a shared build resolves over one index; the output is identical.
     """
     items = _entry_items(entries)
-    index = build_resolution_index(items)
+    index = resolution_index if resolution_index is not None else build_resolution_index(items)
     relationships: list[Relationship] = []
     for path, product, spec in items:
         if spec is None:


### PR DESCRIPTION
# Summary

Progress on `rac/decisions/adr-108-term-range-partitioned-parallel-merge.md`: the de-risking precondition for the parallel-merge fan-out, and a standalone serial perf win.

The cold build resolved the reference graph **three times**: once in the derive (`relationships_from_corpus`) and twice more inside the portfolio — its relationship summary (`summary_from_corpus` to `_summarize`) and its relationship validation (`validation_from_corpus` to `_validate`) each built their own `build_resolution_index`. Bundle 1 removed only the derive's double-resolve.

Adds:
- An optional prebuilt `resolution_index` on `relationships_from_corpus`, `summary_from_corpus`, `validation_from_corpus` (and the `_summarize`/`_validate` cores), plus a `resolution_index_from_entries` helper.
- `build_derived_index_from_entries` builds the index once and threads it through the relationships build and the portfolio, so the whole derive resolves over one index.

# Roadmap / ADR Trace

Roadmap: `rac/roadmaps/rebuild-scale.md` (residual: `single-node-scale-residuals.md`)
ADR: `rac/decisions/adr-108-term-range-partitioned-parallel-merge.md`

# Scope

## Included
- One shared resolution index across the derived build's three resolution consumers.
- Byte-identical output: the index is a pure, deterministic function of the snapshot — the same object each consumer would otherwise construct.
- Other callers (`rac relationships`, `rac review`, doctor, watchkeeper) pass nothing and rebuild exactly as before.

## Excluded
- The parallel-merge fan-out itself (workers emitting compact fragments; the parent reproducing every derivation from them). This change de-risks that by concentrating the portfolio's resolution on one shared index, but the fan-out is a separate, larger follow-up.

# Product / Architecture Decisions
- The shared index is threaded, not global: each public function keeps its no-arg behaviour, so nothing outside the derived build changes. The derive is the only caller that supplies it.
- Byte-parity is structural (same pure function), not merely tested — so this carries no risk to the store or served output.

# User-Facing Contract
No CLI, JSON, or exit-code change. Purely an internal serial-work reduction; every output is byte-identical.

# Verification

## Ran
- `python -m pytest` — full suite: **2146 passed**.
- `ruff check src/` and `mypy src/`: clean.

## Covered
- The resolution/portfolio drift-catching suites (`test_b2_index_store`, `test_b5_scale_hardening`, `test_b1_read_model`, `test_relationships`, `test_portfolio` — 110 tests) pass, including store == fresh build and worker-count invariance; the portfolio dict and relationship summary/validation are unchanged.

# Review Path
1. `src/rac/services/relationships.py` — the `resolution_index` params + `resolution_index_from_entries`.
2. `src/rac/services/portfolio.py` — shares one index across summary + validation.
3. `src/rac/services/derived_cache.py` — builds it once, threads it through the derive.

# Notes For Reviewer
- Small, byte-safe refactor. Its main purpose beyond the perf win is to concentrate the portfolio's resolution so the upcoming ADR-108 fan-out can reproduce the portfolio from compact rows against a single shared resolution.

# Implementation Process
Implemented with AI assistance under the roadmap contract; final scope, review, and acceptance decisions were made by the maintainer.