### PR TITLE
fix(release): repoint the requirements-as-code shim floor to the SemVer line

### DIFF
--- a/packaging/requirements-as-code-shim/PUBLISHING.md
+++ b/packaging/requirements-as-code-shim/PUBLISHING.md
@@ -13,9 +13,15 @@ unpinned dependency floor — it never needs republishing when `rac-core` update
 2. **Confirm the version** in `pyproject.toml` is strictly greater than the last
    real `requirements-as-code` release (currently `2026.06.4`), so an unpinned
    `pip install requirements-as-code` resolves here. `2026.6.99` satisfies this
-   and signals "final". Optionally tighten `dependencies` to
-   `rac-core>=<first rac-core version>`.
-3. **Publish** via the workflow below.
+   and signals "final". It stays CalVer on purpose even though `rac-core` reverted
+   to SemVer (ADR-111): no SemVer number can outrank a `2026.x` CalVer release in
+   PEP 440, so a SemVer version here would not resolve as default without yanking
+   the historical releases — which this redirect deliberately avoids.
+3. **Confirm the dependency floor** is the SemVer line: `dependencies =
+   ["rac-core>=0.22.0"]`. A CalVer floor (`>=2026.6`) would reject every SemVer
+   `rac-core` (`0.22.0 < 2026.6`) and, once the CalVer `rac-core` dists are yanked,
+   resolve to nothing — a redirect that cannot install.
+4. **Publish** via the workflow below.
 
 ## Publish — Trusted Publishing via `publish-shim.yml` (no token)
 

--- a/packaging/requirements-as-code-shim/pyproject.toml
+++ b/packaging/requirements-as-code-shim/pyproject.toml
@@ -15,6 +15,12 @@ name = "requirements-as-code"
 # Must be strictly greater than the final real requirements-as-code release so an
 # unpinned `pip install requirements-as-code` resolves to this redirect. `==<old>`
 # pins still resolve to the real historical releases. Confirm/bump before publish.
+#
+# Intentionally CalVer, even though rac-core reverted to SemVer (ADR-111): no
+# SemVer number can outrank the last real CalVer release (`1.0.0 < 2026.6.4` in
+# PEP 440), so a SemVer version here would NOT resolve as default without yanking
+# the historical releases. `2026.6.99` outranks them and needs no yank. Do not
+# "fix" this to SemVer without also yanking 2026.6.x on this project.
 version = "2026.6.99"
 description = "Renamed to rac-core. Transitional redirect — install rac-core instead."
 readme = "README.md"
@@ -22,10 +28,13 @@ requires-python = ">=3.11"
 license = "Apache-2.0"
 authors = [{ name = "Tom Ballard", email = "tom@armytage.co" }]
 keywords = ["requirements-as-code", "rac", "rac-core", "moved", "renamed"]
-# The whole point: pulling this in pulls in the renamed package. Pin the floor to
-# the first rac-core release so the redirect can never resolve to nothing
-# (tighten to the exact first rac-core version once it is published).
-dependencies = ["rac-core>=2026.6"]
+# The whole point: pulling this in pulls in the renamed package. The floor is the
+# first SemVer rac-core release (ADR-111 reverted CalVer): it must NOT be a CalVer
+# floor like `>=2026.6`, because `0.22.0 < 2026.6` in PEP 440 — such a floor would
+# reject every SemVer rac-core and, once the CalVer dists are yanked, resolve to
+# nothing. `>=0.22.0` follows the SemVer line forever and never lands on a yanked
+# CalVer build.
+dependencies = ["rac-core>=0.22.0"]
 
 [project.urls]
 Homepage = "https://github.com/itsthelore/rac-core"


### PR DESCRIPTION
## Why

The one-time `requirements-as-code` redirect shim (unpublished, in `packaging/requirements-as-code-shim/`) declared a **CalVer dependency floor** that the SemVer revert (ADR-111) silently broke:

```toml
dependencies = ["rac-core>=2026.6"]
```

In PEP 440, `0.22.0 < 2026.6` (first segment `0 < 2026`), so this floor **rejects every SemVer `rac-core`**. Once the CalVer `rac-core` dists are yanked, it resolves to **nothing** — publishing the shim as-is would create a redirect that cannot install. Verified:

```
rac-core 0.22.0 satisfies 'rac-core>=2026.6'?  False
```

## What

- **`pyproject.toml`** — floor `rac-core>=2026.6` → **`rac-core>=0.22.0`** (follows the SemVer line forever, never lands on a yanked CalVer build). Also documents *why the shim's own version intentionally stays CalVer* `2026.6.99`: no SemVer number can outrank the last real `2026.6.4` in PEP 440 (`1.0.0 < 2026.6.4`), so a SemVer version here would not resolve as default without yanking the historical releases — which this redirect deliberately avoids.
- **`PUBLISHING.md`** — adds a dependency-floor confirmation step and records the CalVer-version rationale.

Shim metadata only. The old name stays frozen and redirect-only; **no PyPI yanks** — pinned installs (`requirements-as-code==2026.06.4`) still resolve to the historical builds, and the unpinned install lands on `2026.6.99` → pulls `rac-core` (SemVer).

## Verification

```
floor: rac-core>=0.22.0
  rac-core 0.22.0 satisfies floor? True
  rac-core 0.23.0 satisfies floor? True
  rac-core 1.0.0  satisfies floor? True
```
No other `rac-core>=2026` references remain in the tree.
