### PR TITLE
Revert to SemVer and cut v0.22.0 "scale" release [release:v0.22.0]

### DIFF
--- a/.cursor/rules
+++ b/.cursor/rules
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: 3d79e93ec7ce3f503bab797a7d7204d82b9bf4f8877d825ec7e89c6c79251b5c) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: 181a8250d554295d30c2d1acde55e7660a72a02c82bcd735b23394983df84ae5) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -57,7 +57,6 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KVJY1KJEWZ87** — ADR-073: Backend Connectors Are Export-Contract Consumers, Not Per-Provider Repos _(Architecture)_
 - **RAC-KVK19NPWFYC9** — ADR-074: The Graph Export Surfaces Typed Relationship Edges _(Technical)_
 - **RAC-KVNM01QPBPXB** — ADR-075: The Pre-Merge Check Tier Is a Required Merge Gate on `main` _(Process)_
-- **RAC-KVPTVX3YZ87K** — ADR-076: Adopt CalVer (`YYYY.MM.N`) for RAC Releases _(Process)_
 - **RAC-KVSQ2A0BB9XF** — ADR-079: Note-Tool Exports Are Ingested by Normalisation, Not markitdown _(Architecture)_
 - **RAC-KVTS86ZGVJV7** — ADR-077: The Two-Gate Capture Write Model _(Architecture)_
 - **RAC-KW2YW6XK593X** — ADR-084: Read-Access Audit Recorder _(Product)_
@@ -83,4 +82,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KWY0SHYCVY2D** — ADR-108: Term-Range-Partitioned Parallel Merge for the Cold Build _(Architecture)_
 - **RAC-KWY7886GSEE5** — ADR-109: Tag Search Tier and Tag Facet _(Technical)_
 - **RAC-KWYEHJXR0M3G** — ADR-110: One-Shot `rac find --cache` Reuses the Persistent Store _(Technical)_
+- **RAC-KX04DH293JG8** — ADR-111: Revert to SemVer Release Versioning _(Process)_
 <!-- END RAC MANAGED BLOCK -->

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: 3d79e93ec7ce3f503bab797a7d7204d82b9bf4f8877d825ec7e89c6c79251b5c) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: 181a8250d554295d30c2d1acde55e7660a72a02c82bcd735b23394983df84ae5) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -57,7 +57,6 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KVJY1KJEWZ87** — ADR-073: Backend Connectors Are Export-Contract Consumers, Not Per-Provider Repos _(Architecture)_
 - **RAC-KVK19NPWFYC9** — ADR-074: The Graph Export Surfaces Typed Relationship Edges _(Technical)_
 - **RAC-KVNM01QPBPXB** — ADR-075: The Pre-Merge Check Tier Is a Required Merge Gate on `main` _(Process)_
-- **RAC-KVPTVX3YZ87K** — ADR-076: Adopt CalVer (`YYYY.MM.N`) for RAC Releases _(Process)_
 - **RAC-KVSQ2A0BB9XF** — ADR-079: Note-Tool Exports Are Ingested by Normalisation, Not markitdown _(Architecture)_
 - **RAC-KVTS86ZGVJV7** — ADR-077: The Two-Gate Capture Write Model _(Architecture)_
 - **RAC-KW2YW6XK593X** — ADR-084: Read-Access Audit Recorder _(Product)_
@@ -83,4 +82,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KWY0SHYCVY2D** — ADR-108: Term-Range-Partitioned Parallel Merge for the Cold Build _(Architecture)_
 - **RAC-KWY7886GSEE5** — ADR-109: Tag Search Tier and Tag Facet _(Technical)_
 - **RAC-KWYEHJXR0M3G** — ADR-110: One-Shot `rac find --cache` Reuses the Persistent Store _(Technical)_
+- **RAC-KX04DH293JG8** — ADR-111: Revert to SemVer Release Versioning _(Process)_
 <!-- END RAC MANAGED BLOCK -->

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -22,9 +22,10 @@ jobs:
     uses: ./.github/workflows/tests.yml
 
   verify-release:
-    # Fail-closed CalVer gate (REQ-Release-Versioning REQ-007, ADR-076): the
-    # release tag must be a well-formed YYYY.MM.N identifier and have a matching
-    # CHANGELOG.md entry, or nothing is built or published.
+    # Fail-closed SemVer gate (REQ-Release-Versioning REQ-007, ADR-111): the
+    # release tag must be a well-formed vX.Y.Z identifier (a CalVer YYYY.MM.N tag
+    # is rejected) and have a matching CHANGELOG.md entry, or nothing is built or
+    # published.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: 3d79e93ec7ce3f503bab797a7d7204d82b9bf4f8877d825ec7e89c6c79251b5c) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: 181a8250d554295d30c2d1acde55e7660a72a02c82bcd735b23394983df84ae5) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -57,7 +57,6 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KVJY1KJEWZ87** — ADR-073: Backend Connectors Are Export-Contract Consumers, Not Per-Provider Repos _(Architecture)_
 - **RAC-KVK19NPWFYC9** — ADR-074: The Graph Export Surfaces Typed Relationship Edges _(Technical)_
 - **RAC-KVNM01QPBPXB** — ADR-075: The Pre-Merge Check Tier Is a Required Merge Gate on `main` _(Process)_
-- **RAC-KVPTVX3YZ87K** — ADR-076: Adopt CalVer (`YYYY.MM.N`) for RAC Releases _(Process)_
 - **RAC-KVSQ2A0BB9XF** — ADR-079: Note-Tool Exports Are Ingested by Normalisation, Not markitdown _(Architecture)_
 - **RAC-KVTS86ZGVJV7** — ADR-077: The Two-Gate Capture Write Model _(Architecture)_
 - **RAC-KW2YW6XK593X** — ADR-084: Read-Access Audit Recorder _(Product)_
@@ -83,4 +82,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KWY0SHYCVY2D** — ADR-108: Term-Range-Partitioned Parallel Merge for the Cold Build _(Architecture)_
 - **RAC-KWY7886GSEE5** — ADR-109: Tag Search Tier and Tag Facet _(Technical)_
 - **RAC-KWYEHJXR0M3G** — ADR-110: One-Shot `rac find --cache` Reuses the Persistent Store _(Technical)_
+- **RAC-KX04DH293JG8** — ADR-111: Revert to SemVer Release Versioning _(Process)_
 <!-- END RAC MANAGED BLOCK -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,17 @@ details, release history over commit history.
 
 ## Unreleased
 
-The **decision-to-code-proximity** programme: recorded decisions now know which
+_Nothing yet._
+
+## v0.22.0 — the "scale" release
+
+Two headline movements on top of a large accumulated release. **Search by tags**:
+the frontmatter `tags` you already write become a first-class search signal — a
+query term matches them, and a `--tag` facet narrows by them. And **single-node
+scale**: retrieval stops growing with corpus size — a persistent memory-mapped
+index, postings-served search, incremental recompute, and a parallel cold build,
+every piece opt-in and byte-identical to the uncached path. Alongside them, the
+**decision-to-code-proximity** programme: recorded decisions now know which
 code they govern, and you can ask which decisions govern a path — declared and
 validated, never inferred; deterministic and offline. Plus the completed
 **lore-at-team-scale** programme: `rac mcp` can now serve the whole team over one
@@ -19,6 +29,41 @@ as candidate relationships.
 
 ### Added
 
+- **Tags are part of search.** The frontmatter `tags` you already write were
+  validated but invisible to retrieval — now a query term matches an artifact's
+  tags (a metadata tier between title and path, tokenised by the same rule as
+  every field, so `model` finds a `data-model` tag), and a repeatable `--tag`
+  facet on `rac find` plus a `tags` argument on the `search_artifacts` MCP tool
+  narrow results to artifacts carrying *every* requested tag (whole-tag,
+  case-insensitive, AND semantics). The tier matches tokenised tags; the facet
+  matches whole tags — one mechanism for "find things about X," one for "only
+  things labelled X." Deterministic and lexical throughout, never an embedding
+  (ADR-037/038/109). A tagged search hit now carries its `tags` additively
+  (emitted only when non-empty, so an untagged hit is byte-identical to before).
+- **Retrieval stops scaling with corpus size.** For large corpora the engine no
+  longer re-derives its expensive structures from disk on every read. The derived
+  index — the repository index, the resolved relationship graph, and the search
+  token vectors — is now a persistent, **memory-mapped segment store**, so the
+  working-set memory stays bounded (the index lives on disk, never fully
+  resident); search is served from **term-major postings**; the shared server
+  tracks freshness **incrementally** instead of re-hashing the whole corpus on
+  each call; and the **cold build parallelises** the whole parse-and-derive across
+  cores. Every piece is opt-in and disposable — keyed on a corpus content hash,
+  byte-identical to the uncached path, and safe to delete (it costs only latency)
+  — so enabling it can never change an answer, only its speed
+  (ADR-103/104/105/107/108). The measured before/after scale curve lives in the
+  `rac-benchmarks` harness, not here.
+- **`rac find --cache`.** An opt-in flag that serves a one-shot query from the
+  persistent index store instead of a fresh walk, so a benchmark or an agent
+  issuing many queries against a stable corpus skips the parse and graph rebuild
+  on every warm invocation. Byte-identical to the uncached `rac find` for every
+  mode — search, `--decisions`, `--type`, `--tag`, `--explain` — cold and warm;
+  off by default (ADR-110).
+- **`rac validate --cache`.** Opt-in incremental validation: a per-file result
+  cache keyed on each file's content hash × the active config fingerprint, so
+  re-validating after a small change is proportional to what changed rather than
+  to corpus size. Disposable and byte-identical to the uncached run; a changed
+  config or a corrupt cache recomputes from scratch (ADR-106). Off by default.
 - **Decisions can declare the code they govern.** A decision may list the paths
   or components it applies to in an optional `## Applies To` section. Literal
   path and directory entries are existence-checked by
@@ -141,7 +186,31 @@ as candidate relationships.
   compression (ADR-066); the selective-by-default guarantee is now asserted in the
   test suite.
 
-## 2026.06.5 — the "rename" release
+### Changed
+
+- **Versioning reverted from CalVer back to SemVer (`vX.Y.Z`).** RAC's brief
+  CalVer detour (`YYYY.MM.N`) is reverted (ADR-111 supersedes ADR-076): the
+  release number communicates release intent again, and the release line
+  re-aligns with the `v0.22.x` roadmap series. The three CalVer releases are
+  remapped to SemVer — `v0.23.0` (Hardening) → `v0.20.0`, `2026.06.4` →
+  `v0.21.0`, `2026.06.5` → `v0.21.1` — this release is `v0.22.0`, and the CalVer
+  PyPI releases are yanked so the SemVer line resolves as "latest". Compatibility
+  still lives on `schema_version` (ADR-007), not the release number.
+- **Search `evidence.tier` integers shifted by one.** Adding the tags tier at
+  rank 2 renumbers the lower tiers in the `--explain` / `search_artifacts` tier
+  field: path `2 → 3`, heading `3 → 4`, body `4 → 5`. The *ranking order* of
+  results is unchanged (it is BM25F-driven, not tier-driven — ADR-078); only the
+  numeric tier label moved, and the matched field name (`path`/`heading`/`body`)
+  is unchanged (ADR-109). A consumer that reads the field name is unaffected; one
+  that pinned the integer should re-read it.
+- **The persisted index store format changed (a rebuild, never an answer
+  change).** The tags field and the memory-mapped segment layout bump the store's
+  format and bundle versions; an index built by an older `rac` fails the version
+  gate closed and is transparently rebuilt on next use. The store is a disposable
+  derived structure, so this costs a one-time rebuild, never a different result
+  (ADR-104/109).
+
+## v0.21.1 — the "rename" release
 
 The release that renames the package to match the project. The PyPI distribution
 is now **`rac-core`** (was `requirements-as-code`); the import package `rac` and
@@ -192,15 +261,13 @@ deterministic, content-free defaults.
   through the two-gate capture write model (ADR-077).
 
 
-## 2026.06.4 — the "unlock" release
+## v0.21.0 — the "unlock" release
 
-The first release under **CalVer** (`YYYY.MM.N`, ADR-076): RAC's version now says
-*when* a build was cut, not a SemVer compatibility claim it never kept.
-Compatibility lives on `schema_version` (ADR-007); the roadmap `vX.Y.Z` numbers
-continue as internal planning scope-fences. This is a one-way cutover — every
-prior `vX.Y.Z` tag is retained, and `2026.06.4` supersedes `v0.19.0` as the
-latest release. It also ships the user-facing work accumulated across the
-v0.23–v0.26 scope-fences:
+The release that shipped the user-facing work accumulated across the v0.23–v0.26
+scope-fences. It also moved the version string to **CalVer** (`YYYY.MM.N`,
+ADR-076) — a scheme later **reverted to SemVer** in v0.22.0 (ADR-111), which is
+why this release now carries a `vX.Y.Z` number; compatibility stays on
+`schema_version` (ADR-007) throughout. Its user-facing work:
 
 - **A reimagined Explorer (TUI).** Three themes — `lantern` (dark default),
   `parchment` (warm light), and `high-contrast` — switchable in `/settings` and
@@ -227,8 +294,8 @@ v0.23–v0.26 scope-fences:
   gated, deterministic grounding benchmark (`rac eval --check`).
 
 - **Release tooling.** A fail-closed publish gate (`python -m rac.release`)
-  rejects any tag that is not a well-formed `YYYY.MM.N` identifier or that lacks a
-  changelog entry, so a malformed or undocumented release can never reach PyPI.
+  rejects a malformed or undocumented release before it can reach PyPI. (This
+  release's gate checked the CalVer form; v0.22.0 reverted it to check `vX.Y.Z`.)
 
 ### Changed
 
@@ -338,7 +405,7 @@ v0.23–v0.26 scope-fences:
   names are unchanged (PyPI `requirements-as-code`, CLI `rac`, server identity
   `lore`). See `rac/decisions/adr-071-apache-2-relicense-and-dco.md`.
 
-## v0.23.0 — Hardening
+## v0.20.0 — Hardening
 
 The release that turns the grounding claim from "trust us" into something proven
 and legible. Everything a user feels:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ to the corpus artifact and they load through the imports below.
 - Previous series: `rac/roadmaps/v0.21.x-editor/` (complete)
 - Decisions (ADRs): `rac/decisions/`
 
-<!-- BEGIN RAC MANAGED BLOCK (digest: 3d79e93ec7ce3f503bab797a7d7204d82b9bf4f8877d825ec7e89c6c79251b5c) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: 181a8250d554295d30c2d1acde55e7660a72a02c82bcd735b23394983df84ae5) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -82,7 +82,6 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KVJY1KJEWZ87** — ADR-073: Backend Connectors Are Export-Contract Consumers, Not Per-Provider Repos _(Architecture)_
 - **RAC-KVK19NPWFYC9** — ADR-074: The Graph Export Surfaces Typed Relationship Edges _(Technical)_
 - **RAC-KVNM01QPBPXB** — ADR-075: The Pre-Merge Check Tier Is a Required Merge Gate on `main` _(Process)_
-- **RAC-KVPTVX3YZ87K** — ADR-076: Adopt CalVer (`YYYY.MM.N`) for RAC Releases _(Process)_
 - **RAC-KVSQ2A0BB9XF** — ADR-079: Note-Tool Exports Are Ingested by Normalisation, Not markitdown _(Architecture)_
 - **RAC-KVTS86ZGVJV7** — ADR-077: The Two-Gate Capture Write Model _(Architecture)_
 - **RAC-KW2YW6XK593X** — ADR-084: Read-Access Audit Recorder _(Product)_
@@ -108,4 +107,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KWY0SHYCVY2D** — ADR-108: Term-Range-Partitioned Parallel Merge for the Cold Build _(Architecture)_
 - **RAC-KWY7886GSEE5** — ADR-109: Tag Search Tier and Tag Facet _(Technical)_
 - **RAC-KWYEHJXR0M3G** — ADR-110: One-Shot `rac find --cache` Reuses the Persistent Store _(Technical)_
+- **RAC-KX04DH293JG8** — ADR-111: Revert to SemVer Release Versioning _(Process)_
 <!-- END RAC MANAGED BLOCK -->

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -40,8 +40,16 @@ content issues.
 
 - **Input:** `rac validate <path>` — a Markdown file, a directory, or `-` for stdin.
 - **Options:** `--json` · `--top-level` · `--recursive` (directory mode) ·
+  `--cache` (incremental directory validation) ·
   `--corpus DIR` (stdin / single-file mode — see below)
 - **Exit codes:** `0` no errors · `1` validation errors · `2` path not found / unreadable
+
+**`--cache` makes directory validation incremental (ADR-106).** Off by default,
+`--cache` reuses a per-file result cache keyed on each file's content hash × the
+active config fingerprint, so re-validating a large corpus after a small change
+does work proportional to what changed rather than to corpus size. It is
+disposable and byte-identical to the uncached run: a changed config invalidates
+the affected results, and a corrupt or missing cache recomputes from scratch.
 
 ```bash
 rac validate login-flow.md
@@ -1296,25 +1304,50 @@ rac resolve adr-015 rac/ --json
 
 ## find
 
-Search artifacts by ID, title, filename, path, heading, or body — deterministic,
-case-insensitive token-boundary matching (ADR-037); a multi-term query requires
-every term to match somewhere. Results are ordered by a **deterministic relevance
-score** (ADR-078): a field-weighted BM25 lexical score and a bounded
-inbound-reference graph boost, fused with Reciprocal Rank Fusion, with sorted
-path as the tiebreak. No embeddings or semantic scoring — identical bytes and
-query yield a byte-identical order. An empty result is a valid outcome, not an
-error.
+Search artifacts by ID, title, **tags**, filename, path, heading, or body —
+deterministic, case-insensitive token-boundary matching (ADR-037); a multi-term
+query requires every term to match somewhere. Results are ordered by a
+**deterministic relevance score** (ADR-078): a field-weighted BM25 lexical score
+and a bounded inbound-reference graph boost, fused with Reciprocal Rank Fusion,
+with sorted path as the tiebreak. No embeddings or semantic scoring — identical
+bytes and query yield a byte-identical order. An empty result is a valid outcome,
+not an error.
 
 - **Input:** `rac find <query> [directory]` — directory defaults to the
   current directory.
-- **Options:** `--type TYPE` (only match one artifact type) · `--json` ·
-  `--explain` · `--top-level` · `--recursive`
+- **Options:** `--type TYPE` (only match one artifact type) · `--tag TAG`
+  (repeatable; only artifacts carrying every given tag) · `--cache` (serve from
+  the persistent index store) · `--json` · `--explain` · `--top-level` ·
+  `--recursive`
 - **Exit codes:** `0` search completed (matches or none) · `2` not a directory
+
+**Tags are searchable (ADR-109).** A query term matches an artifact's frontmatter
+`tags` as a metadata tier between title and path — tokenised by the same rule as
+every field, so a term like `model` matches a `data-model` tag. Two mechanisms,
+one need each: the **tier** matches tokenised tags (so a query finds things
+*about* a topic), while the **`--tag` facet** matches whole tags exactly (so
+`--tag data-model` narrows to that label and never the token `model`). `--tag` is
+repeatable with AND semantics — `--tag security --tag api` returns only artifacts
+carrying both — and is case-insensitive. A tagged hit surfaces its `tags`
+additively (present only when non-empty). The `search_artifacts` MCP tool takes
+the same `tags` argument.
+
+**`--cache` serves from the persistent index store (ADR-110).** Off by default,
+`--cache` answers the query from the memory-mapped derived index (ADR-104)
+instead of a fresh walk — a warm run against an unchanged corpus skips the parse
+and graph rebuild; a cold run builds fresh and writes the store for next time.
+The output is byte-identical to the uncached `rac find` for every mode. The store
+is disposable and content-addressed (any byte change rebuilds it), lives under
+`RAC_CACHE_DIR` / `$XDG_CACHE_HOME`, and is safe to delete — it costs only
+latency. A single one-shot is net-neutral (the cold build and content hash have
+their own cost); the win is many warm queries against a stable corpus.
 
 `--explain` adds, per match, the matched field/terms/tier plus the relevance
 score and its components (`bm25`, `lexical_rank`, `graph_rank`, `inbound`), so a
 caller can see why one result outranks another. It is additive: the default
-output (without `--explain`) is unchanged, and `schema_version` stays `1`.
+output (without `--explain`) is unchanged, and `schema_version` stays `1`. (The
+tags tier renumbered the `tier` integer for path/heading/body by one; the field
+name and result order are unchanged.)
 
 Each match also carries a **`recency`** object — git-derived freshness so you
 can see which result has decayed without opening it (ADR-045). `last_committed`

--- a/docs/scale.md
+++ b/docs/scale.md
@@ -1,0 +1,94 @@
+# Scale & performance
+
+Lore is designed so a growing corpus stays fast on a single node. The engine's
+original posture (ADR-032) re-derived its expensive structures — the repository
+index, the resolved relationship graph, and the search token vectors — from disk
+on **every** read. That is the right default at hundreds of artifacts, but its
+per-call cost grows with corpus size. The work described here supersedes those
+speed-pinning decisions with recorded ones, so retrieval stays scale-invariant at
+enterprise size on one node.
+
+Every mechanism below shares three guarantees, so turning it on can never change
+an answer — only its speed:
+
+- **Byte-identical.** Cached and uncached paths produce the same bytes. This is a
+  hard test gate (a store built from the cache equals a fresh build, and a
+  parallel build equals a single-process one, segment-for-segment).
+- **Content-addressed.** Every cache is keyed on a hash of the corpus (or of a
+  file × the active config). Any byte change to any artifact changes the key and
+  forces a rebuild — there is no time- or event-based staleness.
+- **Disposable.** The files in git are the truth; the index is a rebuildable
+  derived structure. Deleting it — or hitting a corrupt or format-outdated one —
+  costs only latency, never correctness. No daemon, no lockfile, no database
+  (ADR-080).
+
+Nothing here uses AI or approximation: retrieval stays deterministic and lexical
+(ADR-037/038/066).
+
+## 1. A persistent, memory-mapped index
+
+The derived index is a persistent **memory-mapped segment store** (ADR-104), not
+an in-memory blob rebuilt per call. Segments — the term dictionary, term-major
+postings, the document store, the relationship graph — are mapped from disk and
+paged in on demand, so the working-set memory stays **bounded** regardless of
+corpus size: the index lives on disk and is never fully resident. Search is
+served directly from the term-major postings (ADR-038), and point lookups resolve
+through mapped identity segments without materialising the whole corpus.
+
+## 2. Opt-in caching on the paths that matter
+
+Reuse of that store is **opt-in**, off by default, on the three surfaces where
+repeated reads against a stable corpus dominate:
+
+| Command | Flag | What it reuses |
+| --- | --- | --- |
+| `rac mcp` | `--cache` | The whole derived read-model for a long-lived server (ADR-099/104). |
+| `rac find` | `--cache` | The persistent store for one-shot queries, instead of a fresh walk (ADR-110). |
+| `rac validate` | `--cache` | A per-file result cache, so re-validation is incremental (ADR-106). |
+
+For the long-lived `rac mcp --cache` server, freshness is tracked
+**incrementally** by an event-sourced watcher (ADR-105) rather than re-hashing the
+whole corpus on every call, so a warm endpoint answers without re-reading files
+that did not change. A one-shot `rac find --cache` has no long-lived process to
+hold that watcher, so it still pays a corpus content-hash to detect change before
+reusing anything — it skips the expensive parse and derive, not the hash — which
+is why a single query is net-neutral and the win is *many* warm queries.
+
+`rac validate --cache` keys each file's result on its content hash × the active
+config fingerprint, so validating a large corpus after a small edit does work
+proportional to what changed. A changed config invalidates exactly the affected
+results; a corrupt cache recomputes from scratch.
+
+## 3. A parallel cold build
+
+Building the index from nothing (the cold-miss path) fans out across CPU cores
+(ADR-107/108). Workers each parse a contiguous range of the sorted file list and
+emit compact per-document *derived fragments*; the parent reproduces the
+read-model from them in sorted-path order. Only compact rows cross the process
+boundary — never parsed documents — so both the parse **and** the derive
+parallelise while the result stays worker-count-invariant: a build with four
+workers writes the same store, segment-for-segment, as a single-process build.
+The parallel path is a latency lever, never a correctness dependency — below a
+file-count / core threshold, or on any worker fault, the build falls back to the
+authoritative single-process path and discards partial results whole.
+
+## 4. The numbers
+
+Concrete latency and throughput figures — the before/after scale curve across a
+1k → millions-of-artifacts corpus on a fixed reference node — live in the
+[`rac-benchmarks`](https://github.com/itsthelore/rac-benchmarks) harness, which
+consumes `rac` strictly as an external CLI so the numbers survive engine
+rebuilds. The design target is a **flat** warm-retrieval curve as the corpus
+grows and a cold build that scales linearly and parallel; the harness reports
+each number as measured or extrapolated, never faked, with the reference node
+stated alongside it. Distribution and sharding are explicitly out of scope — the
+levers here are single-node.
+
+## Related decisions
+
+- [ADR-104](https://github.com/itsthelore/rac-core/blob/main/rac/decisions/adr-104-persistent-mmap-index-store.md) — persistent memory-mapped index store
+- [ADR-105](https://github.com/itsthelore/rac-core/blob/main/rac/decisions/adr-105-event-sourced-serving-freshness.md) — event-sourced serving freshness
+- [ADR-106](https://github.com/itsthelore/rac-core/blob/main/rac/decisions/adr-106-incremental-validation.md) — incremental directory validation
+- [ADR-107](https://github.com/itsthelore/rac-core/blob/main/rac/decisions/adr-107-parallel-cold-build.md) — parallel cold build
+- [ADR-108](https://github.com/itsthelore/rac-core/blob/main/rac/decisions/adr-108-term-range-partitioned-parallel-merge.md) — term-range-partitioned parallel merge
+- [ADR-110](https://github.com/itsthelore/rac-core/blob/main/rac/decisions/adr-110-one-shot-find-store-reuse.md) — one-shot `rac find` store reuse

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,6 +42,7 @@ nav:
   - Shared Server: shared-server.md
   - CLI Reference: cli.md
   - Context Cost: context-cost.md
+  - Scale & Performance: scale.md
   - Watchkeeper: watchkeeper.md
   - Artifacts: artifacts.md
   - Relationships: relationships.md

--- a/rac/decisions/adr-076-calver-release-versioning.md
+++ b/rac/decisions/adr-076-calver-release-versioning.md
@@ -121,7 +121,12 @@ Rejected; the requirement was revised to the month-granular `YYYY.MM.N`.
 
 ## Status
 
-Accepted
+Superseded
+
+Superseded by ADR-111, which reverts RAC to SemVer (`vX.Y.Z`). The CalVer scheme
+this ADR adopted did not fit how the maintainer wants to communicate releases;
+the three CalVer releases are remapped to SemVer and the CalVer PyPI releases are
+yanked. See ADR-111 for the reversal and the remap.
 
 ## Category
 

--- a/rac/decisions/adr-093-roadmap-execution-in-issues.md
+++ b/rac/decisions/adr-093-roadmap-execution-in-issues.md
@@ -126,6 +126,6 @@ assignment or task state.
 - adr-017
 - adr-087
 - adr-061
-- adr-076
+- adr-111
 - adr-002
 - adr-032

--- a/rac/decisions/adr-094-roadmaps-identified-by-codename.md
+++ b/rac/decisions/adr-094-roadmaps-identified-by-codename.md
@@ -114,7 +114,7 @@ artifact re-imports the coupling that decision removed.
 ## Related Decisions
 
 - adr-093
-- adr-076
+- adr-111
 - adr-061
 - adr-026
 - adr-047

--- a/rac/decisions/adr-111-revert-to-semver.md
+++ b/rac/decisions/adr-111-revert-to-semver.md
@@ -1,0 +1,157 @@
+---
+schema_version: 1
+id: RAC-KX04DH293JG8
+type: decision
+---
+# ADR-111: Revert to SemVer Release Versioning
+
+## Context
+
+ADR-076 (`RAC-KVPTVX3YZ87K`) moved RAC's releases from SemVer (`vX.Y.Z`) to
+CalVer (`YYYY.MM.N`), normatively specified by REQ-Release-Versioning
+(`RAC-KV3GGM1TFHY4`). Its reasoning was sound for the problem as framed: the
+SemVer minors had become planning scope-fences that asserted a compatibility
+contract RAC does not keep, the published package had stalled at `v0.19.0` while
+the roadmap numbers ran ahead, and a date sorts above `0.19.0` so it becomes
+"latest" on PyPI cleanly. Three CalVer releases shipped under it —
+`2026.06.1`, `2026.06.4` ("unlock"), and `2026.06.5` ("rename").
+
+In use, CalVer did not fit how the maintainer wants to communicate releases. A
+date answers *how recent* but says nothing about *what changed or how much*, and
+the maintainer wants the release identifier to carry that intent again — the
+readable major/minor/patch cadence a reader and a changelog reader both reason
+about — and to re-converge the release line with the long-running `vX.Y.Z`
+roadmap series rather than keep two numbering worlds apart. ADR-076 recorded its
+own cutover as one-way (its Decision §4, Negative §1); this decision reverses
+that on the maintainer's judgement and records the reversal honestly rather than
+letting the corpus and the tooling disagree with practice.
+
+The one hard constraint ADR-076 leaned on remains real: PyPI resolves the
+highest version, and a CalVer `2026.x` sorts *above* any `0.x`, so a SemVer
+release cannot become "latest" while the CalVer releases stand. The answer is to
+**yank** the three CalVer PyPI releases — a one-time cleanup the maintainer
+accepts — after which the SemVer line resolves as latest.
+
+## Decision
+
+RAC returns to **Semantic Versioning** (`vX.Y.Z`) as its release identifier,
+superseding ADR-076. REQ-Release-Versioning is rewritten to specify SemVer
+normatively.
+
+1. **The release identifier is `vX.Y.Z`.** setuptools-scm derives the build from
+   the tag, exactly as before the CalVer cutover; the fail-closed release
+   verifier (`python -m rac.release`) is updated to accept a well-formed
+   `vX.Y.Z` / `X.Y.Z` tag and reject a `YYYY.MM.N` one, and to require a matching
+   `CHANGELOG.md` entry (REQ-007 unchanged in spirit).
+2. **Compatibility still has its own home.** `schema_version` (ADR-007) remains
+   where contract compatibility is versioned; SemVer's minor/patch here signal
+   the *shape and size* of a release for humans, not a machine-resolved
+   contract, and the changelog remains the authority on what changed.
+3. **The CalVer detour is remapped to SemVer, not erased.** The three CalVer
+   releases and the untagged `v0.23.0 "Hardening"` changelog label are renumbered
+   into one monotonic SemVer line, and the current release is cut as `v0.22.0`,
+   re-aligning the published line with the `v0.22.x` roadmap series:
+
+   | CalVer / label | SemVer | Release |
+   | --- | --- | --- |
+   | `v0.23.0` (untagged label) | **v0.20.0** | Hardening |
+   | `2026.06.1` → `2026.06.4` | **v0.21.0** | "unlock" (CalVer adoption + first wave) |
+   | `2026.06.5` | **v0.21.1** | "rename" |
+   | *(this release)* | **v0.22.0** | "scale" |
+
+4. **Tags and PyPI.** The three CalVer git tags (`2026.06.1`, `2026.06.4`,
+   `2026.06.5`) are deleted; retroactive `v0.20.0` / `v0.21.0` / `v0.21.1` tags
+   are added as git-only historical markers (not re-published), and `v0.22.0` is
+   tagged on the release commit and published. The three CalVer PyPI releases are
+   **yanked**, so the SemVer line — though it sorts numerically below `2026.x` —
+   becomes the highest non-yanked version and resolves as "latest".
+5. **Roadmap numbers and releases re-converge.** The `vX.Y.Z` roadmap series
+   codenames (ADR-094) and the release identifiers share a numbering world again;
+   ADR-076's split of the two is unwound. This is a convenience, not a promise —
+   a roadmap codename is still a planning boundary, not a guarantee that a release
+   of that number exists.
+
+## Consequences
+
+### Positive
+
+- The release number communicates release intent (major/minor/patch) again,
+  which is what the maintainer wants a reader to get from it.
+- The published line re-aligns with the `v0.22.x` roadmap series, ending the
+  two-numbering-worlds drift from the other direction.
+- The corpus, the tooling, and practice agree: the recorded decision matches how
+  releases are actually cut.
+
+### Negative
+
+- A one-time PyPI cleanup: the three CalVer releases must be yanked, and the
+  retroactive SemVer versions for the older releases are git-only (not
+  re-published), so the PyPI history shows a CalVer gap rather than a continuous
+  SemVer line.
+- SemVer's minor/patch can still be *read* as a compatibility promise RAC does
+  not machine-enforce; this is mitigated by keeping `schema_version` (ADR-007) as
+  the contract signal and treating the SemVer number as human-facing intent.
+- Reversing a decision ADR-076 recorded as one-way sets the precedent that even
+  "irreversible" process decisions can be revisited; recording it as a
+  superseding ADR keeps that legible rather than silent.
+
+## Status
+
+Accepted
+
+## Category
+
+Process
+
+## Alternatives Considered
+
+### Stay on CalVer
+
+Keep `YYYY.MM.N` as ADR-076 decided.
+
+#### Pros
+
+- No tooling, tag, or PyPI churn; honours ADR-076's stated one-way cutover.
+
+#### Cons
+
+- Leaves the release identifier saying only *when*, which the maintainer has
+  determined does not serve how they want to communicate releases, and keeps the
+  release line and the roadmap series in separate numbering worlds.
+
+Rejected on the maintainer's judgement that the fit is wrong.
+
+### Start SemVer fresh at `v0.22.0`, leave the CalVer releases as historical CalVer
+
+Resume SemVer going forward without renumbering the three CalVer releases.
+
+#### Pros
+
+- Less changelog and tag surgery.
+
+#### Cons
+
+- Leaves a permanent CalVer island in the middle of an otherwise SemVer history,
+  and the CalVer PyPI releases still sort above `v0.22.0` unless yanked — so the
+  yank is required either way, and remapping is the cheap part that makes the
+  history one legible line.
+
+Rejected in favour of the monotonic remap.
+
+## Success Measures
+
+- `v0.22.0` publishes to PyPI and, with the CalVer releases yanked, resolves as
+  "latest".
+- The release verifier accepts `vX.Y.Z` and rejects `YYYY.MM.N`; no release
+  publishes with a malformed version or a missing changelog entry.
+- The corpus validates with ADR-076 `Superseded` and no live artifact referencing
+  a retired decision.
+
+## Supersedes
+
+- ADR-076
+
+## Related Decisions
+
+- ADR-007
+- ADR-094

--- a/rac/prompts/rac-agent-session-start.md
+++ b/rac/prompts/rac-agent-session-start.md
@@ -31,7 +31,7 @@ families include Requirements, Decisions, Roadmaps, Prompts, and Design.
 - Deterministic classification.
 - Structural validation, not semantic scoring unless explicitly planned.
 - CLI contracts matter: human output, JSON output, exit codes, and templates must be specified.
-- Roadmaps are identified by codename, not a version; release versions are CalVer dates (ADR-094, ADR-076).
+- Roadmaps are identified by codename, not a version; release versions are SemVer `vX.Y.Z` (ADR-094, ADR-111, which reverted the CalVer of ADR-076).
 - Prefer schema/artifact-spec-driven behavior over artifact-specific branches.
 - Keep classification separate from validation.
 - Invalid but recognizable artifacts may still classify as their artifact type, then fail validation.

--- a/rac/requirements/rac-release-versioning.md
+++ b/rac/requirements/rac-release-versioning.md
@@ -15,92 +15,80 @@ Accepted
 
 ## Problem
 
-RAC published its own releases under Semantic Versioning (`vX.Y.Z`), and
-setuptools-scm derived the package version from those tags. SemVer makes a
-promise RAC's release stream does not keep: a patch bump asserts a
-backward-compatible bug fix, a minor bump asserts backward-compatible new
-behaviour, yet RAC's user-visible changes — CLI output, validation strictness,
-artifact rules — do not map cleanly onto that contract, and no programmatic
-consumer resolves these version constraints. In practice the SemVer minors were
-used as roadmap scope-fences, not releases: the planning numbers ran to v0.26
-while the published package sat at `v0.19.0`, and the number was read by humans
-scanning history, where the question is really *how recent is this build*, not
-*is it compatible with my pin*.
+RAC first published under SemVer (`vX.Y.Z`), then adopted CalVer (`YYYY.MM.N`)
+via ADR-076 to answer *how recent is this build* and to sort a release above the
+stalled `v0.19.0` on PyPI. In use the date-only identifier did not fit how the
+maintainer wants to communicate releases — it says nothing about *what changed or
+how much* — and it kept the release line and the `vX.Y.Z` roadmap series in two
+numbering worlds. ADR-111 reverts to SemVer and this requirement is rewritten to
+specify it normatively; the three CalVer releases are remapped to SemVer and the
+CalVer PyPI releases yanked, so a SemVer release resolves as "latest" again.
 
-A date-based release identity answers the question that is actually asked. It
-states *when* a release was cut and stops encoding a compatibility claim RAC does
-not maintain on the version string. Compatibility, where RAC needs to signal it,
-already has an independent home in the schema/contract version (ADR-007), so the
-two concerns are separated cleanly rather than overloaded onto one identifier.
-
-This requirement is `Accepted` and adopted by ADR-076. The release cadence is
-monthly rather than daily, so the identifier is month-granular with a
-within-month counter (`YYYY.MM.N`) rather than a full calendar date. The
-versioned roadmap series (`vX.Y.Z`) were, at the time of the CalVer cutover,
-explicitly **internal scope-fences** decoupled from release identifiers (ADR-094
-later retired that scheme for *live* roadmaps in favour of codenames; shipped and
-historical series keep their versioned names as the record); the pre-cutover
-SemVer tags stand immutably.
+Compatibility, where RAC needs to signal it, still has an independent home in the
+schema/contract version (ADR-007), so the release identifier is not overloaded
+with a machine-resolved contract claim: the SemVer number is human-facing release
+intent, and the changelog is the authority on what changed.
 
 ## Requirements
 
-- [REQ-001] A release version MUST be of the form `YYYY.MM.N`, where `YYYY` is a four-digit UTC year, `MM` a zero-padded month `01`–`12`, and `N` a within-month release counter; the year and month MUST be the UTC year and month in which the release is cut, so the identifier is deterministic and timezone-independent.
+- [REQ-001] A release version MUST be of the form `vX.Y.Z` (major, minor, patch), where `X`, `Y`, and `Z` are non-negative integers without leading zeros; the canonical tag form is `v`-prefixed (`v0.22.0`) and the PEP 440 normalised distribution form drops the prefix (`0.22.0`).
 
-- [REQ-002] The counter `N` MUST start at `1` for the first release of a given month and rise by one for each subsequent release that month (`2026.06.1`, `2026.06.2`, …); a counter of `0`, a leading-zero counter (`01`), and a bare `YYYY.MM` with no counter are invalid.
+- [REQ-002] The three components MUST follow Semantic Versioning ordering: the patch `Z` rises within a minor, the minor `Y` within a major, and a higher component resets the lower ones to `0` (`v0.22.0`, `v0.22.1`, `v0.23.0`).
 
-- [REQ-003] Release precedence MUST be the lexicographic order of the tuple `(YYYY, MM, N)`, so that `2026.06.1` precedes `2026.06.2`, which precedes `2026.07.1`.
+- [REQ-003] Release precedence MUST be the SemVer precedence of the tuple `(X, Y, Z)`, so that `v0.22.0` precedes `v0.22.1`, which precedes `v0.23.0`.
 
-- [REQ-004] The release version MUST NOT encode any compatibility, stability, or severity signal; any such signal MUST live on the independent schema/contract version (ADR-007, `schema_version`), which versions and stabilises RAC's contracts separately from the release identifier.
+- [REQ-004] The release version MUST NOT be relied on as a machine-resolved compatibility contract; contract compatibility MUST live on the schema/contract version (ADR-007, `schema_version`), which versions RAC's contracts separately from the release identifier — the SemVer major/minor/patch is human-facing release intent, not a guarantee the tooling enforces.
 
 - [REQ-005] A release MUST be event-triggered, assigning a new release version only when released content has changed; each release MUST correspond to exactly one commit and exactly one immutable tag, and MUST have a changelog entry recording its user-visible changes.
 
-- [REQ-006] A build that is not itself a release MUST carry a VCS-derived identifier (for example a development or local segment over the base release) that orders strictly after its base release and strictly before the next release or same-month increment, and a build identifier MUST NOT be mistaken for a release version.
+- [REQ-006] A build that is not itself a release MUST carry a VCS-derived identifier (for example a development or local segment over the base release) that orders strictly after its base release and strictly before the next release, and a build identifier MUST NOT be mistaken for a release version.
 
-- [REQ-007] Release verification MUST fail closed: a candidate version that is not a well-formed `YYYY.MM.N` identifier under REQ-001–REQ-003, or that lacks the changelog entry required by REQ-005, MUST NOT be published.
+- [REQ-007] Release verification MUST fail closed: a candidate version that is not a well-formed `vX.Y.Z` identifier under REQ-001–REQ-003, or that lacks the changelog entry required by REQ-005, MUST NOT be published, and a `YYYY.MM.N` CalVer identifier MUST be rejected by the verifier.
 
-- [REQ-008] Adoption MUST be a one-way cutover: pre-cutover SemVer tags (`vX.Y.Z`) MUST be retained immutably and MUST NOT be reinterpreted as dates, and RAC's own tooling MUST NOT co-order date versions and SemVer versions in one precedence relation, so the two remain distinct ordering domains separated at the cutover boundary. (At the packaging layer a date version such as `2026.06.1` necessarily sorts above the final SemVer `0.19.0`, which is what lets it become "latest" on the index; this requirement constrains RAC's verifier, not the index's numeric ordering.)
+- [REQ-008] The CalVer detour is remapped, not co-ordered: the three published CalVer releases (`2026.06.1`, `2026.06.4`, `2026.06.5`) and the untagged `v0.23.0` changelog label MUST be renumbered into one monotonic SemVer line (`v0.20.0`, `v0.21.0`, `v0.21.1`, `v0.22.0`), their CalVer git tags deleted and the CalVer PyPI releases yanked; RAC's tooling MUST NOT co-order CalVer and SemVer identifiers in one precedence relation, and because a CalVer `2026.x` sorts above any `0.x` on PyPI, yanking the CalVer releases is what lets the SemVer line resolve as "latest".
 
-- [REQ-009] The canonical display and tag form MUST be the zero-padded `YYYY.MM.N`, and a tool comparing versions MUST treat the PEP 440 normalised form (for example `2026.6.1`) as equal to its zero-padded canonical form (`2026.06.1`), so packaging-layer normalisation does not create a spurious mismatch.
+- [REQ-009] The canonical display and tag form MUST be `v`-prefixed `vX.Y.Z`, and a tool comparing versions MUST treat the PEP 440 normalised form (`0.22.0`) as equal to its canonical tag form (`v0.22.0`), so packaging-layer normalisation does not create a spurious mismatch.
 
 ## Acceptance Criteria
 
-- A verifier accepts `2026.06.1`, `2026.06.2`, `2026.12.1`, and `2027.01.10`,
-  and rejects `2026.13.1`, `2026.00.1`, `2026.06.0`, `2026.06.01`, the bare
-  `2026.06`, and any SemVer-form tag (`v0.19.0`) presented as a release version.
-- The normalised spelling `2026.6.1` parses equal to the canonical `2026.06.1`.
-- Sorting a set of valid release versions yields the REQ-003 order.
+- A verifier accepts `v0.22.0`, `v0.22.1`, `v1.0.0`, and `v2.3.10`, and rejects
+  `2026.06.1`, `v0.22`, `v01.2.3`, a bare `0.22`, and any `YYYY.MM.N` CalVer tag
+  presented as a release version.
+- The normalised spelling `0.22.0` parses equal to the canonical `v0.22.0`.
+- Sorting a set of valid release versions yields the REQ-003 (SemVer) order.
 - A release lacking a changelog entry is rejected by the fail-closed check.
-- Pre-cutover SemVer tags remain present and unmodified after the cutover, and no
-  comparison places a date version and a SemVer version in one ordered sequence.
+- After the remap, `v0.22.0` publishes and — with the CalVer PyPI releases
+  yanked — resolves as "latest".
 
 ## Success Metrics
 
-- Every published release version is a well-formed `YYYY.MM.N` identifier that
+- Every published release version is a well-formed `vX.Y.Z` identifier that
   round-trips through parse → sort → display without ambiguity.
 - The release identifier and the schema/contract version (ADR-007) move
   independently: a release can be cut without a contract change, and a contract
   change is recorded on its own version, neither overloading the other.
-- The cutover is documented once and requires no rewriting of historical tags.
+- The release line and the `vX.Y.Z` roadmap series share one numbering world
+  again, with the CalVer detour recorded as remapped history.
 
 ## Risks
 
-- A cutover that co-orders SemVer and date tags under one relation would corrupt
-  "latest release" selection. Mitigated by REQ-008's distinct ordering domains and
-  immutable retention.
-- Packaging-layer normalisation (PEP 440 dropping zero padding) could make a tool
-  see two spellings of one version. Mitigated by REQ-009.
-- Month granularity cannot distinguish two releases in the same month on its own.
-  Mitigated by REQ-002's within-month counter.
+- SemVer's minor/patch can be *read* as a compatibility promise RAC does not
+  machine-enforce. Mitigated by REQ-004: compatibility lives on `schema_version`,
+  and the SemVer number is treated as human-facing intent, not a resolved pin.
+- The CalVer PyPI releases sort above `v0.22.0`, so a stale index could resolve a
+  CalVer release. Mitigated by yanking them (REQ-008), after which the SemVer
+  line is the highest non-yanked version.
+- Retroactive SemVer versions for the older releases are git-only, so the PyPI
+  history shows a CalVer gap rather than a continuous SemVer line. Accepted as a
+  one-time cost of the reversal.
 
 ## Assumptions
 
 - Compatibility signalling has, or can have, an independent home on the
   schema/contract version (ADR-007); this requirement concerns the *release*
   identifier, not that mechanism.
-- Release year and month are assigned in UTC by the release process, so the
-  identifier is deterministic regardless of the releaser's local timezone.
-- The release cadence is monthly or slower; a same-month second release is the
-  exception handled by the counter, not the norm.
+- The release cadence and its labelling are the maintainer's to set; this
+  requirement fixes the *form* and *ordering* of the identifier, not the pace.
 
 ## Priority
 
@@ -111,5 +99,5 @@ how RAC labels its own releases, not what `rac validate` or `rac relationships
 ## Related Decisions
 
 - ADR-007
-- ADR-076
 - ADR-094
+- ADR-111

--- a/rac/roadmaps/agnostic-surfaces.md
+++ b/rac/roadmaps/agnostic-surfaces.md
@@ -124,7 +124,7 @@ graduates to execution with a GitHub issue per ADR-093.
 - ADR-027
 - ADR-054
 - ADR-063
-- ADR-076
+- ADR-111
 - ADR-086
 - ADR-092
 - ADR-093

--- a/rac/roadmaps/corpus-sync.md
+++ b/rac/roadmaps/corpus-sync.md
@@ -221,7 +221,7 @@ rather than duplicating them.
 - adr-066
 - adr-073
 - adr-074
-- adr-076
+- adr-111
 - adr-080
 - adr-085
 - adr-089

--- a/rac/roadmaps/oci-image.md
+++ b/rac/roadmaps/oci-image.md
@@ -85,7 +85,7 @@ consume the image rather than re-solving installation.
 
 ## Related Decisions
 
-- ADR-076
+- ADR-111
 - ADR-086
 - ADR-092
 

--- a/rac/roadmaps/v0.27.x-calver/v0.27.0-calver-cutover.md
+++ b/rac/roadmaps/v0.27.x-calver/v0.27.0-calver-cutover.md
@@ -7,7 +7,12 @@ type: roadmap
 
 ## Status
 
-Achieved
+Superseded
+
+Superseded by ADR-111: RAC reverts from CalVer back to SemVer (`vX.Y.Z`). The
+cutover this roadmap achieved is unwound — the three CalVer releases are remapped
+to SemVer and the CalVer PyPI releases yanked. Retained as the historical record
+of the CalVer detour.
 
 ## Context
 

--- a/src/rac/release.py
+++ b/src/rac/release.py
@@ -1,12 +1,14 @@
-"""Release-version verification — the fail-closed CalVer gate.
+"""Release-version verification — the fail-closed SemVer gate.
 
-RAC releases use a CalVer identifier ``YYYY.MM.N`` (REQ-Release-Versioning,
-ADR-076): the UTC year and zero-padded month a release is cut, plus a
-within-month counter starting at 1. The identifier carries no compatibility
-signal — that lives on ``schema_version`` (ADR-007). This module is the
-fail-closed verification REQ-007 requires: a release whose version is not a
-well-formed ``YYYY.MM.N`` identifier, or that has no matching ``CHANGELOG.md``
-entry, must not be published.
+RAC releases use a SemVer identifier ``vX.Y.Z`` (REQ-Release-Versioning,
+ADR-111, which reverted the CalVer of ADR-076): major, minor, patch, with the
+canonical tag form ``v``-prefixed and the PEP 440 normalised distribution form
+dropping the prefix (``v0.22.0`` ⇔ ``0.22.0``). The identifier carries no
+machine-resolved compatibility contract — that lives on ``schema_version``
+(ADR-007). This module is the fail-closed verification REQ-007 requires: a
+release whose version is not a well-formed ``vX.Y.Z`` identifier (a ``YYYY.MM.N``
+CalVer tag is rejected), or that has no matching ``CHANGELOG.md`` entry, must not
+be published.
 
 This is internal release tooling, not part of RAC's public CLI or SDK surface
 (ADR-005, ADR-062): it is invoked by the publish workflow as ``python -m
@@ -19,37 +21,41 @@ import re
 import sys
 from pathlib import Path
 
-# Canonical identifier: four-digit year, zero-padded month 01-12, a counter
-# starting at 1 with no leading zero and no `.0`. This is the form a release
-# tag MUST use (REQ-001/002/009).
-_CANONICAL_RE = re.compile(r"^(?P<year>\d{4})\.(?P<month>0[1-9]|1[0-2])\.(?P<minor>[1-9]\d*)$")
+# A SemVer component: ``0`` or a non-zero-leading run of digits (no leading
+# zeros, REQ-001). Reused for major, minor, and patch.
+_COMPONENT = r"(?:0|[1-9]\d*)"
 
-# Lenient parse: accepts the PEP 440 normalised spelling too (month without the
-# leading zero, e.g. `2026.6.1`), which packaging tools emit, so the two
-# spellings compare equal (REQ-009). The minor still rejects `.0` / leading zero.
-_PARSE_RE = re.compile(r"^(?P<year>\d{4})\.(?P<month>\d{1,2})\.(?P<minor>[1-9]\d*)$")
+# Canonical identifier: the ``v``-prefixed tag form a release MUST use
+# (REQ-001/009), e.g. ``v0.22.0``.
+_CANONICAL_RE = re.compile(
+    rf"^v(?P<major>{_COMPONENT})\.(?P<minor>{_COMPONENT})\.(?P<patch>{_COMPONENT})$"
+)
+
+# Lenient parse: also accepts the PEP 440 normalised spelling without the ``v``
+# prefix (``0.22.0``), which packaging tools emit, so the two spellings compare
+# equal (REQ-009). Leading zeros are still rejected.
+_PARSE_RE = re.compile(
+    rf"^v?(?P<major>{_COMPONENT})\.(?P<minor>{_COMPONENT})\.(?P<patch>{_COMPONENT})$"
+)
 
 
 def parse_release_version(version: str) -> tuple[int, int, int] | None:
-    """Return ``(year, month, minor)`` for a release version, else ``None``.
+    """Return ``(major, minor, patch)`` for a release version, else ``None``.
 
-    Accepts both the canonical zero-padded form (``2026.06.1``) and its PEP 440
-    normalised spelling (``2026.6.1``) so they map to the same tuple (REQ-009).
-    Rejects an out-of-range month and any non-``YYYY.MM.N`` string.
+    Accepts both the canonical ``v``-prefixed tag form (``v0.22.0``) and its
+    PEP 440 normalised spelling (``0.22.0``) so they map to the same tuple
+    (REQ-009). Rejects leading zeros, a missing component, and any non-SemVer
+    string — a ``YYYY.MM.N`` CalVer tag such as ``2026.06.1`` fails because its
+    zero-padded month is a leading-zero component.
     """
     match = _PARSE_RE.match(version.strip())
     if match is None:
         return None
-    year = int(match["year"])
-    month = int(match["month"])
-    minor = int(match["minor"])
-    if not 1 <= month <= 12:
-        return None
-    return (year, month, minor)
+    return (int(match["major"]), int(match["minor"]), int(match["patch"]))
 
 
 def is_canonical_release_version(version: str) -> bool:
-    """True when ``version`` is the canonical, zero-padded ``YYYY.MM.N`` tag form."""
+    """True when ``version`` is the canonical, ``v``-prefixed ``vX.Y.Z`` tag form."""
     return _CANONICAL_RE.match(version.strip()) is not None
 
 
@@ -69,8 +75,8 @@ def verify_release(version: str, changelog_path: Path) -> list[str]:
     errors: list[str] = []
     if not is_canonical_release_version(version):
         errors.append(
-            f"version {version!r} is not a canonical CalVer release identifier "
-            "(expected YYYY.MM.N, zero-padded month, counter from 1)"
+            f"version {version!r} is not a canonical SemVer release identifier "
+            "(expected v-prefixed vX.Y.Z, no leading zeros; CalVer YYYY.MM.N is rejected)"
         )
         # A malformed version cannot have a meaningful changelog entry; stop here.
         return errors

--- a/tests/test_release_version.py
+++ b/tests/test_release_version.py
@@ -1,7 +1,8 @@
-"""Release-version verifier tests (REQ-Release-Versioning, ADR-076).
+"""Release-version verifier tests (REQ-Release-Versioning, ADR-111).
 
-Covers the CalVer identifier grammar (YYYY.MM.N), the PEP 440 normalised
-equivalence, precedence ordering, and the fail-closed publish gate.
+Covers the SemVer identifier grammar (``vX.Y.Z``), the PEP 440 normalised
+equivalence, SemVer precedence ordering, rejection of the reverted CalVer form,
+and the fail-closed publish gate.
 """
 
 from __future__ import annotations
@@ -18,7 +19,7 @@ from rac.release import (
 )
 
 
-@pytest.mark.parametrize("version", ["2026.06.1", "2026.06.2", "2026.12.1", "2027.01.10"])
+@pytest.mark.parametrize("version", ["v0.22.0", "v0.22.1", "v1.0.0", "v2.3.10"])
 def test_canonical_versions_accepted(version: str) -> None:
     assert is_canonical_release_version(version)
     assert parse_release_version(version) is not None
@@ -27,14 +28,13 @@ def test_canonical_versions_accepted(version: str) -> None:
 @pytest.mark.parametrize(
     "version",
     [
-        "2026.13.1",  # month out of range
-        "2026.00.1",  # month zero
-        "2026.06.0",  # minor zero
-        "2026.06.01",  # leading-zero minor
-        "2026.06",  # bare month, no counter
-        "2026.6.1",  # not zero-padded — valid to parse, not canonical
-        "v0.19.0",  # SemVer tag
-        "0.19.0",  # SemVer version
+        "0.22.0",  # normalised (no v) — valid to parse, not canonical
+        "v0.22",  # missing patch
+        "v0.22.0.1",  # too many components
+        "v01.2.3",  # leading-zero major
+        "v0.02.3",  # leading-zero minor
+        "2026.06.1",  # reverted CalVer form
+        "2026.06.01",  # CalVer with leading-zero counter
         "",
     ],
 )
@@ -43,51 +43,52 @@ def test_non_canonical_versions_rejected(version: str) -> None:
 
 
 def test_normalised_spelling_parses_equal_to_canonical() -> None:
-    # PEP 440 drops the leading zero on the published version; the two spellings
+    # PEP 440 drops the leading ``v`` on the published version; the two spellings
     # MUST map to the same tuple (REQ-009).
-    assert parse_release_version("2026.6.1") == parse_release_version("2026.06.1") == (2026, 6, 1)
+    assert parse_release_version("0.22.0") == parse_release_version("v0.22.0") == (0, 22, 0)
 
 
-@pytest.mark.parametrize("bad", ["2026.13.1", "2026.00.1", "2026.06.0", "2026.06.01", "nope"])
+@pytest.mark.parametrize("bad", ["v0.22", "v01.2.3", "2026.06.1", "2026.06.01", "nope", ""])
 def test_invalid_versions_do_not_parse(bad: str) -> None:
     assert parse_release_version(bad) is None
 
 
-def test_precedence_is_year_month_minor() -> None:
-    # REQ-003: lexicographic over (YYYY, MM, N).
-    versions = ["2026.07.1", "2026.06.2", "2026.06.10", "2026.06.1", "2027.01.1"]
+def test_precedence_is_semver_major_minor_patch() -> None:
+    # REQ-003: SemVer precedence over (major, minor, patch) — 0.10.0 sorts above
+    # 0.2.0, unlike a lexicographic string sort.
+    versions = ["v0.22.1", "v0.2.0", "v0.10.0", "v0.2.1", "v1.0.0"]
     ordered = sorted(versions, key=parse_release_version)
-    assert ordered == ["2026.06.1", "2026.06.2", "2026.06.10", "2026.07.1", "2027.01.1"]
+    assert ordered == ["v0.2.0", "v0.2.1", "v0.10.0", "v0.22.1", "v1.0.0"]
 
 
 def test_changelog_entry_detected_with_and_without_title() -> None:
-    assert changelog_has_entry("2026.06.1", "# Changelog\n\n## 2026.06.1 — CalVer cutover\n")
-    assert changelog_has_entry("2026.06.1", "## 2026.06.1\n")
-    assert not changelog_has_entry("2026.06.1", "## 2026.06.2 — later\n")
+    assert changelog_has_entry("v0.22.0", '# Changelog\n\n## v0.22.0 — the "scale" release\n')
+    assert changelog_has_entry("v0.22.0", "## v0.22.0\n")
+    assert not changelog_has_entry("v0.22.0", "## v0.22.1 — later\n")
     # A prefix must not match a longer version (word boundary).
-    assert not changelog_has_entry("2026.06.1", "## 2026.06.10 — other\n")
+    assert not changelog_has_entry("v0.22.1", "## v0.22.10 — other\n")
 
 
 def test_verify_release_passes_for_wellformed_with_entry(tmp_path: Path) -> None:
     changelog = tmp_path / "CHANGELOG.md"
-    changelog.write_text("# Changelog\n\n## 2026.06.1 — CalVer cutover\n", encoding="utf-8")
-    assert verify_release("2026.06.1", changelog) == []
+    changelog.write_text('# Changelog\n\n## v0.22.0 — the "scale" release\n', encoding="utf-8")
+    assert verify_release("v0.22.0", changelog) == []
 
 
-def test_verify_release_fails_closed_on_bad_version(tmp_path: Path) -> None:
+def test_verify_release_fails_closed_on_calver_version(tmp_path: Path) -> None:
     changelog = tmp_path / "CHANGELOG.md"
     changelog.write_text("## 2026.06.1\n", encoding="utf-8")
-    errors = verify_release("v0.20.0", changelog)
+    errors = verify_release("2026.06.1", changelog)
     assert errors and "canonical" in errors[0]
 
 
 def test_verify_release_fails_closed_on_missing_entry(tmp_path: Path) -> None:
     changelog = tmp_path / "CHANGELOG.md"
-    changelog.write_text("# Changelog\n\n## 2026.05.1 — earlier\n", encoding="utf-8")
-    errors = verify_release("2026.06.1", changelog)
-    assert errors and "no '## 2026.06.1' entry" in errors[0]
+    changelog.write_text("# Changelog\n\n## v0.21.1 — earlier\n", encoding="utf-8")
+    errors = verify_release("v0.22.0", changelog)
+    assert errors and "no '## v0.22.0' entry" in errors[0]
 
 
 def test_verify_release_fails_closed_on_unreadable_changelog(tmp_path: Path) -> None:
-    errors = verify_release("2026.06.1", tmp_path / "does-not-exist.md")
+    errors = verify_release("v0.22.0", tmp_path / "does-not-exist.md")
     assert errors and "could not read changelog" in errors[0]


### PR DESCRIPTION
# Summary

Reverts RAC's release versioning from **CalVer (`YYYY.MM.N`) back to SemVer (`vX.Y.Z`)** on the maintainer's decision, and cuts the accumulated release as **`v0.22.0`**. Supersedes #334 (the CalVer-labelled `2026.07.1` release-prep) — please close that one in favour of this.

CalVer's date-only identifier did not fit how releases should be communicated, and it kept the release line and the `vX.Y.Z` roadmap series in two numbering worlds. This records the reversal as a decision, flips the tooling, and remaps the brief CalVer detour into one monotonic SemVer history.

## The remap

| CalVer / label | → SemVer | Release |
| --- | --- | --- |
| `v0.23.0` (untagged label) | **v0.20.0** | Hardening |
| `2026.06.1` → `2026.06.4` | **v0.21.0** | "unlock" |
| `2026.06.5` | **v0.21.1** | "rename" |
| *(this release)* | **v0.22.0** | "scale" |

## What changed

**Decision (corpus)** — `docs(decisions)` commit
- **ADR-111** (new): reverts to SemVer, records the remap + PyPI yank; `## Supersedes: adr-076`.
- **ADR-076** → `Superseded`. **REQ-Release-Versioning** rewritten to mandate `vX.Y.Z`.
- Repointed the 6 live `## Related Decisions: adr-076` links → `adr-111` (ADR-093/094, the `agnostic-surfaces`/`corpus-sync`/`oci-image` roadmaps); `v0.27.0-calver-cutover` roadmap → `Superseded`.
- Fixed the CalVer prose in the session-start prompt; regenerated the managed agent-rules blocks (ADR-111 in, superseded ADR-076 out).

**Tooling** — `refactor(release)` commit
- `src/rac/release.py` now verifies a canonical `vX.Y.Z` tag (with `0.22.0` normalised-equal, REQ-009), orders by SemVer precedence, and **rejects a CalVer tag**. Tests rewritten. setuptools-scm already derives from `vX.Y.Z` tags by default; the publish workflow passes the tag unchanged (only its comment updated).

**Changelog + docs** — `docs(release)` commit
- Retitled the CalVer/label headings to the SemVer remap; cut the release as `## v0.22.0 — the "scale" release`; rewrote the `v0.21.0` intro so a SemVer changelog doesn't lead with the reverted CalVer adoption; recorded the versioning revert itself as a `### Changed` item.
- Folds in the tags-search + single-node-scale notes, the `--tag` / `--cache` CLI docs, and the new **Scale & Performance** docs page (previously in #334).

## Verification

- `rac validate rac/` 404 valid / 0 invalid; `rac relationships rac/ --validate` 0 issues; `rac review` 95/100; `rac export --agent-rules --check` in sync.
- `python -m rac.release v0.22.0 CHANGELOG.md` → accepts; a CalVer tag → rejected.
- `mkdocs build --strict` clean; `ruff check` + `ruff format --check` + `mypy src/` clean.
- Full `pytest` — running; will confirm green before merge.

## After merge (not in this PR)

- **Git tags** (mine, on your go-ahead): delete `2026.06.1/4/5`; add `v0.20.0` / `v0.21.0` / `v0.21.1` (git-only) and `v0.22.0` on the release commit.
- **PyPI** (yours): yank `2026.06.1/4/5` so the SemVer line resolves as "latest", then publish `v0.22.0`.

# Implementation Process
Implemented with AI assistance under the roadmap contract; final scope, review, and acceptance decisions were made by the maintainer.