### PR TITLE
perf(engine): add P6.2 incremental identity generation

### DIFF
--- a/rac/decisions/adr-119-base-plus-delta-serving-generations.md
+++ b/rac/decisions/adr-119-base-plus-delta-serving-generations.md
@@ -55,6 +55,12 @@ the default CLI or MCP server. Later slices may incrementally maintain:
 4. scope rows, live-decision state, and portfolio summary counters; and
 5. durable compaction without snapshot shedding.
 
+P6.2 implements item 1 behind the same preview boundary. Identity and status
+rows are shared across generations, changed rows and tombstones are staged in
+the overlay, and exact point resolution reads the published identity generation.
+The complete derived model remains a referee and the default serving path is
+still unchanged.
+
 No slice becomes the default until mutation referees show byte-identical output
 against a fresh whole-corpus rebuild and scale tests show bounded regression.
 
@@ -64,6 +70,11 @@ P6.1 makes the publication and lifecycle rules executable without changing
 production behavior. Add, edit, delete, rename, compaction, and first-edit-after-
 compaction tests compare the preview's persisted segments byte-for-byte with a
 fresh derivation.
+
+P6.2 adds identity/status and exact-resolution referees for those mutation
+classes, including casefolded aliases and duplicate identities. Staging shares
+the compacted base maps and clones only the bounded overlay; compaction reuses
+unchanged identity rows.
 
 The first slice does not claim mutation-latency improvement for derivation: it
 still materializes live documents and rebuilds all derived structures. Its

--- a/rust/INDEX-REPORT.md
+++ b/rust/INDEX-REPORT.md
@@ -350,6 +350,27 @@ small-corpus band (19.2 ms p50 observed versus P5's 17.2 ms), so no 5k win is
 claimed. Linux clean latency is gated by the inotify integration tests and
 must be benchmarked on the CI/reference Linux host.
 
+### P6.2 incremental-identity result
+
+P6.2 adds the first independently maintained derived family behind ADR-119's
+preview-only publication boundary. Compacted identity and casefolded-alias maps
+are immutable shared bases. A candidate generation stages only changed identity
+and status rows plus tombstones; exact resolution masks replaced base rows,
+uses the compacted alias lookup, and scans only the bounded overlay. Compaction
+reuses unchanged rows by shared ownership rather than rebuilding them.
+
+The mutation referee compares canonical IDs, aliases, artifact type, title,
+status, exact-resolution outcomes, and duplicate-path ordering against a fresh
+whole-corpus build across edit, add, delete, rename, and compaction. A routing
+test deliberately gives the preview a stale full derived index and a current
+identity generation, proving MCP point resolution consumes the incremental
+identity projection.
+
+This changes identity staging from corpus-bound to changeset/overlay-bound, but
+does not claim an end-to-end mutation-latency win: P6.2 intentionally retains
+the complete derived rebuild as a referee while postings, graph, scope, and
+summary remain future slices. The default CLI and MCP paths are unchanged.
+
 ## Performance
 
 See the `PERF-REPORT.md` warm-path addendum. Headline (5k synthetic

--- a/rust/rac-engine/src/delta_generation.rs
+++ b/rust/rac-engine/src/delta_generation.rs
@@ -5,16 +5,186 @@
 //!
 //! `(base - tombstones) + upserts`
 //!
-//! This first P6 slice deliberately still derives the complete read model
-//! from the live documents.  Later slices move postings, graph, scope, and
-//! summary structures into the overlay without changing this publication
-//! boundary.
+//! P6.2 adds an independently staged identity/status projection and exact
+//! resolution over the overlay. The complete derived model remains as the
+//! mutation referee while later slices move postings, graph, scope, and
+//! summary structures behind the same publication boundary.
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 
 use crate::derived::DerivedIndex;
+use crate::pycompat::{py_casefold, py_strip};
 use crate::relationships::CorpusItem;
+use crate::resolve::{
+    artifact_status, identity_entry_from_item, resolved_from_entry, IndexEntry, ResolutionResult,
+    OUTCOME_DUPLICATE, OUTCOME_NOT_FOUND, OUTCOME_RESOLVED,
+};
+
+/// The identity/status projection for one parsed artifact. Rows are shared by
+/// `Arc` so compaction promotes unchanged identities without rebuilding them.
+#[derive(Clone)]
+pub struct IdentityRow {
+    pub entry: IndexEntry,
+    pub status: String,
+}
+
+impl IdentityRow {
+    fn from_item(item: &CorpusItem) -> Self {
+        Self {
+            entry: identity_entry_from_item(item),
+            status: artifact_status(&item.artifact),
+        }
+    }
+}
+
+/// Immutable base identity rows plus a cumulative changeset-bound overlay.
+///
+/// The compacted alias map stays shared. Point resolution consults that map,
+/// masks base rows changed in the overlay, and scans only the (bounded) delta
+/// aliases. Staging therefore never clones or walks the full base.
+#[derive(Clone, Default)]
+pub struct IdentityGeneration {
+    base: Arc<BTreeMap<String, Arc<IdentityRow>>>,
+    base_aliases: Arc<BTreeMap<String, Vec<String>>>,
+    upserts: BTreeMap<String, Arc<IdentityRow>>,
+    tombstones: BTreeSet<String>,
+}
+
+impl IdentityGeneration {
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    pub fn stage(&self, changed: &BTreeSet<String>, parsed: &BTreeMap<String, CorpusItem>) -> Self {
+        let mut next = self.clone();
+        for path in changed {
+            if let Some(item) = parsed.get(path) {
+                next.upserts
+                    .insert(path.clone(), Arc::new(IdentityRow::from_item(item)));
+                next.tombstones.remove(path);
+            } else {
+                next.upserts.remove(path);
+                if next.base.contains_key(path) {
+                    next.tombstones.insert(path.clone());
+                } else {
+                    next.tombstones.remove(path);
+                }
+            }
+        }
+        next
+    }
+
+    pub fn from_items<'a>(items: impl IntoIterator<Item = (&'a str, &'a CorpusItem)>) -> Self {
+        let base: BTreeMap<String, Arc<IdentityRow>> = items
+            .into_iter()
+            .map(|(path, item)| (path.to_string(), Arc::new(IdentityRow::from_item(item))))
+            .collect();
+        Self {
+            base_aliases: Arc::new(alias_map(&base)),
+            base: Arc::new(base),
+            upserts: BTreeMap::new(),
+            tombstones: BTreeSet::new(),
+        }
+    }
+
+    pub fn promote(&mut self) {
+        let mut base = self.base.as_ref().clone();
+        for path in &self.tombstones {
+            base.remove(path);
+        }
+        for (path, row) in &self.upserts {
+            base.insert(path.clone(), Arc::clone(row));
+        }
+        self.base_aliases = Arc::new(alias_map(&base));
+        self.base = Arc::new(base);
+        self.upserts.clear();
+        self.tombstones.clear();
+    }
+
+    pub fn resolve(&self, artifact_id: &str) -> ResolutionResult {
+        let wanted = py_casefold(py_strip(artifact_id));
+        let mut matches: Vec<&IndexEntry> = self
+            .base_aliases
+            .get(&wanted)
+            .into_iter()
+            .flatten()
+            .filter(|path| !self.tombstones.contains(*path) && !self.upserts.contains_key(*path))
+            .filter_map(|path| self.base.get(path).map(|row| &row.entry))
+            .collect();
+        matches.extend(
+            self.upserts
+                .values()
+                .filter(|row| {
+                    row.entry
+                        .aliases
+                        .iter()
+                        .any(|alias| py_casefold(alias) == wanted)
+                })
+                .map(|row| &row.entry),
+        );
+        if matches.is_empty() {
+            return ResolutionResult {
+                artifact_id: artifact_id.to_string(),
+                outcome: OUTCOME_NOT_FOUND,
+                artifact: None,
+                duplicate_paths: Vec::new(),
+            };
+        }
+        if matches.len() > 1 {
+            let mut duplicate_paths: Vec<String> =
+                matches.iter().map(|entry| entry.path.clone()).collect();
+            duplicate_paths.sort();
+            return ResolutionResult {
+                artifact_id: artifact_id.to_string(),
+                outcome: OUTCOME_DUPLICATE,
+                artifact: None,
+                duplicate_paths,
+            };
+        }
+        ResolutionResult {
+            artifact_id: artifact_id.to_string(),
+            outcome: OUTCOME_RESOLVED,
+            artifact: Some(resolved_from_entry(matches[0])),
+            duplicate_paths: Vec::new(),
+        }
+    }
+
+    pub fn status_for_path(&self, path: &str) -> Option<&str> {
+        if let Some(row) = self.upserts.get(path) {
+            return Some(&row.status);
+        }
+        if self.tombstones.contains(path) {
+            return None;
+        }
+        self.base.get(path).map(|row| row.status.as_str())
+    }
+
+    pub fn base_len(&self) -> usize {
+        self.base.len()
+    }
+
+    pub fn upsert_len(&self) -> usize {
+        self.upserts.len()
+    }
+
+    pub fn tombstone_len(&self) -> usize {
+        self.tombstones.len()
+    }
+}
+
+fn alias_map(rows: &BTreeMap<String, Arc<IdentityRow>>) -> BTreeMap<String, Vec<String>> {
+    let mut aliases: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for (path, row) in rows {
+        for alias in &row.entry.aliases {
+            aliases
+                .entry(py_casefold(alias))
+                .or_default()
+                .push(path.clone());
+        }
+    }
+    aliases
+}
 
 /// Parsed documents for an immutable base plus one cumulative overlay.
 #[derive(Clone, Default)]
@@ -132,6 +302,7 @@ pub struct DeltaGeneration {
     pub base_generation: u64,
     pub serving_generation: u64,
     pub changed_paths: Vec<String>,
+    pub identity: IdentityGeneration,
     pub derived: DerivedIndex,
 }
 
@@ -139,10 +310,11 @@ pub struct DeltaGeneration {
 mod tests {
     use super::*;
 
-    const DOC: &str = "# ADR-1: Delta\n\n## Context\n\nTest.\n\n## Decision\n\nKeep.\n\n## Consequences\n\nNone.\n\n## Status\n\nAccepted\n";
+    const DOC: &str = "---\nschema_version: 1\nid: ADR-1\ntype: decision\n---\n# ADR-1: Delta\n\n## Context\n\nTest.\n\n## Decision\n\nKeep.\n\n## Consequences\n\nNone.\n\n## Status\n\nAccepted\n";
 
-    fn item(path: &str) -> CorpusItem {
-        let artifact = crate::parse::parse_text(DOC, path);
+    fn item(path: &str, id: &str, status: &str) -> CorpusItem {
+        let text = DOC.replace("ADR-1", id).replace("Accepted", status);
+        let artifact = crate::parse::parse_text(&text, path);
         let spec = crate::spec::spec_for(&crate::classify::classify(&artifact).artifact_type);
         CorpusItem {
             path: path.to_string(),
@@ -154,8 +326,14 @@ mod tests {
     #[test]
     fn overlay_stage_promote_and_changed_order_are_canonical() {
         let initial = BTreeMap::from([
-            ("b.md".to_string(), item("b.md")),
-            ("d.md".to_string(), item("d.md")),
+            (
+                "b.md".to_string(),
+                item("b.md", "RAC-111111111111", "Accepted"),
+            ),
+            (
+                "d.md".to_string(),
+                item("d.md", "RAC-222222222222", "Accepted"),
+            ),
         ]);
         let mut documents = DeltaDocuments::empty().stage(
             &BTreeSet::from(["b.md".to_string(), "d.md".to_string()]),
@@ -164,14 +342,16 @@ mod tests {
         documents.promote(["b.md", "d.md"]);
 
         documents = documents.stage(
-            &BTreeSet::from([
-                "a.md".to_string(),
-                "b.md".to_string(),
-                "d.md".to_string(),
-            ]),
+            &BTreeSet::from(["a.md".to_string(), "b.md".to_string(), "d.md".to_string()]),
             BTreeMap::from([
-                ("a.md".to_string(), item("a.md")),
-                ("d.md".to_string(), item("d.md")),
+                (
+                    "a.md".to_string(),
+                    item("a.md", "RAC-333333333333", "Proposed"),
+                ),
+                (
+                    "d.md".to_string(),
+                    item("d.md", "RAC-222222222222", "Accepted"),
+                ),
             ]),
         );
         assert_eq!(documents.base_len(), 2);
@@ -188,5 +368,65 @@ mod tests {
         documents.promote(["a.md", "d.md"]);
         assert_eq!(documents.base_len(), 2);
         assert_eq!(documents.delta_len(), 0);
+    }
+
+    #[test]
+    fn identity_overlay_resolves_masks_duplicates_and_promotes() {
+        let base_items = BTreeMap::from([
+            (
+                "b.md".to_string(),
+                item("b.md", "RAC-111111111111", "Accepted"),
+            ),
+            (
+                "d.md".to_string(),
+                item("d.md", "RAC-222222222222", "Accepted"),
+            ),
+        ]);
+        let mut identity = IdentityGeneration::from_items(
+            base_items.iter().map(|(path, item)| (path.as_str(), item)),
+        );
+        assert_eq!(
+            identity.resolve(" rac-111111111111 ").outcome,
+            OUTCOME_RESOLVED
+        );
+        assert_eq!(identity.status_for_path("b.md"), Some("Accepted"));
+
+        let changed = BTreeSet::from(["a.md".to_string(), "b.md".to_string(), "d.md".to_string()]);
+        let parsed = BTreeMap::from([
+            (
+                "a.md".to_string(),
+                item("a.md", "RAC-333333333333", "Proposed"),
+            ),
+            (
+                "d.md".to_string(),
+                item("d.md", "RAC-333333333333", "Accepted"),
+            ),
+        ]);
+        let shared_base = Arc::clone(&identity.base);
+        let shared_aliases = Arc::clone(&identity.base_aliases);
+        identity = identity.stage(&changed, &parsed);
+        assert!(Arc::ptr_eq(&shared_base, &identity.base));
+        assert!(Arc::ptr_eq(&shared_aliases, &identity.base_aliases));
+        assert_eq!(
+            identity.resolve("RAC-111111111111").outcome,
+            OUTCOME_NOT_FOUND
+        );
+        let duplicate = identity.resolve("RAC-333333333333");
+        assert_eq!(duplicate.outcome, OUTCOME_DUPLICATE);
+        assert_eq!(duplicate.duplicate_paths, vec!["a.md", "d.md"]);
+        assert_eq!(identity.status_for_path("a.md"), Some("Proposed"));
+        assert_eq!(identity.status_for_path("b.md"), None);
+        assert_eq!(identity.base_len(), 2);
+        assert_eq!(identity.upsert_len(), 2);
+        assert_eq!(identity.tombstone_len(), 1);
+
+        identity.promote();
+        assert_eq!(identity.base_len(), 2);
+        assert_eq!(identity.upsert_len(), 0);
+        assert_eq!(identity.tombstone_len(), 0);
+        assert_eq!(
+            identity.resolve("RAC-333333333333").duplicate_paths,
+            vec!["a.md", "d.md"]
+        );
     }
 }

--- a/rust/rac-engine/src/freshness.rs
+++ b/rust/rac-engine/src/freshness.rs
@@ -12,8 +12,8 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::path::PathBuf;
 
+use crate::delta_generation::{DeltaDocuments, DeltaGeneration, IdentityGeneration};
 use crate::derived::{build_derived_index_from_items, DerivedIndex, SCHEMA_VERSION};
-use crate::delta_generation::{DeltaDocuments, DeltaGeneration};
 use crate::derived_cache::{corpus_hash_from_complete_manifest, stat_scan};
 use crate::freshness_watch::EventWatch;
 use crate::index_store::{open_store, write_store, FileState, MmapIndexReader};
@@ -50,6 +50,7 @@ pub struct FreshnessTracker {
     /// established snapshot lifecycle until the later delta slices pass the
     /// referee and scale gates.
     delta_documents: Option<DeltaDocuments>,
+    delta_identity: Option<IdentityGeneration>,
     /// ADR-107 RSS finalization: after compaction the resident parsed
     /// snapshot is shed and the mapped base is the whole answer; the next
     /// change repopulates by a full re-parse on demand.
@@ -90,6 +91,7 @@ impl FreshnessTracker {
             serving_generation: 0,
             delta_paths: HashSet::new(),
             delta_documents: None,
+            delta_identity: None,
             snapshot_shed: false,
             last_parse_workers: 1,
             last_parse_files: 0,
@@ -97,7 +99,7 @@ impl FreshnessTracker {
         }
     }
 
-    /// Opt in to the P6.1 generation boundary. This is intentionally a
+    /// Opt in to the P6 generation preview. This is intentionally a
     /// separate constructor so normal MCP serving cannot adopt the preview by
     /// accident.
     pub fn new_delta_preview(
@@ -107,6 +109,7 @@ impl FreshnessTracker {
     ) -> Self {
         let mut tracker = Self::new_with_watcher(cache_dir, root, threshold, true);
         tracker.delta_documents = Some(DeltaDocuments::empty());
+        tracker.delta_identity = Some(IdentityGeneration::empty());
         tracker
     }
 
@@ -364,18 +367,25 @@ impl FreshnessTracker {
         // A parser omission would make the staged generation incomplete.
         // Reparse the current corpus from an empty base instead of publishing
         // a partial overlay.
-        let candidate = if parsed.len() == present.len() {
-            self.delta_documents
+        let (candidate, identity_candidate) = if parsed.len() == present.len() {
+            let identity = self
+                .delta_identity
+                .as_ref()
+                .expect("preview identity")
+                .stage(changed, &parsed);
+            let documents = self
+                .delta_documents
                 .as_ref()
                 .expect("preview documents")
-                .stage(changed, parsed)
+                .stage(changed, parsed);
+            (documents, identity)
         } else {
             self.full_delta_candidate()
         };
         let ordered_paths: Vec<String> = self.manifest.iter().map(|(rel, _)| rel.clone()).collect();
         let ordered_items = candidate.ordered_items(ordered_paths.iter().map(String::as_str));
-        let candidate = if ordered_items.len() == self.manifest.len() {
-            candidate
+        let (candidate, identity_candidate) = if ordered_items.len() == self.manifest.len() {
+            (candidate, identity_candidate)
         } else {
             self.full_delta_candidate()
         };
@@ -386,18 +396,24 @@ impl FreshnessTracker {
             base_generation: self.base_generation,
             serving_generation,
             changed_paths: candidate.changed_paths(),
+            identity: identity_candidate.clone(),
             derived: build_derived_index_from_items(&self.root_str, &ordered_items, true),
         };
 
         self.delta_documents = Some(candidate);
+        self.delta_identity = Some(identity_candidate);
         self.hash = Some(hash);
         self.serving_generation = serving_generation;
         self.model = Some(TrackerModel::Delta(generation));
     }
 
-    fn full_delta_candidate(&mut self) -> DeltaDocuments {
+    fn full_delta_candidate(&mut self) -> (DeltaDocuments, IdentityGeneration) {
         let root = PathBuf::from(&self.root_str);
-        let paths: Vec<PathBuf> = self.manifest.iter().map(|(rel, _)| root.join(rel)).collect();
+        let paths: Vec<PathBuf> = self
+            .manifest
+            .iter()
+            .map(|(rel, _)| root.join(rel))
+            .collect();
         let (parsed, workers) = crate::parallel_build::parallel_parse_paths(&paths);
         self.last_parse_workers = workers;
         self.last_parse_files = paths.len();
@@ -405,8 +421,10 @@ impl FreshnessTracker {
             .into_iter()
             .map(|item| (rel_of(&self.root_str, &item.path), item))
             .collect();
+        let identity =
+            IdentityGeneration::from_items(parsed.iter().map(|(path, item)| (path.as_str(), item)));
         let changed = self.manifest.iter().map(|(rel, _)| rel.clone()).collect();
-        DeltaDocuments::empty().stage(&changed, parsed)
+        (DeltaDocuments::empty().stage(&changed, parsed), identity)
     }
 
     // --- compaction -----------------------------------------------------------
@@ -451,6 +469,10 @@ impl FreshnessTracker {
         if let Some(documents) = self.delta_documents.as_mut() {
             let ordered_paths: Vec<&str> = self.manifest.iter().map(|(rel, _)| rel.as_str()).collect();
             documents.promote(ordered_paths);
+            self.delta_identity
+                .as_mut()
+                .expect("preview identity")
+                .promote();
             // P6 removes snapshot shedding for its parsed document base so
             // the first post-compaction edit remains change-bound.
             self.snapshot_shed = false;

--- a/rust/rac-engine/src/resolve.rs
+++ b/rust/rac-engine/src/resolve.rs
@@ -129,7 +129,7 @@ pub struct IndexEntry {
 /// `_identity_index` never reads tags/sections/graph, so those stay at their
 /// empty defaults — the resolved artifact matches the oracle's shape exactly
 /// and the discarded clones never happen.
-fn identity_entry_from_item(item: &CorpusItem) -> IndexEntry {
+pub(crate) fn identity_entry_from_item(item: &CorpusItem) -> IndexEntry {
     let artifact_type = item
         .spec
         .map(|s| s.name.clone())

--- a/rust/rac-engine/tests/freshness_tracker.rs
+++ b/rust/rac-engine/tests/freshness_tracker.rs
@@ -54,7 +54,10 @@ fn base_delta_compaction_lifecycle() {
     // One change: the delta window opens; serving switches to the
     // re-derived snapshot (no base rewrite below the threshold).
     fs::write(corpus.join("adr-2-two.md"), DOC.replace("ADR-1", "ADR-2")).unwrap();
-    assert!(matches!(tracker.read_model(false), TrackerModel::Snapshot(_)));
+    assert!(matches!(
+        tracker.read_model(false),
+        TrackerModel::Snapshot(_)
+    ));
     assert!(tracker.last_detect_scanned());
     assert_eq!(tracker.base_generation(), 1);
     assert_eq!(tracker.serving_generation(), 2);
@@ -204,6 +207,48 @@ fn assert_delta_matches_fresh(model: &TrackerModel, root: &str, tag: &str) {
         store_hashes(&fresh_cache, key),
         "preview generation must be byte-identical to a fresh derivation"
     );
+    let fresh_items = rac_engine::relationships::corpus_items(root, true);
+    let fresh_index = rac_engine::resolve::index_from_items(&fresh_items);
+    for entry in &fresh_index {
+        for alias in &entry.aliases {
+            let expected = rac_engine::resolve::resolve_in_index(&fresh_index, alias);
+            let actual = generation.identity.resolve(alias);
+            assert_eq!(
+                actual.outcome, expected.outcome,
+                "identity outcome for {alias}"
+            );
+            assert_eq!(actual.duplicate_paths, expected.duplicate_paths);
+            assert_eq!(
+                actual.artifact.as_ref().map(|artifact| (
+                    artifact.id.as_str(),
+                    artifact.artifact_type.as_str(),
+                    artifact.title.as_deref(),
+                    artifact.path.as_str(),
+                )),
+                expected.artifact.as_ref().map(|artifact| (
+                    artifact.id.as_str(),
+                    artifact.artifact_type.as_str(),
+                    artifact.title.as_deref(),
+                    artifact.path.as_str(),
+                )),
+                "identity row for {alias}"
+            );
+        }
+    }
+    let root_path = Path::new(root);
+    for item in &fresh_items {
+        let relative = Path::new(&item.path)
+            .strip_prefix(root_path)
+            .unwrap()
+            .to_string_lossy()
+            .into_owned();
+        let expected_status = rac_engine::resolve::artifact_status(&item.artifact);
+        assert_eq!(
+            generation.identity.status_for_path(&relative),
+            Some(expected_status.as_str()),
+            "status row for {relative}"
+        );
+    }
     let _ = fs::remove_dir_all(candidate_cache);
     let _ = fs::remove_dir_all(fresh_cache);
 }

--- a/rust/rac-mcp/src/tools.rs
+++ b/rust/rac-mcp/src/tools.rs
@@ -84,13 +84,7 @@ fn resolve_for(
             }
             result
         }
-        Some(TrackerModel::Delta(generation)) => {
-            let mut result = resolve_in_index(&generation.derived.index_entries, artifact_id);
-            if let Some(artifact) = &mut result.artifact {
-                artifact.tags = Vec::new();
-            }
-            result
-        }
+        Some(TrackerModel::Delta(generation)) => generation.identity.resolve(artifact_id),
         None => resolve_in_index(&build_index(root, true), artifact_id),
     }
 }
@@ -437,4 +431,51 @@ pub fn retrieve_grounding(
         ),
     };
     serialize(&payload, effective)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rac_engine::delta_generation::{DeltaGeneration, IdentityGeneration};
+    use rac_engine::freshness::TrackerModel;
+
+    fn decision(id: &str) -> String {
+        format!(
+            "---\nschema_version: 1\nid: {id}\ntype: decision\n---\n# {id}: Identity\n\n## Context\n\nTest.\n\n## Decision\n\nKeep.\n\n## Consequences\n\nNone.\n\n## Status\n\nAccepted\n"
+        )
+    }
+
+    #[test]
+    fn delta_point_resolution_uses_identity_generation() {
+        let root =
+            std::env::temp_dir().join(format!("rac-p6-identity-route-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+        let path = root.join("decision.md");
+        std::fs::write(&path, decision("RAC-111111111111")).unwrap();
+        let root_str = root.to_string_lossy().into_owned();
+        let stale_derived = rac_engine::derived::build_derived_index(&root_str, true);
+
+        std::fs::write(&path, decision("RAC-222222222222")).unwrap();
+        let items = rac_engine::relationships::corpus_items(&root_str, true);
+        let identity =
+            IdentityGeneration::from_items(items.iter().map(|item| ("decision.md", item)));
+        let model = TrackerModel::Delta(DeltaGeneration {
+            base_generation: 1,
+            serving_generation: 2,
+            changed_paths: vec!["decision.md".to_string()],
+            identity,
+            derived: stale_derived,
+        });
+
+        assert_eq!(
+            resolve_for(&root_str, Some(&model), "RAC-222222222222").outcome,
+            rac_engine::resolve::OUTCOME_RESOLVED
+        );
+        assert_eq!(
+            resolve_for(&root_str, Some(&model), "RAC-111111111111").outcome,
+            rac_engine::resolve::OUTCOME_NOT_FOUND
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
 }


### PR DESCRIPTION
## Summary

- add immutable shared identity/status base rows with bounded upsert and tombstone overlays
- route preview exact point resolution through the published identity generation
- promote overlays at compaction while reusing unchanged identity rows
- extend ADR-119 and the native index report with the bounded P6.2 claim

## Correctness

- fresh-build referee compares IDs, aliases, type, title, status, outcomes, and duplicate ordering across mutations
- MCP routing test uses a stale full derived model plus a current identity generation to prove the incremental route is authoritative
- default CLI and MCP serving remain unchanged; postings, graph, scope, and summary remain later P6.x slices

## Verification

- `cargo test --workspace --release`
- `cargo test -p rac-engine delta_generation --release`
- `cargo test -p rac-engine --test freshness_tracker --release`
- `cargo test -p rac-mcp delta_point_resolution_uses_identity_generation --release`
- `cargo clippy --release --no-deps -- -D warnings`
- `.venv/bin/rac export rac/ --agent-rules --check`
- `.venv/bin/rac validate rac/decisions/adr-119-base-plus-delta-serving-generations.md --json`

Closes #363