### PR TITLE
docs(release): assemble the 2026.07.1 "scale" release notes and scale docs [release:2026.07.1]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,17 @@ details, release history over commit history.
 
 ## Unreleased
 
-The **decision-to-code-proximity** programme: recorded decisions now know which
+_Nothing yet._
+
+## 2026.07.1 — the "scale" release
+
+Two headline movements on top of a large accumulated release. **Search by tags**:
+the frontmatter `tags` you already write become a first-class search signal — a
+query term matches them, and a `--tag` facet narrows by them. And **single-node
+scale**: retrieval stops growing with corpus size — a persistent memory-mapped
+index, postings-served search, incremental recompute, and a parallel cold build,
+every piece opt-in and byte-identical to the uncached path. Alongside them, the
+**decision-to-code-proximity** programme: recorded decisions now know which
 code they govern, and you can ask which decisions govern a path — declared and
 validated, never inferred; deterministic and offline. Plus the completed
 **lore-at-team-scale** programme: `rac mcp` can now serve the whole team over one
@@ -19,6 +29,41 @@ as candidate relationships.
 
 ### Added
 
+- **Tags are part of search.** The frontmatter `tags` you already write were
+  validated but invisible to retrieval — now a query term matches an artifact's
+  tags (a metadata tier between title and path, tokenised by the same rule as
+  every field, so `model` finds a `data-model` tag), and a repeatable `--tag`
+  facet on `rac find` plus a `tags` argument on the `search_artifacts` MCP tool
+  narrow results to artifacts carrying *every* requested tag (whole-tag,
+  case-insensitive, AND semantics). The tier matches tokenised tags; the facet
+  matches whole tags — one mechanism for "find things about X," one for "only
+  things labelled X." Deterministic and lexical throughout, never an embedding
+  (ADR-037/038/109). A tagged search hit now carries its `tags` additively
+  (emitted only when non-empty, so an untagged hit is byte-identical to before).
+- **Retrieval stops scaling with corpus size.** For large corpora the engine no
+  longer re-derives its expensive structures from disk on every read. The derived
+  index — the repository index, the resolved relationship graph, and the search
+  token vectors — is now a persistent, **memory-mapped segment store**, so the
+  working-set memory stays bounded (the index lives on disk, never fully
+  resident); search is served from **term-major postings**; the shared server
+  tracks freshness **incrementally** instead of re-hashing the whole corpus on
+  each call; and the **cold build parallelises** the whole parse-and-derive across
+  cores. Every piece is opt-in and disposable — keyed on a corpus content hash,
+  byte-identical to the uncached path, and safe to delete (it costs only latency)
+  — so enabling it can never change an answer, only its speed
+  (ADR-103/104/105/107/108). The measured before/after scale curve lives in the
+  `rac-benchmarks` harness, not here.
+- **`rac find --cache`.** An opt-in flag that serves a one-shot query from the
+  persistent index store instead of a fresh walk, so a benchmark or an agent
+  issuing many queries against a stable corpus skips the parse and graph rebuild
+  on every warm invocation. Byte-identical to the uncached `rac find` for every
+  mode — search, `--decisions`, `--type`, `--tag`, `--explain` — cold and warm;
+  off by default (ADR-110).
+- **`rac validate --cache`.** Opt-in incremental validation: a per-file result
+  cache keyed on each file's content hash × the active config fingerprint, so
+  re-validating after a small change is proportional to what changed rather than
+  to corpus size. Disposable and byte-identical to the uncached run; a changed
+  config or a corrupt cache recomputes from scratch (ADR-106). Off by default.
 - **Decisions can declare the code they govern.** A decision may list the paths
   or components it applies to in an optional `## Applies To` section. Literal
   path and directory entries are existence-checked by
@@ -140,6 +185,22 @@ as candidate relationships.
   supported, neither is deprecated). Selectivity is by scoping, never by lossy
   compression (ADR-066); the selective-by-default guarantee is now asserted in the
   test suite.
+
+### Changed
+
+- **Search `evidence.tier` integers shifted by one.** Adding the tags tier at
+  rank 2 renumbers the lower tiers in the `--explain` / `search_artifacts` tier
+  field: path `2 → 3`, heading `3 → 4`, body `4 → 5`. The *ranking order* of
+  results is unchanged (it is BM25F-driven, not tier-driven — ADR-078); only the
+  numeric tier label moved, and the matched field name (`path`/`heading`/`body`)
+  is unchanged (ADR-109). A consumer that reads the field name is unaffected; one
+  that pinned the integer should re-read it.
+- **The persisted index store format changed (a rebuild, never an answer
+  change).** The tags field and the memory-mapped segment layout bump the store's
+  format and bundle versions; an index built by an older `rac` fails the version
+  gate closed and is transparently rebuilt on next use. The store is a disposable
+  derived structure, so this costs a one-time rebuild, never a different result
+  (ADR-104/109).
 
 ## 2026.06.5 — the "rename" release
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -40,8 +40,16 @@ content issues.
 
 - **Input:** `rac validate <path>` — a Markdown file, a directory, or `-` for stdin.
 - **Options:** `--json` · `--top-level` · `--recursive` (directory mode) ·
+  `--cache` (incremental directory validation) ·
   `--corpus DIR` (stdin / single-file mode — see below)
 - **Exit codes:** `0` no errors · `1` validation errors · `2` path not found / unreadable
+
+**`--cache` makes directory validation incremental (ADR-106).** Off by default,
+`--cache` reuses a per-file result cache keyed on each file's content hash × the
+active config fingerprint, so re-validating a large corpus after a small change
+does work proportional to what changed rather than to corpus size. It is
+disposable and byte-identical to the uncached run: a changed config invalidates
+the affected results, and a corrupt or missing cache recomputes from scratch.
 
 ```bash
 rac validate login-flow.md
@@ -1296,25 +1304,50 @@ rac resolve adr-015 rac/ --json
 
 ## find
 
-Search artifacts by ID, title, filename, path, heading, or body — deterministic,
-case-insensitive token-boundary matching (ADR-037); a multi-term query requires
-every term to match somewhere. Results are ordered by a **deterministic relevance
-score** (ADR-078): a field-weighted BM25 lexical score and a bounded
-inbound-reference graph boost, fused with Reciprocal Rank Fusion, with sorted
-path as the tiebreak. No embeddings or semantic scoring — identical bytes and
-query yield a byte-identical order. An empty result is a valid outcome, not an
-error.
+Search artifacts by ID, title, **tags**, filename, path, heading, or body —
+deterministic, case-insensitive token-boundary matching (ADR-037); a multi-term
+query requires every term to match somewhere. Results are ordered by a
+**deterministic relevance score** (ADR-078): a field-weighted BM25 lexical score
+and a bounded inbound-reference graph boost, fused with Reciprocal Rank Fusion,
+with sorted path as the tiebreak. No embeddings or semantic scoring — identical
+bytes and query yield a byte-identical order. An empty result is a valid outcome,
+not an error.
 
 - **Input:** `rac find <query> [directory]` — directory defaults to the
   current directory.
-- **Options:** `--type TYPE` (only match one artifact type) · `--json` ·
-  `--explain` · `--top-level` · `--recursive`
+- **Options:** `--type TYPE` (only match one artifact type) · `--tag TAG`
+  (repeatable; only artifacts carrying every given tag) · `--cache` (serve from
+  the persistent index store) · `--json` · `--explain` · `--top-level` ·
+  `--recursive`
 - **Exit codes:** `0` search completed (matches or none) · `2` not a directory
+
+**Tags are searchable (ADR-109).** A query term matches an artifact's frontmatter
+`tags` as a metadata tier between title and path — tokenised by the same rule as
+every field, so a term like `model` matches a `data-model` tag. Two mechanisms,
+one need each: the **tier** matches tokenised tags (so a query finds things
+*about* a topic), while the **`--tag` facet** matches whole tags exactly (so
+`--tag data-model` narrows to that label and never the token `model`). `--tag` is
+repeatable with AND semantics — `--tag security --tag api` returns only artifacts
+carrying both — and is case-insensitive. A tagged hit surfaces its `tags`
+additively (present only when non-empty). The `search_artifacts` MCP tool takes
+the same `tags` argument.
+
+**`--cache` serves from the persistent index store (ADR-110).** Off by default,
+`--cache` answers the query from the memory-mapped derived index (ADR-104)
+instead of a fresh walk — a warm run against an unchanged corpus skips the parse
+and graph rebuild; a cold run builds fresh and writes the store for next time.
+The output is byte-identical to the uncached `rac find` for every mode. The store
+is disposable and content-addressed (any byte change rebuilds it), lives under
+`RAC_CACHE_DIR` / `$XDG_CACHE_HOME`, and is safe to delete — it costs only
+latency. A single one-shot is net-neutral (the cold build and content hash have
+their own cost); the win is many warm queries against a stable corpus.
 
 `--explain` adds, per match, the matched field/terms/tier plus the relevance
 score and its components (`bm25`, `lexical_rank`, `graph_rank`, `inbound`), so a
 caller can see why one result outranks another. It is additive: the default
-output (without `--explain`) is unchanged, and `schema_version` stays `1`.
+output (without `--explain`) is unchanged, and `schema_version` stays `1`. (The
+tags tier renumbered the `tier` integer for path/heading/body by one; the field
+name and result order are unchanged.)
 
 Each match also carries a **`recency`** object — git-derived freshness so you
 can see which result has decayed without opening it (ADR-045). `last_committed`

--- a/docs/scale.md
+++ b/docs/scale.md
@@ -1,0 +1,94 @@
+# Scale & performance
+
+Lore is designed so a growing corpus stays fast on a single node. The engine's
+original posture (ADR-032) re-derived its expensive structures — the repository
+index, the resolved relationship graph, and the search token vectors — from disk
+on **every** read. That is the right default at hundreds of artifacts, but its
+per-call cost grows with corpus size. The work described here supersedes those
+speed-pinning decisions with recorded ones, so retrieval stays scale-invariant at
+enterprise size on one node.
+
+Every mechanism below shares three guarantees, so turning it on can never change
+an answer — only its speed:
+
+- **Byte-identical.** Cached and uncached paths produce the same bytes. This is a
+  hard test gate (a store built from the cache equals a fresh build, and a
+  parallel build equals a single-process one, segment-for-segment).
+- **Content-addressed.** Every cache is keyed on a hash of the corpus (or of a
+  file × the active config). Any byte change to any artifact changes the key and
+  forces a rebuild — there is no time- or event-based staleness.
+- **Disposable.** The files in git are the truth; the index is a rebuildable
+  derived structure. Deleting it — or hitting a corrupt or format-outdated one —
+  costs only latency, never correctness. No daemon, no lockfile, no database
+  (ADR-080).
+
+Nothing here uses AI or approximation: retrieval stays deterministic and lexical
+(ADR-037/038/066).
+
+## 1. A persistent, memory-mapped index
+
+The derived index is a persistent **memory-mapped segment store** (ADR-104), not
+an in-memory blob rebuilt per call. Segments — the term dictionary, term-major
+postings, the document store, the relationship graph — are mapped from disk and
+paged in on demand, so the working-set memory stays **bounded** regardless of
+corpus size: the index lives on disk and is never fully resident. Search is
+served directly from the term-major postings (ADR-038), and point lookups resolve
+through mapped identity segments without materialising the whole corpus.
+
+## 2. Opt-in caching on the paths that matter
+
+Reuse of that store is **opt-in**, off by default, on the three surfaces where
+repeated reads against a stable corpus dominate:
+
+| Command | Flag | What it reuses |
+| --- | --- | --- |
+| `rac mcp` | `--cache` | The whole derived read-model for a long-lived server (ADR-099/104). |
+| `rac find` | `--cache` | The persistent store for one-shot queries, instead of a fresh walk (ADR-110). |
+| `rac validate` | `--cache` | A per-file result cache, so re-validation is incremental (ADR-106). |
+
+For the long-lived `rac mcp --cache` server, freshness is tracked
+**incrementally** by an event-sourced watcher (ADR-105) rather than re-hashing the
+whole corpus on every call, so a warm endpoint answers without re-reading files
+that did not change. A one-shot `rac find --cache` has no long-lived process to
+hold that watcher, so it still pays a corpus content-hash to detect change before
+reusing anything — it skips the expensive parse and derive, not the hash — which
+is why a single query is net-neutral and the win is *many* warm queries.
+
+`rac validate --cache` keys each file's result on its content hash × the active
+config fingerprint, so validating a large corpus after a small edit does work
+proportional to what changed. A changed config invalidates exactly the affected
+results; a corrupt cache recomputes from scratch.
+
+## 3. A parallel cold build
+
+Building the index from nothing (the cold-miss path) fans out across CPU cores
+(ADR-107/108). Workers each parse a contiguous range of the sorted file list and
+emit compact per-document *derived fragments*; the parent reproduces the
+read-model from them in sorted-path order. Only compact rows cross the process
+boundary — never parsed documents — so both the parse **and** the derive
+parallelise while the result stays worker-count-invariant: a build with four
+workers writes the same store, segment-for-segment, as a single-process build.
+The parallel path is a latency lever, never a correctness dependency — below a
+file-count / core threshold, or on any worker fault, the build falls back to the
+authoritative single-process path and discards partial results whole.
+
+## 4. The numbers
+
+Concrete latency and throughput figures — the before/after scale curve across a
+1k → millions-of-artifacts corpus on a fixed reference node — live in the
+[`rac-benchmarks`](https://github.com/itsthelore/rac-benchmarks) harness, which
+consumes `rac` strictly as an external CLI so the numbers survive engine
+rebuilds. The design target is a **flat** warm-retrieval curve as the corpus
+grows and a cold build that scales linearly and parallel; the harness reports
+each number as measured or extrapolated, never faked, with the reference node
+stated alongside it. Distribution and sharding are explicitly out of scope — the
+levers here are single-node.
+
+## Related decisions
+
+- [ADR-104](https://github.com/itsthelore/rac-core/blob/main/rac/decisions/adr-104-persistent-mmap-index-store.md) — persistent memory-mapped index store
+- [ADR-105](https://github.com/itsthelore/rac-core/blob/main/rac/decisions/adr-105-event-sourced-serving-freshness.md) — event-sourced serving freshness
+- [ADR-106](https://github.com/itsthelore/rac-core/blob/main/rac/decisions/adr-106-incremental-validation.md) — incremental directory validation
+- [ADR-107](https://github.com/itsthelore/rac-core/blob/main/rac/decisions/adr-107-parallel-cold-build.md) — parallel cold build
+- [ADR-108](https://github.com/itsthelore/rac-core/blob/main/rac/decisions/adr-108-term-range-partitioned-parallel-merge.md) — term-range-partitioned parallel merge
+- [ADR-110](https://github.com/itsthelore/rac-core/blob/main/rac/decisions/adr-110-one-shot-find-store-reuse.md) — one-shot `rac find` store reuse

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,6 +42,7 @@ nav:
   - Shared Server: shared-server.md
   - CLI Reference: cli.md
   - Context Cost: context-cost.md
+  - Scale & Performance: scale.md
   - Watchkeeper: watchkeeper.md
   - Artifacts: artifacts.md
   - Relationships: relationships.md


### PR DESCRIPTION
# Summary

Prepares the **2026.07.1 — the "scale" release** notes and supporting docs. Cuts the accumulated `## Unreleased` changelog to a dated CalVer section (ADR-076 / REQ-Release-Versioning), fills the two gaps the notes were missing, and documents the new user-facing surface. No engine change — docs and changelog only.

The version derives from the `2026.07.1` tag (setuptools-scm, no manual version edit); this PR lands the changelog entry that REQ-005 requires a release to carry. **Tagging and publishing stay with you** — merge this, then tag `2026.07.1` on `main`.

# What changed

- **`CHANGELOG.md`** — retitle `## Unreleased` → `## 2026.07.1 — the "scale" release`, open a fresh empty `## Unreleased`, and add the two programmes that were absent from the notes:
  - **Search by tags** (candidate-discovery): the tags search tier, `rac find --tag`, and the `search_artifacts` `tags` argument (ADR-109).
  - **Single-node scale** (rebuild-scale): the persistent memory-mapped index, `rac find --cache`, incremental `rac validate --cache`, postings-served search, and the parallel cold build / fan-out (ADR-104/105/106/107/108/110).
  - Two `### Changed` notes: the `evidence.tier` renumber and the persisted-store format bump (both byte-safe — order unchanged, store transparently rebuilt).
- **`docs/cli.md`** — `--tag` / `--cache` on `rac find` (with the tier-vs-facet explanation), and `--cache` on `rac validate`.
- **`docs/scale.md`** (new) + nav — a Scale & Performance guide covering the memory-mapped index, the opt-in caches, the parallel cold build, and the byte-parity / disposability guarantees; numbers deferred to the `rac-benchmarks` harness.

# Verification

- `mkdocs build --strict` — passes (exit 0, no warnings; the pre-existing `integration-recipes.md` INFO lines are unrelated).
- `rac validate rac/` — 403 valid, 0 invalid (no `rac/` artifact changed).
- Version identifier `2026.07.1` is well-formed `YYYY.MM.N` for the UTC month cut (REQ-001/002).

# Notes for reviewer
- The `### Changed` tier renumber is the only behaviour note a downstream consumer needs: the matched field *name* and result *order* are unchanged; only the numeric `tier` label moved (ADR-109).
- A GitHub Release body (a reader-facing distillation of these notes) is drafted separately for you to paste when you cut the tag.

# Implementation Process
Implemented with AI assistance under the roadmap contract; final scope, review, and acceptance decisions were made by the maintainer.