### PR TITLE
docs(release): flip two stale CalVer references to SemVer

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -102,7 +102,7 @@ jobs:
   image-publish:
     # Official container image, published in lockstep with the PyPI release
     # (rac/roadmaps/future/oci-image.md): same trigger, same wheel, same
-    # CalVer tag. Runs after pypi-publish so the image never exists for a
+    # SemVer tag. Runs after pypi-publish so the image never exists for a
     # version PyPI does not have.
     runs-on: ubuntu-latest
     needs:

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -27,7 +27,7 @@ rac --version
 ### No Python? Use the container image
 
 Every release also publishes an official container image to GHCR, versioned
-in lockstep with the PyPI package — the image tag is the same CalVer version:
+in lockstep with the PyPI package — the image tag is the same SemVer version:
 
 ```bash
 docker run --rm -v "$PWD:/work" ghcr.io/itsthelore/rac:latest validate rac/


### PR DESCRIPTION
## Why

Follow-through on the CalVer→SemVer revert (ADR-111). Two **operational** references still described the release/image tag as CalVer, after the rest of the revert already landed. Prose/comment only — no behaviour change.

## What

- **`docs/quickstart.md`** — the GHCR image tag is the same **SemVer** version, not CalVer.
- **`.github/workflows/python-publish.yml`** — the `image-publish` comment said "same **CalVer** tag"; it tracks the SemVer release tag (`vX.Y.Z`).

All other in-repo CalVer mentions are intentional and correct (ADR-111/076, the release-versioning requirement, the session-start prompt, the superseded CalVer-cutover roadmap, and the CHANGELOG note — they *document* the reversal). The `requirements-as-code` shim's `PUBLISHING.md` `2026.06.4` is that separate package's own history and is left as-is.
