### PR TITLE
perf(engine): add P6.4 incremental graph generation

### DIFF
--- a/rac/decisions/adr-119-base-plus-delta-serving-generations.md
+++ b/rac/decisions/adr-119-base-plus-delta-serving-generations.md
@@ -64,7 +64,15 @@ still unchanged.
 P6.3 implements item 2. Token rows and compacted postings are immutable shared
 bases; changed rows and tombstones form the search overlay. Candidate discovery,
 filters, field vectors, and exact corpus-global BM25 statistics read that
-overlay. Inbound graph counts still come from the complete referee until item 3.
+overlay.
+
+P6.4 implements item 3. Validation rows, resolved edge lists, reverse raw-target
+buckets, and inbound-count bases are immutable and shared. Source changes
+replace only that source's rows and edges. Identity or alias changes use the
+raw-target buckets to re-resolve the otherwise unchanged sources that mention
+an affected identifier. Inbound counts are adjusted by subtracting replaced
+edges and adding their replacements. Preview graph reads and search graph
+scoring now consume this generation rather than the complete referee.
 
 No slice becomes the default until mutation referees show byte-identical output
 against a fresh whole-corpus rebuild and scale tests show bounded regression.
@@ -85,6 +93,12 @@ P6.3 extends the same mutation referee to complete search payloads, including
 prefix/AND candidates, duplicate query tokens, type/tag/live filters, snippets,
 scores, ranks, and ordering. Staging shares the compacted token and posting
 bases and clones only the bounded overlay.
+
+P6.4 extends the referee to canonical resolved-edge payloads and inbound counts
+across source edits, deletion, identity changes, unresolved-to-resolved and
+resolved-to-ambiguous transitions, and compaction. Staging shares the compacted
+row, edge, reverse-target, and inbound-count bases; its work is bounded by the
+changed documents plus sources in affected raw-target buckets.
 
 The first slice does not claim mutation-latency improvement for derivation: it
 still materializes live documents and rebuilds all derived structures. Its

--- a/rust/rac-engine/src/delta_generation.rs
+++ b/rust/rac-engine/src/delta_generation.rs
@@ -7,16 +7,20 @@
 //!
 //! P6.2 adds an independently staged identity/status projection and exact
 //! resolution over the overlay. P6.3 adds token rows, postings, filters, and
-//! exact global search statistics. The complete derived model remains as the
-//! mutation and graph-signal referee while later slices move graph, scope, and
-//! summary structures behind the same publication boundary.
+//! exact global search statistics. P6.4 adds relationship rows, reverse target
+//! buckets, resolved edges, and inbound counts. The complete derived model
+//! remains as the mutation referee while later slices move scope and summary
+//! structures behind the same publication boundary.
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::sync::Arc;
 
 use crate::derived::DerivedIndex;
 use crate::pycompat::{py_casefold, py_strip};
-use crate::relationships::CorpusItem;
+use crate::relationships::{
+    edge_spec, rows_from_corpus_items, CorpusItem, Relationship, ValidationRow,
+    ISSUE_SELF_REFERENCE, ISSUE_TARGET_AMBIGUOUS, ISSUE_TARGET_NOT_FOUND,
+};
 use crate::resolve::{
     artifact_status, entry_from_item, entry_has_tags, field_tokens_of, identity_entry_from_item,
     is_retired_status, match_entry_with_fields, rank_and_build, resolved_from_entry, tokenize,
@@ -163,6 +167,23 @@ impl IdentityGeneration {
         self.base.get(path).map(|row| row.status.as_str())
     }
 
+    pub fn entries(&self) -> Vec<IndexEntry> {
+        self.base
+            .keys()
+            .chain(self.upserts.keys())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .filter_map(|path| {
+                self.upserts.get(path).or_else(|| {
+                    (!self.tombstones.contains(path))
+                        .then(|| self.base.get(path))
+                        .flatten()
+                })
+            })
+            .map(|row| row.entry.clone())
+            .collect()
+    }
+
     pub fn base_len(&self) -> usize {
         self.base.len()
     }
@@ -174,6 +195,282 @@ impl IdentityGeneration {
     pub fn tombstone_len(&self) -> usize {
         self.tombstones.len()
     }
+}
+
+/// Immutable relationship rows plus a cumulative source overlay. Raw target
+/// buckets let an identity/alias edit re-resolve only sources that mention an
+/// affected identifier, including otherwise unchanged documents.
+#[derive(Clone, Default)]
+pub struct GraphGeneration {
+    base_rows: Arc<BTreeMap<String, Arc<ValidationRow>>>,
+    base_relationships: Arc<BTreeMap<String, Arc<Vec<Relationship>>>>,
+    base_referrers: Arc<BTreeMap<String, Vec<String>>>,
+    base_inbound: Arc<BTreeMap<String, i64>>,
+    row_upserts: BTreeMap<String, Arc<ValidationRow>>,
+    relationship_upserts: BTreeMap<String, Arc<Vec<Relationship>>>,
+    tombstones: BTreeSet<String>,
+    inbound_delta: BTreeMap<String, i64>,
+}
+
+impl GraphGeneration {
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    pub fn from_items<'a>(
+        items: impl IntoIterator<Item = (&'a str, &'a CorpusItem)>,
+        identity: &IdentityGeneration,
+    ) -> Self {
+        let owned: Vec<(&str, &CorpusItem)> = items.into_iter().collect();
+        let corpus: Vec<CorpusItem> = owned.iter().map(|(_, item)| (*item).clone()).collect();
+        let rows = rows_from_corpus_items(&corpus);
+        let base_rows: BTreeMap<String, Arc<ValidationRow>> = rows
+            .into_iter()
+            .zip(owned.iter())
+            .map(|(row, (key, _))| ((*key).to_string(), Arc::new(row)))
+            .collect();
+        let base_relationships: BTreeMap<String, Arc<Vec<Relationship>>> = base_rows
+            .iter()
+            .map(|(path, row)| (path.clone(), Arc::new(resolve_graph_row(row, identity))))
+            .collect();
+        let base_inbound =
+            inbound_for_relationships(base_relationships.values().flat_map(|v| v.iter()));
+        Self {
+            base_referrers: Arc::new(referrer_map(&base_rows)),
+            base_rows: Arc::new(base_rows),
+            base_relationships: Arc::new(base_relationships),
+            base_inbound: Arc::new(base_inbound),
+            row_upserts: BTreeMap::new(),
+            relationship_upserts: BTreeMap::new(),
+            tombstones: BTreeSet::new(),
+            inbound_delta: BTreeMap::new(),
+        }
+    }
+
+    pub fn stage(
+        &self,
+        changed: &BTreeSet<String>,
+        parsed: &BTreeMap<String, CorpusItem>,
+        identity: &IdentityGeneration,
+    ) -> Self {
+        let mut next = self.clone();
+        let mut affected_aliases = BTreeSet::new();
+        for path in changed {
+            if let Some(old) = self.row(path) {
+                affected_aliases.extend(old.identifiers.iter().map(|id| py_casefold(id)));
+            }
+            if let Some(item) = parsed.get(path) {
+                let row = rows_from_corpus_items(std::slice::from_ref(item))
+                    .into_iter()
+                    .next()
+                    .expect("one graph row per parsed item");
+                affected_aliases.extend(row.identifiers.iter().map(|id| py_casefold(id)));
+                next.row_upserts.insert(path.clone(), Arc::new(row));
+                next.tombstones.remove(path);
+            } else {
+                next.row_upserts.remove(path);
+                next.relationship_upserts.remove(path);
+                if next.base_rows.contains_key(path) {
+                    next.tombstones.insert(path.clone());
+                } else {
+                    next.tombstones.remove(path);
+                }
+            }
+        }
+
+        let mut affected_sources = changed.clone();
+        for alias in affected_aliases {
+            if let Some(paths) = self.base_referrers.get(&alias) {
+                affected_sources.extend(paths.iter().cloned());
+            }
+            for (path, row) in &next.row_upserts {
+                if row_references(row, &alias) {
+                    affected_sources.insert(path.clone());
+                }
+            }
+        }
+        for path in affected_sources {
+            if let Some(edges) = self.relationships_for_source(&path) {
+                adjust_inbound(&mut next.inbound_delta, edges, -1);
+            }
+            if let Some(row) = next.row(&path) {
+                let edges = Arc::new(resolve_graph_row(row, identity));
+                adjust_inbound(&mut next.inbound_delta, &edges, 1);
+                next.relationship_upserts.insert(path, edges);
+            } else {
+                next.relationship_upserts.remove(&path);
+            }
+        }
+        next
+    }
+
+    pub fn promote(&mut self) {
+        let mut rows = self.base_rows.as_ref().clone();
+        let mut relationships = self.base_relationships.as_ref().clone();
+        for path in &self.tombstones {
+            rows.remove(path);
+            relationships.remove(path);
+        }
+        for (path, row) in &self.row_upserts {
+            rows.insert(path.clone(), Arc::clone(row));
+        }
+        for (path, edges) in &self.relationship_upserts {
+            relationships.insert(path.clone(), Arc::clone(edges));
+        }
+        self.base_referrers = Arc::new(referrer_map(&rows));
+        self.base_inbound = Arc::new(inbound_for_relationships(
+            relationships.values().flat_map(|edges| edges.iter()),
+        ));
+        self.base_rows = Arc::new(rows);
+        self.base_relationships = Arc::new(relationships);
+        self.row_upserts.clear();
+        self.relationship_upserts.clear();
+        self.tombstones.clear();
+        self.inbound_delta.clear();
+    }
+
+    pub fn relationships(&self) -> Vec<Relationship> {
+        self.base_relationships
+            .keys()
+            .chain(self.relationship_upserts.keys())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .filter_map(|path| self.relationships_for_source(path))
+            .flat_map(|edges| edges.iter().cloned())
+            .collect()
+    }
+
+    pub fn inbound_count(&self, path: &str) -> i64 {
+        self.inbound_counts().get(path).copied().unwrap_or(0)
+    }
+
+    pub fn inbound_counts(&self) -> HashMap<String, i64> {
+        let mut counts: HashMap<String, i64> = self
+            .base_inbound
+            .iter()
+            .map(|(path, count)| (path.clone(), *count))
+            .collect();
+        for (path, delta) in &self.inbound_delta {
+            let count = counts.entry(path.clone()).or_insert(0);
+            *count += delta;
+            if *count == 0 {
+                counts.remove(path);
+            }
+        }
+        counts
+    }
+
+    fn row(&self, path: &str) -> Option<&ValidationRow> {
+        self.row_upserts.get(path).map(AsRef::as_ref).or_else(|| {
+            (!self.tombstones.contains(path))
+                .then(|| self.base_rows.get(path).map(AsRef::as_ref))
+                .flatten()
+        })
+    }
+
+    fn relationships_for_source(&self, path: &str) -> Option<&[Relationship]> {
+        self.relationship_upserts
+            .get(path)
+            .map(|edges| edges.as_slice())
+            .or_else(|| {
+                (!self.tombstones.contains(path))
+                    .then(|| {
+                        self.base_relationships
+                            .get(path)
+                            .map(|edges| edges.as_slice())
+                    })
+                    .flatten()
+            })
+    }
+
+    pub fn base_len(&self) -> usize {
+        self.base_rows.len()
+    }
+    pub fn upsert_len(&self) -> usize {
+        self.row_upserts.len()
+    }
+    pub fn tombstone_len(&self) -> usize {
+        self.tombstones.len()
+    }
+}
+
+fn adjust_inbound(deltas: &mut BTreeMap<String, i64>, edges: &[Relationship], direction: i64) {
+    for edge in edges {
+        if let Some(path) = &edge.resolved_path {
+            *deltas.entry(path.clone()).or_insert(0) += direction;
+        }
+    }
+    deltas.retain(|_, delta| *delta != 0);
+}
+
+fn inbound_for_relationships<'a>(
+    edges: impl IntoIterator<Item = &'a Relationship>,
+) -> BTreeMap<String, i64> {
+    let mut inbound = BTreeMap::new();
+    for edge in edges {
+        if let Some(path) = &edge.resolved_path {
+            *inbound.entry(path.clone()).or_insert(0) += 1;
+        }
+    }
+    inbound
+}
+
+fn row_references(row: &ValidationRow, wanted: &str) -> bool {
+    row.edges
+        .iter()
+        .any(|(_, refs)| refs.iter().any(|target| py_casefold(target) == wanted))
+}
+
+fn referrer_map(rows: &BTreeMap<String, Arc<ValidationRow>>) -> BTreeMap<String, Vec<String>> {
+    let mut refs: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for (path, row) in rows {
+        for (_, targets) in &row.edges {
+            for target in targets {
+                refs.entry(py_casefold(target))
+                    .or_default()
+                    .push(path.clone());
+            }
+        }
+    }
+    refs
+}
+
+fn resolve_graph_row(row: &ValidationRow, identity: &IdentityGeneration) -> Vec<Relationship> {
+    let mut edges = Vec::new();
+    for (section, targets) in &row.edges {
+        let external = edge_spec(section).is_some_and(|spec| spec.external);
+        for target in targets {
+            let (resolved_path, issue) = if external {
+                (None, None)
+            } else {
+                let result = identity.resolve(target);
+                match result.outcome {
+                    OUTCOME_NOT_FOUND => (None, Some(ISSUE_TARGET_NOT_FOUND.to_string())),
+                    OUTCOME_DUPLICATE => (None, Some(ISSUE_TARGET_AMBIGUOUS.to_string())),
+                    OUTCOME_RESOLVED => {
+                        let path = result
+                            .artifact
+                            .expect("resolved identity has artifact")
+                            .path;
+                        if path == row.path {
+                            (None, Some(ISSUE_SELF_REFERENCE.to_string()))
+                        } else {
+                            (Some(path), None)
+                        }
+                    }
+                    _ => unreachable!("identity resolution outcome"),
+                }
+            };
+            edges.push(Relationship {
+                source_path: row.path.clone(),
+                relationship: section.clone(),
+                target: target.clone(),
+                resolved_path,
+                issue,
+            });
+        }
+    }
+    edges
 }
 
 fn alias_map(rows: &BTreeMap<String, Arc<IdentityRow>>) -> BTreeMap<String, Vec<String>> {
@@ -189,8 +486,8 @@ fn alias_map(rows: &BTreeMap<String, Arc<IdentityRow>>) -> BTreeMap<String, Vec<
     aliases
 }
 
-/// Searchable row owned by the P6.3 generation. Graph-derived inbound counts
-/// remain supplied by the complete referee until the later graph slice.
+/// Searchable row owned by the P6.3 generation. P6.4 supplies graph-derived
+/// inbound counts at query time so the token row remains graph-independent.
 #[derive(Clone)]
 pub struct SearchRow {
     pub entry: IndexEntry,
@@ -283,7 +580,7 @@ impl SearchGeneration {
         artifact_type: Option<&str>,
         tags: &[String],
         live_only: bool,
-        referee_entries: &[IndexEntry],
+        graph: &GraphGeneration,
     ) -> SearchResult {
         let terms = tokenize(query);
         if terms.is_empty() {
@@ -303,10 +600,7 @@ impl SearchGeneration {
         }
 
         let tag_filter: Vec<String> = tags.iter().map(|tag| py_casefold(tag)).collect();
-        let inbound_by_path: HashMap<&str, i64> = referee_entries
-            .iter()
-            .map(|entry| (entry.path.as_str(), entry.inbound_count))
-            .collect();
+        let inbound_by_path = graph.inbound_counts();
         let mut prepared = Vec::new();
         for path in candidates.unwrap_or_default() {
             let Some(row) = self.row(&path) else {
@@ -324,11 +618,11 @@ impl SearchGeneration {
             let Some(tier) = match_entry_with_fields(&row.entry, &row.fields, &terms) else {
                 continue;
             };
-            let Some(inbound_count) = inbound_by_path.get(row.entry.path.as_str()) else {
-                return empty_search(query, artifact_type);
-            };
             let mut entry = row.entry.clone();
-            entry.inbound_count = *inbound_count;
+            entry.inbound_count = inbound_by_path
+                .get(row.entry.path.as_str())
+                .copied()
+                .unwrap_or(0);
             prepared.push((entry, &row.fields, tier));
         }
         if prepared.is_empty() {
@@ -604,12 +898,15 @@ pub struct DeltaGeneration {
     pub changed_paths: Vec<String>,
     pub identity: IdentityGeneration,
     pub search: SearchGeneration,
+    pub graph: GraphGeneration,
     pub derived: DerivedIndex,
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    type EdgeSignature = (String, String, String, Option<String>, Option<String>);
 
     const DOC: &str = "---\nschema_version: 1\nid: ADR-1\ntype: decision\n---\n# ADR-1: Delta\n\n## Context\n\nTest.\n\n## Decision\n\nKeep.\n\n## Consequences\n\nNone.\n\n## Status\n\nAccepted\n";
 
@@ -642,6 +939,49 @@ mod tests {
         }
     }
 
+    fn related_item(path: &str, id: &str, target: &str) -> CorpusItem {
+        let text = format!(
+            "---\nschema_version: 1\nid: {id}\ntype: requirement\n---\n# Requirement\n\n## Status\n\nAccepted\n\n## Problem\n\nTest.\n\n## Requirements\n\n- [REQ-001] Keep the graph exact.\n\n## Related Decisions\n\n- {target}\n"
+        );
+        let artifact = crate::parse::parse_text(&text, path);
+        let spec = crate::spec::spec_for(&crate::classify::classify(&artifact).artifact_type);
+        CorpusItem {
+            path: path.to_string(),
+            artifact,
+            spec,
+        }
+    }
+
+    fn edge_signature(edges: Vec<Relationship>) -> Vec<EdgeSignature> {
+        edges
+            .into_iter()
+            .map(|edge| {
+                (
+                    edge.source_path,
+                    edge.relationship,
+                    edge.target,
+                    edge.resolved_path,
+                    edge.issue,
+                )
+            })
+            .collect()
+    }
+
+    fn assert_graph_matches_fresh(graph: &GraphGeneration, items: &BTreeMap<String, CorpusItem>) {
+        let ordered: Vec<CorpusItem> = items.values().cloned().collect();
+        assert_eq!(
+            edge_signature(graph.relationships()),
+            edge_signature(crate::relationships::relationships_from_corpus(&ordered)),
+        );
+        let mut expected = HashMap::new();
+        for edge in crate::relationships::relationships_from_corpus(&ordered) {
+            if let Some(path) = edge.resolved_path {
+                *expected.entry(path).or_insert(0) += 1;
+            }
+        }
+        assert_eq!(graph.inbound_counts(), expected);
+    }
+
     fn assert_search_matches_fresh(
         search: &SearchGeneration,
         items: &BTreeMap<String, CorpusItem>,
@@ -652,6 +992,13 @@ mod tests {
     ) {
         let ordered: Vec<CorpusItem> = items.values().cloned().collect();
         let referee = crate::resolve::index_from_items(&ordered);
+        let identity = IdentityGeneration::from_items(
+            items.iter().map(|(path, item)| (path.as_str(), item)),
+        );
+        let graph = GraphGeneration::from_items(
+            items.iter().map(|(path, item)| (path.as_str(), item)),
+            &identity,
+        );
         let expected = crate::resolve::search_index_filtered(
             &referee,
             query,
@@ -659,7 +1006,7 @@ mod tests {
             tags,
             live_only,
         );
-        let actual = search.search(query, artifact_type, tags, live_only, &referee);
+        let actual = search.search(query, artifact_type, tags, live_only, &graph);
         assert_eq!(
             crate::output::search_result_value(&actual, true),
             crate::output::search_result_value(&expected, true),
@@ -772,6 +1119,112 @@ mod tests {
             identity.resolve("RAC-333333333333").duplicate_paths,
             vec!["a.md", "d.md"]
         );
+    }
+
+    #[test]
+    fn graph_overlay_re_resolves_unchanged_referrers_for_identity_changes() {
+        let mut items = BTreeMap::from([
+            ("a.md".to_string(), related_item("a.md", "REQ-001", "RAC-222222222222")),
+            ("b.md".to_string(), item("b.md", "RAC-222222222222", "Accepted")),
+        ]);
+        let mut identity = IdentityGeneration::from_items(
+            items.iter().map(|(path, item)| (path.as_str(), item)),
+        );
+        let mut graph = GraphGeneration::from_items(
+            items.iter().map(|(path, item)| (path.as_str(), item)),
+            &identity,
+        );
+        assert_graph_matches_fresh(&graph, &items);
+        assert_eq!(graph.inbound_count("b.md"), 1);
+
+        let shared_rows = Arc::clone(&graph.base_rows);
+        let shared_edges = Arc::clone(&graph.base_relationships);
+        let changed = BTreeSet::from(["b.md".to_string()]);
+        let parsed = BTreeMap::from([(
+            "b.md".to_string(),
+            item("b.md", "RAC-333333333333", "Accepted"),
+        )]);
+        identity = identity.stage(&changed, &parsed);
+        graph = graph.stage(&changed, &parsed, &identity);
+        items.insert("b.md".to_string(), parsed["b.md"].clone());
+        assert!(Arc::ptr_eq(&shared_rows, &graph.base_rows));
+        assert!(Arc::ptr_eq(&shared_edges, &graph.base_relationships));
+        assert_graph_matches_fresh(&graph, &items);
+        assert_eq!(
+            graph.relationships()[0].issue.as_deref(),
+            Some(ISSUE_TARGET_NOT_FOUND)
+        );
+
+        let changed = BTreeSet::from(["d.md".to_string()]);
+        let parsed = BTreeMap::from([(
+            "d.md".to_string(),
+            item("d.md", "RAC-222222222222", "Accepted"),
+        )]);
+        identity = identity.stage(&changed, &parsed);
+        graph = graph.stage(&changed, &parsed, &identity);
+        items.insert("d.md".to_string(), parsed["d.md"].clone());
+        assert_graph_matches_fresh(&graph, &items);
+        assert_eq!(
+            graph.relationships()[0].resolved_path.as_deref(),
+            Some("d.md")
+        );
+
+        graph.promote();
+        identity.promote();
+        assert_eq!(graph.base_len(), 3);
+        assert_eq!(graph.upsert_len(), 0);
+        assert_eq!(graph.tombstone_len(), 0);
+        assert_graph_matches_fresh(&graph, &items);
+    }
+
+    #[test]
+    fn graph_overlay_handles_source_edit_delete_and_ambiguity() {
+        let mut items = BTreeMap::from([
+            ("a.md".to_string(), related_item("a.md", "REQ-001", "RAC-222222222222")),
+            ("b.md".to_string(), item("b.md", "RAC-222222222222", "Accepted")),
+            ("c.md".to_string(), item("c.md", "RAC-333333333333", "Accepted")),
+        ]);
+        let mut identity = IdentityGeneration::from_items(
+            items.iter().map(|(path, item)| (path.as_str(), item)),
+        );
+        let mut graph = GraphGeneration::from_items(
+            items.iter().map(|(path, item)| (path.as_str(), item)),
+            &identity,
+        );
+
+        let changed = BTreeSet::from(["a.md".to_string()]);
+        let parsed = BTreeMap::from([(
+            "a.md".to_string(),
+            related_item("a.md", "REQ-001", "RAC-333333333333"),
+        )]);
+        identity = identity.stage(&changed, &parsed);
+        graph = graph.stage(&changed, &parsed, &identity);
+        items.insert("a.md".to_string(), parsed["a.md"].clone());
+        assert_graph_matches_fresh(&graph, &items);
+        assert_eq!(graph.inbound_count("c.md"), 1);
+
+        let changed = BTreeSet::from(["b.md".to_string()]);
+        let parsed = BTreeMap::from([(
+            "b.md".to_string(),
+            item("b.md", "RAC-333333333333", "Accepted"),
+        )]);
+        identity = identity.stage(&changed, &parsed);
+        graph = graph.stage(&changed, &parsed, &identity);
+        items.insert("b.md".to_string(), parsed["b.md"].clone());
+        assert_graph_matches_fresh(&graph, &items);
+        assert_eq!(
+            graph.relationships()[0].issue.as_deref(),
+            Some(ISSUE_TARGET_AMBIGUOUS)
+        );
+        assert!(graph.inbound_counts().is_empty());
+
+        let changed = BTreeSet::from(["a.md".to_string()]);
+        let parsed = BTreeMap::new();
+        identity = identity.stage(&changed, &parsed);
+        graph = graph.stage(&changed, &parsed, &identity);
+        items.remove("a.md");
+        assert_graph_matches_fresh(&graph, &items);
+        assert!(graph.relationships().is_empty());
     }
 
     #[test]

--- a/rust/rac-engine/src/freshness.rs
+++ b/rust/rac-engine/src/freshness.rs
@@ -13,7 +13,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::path::PathBuf;
 
 use crate::delta_generation::{
-    DeltaDocuments, DeltaGeneration, IdentityGeneration, SearchGeneration,
+    DeltaDocuments, DeltaGeneration, GraphGeneration, IdentityGeneration, SearchGeneration,
 };
 use crate::derived::{build_derived_index_from_items, DerivedIndex, SCHEMA_VERSION};
 use crate::derived_cache::{corpus_hash_from_complete_manifest, stat_scan};
@@ -54,6 +54,7 @@ pub struct FreshnessTracker {
     delta_documents: Option<DeltaDocuments>,
     delta_identity: Option<IdentityGeneration>,
     delta_search: Option<SearchGeneration>,
+    delta_graph: Option<GraphGeneration>,
     /// ADR-107 RSS finalization: after compaction the resident parsed
     /// snapshot is shed and the mapped base is the whole answer; the next
     /// change repopulates by a full re-parse on demand.
@@ -96,6 +97,7 @@ impl FreshnessTracker {
             delta_documents: None,
             delta_identity: None,
             delta_search: None,
+            delta_graph: None,
             snapshot_shed: false,
             last_parse_workers: 1,
             last_parse_files: 0,
@@ -115,6 +117,7 @@ impl FreshnessTracker {
         tracker.delta_documents = Some(DeltaDocuments::empty());
         tracker.delta_identity = Some(IdentityGeneration::empty());
         tracker.delta_search = Some(SearchGeneration::empty());
+        tracker.delta_graph = Some(GraphGeneration::empty());
         tracker
     }
 
@@ -372,31 +375,42 @@ impl FreshnessTracker {
         // A parser omission would make the staged generation incomplete.
         // Reparse the current corpus from an empty base instead of publishing
         // a partial overlay.
-        let (candidate, identity_candidate, search_candidate) = if parsed.len() == present.len() {
-            let identity = self
-                .delta_identity
-                .as_ref()
-                .expect("preview identity")
-                .stage(changed, &parsed);
-            let search = self
-                .delta_search
-                .as_ref()
-                .expect("preview search")
-                .stage(changed, &parsed);
-            let documents = self
-                .delta_documents
-                .as_ref()
-                .expect("preview documents")
-                .stage(changed, parsed);
-            (documents, identity, search)
-        } else {
-            self.full_delta_candidate()
-        };
+        let (candidate, identity_candidate, search_candidate, graph_candidate) =
+            if parsed.len() == present.len() {
+                let identity = self
+                    .delta_identity
+                    .as_ref()
+                    .expect("preview identity")
+                    .stage(changed, &parsed);
+                let search = self
+                    .delta_search
+                    .as_ref()
+                    .expect("preview search")
+                    .stage(changed, &parsed);
+                let graph = self
+                    .delta_graph
+                    .as_ref()
+                    .expect("preview graph")
+                    .stage(changed, &parsed, &identity);
+                let documents = self
+                    .delta_documents
+                    .as_ref()
+                    .expect("preview documents")
+                    .stage(changed, parsed);
+                (documents, identity, search, graph)
+            } else {
+                self.full_delta_candidate()
+            };
         let ordered_paths: Vec<String> = self.manifest.iter().map(|(rel, _)| rel.clone()).collect();
         let ordered_items = candidate.ordered_items(ordered_paths.iter().map(String::as_str));
-        let (candidate, identity_candidate, search_candidate) =
+        let (candidate, identity_candidate, search_candidate, graph_candidate) =
             if ordered_items.len() == self.manifest.len() {
-                (candidate, identity_candidate, search_candidate)
+                (
+                    candidate,
+                    identity_candidate,
+                    search_candidate,
+                    graph_candidate,
+                )
             } else {
                 self.full_delta_candidate()
             };
@@ -409,12 +423,14 @@ impl FreshnessTracker {
             changed_paths: candidate.changed_paths(),
             identity: identity_candidate.clone(),
             search: search_candidate.clone(),
+            graph: graph_candidate.clone(),
             derived: build_derived_index_from_items(&self.root_str, &ordered_items, true),
         };
 
         self.delta_documents = Some(candidate);
         self.delta_identity = Some(identity_candidate);
         self.delta_search = Some(search_candidate);
+        self.delta_graph = Some(graph_candidate);
         self.hash = Some(hash);
         self.serving_generation = serving_generation;
         self.model = Some(TrackerModel::Delta(Box::new(generation)));
@@ -422,7 +438,12 @@ impl FreshnessTracker {
 
     fn full_delta_candidate(
         &mut self,
-    ) -> (DeltaDocuments, IdentityGeneration, SearchGeneration) {
+    ) -> (
+        DeltaDocuments,
+        IdentityGeneration,
+        SearchGeneration,
+        GraphGeneration,
+    ) {
         let root = PathBuf::from(&self.root_str);
         let paths: Vec<PathBuf> = self
             .manifest
@@ -440,11 +461,16 @@ impl FreshnessTracker {
             IdentityGeneration::from_items(parsed.iter().map(|(path, item)| (path.as_str(), item)));
         let search =
             SearchGeneration::from_items(parsed.iter().map(|(path, item)| (path.as_str(), item)));
+        let graph = GraphGeneration::from_items(
+            parsed.iter().map(|(path, item)| (path.as_str(), item)),
+            &identity,
+        );
         let changed = self.manifest.iter().map(|(rel, _)| rel.clone()).collect();
         (
             DeltaDocuments::empty().stage(&changed, parsed),
             identity,
             search,
+            graph,
         )
     }
 
@@ -497,6 +523,10 @@ impl FreshnessTracker {
             self.delta_search
                 .as_mut()
                 .expect("preview search")
+                .promote();
+            self.delta_graph
+                .as_mut()
+                .expect("preview graph")
                 .promote();
             // P6 removes snapshot shedding for its parsed document base so
             // the first post-compaction edit remains change-bound.

--- a/rust/rac-engine/tests/freshness_tracker.rs
+++ b/rust/rac-engine/tests/freshness_tracker.rs
@@ -208,6 +208,27 @@ fn assert_delta_matches_fresh(model: &TrackerModel, root: &str, tag: &str) {
         "preview generation must be byte-identical to a fresh derivation"
     );
     let fresh_items = rac_engine::relationships::corpus_items(root, true);
+    let relationship_signature = |edges: Vec<rac_engine::relationships::Relationship>| {
+        edges
+            .into_iter()
+            .map(|edge| {
+                (
+                    edge.source_path,
+                    edge.relationship,
+                    edge.target,
+                    edge.resolved_path,
+                    edge.issue,
+                )
+            })
+            .collect::<Vec<_>>()
+    };
+    assert_eq!(
+        relationship_signature(generation.graph.relationships()),
+        relationship_signature(rac_engine::relationships::relationships_from_corpus(
+            &fresh_items,
+        )),
+        "graph generation must equal fresh relationship resolution"
+    );
     let fresh_index = rac_engine::resolve::index_from_items(&fresh_items);
     for entry in &fresh_index {
         for alias in &entry.aliases {
@@ -269,7 +290,7 @@ fn assert_delta_matches_fresh(model: &TrackerModel, root: &str, tag: &str) {
             artifact_type,
             &[],
             live_only,
-            &generation.derived.index_entries,
+            &generation.graph,
         );
         assert_eq!(
             rac_engine::output::search_result_value(&actual, true),

--- a/rust/rac-mcp/src/graph.rs
+++ b/rust/rac-mcp/src/graph.rs
@@ -100,13 +100,8 @@ impl GraphView {
                 derived.relationships.clone(),
             ),
             TrackerModel::Delta(generation) => Self::new(
-                generation
-                    .derived
-                    .index_entries
-                    .iter()
-                    .map(identity_projection)
-                    .collect(),
-                generation.derived.relationships.clone(),
+                generation.identity.entries(),
+                generation.graph.relationships(),
             ),
         }
     }

--- a/rust/rac-mcp/src/tools.rs
+++ b/rust/rac-mcp/src/tools.rs
@@ -145,7 +145,7 @@ pub fn search_artifacts(
             artifact_type,
             tags,
             live_only,
-            &generation.derived.index_entries,
+            &generation.graph,
         ),
         None => {
             let entries = build_index(root, true);
@@ -467,6 +467,10 @@ mod tests {
             identity,
             search: rac_engine::delta_generation::SearchGeneration::from_items(
                 items.iter().map(|item| ("decision.md", item)),
+            ),
+            graph: rac_engine::delta_generation::GraphGeneration::from_items(
+                items.iter().map(|item| ("decision.md", item)),
+                &IdentityGeneration::from_items(items.iter().map(|item| ("decision.md", item))),
             ),
             derived: stale_derived,
         }));


### PR DESCRIPTION
## Summary
- add ADR-119 P6.4 base-plus-delta relationship rows, resolved edges, reverse raw-target buckets, and inbound-count deltas
- re-resolve changed sources plus otherwise unchanged sources affected by identity/alias changes
- publish graph state atomically with document, identity, and search generations
- route preview graph reads and search inbound scoring through the graph generation instead of the full derived referee
- extend fresh-build referees across source edits, deletion, alias changes, unresolved/resolved/ambiguous transitions, and compaction

## Performance boundary
- immutable graph bases remain shared across staged generations
- staging work is bounded by changed documents plus sources in affected raw-target buckets
- inbound counts update by subtracting replaced edges and adding replacements
- the complete derived model remains only as the later-slice referee; default serving remains unchanged

## Validation
- `cargo test --workspace`
- `cargo test --workspace --release`
- `cargo clippy --release --no-deps -- -D warnings`
- `target/release/rac validate ../rac/decisions/adr-119-base-plus-delta-serving-generations.md --json`
- `rust/target/release/rac export rac/ --agent-rules --check`
- `python3 tools/live_corpus_invariants.py --engine target/release/rac --corpus ../rac`

Closes #367
