### PR TITLE
perf(engine): add P6.3 incremental search generation

### DIFF
--- a/rac/decisions/adr-119-base-plus-delta-serving-generations.md
+++ b/rac/decisions/adr-119-base-plus-delta-serving-generations.md
@@ -61,6 +61,11 @@ the overlay, and exact point resolution reads the published identity generation.
 The complete derived model remains a referee and the default serving path is
 still unchanged.
 
+P6.3 implements item 2. Token rows and compacted postings are immutable shared
+bases; changed rows and tombstones form the search overlay. Candidate discovery,
+filters, field vectors, and exact corpus-global BM25 statistics read that
+overlay. Inbound graph counts still come from the complete referee until item 3.
+
 No slice becomes the default until mutation referees show byte-identical output
 against a fresh whole-corpus rebuild and scale tests show bounded regression.
 
@@ -75,6 +80,11 @@ P6.2 adds identity/status and exact-resolution referees for those mutation
 classes, including casefolded aliases and duplicate identities. Staging shares
 the compacted base maps and clones only the bounded overlay; compaction reuses
 unchanged identity rows.
+
+P6.3 extends the same mutation referee to complete search payloads, including
+prefix/AND candidates, duplicate query tokens, type/tag/live filters, snippets,
+scores, ranks, and ordering. Staging shares the compacted token and posting
+bases and clones only the bounded overlay.
 
 The first slice does not claim mutation-latency improvement for derivation: it
 still materializes live documents and rebuilds all derived structures. Its

--- a/rust/INDEX-REPORT.md
+++ b/rust/INDEX-REPORT.md
@@ -371,6 +371,27 @@ does not claim an end-to-end mutation-latency win: P6.2 intentionally retains
 the complete derived rebuild as a referee while postings, graph, scope, and
 summary remain future slices. The default CLI and MCP paths are unchanged.
 
+### P6.3 incremental-search result
+
+P6.3 adds shared compacted token rows and token-to-path postings plus changed-row
+upserts and tombstones. Prefix postings drive AND candidate intersection;
+overlay-aware posting counts and field-length sums reproduce the corpus-global
+BM25 statistics, including the contract's duplicate-query-token behavior.
+Type, tag, and live-status filters consume the same staged rows.
+
+Search rows retain identity, tags, sections, and flat field vectors. Until P6.4
+moves graph state, the complete referee contributes only current inbound counts;
+the incremental row remains authoritative for matching, snippets, scoring inputs,
+and response projection. A routing test pairs a stale full row with current P6.2
+and P6.3 generations to prove both point resolution and search use their overlays.
+
+Mutation referees compare the complete serialized search payload against a fresh
+whole-corpus build across edits, additions, deletions, renames, compaction,
+prefix/AND queries, duplicate terms, filters, and no-match cases. Pointer-identity
+checks prove staging shares both compacted rows and postings. The default serving
+path remains unchanged, and no end-to-end mutation-latency claim is made while
+the full graph/scope/summary referee still rebuilds.
+
 ## Performance
 
 See the `PERF-REPORT.md` warm-path addendum. Headline (5k synthetic

--- a/rust/rac-engine/src/delta_generation.rs
+++ b/rust/rac-engine/src/delta_generation.rs
@@ -6,19 +6,22 @@
 //! `(base - tombstones) + upserts`
 //!
 //! P6.2 adds an independently staged identity/status projection and exact
-//! resolution over the overlay. The complete derived model remains as the
-//! mutation referee while later slices move postings, graph, scope, and
+//! resolution over the overlay. P6.3 adds token rows, postings, filters, and
+//! exact global search statistics. The complete derived model remains as the
+//! mutation and graph-signal referee while later slices move graph, scope, and
 //! summary structures behind the same publication boundary.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::sync::Arc;
 
 use crate::derived::DerivedIndex;
 use crate::pycompat::{py_casefold, py_strip};
 use crate::relationships::CorpusItem;
 use crate::resolve::{
-    artifact_status, identity_entry_from_item, resolved_from_entry, IndexEntry, ResolutionResult,
-    OUTCOME_DUPLICATE, OUTCOME_NOT_FOUND, OUTCOME_RESOLVED,
+    artifact_status, entry_from_item, entry_has_tags, field_tokens_of, identity_entry_from_item,
+    is_retired_status, match_entry_with_fields, rank_and_build, resolved_from_entry, tokenize,
+    CorpusStats, FieldTokens, IndexEntry, ResolutionResult, SearchResult, OUTCOME_DUPLICATE,
+    OUTCOME_NOT_FOUND, OUTCOME_RESOLVED,
 };
 
 /// The identity/status projection for one parsed artifact. Rows are shared by
@@ -186,6 +189,303 @@ fn alias_map(rows: &BTreeMap<String, Arc<IdentityRow>>) -> BTreeMap<String, Vec<
     aliases
 }
 
+/// Searchable row owned by the P6.3 generation. Graph-derived inbound counts
+/// remain supplied by the complete referee until the later graph slice.
+#[derive(Clone)]
+pub struct SearchRow {
+    pub entry: IndexEntry,
+    pub fields: FieldTokens,
+    pub status: String,
+}
+
+impl SearchRow {
+    fn from_item(item: &CorpusItem) -> Self {
+        let entry = entry_from_item(item, 0);
+        Self {
+            fields: field_tokens_of(&entry),
+            status: artifact_status(&item.artifact),
+            entry,
+        }
+    }
+}
+
+/// Immutable compacted token/posting base plus a cumulative search overlay.
+#[derive(Clone, Default)]
+pub struct SearchGeneration {
+    base: Arc<BTreeMap<String, Arc<SearchRow>>>,
+    base_postings: Arc<BTreeMap<String, Vec<String>>>,
+    base_length_sums: [i64; 6],
+    upserts: BTreeMap<String, Arc<SearchRow>>,
+    tombstones: BTreeSet<String>,
+}
+
+impl SearchGeneration {
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    pub fn from_items<'a>(items: impl IntoIterator<Item = (&'a str, &'a CorpusItem)>) -> Self {
+        let base: BTreeMap<String, Arc<SearchRow>> = items
+            .into_iter()
+            .map(|(path, item)| (path.to_string(), Arc::new(SearchRow::from_item(item))))
+            .collect();
+        Self {
+            base_postings: Arc::new(postings_for(&base)),
+            base_length_sums: length_sums(base.values().map(AsRef::as_ref)),
+            base: Arc::new(base),
+            upserts: BTreeMap::new(),
+            tombstones: BTreeSet::new(),
+        }
+    }
+
+    pub fn stage(
+        &self,
+        changed: &BTreeSet<String>,
+        parsed: &BTreeMap<String, CorpusItem>,
+    ) -> Self {
+        let mut next = self.clone();
+        for path in changed {
+            if let Some(item) = parsed.get(path) {
+                next
+                    .upserts
+                    .insert(path.clone(), Arc::new(SearchRow::from_item(item)));
+                next.tombstones.remove(path);
+            } else {
+                next.upserts.remove(path);
+                if next.base.contains_key(path) {
+                    next.tombstones.insert(path.clone());
+                } else {
+                    next.tombstones.remove(path);
+                }
+            }
+        }
+        next
+    }
+
+    pub fn promote(&mut self) {
+        let mut base = self.base.as_ref().clone();
+        for path in &self.tombstones {
+            base.remove(path);
+        }
+        for (path, row) in &self.upserts {
+            base.insert(path.clone(), Arc::clone(row));
+        }
+        self.base_postings = Arc::new(postings_for(&base));
+        self.base_length_sums = length_sums(base.values().map(AsRef::as_ref));
+        self.base = Arc::new(base);
+        self.upserts.clear();
+        self.tombstones.clear();
+    }
+
+    pub fn search(
+        &self,
+        query: &str,
+        artifact_type: Option<&str>,
+        tags: &[String],
+        live_only: bool,
+        referee_entries: &[IndexEntry],
+    ) -> SearchResult {
+        let terms = tokenize(query);
+        if terms.is_empty() {
+            return empty_search(query, artifact_type);
+        }
+        let distinct: BTreeSet<&str> = terms.iter().map(String::as_str).collect();
+        let mut candidates: Option<BTreeSet<String>> = None;
+        for term in distinct {
+            let paths = self.paths_for_term(term);
+            candidates = Some(match candidates {
+                Some(current) => current.intersection(&paths).cloned().collect(),
+                None => paths,
+            });
+            if candidates.as_ref().is_some_and(BTreeSet::is_empty) {
+                return empty_search(query, artifact_type);
+            }
+        }
+
+        let tag_filter: Vec<String> = tags.iter().map(|tag| py_casefold(tag)).collect();
+        let inbound_by_path: HashMap<&str, i64> = referee_entries
+            .iter()
+            .map(|entry| (entry.path.as_str(), entry.inbound_count))
+            .collect();
+        let mut prepared = Vec::new();
+        for path in candidates.unwrap_or_default() {
+            let Some(row) = self.row(&path) else {
+                continue;
+            };
+            if artifact_type.is_some_and(|wanted| row.entry.artifact_type != wanted) {
+                continue;
+            }
+            if !tag_filter.is_empty() && !entry_has_tags(&row.entry, &tag_filter) {
+                continue;
+            }
+            if live_only && is_retired_status(&row.entry.artifact_type, &row.status) {
+                continue;
+            }
+            let Some(tier) = match_entry_with_fields(&row.entry, &row.fields, &terms) else {
+                continue;
+            };
+            let Some(inbound_count) = inbound_by_path.get(row.entry.path.as_str()) else {
+                return empty_search(query, artifact_type);
+            };
+            let mut entry = row.entry.clone();
+            entry.inbound_count = *inbound_count;
+            prepared.push((entry, &row.fields, tier));
+        }
+        if prepared.is_empty() {
+            return empty_search(query, artifact_type);
+        }
+        let stats = self.stats(&terms);
+        let matched = prepared
+            .iter()
+            .map(|(entry, fields, tier)| (entry, *fields, tier.clone()))
+            .collect();
+        rank_and_build(query, artifact_type, matched, &terms, &stats)
+    }
+
+    fn row(&self, path: &str) -> Option<&SearchRow> {
+        self.upserts.get(path).map(AsRef::as_ref).or_else(|| {
+            (!self.tombstones.contains(path))
+                .then(|| self.base.get(path).map(AsRef::as_ref))
+                .flatten()
+        })
+    }
+
+    fn paths_for_term(&self, term: &str) -> BTreeSet<String> {
+        let mut paths = BTreeSet::new();
+        for (token, posting) in self.base_postings.range(term.to_string()..) {
+            if !token.starts_with(term) {
+                break;
+            }
+            paths.extend(posting.iter().filter(|path| {
+                !self.tombstones.contains(*path) && !self.upserts.contains_key(*path)
+            }).cloned());
+        }
+        for (path, row) in &self.upserts {
+            if row_has_term(row, term) {
+                paths.insert(path.clone());
+            }
+        }
+        paths
+    }
+
+    fn stats(&self, terms: &[String]) -> CorpusStats {
+        let mut df = HashMap::new();
+        for term in terms {
+            let count = self.paths_for_term(term).len() as i64;
+            *df.entry(term.clone()).or_insert(0) += count;
+        }
+        let mut sums = self.base_length_sums;
+        for path in self.tombstones.iter().chain(self.upserts.keys()) {
+            if let Some(row) = self.base.get(path) {
+                subtract_lengths(&mut sums, &row.fields);
+            }
+        }
+        for row in self.upserts.values() {
+            add_lengths(&mut sums, &row.fields);
+        }
+        let replaced = self
+            .upserts
+            .keys()
+            .filter(|path| self.base.contains_key(*path))
+            .count();
+        let n = self.base.len() - self.tombstones.len() - replaced + self.upserts.len();
+        let mut avglen = [0.0; 6];
+        if n != 0 {
+            for (average, sum) in avglen.iter_mut().zip(sums) {
+                *average = sum as f64 / n as f64;
+            }
+        }
+        CorpusStats {
+            n: n as i64,
+            df,
+            avglen,
+        }
+    }
+
+    pub fn base_len(&self) -> usize {
+        self.base.len()
+    }
+
+    pub fn upsert_len(&self) -> usize {
+        self.upserts.len()
+    }
+
+    pub fn tombstone_len(&self) -> usize {
+        self.tombstones.len()
+    }
+}
+
+fn empty_search(query: &str, artifact_type: Option<&str>) -> SearchResult {
+    SearchResult {
+        query: query.to_string(),
+        artifact_type: artifact_type.map(str::to_string),
+        matches: Vec::new(),
+    }
+}
+
+fn field_lengths(fields: &FieldTokens) -> [i64; 6] {
+    [
+        fields.id.len() as i64,
+        fields.title.len() as i64,
+        fields.path.len() as i64,
+        fields.heading.len() as i64,
+        fields.body.len() as i64,
+        fields.tags.len() as i64,
+    ]
+}
+
+fn add_lengths(sums: &mut [i64; 6], fields: &FieldTokens) {
+    for (sum, length) in sums.iter_mut().zip(field_lengths(fields)) {
+        *sum += length;
+    }
+}
+
+fn subtract_lengths(sums: &mut [i64; 6], fields: &FieldTokens) {
+    for (sum, length) in sums.iter_mut().zip(field_lengths(fields)) {
+        *sum -= length;
+    }
+}
+
+fn length_sums<'a>(rows: impl IntoIterator<Item = &'a SearchRow>) -> [i64; 6] {
+    let mut sums = [0; 6];
+    for row in rows {
+        add_lengths(&mut sums, &row.fields);
+    }
+    sums
+}
+
+fn row_has_term(row: &SearchRow, term: &str) -> bool {
+    all_tokens(&row.fields).any(|token| token.starts_with(term))
+}
+
+fn all_tokens(fields: &FieldTokens) -> impl Iterator<Item = &str> {
+    fields
+        .id
+        .iter()
+        .chain(&fields.title)
+        .chain(&fields.path)
+        .chain(&fields.heading)
+        .chain(&fields.body)
+        .chain(&fields.tags)
+        .map(String::as_str)
+}
+
+fn postings_for(rows: &BTreeMap<String, Arc<SearchRow>>) -> BTreeMap<String, Vec<String>> {
+    let mut postings: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    for (path, row) in rows {
+        for token in all_tokens(&row.fields) {
+            postings
+                .entry(token.to_string())
+                .or_default()
+                .insert(path.clone());
+        }
+    }
+    postings
+        .into_iter()
+        .map(|(token, paths)| (token, paths.into_iter().collect()))
+        .collect()
+}
+
 /// Parsed documents for an immutable base plus one cumulative overlay.
 #[derive(Clone, Default)]
 pub struct DeltaDocuments {
@@ -303,6 +603,7 @@ pub struct DeltaGeneration {
     pub serving_generation: u64,
     pub changed_paths: Vec<String>,
     pub identity: IdentityGeneration,
+    pub search: SearchGeneration,
     pub derived: DerivedIndex,
 }
 
@@ -321,6 +622,49 @@ mod tests {
             artifact,
             spec,
         }
+    }
+
+    fn tagged_item(path: &str, id: &str, status: &str, tag: &str) -> CorpusItem {
+        let text = DOC
+            .replace("ADR-1", id)
+            .replace("Accepted", status)
+            .replacen(
+                "type: decision\n---",
+                &format!("type: decision\ntags: [{tag}]\n---"),
+                1,
+            );
+        let artifact = crate::parse::parse_text(&text, path);
+        let spec = crate::spec::spec_for(&crate::classify::classify(&artifact).artifact_type);
+        CorpusItem {
+            path: path.to_string(),
+            artifact,
+            spec,
+        }
+    }
+
+    fn assert_search_matches_fresh(
+        search: &SearchGeneration,
+        items: &BTreeMap<String, CorpusItem>,
+        query: &str,
+        artifact_type: Option<&str>,
+        tags: &[String],
+        live_only: bool,
+    ) {
+        let ordered: Vec<CorpusItem> = items.values().cloned().collect();
+        let referee = crate::resolve::index_from_items(&ordered);
+        let expected = crate::resolve::search_index_filtered(
+            &referee,
+            query,
+            artifact_type,
+            tags,
+            live_only,
+        );
+        let actual = search.search(query, artifact_type, tags, live_only, &referee);
+        assert_eq!(
+            crate::output::search_result_value(&actual, true),
+            crate::output::search_result_value(&expected, true),
+            "query={query} type={artifact_type:?} tags={tags:?} live={live_only}"
+        );
     }
 
     #[test]
@@ -428,5 +772,81 @@ mod tests {
             identity.resolve("RAC-333333333333").duplicate_paths,
             vec!["a.md", "d.md"]
         );
+    }
+
+    #[test]
+    fn search_overlay_matches_fresh_stats_filters_and_ranking() {
+        let mut items = BTreeMap::from([
+            (
+                "a.md".to_string(),
+                tagged_item("a.md", "RAC-111111111111", "Accepted", "alpha"),
+            ),
+            (
+                "b.md".to_string(),
+                tagged_item("b.md", "RAC-222222222222", "Superseded", "beta"),
+            ),
+        ]);
+        let mut search = SearchGeneration::from_items(
+            items.iter().map(|(path, item)| (path.as_str(), item)),
+        );
+        for (query, artifact_type, tags, live_only) in [
+            ("delta", None, vec![], false),
+            ("rac 111111111111", Some("decision"), vec![], false),
+            ("delta delta", None, vec![], false),
+            ("delta", None, vec!["alpha".to_string()], false),
+            ("zzzz-no-match", None, vec![], false),
+        ] {
+            assert_search_matches_fresh(
+                &search,
+                &items,
+                query,
+                artifact_type,
+                &tags,
+                live_only,
+            );
+        }
+
+        let shared_base = Arc::clone(&search.base);
+        let shared_postings = Arc::clone(&search.base_postings);
+        let changed = BTreeSet::from([
+            "a.md".to_string(),
+            "b.md".to_string(),
+            "c.md".to_string(),
+        ]);
+        let parsed = BTreeMap::from([
+            (
+                "b.md".to_string(),
+                tagged_item("b.md", "RAC-333333333333", "Accepted", "alpha"),
+            ),
+            (
+                "c.md".to_string(),
+                tagged_item("c.md", "RAC-444444444444", "Accepted", "gamma"),
+            ),
+        ]);
+        search = search.stage(&changed, &parsed);
+        assert!(Arc::ptr_eq(&shared_base, &search.base));
+        assert!(Arc::ptr_eq(&shared_postings, &search.base_postings));
+        items.remove("a.md");
+        items.extend(parsed);
+        for query in ["delta", "rac 333333333333", "delta delta"] {
+            assert_search_matches_fresh(&search, &items, query, None, &[], false);
+        }
+        assert_search_matches_fresh(
+            &search,
+            &items,
+            "delta",
+            None,
+            &["alpha".to_string()],
+            true,
+        );
+        assert_eq!(search.base_len(), 2);
+        assert_eq!(search.upsert_len(), 2);
+        assert_eq!(search.tombstone_len(), 1);
+
+        search.promote();
+        assert_eq!(search.base_len(), 2);
+        assert_eq!(search.upsert_len(), 0);
+        assert_eq!(search.tombstone_len(), 0);
+        assert_search_matches_fresh(&search, &items, "delta", None, &[], false);
     }
 }

--- a/rust/rac-engine/src/freshness.rs
+++ b/rust/rac-engine/src/freshness.rs
@@ -12,7 +12,9 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::path::PathBuf;
 
-use crate::delta_generation::{DeltaDocuments, DeltaGeneration, IdentityGeneration};
+use crate::delta_generation::{
+    DeltaDocuments, DeltaGeneration, IdentityGeneration, SearchGeneration,
+};
 use crate::derived::{build_derived_index_from_items, DerivedIndex, SCHEMA_VERSION};
 use crate::derived_cache::{corpus_hash_from_complete_manifest, stat_scan};
 use crate::freshness_watch::EventWatch;
@@ -27,7 +29,7 @@ pub enum TrackerModel {
     /// P6 preview generation. The document overlay is immutable for the
     /// lifetime of this served model and is published only after its complete
     /// derived referee has been built.
-    Delta(DeltaGeneration),
+    Delta(Box<DeltaGeneration>),
 }
 
 pub struct FreshnessTracker {
@@ -51,6 +53,7 @@ pub struct FreshnessTracker {
     /// referee and scale gates.
     delta_documents: Option<DeltaDocuments>,
     delta_identity: Option<IdentityGeneration>,
+    delta_search: Option<SearchGeneration>,
     /// ADR-107 RSS finalization: after compaction the resident parsed
     /// snapshot is shed and the mapped base is the whole answer; the next
     /// change repopulates by a full re-parse on demand.
@@ -92,6 +95,7 @@ impl FreshnessTracker {
             delta_paths: HashSet::new(),
             delta_documents: None,
             delta_identity: None,
+            delta_search: None,
             snapshot_shed: false,
             last_parse_workers: 1,
             last_parse_files: 0,
@@ -110,6 +114,7 @@ impl FreshnessTracker {
         let mut tracker = Self::new_with_watcher(cache_dir, root, threshold, true);
         tracker.delta_documents = Some(DeltaDocuments::empty());
         tracker.delta_identity = Some(IdentityGeneration::empty());
+        tracker.delta_search = Some(SearchGeneration::empty());
         tracker
     }
 
@@ -367,28 +372,34 @@ impl FreshnessTracker {
         // A parser omission would make the staged generation incomplete.
         // Reparse the current corpus from an empty base instead of publishing
         // a partial overlay.
-        let (candidate, identity_candidate) = if parsed.len() == present.len() {
+        let (candidate, identity_candidate, search_candidate) = if parsed.len() == present.len() {
             let identity = self
                 .delta_identity
                 .as_ref()
                 .expect("preview identity")
+                .stage(changed, &parsed);
+            let search = self
+                .delta_search
+                .as_ref()
+                .expect("preview search")
                 .stage(changed, &parsed);
             let documents = self
                 .delta_documents
                 .as_ref()
                 .expect("preview documents")
                 .stage(changed, parsed);
-            (documents, identity)
+            (documents, identity, search)
         } else {
             self.full_delta_candidate()
         };
         let ordered_paths: Vec<String> = self.manifest.iter().map(|(rel, _)| rel.clone()).collect();
         let ordered_items = candidate.ordered_items(ordered_paths.iter().map(String::as_str));
-        let (candidate, identity_candidate) = if ordered_items.len() == self.manifest.len() {
-            (candidate, identity_candidate)
-        } else {
-            self.full_delta_candidate()
-        };
+        let (candidate, identity_candidate, search_candidate) =
+            if ordered_items.len() == self.manifest.len() {
+                (candidate, identity_candidate, search_candidate)
+            } else {
+                self.full_delta_candidate()
+            };
         let ordered_items = candidate.ordered_items(ordered_paths.iter().map(String::as_str));
         let hash = corpus_hash_from_complete_manifest(&self.manifest);
         let serving_generation = self.serving_generation + 1;
@@ -397,17 +408,21 @@ impl FreshnessTracker {
             serving_generation,
             changed_paths: candidate.changed_paths(),
             identity: identity_candidate.clone(),
+            search: search_candidate.clone(),
             derived: build_derived_index_from_items(&self.root_str, &ordered_items, true),
         };
 
         self.delta_documents = Some(candidate);
         self.delta_identity = Some(identity_candidate);
+        self.delta_search = Some(search_candidate);
         self.hash = Some(hash);
         self.serving_generation = serving_generation;
-        self.model = Some(TrackerModel::Delta(generation));
+        self.model = Some(TrackerModel::Delta(Box::new(generation)));
     }
 
-    fn full_delta_candidate(&mut self) -> (DeltaDocuments, IdentityGeneration) {
+    fn full_delta_candidate(
+        &mut self,
+    ) -> (DeltaDocuments, IdentityGeneration, SearchGeneration) {
         let root = PathBuf::from(&self.root_str);
         let paths: Vec<PathBuf> = self
             .manifest
@@ -423,8 +438,14 @@ impl FreshnessTracker {
             .collect();
         let identity =
             IdentityGeneration::from_items(parsed.iter().map(|(path, item)| (path.as_str(), item)));
+        let search =
+            SearchGeneration::from_items(parsed.iter().map(|(path, item)| (path.as_str(), item)));
         let changed = self.manifest.iter().map(|(rel, _)| rel.clone()).collect();
-        (DeltaDocuments::empty().stage(&changed, parsed), identity)
+        (
+            DeltaDocuments::empty().stage(&changed, parsed),
+            identity,
+            search,
+        )
     }
 
     // --- compaction -----------------------------------------------------------
@@ -472,6 +493,10 @@ impl FreshnessTracker {
             self.delta_identity
                 .as_mut()
                 .expect("preview identity")
+                .promote();
+            self.delta_search
+                .as_mut()
+                .expect("preview search")
                 .promote();
             // P6 removes snapshot shedding for its parsed document base so
             // the first post-compaction edit remains change-bound.

--- a/rust/rac-engine/tests/freshness_tracker.rs
+++ b/rust/rac-engine/tests/freshness_tracker.rs
@@ -249,6 +249,34 @@ fn assert_delta_matches_fresh(model: &TrackerModel, root: &str, tag: &str) {
             "status row for {relative}"
         );
     }
+    for (query, artifact_type, live_only) in [
+        ("widget", None, false),
+        ("widget", None, true),
+        ("adr widget", Some("decision"), false),
+        ("widget widget", None, false),
+        ("accepted", None, true),
+        ("zzzz-no-match", None, false),
+    ] {
+        let expected = rac_engine::resolve::search_index_filtered(
+            &fresh_index,
+            query,
+            artifact_type,
+            &[],
+            live_only,
+        );
+        let actual = generation.search.search(
+            query,
+            artifact_type,
+            &[],
+            live_only,
+            &generation.derived.index_entries,
+        );
+        assert_eq!(
+            rac_engine::output::search_result_value(&actual, true),
+            rac_engine::output::search_result_value(&expected, true),
+            "search generation for {query}"
+        );
+    }
     let _ = fs::remove_dir_all(candidate_cache);
     let _ = fs::remove_dir_all(fresh_cache);
 }
@@ -271,7 +299,8 @@ fn delta_preview_stages_mutations_compacts_and_keeps_parsed_base() {
 
     fs::write(
         corpus.join("adr-1-base.md"),
-        DOC.replace("Keep.", "Keep the edited base."),
+        DOC.replace("Keep.", "Keep the edited base.")
+            .replace("Accepted", "Superseded"),
     )
     .unwrap();
     let serving = tracker.serving_generation() + 1;

--- a/rust/rac-mcp/src/tools.rs
+++ b/rust/rac-mcp/src/tools.rs
@@ -140,12 +140,12 @@ pub fn search_artifacts(
         Some(TrackerModel::Snapshot(derived)) => {
             search_index_filtered(&derived.index_entries, query, artifact_type, tags, live_only)
         }
-        Some(TrackerModel::Delta(generation)) => search_index_filtered(
-            &generation.derived.index_entries,
+        Some(TrackerModel::Delta(generation)) => generation.search.search(
             query,
             artifact_type,
             tags,
             live_only,
+            &generation.derived.index_entries,
         ),
         None => {
             let entries = build_index(root, true);
@@ -446,7 +446,7 @@ mod tests {
     }
 
     #[test]
-    fn delta_point_resolution_uses_identity_generation() {
+    fn delta_point_and_search_routes_use_incremental_generations() {
         let root =
             std::env::temp_dir().join(format!("rac-p6-identity-route-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&root);
@@ -460,13 +460,16 @@ mod tests {
         let items = rac_engine::relationships::corpus_items(&root_str, true);
         let identity =
             IdentityGeneration::from_items(items.iter().map(|item| ("decision.md", item)));
-        let model = TrackerModel::Delta(DeltaGeneration {
+        let model = TrackerModel::Delta(Box::new(DeltaGeneration {
             base_generation: 1,
             serving_generation: 2,
             changed_paths: vec!["decision.md".to_string()],
             identity,
+            search: rac_engine::delta_generation::SearchGeneration::from_items(
+                items.iter().map(|item| ("decision.md", item)),
+            ),
             derived: stale_derived,
-        });
+        }));
 
         assert_eq!(
             resolve_for(&root_str, Some(&model), "RAC-222222222222").outcome,
@@ -476,6 +479,17 @@ mod tests {
             resolve_for(&root_str, Some(&model), "RAC-111111111111").outcome,
             rac_engine::resolve::OUTCOME_NOT_FOUND
         );
+        let search = search_artifacts(
+            &root_str,
+            Some(&model),
+            "222222222222",
+            None,
+            &[],
+            false,
+            16_384,
+        );
+        assert!(search.contains("RAC-222222222222"));
+        assert!(!search.contains("RAC-111111111111"));
         let _ = std::fs::remove_dir_all(root);
     }
 }


### PR DESCRIPTION
## Summary

- add immutable shared token rows and compacted token-to-path postings with bounded upserts/tombstones
- derive exact overlay-aware document frequencies and field-length averages, including duplicate query-token semantics
- route preview search candidate discovery, filters, field vectors, snippets, and projection through P6.3
- retain the complete model only for inbound graph counts/referee input until P6.4
- promote the search overlay at compaction while reusing unchanged rows

## Correctness

- fresh-build mutation referees compare complete serialized search payloads across edits, additions, deletions, renames, compaction, prefixes, AND queries, duplicate terms, filters, live status, and no-match cases
- routing test pairs current P6.2/P6.3 generations with a stale full row to prove point and search surfaces use their overlays
- pointer-identity checks pin changeset-bound staging of compacted rows and postings
- default CLI and MCP serving remain unchanged

## Verification

- `cargo test --workspace --release`
- focused P6 generation, freshness, and MCP routing tests
- `cargo clippy --release --no-deps -- -D warnings`
- `.venv/bin/rac export rac/ --agent-rules --check`
- `.venv/bin/rac validate rac/decisions/adr-119-base-plus-delta-serving-generations.md --json`

Closes #365