### PR TITLE
feat(cache): default the cache on with stat-proxy freshness [roadmap:warm-by-default]

### DIFF
--- a/.cursor/rules
+++ b/.cursor/rules
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: 181a8250d554295d30c2d1acde55e7660a72a02c82bcd735b23394983df84ae5) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: cd72659c13336cefafdf6eb7016cd29552662e381de5bc57728a4f72016fb852) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -81,6 +81,6 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KWV63BR8AW71** — ADR-102: Org-Site Brand Direction — Light, Restrained, Site Rhymes With Product UI _(Product)_
 - **RAC-KWY0SHYCVY2D** — ADR-108: Term-Range-Partitioned Parallel Merge for the Cold Build _(Architecture)_
 - **RAC-KWY7886GSEE5** — ADR-109: Tag Search Tier and Tag Facet _(Technical)_
-- **RAC-KWYEHJXR0M3G** — ADR-110: One-Shot `rac find --cache` Reuses the Persistent Store _(Technical)_
 - **RAC-KX04DH293JG8** — ADR-111: Revert to SemVer Release Versioning _(Process)_
+- **RAC-KX2WTHEMDEY0** — ADR-112: Cache On by Default, Stat-Proxy Freshness as the Floor _(Technical)_
 <!-- END RAC MANAGED BLOCK -->

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: 181a8250d554295d30c2d1acde55e7660a72a02c82bcd735b23394983df84ae5) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: cd72659c13336cefafdf6eb7016cd29552662e381de5bc57728a4f72016fb852) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -81,6 +81,6 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KWV63BR8AW71** — ADR-102: Org-Site Brand Direction — Light, Restrained, Site Rhymes With Product UI _(Product)_
 - **RAC-KWY0SHYCVY2D** — ADR-108: Term-Range-Partitioned Parallel Merge for the Cold Build _(Architecture)_
 - **RAC-KWY7886GSEE5** — ADR-109: Tag Search Tier and Tag Facet _(Technical)_
-- **RAC-KWYEHJXR0M3G** — ADR-110: One-Shot `rac find --cache` Reuses the Persistent Store _(Technical)_
 - **RAC-KX04DH293JG8** — ADR-111: Revert to SemVer Release Versioning _(Process)_
+- **RAC-KX2WTHEMDEY0** — ADR-112: Cache On by Default, Stat-Proxy Freshness as the Floor _(Technical)_
 <!-- END RAC MANAGED BLOCK -->

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -96,7 +96,7 @@ jobs:
           - name: relationships
             paths: "tests/test_relationships.py tests/test_relationships_cmd.py tests/test_relationship_validation.py tests/test_relationship_graph.py tests/test_lifecycle_status.py tests/test_rename.py"
           - name: resolve
-            paths: "tests/test_resolve.py tests/test_find_decisions.py tests/test_scope.py tests/test_explain.py tests/test_selective_retrieval.py tests/test_find_cache.py"
+            paths: "tests/test_resolve.py tests/test_find_decisions.py tests/test_scope.py tests/test_explain.py tests/test_selective_retrieval.py tests/test_find_cache.py tests/test_find_manifest.py"
           - name: eval
             paths: "tests/test_eval.py"
           - name: review

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: 181a8250d554295d30c2d1acde55e7660a72a02c82bcd735b23394983df84ae5) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: cd72659c13336cefafdf6eb7016cd29552662e381de5bc57728a4f72016fb852) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -81,6 +81,6 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KWV63BR8AW71** — ADR-102: Org-Site Brand Direction — Light, Restrained, Site Rhymes With Product UI _(Product)_
 - **RAC-KWY0SHYCVY2D** — ADR-108: Term-Range-Partitioned Parallel Merge for the Cold Build _(Architecture)_
 - **RAC-KWY7886GSEE5** — ADR-109: Tag Search Tier and Tag Facet _(Technical)_
-- **RAC-KWYEHJXR0M3G** — ADR-110: One-Shot `rac find --cache` Reuses the Persistent Store _(Technical)_
 - **RAC-KX04DH293JG8** — ADR-111: Revert to SemVer Release Versioning _(Process)_
+- **RAC-KX2WTHEMDEY0** — ADR-112: Cache On by Default, Stat-Proxy Freshness as the Floor _(Technical)_
 <!-- END RAC MANAGED BLOCK -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,18 @@ details, release history over commit history.
 
 ## Unreleased
 
-_Nothing yet._
+**The cache is on by default** (ADR-112, supersedes ADR-110). `rac find`,
+`rac validate`, and `rac mcp` now reuse the persistent derived-index and
+per-file result caches without a flag — repeated queries against an unchanged
+corpus are bound by query selectivity, not corpus size, and stay byte-identical
+to the uncached walk. Freshness is verified by a stat scan by default (one-shot
+`rac find` runs gain a persisted stat manifest, so a warm run reads zero
+artifact bytes); the new `--verify` flag on `find`/`validate` forces the full
+byte re-hash floor, which catches the one rewrite shape stats cannot see (a
+size- and mtime-preserving in-place rewrite). Escapes: `--no-cache` per
+invocation, `RAC_NO_CACHE=1` per environment. Environments with no resolvable
+home degrade to a temp-dir cache — a missing cache location never fails a
+query.
 
 ## v0.22.0 — the "scale" release
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ to the corpus artifact and they load through the imports below.
 - Previous series: `rac/roadmaps/v0.21.x-editor/` (complete)
 - Decisions (ADRs): `rac/decisions/`
 
-<!-- BEGIN RAC MANAGED BLOCK (digest: 181a8250d554295d30c2d1acde55e7660a72a02c82bcd735b23394983df84ae5) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: cd72659c13336cefafdf6eb7016cd29552662e381de5bc57728a4f72016fb852) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -106,6 +106,6 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KWV63BR8AW71** — ADR-102: Org-Site Brand Direction — Light, Restrained, Site Rhymes With Product UI _(Product)_
 - **RAC-KWY0SHYCVY2D** — ADR-108: Term-Range-Partitioned Parallel Merge for the Cold Build _(Architecture)_
 - **RAC-KWY7886GSEE5** — ADR-109: Tag Search Tier and Tag Facet _(Technical)_
-- **RAC-KWYEHJXR0M3G** — ADR-110: One-Shot `rac find --cache` Reuses the Persistent Store _(Technical)_
 - **RAC-KX04DH293JG8** — ADR-111: Revert to SemVer Release Versioning _(Process)_
+- **RAC-KX2WTHEMDEY0** — ADR-112: Cache On by Default, Stat-Proxy Freshness as the Floor _(Technical)_
 <!-- END RAC MANAGED BLOCK -->

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -40,16 +40,21 @@ content issues.
 
 - **Input:** `rac validate <path>` — a Markdown file, a directory, or `-` for stdin.
 - **Options:** `--json` · `--top-level` · `--recursive` (directory mode) ·
-  `--cache` (incremental directory validation) ·
+  `--no-cache` / `--verify` (directory-validation cache controls) ·
   `--corpus DIR` (stdin / single-file mode — see below)
 - **Exit codes:** `0` no errors · `1` validation errors · `2` path not found / unreadable
 
-**`--cache` makes directory validation incremental (ADR-106).** Off by default,
-`--cache` reuses a per-file result cache keyed on each file's content hash × the
-active config fingerprint, so re-validating a large corpus after a small change
-does work proportional to what changed rather than to corpus size. It is
+**Directory validation is incremental by default (ADR-106, default-on per
+ADR-112).** A per-file result cache keyed on each file's content hash × the
+active config fingerprint means re-validating a large corpus after a small
+change does work proportional to what changed rather than to corpus size. It is
 disposable and byte-identical to the uncached run: a changed config invalidates
 the affected results, and a corrupt or missing cache recomputes from scratch.
+`--no-cache` revalidates every file from disk for one invocation (setting
+`RAC_NO_CACHE=1` does the same environment-wide), and `--verify` forces the
+freshness check to re-read every file's bytes — the full-hash floor that
+catches the one rewrite shape the default stat scan accepts (a size- and
+mtime-preserving in-place rewrite, ADR-105's S5).
 
 ```bash
 rac validate login-flow.md
@@ -1316,9 +1321,9 @@ not an error.
 - **Input:** `rac find <query> [directory]` — directory defaults to the
   current directory.
 - **Options:** `--type TYPE` (only match one artifact type) · `--tag TAG`
-  (repeatable; only artifacts carrying every given tag) · `--cache` (serve from
-  the persistent index store) · `--json` · `--explain` · `--top-level` ·
-  `--recursive`
+  (repeatable; only artifacts carrying every given tag) · `--no-cache` /
+  `--verify` (persistent-store controls) · `--json` · `--explain` ·
+  `--top-level` · `--recursive`
 - **Exit codes:** `0` search completed (matches or none) · `2` not a directory
 
 **Tags are searchable (ADR-109).** A query term matches an artifact's frontmatter
@@ -1332,15 +1337,21 @@ carrying both — and is case-insensitive. A tagged hit surfaces its `tags`
 additively (present only when non-empty). The `search_artifacts` MCP tool takes
 the same `tags` argument.
 
-**`--cache` serves from the persistent index store (ADR-110).** Off by default,
-`--cache` answers the query from the memory-mapped derived index (ADR-104)
-instead of a fresh walk — a warm run against an unchanged corpus skips the parse
-and graph rebuild; a cold run builds fresh and writes the store for next time.
-The output is byte-identical to the uncached `rac find` for every mode. The store
-is disposable and content-addressed (any byte change rebuilds it), lives under
+**`rac find` serves from the persistent index store by default (ADR-112, née
+ADR-110's opt-in).** The query is answered from the memory-mapped derived index
+(ADR-104) instead of a fresh walk — a warm run against an unchanged corpus
+skips the parse and graph rebuild, with freshness confirmed by a persisted stat
+manifest (every file is stat'ed; only stat-changed files are re-read); a cold
+run builds fresh and writes the store for next time. The output is
+byte-identical to the uncached `rac find` for every mode. The store is
+disposable and content-addressed (any byte change rebuilds it), lives under
 `RAC_CACHE_DIR` / `$XDG_CACHE_HOME`, and is safe to delete — it costs only
-latency. A single one-shot is net-neutral (the cold build and content hash have
-their own cost); the win is many warm queries against a stable corpus.
+latency. `--no-cache` restores the plain walk for one invocation
+(`RAC_NO_CACHE=1` restores it environment-wide — the right lever for a genuine
+one-off query, which skips the cold build), and `--verify` re-reads every
+file's bytes when checking freshness — the full-hash floor that catches the one
+rewrite shape the stat scan accepts (a size- and mtime-preserving in-place
+rewrite, ADR-105's S5).
 
 `--explain` adds, per match, the matched field/terms/tier plus the relevance
 score and its components (`bm25`, `lexical_rank`, `graph_rank`, `inbound`), so a

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -420,25 +420,27 @@ Keeping the fronted checkout current with `main` — a merge webhook or a period
 container, authenticating proxy, keep-current step, and observability — is on the
 [Shared Server](shared-server.md) page.
 
-### Derived-index cache (large corpora)
+### Derived-index cache
 
-By default every tool call rebuilds the derived structures — the repository
-index, the relationship graph, and the search token vectors — from disk. On a
-large corpus that re-indexing and re-tokenising costs real latency. Add
-`--cache` to reuse those structures across calls
-([ADR-099](https://github.com/itsthelore/rac-core/blob/main/rac/decisions/adr-099-derived-index-cache.md)):
+By default the server reuses the derived structures — the repository index, the
+relationship graph, and the search token vectors — across calls, kept fresh by
+an event-sourced watcher
+([ADR-099](https://github.com/itsthelore/rac-core/blob/main/rac/decisions/adr-099-derived-index-cache.md),
+default-on per ADR-112):
 
 ```bash
-rac mcp --root /path/to/your/repo --transport http --cache
+rac mcp --root /path/to/your/repo --transport http
 ```
 
 The cache is **content-addressed and disposable**. It is keyed on a hash of the
 corpus bytes, so any change to any artifact — an edit, add, remove, or rename —
-changes the key and forces a rebuild; the key is recomputed every call, so no
-call ever serves stale state. Output with `--cache` is **byte-identical** to the
-uncached path. The cache lives at `$XDG_CACHE_HOME/rac/derived` (override with
-`RAC_CACHE_DIR`); deleting it costs only latency, never correctness — the files
-in git remain the single source of truth. It is off by default.
+changes the key and forces a rebuild; freshness is confirmed before every call,
+so no call ever serves stale state. Output with the cache is **byte-identical**
+to the uncached path. The cache lives at `$XDG_CACHE_HOME/rac/derived`
+(override with `RAC_CACHE_DIR`); deleting it costs only latency, never
+correctness — the files in git remain the single source of truth. Pass
+`--no-cache` (or set `RAC_NO_CACHE=1`) to restore the zero-state posture where
+every tool call re-reads the repository from disk.
 
 ## 10. Troubleshooting
 

--- a/docs/scale.md
+++ b/docs/scale.md
@@ -35,29 +35,35 @@ corpus size: the index lives on disk and is never fully resident. Search is
 served directly from the term-major postings (ADR-038), and point lookups resolve
 through mapped identity segments without materialising the whole corpus.
 
-## 2. Opt-in caching on the paths that matter
+## 2. Caching on by default on the paths that matter
 
-Reuse of that store is **opt-in**, off by default, on the three surfaces where
-repeated reads against a stable corpus dominate:
+Reuse of that store is **the default** (ADR-112) on the three surfaces where
+repeated reads against a stable corpus dominate — `--no-cache` disables it per
+invocation, `RAC_NO_CACHE=1` per environment:
 
-| Command | Flag | What it reuses |
+| Command | Default reuse | What it reuses |
 | --- | --- | --- |
-| `rac mcp` | `--cache` | The whole derived read-model for a long-lived server (ADR-099/104). |
-| `rac find` | `--cache` | The persistent store for one-shot queries, instead of a fresh walk (ADR-110). |
-| `rac validate` | `--cache` | A per-file result cache, so re-validation is incremental (ADR-106). |
+| `rac mcp` | on | The whole derived read-model for a long-lived server (ADR-099/104). |
+| `rac find` | on | The persistent store for one-shot queries, instead of a fresh walk (ADR-110/112). |
+| `rac validate` | on | A per-file result cache, so re-validation is incremental (ADR-106). |
 
-For the long-lived `rac mcp --cache` server, freshness is tracked
-**incrementally** by an event-sourced watcher (ADR-105) rather than re-hashing the
-whole corpus on every call, so a warm endpoint answers without re-reading files
-that did not change. A one-shot `rac find --cache` has no long-lived process to
-hold that watcher, so it still pays a corpus content-hash to detect change before
-reusing anything — it skips the expensive parse and derive, not the hash — which
-is why a single query is net-neutral and the win is *many* warm queries.
+For the long-lived `rac mcp` server, freshness is tracked **incrementally** by
+an event-sourced watcher (ADR-105) rather than re-hashing the whole corpus on
+every call, so a warm endpoint answers without re-reading files that did not
+change. A one-shot `rac find` has no long-lived process to hold that watcher,
+so it verifies freshness through a **persisted stat manifest** (ADR-112): every
+enumerated file is stat'ed and only stat-changed files are re-read, so an
+unchanged corpus is confirmed at O(files) stat cost with zero artifact-byte
+reads. The one rewrite shape stats cannot see — a size- and mtime-preserving
+in-place rewrite (ADR-105's S5) — is caught by `--verify`, which forces the
+full byte re-hash floor. The first-ever query against a corpus pays the cold
+build; every later warm query rides the store.
 
-`rac validate --cache` keys each file's result on its content hash × the active
-config fingerprint, so validating a large corpus after a small edit does work
+`rac validate` keys each file's result on its content hash × the active config
+fingerprint, so validating a large corpus after a small edit does work
 proportional to what changed. A changed config invalidates exactly the affected
-results; a corrupt cache recomputes from scratch.
+results; a corrupt cache recomputes from scratch; `--verify` applies the same
+full-hash freshness floor.
 
 ## 3. A parallel cold build
 

--- a/docs/shared-server.md
+++ b/docs/shared-server.md
@@ -54,9 +54,10 @@ Three moving parts, and not one of them is a database:
 
 ## 3. The container
 
-Run the HTTP transport against a read-only checkout. The `--cache` flag enables
-the disposable [derived-index cache](mcp.md#derived-index-cache-large-corpora)
-so per-call latency stays flat as the corpus grows.
+Run the HTTP transport against a read-only checkout. The disposable
+[derived-index cache](mcp.md#derived-index-cache) is on by default (ADR-112),
+so per-call latency stays flat as the corpus grows; `--cache` remains accepted
+as an explicit affirmation.
 
 ```dockerfile
 FROM python:3.12-slim
@@ -65,7 +66,7 @@ RUN pip install --no-cache-dir rac-core
 WORKDIR /corpus
 EXPOSE 8000
 CMD ["rac", "mcp", "--root", "/corpus", \
-     "--transport", "http", "--host", "0.0.0.0", "--port", "8000", "--cache"]
+     "--transport", "http", "--host", "0.0.0.0", "--port", "8000"]
 ```
 
 HTTP serving is **mandatory audit-on**: the server refuses to start without a

--- a/rac/decisions/adr-110-one-shot-find-store-reuse.md
+++ b/rac/decisions/adr-110-one-shot-find-store-reuse.md
@@ -79,7 +79,14 @@ the uncached walk.
 
 ## Status
 
-Accepted
+Superseded
+
+Superseded by ADR-112, which makes the cache the default across `find`,
+`validate`, and `mcp` and replaces the per-call full re-hash with a persisted
+stat-proxy manifest — adopting both alternatives this record rejected. The
+store-reuse mechanics this record introduced (one-shot `load_or_build`,
+cross-process content-addressed reuse, byte-parity, the recency join) carry
+forward unchanged.
 
 ## Category
 

--- a/rac/decisions/adr-112-cache-on-by-default.md
+++ b/rac/decisions/adr-112-cache-on-by-default.md
@@ -1,0 +1,187 @@
+---
+schema_version: 1
+id: RAC-KX2WTHEMDEY0
+type: decision
+---
+# ADR-112: Cache On by Default, Stat-Proxy Freshness as the Floor
+
+## Context
+
+Every surface that can serve from the persistent memory-mapped index store
+ships opt-in: `rac find --cache` (ADR-110), `rac validate --cache` (ADR-106),
+`rac mcp --cache` (ADR-099/ADR-105). ADR-110 recorded the two honest costs
+that justified the opt-in posture for one-shot runs: a cold `--cache` run is
+heavier than the plain walk (fork + store write), and a warm one-shot still
+pays an Ω(bytes) full re-hash of the corpus to detect change before reusing
+anything — only the long-lived server escapes the hash via its event watcher.
+ADR-110 also considered and rejected two alternatives: making `--cache` the
+default, and a per-invocation stat-only changeset scan, deferring the latter
+to the single-node-scale residuals.
+
+Both premises have shifted. First, the stat-proxy scan is no longer
+speculative: it ships as the authoritative differ inside the server's
+freshness ladder (ADR-105) and as the default detection inside incremental
+validation (ADR-106) — `(size, mtime_ns)` as a prefilter that selects which
+files to content-confirm, content hashing as the truth, with one named,
+test-pinned accepted miss (S5: a size- and mtime-preserving in-place
+rewrite). The only cached surface still paying the byte-hash toll per call is
+one-shot `rac find`, and only because no manifest survives a one-shot
+process — the machinery exists; the persistence does not. Second, the
+adoption evidence points the other way from opt-in: the callers who benefit
+most from the warm path — agents, benchmark harnesses, editor integrations
+issuing many one-shot queries against a stable corpus — are precisely the
+callers least able to discover or pass a flag, so the engineered fast path
+lies dormant on exactly the workload it was built for, and the tool's
+effective performance is its default's.
+
+The `warm-by-default` roadmap schedules the flip; this decision records it.
+
+## Decision
+
+The persistent cache becomes the default, and stat-proxy freshness becomes
+the default verification, on every surface that supports them.
+
+- **Default-on with first-class escapes.** `--cache` defaults to on for
+  `rac find`, `rac validate`, and `rac mcp` (the flag remains parseable as an
+  explicit affirmation). `--no-cache` restores the zero-state walk for one
+  invocation; a non-empty `RAC_NO_CACHE` environment variable restores it
+  environment-wide for callers that cannot pass flags (CI, hooks, generated
+  integrations). The cache remains disposable and content-addressed under
+  `$XDG_CACHE_HOME` / `RAC_CACHE_DIR` (ADR-099/ADR-104); deleting it costs
+  only latency.
+- **A persisted one-shot freshness manifest.** `rac find`'s cache path gains
+  a per-root, recursion-mode-keyed stat manifest
+  (`manifest/v1/{root_key}.fseg`, the `.vseg` store discipline: checksummed
+  framing, fail-closed decode, atomic replace), written best-effort after
+  every `load_or_build`. A later one-shot process runs the shared
+  stat-manifest scan against it — stats every enumerated file, reuses the
+  prior content hash when `(size, mtime_ns)` is unchanged, content-confirms
+  only stat-changed or new files — and recomposes the corpus key from the
+  manifest at O(files) enumeration cost, byte-identical to the full re-hash
+  for every non-S5 state. A missing, corrupt, or unreadable manifest fails
+  closed into the content-confirm-all scan and is rewritten (self-healing);
+  a failed manifest write is ignored — the manifest can change only latency,
+  never an answer.
+- **The full re-hash becomes the opt-in floor.** A `--verify` flag on
+  `rac find` and `rac validate` forces the content-confirm-all scan — byte
+  for byte the legacy `corpus_content_hash` check — catching the S5 rewrite
+  the stat rung accepts, and repairing the manifest as it does. The server's
+  ladder is unchanged (its `verify` rung stays an internal surface; inotify
+  still only asserts *clean*, ADR-105).
+- **The S5 acceptance extends to one-shot runs, on the record.** The single
+  missable case — an in-place rewrite preserving both `size` and `mtime_ns`
+  between two cached one-shot invocations — is accepted by this decision
+  exactly as ADR-105 accepted it for the server, pinned by a test that
+  documents the stale serve and proves `--verify` returns fresh output. Add,
+  remove, and rename are never at risk: enumeration detects them from the
+  path set.
+- **Degrade-never-fail hardens for default-on.** A homeless environment
+  (unresolvable home directory with no `RAC_CACHE_DIR`/`XDG_CACHE_HOME`)
+  falls back to a temp-directory cache location; that failing too, the
+  existing chain holds — an unwritable store or cache directory degrades to
+  the fresh walk. No query fails, and no output changes, because a cache
+  could not be used.
+
+The carried non-negotiables are restated, not renegotiated: byte-parity to
+the fresh walk for every non-S5 corpus state (search, `--decisions`,
+`--type`, `--tag`, `--explain`, validate's outputs), content-addressed
+integrity on the corpus key, disposability, fail-closed schema and
+scoring-constant gates, no code-bearing deserialisation, and atomic writes.
+
+## Consequences
+
+A caller who types nothing now gets the engineered path: repeated one-shot
+queries against an unchanged corpus read zero artifact bytes — enumeration
+and stats only — and the warm line the store bought reaches the CLI's
+default, not just its flag. The two costs ADR-110 recorded are re-priced
+rather than denied: the Ω(bytes) warm toll is replaced by an O(files) stat
+scan (the sub-stat git/fsmonitor fast path remains a single-node-scale
+residual), and the cold-build penalty still exists but is now paid once per
+corpus rather than guarded by a flag nobody finds — with `--no-cache` and
+`RAC_NO_CACHE` restoring the old posture for genuinely one-off invocations
+and policy-constrained environments.
+
+The trade-offs are accepted on the record. Default paths are no longer
+zero-state: commands that previously wrote nothing now write a disposable
+cache, which test harnesses and sandboxes must isolate (the suite's own
+hermeticity fix ships with the flip). The S5 window, previously confined to
+opt-in surfaces, is now a property of the default — that is the substance of
+this decision, and it is bounded (one enumerated case, stat-preserving
+rewrites only), pinned by test, and floored by `--verify`. And ADR-032's
+zero-state posture, already revised narrowly for the opt-in cache path by
+ADR-105, is now revised for the default path too: what is preserved is not
+statelessness but the contract statelessness served — no query acts on stale
+state beyond the named S5 window, and a wrong answer is still worse than a
+slow one.
+
+## Status
+
+Accepted
+
+## Category
+
+Technical
+
+## Alternatives Considered
+
+### Keep the opt-in posture (ADR-110 unchanged)
+
+The flags exist; adoption does not follow. The callers the warm path was
+built for cannot discover it, every integrator decides the default
+independently, and the measured product is the slow path. Rejected: a fast
+path that ships dark is a cost without a constituency.
+
+### Default-on, but keep the full re-hash as the warm check
+
+Flip the default and retain the per-call `corpus_content_hash`. Simpler — no
+manifest — but every warm one-shot keeps the Ω(bytes) toll, so the default
+buys parse/derive skips while still reading the whole corpus per query;
+ADR-110's cost objection stood against exactly this variant. Rejected in
+favour of persisting the already-proven stat rung.
+
+### Sub-stat changed-set detection (git/fsmonitor)
+
+Detect change below the O(files) stat floor. Remains deferred to the
+single-node-scale residuals: it needs a service mode or an external event
+source, and the stat floor passes the current gates at the corpus sizes the
+one-shot path serves.
+
+## Supersedes
+
+- ADR-110
+
+## Relationship to Other Decisions
+
+- ADR-110: superseded. Its store-reuse mechanics (`load_or_build` on the
+  one-shot path, cross-process content-addressed reuse, byte-parity,
+  recency joined per-match after ranking per ADR-045) carry forward
+  unchanged; its opt-in default, its accepted per-call hash floor, and its
+  two rejected alternatives — which this decision adopts — do not.
+- ADR-099: its "opt-in, off by default" enablement clause is amended to
+  default-on. The content-addressed key contract is unchanged: the key is
+  now recomposed from the persisted manifest, byte-identical to the full
+  re-hash for every non-S5 state.
+- ADR-104: the opt-in posture it established is amended; the store format,
+  schema and scoring-fingerprint gates, and disposability are untouched.
+- ADR-105: extended, not amended. Its fallback ladder and S5 acceptance
+  become the default posture and reach one-shot processes through the
+  persisted manifest; the server's tracker, drain barrier, and rungs are
+  unchanged.
+- ADR-106: "opt-in behind the same `--cache` flag" is amended to default-on,
+  and its existing internal `verify` parameter is surfaced as the
+  `--verify` flag; the incremental validation machinery is unchanged.
+- ADR-032: revised for the default path. ADR-105 revised it narrowly for the
+  opt-in cache mode; this decision makes that revision the default posture
+  for `find`, `validate`, and `mcp`, preserving the correctness contract
+  (never act on stale state; the S5 window is the named, floored exception)
+  rather than the mechanism (per-call zero-state re-reads). `--no-cache` and
+  `RAC_NO_CACHE` keep the pure ADR-032 posture reachable everywhere.
+- ADR-080: disposability is load-bearing for default-on — a corrupt,
+  unwritable, or absent store or manifest degrades to a fresh build, never
+  a wrong answer or a failed query.
+
+## Related Roadmaps
+
+- warm-by-default
+- candidate-discovery
+- single-node-scale-residuals

--- a/rac/roadmaps/candidate-discovery.md
+++ b/rac/roadmaps/candidate-discovery.md
@@ -41,14 +41,16 @@ as scheduled work rather than latent gaps.
   and add a `--tag` / `tags` facet with AND semantics to `rac find` and the
   `search_artifacts` tool. Ships behind a persisted-store format bump with the
   byte-parity gate re-proven (ADR-109).
-- One-shot CLI store reuse: an opt-in `rac find --cache` that serves the query
-  from the persistent index store (ADR-104) via `load_or_build` instead of a
-  fresh walk, so a benchmark or agent issuing many one-shot queries against a
+- One-shot CLI store reuse: `rac find --cache` serves the query from the
+  persistent index store (ADR-104) via `load_or_build` instead of a fresh
+  walk, so a benchmark or agent issuing many one-shot queries against a
   stable corpus skips the parse and graph rebuild on every warm invocation.
-  Byte-identical to the uncached walk (ADR-110).
+  Byte-identical to the uncached walk. Shipped opt-in under ADR-110; the
+  `warm-by-default` roadmap has since flipped it to the default, with a
+  persisted stat manifest replacing the per-call byte-hash freshness check.
 - (Deferred, tracked elsewhere) Folding delta-window postings into discovery so
   edited corpora keep the fast path before compaction, and lowering the one-shot
-  freshness cost below the O(n) byte-hash floor (a stat/fsmonitor fast path) —
+  freshness cost below the O(files) stat floor (a git/fsmonitor fast path) —
   recorded in the single-node-scale residuals, not this item.
 
 ## Success Measures
@@ -85,3 +87,4 @@ as scheduled work rather than latent gaps.
 ## Related Roadmaps
 
 - single-node-scale-residuals
+- warm-by-default

--- a/rac/roadmaps/future/single-node-scale-residuals.md
+++ b/rac/roadmaps/future/single-node-scale-residuals.md
@@ -67,7 +67,10 @@ so they are scheduled deliberately rather than rediscovered.
   1M measurement shows recompute flat at 3.0 s for a 1,000-file changeset
   but stat detection at 17.9 s — the O(files) slope ADR-106 records fails
   the 5 s gate past a few hundred thousand files without a service mode
-  or a git/fsmonitor fast path; that fast path is the initiative.
+  or a git/fsmonitor fast path; that fast path is the initiative. (The
+  stat rung itself now ships as the one-shot default via the persisted
+  manifest of the `warm-by-default` roadmap; what remains here is only
+  the sub-stat fast path.)
 - Graph-read and per-match constants: get_related sits 2 ms over the
   30 ms p50 budget at 100k (the Theta(edges) incoming-scan), and match
   scoring costs ~1.6 ms per matching document against legacy's ~3 ms/match
@@ -112,3 +115,4 @@ so they are scheduled deliberately rather than rediscovered.
 ## Related Roadmaps
 
 - rebuild-scale
+- warm-by-default

--- a/rac/roadmaps/warm-by-default.md
+++ b/rac/roadmaps/warm-by-default.md
@@ -1,0 +1,125 @@
+---
+schema_version: 1
+id: RAC-KX2WNYNH8Z5X
+type: roadmap
+---
+# Warm by Default
+
+## Status
+
+Planned
+
+Codename: `warm-by-default`. Reverses the opt-in persistent-cache posture:
+the cache becomes the default on every surface that supports it, and the
+stat-proxy freshness scan becomes the default verification, with the full
+byte re-hash demoted to an opt-in floor.
+
+## Context
+
+The persistent memory-mapped index store made warm retrieval scale-invariant,
+but every surface that can use it — `rac find --cache`, `rac validate
+--cache`, `rac mcp --cache` — ships opt-in, so the default paths still walk,
+parse, and rebuild on every invocation. ADR-110 recorded the two honest costs
+that justified opt-in at the time: a cold `--cache` run is heavier than the
+plain walk, and the warm path still pays an O(bytes) full re-hash to detect
+corpus change. The second cost is no longer structural: the stat-proxy scan
+(size + mtime_ns per file, content-confirm on stat mismatch) already ships as
+the default freshness rung on the server (ADR-105) and inside incremental
+validation (ADR-106) — only the one-shot `rac find` path lacks it, because
+its freshness key is recomputed from file bytes on every call and no manifest
+survives the process. Meanwhile the callers who benefit most from the warm
+path — agents, benchmark harnesses, editor integrations issuing many
+one-shot queries — are exactly the callers least likely to discover a flag.
+
+The residual "changed-set detection below the stat floor" initiative in the
+single-node-scale record pointed at this gap; this roadmap promotes the
+stat-rung part of it to scheduled work and flips the posture, per ADR-112.
+
+## Outcomes
+
+- A caller who types nothing gets the warm path: repeated `rac find`,
+  `rac validate`, and Lore MCP queries against a stable corpus are bound by
+  query selectivity, not corpus size, with no flag knowledge required.
+- Freshness verification on cached surfaces costs stats, not bytes: an
+  unchanged corpus is confirmed unchanged without reading artifact contents,
+  and the full byte re-hash remains available on demand as the always-correct
+  floor.
+- The escape hatches are first-class: `--no-cache` restores the zero-state
+  walk per invocation, and `RAC_NO_CACHE` restores it environment-wide for
+  callers who cannot pass flags (CI, hooks, third-party harnesses).
+
+## Initiatives
+
+- Flip the three cache defaults: `--cache` becomes the default on `rac find`,
+  `rac validate`, and `rac mcp`; add `--no-cache` and the `RAC_NO_CACHE`
+  environment escape; keep `--cache` parseable as an explicit affirmation.
+- Persist the one-shot freshness manifest: a per-root, recursion-mode-keyed
+  stat manifest beside the store, written best-effort after every
+  `load_or_build`, so a later one-shot process verifies freshness with the
+  shared stat scan and reconstructs the corpus key byte-identically from
+  cached per-file hashes instead of re-reading every file.
+- Expose the verify floor: a `--verify` flag on `rac find` and `rac validate`
+  that forces the content-confirm-all scan (the pre-flip full-hash
+  behaviour), catching the stat-preserving rewrites the default scan accepts.
+- Degrade-never-fail hardening for default-on: a homeless environment (no
+  resolvable home, no cache-dir override) or an unwritable cache directory
+  must fall back to the fresh walk, never fail the query.
+- Flip the documentation posture across the CLI, MCP, shared-server, and
+  scale docs: the cache is the default; the flags documented are the escapes.
+- (Follow-on, unscheduled) Seed the MCP server tracker's cold start from the
+  persisted manifest, so a server restart pays stat cost instead of byte
+  cost before the watcher takes over.
+
+## Success Measures
+
+- A warm default `rac find` against an unchanged corpus reads zero artifact
+  bytes: enumeration and stats only, confirmed by test.
+- Default output is byte-identical to `--no-cache` for search, the
+  `--decisions` query, `--type`, `--tag`, and `--explain`, and for validate's
+  human and JSON outputs, across cold, warm, and every non-S5 corpus
+  transition (edit, add, remove, rename).
+- The S5 accepted miss (a size- and mtime-preserving rewrite) is pinned by
+  test on the one-shot path, and `--verify` both returns fresh output and
+  repairs the manifest so subsequent default runs are fresh.
+- `RAC_NO_CACHE=1` leaves the cache directory untouched; an unwritable or
+  homeless cache environment never fails a query or changes its output.
+
+## Assumptions
+
+- The stat-proxy model's accepted-miss window (ADR-105's S5) is acceptable as
+  a default for one-shot runs exactly as it is for the long-lived server; the
+  `--verify` floor and the pinning test keep the acceptance honest.
+- The persisted manifest, like the store, is a disposable derived structure:
+  deleting it costs one full-confirm scan, never a wrong answer.
+
+## Risks
+
+- A default-on cache writes to disk from commands that previously wrote
+  nothing; environments with read-only or unusual home layouts must hit the
+  degrade path, not an error — hardening is in scope, and the escape hatches
+  exist for policy-constrained environments.
+- The first-ever run against a corpus pays the cold build (parallel parse +
+  store write) that ADR-110 recorded as heavier than the plain walk; the cost
+  amortises from the second query onward and `--no-cache`/`RAC_NO_CACHE`
+  restore the old behaviour for genuinely one-off invocations.
+- Suite hermeticity: with the cache on by default, tests that drive the CLI
+  must isolate the cache directory or they pollute the developer's real
+  cache; the test harness change is part of the work, not an afterthought.
+
+## Related Decisions
+
+- ADR-099
+- ADR-104
+- ADR-105
+- ADR-106
+- ADR-110
+
+## Related Roadmaps
+
+- candidate-discovery
+- single-node-scale-residuals
+- rebuild-scale
+
+## Related Tickets
+
+- itsthelore/rac-core#340

--- a/rac/roadmaps/warm-by-default.md
+++ b/rac/roadmaps/warm-by-default.md
@@ -108,11 +108,11 @@ stat-rung part of it to scheduled work and flips the posture, per ADR-112.
 
 ## Related Decisions
 
+- ADR-112
 - ADR-099
 - ADR-104
 - ADR-105
 - ADR-106
-- ADR-110
 
 ## Related Roadmaps
 

--- a/src/rac/cli.py
+++ b/src/rac/cli.py
@@ -173,6 +173,16 @@ def _usage_error(message: str) -> NoReturn:
     raise SystemExit(EXIT_USAGE)
 
 
+def _cache_enabled(args: argparse.Namespace) -> bool:
+    """Whether the persistent cache is active for this invocation (ADR-112).
+
+    On by default; ``--no-cache`` disables it per invocation and a non-empty
+    ``RAC_NO_CACHE`` disables it environment-wide — the escape for callers that
+    cannot pass flags (CI containers, hooks, third-party harnesses).
+    """
+    return args.cache and not os.environ.get("RAC_NO_CACHE")
+
+
 def _emit(
     args: argparse.Namespace,
     *,
@@ -239,11 +249,17 @@ def cmd_validate(args: argparse.Namespace) -> int:
             # directory target already validates every artifact in place, so the
             # flag is redundant and ambiguous there (ADR-067, v0.21.17).
             _usage_error("--corpus applies to stdin ('-') or a single file")
-        # --cache reuses per-file results across runs (ADR-106), byte-identical
-        # to the uncached path; off by default keeps today's path untouched.
+        # The cache reuses per-file results across runs (ADR-106), byte-identical
+        # to the uncached path; on by default per ADR-112, with --no-cache /
+        # RAC_NO_CACHE restoring the full revalidation and --verify forcing the
+        # full-hash freshness floor.
         result = (
-            validate_directory_incremental(args.file, recursive=not args.top_level)
-            if getattr(args, "cache", False)
+            validate_directory_incremental(
+                args.file,
+                recursive=not args.top_level,
+                verify=getattr(args, "verify", False),
+            )
+            if _cache_enabled(args)
             else validate_directory(args.file, recursive=not args.top_level)
         )
         _emit(
@@ -933,7 +949,7 @@ def cmd_mcp(args: argparse.Namespace) -> int:
             host=args.host,
             port=args.port,
             path=args.path,
-            cache_enabled=args.cache,
+            cache_enabled=_cache_enabled(args),
         )
     except MalformedAuditConfig as exc:  # bad `audit:` stanza (ADR-084)
         _usage_error(str(exc))
@@ -1028,21 +1044,25 @@ def cmd_resolve(args: argparse.Namespace) -> int:
 
 
 def _find_from_store(args: argparse.Namespace) -> SearchResult:
-    """Serve `rac find --cache` from the persistent index store (ADR-110).
+    """Serve `rac find` from the persistent index store (ADR-112, default-on).
 
     Reuses ``DerivedIndexCache.load_or_build``: a warm run against an unchanged
-    corpus serves from the memory-mapped store with no walk/parse/graph rebuild;
-    a cold run builds fresh and writes the store for the next invocation. The
-    result is byte-identical to the uncached walk — the store fast path and the
-    fresh build are branched exactly as ``mcp/server.py`` does (ADR-104 parity).
-    When the store cannot be written, ``load_or_build`` returns a fresh
-    ``DerivedIndex`` and the ``else`` branches handle it.
+    corpus serves from the memory-mapped store with no walk/parse/graph rebuild
+    — freshness confirmed by the persisted stat manifest, or the full-hash
+    floor under ``--verify`` — and a cold run builds fresh and writes the store
+    for the next invocation. The result is byte-identical to the uncached walk
+    — the store fast path and the fresh build are branched exactly as
+    ``mcp/server.py`` does (ADR-104 parity). When the store cannot be written,
+    ``load_or_build`` returns a fresh ``DerivedIndex`` and the ``else``
+    branches handle it.
     """
     from rac.services.derived_cache import DerivedIndexCache
     from rac.services.index_store import ReadModelView
     from rac.services.resolve import find_decisions_in, search_index
 
-    view = DerivedIndexCache().load_or_build(args.directory, recursive=not args.top_level)
+    view = DerivedIndexCache().load_or_build(
+        args.directory, recursive=not args.top_level, verify=args.verify
+    )
     if args.decisions:
         if isinstance(view, ReadModelView):
             return view.find_decisions(args.query)
@@ -1068,9 +1088,10 @@ def cmd_find(args: argparse.Namespace) -> int:
 
     if not Path(args.directory).is_dir():
         _usage_error(f"not a directory: {args.directory}")
-    if args.cache:
-        # Opt-in store reuse (ADR-110): serve from the persistent index store
-        # instead of a fresh walk, byte-identical to the uncached path below.
+    if _cache_enabled(args):
+        # Default store reuse (ADR-112): serve from the persistent index store
+        # instead of a fresh walk, byte-identical to the uncached path below;
+        # --no-cache / RAC_NO_CACHE select the walk.
         result = _find_from_store(args)
     elif args.decisions:
         # `--decisions` is the live decision query (ADR-067): it implies the
@@ -1503,7 +1524,7 @@ def build_parser() -> argparse.ArgumentParser:
             "generated Claude Code pre-edit hook."
         ),
     )
-    # Incremental directory validation (ADR-106): opt-in, off by default. Reuses
+    # Incremental directory validation (ADR-106, default-on per ADR-112). Reuses
     # per-file validation results keyed by content-hash × config fingerprint, so a
     # re-validate after a small changeset recomputes only the changed files —
     # byte-identical to the uncached run. Disposable cache under
@@ -1511,10 +1532,33 @@ def build_parser() -> argparse.ArgumentParser:
     p_validate.add_argument(
         "--cache",
         action="store_true",
+        default=True,
         help=(
-            "Reuse per-file validation results across runs for large corpora, "
-            "recomputing only changed files; disposable and byte-identical to the "
-            "uncached run (directory validation only, off by default, ADR-106)."
+            "Reuse per-file validation results across runs, recomputing only "
+            "changed files; disposable and byte-identical to the uncached run "
+            "(directory validation only; the default, kept as an explicit "
+            "affirmation, ADR-112)."
+        ),
+    )
+    p_validate.add_argument(
+        "--no-cache",
+        action="store_false",
+        dest="cache",
+        help=(
+            "Disable the validation-result cache: revalidate every file from "
+            "disk for this invocation (the pre-ADR-112 default; RAC_NO_CACHE=1 "
+            "disables it environment-wide)."
+        ),
+    )
+    p_validate.add_argument(
+        "--verify",
+        action="store_true",
+        help=(
+            "Re-read every file's bytes when checking cache freshness (the "
+            "full-hash floor): catches the size- and mtime-preserving rewrites "
+            "the default stat scan accepts (S5, ADR-105/ADR-112). The uncached "
+            "path always reads every file, so this matters only with the cache "
+            "enabled."
         ),
     )
     p_validate.set_defaults(func=cmd_validate)
@@ -1999,17 +2043,28 @@ def build_parser() -> argparse.ArgumentParser:
         default="/mcp",
         help="HTTP path to serve for --transport http (default: /mcp).",
     )
-    # Derived-index cache (ADR-099): opt-in, off by default. Reuses the expensive
+    # Derived-index cache (ADR-099, default-on per ADR-112). Reuses the expensive
     # derived structures under an unchanged corpus content hash, byte-identically
     # to the uncached path; location is $XDG_CACHE_HOME/rac/derived (RAC_CACHE_DIR
     # overrides). Deleting the cache costs only latency.
     p_mcp.add_argument(
         "--cache",
         action="store_true",
+        default=True,
         help=(
-            "Reuse content-addressed derived structures across calls for large "
-            "corpora; disposable and byte-identical to the uncached path "
-            "(off by default, ADR-099)."
+            "Reuse content-addressed derived structures across calls; disposable "
+            "and byte-identical to the uncached path (the default, kept as an "
+            "explicit affirmation, ADR-112)."
+        ),
+    )
+    p_mcp.add_argument(
+        "--no-cache",
+        action="store_false",
+        dest="cache",
+        help=(
+            "Disable the derived-structure cache: re-read and rebuild from disk "
+            "on every call (the pre-ADR-112 default; RAC_NO_CACHE=1 disables it "
+            "environment-wide)."
         ),
     )
     p_mcp.set_defaults(func=cmd_mcp)
@@ -2213,14 +2268,40 @@ def build_parser() -> argparse.ArgumentParser:
             "required). Narrows the query by tag (ADR-109)."
         ),
     )
+    # Persistent store reuse (ADR-112): on by default. Freshness is verified by
+    # the persisted stat manifest (only stat-changed files are re-read); the
+    # store lives under $XDG_CACHE_HOME/rac/derived (RAC_CACHE_DIR overrides)
+    # and is disposable — deleting it costs only latency.
     p_find.add_argument(
         "--cache",
         action="store_true",
+        default=True,
         help=(
-            "Reuse the persistent index store across runs for large corpora, "
-            "skipping the walk and parse on an unchanged corpus; disposable and "
-            "byte-identical to the uncached run (off by default, RAC_CACHE_DIR / "
-            "$XDG_CACHE_HOME, ADR-110)."
+            "Serve from the persistent index store, skipping the walk and parse "
+            "on an unchanged corpus; disposable and byte-identical to the "
+            "uncached run (the default; kept as an explicit affirmation, "
+            "ADR-112)."
+        ),
+    )
+    p_find.add_argument(
+        "--no-cache",
+        action="store_false",
+        dest="cache",
+        help=(
+            "Disable the persistent cache: walk, parse, and rebuild from disk "
+            "for this invocation (the pre-ADR-112 default; RAC_NO_CACHE=1 "
+            "disables it environment-wide)."
+        ),
+    )
+    p_find.add_argument(
+        "--verify",
+        action="store_true",
+        help=(
+            "Re-read every file's bytes when checking cache freshness (the "
+            "full-hash floor): catches the size- and mtime-preserving rewrites "
+            "the default stat scan accepts (S5, ADR-105/ADR-112). The uncached "
+            "walk always reads every file, so this matters only with the cache "
+            "enabled."
         ),
     )
     p_find.add_argument(

--- a/src/rac/mcp/server.py
+++ b/src/rac/mcp/server.py
@@ -15,12 +15,13 @@ and shapes their results for the wire. It re-implements no parsing, resolution,
 relationship extraction, or scoring, and imports no write-capable service. The
 isolation battery (``tests/test_mcp_isolation.py``) enforces both.
 
-By default every tool call re-reads the repository from disk (ADR-032): no cache,
-no file watcher, no session state. With the opt-in ``--cache`` a server-lifetime
+By default (ADR-112) a server-lifetime
 :class:`~rac.services.freshness.FreshnessTracker` keeps the derived read-model
 fresh by event-sourced change detection instead of the per-call whole-corpus
 re-hash (ADR-105), so warm serving latency stops scaling with corpus size — and
 every response stays byte-identical to a fresh disk walk of the current corpus.
+With ``--no-cache`` (or ``RAC_NO_CACHE``) every tool call re-reads the
+repository from disk (ADR-032): no cache, no file watcher, no session state.
 Either way, identical repository bytes and identical input produce identical
 output, within the per-response character budget (ADR-033, see
 :mod:`rac.mcp.budget`).
@@ -485,9 +486,10 @@ def build_server(
     server: FastMCP = FastMCP(SERVER_NAME)
 
     # The freshness tracker is the read-model source under the cache: server-lifetime
-    # state that supersedes ADR-032's per-call re-read for the opt-in cache path
-    # (ADR-105). Off by default — with ``cache`` None every closure below builds
-    # fresh from disk on each call, exactly ADR-032.
+    # state that supersedes ADR-032's per-call re-read for the cache path
+    # (ADR-105; the default per ADR-112). With ``cache`` None (--no-cache /
+    # RAC_NO_CACHE) every closure below builds fresh from disk on each call,
+    # exactly ADR-032.
     reader: FreshnessTracker | None = FreshnessTracker(cache, root) if cache is not None else None
 
     def observed(
@@ -620,7 +622,7 @@ def run_server(
     host: str = transport.DEFAULT_HOST,
     port: int = transport.DEFAULT_PORT,
     path: str = transport.DEFAULT_PATH,
-    cache_enabled: bool = False,
+    cache_enabled: bool = True,
 ) -> int:
     """Run the Guide server over stdio (default) or streamable HTTP.
 
@@ -634,10 +636,11 @@ def run_server(
     mandatory-audit-on: it refuses to start without a working audit sink
     (ADR-084), asserted before the endpoint opens.
 
-    ``cache_enabled`` turns on the derived-index cache (ADR-099): the expensive
+    ``cache_enabled`` selects the derived-index cache (ADR-099): the expensive
     derived structures are persisted content-addressed and reused under an
-    unchanged corpus hash, byte-identically to the uncached path. Off by default —
-    the serving path is exactly ADR-032's re-read-per-call otherwise.
+    unchanged corpus hash, byte-identically to the uncached path. On by default
+    (ADR-112) — the CLI's ``--no-cache`` / ``RAC_NO_CACHE`` pass ``False``,
+    restoring ADR-032's re-read-per-call posture.
 
     Emits a one-line notice to stderr when the repository root contains no
     recognized artifacts (v0.10.1 startup hardening), and another when
@@ -672,9 +675,10 @@ def run_server(
     if cache_enabled:
         cache = DerivedIndexCache()
         print(
-            "rac mcp: derived-index cache on — reusing content-addressed derived "
-            f"structures under {cache.cache_dir} (disposable; byte-identical to the "
-            "uncached path, ADR-099).",
+            "rac mcp: derived-index cache on (the default) — reusing "
+            f"content-addressed derived structures under {cache.cache_dir} "
+            "(disposable; byte-identical to the uncached path, ADR-112; "
+            "--no-cache or RAC_NO_CACHE=1 disables).",
             file=sys.stderr,
         )
     server = build_server(

--- a/src/rac/services/derived_cache.py
+++ b/src/rac/services/derived_cache.py
@@ -15,6 +15,10 @@ The cache is a pure optimisation behind the corpus-snapshot seam:
   and forces a rebuild. There is no time- or event-based invalidation.
 - **Fresh per call** (ADR-032): the key is recomputed every call, so no call can
   observe stale state; derived structures are reused only under an unchanged key.
+  Since ADR-112 the key is recomposed through the persisted stat manifest — every
+  file is stat'ed, only stat-changed files are re-read — byte-identical to the
+  full re-hash for every state except the named S5 accepted miss, which the
+  ``verify`` floor (the content-confirm-all scan) always catches.
 - **Disposable, never authoritative** (ADR-080): the files in git are the truth;
   this is a rebuildable index. Deleting the cache directory — or a corrupt or
   unreadable cache file — costs only latency, never correctness: the reader falls
@@ -37,7 +41,7 @@ from pathlib import Path
 from typing import Protocol
 
 from rac.core.artifacts import spec_for
-from rac.core.corpus import CorpusEntry, corpus_content_hash, walk_corpus
+from rac.core.corpus import CorpusEntry, walk_corpus
 from rac.core.identity import artifact_identifier
 from rac.core.models import SearchSection
 from rac.services.agent_rules import artifact_status, is_live_decision
@@ -402,11 +406,20 @@ def default_cache_dir() -> Path:
     """The derived-cache directory: ``RAC_CACHE_DIR`` > ``$XDG_CACHE_HOME/rac/derived``.
 
     A cache location, not a state location — deleting it is always safe (ADR-080).
+    With the cache on by default (ADR-112) this must resolve *somewhere* even in a
+    homeless environment (no ``HOME``, no overrides — bare containers): it falls
+    back to the system temp directory rather than raising, and if that location is
+    unwritable too the store/manifest write failures degrade to fresh builds.
     """
     override = os.environ.get(CACHE_DIR_ENV)
     if override:
         return Path(override)
-    base = os.environ.get("XDG_CACHE_HOME") or str(Path.home() / ".cache")
+    base = os.environ.get("XDG_CACHE_HOME")
+    if not base:
+        try:
+            base = str(Path.home() / ".cache")
+        except RuntimeError:
+            base = str(Path(tempfile.gettempdir()) / "rac-cache")
     return Path(base) / "rac" / CACHE_DIRNAME
 
 
@@ -435,12 +448,39 @@ class DerivedIndexCache:
     def _marker_path(self, corpus_hash: str) -> Path:
         return self.cache_dir / f"{corpus_hash}.json"
 
-    def load_or_build(self, directory: str, *, recursive: bool = True) -> CorpusReadModel:
+    def load_or_build(
+        self, directory: str, *, recursive: bool = True, verify: bool = False
+    ) -> CorpusReadModel:
         # Freshness (REQ-006): the key is recomputed every call, so any corpus
         # change since the previous call is observed before anything is reused.
-        from rac.services.index_store import open_read_model, remove_store
+        # The key is recomposed from the persisted stat manifest (ADR-112): every
+        # enumerated file is stat'ed, and only stat-changed or new files are
+        # re-read — byte-identical to the full re-hash for every non-S5 state.
+        # No manifest (first run, corrupt segment) or ``verify`` forces the
+        # content-confirm-all scan, the legacy full-hash floor; the rewrite below
+        # self-heals the manifest either way.
+        from rac.services.freshness import corpus_hash_from_manifest, stat_scan
+        from rac.services.index_store import (
+            manifest_root_key,
+            open_freshness_manifest,
+            open_read_model,
+            remove_store,
+            write_freshness_manifest,
+        )
 
-        corpus_hash = corpus_content_hash(directory, recursive=recursive)
+        root_key = manifest_root_key(directory, recursive=recursive)
+        prev = None if verify else open_freshness_manifest(self.cache_dir, root_key)
+        manifest, _changed = stat_scan(
+            Path(directory),
+            directory,
+            prev or {},
+            content_confirm_all=verify or prev is None,
+            recursive=recursive,
+        )
+        corpus_hash = corpus_hash_from_manifest(Path(directory), manifest, recursive=recursive)
+        # Best-effort persistence: the manifest is a latency structure only, so a
+        # failed write is ignored — the next run simply pays the full-confirm scan.
+        write_freshness_manifest(self.cache_dir, root_key, manifest)
         if self._marker_valid(corpus_hash):
             view = open_read_model(self.cache_dir, corpus_hash, SCHEMA_VERSION)
             if view is not None:

--- a/src/rac/services/freshness.py
+++ b/src/rac/services/freshness.py
@@ -109,15 +109,16 @@ def stat_scan(
     prev_manifest: dict[str, FileState],
     *,
     content_confirm_all: bool,
+    recursive: bool = True,
 ) -> tuple[dict[str, FileState], set[str]]:
     """Diff the corpus against ``prev_manifest`` by stat, content-confirming changes.
 
-    The stat-manifest rung (v2 §2.2) factored out so both the long-lived
-    :class:`FreshnessTracker` and the one-shot CLI incremental-validate path
-    (ADR-106) share one differ — the manifest-scan machinery is identical, so it
-    is defined once here rather than copied. Pure over ``(filesystem, root,
-    prev_manifest)`` with no tracker state, so a caller can drive it with any
-    persisted manifest.
+    The stat-manifest rung (v2 §2.2) factored out so the long-lived
+    :class:`FreshnessTracker`, the one-shot CLI incremental-validate path
+    (ADR-106), and the one-shot find manifest (ADR-112) share one differ — the
+    manifest-scan machinery is identical, so it is defined once here rather
+    than copied. Pure over ``(filesystem, root, prev_manifest)`` with no
+    tracker state, so a caller can drive it with any persisted manifest.
 
     Enumerates the walk's files (``find_markdown_files`` — the exact walk scope),
     stats each for ``(size, mtime_ns)``, and reuses the previous manifest's hash
@@ -131,7 +132,7 @@ def stat_scan(
     """
     changed: set[str] = set()
     new_manifest: dict[str, FileState] = {}
-    for path in find_markdown_files(root_str):
+    for path in find_markdown_files(root_str, recursive=recursive):
         rel = _relposix(root, path)
         try:
             st = path.stat()
@@ -158,18 +159,22 @@ def stat_scan(
     return new_manifest, changed
 
 
-def _corpus_hash_from_manifest(root: Path, manifest: dict[str, FileState]) -> str:
+def corpus_hash_from_manifest(
+    root: Path, manifest: dict[str, FileState], *, recursive: bool = True
+) -> str:
     """Reproduce :func:`corpus_content_hash` from the manifest's cached hashes.
 
     Iterates the *same* sorted ``find_markdown_files`` order and folds the same
     ``rel\\0hash\\0`` bytes, but reuses each file's already-known content hash
     instead of re-reading it — so the key is byte-identical to a full re-hash for
     every non-S5 state, at O(files) enumeration cost with no O(bytes) reads.
+    Public because the one-shot find path (ADR-112) recomposes its
+    content-addressed store key through the same fold.
     """
     import hashlib
 
     hasher = hashlib.sha256()
-    for path in find_markdown_files(str(root)):
+    for path in find_markdown_files(str(root), recursive=recursive):
         rel = _relposix(root, path)
         state = manifest.get(rel)
         digest = state.content_hash if state is not None else content_hash(path)
@@ -560,7 +565,7 @@ class FreshnessTracker:
                 self._entries.pop(rel, None)
         if changed:
             self._delta_paths |= changed
-        self._hash = _corpus_hash_from_manifest(self._root, self._manifest)
+        self._hash = corpus_hash_from_manifest(self._root, self._manifest)
 
     def _reparse_full(self) -> None:
         """Rebuild the full parsed snapshot from the current manifest (parallel).

--- a/src/rac/services/index_store.py
+++ b/src/rac/services/index_store.py
@@ -1412,3 +1412,110 @@ def _silent_unlink_path(path: Path) -> None:
         path.unlink()
     except OSError:
         pass
+
+
+# =============================================================================
+# Per-root freshness-manifest store — the one-shot stat substrate (ADR-112).
+# =============================================================================
+#
+# The one-shot `rac find` cache path verifies freshness with the shared
+# stat-manifest scan (freshness.stat_scan) instead of a full byte re-hash, but a
+# one-shot process holds no manifest across invocations, so the manifest — each
+# file's `(size, mtime_ns, content_hash)` stat proxy — persists here, one binary
+# segment file per corpus root and recursion mode. It follows the same discipline
+# as the `.vseg` store: fixed struct reads (no pickle), fail-closed on corruption
+# (any decode failure is a miss → content-confirm-all scan, which rewrites it),
+# atomic writes. The manifest is a pure latency structure: it can never change an
+# answer, only how many bytes freshness detection reads (ADR-080).
+
+MANIFEST_DIRNAME = "manifest"
+MANIFEST_LAYOUT_VERSION = "v1"
+_MANIFEST_FORMAT_VERSION = 1
+
+
+def manifest_store_root(cache_dir: Path) -> Path:
+    return cache_dir / MANIFEST_DIRNAME / MANIFEST_LAYOUT_VERSION
+
+
+def manifest_root_key(directory: str, *, recursive: bool = True) -> str:
+    """A stable key for one corpus root in one recursion mode.
+
+    The recursion mode folds into the key because `rac find` and
+    `rac find --top-level` walk different file sets from the same root: a shared
+    manifest would thrash between them and could vouch for files the narrower
+    walk never enumerates.
+    """
+    import hashlib
+
+    mode = "recursive" if recursive else "top-level"
+    seed = f"{Path(directory).resolve()}\0{mode}"
+    return hashlib.sha256(seed.encode("utf-8")).hexdigest()
+
+
+def _manifest_store_path(cache_dir: Path, root_key: str) -> Path:
+    return manifest_store_root(cache_dir) / f"{root_key}.fseg"
+
+
+def open_freshness_manifest(cache_dir: Path, root_key: str) -> dict | None:
+    """Load the persisted stat manifest for a corpus root, or ``None`` on a miss.
+
+    A missing file, a corrupt or truncated segment, or a format-version mismatch
+    all return ``None`` — the caller then runs the content-confirm-all scan, so
+    the answer is fresh either way and the rewrite self-heals the store. Never
+    raises to the caller.
+    """
+    from rac.services.freshness import FileState
+
+    path = _manifest_store_path(cache_dir, root_key)
+    try:
+        data = path.read_bytes()
+    except OSError:
+        return None
+    try:
+        reader = Reader(segment_payload(memoryview(data)))
+        if reader.u32() != _MANIFEST_FORMAT_VERSION:
+            return None
+        count = reader.u32()
+        manifest: dict[str, FileState] = {}
+        for _ in range(count):
+            rel = reader.text()
+            size = reader.u64()
+            mtime_ns = reader.u64()
+            digest = reader.text()
+            manifest[rel] = FileState(content_hash=digest, size=size, mtime_ns=mtime_ns)
+        return manifest
+    except (IndexFormatError, ValueError, UnicodeDecodeError):
+        return None
+
+
+def write_freshness_manifest(cache_dir: Path, root_key: str, manifest: dict) -> bool:
+    """Write the stat manifest atomically; return whether it landed.
+
+    Built in memory, written to a temp file, then ``os.replace``d into the
+    root-keyed name in one step. Any OS error degrades to "not written": the
+    scan already produced the fresh manifest in memory, so persistence is a
+    latency nicety, never a requirement.
+    """
+    root = manifest_store_root(cache_dir)
+    writer = Writer()
+    writer.u32(_MANIFEST_FORMAT_VERSION)
+    writer.u32(len(manifest))
+    for rel, state in manifest.items():
+        writer.text(rel)
+        writer.u64(state.size)
+        writer.u64(state.mtime_ns)
+        writer.text(state.content_hash)
+    payload = encode_segment(writer.payload)
+    tmp = root / f".{root_key}.tmp-{os.getpid()}-{os.urandom(4).hex()}"
+    try:
+        root.mkdir(parents=True, exist_ok=True)
+        _write_file(tmp, payload)
+        try:
+            os.replace(tmp, _manifest_store_path(cache_dir, root_key))
+        except OSError:
+            _silent_unlink_path(tmp)
+            return False
+        return True
+    except OSError:
+        _silent_unlink_path(tmp)
+        return False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,13 +20,18 @@ def fixture_path(*parts: str) -> str:
 
 @pytest.fixture(autouse=True)
 def _isolated_xdg(tmp_path_factory, monkeypatch):
-    """Point XDG config/state at a temp dir for every test.
+    """Point XDG config/state/cache at a temp dir for every test.
 
     No test may read or write real user state — and with a live PostHog key
     in source (ADR-041), no test run may ever find a developer's consent
-    record and phone home. Tests that need specific locations still override
-    these variables locally.
+    record and phone home. The cache isolation is load-bearing since the
+    persistent cache went default-on (ADR-112): a test driving the CLI would
+    otherwise write to the developer's real ``~/.cache/rac``. Tests that need
+    specific locations still override these variables locally.
     """
     base = tmp_path_factory.mktemp("xdg")
     monkeypatch.setenv("XDG_CONFIG_HOME", str(base / "config"))
     monkeypatch.setenv("XDG_STATE_HOME", str(base / "state"))
+    monkeypatch.setenv("XDG_CACHE_HOME", str(base / "cache"))
+    monkeypatch.delenv("RAC_CACHE_DIR", raising=False)
+    monkeypatch.delenv("RAC_NO_CACHE", raising=False)

--- a/tests/test_b4_incremental_validate.py
+++ b/tests/test_b4_incremental_validate.py
@@ -313,6 +313,25 @@ def test_size_and_mtime_preserving_rewrite_is_the_accepted_stat_miss(tmp_path, c
     assert verified.to_dict() == fresh.to_dict()
 
 
+def test_cli_verify_flag_reaches_the_full_hash_floor(tmp_path, capsys, monkeypatch):
+    # The same S5 scenario through the CLI: the default (cached) run serves the
+    # stale result; `rac validate --verify` forces the content-confirm-all scan
+    # and reports the rewrite (ADR-112 flag wiring).
+    corpus = _corpus(tmp_path, {"a.md": _decision(_D1, "A", status="Accepted")})
+    monkeypatch.setenv("RAC_CACHE_DIR", str(tmp_path / "cache"))
+    path = corpus / "a.md"
+    before = path.stat()
+
+    assert main(["validate", str(corpus)]) == 0
+    path.write_text(_decision(_D1, "A", status="Rejected"), encoding="utf-8")
+    os.utime(path, ns=(before.st_atime_ns, before.st_mtime_ns))
+
+    assert main(["validate", str(corpus)]) == 0, "the default stat scan accepts the S5 miss"
+    assert main(["validate", str(corpus), "--verify"]) == 1, "--verify must catch the rewrite"
+    assert main(["validate", str(corpus)]) == 1, "verify must repair the manifest for later runs"
+    capsys.readouterr()
+
+
 # --- (e) corrupt store → full recompute, never a wrong answer -----------------
 
 

--- a/tests/test_derived_cache.py
+++ b/tests/test_derived_cache.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import asyncio
 import shutil
 
+import pytest
 from conftest import fixture_path
 
 from rac import cli
@@ -248,10 +249,28 @@ def test_warm_cache_skips_retokenization(tmp_path, monkeypatch):
 # --- CLI wiring (REQ-001) ----------------------------------------------------
 
 
-def test_cache_flag_defaults_off_and_parses():
+def test_cache_flag_defaults_on_with_no_cache_escape():
+    # ADR-112: default-on across all three surfaces, --no-cache restores the
+    # walk, --cache stays parseable as an explicit affirmation, and --verify
+    # (the full-hash floor) exists on find/validate but not mcp.
     parser = cli.build_parser()
-    assert parser.parse_args(["mcp", "--root", CORPUS]).cache is False
-    assert parser.parse_args(["mcp", "--root", CORPUS, "--cache"]).cache is True
+    for argv in (["mcp", "--root", CORPUS], ["find", "q", CORPUS], ["validate", CORPUS]):
+        assert parser.parse_args(argv).cache is True, f"{argv[0]} must default cache-on"
+        assert parser.parse_args(argv + ["--cache"]).cache is True
+        assert parser.parse_args(argv + ["--no-cache"]).cache is False
+    assert parser.parse_args(["find", "q", CORPUS, "--verify"]).verify is True
+    assert parser.parse_args(["validate", CORPUS, "--verify"]).verify is True
+    with pytest.raises(SystemExit):
+        parser.parse_args(["mcp", "--root", CORPUS, "--verify"])
+
+
+def test_rac_no_cache_env_disables_the_default(monkeypatch):
+    parser = cli.build_parser()
+    args = parser.parse_args(["find", "q", CORPUS])
+    monkeypatch.delenv("RAC_NO_CACHE", raising=False)
+    assert cli._cache_enabled(args) is True
+    monkeypatch.setenv("RAC_NO_CACHE", "1")
+    assert cli._cache_enabled(args) is False
 
 
 def test_run_server_cache_enabled_builds_a_cache(monkeypatch):
@@ -270,5 +289,8 @@ def test_run_server_cache_enabled_builds_a_cache(monkeypatch):
     monkeypatch.setattr(mcp_server, "build_server", _fake_build)
     monkeypatch.setattr(mcp_server, "_maybe_start_sharing", lambda *a, **k: None)
     monkeypatch.setattr(mcp_server, "_check_corpus", lambda *a, **k: None)
-    assert mcp_server.run_server(CORPUS, cache_enabled=True) == 0
+    assert mcp_server.run_server(CORPUS) == 0, "cache_enabled must default on (ADR-112)"
     assert isinstance(captured["cache"], DerivedIndexCache)
+    captured.clear()
+    assert mcp_server.run_server(CORPUS, cache_enabled=False) == 0
+    assert captured["cache"] is None, "cache_enabled=False must build no cache"

--- a/tests/test_find_cache.py
+++ b/tests/test_find_cache.py
@@ -97,6 +97,45 @@ def test_cache_falls_back_to_fresh_when_store_unwritable(corpus, monkeypatch):
     assert walk == cached
 
 
+def test_s5_rewrite_serves_stale_until_verify(corpus):
+    # The accepted S5 miss (ADR-105/ADR-112) through the CLI: a size- and
+    # mtime-preserving rewrite is invisible to the warm default run; --verify
+    # is the full-hash floor that observes it and repairs the manifest.
+    import os
+
+    _run(["find", "shared", str(corpus), "--json"])  # cold: store + manifest written
+    target = corpus / "a.md"
+    st = target.stat()
+    old = target.read_text(encoding="utf-8")
+    new = old.replace("shared alpha", "shared aleph")  # same byte length
+    assert len(new.encode()) == st.st_size and new != old
+    target.write_text(new, encoding="utf-8")
+    os.utime(target, ns=(st.st_atime_ns, st.st_mtime_ns))
+
+    _, stale = _run(["find", "aleph", str(corpus), "--json"])
+    assert '"match_count": 0' in stale, "the S5 rewrite is the accepted stat miss"
+    _, verified = _run(["find", "aleph", str(corpus), "--json", "--verify"])
+    assert '"match_count": 1' in verified, "--verify must observe the rewrite"
+    _, after = _run(["find", "aleph", str(corpus), "--json"])
+    assert '"match_count": 1' in after, "verify must repair the manifest for later runs"
+
+
+def test_default_find_survives_a_homeless_environment(corpus, monkeypatch):
+    # Default-on must never fail a query because no cache location resolves
+    # (ADR-112 degrade-never-fail): no HOME, no XDG_CACHE_HOME, no RAC_CACHE_DIR.
+    from pathlib import Path
+
+    def _no_home() -> Path:
+        raise RuntimeError("no usable home directory")
+
+    monkeypatch.delenv("RAC_CACHE_DIR", raising=False)
+    monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+    monkeypatch.delenv("HOME", raising=False)
+    monkeypatch.setattr(Path, "home", staticmethod(_no_home))
+    rc, out = _run(["find", "shared", str(corpus), "--json"])
+    assert rc == 0 and '"match_count": 2' in out
+
+
 def test_top_level_composes_with_cache(corpus):
     # The default cache honours --top-level (its own content-hash / store /
     # manifest key); still identical to the walk.

--- a/tests/test_find_cache.py
+++ b/tests/test_find_cache.py
@@ -1,11 +1,11 @@
-"""`rac find --cache` byte-parity with the uncached walk (ADR-110).
+"""`rac find` cache byte-parity with the uncached walk (ADR-112, née ADR-110).
 
-One-shot `rac find --cache` serves from the persistent index store instead of a
-fresh walk. The contract is that its output is byte-identical to the uncached
-`rac find` for every mode, cold (store just written) and warm (store reused),
-and that a cold run writes the store for the next invocation. When the store
-cannot be written, `load_or_build` returns a fresh `DerivedIndex` and the CLI
-serves from that — still byte-identical.
+One-shot `rac find` serves from the persistent index store by default. The
+contract is that its output is byte-identical to `--no-cache` for every mode,
+cold (store just written) and warm (store reused), and that a cold run writes
+the store for the next invocation. When the store cannot be written,
+`load_or_build` returns a fresh `DerivedIndex` and the CLI serves from that —
+still byte-identical.
 """
 
 from __future__ import annotations
@@ -59,38 +59,49 @@ def _run(argv: list[str]) -> tuple[int, str]:
 )
 def test_find_cache_is_byte_identical_to_the_walk(corpus, extra):
     base = ["find", "shared", str(corpus), "--json"]
-    rc_walk, walk = _run(base + extra)
-    rc_cold, cold = _run(base + ["--cache"] + extra)  # cold miss: builds + writes the store
-    rc_warm, warm = _run(base + ["--cache"] + extra)  # warm hit: served from the store
-    assert rc_walk == rc_cold == rc_warm == 0
-    assert walk == cold, "cached (cold) output must equal the uncached walk"
-    assert cold == warm, "warm store-served output must equal the cold run"
+    rc_walk, walk = _run(base + ["--no-cache"] + extra)
+    rc_cold, cold = _run(base + extra)  # default, cold miss: builds + writes the store
+    rc_warm, warm = _run(base + extra)  # default, warm hit: served from the store
+    rc_affirm, affirmed = _run(base + ["--cache"] + extra)  # explicit affirmation
+    rc_verify, verified = _run(base + ["--verify"] + extra)  # full-hash floor
+    assert rc_walk == rc_cold == rc_warm == rc_affirm == rc_verify == 0
+    assert walk == cold, "cached (cold) output must equal the --no-cache walk"
+    assert cold == warm == affirmed == verified, "every cached mode must serve the same bytes"
 
 
-def test_cold_cache_run_writes_the_store(corpus):
+def test_cold_default_run_writes_the_store(corpus):
     from rac.services.index_store import store_root
 
-    _run(["find", "shared", str(corpus), "--json", "--cache"])
+    _run(["find", "shared", str(corpus), "--json"])
     root = store_root(corpus / "cache")
-    assert root.exists() and any(root.iterdir()), "a cold --cache run must persist the store"
+    assert root.exists() and any(root.iterdir()), "a cold default run must persist the store"
+
+
+def test_no_cache_and_rac_no_cache_write_nothing(corpus, monkeypatch):
+    _run(["find", "shared", str(corpus), "--json", "--no-cache"])
+    assert not (corpus / "cache").exists(), "--no-cache must not touch the cache dir"
+    monkeypatch.setenv("RAC_NO_CACHE", "1")
+    _run(["find", "shared", str(corpus), "--json"])
+    assert not (corpus / "cache").exists(), "RAC_NO_CACHE must disable the default cache"
 
 
 def test_cache_falls_back_to_fresh_when_store_unwritable(corpus, monkeypatch):
     # When the store can't be written, load_or_build returns a fresh DerivedIndex
-    # and the CLI serves from that — output must still equal the walk.
+    # and the CLI serves from that — the default path must still equal the walk.
     from rac.services.derived_cache import DerivedIndexCache
 
     monkeypatch.setattr(DerivedIndexCache, "_write_store", lambda self, h, d: False)
-    rc_walk, walk = _run(["find", "shared", str(corpus), "--json"])
-    rc_cache, cached = _run(["find", "shared", str(corpus), "--json", "--cache"])
+    rc_walk, walk = _run(["find", "shared", str(corpus), "--json", "--no-cache"])
+    rc_cache, cached = _run(["find", "shared", str(corpus), "--json"])
     assert rc_walk == rc_cache == 0
     assert walk == cached
 
 
 def test_top_level_composes_with_cache(corpus):
-    # --cache honours --top-level (its own content-hash / store); still identical.
+    # The default cache honours --top-level (its own content-hash / store /
+    # manifest key); still identical to the walk.
     base = ["find", "shared", str(corpus), "--json", "--top-level"]
-    rc_walk, walk = _run(base)
-    rc_cache, cached = _run(base + ["--cache"])
+    rc_walk, walk = _run(base + ["--no-cache"])
+    rc_cache, cached = _run(base)
     assert rc_walk == rc_cache == 0
     assert walk == cached

--- a/tests/test_find_manifest.py
+++ b/tests/test_find_manifest.py
@@ -113,3 +113,107 @@ def test_warm_scan_against_persisted_manifest_reads_no_bytes(tmp_path, monkeypat
     rescanned, changed = stat_scan(tmp_path, str(tmp_path), prev, content_confirm_all=False)
     assert reads == [], "an unchanged corpus must be confirmed by stats alone"
     assert changed == set() and rescanned == manifest
+
+
+# =============================================================================
+# load_or_build over the persisted manifest (ADR-112).
+# =============================================================================
+
+
+def _artifact(ident: str, title: str, body: str) -> str:
+    return (
+        f"---\nschema_version: 1\nid: {ident}\ntype: decision\n---\n"
+        f"# {title}\n\n## Status\n\nAccepted\n\n## Category\n\nArchitecture\n\n"
+        f"## Context\n\n{body}\n\n## Decision\n\nD.\n\n## Consequences\n\nE.\n"
+    )
+
+
+def _cache_corpus(tmp_path: Path) -> tuple[Path, Path]:
+    root = tmp_path / "corpus"
+    root.mkdir()
+    (root / "a.md").write_text(_artifact("RAC-01JY4MAN1FA1", "Alpha", "body one"), "utf-8")
+    (root / "b.md").write_text(_artifact("RAC-01JY4MAN1FB2", "Beta", "body two"), "utf-8")
+    return root, tmp_path / "cache"
+
+
+def test_load_or_build_persists_the_manifest_and_warms_by_stat(tmp_path, monkeypatch):
+    from rac.services.derived_cache import DerivedIndexCache
+
+    root, cache_dir = _cache_corpus(tmp_path)
+    cache = DerivedIndexCache(cache_dir)
+    cold = cache.load_or_build(str(root))
+    key = manifest_root_key(str(root))
+    assert open_freshness_manifest(cache_dir, key), "a cold run must persist the manifest"
+
+    import rac.services.freshness as freshness
+
+    reads: list[str] = []
+    real = freshness.content_hash
+    monkeypatch.setattr(freshness, "content_hash", lambda p: (reads.append(str(p)), real(p))[1])
+    warm = cache.load_or_build(str(root))
+    assert reads == [], "a warm run against an unchanged corpus must read zero artifact bytes"
+    assert warm == cold
+
+
+def test_ordinary_edit_is_detected_through_the_manifest(tmp_path):
+    from rac.services.derived_cache import DerivedIndexCache, build_derived_index
+
+    root, cache_dir = _cache_corpus(tmp_path)
+    cache = DerivedIndexCache(cache_dir)
+    cache.load_or_build(str(root))
+    (root / "a.md").write_text(_artifact("RAC-01JY4MAN1FA1", "Alpha Prime", "body one"), "utf-8")
+    assert cache.load_or_build(str(root)) == build_derived_index(str(root))
+
+
+def test_s5_rewrite_is_the_accepted_miss_and_verify_repairs(tmp_path):
+    """The one enumerated stale case (ADR-105 S5, extended by ADR-112).
+
+    A rewrite preserving both size and mtime_ns is invisible to the stat rung,
+    so the default warm run serves the previous corpus state — the documented
+    accepted miss. ``verify=True`` (the full-hash floor) returns fresh output
+    and repairs the manifest, so the *next* default run is fresh too.
+    """
+    import os
+
+    from rac.services.derived_cache import DerivedIndexCache, build_derived_index
+
+    root, cache_dir = _cache_corpus(tmp_path)
+    cache = DerivedIndexCache(cache_dir)
+    stale = cache.load_or_build(str(root))
+
+    target = root / "a.md"
+    st = target.stat()
+    old = target.read_text(encoding="utf-8")
+    new = old.replace("body one", "body ten")  # same byte length
+    assert len(new.encode()) == st.st_size and new != old
+    target.write_text(new, encoding="utf-8")
+    os.utime(target, ns=(st.st_atime_ns, st.st_mtime_ns))
+
+    assert cache.load_or_build(str(root)) == stale, "the S5 rewrite is the accepted stat miss"
+    fresh = build_derived_index(str(root))
+    assert cache.load_or_build(str(root), verify=True) == fresh, "--verify is the floor"
+    assert cache.load_or_build(str(root)) == fresh, "verify must repair the manifest"
+
+
+def test_corrupt_manifest_self_heals_through_full_confirm(tmp_path):
+    from rac.services.derived_cache import DerivedIndexCache, build_derived_index
+
+    root, cache_dir = _cache_corpus(tmp_path)
+    cache = DerivedIndexCache(cache_dir)
+    cache.load_or_build(str(root))
+    key = manifest_root_key(str(root))
+    (manifest_store_root(cache_dir) / f"{key}.fseg").write_bytes(b"garbage")
+    assert cache.load_or_build(str(root)) == build_derived_index(str(root))
+    assert open_freshness_manifest(cache_dir, key), "the corrupt manifest must be rewritten"
+
+
+def test_default_cache_dir_survives_a_homeless_environment(monkeypatch):
+    from rac.services.derived_cache import default_cache_dir
+
+    def _no_home() -> Path:
+        raise RuntimeError("no usable home directory")
+
+    monkeypatch.delenv("RAC_CACHE_DIR", raising=False)
+    monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+    monkeypatch.setattr(Path, "home", staticmethod(_no_home))
+    assert default_cache_dir().name  # resolves somewhere instead of raising

--- a/tests/test_find_manifest.py
+++ b/tests/test_find_manifest.py
@@ -207,6 +207,25 @@ def test_corrupt_manifest_self_heals_through_full_confirm(tmp_path):
     assert open_freshness_manifest(cache_dir, key), "the corrupt manifest must be rewritten"
 
 
+def test_manifest_present_store_deleted_rebuilds_and_rewrites(tmp_path):
+    # The manifest and the store are independently disposable: a valid manifest
+    # over a missing store recomposes the key by stat, misses the marker/store,
+    # rebuilds, and rewrites the store — never a wrong answer.
+    import shutil
+
+    from rac.services.derived_cache import DerivedIndexCache, build_derived_index
+    from rac.services.index_store import store_root
+
+    root, cache_dir = _cache_corpus(tmp_path)
+    cache = DerivedIndexCache(cache_dir)
+    cache.load_or_build(str(root))
+    shutil.rmtree(store_root(cache_dir))
+    for marker in cache_dir.glob("*.json"):
+        marker.unlink()
+    assert cache.load_or_build(str(root)) == build_derived_index(str(root))
+    assert store_root(cache_dir).exists(), "the rebuild must rewrite the store"
+
+
 def test_default_cache_dir_survives_a_homeless_environment(monkeypatch):
     from rac.services.derived_cache import default_cache_dir
 

--- a/tests/test_find_manifest.py
+++ b/tests/test_find_manifest.py
@@ -1,0 +1,115 @@
+"""The persisted one-shot freshness manifest (`.fseg`, ADR-112).
+
+The one-shot find cache verifies freshness through a per-root stat manifest
+persisted beside the store. The store primitives fail closed (missing, corrupt,
+truncated, or version-mismatched segments are a miss, never an error), writes
+are atomic and best-effort, keys separate corpus roots and recursion modes, and
+the manifest-recomposed corpus key is byte-identical to the full re-hash.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from rac.core.corpus import corpus_content_hash
+from rac.services.freshness import FileState, corpus_hash_from_manifest, stat_scan
+from rac.services.index_store import (
+    manifest_root_key,
+    manifest_store_root,
+    open_freshness_manifest,
+    write_freshness_manifest,
+)
+
+
+def _state(path: Path) -> FileState:
+    from rac.core.corpus import content_hash
+
+    st = path.stat()
+    return FileState(content_hash=content_hash(path), size=st.st_size, mtime_ns=st.st_mtime_ns)
+
+
+def _write_corpus(tmp_path: Path) -> dict[str, FileState]:
+    (tmp_path / "sub").mkdir()
+    files = {
+        "a.md": "# Alpha\n\nbody alpha\n",
+        "b.md": "# Beta\n\nbody beta\n",
+        "sub/c.md": "# Gamma\n\nbody gamma\n",
+    }
+    for rel, text in files.items():
+        (tmp_path / rel).write_text(text, encoding="utf-8")
+    return {rel: _state(tmp_path / rel) for rel in files}
+
+
+def test_manifest_round_trips(tmp_path):
+    manifest = _write_corpus(tmp_path)
+    cache = tmp_path / "cache"
+    key = manifest_root_key(str(tmp_path))
+    assert write_freshness_manifest(cache, key, manifest)
+    assert open_freshness_manifest(cache, key) == manifest
+
+
+def test_missing_corrupt_and_truncated_manifests_are_a_miss(tmp_path):
+    manifest = _write_corpus(tmp_path)
+    cache = tmp_path / "cache"
+    key = manifest_root_key(str(tmp_path))
+    assert open_freshness_manifest(cache, key) is None, "missing file is a miss"
+
+    write_freshness_manifest(cache, key, manifest)
+    seg = manifest_store_root(cache) / f"{key}.fseg"
+    payload = seg.read_bytes()
+
+    seg.write_bytes(b"garbage")
+    assert open_freshness_manifest(cache, key) is None, "corrupt segment is a miss"
+
+    seg.write_bytes(payload[: len(payload) // 2])
+    assert open_freshness_manifest(cache, key) is None, "truncated segment is a miss"
+
+
+def test_manifest_write_failure_degrades_to_false(tmp_path, monkeypatch):
+    manifest = _write_corpus(tmp_path)
+    cache = tmp_path / "cache"
+    cache.mkdir()
+    (cache / "manifest").touch()  # a file where the store dir must go → mkdir fails
+    assert write_freshness_manifest(cache, manifest_root_key(str(tmp_path)), manifest) is False
+
+
+def test_root_key_separates_roots_and_recursion_modes(tmp_path):
+    a, b = tmp_path / "a", tmp_path / "b"
+    a.mkdir(), b.mkdir()
+    assert manifest_root_key(str(a)) != manifest_root_key(str(b))
+    assert manifest_root_key(str(a)) != manifest_root_key(str(a), recursive=False)
+    assert manifest_root_key(str(a)) == manifest_root_key(str(a), recursive=True)
+
+
+def test_manifest_hash_matches_full_rehash_for_both_modes(tmp_path):
+    _write_corpus(tmp_path)
+    for recursive in (True, False):
+        manifest, _ = stat_scan(
+            tmp_path, str(tmp_path), {}, content_confirm_all=True, recursive=recursive
+        )
+        assert corpus_hash_from_manifest(
+            tmp_path, manifest, recursive=recursive
+        ) == corpus_content_hash(str(tmp_path), recursive=recursive)
+
+
+def test_stat_scan_recursive_flag_bounds_the_walk(tmp_path):
+    _write_corpus(tmp_path)
+    top_only, _ = stat_scan(tmp_path, str(tmp_path), {}, content_confirm_all=True, recursive=False)
+    assert set(top_only) == {"a.md", "b.md"}
+
+
+def test_warm_scan_against_persisted_manifest_reads_no_bytes(tmp_path, monkeypatch):
+    manifest = _write_corpus(tmp_path)
+    cache = tmp_path / "cache"
+    key = manifest_root_key(str(tmp_path))
+    write_freshness_manifest(cache, key, manifest)
+
+    import rac.services.freshness as freshness
+
+    reads: list[str] = []
+    real = freshness.content_hash
+    monkeypatch.setattr(freshness, "content_hash", lambda p: (reads.append(str(p)), real(p))[1])
+    prev = open_freshness_manifest(cache, key)
+    rescanned, changed = stat_scan(tmp_path, str(tmp_path), prev, content_confirm_all=False)
+    assert reads == [], "an unchanged corpus must be confirmed by stats alone"
+    assert changed == set() and rescanned == manifest


### PR DESCRIPTION
# Summary

Implements `rac/roadmaps/warm-by-default.md` (itsthelore/rac-core#340), decided in ADR-112.

Adds:
- Cache on by default across `rac find`, `rac validate`, and `rac mcp`, with `--no-cache` per invocation and a `RAC_NO_CACHE` environment escape; `--cache` stays parseable as an explicit affirmation.
- Stat-proxy freshness as the default verification everywhere: one-shot `rac find` gains a persisted per-root stat manifest (`manifest/v1/{root_key}.fseg`) so a warm run confirms an unchanged corpus by stats alone — zero artifact-byte reads — instead of the previous per-call full re-hash.
- A `--verify` flag on `find`/`validate` forcing the content-confirm-all scan (the full-hash floor) that catches, and repairs the manifest after, the one rewrite shape stats cannot see.
- Degrade-never-fail hardening for default-on (`default_cache_dir` falls back to a temp dir when no home resolves), suite cache hermeticity, tests, and the docs flip.

# Roadmap / ADR Trace

Roadmap:
- `rac/roadmaps/warm-by-default.md` (new; tracked in #340)

Relevant ADRs:
- `rac/decisions/adr-112-cache-on-by-default.md` (new, Accepted — supersedes ADR-110)
- `rac/decisions/adr-110-one-shot-find-store-reuse.md` (flipped to Superseded; its store-reuse mechanics carry forward)
- ADR-099/104/106 (opt-in enablement clauses amended in-body by ADR-112), ADR-105 (extended: its ladder and S5 model become the default), ADR-032 (zero-state default revised; the correctness contract is preserved, the mechanism is not)

# Scope

## Included
- Default-on `--cache` on the three surfaces; `--no-cache`; `RAC_NO_CACHE`; `--verify` on `find` and `validate`.
- The `.fseg` freshness-manifest store in `index_store.py`, following the `.vseg` discipline exactly: checksummed segment framing, fail-closed decode (missing/corrupt/truncated/version-mismatch → miss → content-confirm-all scan that self-heals it), atomic best-effort writes.
- `load_or_build(directory, *, recursive, verify)` recomposes the content-addressed key via `corpus_hash_from_manifest` (promoted to public; byte-identical fold to `corpus_content_hash`), stats every enumerated file, and re-reads only stat-changed or new files.
- `stat_scan` gains a `recursive` mode so `--top-level` and recursive walks keep distinct, correctly-bounded manifests (the recursion mode folds into the manifest root key).
- Test-harness hermeticity: `_isolated_xdg` now isolates `XDG_CACHE_HOME` and clears `RAC_CACHE_DIR`/`RAC_NO_CACHE` — load-bearing once the default writes a cache.
- Docs flip (`docs/cli.md`, `docs/mcp.md`, `docs/scale.md`, `docs/shared-server.md`), changelog entry, regenerated agent-rules managed blocks.

## Excluded
- No `--verify` on `rac mcp` — the ADR-105 ladder (inotify → stat → rehash) already owns server freshness; its `verify` rung stays internal.
- No sub-stat changed-set detection (git/fsmonitor): remains a `single-node-scale-residuals` initiative; this change narrows that residual to the sub-stat fast path only.
- No seeding of the MCP tracker cold start from the persisted manifest — recorded as an unscheduled follow-on initiative in the roadmap.
- No change to store format, schema/scoring-fingerprint gates, ranking, or any response bytes.

# Product / Architecture Decisions

- **The S5 accepted miss becomes a property of the default.** A size- and mtime-preserving in-place rewrite between two cached one-shot runs is served stale — accepted by ADR-112 exactly as ADR-105 accepted it for the server, pinned by tests that document the stale serve, and floored by `--verify` (which also repairs the manifest). Add/remove/rename are never at risk: enumeration detects them from the path set.
- **A separate `.fseg` store, not an extension of the marker or `.vseg`.** The `{hash}.json` marker is keyed by the corpus hash — unlocatable without the hash the manifest exists to compute; `.vseg` rows carry validation outcomes under a config fingerprint that find must not couple to. The duplication of stat triples between `.fseg` and `.vseg` is accepted.
- **The recursion mode folds into the manifest root key** (sha256 over the resolved directory, a NUL byte, and the mode label), so `rac find` and `rac find --top-level` cannot thrash or vouch for files the narrower walk never enumerates.
- **Escapes are paired plain-argparse flags** (`--cache` default-true plus `--no-cache` store-false), matching repo style — no `BooleanOptionalAction`; plus `RAC_NO_CACHE` for callers that cannot pass flags (CI, hooks, generated integrations).
- **Degrade-never-fail extends to cache-location resolution**: an unresolvable home falls back under `tempfile.gettempdir()`; an unwritable store/manifest was already a fresh-build fallback. No query fails, and no output changes, because a cache could not be used.
- **Key parity is guaranteed by re-walking, not by sorting the manifest**: `corpus_hash_from_manifest` folds the same rel/hash byte pairs in `find_markdown_files` order, byte-identical to the full re-hash for every non-S5 state.

# User-Facing Contract

## CLI
- `rac find QUERY [DIR]` — served from the persistent store by default; `--no-cache` restores the walk; `--verify` forces the full-hash freshness floor.
- `rac validate DIR` — incremental by default; same `--no-cache`/`--verify` controls (directory mode).
- `rac mcp` — derived-index cache and freshness tracker on by default; `--no-cache` restores per-call re-reads.
- `RAC_NO_CACHE=1` disables the cache environment-wide; `RAC_CACHE_DIR`/`XDG_CACHE_HOME` still place it.

## Human Output
Byte-identical to the pre-flip output in every mode. The `rac mcp` stderr startup notice now announces the cache default and names the escapes.

## JSON Output
Unchanged — byte parity between cached and uncached paths is the pinned contract; `schema_version` stays `1`.

## Exit Codes
- `0`: unchanged semantics (a query always succeeds; an unusable cache location degrades, never errors)
- `1`: unchanged (validation errors; under the S5 window `--verify` is the run that surfaces them)
- `2`: unchanged (usage / not a directory)

# Verification

## Ran
- `pytest tests/` — 2,175 passed (full suite, cache-on default bearing the whole battery).
- `ruff check src/ tests/` clean; `ruff format` clean.
- `rac validate rac/` — 406/406 valid; `rac relationships rac/ --validate` — 2,357 checked, 0 issues; `rac review rac/` — no P1–P2 findings.
- Smoke matrix in a scratch `RAC_CACHE_DIR`: cold/warm/`--verify`/`--no-cache` outputs byte-compared equal (`cmp`); read-only cache dir → exit 0; `RAC_NO_CACHE=1` leaves the cache dir nonexistent; cold 2323 ms vs warm 411 ms on this repository. 

## Covered
- Byte parity: default vs `--cache` vs `--no-cache` vs `--verify` across search, `--decisions`, `--type`, `--tag`, `--explain`, `--top-level`, and every validate output; unwritable-store fallback on the default path.
- Freshness: warm run reads zero artifact bytes (counting seam on `content_hash`); ordinary edit/add/delete/rename rebuild byte-identically; the S5 rewrite is pinned as the accepted stale serve at both the `load_or_build` seam and through both CLIs, with `--verify` observing it and repairing the manifest for subsequent default runs.
- Resilience: missing/corrupt/truncated `.fseg` is a miss that self-heals; manifest-present/store-deleted rebuilds and rewrites; homeless environment (no `HOME`, no overrides) answers with exit 0; manifest write failure degrades silently.
- Flags: default-on parses on all three commands; `--verify` rejected on `mcp`; `RAC_NO_CACHE` gates `_cache_enabled` and writes nothing end-to-end; `run_server` builds a cache by default and none with `cache_enabled=False`.

# Review Path

1. `rac/decisions/adr-112-cache-on-by-default.md` and the ADR-110 status flip — the contract.
2. `src/rac/services/index_store.py` (the `.fseg` block) and `src/rac/services/freshness.py` (`recursive`, public `corpus_hash_from_manifest`).
3. `src/rac/services/derived_cache.py` — the new `load_or_build` freshness algorithm and `default_cache_dir` hardening.
4. `src/rac/cli.py` / `src/rac/mcp/server.py` — flag surface, `_cache_enabled`, wiring.
5. `tests/test_find_manifest.py`, `tests/test_find_cache.py`, `tests/test_derived_cache.py`, `tests/test_b4_incremental_validate.py`, `tests/conftest.py`.
6. Docs and changelog.

# Notes For Reviewer

- The one behavioral window this PR knowingly opens is S5 on default one-shot runs — the substance of the decision; see the Consequences section of ADR-112 for the bound and the floor.
- The `XDG_CACHE_HOME` isolation in `tests/conftest.py` is load-bearing: without it any CLI-driving test writes to the real developer cache under `~/.cache/rac`.
- The first-ever cached run against a corpus pays the cold parallel build ADR-110 recorded as heavier than a plain walk; `--no-cache`/`RAC_NO_CACHE` is the documented lever for genuinely one-off invocations.
- Deferred follow-ups live in `rac/roadmaps/warm-by-default.md` (MCP tracker seeding) and `rac/roadmaps/future/single-node-scale-residuals.md` (sub-stat detection).

# Implementation Process

Implemented with AI assistance under the roadmap contract; final scope, review, and acceptance decisions rest with the maintainer.