### PR TITLE
docs(roadmap): mint agentic-demand-alignment, three gap designs, ADR-113 [roadmap:agentic-demand-alignment]

### DIFF
--- a/.cursor/rules
+++ b/.cursor/rules
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: cd72659c13336cefafdf6eb7016cd29552662e381de5bc57728a4f72016fb852) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: 031ef5512b2606ff5eb612131db2e816624be8419e93a6a222505eeaed2e7e5c) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -83,4 +83,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KWY7886GSEE5** — ADR-109: Tag Search Tier and Tag Facet _(Technical)_
 - **RAC-KX04DH293JG8** — ADR-111: Revert to SemVer Release Versioning _(Process)_
 - **RAC-KX2WTHEMDEY0** — ADR-112: Cache On by Default, Stat-Proxy Freshness as the Floor _(Technical)_
+- **RAC-KX8GEA45HRBM** — ADR-113: Capture Writes Arrive Through a Sibling Surface, Not Guide _(Architecture)_
 <!-- END RAC MANAGED BLOCK -->

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: cd72659c13336cefafdf6eb7016cd29552662e381de5bc57728a4f72016fb852) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: 031ef5512b2606ff5eb612131db2e816624be8419e93a6a222505eeaed2e7e5c) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -83,4 +83,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KWY7886GSEE5** — ADR-109: Tag Search Tier and Tag Facet _(Technical)_
 - **RAC-KX04DH293JG8** — ADR-111: Revert to SemVer Release Versioning _(Process)_
 - **RAC-KX2WTHEMDEY0** — ADR-112: Cache On by Default, Stat-Proxy Freshness as the Floor _(Technical)_
+- **RAC-KX8GEA45HRBM** — ADR-113: Capture Writes Arrive Through a Sibling Surface, Not Guide _(Architecture)_
 <!-- END RAC MANAGED BLOCK -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- BEGIN RAC MANAGED BLOCK (digest: cd72659c13336cefafdf6eb7016cd29552662e381de5bc57728a4f72016fb852) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: 031ef5512b2606ff5eb612131db2e816624be8419e93a6a222505eeaed2e7e5c) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -83,4 +83,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KWY7886GSEE5** — ADR-109: Tag Search Tier and Tag Facet _(Technical)_
 - **RAC-KX04DH293JG8** — ADR-111: Revert to SemVer Release Versioning _(Process)_
 - **RAC-KX2WTHEMDEY0** — ADR-112: Cache On by Default, Stat-Proxy Freshness as the Floor _(Technical)_
+- **RAC-KX8GEA45HRBM** — ADR-113: Capture Writes Arrive Through a Sibling Surface, Not Guide _(Architecture)_
 <!-- END RAC MANAGED BLOCK -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ to the corpus artifact and they load through the imports below.
 - Previous series: `rac/roadmaps/v0.21.x-editor/` (complete)
 - Decisions (ADRs): `rac/decisions/`
 
-<!-- BEGIN RAC MANAGED BLOCK (digest: cd72659c13336cefafdf6eb7016cd29552662e381de5bc57728a4f72016fb852) -->
+<!-- BEGIN RAC MANAGED BLOCK (digest: 031ef5512b2606ff5eb612131db2e816624be8419e93a6a222505eeaed2e7e5c) -->
 <!-- Managed by `rac export --agent-rules`. Edit decisions in rac/, not here; content outside this block is preserved. -->
 ## Settled decisions (RAC)
 
@@ -108,4 +108,5 @@ These decisions are already accepted. Do not re-open or contradict them; ask the
 - **RAC-KWY7886GSEE5** — ADR-109: Tag Search Tier and Tag Facet _(Technical)_
 - **RAC-KX04DH293JG8** — ADR-111: Revert to SemVer Release Versioning _(Process)_
 - **RAC-KX2WTHEMDEY0** — ADR-112: Cache On by Default, Stat-Proxy Freshness as the Floor _(Technical)_
+- **RAC-KX8GEA45HRBM** — ADR-113: Capture Writes Arrive Through a Sibling Surface, Not Guide _(Architecture)_
 <!-- END RAC MANAGED BLOCK -->

--- a/rac/decisions/adr-113-capture-sibling-surface.md
+++ b/rac/decisions/adr-113-capture-sibling-surface.md
@@ -1,0 +1,114 @@
+---
+schema_version: 1
+id: RAC-KX8GEA45HRBM
+type: decision
+---
+# ADR-113: Capture Writes Arrive Through a Sibling Surface, Not Guide
+
+## Status
+
+Accepted
+
+## Category
+
+Architecture
+
+## Context
+
+The `guide-capture-path` design proposes an agent-facing capture path: a
+draft-only `propose_artifact` capability that writes untrusted drafts,
+preserving both gates of the two-gate capture model (ADR-077) and the
+human-review trust boundary (ADR-065). Its open question was where the
+capability mounts.
+
+Mounting it inside Guide is not an amendment-free option. Guide's
+read-only property is ratified decision text, not an incidental posture:
+ADR-031 pins "no file creation, modification, deletion, or Git operation
+is importable from the server layer, enforced by an isolation test";
+ADR-032 frames every tool call as a stateless read; ADR-030 pins the
+tools-only, read-only surface enumeration and its description budget
+(ADR-033). Any write tool inside Guide falsifies that text and requires
+superseding three decisions at once.
+
+A second force points the same way. RAC's presence is expanding beyond
+the CLI and MCP — the editor extension exists (ADR-067, ADR-068), and a
+desktop or web application face is a plausible next surface (the Explorer
+line, ADR-028/ADR-029; the overlay and capture host surfaces recorded in
+`lore-capture-followups`). Every such face needs the same write
+capability with the same guarantees. Binding capture to Guide's MCP
+contract would couple a general write path to one delivery channel and
+its budget; each new face would re-open the Guide contract again.
+
+## Decision
+
+Capture writes arrive through a sibling write surface, separate from
+Guide. Guide remains read-only; ADR-030, ADR-031, ADR-032, and ADR-033
+are not amended.
+
+- The sibling surface is a separately-mounted module that the Guide
+  server layer never imports. The ADR-031 isolation battery continues to
+  pass unchanged, and gains a counterpart: the sibling surface imports
+  write services but must not be importable from Guide.
+- The surface is draft-only by construction: it can mint and write
+  untrusted drafts (ADR-077 gate one's mechanical step) and can never
+  write into the trusted corpus tree, merge, or promote. Promotion stays
+  human-reviewed PR (ADR-065).
+- It is one write path with many faces: the MCP capture tool is its first
+  consumer, and any future desktop or web application face consumes the
+  same surface rather than growing its own write path.
+- It ships opt-in and off by default; enabling it is an explicit server
+  or host decision. Audit obligations (ADR-084) extend to its writes.
+- Its tool and endpoint contract is pinned and budgeted in its own design
+  under the same discipline as Guide's (`guide-tool-surface` precedent),
+  but with its own budget — it does not spend Guide's.
+
+## Consequences
+
+- Guide's contract, isolation guarantee, and standing token budget are
+  untouched; existing consumers see no change.
+- Agent capture and any future app face share one tested write path with
+  the two-gate model enforced by construction, not per-surface
+  convention.
+- The cost is a second pinned surface to version and test, and a second
+  mounting step for hosts that want capture — accepted as the price of
+  keeping the read surface's guarantees simple and absolute.
+- A future decision may still mount both surfaces on one server process
+  (one port, two contracts); this decision constrains import graphs and
+  contracts, not process topology (ADR-098 governs shared serving).
+
+## Alternatives Considered
+
+- A sixth tool inside Guide. Rejected: requires superseding the read-only
+  clause of ADR-031, the surface enumeration of ADR-030, and re-measuring
+  the ADR-033 budget; couples every future write-capable face to the MCP
+  contract.
+- Keeping capture CLI/skill-only. Rejected as a terminal state: it leaves
+  the mid-session capture need unmet (July 2026 demand research) and
+  pushes each future app face to invent its own write path.
+- A fully separate server binary. Deferred, not rejected: the sibling
+  module can be packaged either way; ADR-098 topology questions are
+  decided when the first non-MCP face ships.
+
+## Related Decisions
+
+- adr-028
+- adr-029
+- adr-030
+- adr-031
+- adr-032
+- adr-033
+- adr-065
+- adr-067
+- adr-068
+- adr-077
+- adr-084
+- adr-098
+
+## Related Designs
+
+- guide-capture-path
+
+## Related Roadmaps
+
+- agentic-demand-alignment
+- lore-capture-followups

--- a/rac/designs/guide-capture-path.md
+++ b/rac/designs/guide-capture-path.md
@@ -1,0 +1,111 @@
+---
+schema_version: 1
+id: RAC-KX8EACS410ZE
+type: design
+---
+# Guide Capture Path — Agent-Originated Drafts Over MCP
+
+## Status
+
+Proposed
+
+## Context
+
+The Guide surface is read-only by decision (ADR-031, ADR-034): five tools,
+no write-capable service imported, enforced by the MCP isolation battery.
+Capture today is CLI + skill + human PR (the two-gate model, ADR-077). July
+2026 demand research (`research/2026-07-agentic-tooling-demand.md`) shows
+cross-session agent memory as a top unmet need, and the specific failure is
+mid-session: an agent grounds through `lore`, makes or observes a decision
+with its human, and has no path to record it through the same channel — the
+knowledge evaporates when the session ends.
+
+## User Need
+
+A developer working with an agent that is already connected to `lore`. When
+the session produces a decision, requirement, or design worth keeping, they
+need the agent to draft it into the corpus *at the moment it happens*, with
+no context switch to the CLI — while the team keeps the guarantee that
+nothing enters the trusted corpus without human review by someone other
+than the author.
+
+## Design
+
+Add a capture path that writes only untrusted drafts, keeping both gates of
+ADR-077 intact:
+
+- A single additive tool (working name `propose_artifact`) accepting a type,
+  a title, and body Markdown. It runs `rac new` semantics (engine mints the
+  id, canonical template, never overwrites), writes under the untrusted
+  drafts location (`drafts/` or a capture branch, per ADR-077), validates
+  structurally, and returns the draft path plus validation findings. It
+  never writes into the trusted corpus tree and never merges.
+- Gate one remains the human ratifying the draft in conversation; gate two
+  remains promotion by human-reviewed PR (ADR-065). The tool automates only
+  the mechanical write between the gates.
+- The tool ships opt-in (off by default; enabled by explicit server flag or
+  config) so the default Guide surface stays read-only for consumers who
+  ratified that posture.
+- The tool description instructs the agent to interview before proposing,
+  mirroring the `rac-capture` skill's contract, and to report the draft
+  path and next step (open a PR) to the human.
+
+## Constraints
+
+- ADR-034 (agent reasoning boundary) and ADR-031 (in-process core
+  consumption) — the engine still never judges content; validation stays
+  structural.
+- ADR-030 pins the Guide tools-only surface and ADR-033 budgets it; a sixth
+  tool is a ratified contract change and must fit the token budget or ship
+  as a separately-mounted capture surface rather than growing Guide.
+- ADR-065: artifact content is untrusted input; the draft location must be
+  outside what `lore` serves as trusted grounding.
+- ADR-077: both gates preserved; the tool must be incapable of promotion.
+- HTTP serving (ADR-098) must scope the write path per-corpus and keep the
+  audit trail (ADR-084) covering writes as well as reads.
+
+## Rationale
+
+The alternative interpretations — amend ADR-034 to allow general writes, or
+keep capture CLI-only — either dissolve a settled safety boundary or leave
+the demand unmet. Draft-only writes to an untrusted location change neither
+the trust boundary nor the reasoning boundary: the corpus a consumer grounds
+on is exactly as trustworthy as before. The two-gate model was designed for
+precisely this shape of automation.
+
+## Alternatives
+
+- A separate `lore-capture` MCP server binary, fully outside Guide. Cleanest
+  contract story, but doubles the setup burden the demand research flags as
+  the adoption choke point, for the same effective surface.
+- Deep links that pre-fill the `rac-capture` skill or CLI. Zero server
+  change, but breaks the mid-session flow — the agent still cannot act on
+  the channel it grounds through.
+- Amending ADR-034 to permit trusted-tree writes with agent-side review.
+  Rejected outright: it removes the human gate ADR-065 depends on.
+
+## Open Questions
+
+- Does `propose_artifact` mount inside Guide (contract change to ADR-030,
+  budget change to ADR-033) or as a sibling surface on the same server
+  process? The budget measurement should decide.
+- Drafts location: `drafts/` directory versus capture branch — which does
+  the promotion PR flow handle with less friction?
+- Should the tool accept relationship links, or leave linking to the
+  promotion review where the human can see resolution results?
+
+## Related Decisions
+
+- adr-030
+- adr-031
+- adr-033
+- adr-034
+- adr-065
+- adr-077
+- adr-084
+- adr-098
+
+## Related Roadmaps
+
+- lore-capture-followups
+- agentic-demand-alignment

--- a/rac/designs/guide-capture-path.md
+++ b/rac/designs/guide-capture-path.md
@@ -34,6 +34,10 @@ than the author.
 Add a capture path that writes only untrusted drafts, keeping both gates of
 ADR-077 intact:
 
+- The capability mounts as a sibling write surface, not inside Guide
+  (ADR-113): a separately-mounted module the Guide server layer never
+  imports, so the ADR-031 isolation battery passes unchanged and any
+  future desktop or web application face consumes the same write path.
 - A single additive tool (working name `propose_artifact`) accepting a type,
   a title, and body Markdown. It runs `rac new` semantics (engine mints the
   id, canonical template, never overwrites), writes under the untrusted
@@ -55,9 +59,10 @@ ADR-077 intact:
 - ADR-034 (agent reasoning boundary) and ADR-031 (in-process core
   consumption) — the engine still never judges content; validation stays
   structural.
-- ADR-030 pins the Guide tools-only surface and ADR-033 budgets it; a sixth
-  tool is a ratified contract change and must fit the token budget or ship
-  as a separately-mounted capture surface rather than growing Guide.
+- ADR-030 pins the Guide tools-only surface and ADR-033 budgets it;
+  ADR-113 resolves the mounting question — the capture surface is a
+  sibling with its own pinned contract and budget, and Guide is not
+  amended.
 - ADR-065: artifact content is untrusted input; the draft location must be
   outside what `lore` serves as trusted grounding.
 - ADR-077: both gates preserved; the tool must be incapable of promotion.
@@ -86,9 +91,6 @@ precisely this shape of automation.
 
 ## Open Questions
 
-- Does `propose_artifact` mount inside Guide (contract change to ADR-030,
-  budget change to ADR-033) or as a sibling surface on the same server
-  process? The budget measurement should decide.
 - Drafts location: `drafts/` directory versus capture branch — which does
   the promotion PR flow handle with less friction?
 - Should the tool accept relationship links, or leave linking to the
@@ -104,6 +106,7 @@ precisely this shape of automation.
 - adr-077
 - adr-084
 - adr-098
+- adr-113
 
 ## Related Roadmaps
 

--- a/rac/designs/paraphrase-recall-response.md
+++ b/rac/designs/paraphrase-recall-response.md
@@ -1,0 +1,117 @@
+---
+schema_version: 1
+id: RAC-KX8EAEPHWWQQ
+type: design
+---
+# Paraphrase Recall Response — Closing the Miss Side of Deterministic Search
+
+## Status
+
+Proposed
+
+## Context
+
+Retrieval is deterministic and lexical by hard decision: token-boundary
+matching (ADR-037), a body-text tier (ADR-038), tag tier (ADR-109), BM25 +
+RRF fusion with a bounded graph boost, and no embeddings or LLM judging
+anywhere in core (ADR-066, ADR-002). The recorded cost is the paraphrase
+gap: a query with zero keyword overlap misses silently. July 2026 demand
+research (`research/2026-07-agentic-tooling-demand.md`) puts context-supply
+over MCP at the centre of what agent-equipped teams want, and they will
+judge it by recall. The outbound Supermemory adapter
+(`lore-supermemory-grounding`) records the sidecar direction; explain-miss
+diagnostics are recorded in `retrieval-diagnostics`. This design ties those
+threads into one answer to the question "what happens when a well-formed
+query misses?"
+
+## User Need
+
+An agent (or its human) asks `lore` a reasonable question phrased in words
+the corpus does not use — "what did we decide about caching defaults?"
+against an artifact titled "warm-by-default" — and gets an empty result.
+They need either the right artifact anyway, or a legible explanation of the
+miss and a cheap next move, instead of silently concluding the knowledge
+does not exist.
+
+## Design
+
+Three layers, none of which put semantics inside core:
+
+- **Deterministic reformulation guidance (core).** On a low-confidence or
+  empty result, `search_artifacts` returns a structured miss payload
+  instead of a bare empty list: nearest lexical neighbours (existing index
+  terms with closest token overlap), the tag facet, and a one-line
+  instruction telling the agent to reformulate using corpus vocabulary.
+  The reasoning stays on the agent's side of the ADR-034 boundary — core
+  supplies vocabulary, the model does the paraphrasing. This exploits the
+  fact that every MCP consumer already has a capable model in the loop.
+- **Explain-miss (core).** The `retrieval-diagnostics` explain-miss
+  initiative: `rac find --explain-miss <id>` answers "why did this query
+  not surface artifact X" with the tier-by-tier reason. Serves corpus
+  authors tuning titles and tags so lexical recall improves at the source.
+- **Semantic sidecar (outside core).** For teams that want associative
+  recall, the outbound-only export path of `lore-supermemory-grounding`
+  stands: RAC exports, the sidecar recalls, the artifact id always resolves
+  back through `lore` for the deterministic ground truth. Core never reads
+  the sidecar back.
+
+## Constraints
+
+- ADR-066 and ADR-002 are not amended: no embeddings, no LLM judge, no
+  network calls in core retrieval.
+- ADR-037/ADR-038/ADR-109 tier semantics unchanged; the miss payload is
+  additive to the response shape, subject to JSON contract stability
+  (ADR-007) and the Guide response budget (ADR-033).
+- ADR-032: the miss payload must be computable statelessly from the index.
+- The reformulation loop costs the agent an extra tool call; the payload
+  must be small enough that retry-with-better-vocabulary is cheaper than
+  the agent giving up.
+
+## Rationale
+
+The paraphrase gap does not require abandoning determinism — it requires
+noticing that the consumer is a model. Supplying corpus vocabulary on a
+miss converts "silent empty result" into a one-turn self-correction, keeps
+every core guarantee, and is testable with the deterministic grounding
+eval (ADR-066). The sidecar remains available for teams whose recall needs
+exceed what reformulation delivers, without core inheriting its trust
+problems.
+
+## Alternatives
+
+- Embeddings in core behind a flag. Rejected: splits the determinism
+  guarantee into configuration, contradicts ADR-066 rather than working
+  within it.
+- Static synonym/alias tables in config. Deterministic and honest, but
+  maintenance-heavy and perpetually stale; vocabulary-on-miss achieves the
+  same effect using the model already present.
+- Doing nothing beyond the sidecar. Leaves the default (keyless, core-only)
+  experience with silent misses, which is where the demand research says
+  the judgement happens.
+
+## Open Questions
+
+- Miss-payload trigger: empty results only, or also below a score
+  threshold? A threshold risks noise on genuinely thin corpora.
+- How many neighbour terms fit the ADR-033 budget without crowding out
+  real results on the hit path?
+- Should the grounding eval (ADR-066) grow a paraphrase family to measure
+  whether reformulation actually closes the gap?
+
+## Related Decisions
+
+- adr-002
+- adr-007
+- adr-032
+- adr-033
+- adr-034
+- adr-037
+- adr-038
+- adr-066
+- adr-109
+
+## Related Roadmaps
+
+- retrieval-diagnostics
+- lore-supermemory-grounding
+- agentic-demand-alignment

--- a/rac/designs/spec-driven-handoff.md
+++ b/rac/designs/spec-driven-handoff.md
@@ -1,0 +1,119 @@
+---
+schema_version: 1
+id: RAC-KX8EAGMSD98N
+type: design
+---
+# Spec-Driven Handoff — Roadmap Decomposition and Session Context Packets
+
+## Status
+
+Proposed
+
+## Context
+
+Spec-driven development is the dominant community workflow in the July 2026
+demand research (`research/2026-07-agentic-tooling-demand.md`): specs and
+plans in git-tracked Markdown, decomposed into subtasks with acceptance
+criteria, a fresh agent session per subtask. RAC models the upstream half —
+roadmaps, designs, decisions, validated and linked — but stops at the
+boundary: ADR-093 puts execution tracking in GitHub Issues and ADR-017
+keeps RAC out of work management. Nothing today turns a roadmap initiative
+into agent-sized work items, and nothing assembles the context a fresh
+session needs. The community routes around the gap with hand-rolled
+markdown; the boundary itself is untooled.
+
+## User Need
+
+A developer (often solo, agent-equipped) has a scoped roadmap item in the
+corpus and wants to execute it as a series of fresh agent sessions. They
+need each subtask to carry its acceptance criteria and its slice of
+corpus context — governing decisions, the initiative's intent, links back
+to the artifacts — without hand-assembling a context file per session, and
+without RAC becoming the tracker.
+
+## Design
+
+Two additive, deterministic projections at the corpus/tracker boundary:
+
+- **Decomposition export.** `rac export --issues <roadmap-artifact>` emits
+  one issue body per initiative of a roadmap artifact: initiative text,
+  acceptance criteria derived from the artifact's success measures and any
+  linked requirement statements, plus a footer naming the governing
+  artifact ids. Output is files (or `--json`), file-first per ADR-011 —
+  a wrapper or the GitHub Action pushes them to the tracker; core never
+  calls a tracker API. Round-trip traceability uses the external-reference
+  edge vocabulary already ratified (ADR-087, ADR-096): the issue links the
+  artifact id, the artifact may carry the ticket reference.
+- **Context packet.** `rac export --context <path-or-artifact-id>` emits a
+  single bounded Markdown packet for starting a fresh agent session on one
+  subtask: the governing decisions for the code scope (the existing
+  `decisions_for_path` reader), the initiative text and acceptance
+  criteria, linked designs, and pointers (ids, not bodies) to everything
+  else — the corpus-backed version of the fresh-session-per-subtask
+  pattern the community assembles by hand. Deterministic and byte-stable
+  for identical corpus bytes, same discipline as `--agent-rules`
+  (agent-decision-enforcement, ADR-067).
+
+## Constraints
+
+- ADR-017 and ADR-093 are not amended: RAC emits projections; issue
+  lifecycle, assignment, and status live in the tracker. The export is
+  one-way and stateless.
+- ADR-011 file-first: outputs are files; tracker delivery is a consumer's
+  job (Action, wrapper, or the human).
+- ADR-005/ADR-007: both verbs carry human and JSON output under the
+  stability contract.
+- ADR-002: decomposition is structural (initiative sections, linked
+  requirement statements) — no model in core inventing acceptance criteria
+  that are not in the artifacts.
+- Context packets compete for the agent's attention budget; the packet
+  must be distilled with pointers, the same lesson as the ADR-067 rules
+  block.
+
+## Rationale
+
+The demand is real but the settled boundary is right: owning execution
+state would make RAC a work tracker (rejected in ADR-017 deliberately).
+Projections capture the value — the corpus becomes the source both for
+what the work is and for what a session needs to know — while the tracker
+keeps the state. It also positions orchestrators and verification gates
+(demand categories RAC should not compete in) as consumers: they spawn the
+sessions; RAC supplies the packets.
+
+## Alternatives
+
+- A task/subtask artifact family inside RAC. Rejected: contradicts ADR-017;
+  duplicates tracker state that goes stale immediately.
+- Tracker-API integration in core (create issues directly). Rejected:
+  breaks ADR-011 file-first and drags provider auth into core; the
+  connectors layer (ADR-073) is the home for outbound delivery.
+- Leaving decomposition entirely to the agent with the corpus as reference.
+  Status quo; forfeits determinism and repeatability at exactly the step
+  where drift between spec and work items begins.
+
+## Open Questions
+
+- Does the decomposition unit map 1:1 to roadmap initiatives, or do large
+  initiatives need a structured sub-item convention inside the artifact?
+- Where does `--context` draw the packet size line, and is the budget
+  configurable or fixed like the Guide surface (ADR-033)?
+- Should the GitHub Action grow an issue-sync mode, and does that belong
+  to this repo or a connector (ADR-073, ADR-092)?
+
+## Related Decisions
+
+- adr-002
+- adr-005
+- adr-007
+- adr-011
+- adr-017
+- adr-067
+- adr-073
+- adr-087
+- adr-093
+- adr-096
+
+## Related Roadmaps
+
+- decisions-on-pr
+- agentic-demand-alignment

--- a/rac/roadmaps/future/agentic-demand-alignment.md
+++ b/rac/roadmaps/future/agentic-demand-alignment.md
@@ -47,10 +47,11 @@ excluded because the native-core rewrite addresses them separately.
   explain-miss diagnostics, and the semantic sidecar for teams that want
   it. Owned by the `paraphrase-recall-response` design, with
   `retrieval-diagnostics` and `lore-supermemory-grounding`.
-- **Agent-originated capture.** A draft-only write path adjacent to the
-  Guide surface, preserving ADR-077's two gates and ADR-065's trust
-  boundary. Owned by the `guide-capture-path` design, alongside the host
-  surfaces recorded in `lore-capture-followups`.
+- **Agent-originated capture.** A draft-only write path on a sibling
+  surface separate from Guide (ADR-113), preserving ADR-077's two gates
+  and ADR-065's trust boundary, and reusable by a future desktop or web
+  application face. Owned by the `guide-capture-path` design, alongside
+  the host surfaces recorded in `lore-capture-followups`.
 - **Own the spec-driven loop's boundary.** Issue decomposition and
   session context packets as deterministic exports, plus the
   `decisions-on-pr` surfacing lever whose dependencies already shipped.
@@ -88,8 +89,9 @@ excluded because the native-core rewrite addresses them separately.
 
 ## Risks
 
-- The capture path's surface decision (inside Guide versus sibling) stalls
-  on the ADR-030/ADR-033 contract question and the demand window passes.
+- The capture surface's own contract and budget (ADR-113 requires both)
+  are under-specified before implementation and drift the way the Guide
+  surface's discipline was designed to prevent.
 - Miss payloads bloat the response budget and degrade the hit path they
   were meant to protect.
 - Decomposition export quietly becomes a tracker: scope discipline against
@@ -110,6 +112,7 @@ excluded because the native-core rewrite addresses them separately.
 - adr-087
 - adr-093
 - adr-096
+- adr-113
 
 ## Related Designs
 

--- a/rac/roadmaps/future/agentic-demand-alignment.md
+++ b/rac/roadmaps/future/agentic-demand-alignment.md
@@ -1,0 +1,128 @@
+---
+schema_version: 1
+id: RAC-KX8EAJGK1XF1
+type: roadmap
+---
+# Agentic Demand Alignment (Future)
+
+## Status
+
+Planned
+
+Unscheduled — captured as future intent, not yet on a release. This item
+organises the gap analysis against the July 2026 agentic-tooling demand
+research; each initiative points at the artifact that owns the work.
+
+## Context
+
+Community demand research over the last-30-days window 2026-06-10 to
+2026-07-10 (`research/2026-07-agentic-tooling-demand.md`) ranked the tool
+categories indie, agent-equipped developers are actually asking for. Three
+of the top ten — context-supply over MCP, spec-driven development, and
+cross-session artifact memory — are one coherent gap that RAC's
+architecture already targets, and the research concludes RAC should be the
+substrate those workflows consume rather than compete with orchestrators,
+verification gates, or review agents. A repo-grounded gap analysis found
+the distance between that positioning and what is shipped. This roadmap
+records the gaps in one place; performance and scalability gaps are
+excluded because the native-core rewrite addresses them separately.
+
+## Outcomes
+
+- An agent connected to `lore` recovers from a paraphrased query instead
+  of missing silently, and a corpus author can see why a query missed.
+- An agent can draft a corpus artifact mid-session through the channel it
+  grounds on, with both gates of the capture model intact.
+- A roadmap item can be executed as fresh agent sessions without
+  hand-assembled context: decomposition and context packets come from the
+  corpus.
+- Corpus staleness is a gate, not an advisory: drifted knowledge cannot
+  silently remain trusted grounding.
+- A newcomer reaches a well-structured, MCP-connected corpus without
+  discovering conventions by trial and error.
+
+## Initiatives
+
+- **Answer the paraphrase gap.** Miss payloads with corpus vocabulary,
+  explain-miss diagnostics, and the semantic sidecar for teams that want
+  it. Owned by the `paraphrase-recall-response` design, with
+  `retrieval-diagnostics` and `lore-supermemory-grounding`.
+- **Agent-originated capture.** A draft-only write path adjacent to the
+  Guide surface, preserving ADR-077's two gates and ADR-065's trust
+  boundary. Owned by the `guide-capture-path` design, alongside the host
+  surfaces recorded in `lore-capture-followups`.
+- **Own the spec-driven loop's boundary.** Issue decomposition and
+  session context packets as deterministic exports, plus the
+  `decisions-on-pr` surfacing lever whose dependencies already shipped.
+  Owned by the `spec-driven-handoff` design.
+- **Graduate freshness from advisory to gate.** The drift CI gate and
+  freshness-biased retrieval fenced out of phase one of
+  `freshness-and-drift-detection`, and the unbuilt code-scope drift
+  consumer recorded in the `code-scope-consumption` seam.
+- **Tool the cold start.** Opinionated corpus conventions, the mega-doc
+  split recipe, and MCP registration guidance recorded in
+  `corpus-setup-guidance`, treated as adoption work rather than docs
+  polish.
+
+## Success Measures
+
+- Grounding eval gains a paraphrase family and its scores improve once
+  miss payloads ship (ADR-066 keeps scoring deterministic).
+- A capture draft created over MCP lands in the trusted corpus only ever
+  via a human-reviewed PR — verified by test, not convention.
+- A roadmap initiative round-trips to tracker issues and back through
+  external-reference edges (ADR-087, ADR-096) with no hand-edited context
+  files in the session transcripts.
+- A corpus with drifted governed code fails the pre-merge tier (ADR-075)
+  instead of passing with a doctor warning.
+
+## Assumptions
+
+- The demand signal holds: agent harnesses remain the primary consumer of
+  team knowledge, and the community keeps preferring reviewable Markdown
+  over opaque agent memory.
+- The native-core rewrite lands the performance and scale floor, so none
+  of these initiatives need to trade contract clarity for speed.
+- Settled boundaries stay settled: no embeddings in core (ADR-066), no
+  work tracking in RAC (ADR-017), read-only trusted grounding (ADR-065).
+
+## Risks
+
+- The capture path's surface decision (inside Guide versus sibling) stalls
+  on the ADR-030/ADR-033 contract question and the demand window passes.
+- Miss payloads bloat the response budget and degrade the hit path they
+  were meant to protect.
+- Decomposition export quietly becomes a tracker: scope discipline against
+  ADR-017 must be tested, not assumed.
+- Five initiatives invite scope creep into a single release; each is
+  independently shippable and should be scheduled that way.
+
+## Related Decisions
+
+- adr-017
+- adr-030
+- adr-033
+- adr-034
+- adr-065
+- adr-066
+- adr-075
+- adr-077
+- adr-087
+- adr-093
+- adr-096
+
+## Related Designs
+
+- guide-capture-path
+- paraphrase-recall-response
+- spec-driven-handoff
+- code-scope-consumption
+
+## Related Roadmaps
+
+- retrieval-diagnostics
+- lore-supermemory-grounding
+- lore-capture-followups
+- freshness-and-drift-detection
+- corpus-setup-guidance
+- decisions-on-pr

--- a/research/2026-07-agentic-tooling-demand.md
+++ b/research/2026-07-agentic-tooling-demand.md
@@ -1,0 +1,124 @@
+# Indie-Dev Agentic Coding Tooling Demand — Research Brief (July 2026)
+
+> Method: run of the `last30days` skill engine (v3.11.1, keyless tier — Hacker
+> News, GitHub, web grounding; Reddit via grounding fallback) across four query
+> framings, supplemented with native web search, window 2026-06-10 → 2026-07-10.
+> Evidence is community engagement (upvotes, thread volume, repo traction), not
+> editorial curation. Prepared as portable session context for rac-core roadmap
+> thinking. Items **6, 7, and 8** are the categories rac-core / Lore aims to
+> solve for — see the mapping section at the end.
+
+## Headline
+
+The demand has moved up the stack. Indie devs are no longer asking "which AI
+coding tool" — Claude Code, Codex CLI, and Cursor are settled defaults. What
+they are hunting for now is everything *around* the agent: orchestration,
+verification, context supply, and sandboxing. The agent is commoditized; the
+harness around the agent is where the unmet demand is.
+
+Two representative community signals:
+
+- On orchestration, from Ask HN ("In the age of agentic coding why no one
+  talks about orchestration tools",
+  https://news.ycombinator.com/item?id=48641682): "it feels like orchestration
+  tools or how to organise agents is one of the most frequently discussed
+  topics? When I posted this comment there were 4 posts on the front page
+  about orchestration, and another 3 on the second page."
+- On verification, from a builder on r/OpenAI
+  (https://www.reddit.com/r/OpenAI/comments/1ue98q4/): "One of the most
+  annoying things with AI coding agents is this pattern: 'Done.' Then you look
+  closer and it never ran the test, build, or app."
+
+## Top 10 most-demanded tool categories (ranked by engagement)
+
+1. **Terminal agent harnesses.** Claude Code dominates (~40+ mentions in the
+   HN AI-dev-stack thread, https://news.ycombinator.com/item?id=48413629),
+   with Codex CLI, OpenCode, and Pi as the control-oriented alternatives.
+   Still the anchor purchase everything else attaches to.
+2. **Multi-agent orchestrators.** Deterministic coordinators such as
+   `bernstein` (spawns parallel Claude Code / Codex / Gemini agents, verifies
+   with tests, auto-commits, zero LLM tokens on coordination) and Conductor
+   for worktree-parallel workspaces. The loudest "why does nothing great exist
+   yet" category. Index: https://github.com/andyrewlee/awesome-agent-orchestrators
+3. **Verification gates / "done-checkers".** Tools that stop an agent claiming
+   success without a passing check: proof-of-run gates, TDD-enforcing hooks
+   (one dev runs a 300k-line SaaS on nothing but red-green-refactor hooks, no
+   skills or MCP).
+4. **Subagent and plugin marketplaces.** `wshobson/agents` (92 plugins, 199
+   agents, 162 skills, multi-harness; https://github.com/wshobson/agents) and
+   VoltAgent's 100+ subagents
+   (https://github.com/VoltAgent/awesome-claude-code-subagents) are among
+   GitHub's hottest repos. Devs want pre-built roles, not prompt-writing.
+5. **Agent sandboxes and runtimes.** `agenttier` (per-agent Kubernetes pod,
+   default-deny networking), `stablyai/orca` (desktop/mobile agent fleets),
+   and home-rolled container setups. Safety for parallel autonomous agents.
+6. **Context-supply / MCP infrastructure.** Strong pull for "company-wide
+   AGENTS.md delivered over MCP"
+   (https://www.reddit.com/r/mcp/comments/1ude5bp/): agents start every
+   session cold, and devs want durable, versioned organisational context
+   served to them rather than pasted in.
+7. **Spec-driven development tooling.** The dominant workflow pattern: specs
+   and plans in git-tracked markdown, decomposed into subtasks with acceptance
+   criteria, fresh session per subtask. Demand is high but tooling is mostly
+   DIY today.
+8. **Memory and cross-session artifact management.** Notable inversion:
+   built-in agent memory is widely *disabled* as harmful; devs prefer
+   markdown-artifact management across sessions (AGENTS.md / CLAUDE.md and
+   plan files) and call durable artifact management out as an unfilled gap.
+9. **Second-agent code review.** Codex or a separate model routinely used as
+   planner/reviewer over the implementing agent's diffs. Demand rising with
+   the "slopcode abandonment" backlash
+   (https://www.osnews.com/story/145469/most-slopcode-projects-are-abandoned-and-deleted-within-months-of-release/).
+10. **Agent session UIs.** Devs juggle tmux/zellij panes to babysit parallel
+    agents and explicitly wish for native GUI alternatives; `orca` and
+    Conductor are early answers, but the category is wide open.
+
+## Mapping to rac-core / Lore (items 6, 7, 8)
+
+These three demand categories are one coherent gap — *durable, versioned,
+typed context that outlives any single agent session* — and they map directly
+onto rac-core's existing architecture:
+
+- **Item 6 (context-supply / MCP)** is Lore's core proposition: typed Markdown
+  artifacts in the repo, served to agents over MCP (ADR-008 agent-ready
+  architecture, ADR-067 context-supply and post-edit enforcement, ADR-098
+  shared HTTP MCP serving, ADR-033 response budget). The community is asking
+  for exactly "a company-wide AGENTS.md delivered with MCP" — Lore's answer is
+  stronger: not one flat file but a validated, relationship-linked corpus.
+- **Item 7 (spec-driven development)** matches the roadmap-driven workflow RAC
+  itself models: Roadmaps for the what/why, Designs for the how, ADRs for
+  decisions, all git-tracked, validated, and gate-checked (ADR-093 roadmap
+  intent lives in the corpus, ADR-047 agent operating guidance as prompt
+  artifacts). The DIY pattern the community converged on — plans in
+  git-tracked markdown with acceptance criteria — is RAC with the types and
+  gates stripped out.
+- **Item 8 (memory / cross-session artifacts)** validates ADR-017 (RAC manages
+  knowledge, not work) and ADR-045 (recency derived from git): the community
+  has independently rejected opaque built-in agent memory in favour of
+  reviewable markdown artifacts. Lore's two-gate capture model (ADR-077) and
+  human-PR-review trust boundary (ADR-065) are the governance layer that DIY
+  markdown memory lacks.
+
+Positioning implication: rac-core does not need to win categories 1-5 or 9-10;
+it needs to be the context/spec/memory substrate those tools consume. The
+adjacent categories (orchestrators, verification gates, review agents) are
+integration surfaces, not competitors.
+
+## Sources
+
+- HN: AI dev stack thread — https://news.ycombinator.com/item?id=48413629
+- HN: orchestration Ask HN — https://news.ycombinator.com/item?id=48641682
+- wshobson/agents — https://github.com/wshobson/agents
+- VoltAgent subagents — https://github.com/VoltAgent/awesome-claude-code-subagents
+- awesome-agent-orchestrators — https://github.com/andyrewlee/awesome-agent-orchestrators
+- awesome-claude-code — https://github.com/hesreallyhim/awesome-claude-code
+- Northflank: top agentic coding tools 2026 — https://northflank.com/blog/agentic-coding-tools
+- Reddit AI tools roundup — https://diyai.io/ai-tools/reddit/best-ai-coding-tools-on-reddit/
+- Faros: best AI coding agents 2026 — https://www.faros.ai/blog/best-ai-coding-agents-2026
+- r/mcp: company-wide AGENTS.md over MCP — https://www.reddit.com/r/mcp/comments/1ude5bp/
+- r/OpenAI: done-gate tool — https://www.reddit.com/r/OpenAI/comments/1ue98q4/
+- Slopcode abandonment — https://www.osnews.com/story/145469/
+
+Caveat: Reddit's public JSON API was unreachable from the research
+environment, so Reddit signal arrived via web-grounding fallback; engagement
+counts there are less precise than the HN and GitHub ones.


### PR DESCRIPTION
# Summary

Implements `rac/roadmaps/future/agentic-demand-alignment.md` (corpus intent only — no engine code changes).

Adds:
- `research/2026-07-agentic-tooling-demand.md` — last-30-days community demand research (2026-06-10 → 2026-07-10) ranking the top-10 agentic-coding tool categories, with a mapping of categories 6–8 (context-supply over MCP, spec-driven development, cross-session artifact memory) onto RAC's recorded decisions
- Three Proposed designs recording the gap analysis: `guide-capture-path`, `paraphrase-recall-response`, `spec-driven-handoff`
- `agentic-demand-alignment` — a Planned, unscheduled future roadmap item organising the five gap initiatives and linking the already-recorded owners
- ADR-113 — capture writes arrive through a sibling surface, not Guide

# Roadmap / ADR Trace

Roadmap:
- `rac/roadmaps/future/agentic-demand-alignment.md` (new)

Relevant ADRs:
- `rac/decisions/adr-113-capture-sibling-surface.md` (new, Accepted)
- Constrained by, and deliberately not amending: ADR-030/031/032/033 (Guide surface), ADR-065/077 (trust boundary, two-gate capture), ADR-066/037/038 (deterministic retrieval), ADR-017/093 (no work tracking), ADR-011 (file-first)

# Scope

## Included
- Corpus artifacts and one research note only. Every design is Proposed intent; the roadmap item is Planned and unscheduled.
- ADR-113 resolves `guide-capture-path`'s mounting question: Guide stays read-only, the ADR-031 isolation battery is untouched, and capture mounts as a separately-mounted sibling module that a future desktop or web application face can consume as the same write path.

## Excluded
- No implementation of any initiative: no `propose_artifact` tool, no miss payloads or `--explain-miss`, no `rac export --issues/--context`, no drift CI gate, no setup-guidance tooling.
- No amendment to any settled decision — the designs are written to fit inside the recorded boundaries, and where that was impossible (capture), the resolution is a new ADR rather than a reinterpretation.
- No scheduling: initiatives are independently shippable and deliberately not fenced to a release.
- Performance and scalability gaps are excluded throughout as owned by the native-core rewrite.

# Product / Architecture Decisions

- **ADR-113 (the one new decision):** capture writes arrive through a sibling write surface the Guide server layer never imports — draft-only by construction (ADR-077 gate one's mechanical step only), opt-in and off by default, audited (ADR-084), with its own pinned contract and budget rather than spending Guide's. One write path with many faces: the MCP capture tool first, any future desktop/web face on the same path. Process topology (shared process vs separate binary) is deliberately deferred to ADR-098 territory.
- The paraphrase gap is answered without semantics in core: structured miss payloads supply corpus vocabulary and the consuming model reformulates — the reasoning stays on the agent's side of the ADR-034 boundary.
- Spec-driven demand is met at the boundary, not by becoming a tracker: `--issues` and `--context` are one-way, stateless, file-first projections; issue lifecycle stays in the tracker per ADR-017/093.

# User-Facing Contract

No CLI, JSON, or exit-code changes. The corpus gains one decision, three designs, one roadmap item; `research/` is a new top-level directory outside `rac/` (not a typed artifact) and outside `docs/` (not published to the site).

# Verification

## Ran
- `rac validate rac/` — PASS, 411/411 artifacts valid, 0 invalid
- `rac relationships rac/ --validate` — 2429 relationships checked, 0 issues
- `rac review rac/` — no priority 1–2 findings (new designs appear only in the same advisory missing-recommended-sections list as existing designs)

## Covered
- All new artifacts minted with `rac new` (engine-assigned ids), classified as their intended types, and structurally valid
- All relationship links (`adr-*` stems, roadmap/design stems) resolve, including the new ADR-113 ↔ guide-capture-path ↔ agentic-demand-alignment edges

# Review Path

1. `research/2026-07-agentic-tooling-demand.md` — the evidence the rest stands on
2. `rac/roadmaps/future/agentic-demand-alignment.md` — the organising intent
3. `rac/decisions/adr-113-capture-sibling-surface.md` — the one ratified choice
4. The three designs, `guide-capture-path` first (it consumes ADR-113)

# Notes For Reviewer

- ADR-113 lands as Accepted on the strength of the maintainer's in-session ratification; per ADR-065 nothing here is trusted until this PR merges under review, so downgrade to Proposed if that reads too strong.
- `guide-capture-path`'s remaining open questions (drafts location, link handling at promotion) are parked deliberately — they are implementation-time calls.
- The research note cites external URLs; freshness decays quickly in this space, so treat it as a dated snapshot, not living documentation.

# Implementation Process

Researched and drafted with AI assistance under the roadmap contract; final scope, the sibling-surface decision, and acceptance were made by the maintainer.