### PR TITLE
feat(index): fan the cold-build derive out to workers via compact fragments [roadmap:rebuild-scale]

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -146,9 +146,13 @@ jobs:
           # adds test_b5_scale_hardening.py — the parallel cold build's worker-count
           # determinism (byte-identical store + serving), parse-semantics parity,
           # post-compaction snapshot-shed RSS bound, worker-crash serial fallback,
-          # and the RAC_TIMING line shape.
+          # and the RAC_TIMING line shape. Bundle B6 (ADR-108) adds
+          # test_b6_parallel_merge.py — the fragment-merge fan-out's per-mutation-class
+          # byte-parity against the serial derive (resolution outcomes, duplicate
+          # identity, range/status, tag-only, scope/live, cross-chunk and uneven
+          # partitions), in-process and end-to-end across a real worker split.
           - name: characterization
-            paths: "tests/test_char_enforce.py tests/test_char_retrieve.py tests/test_char_graph.py tests/test_char_report.py tests/test_char_mcp.py tests/test_char_author.py tests/test_char_compare.py tests/test_char_ingest.py tests/test_char_ops.py tests/test_char_core.py tests/test_b1_read_model.py tests/test_b2_index_store.py tests/test_b3_freshness.py tests/test_b3b_postings_search.py tests/test_b4_incremental_validate.py tests/test_b5_scale_hardening.py tests/test_b5b_point_resolution.py"
+            paths: "tests/test_char_enforce.py tests/test_char_retrieve.py tests/test_char_graph.py tests/test_char_report.py tests/test_char_mcp.py tests/test_char_author.py tests/test_char_compare.py tests/test_char_ingest.py tests/test_char_ops.py tests/test_char_core.py tests/test_b1_read_model.py tests/test_b2_index_store.py tests/test_b3_freshness.py tests/test_b3b_postings_search.py tests/test_b4_incremental_validate.py tests/test_b5_scale_hardening.py tests/test_b5b_point_resolution.py tests/test_b6_parallel_merge.py"
           # Trust gates (v0.7.9): dogfood validates RAC's own rac/ corpus,
           # golden pins CLI stdout byte-for-byte against committed files.
           - name: dogfood

--- a/src/rac/services/derived_cache.py
+++ b/src/rac/services/derived_cache.py
@@ -176,6 +176,36 @@ class CorpusReadModel(Protocol):
     def scope_rows(self) -> list[ScopeRow]: ...
 
 
+def scope_row_from_entry(entry: CorpusEntry) -> ScopeRow | None:
+    """The path-mode :class:`ScopeRow` for one entry, or None when it declares none.
+
+    The per-document projection shared by the serial :func:`_scope_rows_from_corpus`
+    and the parallel merge (ADR-108). Faithful to ``scope._governing``'s extraction:
+    only a live decision that declares ``## Applies To`` (``SCOPE_SECTIONS``) entries
+    yields a row; anything else returns None (a decision with no scope can never
+    cover a query, so omitting it changes no answer).
+    """
+    product = entry.product
+    if entry.artifact_type != _DECISION_TYPE or not is_live_decision(product):
+        return None
+    spec = spec_for(entry.artifact_type)
+    if spec is None:  # the decision spec is always registered; narrow for typing
+        return None
+    relationships = extract_relationships_full(product, spec)
+    declared: list[str] = []
+    for section in SCOPE_SECTIONS:
+        declared.extend(relationships.get(section.replace(" ", "_"), []))
+    if not declared:
+        return None
+    return ScopeRow(
+        id=artifact_identifier(product, spec, str(entry.path)),
+        title=product.title or "",
+        status=artifact_status(product),
+        path=str(entry.path),
+        scope_entries=tuple(declared),
+    )
+
+
 def _scope_rows_from_corpus(entries: list[CorpusEntry]) -> list[ScopeRow]:
     """Precompute the path-mode scope rows for every live decision that declares scope.
 
@@ -184,30 +214,7 @@ def _scope_rows_from_corpus(entries: list[CorpusEntry]) -> list[ScopeRow]:
     decision that declares no scope can never cover a query, so it is omitted —
     dropping it changes no answer, exactly as ``_governing`` would return ``None``.
     """
-    rows: list[ScopeRow] = []
-    for entry in entries:
-        product = entry.product
-        if entry.artifact_type != _DECISION_TYPE or not is_live_decision(product):
-            continue
-        spec = spec_for(entry.artifact_type)
-        if spec is None:  # the decision spec is always registered; narrow for typing
-            continue
-        relationships = extract_relationships_full(product, spec)
-        declared: list[str] = []
-        for section in SCOPE_SECTIONS:
-            declared.extend(relationships.get(section.replace(" ", "_"), []))
-        if not declared:
-            continue
-        rows.append(
-            ScopeRow(
-                id=artifact_identifier(product, spec, str(entry.path)),
-                title=product.title or "",
-                status=artifact_status(product),
-                path=str(entry.path),
-                scope_entries=tuple(declared),
-            )
-        )
-    return rows
+    return [row for entry in entries if (row := scope_row_from_entry(entry)) is not None]
 
 
 def governing_decisions(scope_rows: list[ScopeRow], directory: str, path: str) -> ScopeLookupResult:

--- a/src/rac/services/index.py
+++ b/src/rac/services/index.py
@@ -121,20 +121,32 @@ def index_from_corpus(
         from rac.services.relationships import inbound_counts_from_corpus
 
         inbound = inbound_counts_from_corpus(entries)
-    artifacts: list[IndexEntry] = []
-    for entry in entries:
-        path, product = entry.path, entry.product
-        spec = spec_for(entry.artifact_type)  # None for Unknown
-        artifacts.append(
-            IndexEntry(
-                id=artifact_identifier(product, spec, str(path)),
-                type=entry.artifact_type,
-                title=product.title,
-                path=str(path),
-                aliases=artifact_identifiers(product, spec, str(path)),
-                search_sections=product.search_sections,
-                inbound_count=inbound.get(str(path), 0),
-                tags=list(product.metadata.tags) if product.metadata else [],
-            )
-        )
+    artifacts = [
+        index_entry_from_corpus_entry(entry, inbound=inbound.get(str(entry.path), 0))
+        for entry in entries
+    ]
     return RepositoryIndex(directory=directory, recursive=recursive, artifacts=artifacts)
+
+
+def index_entry_from_corpus_entry(entry: CorpusEntry, *, inbound: int = 0) -> IndexEntry:
+    """One :class:`IndexEntry` for a corpus entry — the per-document index row.
+
+    The single builder both the serial :func:`index_from_corpus` and the parallel
+    merge (ADR-108) use, so a merged index row is byte-identical to a serially
+    built one by construction. ``inbound`` is the resolved-edge count, a cross-doc
+    signal filled by the caller (0 until the graph is resolved); every other field
+    is a pure function of this one entry.
+    """
+    path = str(entry.path)
+    product = entry.product
+    spec = spec_for(entry.artifact_type)  # None for Unknown
+    return IndexEntry(
+        id=artifact_identifier(product, spec, path),
+        type=entry.artifact_type,
+        title=product.title,
+        path=path,
+        aliases=artifact_identifiers(product, spec, path),
+        search_sections=product.search_sections,
+        inbound_count=inbound,
+        tags=list(product.metadata.tags) if product.metadata else [],
+    )

--- a/src/rac/services/parallel_build.py
+++ b/src/rac/services/parallel_build.py
@@ -51,6 +51,7 @@ from rac.core.corpus import CorpusEntry, walk_corpus
 from rac.core.fs import find_markdown_files
 from rac.core.markdown import parse_file
 from rac.services.derived_cache import DerivedIndex, build_derived_index_from_entries
+from rac.services.parallel_merge import DocFragment, fragment_from_entry, reproduce
 
 _TIMING_ENV = "RAC_TIMING"
 
@@ -181,6 +182,45 @@ def _parse_parallel(paths: list[Path], n_workers: int) -> list[CorpusEntry] | No
     return [entry for chunk in results for entry in chunk]
 
 
+def _worker_fragment(paths: list[Path]) -> list[DocFragment]:
+    """Parse a contiguous range and project each document to a compact fragment.
+
+    The merge-path worker (ADR-108): the same core parse as :func:`_worker_parse`
+    (:func:`parse_file` + :func:`classify`), then :func:`fragment_from_entry` runs
+    every per-document derivation and keeps only the compact projection the parent
+    merge reads. Only the fragments cross the process boundary — never a parsed
+    ``Product``. The fault hook is honoured identically, so the crash-resilience
+    path is exercised in a real spawned subprocess.
+    """
+    if os.environ.get(_FAULT_ENV):
+        raise RuntimeError("parallel-build worker fault (injected)")
+    fragments: list[DocFragment] = []
+    for path in paths:
+        product = parse_file(str(path))
+        entry = CorpusEntry(path=path, product=product, classification=classify(product))
+        fragments.append(fragment_from_entry(entry))
+    return fragments
+
+
+def _fragment_parallel(paths: list[Path], n_workers: int) -> list[DocFragment] | None:
+    """Fan the parse+fragment across ``n_workers`` spawned processes, or None on fault.
+
+    Contiguous chunks in sorted-path order, concatenated in list order, so the
+    fragment sequence is byte-for-byte what a serial parse+fragment yields —
+    worker-count-invariant. Any child fault (exception, crash, pickling failure)
+    collapses to None and the caller falls back to the serial floor; a partial
+    result is discarded whole, never merged.
+    """
+    chunks = _contiguous_chunks(paths, n_workers)
+    try:
+        ctx = mp.get_context("spawn")
+        with ctx.Pool(len(chunks)) as pool:
+            results = pool.map(_worker_fragment, chunks)
+    except BaseException:
+        return None
+    return [fragment for chunk in results for fragment in chunk]
+
+
 def parallel_parse_paths(
     paths: list[Path], *, workers: int | None = None
 ) -> tuple[list[CorpusEntry], int]:
@@ -200,45 +240,45 @@ def parallel_parse_paths(
     return entries, n_workers
 
 
-def parallel_walk(
-    directory: str, *, recursive: bool = True, workers: int | None = None
-) -> tuple[list[CorpusEntry], int]:
-    """Parse a whole corpus, parallel when it pays; entries in sorted-path order.
-
-    The parallel analogue of ``list(walk_corpus(directory))``: byte-identical
-    output (same entries, same sorted order), only fanned across processes. When
-    the single-process path runs it delegates to :func:`walk_corpus` so the two
-    code paths share one definition of the serial walk.
-    """
-    paths = find_markdown_files(directory, recursive=recursive)
-    n_workers = _resolve_workers(workers, len(paths))
-    if n_workers <= 1:
-        return list(walk_corpus(directory, recursive=recursive)), 1
-    entries = _parse_parallel(paths, n_workers)
-    if entries is None:
-        return list(walk_corpus(directory, recursive=recursive)), 1
-    return entries, n_workers
-
-
 def build_derived_index_parallel(
     directory: str, *, recursive: bool = True, workers: int | None = None
 ) -> tuple[DerivedIndex, BuildStats]:
-    """Build the derived read-model with a parallel parse, then the serial derive.
+    """Build the derived read-model with a parallel parse *and* a parallel derive (ADR-108).
 
-    Byte-identical to :func:`rac.services.derived_cache.build_derived_index`: the
-    parse is fanned out but produces the same ordered snapshot, and the derive
-    phase (:func:`build_derived_index_from_entries`) is the same pure function of
-    that snapshot. Returns the derived index plus the per-phase timings the
-    ``RAC_TIMING`` scorecard reports; ``write_ms`` is filled by the caller that
-    serialises the store.
+    Byte-identical to :func:`rac.services.derived_cache.build_derived_index`: each
+    worker parses a contiguous path range and projects every document to a compact
+    :class:`~rac.services.parallel_merge.DocFragment`, and the parent reproduces the
+    read-model from the fragments in sorted-path order
+    (:func:`~rac.services.parallel_merge.reproduce`) — the same compact-row seams the
+    serial derive uses, so the store bytes are worker-count-invariant. The fan-out
+    is a latency lever, never a correctness dependency: below the file-count / core
+    threshold, or on any worker fault, the build falls back to the authoritative
+    serial :func:`walk_corpus` + :func:`build_derived_index_from_entries` floor, whose
+    partial results are never written. Returns the derived index plus the per-phase
+    timings the ``RAC_TIMING`` scorecard reports; ``write_ms`` is filled by the caller
+    that serialises the store.
     """
     t0 = time.perf_counter()
-    entries, used = parallel_walk(directory, recursive=recursive, workers=workers)
-    t1 = time.perf_counter()
-    derived = build_derived_index_from_entries(directory, entries, recursive=recursive)
+    paths = find_markdown_files(directory, recursive=recursive)
+    n_workers = _resolve_workers(workers, len(paths))
+    fragments = _fragment_parallel(paths, n_workers) if n_workers > 1 else None
+    if fragments is not None:
+        used = n_workers
+        t1 = time.perf_counter()
+        derived = reproduce(fragments, directory, recursive=recursive)
+        n_files = len(fragments)
+    else:
+        # Serial floor: the single-process path (small corpus, cpu_count() <= 2, or
+        # an explicit workers=1) and the worker-fault fallback share one
+        # authoritative serial derive over the whole ordered snapshot.
+        entries = list(walk_corpus(directory, recursive=recursive))
+        used = 1
+        t1 = time.perf_counter()
+        derived = build_derived_index_from_entries(directory, entries, recursive=recursive)
+        n_files = len(entries)
     t2 = time.perf_counter()
     return derived, BuildStats(
-        files=len(entries),
+        files=n_files,
         workers=used,
         parse_ms=(t1 - t0) * 1000.0,
         derive_ms=(t2 - t1) * 1000.0,

--- a/src/rac/services/parallel_merge.py
+++ b/src/rac/services/parallel_merge.py
@@ -1,0 +1,139 @@
+"""Term-range-partitioned parallel merge of the derived read-model (ADR-108).
+
+ADR-107 fanned the cold build's *parse* across processes but left the whole
+*derive* serial: workers shipped parsed :class:`~rac.core.corpus.CorpusEntry`
+objects and the parent ran :func:`build_derived_index_from_entries` alone.
+ADR-108 finishes the fan-out — workers emit compact per-document *derived
+fragments* and the parent reproduces the read-model from them, so the
+per-document derivations (validation, tokenisation, scope/live projection) run in
+the workers too and only compact rows cross the process boundary.
+
+**A fragment is the whole per-document projection each derivation reads, with the
+``Product`` dropped.** :class:`DocFragment` carries the index row, the six BM25
+field-token vectors, the portfolio row (its validation projection and per-document
+findings), the live-decision flag, and the scope row — every field a pure function
+of one parsed document. :func:`fragment_from_entry` builds one in the parent (from
+a parsed entry); the worker builds the same fragment from the same parse, so the
+two are identical.
+
+**The merge is the cross-document step, and only the cross-document step.**
+:func:`reproduce` resolves the reference graph over the fragments' identifier and
+edge rows (in sorted-path order, so the docids and every derived byte are
+worker-count-invariant), fills each index row's inbound count from that graph,
+and reads every other field straight off the fragments. It routes through the
+same compact-row seams the serial build uses — :func:`resolution_index_from_rows`,
+:func:`relationships_from_rows`, :func:`portfolio_from_rows` — so the reproduced
+:class:`DerivedIndex` is byte-identical to :func:`build_derived_index_from_entries`
+over the same snapshot by construction, not by coincidence. That equality is the
+ADR-108 gate the tests pin.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+
+from rac.core.corpus import CorpusEntry
+from rac.services.agent_rules import is_live_decision
+from rac.services.derived_cache import DerivedIndex, ScopeRow, scope_row_from_entry
+from rac.services.index import IndexEntry, index_entry_from_corpus_entry
+from rac.services.portfolio import PortfolioRow, portfolio_from_rows, portfolio_row
+from rac.services.relationships import (
+    Relationship,
+    ValidationRow,
+    inbound_counts_from_relationships,
+    relationships_from_rows,
+    resolution_index_from_rows,
+)
+from rac.services.resolve import field_tokens_for_entries
+
+# Decisions are the only type with a live/scope projection; the same constant the
+# read-model derivations scope to, named locally so the predicate reuse reads
+# cleanly. Liveness itself is delegated to ``is_live_decision`` (one source of
+# truth) rather than re-derived here.
+_DECISION_TYPE = "decision"
+
+
+@dataclass(frozen=True)
+class DocFragment:
+    """One document's compact derived projection — the unit workers emit (ADR-108).
+
+    Every field is a pure function of a single parsed document, so a fragment
+    built in the parent and a fragment shipped from a worker over the same file
+    are identical:
+
+    - ``index_entry`` — the repository index row (identity, type, title, path,
+      aliases, searchable sections, tags). ``inbound_count`` is a cross-document
+      signal, so it stays 0 here and the merge fills it from the resolved graph.
+    - ``field_tokens`` — the six BM25 field-token vectors, tokenised once.
+    - ``portfolio`` — the portfolio row: its :class:`ValidationRow` (identity,
+      retired flag, declared edges, unsupported sections) for the relationship
+      summary and gate, plus the per-document ``validate`` findings and
+      recommended-slot projection.
+    - ``is_live_decision`` — whether this is a live (Accepted, non-retired)
+      decision, so the merge builds ``live_decision_paths`` without re-deriving it.
+    - ``scope_row`` — the path-mode scope row for a live decision that declares
+      ``## Applies To`` scope, else None.
+    """
+
+    index_entry: IndexEntry
+    field_tokens: dict[str, list[str]]
+    portfolio: PortfolioRow
+    is_live_decision: bool
+    scope_row: ScopeRow | None
+
+
+def fragment_from_entry(entry: CorpusEntry) -> DocFragment:
+    """Build the compact :class:`DocFragment` for one parsed corpus entry.
+
+    Pure and deterministic: it runs each per-document derivation over the parsed
+    product and keeps only the projection the merge reads. The parent uses it to
+    reproduce the merge in-process (the byte-parity test); the worker calls the
+    same builder over its own parse, so the fan-out ships exactly these fragments.
+    """
+    index_entry = index_entry_from_corpus_entry(entry)  # inbound filled at merge
+    field_tokens = field_tokens_for_entries([index_entry])[index_entry.path]
+    live = entry.artifact_type == _DECISION_TYPE and is_live_decision(entry.product)
+    return DocFragment(
+        index_entry=index_entry,
+        field_tokens=field_tokens,
+        portfolio=portfolio_row(entry),
+        is_live_decision=live,
+        scope_row=scope_row_from_entry(entry),
+    )
+
+
+def reproduce(
+    fragments: list[DocFragment], directory: str, *, recursive: bool = True
+) -> DerivedIndex:
+    """Reproduce the derived read-model from per-document fragments (ADR-108).
+
+    Byte-identical to :func:`build_derived_index_from_entries` over the same
+    snapshot: ``fragments`` must be in sorted-path order (the merge assigns no
+    order of its own), and every cross-document structure — the resolution index,
+    the resolved graph, the inbound counts, and the portfolio summary — is built
+    through the same compact-row seams the serial derive uses. The only work the
+    merge does that a worker cannot is the cross-document resolution; everything
+    else is read straight off the fragments.
+    """
+    validation_rows: list[ValidationRow] = [f.portfolio.validation for f in fragments]
+    resolution_index = resolution_index_from_rows(validation_rows)
+    rels: list[Relationship] = relationships_from_rows(
+        validation_rows, resolution_index=resolution_index
+    )
+    inbound = inbound_counts_from_relationships(rels)
+    index_entries = [
+        replace(f.index_entry, inbound_count=inbound.get(f.index_entry.path, 0)) for f in fragments
+    ]
+    return DerivedIndex(
+        index_entries=index_entries,
+        relationships=rels,
+        field_tokens_by_path={f.index_entry.path: f.field_tokens for f in fragments},
+        live_decision_paths=[f.index_entry.path for f in fragments if f.is_live_decision],
+        portfolio_summary=portfolio_from_rows(
+            directory,
+            [f.portfolio for f in fragments],
+            recursive=recursive,
+            resolution_index=resolution_index,
+        ).to_dict(),
+        scope_rows=[f.scope_row for f in fragments if f.scope_row is not None],
+    )

--- a/src/rac/services/portfolio.py
+++ b/src/rac/services/portfolio.py
@@ -31,7 +31,7 @@ from rac.core.classification import missing_sections
 from rac.core.corpus import CorpusEntry, walk_corpus
 from rac.core.identity import artifact_identifier
 from rac.core.overrides import apply_overrides
-from rac.core.validation import has_errors, validate
+from rac.core.validation import Issue, has_errors, validate
 from rac.services.init import load_overrides
 
 from .relationships import (
@@ -40,9 +40,11 @@ from .relationships import (
     ISSUE_TARGET_NOT_FOUND,
     RelationshipSummary,
     ResolutionIndex,
-    resolution_index_from_entries,
-    summary_from_corpus,
-    validation_from_corpus,
+    ValidationRow,
+    resolution_index_from_rows,
+    summary_from_rows,
+    validation_from_rows,
+    validation_row,
 )
 
 # Stable attention codes (part of the JSON contract, ADR-007).
@@ -176,6 +178,63 @@ def build_portfolio_summary(directory: str, recursive: bool = True) -> Portfolio
     return portfolio_from_corpus(directory, entries, recursive=recursive)
 
 
+@dataclass(frozen=True)
+class PortfolioRow:
+    """One document's compact projection for the portfolio summary (ADR-108).
+
+    Carries the per-document derivation outputs the summary reads — its type and
+    identity, the raw ``validate`` findings (overrides are applied at aggregation,
+    ADR-053), the recommended-slot count and the missing recommended sections —
+    plus the :class:`ValidationRow` the relationship summary and gate run over. The
+    ``Product`` is dropped, so a worker can ship the row (the fan-out) or the parent
+    can build it from an entry; the aggregation is byte-identical either way.
+    """
+
+    path: str
+    artifact_type: str
+    identifier: str
+    validation: ValidationRow
+    validate_issues: tuple[Issue, ...]
+    recommended_slots: int
+    missing_recommended: tuple[str, ...]
+
+
+def portfolio_row(entry: CorpusEntry) -> PortfolioRow:
+    """The compact :class:`PortfolioRow` projection of one corpus entry.
+
+    Pure and deterministic: every field is read straight from the parsed product,
+    so a row built here in the parent and a row shipped from a worker over the same
+    document are identical. Unknown documents carry no validation findings and no
+    recommended slots — they are counted in ``by_type`` but neither validated nor
+    completeness-scored, exactly as the item-based pass treats them.
+    """
+    path = str(entry.path)
+    product = entry.product
+    artifact_type = entry.artifact_type
+    spec = spec_for(artifact_type)
+    vrow = validation_row(path, product, spec)
+    if spec is None:
+        return PortfolioRow(
+            path=path,
+            artifact_type=artifact_type,
+            identifier=vrow.canonical_id,
+            validation=vrow,
+            validate_issues=(),
+            recommended_slots=0,
+            missing_recommended=(),
+        )
+    _, missing_rec = missing_sections(product, spec)
+    return PortfolioRow(
+        path=path,
+        artifact_type=artifact_type,
+        identifier=artifact_identifier(product, spec, path),
+        validation=vrow,
+        validate_issues=tuple(validate(product, artifact_type=artifact_type)),
+        recommended_slots=len(spec.recommended),
+        missing_recommended=tuple(missing_rec),
+    )
+
+
 def portfolio_from_corpus(
     directory: str,
     entries: list[CorpusEntry],
@@ -189,11 +248,34 @@ def portfolio_from_corpus(
     the relationship summary, so a portfolio costs one walk instead of two. A
     prebuilt ``resolution_index`` (from the derived build) is shared across the
     relationship summary and validation rather than each rebuilding it — the
-    portfolio dict is byte-identical either way; it is built once here if not
-    supplied.
+    portfolio dict is byte-identical either way. Delegates to the compact-row core
+    (ADR-108) so the serial build and the parallel merge aggregate identically.
     """
+    return portfolio_from_rows(
+        directory,
+        [portfolio_row(entry) for entry in entries],
+        recursive=recursive,
+        resolution_index=resolution_index,
+    )
+
+
+def portfolio_from_rows(
+    directory: str,
+    rows: list[PortfolioRow],
+    recursive: bool = True,
+    *,
+    resolution_index: ResolutionIndex | None = None,
+) -> PortfolioSummary:
+    """Compute the portfolio summary over compact rows (ADR-108).
+
+    The single core the serial :func:`portfolio_from_corpus` and the parallel merge
+    both run. Byte-identical to the item-based pass: the same per-document findings
+    aggregate, and the relationship summary and gate resolve over one shared index
+    (ADR-103), built here from the rows if not supplied.
+    """
+    validation_rows: list[ValidationRow] = [row.validation for row in rows]
     if resolution_index is None:
-        resolution_index = resolution_index_from_entries(entries)
+        resolution_index = resolution_index_from_rows(validation_rows)
 
     # Repository-wide severity overrides (ADR-053): review/portfolio/watchkeeper
     # honour the same .rac/config.yaml policy as `rac validate`.
@@ -214,30 +296,25 @@ def portfolio_from_corpus(
     # second identifier pass.
     path_to_identifier: dict[str, str] = {}
 
-    for entry in entries:
-        path, product = entry.path, entry.product
-        artifact_type = entry.artifact_type
-        by_type[artifact_type] = by_type.get(artifact_type, 0) + 1
+    for row in rows:
+        by_type[row.artifact_type] = by_type.get(row.artifact_type, 0) + 1
 
-        spec = spec_for(artifact_type)
-        if spec is None:
+        if row.validation.spec_name is None:
             # Unknown artifacts: not validated, not scored for completeness.
-            unknown_paths.append(str(path))
+            unknown_paths.append(row.path)
             continue
 
-        identifier = artifact_identifier(product, spec, str(path))
-        path_to_identifier[str(path)] = identifier
+        identifier = row.identifier
+        path_to_identifier[row.path] = identifier
 
         # Validation (overrides applied, ADR-053)
-        issues = apply_overrides(
-            validate(product, artifact_type=artifact_type), artifact_type, overrides
-        )
+        issues = apply_overrides(list(row.validate_issues), row.artifact_type, overrides)
         if has_errors(issues):
             invalid_count += 1
             error_codes = [i.code for i in issues if i.severity == "error"]
             attention.append(
                 AttentionItem(
-                    path=str(path),
+                    path=row.path,
                     identifier=identifier,
                     severity="error",
                     code=ATTENTION_INVALID,
@@ -250,16 +327,16 @@ def portfolio_from_corpus(
         # Completeness (recommended sections only — required failures are already
         # reported as validation errors above, counting them twice would double-
         # penalise in the health score).
-        slots = len(spec.recommended)
+        slots = row.recommended_slots
         recommended_slots += slots
-        _, missing_rec = missing_sections(product, spec)
+        missing_rec = list(row.missing_recommended)
         filled = slots - len(missing_rec)
         filled_slots += filled
         if missing_rec:
             names = ", ".join(s.title() for s in missing_rec)
             attention.append(
                 AttentionItem(
-                    path=str(path),
+                    path=row.path,
                     identifier=identifier,
                     severity="warning",
                     code=ATTENTION_MISSING_RECOMMENDED,
@@ -270,11 +347,11 @@ def portfolio_from_corpus(
     # --- relationship summary ------------------------------------------------
     # Reuses the snapshot (no second walk); per-reference issues become
     # attention items so broken references are surfaced, not just counted.
-    rel_summary = summary_from_corpus(entries, resolution_index=resolution_index)
+    rel_summary = summary_from_rows(validation_rows, resolution_index=resolution_index)
     # The full relationship-validation gate (additive, v0.16.0): same verdict as
     # `rac relationships --validate`, over the same snapshot (no extra walk).
-    relationships_ok = validation_from_corpus(
-        directory, entries, recursive=recursive, resolution_index=resolution_index
+    relationships_ok = validation_from_rows(
+        directory, validation_rows, recursive=recursive, resolution_index=resolution_index
     ).ok
     for issue in rel_summary.issues:
         source = issue.source_path or ""

--- a/src/rac/services/relationships.py
+++ b/src/rac/services/relationships.py
@@ -995,9 +995,7 @@ def _summarize(
     resolution_index: ResolutionIndex | None = None,
 ) -> RelationshipSummary:
     """Summarise a materialised item list via the compact-row core (ADR-108)."""
-    return summary_from_rows(
-        _validation_rows_from_items(items), resolution_index=resolution_index
-    )
+    return summary_from_rows(_validation_rows_from_items(items), resolution_index=resolution_index)
 
 
 def summary_from_rows(

--- a/src/rac/services/relationships.py
+++ b/src/rac/services/relationships.py
@@ -377,21 +377,6 @@ _IdentIndex = dict[str, list[tuple[str, str]]]
 ResolutionIndex = _IdentIndex
 
 
-def _build_identifier_index(
-    items: list[tuple[str, Product, ArtifactSpec | None]],
-) -> _IdentIndex:
-    """Canonical-identifier index over *all* files (Unknown included).
-
-    One entry per file — duplicate-identity detection runs over this index,
-    so only the canonical identifier can collide (ADR-026).
-    """
-    index: _IdentIndex = {}
-    for path, product, spec in items:
-        ident = artifact_identifier(product, spec, path)
-        index.setdefault(ident.casefold(), []).append((path, ident))
-    return index
-
-
 def build_resolution_index(
     items: list[tuple[str, Product, ArtifactSpec | None]],
 ) -> _IdentIndex:
@@ -421,11 +406,104 @@ def resolution_index_from_entries(entries: list[CorpusEntry]) -> ResolutionIndex
     return build_resolution_index(_entry_items(entries))
 
 
-def _resolve_references(
+# --- Compact validation rows (ADR-108) ---------------------------------------
+#
+# The repository validation gate and the relationship summary both read a small,
+# fixed projection of each document: its identity, whether it is retired, the
+# relationship sections it declares (and any its type does not support), and its
+# declared edges. ``ValidationRow`` is exactly that projection with the
+# ``Product`` dropped, so the gate and summary run over compact rows a worker can
+# ship (ADR-108) instead of parsed products. The serial paths build the rows from
+# their items and route through the same cores, so the merge and the serial build
+# validate and summarise the graph identically by construction.
+
+
+@dataclass(frozen=True)
+class ValidationRow:
+    """One document's compact projection for validation and summary (ADR-108).
+
+    ``spec_name`` is the artifact type's name, or ``None`` for an Unknown/untyped
+    document (the ``spec is None`` skip). ``canonical_id`` is the single identifier
+    duplicate detection collides on; ``identifiers`` is the full alias set the
+    resolution index is built from. ``retired`` is the type-aware retired-status
+    flag; ``unsupported_sections`` are the declared relationship sections the type
+    does not support (canonical ``RELATIONSHIP_SECTIONS`` names); ``edges`` are the
+    declared ``(snake_section, refs)`` rows in schema order, empty for Unknown.
+    """
+
+    path: str
+    spec_name: str | None
+    canonical_id: str
+    identifiers: tuple[str, ...]
+    retired: bool
+    unsupported_sections: tuple[str, ...]
+    edges: tuple[tuple[str, tuple[str, ...]], ...]
+
+
+def validation_row(path: str, product: Product, spec: ArtifactSpec | None) -> ValidationRow:
+    """The compact :class:`ValidationRow` projection of one ``(path, product, spec)``.
+
+    Pure and deterministic: every field is read straight from the product, so a
+    row built here in the parent and a row shipped from a worker over the same
+    document are identical. An Unknown document (``spec is None``) carries its
+    identifiers — so it still populates the resolution index and can collide — but
+    no edges and no unsupported sections (it declares no typed relationships).
+    """
+    identifiers = tuple(artifact_identifiers(product, spec, path))
+    canonical_id = artifact_identifier(product, spec, path)
+    if spec is None:
+        return ValidationRow(
+            path=path,
+            spec_name=None,
+            canonical_id=canonical_id,
+            identifiers=identifiers,
+            retired=False,
+            unsupported_sections=(),
+            edges=(),
+        )
+    edges = tuple(
+        (section, tuple(refs))
+        for section, refs in extract_relationships_full(product, spec).items()
+    )
+    return ValidationRow(
+        path=path,
+        spec_name=spec.name,
+        canonical_id=canonical_id,
+        identifiers=identifiers,
+        retired=_is_retired_artifact(product, spec),
+        unsupported_sections=tuple(unsupported_relationship_sections(product, spec)),
+        edges=edges,
+    )
+
+
+def _validation_rows_from_items(
     items: list[tuple[str, Product, ArtifactSpec | None]],
+) -> list[ValidationRow]:
+    """Build the compact validation rows for a materialised item list."""
+    return [validation_row(path, product, spec) for path, product, spec in items]
+
+
+def _resolve_row_from_validation(row: ValidationRow) -> ResolveRow:
+    """The :class:`ResolveRow` view of a validation row (shared resolve seam).
+
+    Byte-identical to :func:`resolve_row` over the same document: the identifiers
+    are the row's, and each edge's external flag is recomputed from its section
+    exactly as :func:`resolve_row` does, so referential resolution runs through the
+    one :func:`resolve_relationships` seam whichever row type it started from.
+    """
+    edges: list[tuple[str, bool, tuple[str, ...]]] = []
+    for section, refs in row.edges:
+        edge = edge_spec(section)
+        external = edge is not None and edge.external
+        edges.append((section, external, refs))
+    return ResolveRow(path=row.path, identifiers=row.identifiers, edges=tuple(edges))
+
+
+def _resolve_references(
+    rows: list[ValidationRow],
     index: _IdentIndex,
 ) -> tuple[int, list[RelationshipIssue], set[str]]:
-    """Resolve every explicit reference in ``items`` against ``index``.
+    """Resolve every explicit reference in ``rows`` against ``index``.
 
     Returns ``(checked, issues, resolved_target_paths)`` where
     ``resolved_target_paths`` is the set of paths that appear as a *resolved*
@@ -436,10 +514,10 @@ def _resolve_references(
     resolved_targets: set[str] = set()
     checked = 0
 
-    for path, product, spec in items:
-        if spec is None:
+    for row in rows:
+        if row.spec_name is None:
             continue
-        for section, refs in extract_relationships_full(product, spec).items():
+        for section, refs in row.edges:
             edge = edge_spec(section)
             if edge is not None and edge.external:
                 continue  # external refs (ADR-087) are format-linted, not resolved
@@ -450,20 +528,22 @@ def _resolve_references(
                     code = ISSUE_TARGET_NOT_FOUND
                 elif len(targets) > 1:
                     code = ISSUE_TARGET_AMBIGUOUS
-                elif targets == [path]:
+                elif targets == [row.path]:
                     code = ISSUE_SELF_REFERENCE
                 else:
                     resolved_targets.add(targets[0])
                     continue  # resolved uniquely to another artifact
                 issues.append(
-                    RelationshipIssue(code=code, source_path=path, relationship=section, target=ref)
+                    RelationshipIssue(
+                        code=code, source_path=row.path, relationship=section, target=ref
+                    )
                 )
 
     return checked, issues, resolved_targets
 
 
 def _acyclic_adjacency(
-    items: list[tuple[str, Product, ArtifactSpec | None]],
+    rows: list[ValidationRow],
     resolution_index: _IdentIndex,
     kind: str,
 ) -> dict[str, list[str]]:
@@ -473,16 +553,16 @@ def _acyclic_adjacency(
     are owned by referential integrity), so the graph reflects real directed edges.
     """
     adjacency: dict[str, list[str]] = {}
-    for path, product, spec in items:
-        if spec is None:
+    for row in rows:
+        if row.spec_name is None:
             continue
         targets: set[str] = set()
-        for ref in extract_relationships_full(product, spec).get(kind, []):
+        for ref in dict(row.edges).get(kind, ()):
             resolved = [p for p, _ in resolution_index.get(ref.casefold(), [])]
-            if len(resolved) == 1 and resolved[0] != path:
+            if len(resolved) == 1 and resolved[0] != row.path:
                 targets.add(resolved[0])
         if targets:
-            adjacency[path] = sorted(targets)
+            adjacency[row.path] = sorted(targets)
     return adjacency
 
 
@@ -531,13 +611,13 @@ def _cyclic_components(adjacency: dict[str, list[str]]) -> list[list[str]]:
 
 
 def _cycle_issues(
-    items: list[tuple[str, Product, ArtifactSpec | None]],
+    rows: list[ValidationRow],
     resolution_index: _IdentIndex,
 ) -> list[RelationshipIssue]:
     """One ``relationship-cycle`` per cyclic component of each acyclic edge kind."""
     issues: list[RelationshipIssue] = []
     for kind in sorted(name for name, edge in REGISTRY.items() if edge.acyclic):
-        adjacency = _acyclic_adjacency(items, resolution_index, kind)
+        adjacency = _acyclic_adjacency(rows, resolution_index, kind)
         for component in _cyclic_components(adjacency):
             issues.append(
                 RelationshipIssue(code=ISSUE_RELATIONSHIP_CYCLE, relationship=kind, paths=component)
@@ -560,22 +640,22 @@ def _cycle_issues(
 
 def _scope_validation_issues(
     directory: str,
-    items: list[tuple[str, Product, ArtifactSpec | None]],
+    rows: list[ValidationRow],
 ) -> list[RelationshipIssue]:
     """One ``applies-to-target-not-found`` per missing literal path/dir entry.
 
     Checks only filesystem-scoped edges (``edge.filesystem_scoped``) and only
     their literal ``path`` entries: each is checked to exist relative to the
     repository root. Glob patterns and component labels are recorded without
-    existence-checking. Deterministic — items in sorted-path order, entries in
+    existence-checking. Deterministic — rows in sorted-path order, entries in
     declared order.
     """
     root = repository_root(directory)
     issues: list[RelationshipIssue] = []
-    for path, product, spec in items:
-        if spec is None:
+    for row in rows:
+        if row.spec_name is None:
             continue
-        for section, refs in extract_relationships_full(product, spec).items():
+        for section, refs in row.edges:
             edge = edge_spec(section)
             if edge is None or not edge.filesystem_scoped:
                 continue
@@ -588,12 +668,27 @@ def _scope_validation_issues(
                 issues.append(
                     RelationshipIssue(
                         code=ISSUE_SCOPE_TARGET_NOT_FOUND,
-                        source_path=path,
+                        source_path=row.path,
                         relationship=section,
                         target=ref,
                     )
                 )
     return issues
+
+
+def resolution_index_from_rows(rows: list[ValidationRow]) -> ResolutionIndex:
+    """The reference-resolution index over validation rows' identifiers (ADR-108).
+
+    Byte-identical to ``build_resolution_index`` over the same documents in the
+    same order — the rows' ``identifiers`` are the ``artifact_identifiers`` tuple.
+    Passing the result into :func:`summary_from_rows` and :func:`validation_from_rows`
+    lets the portfolio resolve over one shared index, as the derived build does.
+    """
+    index: _IdentIndex = {}
+    for row in rows:
+        for ident in row.identifiers:
+            index.setdefault(ident.casefold(), []).append((row.path, ident))
+    return index
 
 
 def _validate(
@@ -603,13 +698,39 @@ def _validate(
     *,
     resolution_index: ResolutionIndex | None = None,
 ) -> RelationshipValidation:
-    index = _build_identifier_index(items)
+    """Validate a materialised item list via the compact-row core (ADR-108)."""
+    return validation_from_rows(
+        directory,
+        _validation_rows_from_items(items),
+        recursive,
+        resolution_index=resolution_index,
+    )
 
+
+def validation_from_rows(
+    directory: str,
+    rows: list[ValidationRow],
+    recursive: bool = True,
+    *,
+    resolution_index: ResolutionIndex | None = None,
+) -> RelationshipValidation:
+    """The repository relationship-validation gate over compact rows (ADR-108).
+
+    The single core the serial :func:`_validate` and the parallel merge both run,
+    so both produce the same findings in the same order by construction. Every
+    check reads only the rows' compact projection — canonical identifier, retired
+    flag, declared edges, unsupported sections — plus the working tree for scope
+    existence, so no parsed ``Product`` is needed.
+    """
     issues: list[RelationshipIssue] = []
 
-    # Duplicate identifiers (repo-level), emitted first, sorted by identifier.
+    # Duplicate identifiers (repo-level), emitted first, sorted by identifier. One
+    # entry per document — only the canonical identifier can collide (ADR-026).
+    ident_index: _IdentIndex = {}
+    for row in rows:
+        ident_index.setdefault(row.canonical_id.casefold(), []).append((row.path, row.canonical_id))
     duplicates: list[tuple[str, list[str]]] = []
-    for entries in index.values():
+    for entries in ident_index.values():
         if len(entries) > 1:
             display = min(entries, key=lambda e: e[0])[1]  # first path's casing
             duplicates.append((display, sorted(p for p, _ in entries)))
@@ -620,20 +741,20 @@ def _validate(
 
     # Edge-legality (v0.14.0, ADR-049): report relationship sections an artifact's
     # type does not declare instead of silently dropping them. Deterministic —
-    # items in sorted-path order, sections in canonical RELATIONSHIP_SECTIONS order.
-    for path, product, spec in items:
-        if spec is None:
+    # rows in sorted-path order, sections in canonical RELATIONSHIP_SECTIONS order.
+    for row in rows:
+        if row.spec_name is None:
             continue
-        for section in unsupported_relationship_sections(product, spec):
+        for section in row.unsupported_sections:
             issues.append(
                 RelationshipIssue(
-                    code=ISSUE_EDGE_UNSUPPORTED, source_path=path, relationship=_snake(section)
+                    code=ISSUE_EDGE_UNSUPPORTED, source_path=row.path, relationship=_snake(section)
                 )
             )
 
     if resolution_index is None:
-        resolution_index = build_resolution_index(items)
-    by_path = {path: (product, spec) for path, product, spec in items}
+        resolution_index = resolution_index_from_rows(rows)
+    by_path = {row.path: row for row in rows}
 
     def _resolved(ref: str, source_path: str) -> str | None:
         """The unique non-self target path for ``ref``, or None.
@@ -649,25 +770,25 @@ def _validate(
     # Range (v0.16.0, ADR-055): a resolved target whose type is not in the edge's
     # declared range is an illegal edge — e.g. a ``## Related Decisions`` reference
     # that resolves to a requirement. Deterministic (sorted-path / spec.optional).
-    for path, product, spec in items:
-        if spec is None:
+    for row in rows:
+        if row.spec_name is None:
             continue
-        for section, refs in extract_relationships_full(product, spec).items():
+        for section, refs in row.edges:
             edge = edge_spec(section)
             if edge is None or edge.external:
                 continue  # external edges (ADR-087) carry no artifact range
             for ref in refs:
-                target = _resolved(ref, path)
+                target = _resolved(ref, row.path)
                 if target is None:
                     continue
-                _, target_spec = by_path[target]
-                if target_spec is None:
+                target_spec_name = by_path[target].spec_name
+                if target_spec_name is None:
                     continue  # untyped document (ADR-010) — not a range violation
-                if target_spec.name not in edge.range:
+                if target_spec_name not in edge.range:
                     issues.append(
                         RelationshipIssue(
                             code=ISSUE_TARGET_TYPE_MISMATCH,
-                            source_path=path,
+                            source_path=row.path,
                             relationship=section,
                             target=ref,
                         )
@@ -676,24 +797,23 @@ def _validate(
     # Status-consistency (v0.14.1, generalised in v0.16.0/ADR-051): a live artifact
     # must not reference a retired target, except via an edge that permits it
     # (``supersedes``, ``forbids_target_status=False``). Reads the resolved
-    # target's status from the materialised items — no second walk.
-    for path, product, spec in items:
-        if spec is None or _is_retired_artifact(product, spec):
+    # target's retired flag from the rows — no second walk.
+    for row in rows:
+        if row.spec_name is None or row.retired:
             continue  # unknown file, or a retired source (historical chains exempt)
-        for section, refs in extract_relationships_full(product, spec).items():
+        for section, refs in row.edges:
             edge = edge_spec(section)
             if edge is None or edge.external or not edge.forbids_target_status:
                 continue  # supersedes/external edges never gate on target status
             for ref in refs:
-                target = _resolved(ref, path)
+                target = _resolved(ref, row.path)
                 if target is None:
                     continue
-                target_product, target_spec = by_path[target]
-                if _is_retired_artifact(target_product, target_spec):
+                if by_path[target].retired:
                     issues.append(
                         RelationshipIssue(
                             code=ISSUE_TARGET_SUPERSEDED,
-                            source_path=path,
+                            source_path=row.path,
                             relationship=section,
                             target=ref,
                         )
@@ -702,15 +822,15 @@ def _validate(
     # Acyclicity (v0.16.0, ADR-055): a cycle in a directional, acyclic edge kind
     # (today ``supersedes``) is illegal — an ordering/replacement edge must not
     # form a loop. Reported per strongly-connected component, deterministically.
-    issues.extend(_cycle_issues(items, resolution_index))
+    issues.extend(_cycle_issues(rows, resolution_index))
 
-    checked, ref_issues, _ = _resolve_references(items, resolution_index)
+    checked, ref_issues, _ = _resolve_references(rows, resolution_index)
     issues.extend(ref_issues)
 
     # Code-scope existence (decision-to-code-proximity, Initiative 1): filesystem-
     # scoped ``## Applies To`` literal paths are checked against the working tree.
     # Appended last, so existing finding order is unchanged (ADR-007).
-    issues.extend(_scope_validation_issues(directory, items))
+    issues.extend(_scope_validation_issues(directory, rows))
 
     return RelationshipValidation(
         directory=directory,
@@ -874,26 +994,37 @@ def _summarize(
     *,
     resolution_index: ResolutionIndex | None = None,
 ) -> RelationshipSummary:
-    if not items:
+    """Summarise a materialised item list via the compact-row core (ADR-108)."""
+    return summary_from_rows(
+        _validation_rows_from_items(items), resolution_index=resolution_index
+    )
+
+
+def summary_from_rows(
+    rows: list[ValidationRow], *, resolution_index: ResolutionIndex | None = None
+) -> RelationshipSummary:
+    """Aggregate relationship health over compact rows (ADR-108).
+
+    The single core the serial :func:`_summarize` and the parallel merge both run.
+    Byte-identical to the item-based summary: the same references resolve against
+    the same index, and coverage/orphan counts read the rows' spec/edge projection.
+    """
+    if not rows:
         return RelationshipSummary(total=0, valid=0, broken=0, orphaned=0, coverage=1.0)
 
-    index = resolution_index if resolution_index is not None else build_resolution_index(items)
-    checked, ref_issues, resolved_targets = _resolve_references(items, index)
+    index = resolution_index if resolution_index is not None else resolution_index_from_rows(rows)
+    checked, ref_issues, resolved_targets = _resolve_references(rows, index)
 
     broken = len(ref_issues)
     valid = checked - broken
 
     # Orphan = known (spec is not None) artifact whose path never appears as a
     # resolved target of another artifact's reference.
-    all_known_paths = {path for path, _, spec in items if spec is not None}
+    all_known_paths = {row.path for row in rows if row.spec_name is not None}
     orphaned = len(all_known_paths - resolved_targets)
 
     # Coverage = fraction of known artifacts that declare >=1 outbound relationship.
-    artifacts_with_rels = sum(
-        1
-        for path, product, spec in items
-        if spec is not None and extract_relationships_full(product, spec)
-    )
+    artifacts_with_rels = sum(1 for row in rows if row.spec_name is not None and row.edges)
     coverage = artifacts_with_rels / len(all_known_paths) if all_known_paths else 1.0
 
     return RelationshipSummary(
@@ -1062,6 +1193,21 @@ def relationships_from_corpus(
     """
     rows = [resolve_row(path, product, spec) for path, product, spec in _entry_items(entries)]
     return resolve_relationships(rows, resolution_index=resolution_index)
+
+
+def relationships_from_rows(
+    rows: list[ValidationRow], *, resolution_index: ResolutionIndex | None = None
+) -> list[Relationship]:
+    """Resolve compact :class:`ValidationRow` items into :class:`Relationship` objects.
+
+    The parallel merge (ADR-108) holds validation rows, not corpus entries; this
+    routes them through the same :func:`resolve_relationships` seam the serial
+    :func:`relationships_from_corpus` uses, so the resolved graph is byte-identical
+    whichever row type it started from.
+    """
+    return resolve_relationships(
+        [_resolve_row_from_validation(row) for row in rows], resolution_index=resolution_index
+    )
 
 
 def inbound_counts_from_relationships(rels: list[Relationship]) -> dict[str, int]:

--- a/src/rac/services/relationships.py
+++ b/src/rac/services/relationships.py
@@ -932,26 +932,84 @@ class Relationship:
     issue: str | None
 
 
-def relationships_from_corpus(
-    entries: list[CorpusEntry], *, resolution_index: ResolutionIndex | None = None
-) -> list[Relationship]:
-    """Every declared reference in a corpus snapshot as :class:`Relationship`.
+# --- Compact resolve seam (ADR-108) ------------------------------------------
+#
+# The parallel merge ships compact per-document rows across the process boundary,
+# not parsed ``Product`` objects. ``ResolveRow`` is exactly what the resolve loop
+# reads about one document — its resolution identifiers and its declared edges,
+# with the ``Product`` dropped. Both the serial ``relationships_from_corpus`` and
+# the merge feed the same :func:`resolve_relationships` over these rows, so the
+# two paths resolve the graph identically by construction rather than by
+# coincidence — the parity the merge rests on is structural.
 
-    Ordering is deterministic: source artifacts in snapshot (sorted path)
-    order, sections in each artifact's own schema order, references in
-    declaration order — matching ``_resolve_references``. A prebuilt
-    ``resolution_index`` (from :func:`resolution_index_from_entries`) is used when
-    supplied, so a shared build resolves over one index; the output is identical.
+
+@dataclass(frozen=True)
+class ResolveRow:
+    """One document's compact projection for relationship resolution (ADR-108).
+
+    ``identifiers`` are the document's canonical identifier plus its legacy
+    aliases — the same tuple :func:`build_resolution_index` reads via
+    ``artifact_identifiers`` — carried for *every* document (Unknown included) so
+    the resolution index and its duplicate collisions are reproduced exactly.
+    ``edges`` are the declared relationship sections as ``(section, external,
+    refs)`` rows, in the artifact's own schema order; Unknown documents carry no
+    edges. This is the whole input the resolve loop needs, with the ``Product``
+    dropped.
     """
-    items = _entry_items(entries)
-    index = resolution_index if resolution_index is not None else build_resolution_index(items)
+
+    path: str
+    identifiers: tuple[str, ...]
+    edges: tuple[tuple[str, bool, tuple[str, ...]], ...]
+
+
+def resolve_row(path: str, product: Product, spec: ArtifactSpec | None) -> ResolveRow:
+    """The compact :class:`ResolveRow` projection of one ``(path, product, spec)``.
+
+    Pure and deterministic: the identifiers and declared edges are read straight
+    from the product, so a row built here in the parent from a parsed entry and a
+    row shipped from a worker over the same document are identical.
+    """
+    identifiers = tuple(artifact_identifiers(product, spec, path))
+    if spec is None:
+        return ResolveRow(path=path, identifiers=identifiers, edges=())
+    edges: list[tuple[str, bool, tuple[str, ...]]] = []
+    for section, refs in extract_relationships_full(product, spec).items():
+        edge = edge_spec(section)
+        external = edge is not None and edge.external
+        edges.append((section, external, tuple(refs)))
+    return ResolveRow(path=path, identifiers=identifiers, edges=tuple(edges))
+
+
+def _index_from_resolve_rows(rows: list[ResolveRow]) -> _IdentIndex:
+    """The reference-resolution index over ``rows`` (Unknown documents included).
+
+    Byte-identical to ``build_resolution_index`` run over the same documents in
+    the same order: each row contributes its identifiers, in order, as
+    ``(path, ident)`` under the casefolded key.
+    """
+    index: _IdentIndex = {}
+    for row in rows:
+        for ident in row.identifiers:
+            index.setdefault(ident.casefold(), []).append((row.path, ident))
+    return index
+
+
+def resolve_relationships(
+    rows: list[ResolveRow], *, resolution_index: ResolutionIndex | None = None
+) -> list[Relationship]:
+    """Resolve compact :class:`ResolveRow` items into :class:`Relationship` objects.
+
+    The single resolve loop shared by the serial corpus path and the parallel
+    merge (ADR-108). Ordering is deterministic: rows in snapshot (sorted path)
+    order, sections in each row's schema order, references in declaration order.
+    A prebuilt ``resolution_index`` is used when supplied; otherwise it is built
+    from the rows' identifiers (:func:`_index_from_resolve_rows`), which equals
+    ``build_resolution_index`` over the same documents.
+    """
+    index = resolution_index if resolution_index is not None else _index_from_resolve_rows(rows)
     relationships: list[Relationship] = []
-    for path, product, spec in items:
-        if spec is None:
-            continue
-        for section, refs in extract_relationships_full(product, spec).items():
-            edge = edge_spec(section)
-            external = edge is not None and edge.external
+    for row in rows:
+        for section, external, refs in row.edges:
             for ref in refs:
                 resolved: str | None = None
                 issue: str | None = None
@@ -960,7 +1018,7 @@ def relationships_from_corpus(
                     # artifact by design — an edge for the graph, never "broken".
                     relationships.append(
                         Relationship(
-                            source_path=path,
+                            source_path=row.path,
                             relationship=section,
                             target=ref,
                             resolved_path=None,
@@ -973,13 +1031,13 @@ def relationships_from_corpus(
                     issue = ISSUE_TARGET_NOT_FOUND
                 elif len(targets) > 1:
                     issue = ISSUE_TARGET_AMBIGUOUS
-                elif targets == [path]:
+                elif targets == [row.path]:
                     issue = ISSUE_SELF_REFERENCE
                 else:
                     resolved = targets[0]
                 relationships.append(
                     Relationship(
-                        source_path=path,
+                        source_path=row.path,
                         relationship=section,
                         target=ref,
                         resolved_path=resolved,
@@ -987,6 +1045,23 @@ def relationships_from_corpus(
                     )
                 )
     return relationships
+
+
+def relationships_from_corpus(
+    entries: list[CorpusEntry], *, resolution_index: ResolutionIndex | None = None
+) -> list[Relationship]:
+    """Every declared reference in a corpus snapshot as :class:`Relationship`.
+
+    Ordering is deterministic: source artifacts in snapshot (sorted path)
+    order, sections in each artifact's own schema order, references in
+    declaration order — matching ``_resolve_references``. A prebuilt
+    ``resolution_index`` (from :func:`resolution_index_from_entries`) is used when
+    supplied, so a shared build resolves over one index; the output is identical.
+    Resolution runs through the shared :func:`resolve_relationships` seam so the
+    serial path and the parallel merge (ADR-108) cannot drift.
+    """
+    rows = [resolve_row(path, product, spec) for path, product, spec in _entry_items(entries)]
+    return resolve_relationships(rows, resolution_index=resolution_index)
 
 
 def inbound_counts_from_relationships(rels: list[Relationship]) -> dict[str, int]:

--- a/tests/test_b6_parallel_merge.py
+++ b/tests/test_b6_parallel_merge.py
@@ -1,0 +1,256 @@
+"""Per-mutation-class byte-parity for the ADR-108 parallel merge.
+
+ADR-107 flagged the fan-out of the *derive* (not just the parse) as the highest
+byte-parity risk in the system: workers emit compact per-document fragments and
+the parent reproduces the derived read-model from them, so any per-document
+derivation that the fragment projects incompletely — or that the merge
+reassembles in the wrong order — would silently diverge from the serial build.
+
+These tests are the risk gate. Each targets one fragile derivation with a corpus
+crafted to exercise it non-trivially, then asserts that the fragment-merge path is
+byte-identical to the serial derive two ways:
+
+- ``reproduce([fragment_from_entry(e) for e in walk])`` equals
+  ``build_derived_index`` — the whole merge, in-process, no worker needed; and
+- an end-to-end ``build_derived_index_parallel`` writes a store whose segment
+  bytes equal a single-process build's, so the fan-out is proven across a real
+  process boundary and a real chunk split (cross-chunk edges, uneven partitions).
+
+The equality is field-for-field (``DerivedIndex`` dataclass equality) and over the
+lossless serialisation, so a divergence in any derived structure — resolution
+outcomes, inbound counts, tokens, the portfolio gate, scope/live rows — fails here.
+
+Identifiers are numeric (``RAC-<12 digits>``) so every fixture artifact is
+schema-valid — the id syntax is Crockford base32, which excludes I/L/O/U — and the
+portfolio gate reflects the relationship finding under test, not an id-syntax error.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+from rac.core.corpus import corpus_content_hash, walk_corpus
+from rac.services.derived_cache import build_derived_index, to_json_obj
+from rac.services.index_store import store_dir, write_store
+from rac.services.parallel_build import build_derived_index_parallel
+from rac.services.parallel_merge import fragment_from_entry, reproduce
+
+_BUNDLE_VERSION = "3"
+
+
+def _id(n: int) -> str:
+    return f"RAC-{n:012d}"
+
+
+# --- fixtures ----------------------------------------------------------------
+
+
+def _decision(
+    ident: str,
+    *,
+    title: str = "Decision",
+    body: str = "alpha beta gamma",
+    status: str = "Accepted",
+    tags: str | None = None,
+    related_decisions: list[str] | None = None,
+    related_requirements: list[str] | None = None,
+    related_tickets: list[str] | None = None,
+    supersedes: list[str] | None = None,
+    applies_to: list[str] | None = None,
+) -> str:
+    tag_line = f"tags: [{', '.join(tags)}]\n" if tags else ""
+    doc = (
+        f"---\nschema_version: 1\nid: {ident}\ntype: decision\n{tag_line}---\n"
+        f"# {title}\n\n## Status\n\n{status}\n\n## Category\n\nArchitecture\n\n"
+        f"## Context\n\n{body}\n\n## Decision\n\nD.\n\n## Consequences\n\nE.\n"
+    )
+    for heading, refs in (
+        ("Related Decisions", related_decisions),
+        ("Related Requirements", related_requirements),
+        ("Related Tickets", related_tickets),
+        ("Supersedes", supersedes),
+        ("Applies To", applies_to),
+    ):
+        if refs:
+            body_lines = "".join(f"- {ref}\n" for ref in refs)
+            doc += f"\n## {heading}\n\n{body_lines}"
+    return doc
+
+
+def _requirement(ident: str, *, title: str = "Requirement", body: str = "need") -> str:
+    return (
+        f"---\nschema_version: 1\nid: {ident}\ntype: requirement\n---\n"
+        f"# {title}\n\n## Problem\n\n{body}\n\n## Requirements\n\n- R.\n"
+    )
+
+
+def _write(directory: Path, name: str, content: str) -> None:
+    (directory / name).write_text(content, encoding="utf-8")
+
+
+def _assert_merge_parity(directory: Path):
+    """The whole fragment-merge equals the serial derive, field-for-field + serialised."""
+    entries = list(walk_corpus(str(directory), recursive=True))
+    serial = build_derived_index(str(directory))
+    merged = reproduce([fragment_from_entry(e) for e in entries], str(directory))
+    assert merged == serial, "reproduce() diverged from build_derived_index()"
+    assert to_json_obj(merged) == to_json_obj(serial), "serialised merge diverged"
+    return serial, merged
+
+
+def _segment_hashes(cache_dir: Path, corpus_hash: str) -> dict[str, str]:
+    directory = store_dir(cache_dir, corpus_hash)
+    return {
+        p.name: hashlib.sha256(p.read_bytes()).hexdigest()
+        for p in sorted(directory.iterdir())
+        if p.is_file()
+    }
+
+
+def _assert_store_parity(directory: Path, cache_root: Path, *, workers: int) -> int:
+    """workers=N store bytes equal workers=1 store bytes; returns the workers actually used."""
+    corpus_hash = corpus_content_hash(str(directory))
+
+    serial, serial_stats = build_derived_index_parallel(str(directory), workers=1)
+    assert write_store(cache_root / "s1", corpus_hash, _BUNDLE_VERSION, serial)
+    serial_hashes = _segment_hashes(cache_root / "s1", corpus_hash)
+
+    parallel, parallel_stats = build_derived_index_parallel(str(directory), workers=workers)
+    assert write_store(cache_root / "sN", corpus_hash, _BUNDLE_VERSION, parallel)
+    parallel_hashes = _segment_hashes(cache_root / "sN", corpus_hash)
+
+    assert serial_stats.workers == 1
+    assert parallel_hashes == serial_hashes, "fan-out store diverged from the serial store"
+    return parallel_stats.workers
+
+
+# --- resolution outcomes -----------------------------------------------------
+
+
+def test_resolution_outcomes_parity(tmp_path):
+    # resolved / not-found / ambiguous / self / external — all five outcomes in one
+    # corpus so the resolved graph, inbound counts, and portfolio gate all diverge
+    # if any outcome is reproduced wrongly.
+    a, b, dup = _id(101), _id(102), _id(103)
+    d = tmp_path
+    _write(d, "a.md", _decision(a, title="A resolves to B", related_decisions=[b]))
+    _write(d, "b.md", _decision(b, title="B", related_decisions=[_id(999999)]))  # not-found
+    _write(d, "c.md", _decision(_id(104), related_decisions=[dup]))  # ambiguous
+    _write(d, "dup1.md", _decision(dup, title="Dup one"))
+    _write(d, "dup2.md", _decision(dup, title="Dup two"))
+    _write(d, "self.md", _decision(_id(105), related_decisions=[_id(105)]))  # self
+    _write(d, "ext.md", _decision(_id(106), related_tickets=["JIRA-123"]))  # external
+
+    _serial, merged = _assert_merge_parity(d)
+    # Sanity: the corpus is non-trivial — resolved, broken, and external edges exist.
+    issues = {r.issue for r in merged.relationships}
+    assert None in issues  # resolved and external edges carry no issue
+    assert any(r.resolved_path for r in merged.relationships)
+    assert any(r.issue for r in merged.relationships)
+    # The duplicate + broken references make the portfolio relationship gate fail.
+    assert merged.portfolio_summary["validation_status"]["relationships_ok"] is False
+
+
+def test_duplicate_identity_parity(tmp_path):
+    dup = _id(200)
+    _write(tmp_path, "one.md", _decision(dup, title="First"))
+    _write(tmp_path, "two.md", _decision(dup, title="Second"))
+    _write(tmp_path, "solo.md", _decision(_id(201)))
+    _serial, merged = _assert_merge_parity(tmp_path)
+    # A duplicate canonical identifier is a relationship-validation finding.
+    assert merged.portfolio_summary["validation_status"]["relationships_ok"] is False
+
+
+def test_alias_and_legacy_id_parity(tmp_path):
+    # A legacy-style filename gives the artifact extra aliases beyond its canonical
+    # frontmatter id; the merge must build the resolution index over every alias.
+    _write(tmp_path, "ADR-042-legacy.md", _decision(_id(300), title="Legacy"))
+    _write(tmp_path, "ref.md", _decision(_id(301), related_decisions=["ADR-042"]))
+    _assert_merge_parity(tmp_path)
+
+
+def test_unknown_type_parity(tmp_path):
+    _write(tmp_path, "d.md", _decision(_id(400)))
+    (tmp_path / "notes.md").write_text("# Just a note\n\nNo frontmatter, no type.\n", "utf-8")
+    _serial, merged = _assert_merge_parity(tmp_path)
+    assert merged.portfolio_summary["artifacts"]["by_type"]["unknown"] == 1
+    assert merged.portfolio_summary["artifacts"]["unknown_paths"]
+
+
+def test_range_and_status_consistency_parity(tmp_path):
+    # A decision whose ``## Related Decisions`` resolves to a requirement is a range
+    # violation; a live decision referencing a superseded decision is a status
+    # violation. Both live only in the ``_validate`` gate the portfolio reproduces.
+    req, retired = _id(500), _id(501)
+    _write(tmp_path, "req.md", _requirement(req))
+    _write(tmp_path, "range.md", _decision(_id(502), related_decisions=[req]))
+    _write(tmp_path, "old.md", _decision(retired, title="Retired", status="Superseded"))
+    _write(tmp_path, "live.md", _decision(_id(503), related_decisions=[retired]))
+    _serial, merged = _assert_merge_parity(tmp_path)
+    assert merged.portfolio_summary["validation_status"]["relationships_ok"] is False
+
+
+def test_tag_only_document_parity(tmp_path):
+    # A term present only in a document's tags must tokenise into the tags field
+    # vector exactly as the serial build does (ADR-109).
+    _write(tmp_path, "tagged.md", _decision(_id(600), tags=["observability", "data-model"]))
+    _write(tmp_path, "plain.md", _decision(_id(601)))
+    _serial, merged = _assert_merge_parity(tmp_path)
+    tokens = merged.field_tokens_by_path[str(tmp_path / "tagged.md")]["tags"]
+    assert "observability" in tokens and "data" in tokens and "model" in tokens
+
+
+def test_scope_and_live_decision_parity(tmp_path):
+    # A live decision with declared ``## Applies To`` scope yields a scope row and a
+    # live path; a superseded decision yields neither.
+    _write(
+        tmp_path,
+        "live.md",
+        _decision(_id(700), title="Live", applies_to=["src/rac/services/"]),
+    )
+    _write(tmp_path, "dead.md", _decision(_id(701), status="Deprecated"))
+    _serial, merged = _assert_merge_parity(tmp_path)
+    assert [r.path for r in merged.scope_rows] == [str(tmp_path / "live.md")]
+    assert merged.live_decision_paths == [str(tmp_path / "live.md")]
+
+
+# --- partition shape ---------------------------------------------------------
+
+
+def test_empty_corpus_parity(tmp_path):
+    _serial, merged = _assert_merge_parity(tmp_path)
+    assert merged.index_entries == []
+    assert merged.relationships == []
+
+
+def test_single_document_parity(tmp_path):
+    _write(tmp_path, "only.md", _decision(_id(800)))
+    _assert_merge_parity(tmp_path)
+
+
+def test_cross_chunk_edge_store_parity(tmp_path):
+    # Source and target land in different worker chunks (sorted paths split in two),
+    # so the merge must resolve an edge whose endpoints came from different workers.
+    src, dst = _id(900), _id(901)
+    _write(tmp_path, "aaa.md", _decision(src, title="Source", related_decisions=[dst]))
+    _write(tmp_path, "mmm.md", _decision(_id(902)))
+    _write(tmp_path, "yyy.md", _decision(_id(903)))
+    _write(tmp_path, "zzz.md", _decision(dst, title="Target"))
+    # In-process reproduce parity, then a real two-worker store parity across the split.
+    _serial, merged = _assert_merge_parity(tmp_path)
+    assert merged.index_entries[0].path == str(tmp_path / "aaa.md")
+    # The target is referenced once — the inbound count must survive the cross-chunk merge.
+    target_entry = next(e for e in merged.index_entries if e.path == str(tmp_path / "zzz.md"))
+    assert target_entry.inbound_count == 1
+    used = _assert_store_parity(tmp_path, tmp_path / "cache", workers=2)
+    assert used >= 2, "the cross-chunk build must actually fan out"
+
+
+def test_uneven_partition_store_parity(tmp_path):
+    # A file count not divisible by the worker count exercises the last, shorter
+    # chunk (contiguous-chunk offset arithmetic) end to end.
+    for i in range(10):
+        _write(tmp_path, f"d{i:02d}.md", _decision(_id(1000 + i), body=f"term{i} shared"))
+    used = _assert_store_parity(tmp_path, tmp_path / "cache", workers=4)
+    assert used >= 2


### PR DESCRIPTION
# Summary

Implements the fan-out half of `rac/decisions/adr-108-term-range-partitioned-parallel-merge.md` — Increment 2, stacked on the now-merged #332 (portfolio single-resolve).

ADR-107 fanned the cold build's **parse** across processes but left the whole **derive** serial: workers shipped parsed `CorpusEntry`/`Product` objects and the parent ran `build_derived_index_from_entries` alone. ADR-107 recorded the derive fan-out as the highest byte-parity risk in the system and deferred it. This finishes it: workers emit compact per-document **derived fragments** and the parent reproduces the read-model from them, so the per-document derivations (validation, tokenisation, scope/live projection) run in the workers too and only compact rows cross the process boundary.

The parity is **structural, not just tested**: the serial derive and the merge run the *same* compact-row seams, so they cannot drift.

Adds:
- Compact-row seams in `relationships.py` (`ResolveRow`/`resolve_relationships`, `ValidationRow`/`validation_from_rows`, `summary_from_rows`) and `portfolio.py` (`PortfolioRow`/`portfolio_from_rows`); the serial paths route through them, byte-identically.
- `parallel_merge.py`: `DocFragment` (the whole per-document projection, Product dropped) + `fragment_from_entry` + `reproduce`, which does only the cross-document work (resolve the graph, fill inbound counts) and reads every other field off the fragments.
- The flip in `build_derived_index_parallel`: workers parse then `fragment_from_entry`; the parent `reproduce`s. The serial `walk_corpus` + `build_derived_index_from_entries` stays the authoritative fault/threshold floor.

# Roadmap / ADR Trace

Roadmap: `rac/roadmaps/rebuild-scale.md` (residual: `single-node-scale-residuals.md`)
ADR: `rac/decisions/adr-108-term-range-partitioned-parallel-merge.md`

# Scope

## Included
- Parse **and** derive both fan out; only compact fragments cross the process boundary.
- Byte-identical to the serial build, worker-count invariant: fragments merge in sorted-path order, and the merge reuses the same row seams the serial derive uses.
- The correctness floor is unchanged: below the file-count / core threshold, or on any worker fault, the build falls back to the serial walk + derive, discarding partial results whole.

## Excluded
- Delta-window postings folded into discovery, and lowering the one-shot O(n) hash floor — recorded in the single-node-scale residuals, not this PR.
- The removed, now-unused `parallel_walk` helper (clean break, ADR-023) is the only deletion; the parse-only `parallel_parse_paths` path (freshness, ADR-105) is untouched.

# Product / Architecture Decisions
- The seam is **per-derivation, not per-object**: a `Product`-shim would still ship the full section dict and keep the derive serial, so it neither shrinks the boundary nor lowers risk. Each derivation is reproduced from compact rows instead.
- Sharing beats duplicating: the merge and the serial build call one set of row-consuming cores, so parity is by construction. Increment 1's single shared resolution index carries through, so the reproduced portfolio resolves the graph once.

# User-Facing Contract
No CLI, JSON, or exit-code change. Purely an internal cold-build restructuring; every store byte and served response is byte-identical.

# Verification

## Ran
- `python -m pytest` — full suite: **2156 passed**, twice from clean.
- `ruff check src/ tests/` and full-tree `mypy src/`: clean.
- `rac validate rac/` — 403 valid, 0 invalid; `rac relationships rac/ --validate` — 2340 checked, 0 issues; `rac review rac/` — no priority 1–2 (health 95/100).
- In-process proof over the real `rac/` corpus (414 artifacts): `reproduce([fragment_from_entry(e) for e in walk])` equals `build_derived_index` field-for-field and over the lossless serialisation.

## Covered
- New `tests/test_b6_parallel_merge.py` (registered in the characterization CI battery, ADR-027): one class per fragile derivation — resolution outcomes (resolved / not-found / ambiguous / self / external), duplicate identity, alias/legacy-id, unknown type, range and status-consistency, tag-only, scope/live, cross-chunk edge, and empty / single / uneven partitions. Each asserts the fragment-merge equals the serial derive; the cross-chunk and uneven cases also assert an end-to-end parallel build writes a store whose segment bytes equal a single-process build's.
- `tests/test_b5_scale_hardening.py`: the `workers=1` vs `workers=4` segment-hash gate and `view == build_derived_index` hold across the flip, with `parallel_used >= 2` so it is not vacuous.

# Review Path
1. `src/rac/services/relationships.py` — the resolve / validation / summary row seams.
2. `src/rac/services/portfolio.py` — `PortfolioRow` / `portfolio_from_rows`.
3. `src/rac/services/parallel_merge.py` — `DocFragment`, `fragment_from_entry`, `reproduce`.
4. `src/rac/services/parallel_build.py` — the worker flip and the serial floor.
5. `tests/test_b6_parallel_merge.py` — the per-mutation-class parity gate.

# Notes For Reviewer
- The riskiest change is `reproduce` reproducing the portfolio: it runs the same `validation_from_rows` / `summary_from_rows` / `portfolio_from_rows` cores the serial build routes through, so `relationships_ok` and the whole portfolio dict match by construction. The gate is `reproduce == build_derived_index` plus the per-mutation-class suite.
- Stacked on `claude/rebuild-scale-parallel-merge` (#332); rebased onto `main` after #332 merged, so the diff is exactly the six Increment 2 commits.

# Implementation Process
Implemented with AI assistance under the roadmap contract; final scope, review, and acceptance decisions were made by the maintainer.