### PR TITLE
docs(release): cut v0.23.0 "warm by default" release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ details, release history over commit history.
 
 ## Unreleased
 
+_Nothing yet._
+
+## v0.23.0 — the "warm by default" release
+
 **The cache is on by default** (ADR-112, supersedes ADR-110). `rac find`,
 `rac validate`, and `rac mcp` now reuse the persistent derived-index and
 per-file result caches without a flag — repeated queries against an unchanged

--- a/sbom.json
+++ b/sbom.json
@@ -6,9 +6,9 @@
     "component": {
       "type": "library",
       "name": "rac-core",
-      "version": "0.22.0",
-      "bom-ref": "rac-core@0.22.0",
-      "purl": "pkg:pypi/rac-core@0.22.0"
+      "version": "0.23.0",
+      "bom-ref": "rac-core@0.23.0",
+      "purl": "pkg:pypi/rac-core@0.23.0"
     }
   },
   "components": [


### PR DESCRIPTION
## Why

`v0.22.0` "scale" is released. The **warm-by-default** work (cache on by default, ADR-112) has since accumulated under `## Unreleased`. This promotes it to a release heading so the `v0.23.0` publish gates resolve — the release verifier needs a `## v0.23.0` CHANGELOG entry and the SBOM test pins the root version to the newest `## vX.Y.Z` heading.

## What

- **`CHANGELOG.md`** — rename `## Unreleased` → `## v0.23.0 — the "warm by default" release` (the cache-on-by-default entry is already written under it); open a fresh empty `## Unreleased`.
- **`sbom.json`** — root component `0.22.0` → `0.23.0` (`version`/`bom-ref`/`purl`). Dependency components untouched.

## Verification

- `tests/test_sbom.py` — 5 passed (root version now matches the newest heading).
- `python -m rac.release v0.23.0` — ✓ well-formed and has a changelog entry.
- `scripts/generate_sbom.py` — regenerates the root at `0.23.0` (agrees with the committed value).

## After this merges

Tag `v0.23.0` at the resulting `main` HEAD and cut the GitHub Release with the `v0.23.0` "warm by default" body. `v0.22.0` is unaffected.
