### PR TITLE
fix(release): follow the SemVer revert through the SBOM and release chars

### DIFF
--- a/sbom.json
+++ b/sbom.json
@@ -6,9 +6,9 @@
     "component": {
       "type": "library",
       "name": "rac-core",
-      "version": "2026.06.5",
-      "bom-ref": "rac-core@2026.06.5",
-      "purl": "pkg:pypi/rac-core@2026.06.5"
+      "version": "0.22.0",
+      "bom-ref": "rac-core@0.22.0",
+      "purl": "pkg:pypi/rac-core@0.22.0"
     }
   },
   "components": [

--- a/scripts/generate_sbom.py
+++ b/scripts/generate_sbom.py
@@ -19,7 +19,8 @@ The root component's version is the latest release heading in ``CHANGELOG.md``,
 not the installed package metadata: a working checkout carries a setuptools-scm
 ``.devN`` version that matches no published artifact, and an SBOM attesting to a
 version nobody can install defeats its purpose. The committed document therefore
-always describes the most recent release.
+always describes the most recent release, in its PEP 440 normalised spelling
+(``0.22.0``, dropping the ``v`` the tag carries — the form PyPI publishes).
 
 Usage::
 
@@ -44,8 +45,10 @@ CHANGELOG = REPO_ROOT / "CHANGELOG.md"
 
 PACKAGE_NAME = "rac-core"
 
-# The latest release heading in CHANGELOG.md: `## YYYY.MM.N — …` (ADR-076).
-_RELEASE_HEADING_RE = re.compile(r"^## (\d{4}\.\d{2}\.\d+)\b", re.MULTILINE)
+# The latest release heading in CHANGELOG.md: `## vX.Y.Z — …` (ADR-111, which
+# reverted the CalVer of ADR-076). The capture drops the ``v`` so the recovered
+# version is the PEP 440 normalised spelling PyPI publishes (``0.22.0``).
+_RELEASE_HEADING_RE = re.compile(r"^## v(\d+\.\d+\.\d+)\b", re.MULTILINE)
 
 # A PEP 508 requirement string starts with the distribution name; strip any
 # version specifier, extras, or environment marker to recover the bare name.
@@ -85,7 +88,7 @@ def _released_version() -> str:
     """
     match = _RELEASE_HEADING_RE.search(CHANGELOG.read_text(encoding="utf-8"))
     if not match:
-        raise SystemExit("no release heading (## YYYY.MM.N) found in CHANGELOG.md")
+        raise SystemExit("no release heading (## vX.Y.Z) found in CHANGELOG.md")
     return match.group(1)
 
 

--- a/tests/test_char_ops.py
+++ b/tests/test_char_ops.py
@@ -135,29 +135,30 @@ def test_pre_commit_hook_allows_commit_when_no_markdown_staged(repo):
 
 def test_release_main_ok_prints_wellformed_and_returns_0(tmp_path, capsys):
     changelog = tmp_path / "CHANGELOG.md"
-    changelog.write_text("## 2026.06.1 — first cut\n", encoding="utf-8")
-    assert release_main(["2026.06.1", str(changelog)]) == 0
+    changelog.write_text("## v0.22.0 — first cut\n", encoding="utf-8")
+    assert release_main(["v0.22.0", str(changelog)]) == 0
     captured = capsys.readouterr()
-    assert captured.out == "✓ release 2026.06.1 is well-formed and has a changelog entry\n"
+    assert captured.out == "✓ release v0.22.0 is well-formed and has a changelog entry\n"
     assert captured.err == ""
 
 
 def test_release_main_rejects_bad_version_returns_1(tmp_path, capsys):
+    # The reverted CalVer form is now rejected (ADR-111).
     changelog = tmp_path / "CHANGELOG.md"
-    changelog.write_text("## 2026.06.1 — first cut\n", encoding="utf-8")
-    assert release_main(["v0.20.0", str(changelog)]) == 1
+    changelog.write_text("## v0.22.0 — first cut\n", encoding="utf-8")
+    assert release_main(["2026.06.1", str(changelog)]) == 1
     err = capsys.readouterr().err
-    assert err.startswith("✗ release v0.20.0 rejected:\n")
-    assert "is not a canonical CalVer release identifier" in err
+    assert err.startswith("✗ release 2026.06.1 rejected:\n")
+    assert "is not a canonical SemVer release identifier" in err
 
 
 def test_release_main_rejects_missing_changelog_entry_returns_1(tmp_path, capsys):
     changelog = tmp_path / "CHANGELOG.md"
     changelog.write_text("nothing relevant here\n", encoding="utf-8")
-    assert release_main(["2026.06.1", str(changelog)]) == 1
+    assert release_main(["v0.22.0", str(changelog)]) == 1
     err = capsys.readouterr().err
-    assert "✗ release 2026.06.1 rejected:" in err
-    assert "no '## 2026.06.1' entry found in CHANGELOG.md (REQ-005)" in err
+    assert "✗ release v0.22.0 rejected:" in err
+    assert "no '## v0.22.0' entry found in CHANGELOG.md (REQ-005)" in err
 
 
 def test_release_main_no_args_is_usage_error_returns_2(capsys):

--- a/tests/test_sbom.py
+++ b/tests/test_sbom.py
@@ -69,9 +69,11 @@ def test_sbom_root_version_is_the_latest_release():
     # The root component attests to the latest released version (the newest
     # CHANGELOG.md heading), never a setuptools-scm dev build that matches no
     # published artifact — an SBOM for an uninstallable version attests nothing.
+    # The heading is SemVer `## vX.Y.Z` (ADR-111); the SBOM records its PEP 440
+    # normalised spelling without the `v` (the form PyPI publishes).
     changelog = (REPO_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
-    heading = re.search(r"^## (\d{4}\.\d{2}\.\d+)\b", changelog, re.MULTILINE)
-    assert heading, "no release heading (## YYYY.MM.N) in CHANGELOG.md"
+    heading = re.search(r"^## v(\d+\.\d+\.\d+)\b", changelog, re.MULTILINE)
+    assert heading, "no release heading (## vX.Y.Z) in CHANGELOG.md"
     root = _sbom()["metadata"]["component"]
     assert root["version"] == heading.group(1)
     assert ".dev" not in root["version"]


### PR DESCRIPTION
## Why

The CalVer→SemVer revert (ADR-111) left three CalVer-shaped assumptions in code that **only the main-only test batteries exercise**. PR checks (`pr-checks.yml`) don't run the `core` or characterization batteries, so #336 was green on its checks but the post-merge `ci.yml` run on `main` went red:

```
tests/test_sbom.py::test_sbom_root_version_is_the_latest_release
  AssertionError: no release heading (## YYYY.MM.N) in CHANGELOG.md
```

## What

- **`scripts/generate_sbom.py` / `tests/test_sbom.py`** — the release-heading regex matched `## YYYY.MM.N`, which no CHANGELOG heading has anymore. Match `## vX.Y.Z` and record the PEP 440 normalised spelling (`0.22.0`, dropping the `v` PyPI drops).
- **`sbom.json`** — root component version `2026.06.5` → `0.22.0` (`bom-ref` and `purl` too). Dependency components untouched.
- **`tests/test_char_ops.py`** — the release-verifier characterization asserted the *inverted* contract (CalVer accepted, SemVer rejected). Flipped to the ADR-111 behaviour.

## Verification

- `core` battery: 220 passed
- characterization battery (incl. `test_char_ops.py`): 234 passed
- `test_release_version.py` + `test_sbom.py` + `test_char_ops.py`: 49 passed
- `ruff check`, `ruff format --check`, `mypy src/` clean
