### PR TITLE
perf(engine): add P6.5 incremental scope and summary generation

### DIFF
--- a/rac/decisions/adr-119-base-plus-delta-serving-generations.md
+++ b/rac/decisions/adr-119-base-plus-delta-serving-generations.md
@@ -74,6 +74,15 @@ an affected identifier. Inbound counts are adjusted by subtracting replaced
 edges and adding their replacements. Preview graph reads and search graph
 scoring now consume this generation rather than the complete referee.
 
+P6.5 implements item 4. Live-decision membership and declared scope rows use
+immutable bases with changed-row overlays. Portfolio parsing, structural
+validation, completeness classification, and attention projections are stored
+as immutable per-document rows; only changed rows are rebuilt. Exact portfolio
+JSON is reduced from those compact rows at publication/read time because
+relationship integrity, orphan counts, global ordering, and health scoring are
+corpus-global. Preview scope lookup, topic-mode live-decision filtering, and
+summary reads consume these generations rather than the complete referee.
+
 No slice becomes the default until mutation referees show byte-identical output
 against a fresh whole-corpus rebuild and scale tests show bounded regression.
 
@@ -99,6 +108,13 @@ across source edits, deletion, identity changes, unresolved-to-resolved and
 resolved-to-ambiguous transitions, and compaction. Staging shares the compacted
 row, edge, reverse-target, and inbound-count bases; its work is bounded by the
 changed documents plus sources in affected raw-target buckets.
+
+P6.5 extends it to scope rows, live-decision membership, and the complete
+portfolio JSON payload across scope/status/type/validity changes, add, delete,
+rename, and compaction. Staging shares validated portfolio and scope bases and
+rebuilds only changed document projections. The final compact-row portfolio
+reduction remains corpus-linear; scale gates must measure it before the full
+referee can be removed or preview serving becomes the default.
 
 The first slice does not claim mutation-latency improvement for derivation: it
 still materializes live documents and rebuilds all derived structures. Its

--- a/rust/rac-engine/src/delta_generation.rs
+++ b/rust/rac-engine/src/delta_generation.rs
@@ -8,14 +8,17 @@
 //! P6.2 adds an independently staged identity/status projection and exact
 //! resolution over the overlay. P6.3 adds token rows, postings, filters, and
 //! exact global search statistics. P6.4 adds relationship rows, reverse target
-//! buckets, resolved edges, and inbound counts. The complete derived model
-//! remains as the mutation referee while later slices move scope and summary
-//! structures behind the same publication boundary.
+//! buckets, resolved edges, and inbound counts. P6.5 adds scope/live-decision
+//! rows and validated portfolio projections. The complete derived model remains
+//! as the mutation referee until durable compaction and default-adoption gates.
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::sync::Arc;
 
+use serde_json::Value;
+
 use crate::derived::DerivedIndex;
+use crate::portfolio::{portfolio_from_rows, portfolio_row, PortfolioRow};
 use crate::pycompat::{py_casefold, py_strip};
 use crate::relationships::{
     edge_spec, rows_from_corpus_items, CorpusItem, Relationship, ValidationRow,
@@ -27,6 +30,7 @@ use crate::resolve::{
     CorpusStats, FieldTokens, IndexEntry, ResolutionResult, SearchResult, OUTCOME_DUPLICATE,
     OUTCOME_NOT_FOUND, OUTCOME_RESOLVED,
 };
+use crate::retrieve::{scope_rows_from_items, ScopeRow};
 
 /// The identity/status projection for one parsed artifact. Rows are shared by
 /// `Arc` so compaction promotes unchanged identities without rebuilding them.
@@ -636,6 +640,22 @@ impl SearchGeneration {
         rank_and_build(query, artifact_type, matched, &terms, &stats)
     }
 
+    pub fn entries(&self, graph: &GraphGeneration) -> Vec<IndexEntry> {
+        let inbound = graph.inbound_counts();
+        self.base
+            .keys()
+            .chain(self.upserts.keys())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .filter_map(|path| self.row(path))
+            .map(|row| {
+                let mut entry = row.entry.clone();
+                entry.inbound_count = inbound.get(&entry.path).copied().unwrap_or(0);
+                entry
+            })
+            .collect()
+    }
+
     fn row(&self, path: &str) -> Option<&SearchRow> {
         self.upserts.get(path).map(AsRef::as_ref).or_else(|| {
             (!self.tombstones.contains(path))
@@ -780,6 +800,242 @@ fn postings_for(rows: &BTreeMap<String, Arc<SearchRow>>) -> BTreeMap<String, Vec
         .collect()
 }
 
+/// Per-document scope and live-decision projections. An entry is present in
+/// `scope` only when the document is a live decision with declared scope;
+/// `live` independently tracks every live decision for topic-mode filtering.
+#[derive(Clone, Default)]
+pub struct ScopeGeneration {
+    base_scope: Arc<BTreeMap<String, Arc<ScopeRow>>>,
+    base_live: Arc<BTreeSet<String>>,
+    scope_upserts: BTreeMap<String, Arc<ScopeRow>>,
+    live_upserts: BTreeSet<String>,
+    tombstones: BTreeSet<String>,
+}
+
+impl ScopeGeneration {
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    pub fn from_items<'a>(items: impl IntoIterator<Item = (&'a str, &'a CorpusItem)>) -> Self {
+        let mut scope = BTreeMap::new();
+        let mut live = BTreeSet::new();
+        for (path, item) in items {
+            if is_live_decision_item(item) {
+                live.insert(path.to_string());
+            }
+            if let Some(row) = scope_row(item) {
+                scope.insert(path.to_string(), Arc::new(row));
+            }
+        }
+        Self {
+            base_scope: Arc::new(scope),
+            base_live: Arc::new(live),
+            scope_upserts: BTreeMap::new(),
+            live_upserts: BTreeSet::new(),
+            tombstones: BTreeSet::new(),
+        }
+    }
+
+    pub fn stage(
+        &self,
+        changed: &BTreeSet<String>,
+        parsed: &BTreeMap<String, CorpusItem>,
+    ) -> Self {
+        let mut next = self.clone();
+        for path in changed {
+            next.scope_upserts.remove(path);
+            next.live_upserts.remove(path);
+            if let Some(item) = parsed.get(path) {
+                if is_live_decision_item(item) {
+                    next.live_upserts.insert(path.clone());
+                }
+                if let Some(row) = scope_row(item) {
+                    next.scope_upserts.insert(path.clone(), Arc::new(row));
+                }
+                if next.base_scope.contains_key(path) || next.base_live.contains(path) {
+                    next.tombstones.insert(path.clone());
+                } else {
+                    next.tombstones.remove(path);
+                }
+            } else if next.base_scope.contains_key(path) || next.base_live.contains(path) {
+                next.tombstones.insert(path.clone());
+            } else {
+                next.tombstones.remove(path);
+            }
+        }
+        next
+    }
+
+    pub fn promote(&mut self) {
+        let mut scope = self.base_scope.as_ref().clone();
+        let mut live = self.base_live.as_ref().clone();
+        for path in &self.tombstones {
+            scope.remove(path);
+            live.remove(path);
+        }
+        for path in self.scope_upserts.keys() {
+            scope.remove(path);
+        }
+        for path in self.live_upserts.iter() {
+            live.remove(path);
+        }
+        for (path, row) in &self.scope_upserts {
+            scope.insert(path.clone(), Arc::clone(row));
+        }
+        for path in &self.live_upserts {
+            live.insert(path.clone());
+        }
+        self.base_scope = Arc::new(scope);
+        self.base_live = Arc::new(live);
+        self.scope_upserts.clear();
+        self.live_upserts.clear();
+        self.tombstones.clear();
+    }
+
+    pub fn rows(&self) -> Vec<ScopeRow> {
+        self.base_scope
+            .keys()
+            .chain(self.scope_upserts.keys())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .filter_map(|path| {
+                self.scope_upserts.get(path).or_else(|| {
+                    (!self.tombstones.contains(path))
+                        .then(|| self.base_scope.get(path))
+                        .flatten()
+                })
+            })
+            .map(|row| row.as_ref().clone())
+            .collect()
+    }
+
+    pub fn live_paths(&self) -> Vec<String> {
+        self.base_live
+            .iter()
+            .chain(self.live_upserts.iter())
+            .filter(|path| {
+                self.live_upserts.contains(*path)
+                    || (!self.tombstones.contains(*path) && self.base_live.contains(*path))
+            })
+            .cloned()
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect()
+    }
+
+    pub fn base_scope_len(&self) -> usize {
+        self.base_scope.len()
+    }
+    pub fn scope_upsert_len(&self) -> usize {
+        self.scope_upserts.len()
+    }
+}
+
+fn is_live_decision_item(item: &CorpusItem) -> bool {
+    item.spec
+        .is_some_and(|spec| spec.name == crate::derived::DECISION_TYPE)
+        && crate::resolve::is_live_decision(&item.artifact)
+}
+
+fn scope_row(item: &CorpusItem) -> Option<ScopeRow> {
+    scope_rows_from_items(std::slice::from_ref(item))
+        .into_iter()
+        .next()
+}
+
+/// Incrementally validated per-document portfolio projections. Global summary
+/// fields reduce these compact rows at publication time; parsing, structural
+/// validation, and completeness classification remain change-bound.
+#[derive(Clone, Default)]
+pub struct SummaryGeneration {
+    base: Arc<BTreeMap<String, Arc<PortfolioRow>>>,
+    upserts: BTreeMap<String, Arc<PortfolioRow>>,
+    tombstones: BTreeSet<String>,
+}
+
+impl SummaryGeneration {
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    pub fn from_items<'a>(items: impl IntoIterator<Item = (&'a str, &'a CorpusItem)>) -> Self {
+        Self {
+            base: Arc::new(
+                items
+                    .into_iter()
+                    .map(|(path, item)| (path.to_string(), Arc::new(portfolio_row(item))))
+                    .collect(),
+            ),
+            upserts: BTreeMap::new(),
+            tombstones: BTreeSet::new(),
+        }
+    }
+
+    pub fn stage(
+        &self,
+        changed: &BTreeSet<String>,
+        parsed: &BTreeMap<String, CorpusItem>,
+    ) -> Self {
+        let mut next = self.clone();
+        for path in changed {
+            if let Some(item) = parsed.get(path) {
+                next
+                    .upserts
+                    .insert(path.clone(), Arc::new(portfolio_row(item)));
+                next.tombstones.remove(path);
+            } else {
+                next.upserts.remove(path);
+                if next.base.contains_key(path) {
+                    next.tombstones.insert(path.clone());
+                } else {
+                    next.tombstones.remove(path);
+                }
+            }
+        }
+        next
+    }
+
+    pub fn value(&self, directory: &str, recursive: bool) -> Value {
+        let rows: Vec<PortfolioRow> = self
+            .base
+            .keys()
+            .chain(self.upserts.keys())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .filter_map(|path| {
+                self.upserts.get(path).or_else(|| {
+                    (!self.tombstones.contains(path))
+                        .then(|| self.base.get(path))
+                        .flatten()
+                })
+            })
+            .map(|row| row.as_ref().clone())
+            .collect();
+        crate::output::portfolio_summary_value(&portfolio_from_rows(directory, &rows, recursive))
+    }
+
+    pub fn promote(&mut self) {
+        let mut base = self.base.as_ref().clone();
+        for path in &self.tombstones {
+            base.remove(path);
+        }
+        for (path, row) in &self.upserts {
+            base.insert(path.clone(), Arc::clone(row));
+        }
+        self.base = Arc::new(base);
+        self.upserts.clear();
+        self.tombstones.clear();
+    }
+
+    pub fn base_len(&self) -> usize {
+        self.base.len()
+    }
+    pub fn upsert_len(&self) -> usize {
+        self.upserts.len()
+    }
+}
+
 /// Parsed documents for an immutable base plus one cumulative overlay.
 #[derive(Clone, Default)]
 pub struct DeltaDocuments {
@@ -899,6 +1155,8 @@ pub struct DeltaGeneration {
     pub identity: IdentityGeneration,
     pub search: SearchGeneration,
     pub graph: GraphGeneration,
+    pub scope: ScopeGeneration,
+    pub summary: SummaryGeneration,
     pub derived: DerivedIndex,
 }
 
@@ -950,6 +1208,29 @@ mod tests {
             artifact,
             spec,
         }
+    }
+
+    fn scoped_item(path: &str, id: &str, status: &str, scope: Option<&str>) -> CorpusItem {
+        let scope = scope
+            .map(|value| format!("\n\n## Applies To\n\n- {value}"))
+            .unwrap_or_default();
+        let text = DOC
+            .replace("ADR-1", id)
+            .replace("Accepted", status)
+            .replace("\n## Status", &format!("{scope}\n\n## Status"));
+        let artifact = crate::parse::parse_text(&text, path);
+        let spec = crate::spec::spec_for(&crate::classify::classify(&artifact).artifact_type);
+        CorpusItem {
+            path: path.to_string(),
+            artifact,
+            spec,
+        }
+    }
+
+    fn scope_signature(rows: Vec<ScopeRow>) -> Vec<(String, String, String, String, Vec<String>)> {
+        rows.into_iter()
+            .map(|row| (row.id, row.title, row.status, row.path, row.scope_entries))
+            .collect()
     }
 
     fn edge_signature(edges: Vec<Relationship>) -> Vec<EdgeSignature> {
@@ -1225,6 +1506,131 @@ mod tests {
         items.remove("a.md");
         assert_graph_matches_fresh(&graph, &items);
         assert!(graph.relationships().is_empty());
+    }
+
+    #[test]
+    fn scope_overlay_tracks_live_status_scope_delete_and_promote() {
+        let mut items = BTreeMap::from([
+            (
+                "b.md".to_string(),
+                scoped_item(
+                    "b.md",
+                    "RAC-111111111111",
+                    "Accepted",
+                    Some("src/**"),
+                ),
+            ),
+            (
+                "d.md".to_string(),
+                scoped_item("d.md", "RAC-222222222222", "Accepted", None),
+            ),
+        ]);
+        let mut scope = ScopeGeneration::from_items(
+            items.iter().map(|(path, item)| (path.as_str(), item)),
+        );
+        assert_eq!(scope.live_paths(), vec!["b.md", "d.md"]);
+        assert_eq!(scope.rows().len(), 1);
+
+        let shared_scope = Arc::clone(&scope.base_scope);
+        let shared_live = Arc::clone(&scope.base_live);
+        let changed = BTreeSet::from(["a.md".to_string(), "b.md".to_string()]);
+        let parsed = BTreeMap::from([
+            (
+                "a.md".to_string(),
+                scoped_item(
+                    "a.md",
+                    "RAC-333333333333",
+                    "Accepted",
+                    Some("docs/**"),
+                ),
+            ),
+            (
+                "b.md".to_string(),
+                scoped_item(
+                    "b.md",
+                    "RAC-111111111111",
+                    "Superseded",
+                    Some("src/**"),
+                ),
+            ),
+        ]);
+        scope = scope.stage(&changed, &parsed);
+        items.extend(parsed.clone());
+        assert!(Arc::ptr_eq(&shared_scope, &scope.base_scope));
+        assert!(Arc::ptr_eq(&shared_live, &scope.base_live));
+        assert_eq!(scope.live_paths(), vec!["a.md", "d.md"]);
+        assert_eq!(
+            scope_signature(scope.rows()),
+            scope_signature(scope_rows_from_items(
+                &items.values().cloned().collect::<Vec<_>>()
+            ))
+        );
+
+        let changed = BTreeSet::from(["d.md".to_string()]);
+        scope = scope.stage(&changed, &BTreeMap::new());
+        items.remove("d.md");
+        assert_eq!(scope.live_paths(), vec!["a.md"]);
+        assert_eq!(
+            scope_signature(scope.rows()),
+            scope_signature(scope_rows_from_items(
+                &items.values().cloned().collect::<Vec<_>>()
+            ))
+        );
+
+        scope.promote();
+        assert_eq!(scope.base_scope_len(), 1);
+        assert_eq!(scope.scope_upsert_len(), 0);
+        assert_eq!(scope.live_paths(), vec!["a.md"]);
+    }
+
+    #[test]
+    fn summary_overlay_reuses_validated_base_rows_and_matches_fresh() {
+        let directory = ".";
+        let mut items = BTreeMap::from([
+            (
+                "b.md".to_string(),
+                item("b.md", "RAC-111111111111", "Accepted"),
+            ),
+            (
+                "d.md".to_string(),
+                tagged_item("d.md", "RAC-222222222222", "Accepted", "alpha"),
+            ),
+        ]);
+        let mut summary = SummaryGeneration::from_items(
+            items.iter().map(|(path, item)| (path.as_str(), item)),
+        );
+        let fresh = |items: &BTreeMap<String, CorpusItem>| {
+            crate::output::portfolio_summary_value(&crate::portfolio::portfolio_from_corpus(
+                directory,
+                &items.values().cloned().collect::<Vec<_>>(),
+                true,
+            ))
+        };
+        assert_eq!(summary.value(directory, true), fresh(&items));
+
+        let shared = Arc::clone(&summary.base);
+        let changed = BTreeSet::from(["a.md".to_string(), "b.md".to_string()]);
+        let parsed = BTreeMap::from([
+            (
+                "a.md".to_string(),
+                item("a.md", "RAC-333333333333", "Proposed"),
+            ),
+            (
+                "b.md".to_string(),
+                item("b.md", "RAC-111111111111", "Superseded"),
+            ),
+        ]);
+        summary = summary.stage(&changed, &parsed);
+        items.extend(parsed);
+        assert!(Arc::ptr_eq(&shared, &summary.base));
+        assert_eq!(summary.value(directory, true), fresh(&items));
+        assert_eq!(summary.base_len(), 2);
+        assert_eq!(summary.upsert_len(), 2);
+
+        summary.promote();
+        assert_eq!(summary.base_len(), 3);
+        assert_eq!(summary.upsert_len(), 0);
+        assert_eq!(summary.value(directory, true), fresh(&items));
     }
 
     #[test]

--- a/rust/rac-engine/src/freshness.rs
+++ b/rust/rac-engine/src/freshness.rs
@@ -13,7 +13,8 @@ use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::path::PathBuf;
 
 use crate::delta_generation::{
-    DeltaDocuments, DeltaGeneration, GraphGeneration, IdentityGeneration, SearchGeneration,
+    DeltaDocuments, DeltaGeneration, GraphGeneration, IdentityGeneration, ScopeGeneration,
+    SearchGeneration, SummaryGeneration,
 };
 use crate::derived::{build_derived_index_from_items, DerivedIndex, SCHEMA_VERSION};
 use crate::derived_cache::{corpus_hash_from_complete_manifest, stat_scan};
@@ -55,6 +56,8 @@ pub struct FreshnessTracker {
     delta_identity: Option<IdentityGeneration>,
     delta_search: Option<SearchGeneration>,
     delta_graph: Option<GraphGeneration>,
+    delta_scope: Option<ScopeGeneration>,
+    delta_summary: Option<SummaryGeneration>,
     /// ADR-107 RSS finalization: after compaction the resident parsed
     /// snapshot is shed and the mapped base is the whole answer; the next
     /// change repopulates by a full re-parse on demand.
@@ -98,6 +101,8 @@ impl FreshnessTracker {
             delta_identity: None,
             delta_search: None,
             delta_graph: None,
+            delta_scope: None,
+            delta_summary: None,
             snapshot_shed: false,
             last_parse_workers: 1,
             last_parse_files: 0,
@@ -118,6 +123,8 @@ impl FreshnessTracker {
         tracker.delta_identity = Some(IdentityGeneration::empty());
         tracker.delta_search = Some(SearchGeneration::empty());
         tracker.delta_graph = Some(GraphGeneration::empty());
+        tracker.delta_scope = Some(ScopeGeneration::empty());
+        tracker.delta_summary = Some(SummaryGeneration::empty());
         tracker
     }
 
@@ -375,7 +382,14 @@ impl FreshnessTracker {
         // A parser omission would make the staged generation incomplete.
         // Reparse the current corpus from an empty base instead of publishing
         // a partial overlay.
-        let (candidate, identity_candidate, search_candidate, graph_candidate) =
+        let (
+            candidate,
+            identity_candidate,
+            search_candidate,
+            graph_candidate,
+            scope_candidate,
+            summary_candidate,
+        ) =
             if parsed.len() == present.len() {
                 let identity = self
                     .delta_identity
@@ -392,24 +406,43 @@ impl FreshnessTracker {
                     .as_ref()
                     .expect("preview graph")
                     .stage(changed, &parsed, &identity);
+                let scope = self
+                    .delta_scope
+                    .as_ref()
+                    .expect("preview scope")
+                    .stage(changed, &parsed);
+                let summary = self
+                    .delta_summary
+                    .as_ref()
+                    .expect("preview summary")
+                    .stage(changed, &parsed);
                 let documents = self
                     .delta_documents
                     .as_ref()
                     .expect("preview documents")
                     .stage(changed, parsed);
-                (documents, identity, search, graph)
+                (documents, identity, search, graph, scope, summary)
             } else {
                 self.full_delta_candidate()
             };
         let ordered_paths: Vec<String> = self.manifest.iter().map(|(rel, _)| rel.clone()).collect();
         let ordered_items = candidate.ordered_items(ordered_paths.iter().map(String::as_str));
-        let (candidate, identity_candidate, search_candidate, graph_candidate) =
+        let (
+            candidate,
+            identity_candidate,
+            search_candidate,
+            graph_candidate,
+            scope_candidate,
+            summary_candidate,
+        ) =
             if ordered_items.len() == self.manifest.len() {
                 (
                     candidate,
                     identity_candidate,
                     search_candidate,
                     graph_candidate,
+                    scope_candidate,
+                    summary_candidate,
                 )
             } else {
                 self.full_delta_candidate()
@@ -424,6 +457,8 @@ impl FreshnessTracker {
             identity: identity_candidate.clone(),
             search: search_candidate.clone(),
             graph: graph_candidate.clone(),
+            scope: scope_candidate.clone(),
+            summary: summary_candidate.clone(),
             derived: build_derived_index_from_items(&self.root_str, &ordered_items, true),
         };
 
@@ -431,6 +466,8 @@ impl FreshnessTracker {
         self.delta_identity = Some(identity_candidate);
         self.delta_search = Some(search_candidate);
         self.delta_graph = Some(graph_candidate);
+        self.delta_scope = Some(scope_candidate);
+        self.delta_summary = Some(summary_candidate);
         self.hash = Some(hash);
         self.serving_generation = serving_generation;
         self.model = Some(TrackerModel::Delta(Box::new(generation)));
@@ -443,6 +480,8 @@ impl FreshnessTracker {
         IdentityGeneration,
         SearchGeneration,
         GraphGeneration,
+        ScopeGeneration,
+        SummaryGeneration,
     ) {
         let root = PathBuf::from(&self.root_str);
         let paths: Vec<PathBuf> = self
@@ -465,12 +504,18 @@ impl FreshnessTracker {
             parsed.iter().map(|(path, item)| (path.as_str(), item)),
             &identity,
         );
+        let scope =
+            ScopeGeneration::from_items(parsed.iter().map(|(path, item)| (path.as_str(), item)));
+        let summary =
+            SummaryGeneration::from_items(parsed.iter().map(|(path, item)| (path.as_str(), item)));
         let changed = self.manifest.iter().map(|(rel, _)| rel.clone()).collect();
         (
             DeltaDocuments::empty().stage(&changed, parsed),
             identity,
             search,
             graph,
+            scope,
+            summary,
         )
     }
 
@@ -527,6 +572,14 @@ impl FreshnessTracker {
             self.delta_graph
                 .as_mut()
                 .expect("preview graph")
+                .promote();
+            self.delta_scope
+                .as_mut()
+                .expect("preview scope")
+                .promote();
+            self.delta_summary
+                .as_mut()
+                .expect("preview summary")
                 .promote();
             // P6 removes snapshot shedding for its parsed document base so
             // the first post-compaction edit remains change-bound.

--- a/rust/rac-engine/src/portfolio.rs
+++ b/rust/rac-engine/src/portfolio.rs
@@ -82,7 +82,8 @@ impl PortfolioSummary {
 }
 
 /// Per-artifact projection matching `PortfolioRow`.
-struct Row {
+#[derive(Clone)]
+pub struct PortfolioRow {
     path: String,
     artifact_type: String,
     identifier: String,
@@ -92,7 +93,7 @@ struct Row {
     missing_recommended: Vec<String>,
 }
 
-fn portfolio_row(item: &CorpusItem) -> Row {
+pub fn portfolio_row(item: &CorpusItem) -> PortfolioRow {
     let path = item.path.clone();
     let artifact_type = item
         .spec
@@ -100,7 +101,7 @@ fn portfolio_row(item: &CorpusItem) -> Row {
         .unwrap_or_else(|| "unknown".to_string());
     let vrow = validation_row(&path, &item.artifact, item.spec);
     match item.spec {
-        None => Row {
+        None => PortfolioRow {
             path,
             artifact_type,
             identifier: vrow.canonical_id.clone(),
@@ -113,7 +114,7 @@ fn portfolio_row(item: &CorpusItem) -> Row {
             let (_, missing_rec) = missing_sections(&item.artifact, spec);
             let identifier =
                 crate::identity::artifact_identifier(&item.artifact, item.spec, &path);
-            Row {
+            PortfolioRow {
                 path,
                 artifact_type: artifact_type.clone(),
                 identifier,
@@ -141,7 +142,15 @@ pub fn portfolio_from_corpus(
     items: &[CorpusItem],
     recursive: bool,
 ) -> PortfolioSummary {
-    let rows: Vec<Row> = items.iter().map(portfolio_row).collect();
+    let rows: Vec<PortfolioRow> = items.iter().map(portfolio_row).collect();
+    portfolio_from_rows(directory, &rows, recursive)
+}
+
+pub fn portfolio_from_rows(
+    directory: &str,
+    rows: &[PortfolioRow],
+    recursive: bool,
+) -> PortfolioSummary {
     let validation_rows: Vec<ValidationRow> = rows.iter().map(|r| r.validation.clone()).collect();
     let overrides: SeverityOverrides = load_overrides(directory);
 
@@ -164,7 +173,7 @@ pub fn portfolio_from_corpus(
     let mut path_to_identifier: std::collections::HashMap<String, String> =
         std::collections::HashMap::new();
 
-    for row in &rows {
+    for row in rows {
         bump(&mut by_type, &row.artifact_type);
         if row.validation.spec_name.is_none() {
             unknown_paths.push(row.path.clone());

--- a/rust/rac-engine/src/retrieve.rs
+++ b/rust/rac-engine/src/retrieve.rs
@@ -339,6 +339,7 @@ fn normalize_query(path: &str, root: &Path) -> Option<String> {
 // ---------------------------------------------------------------------------
 
 /// One live decision's declared `## Applies To` scope (`ScopeRow`).
+#[derive(Clone)]
 pub struct ScopeRow {
     pub id: String,
     pub title: String,
@@ -348,7 +349,7 @@ pub struct ScopeRow {
 }
 
 /// `_scope_rows_from_corpus(entries)` — live decisions with declared scope.
-pub(crate) fn scope_rows_from_items(items: &[CorpusItem]) -> Vec<ScopeRow> {
+pub fn scope_rows_from_items(items: &[CorpusItem]) -> Vec<ScopeRow> {
     let mut rows = Vec::new();
     for item in items {
         let Some(spec) = item.spec else { continue };

--- a/rust/rac-engine/tests/freshness_tracker.rs
+++ b/rust/rac-engine/tests/freshness_tracker.rs
@@ -208,6 +208,35 @@ fn assert_delta_matches_fresh(model: &TrackerModel, root: &str, tag: &str) {
         "preview generation must be byte-identical to a fresh derivation"
     );
     let fresh_items = rac_engine::relationships::corpus_items(root, true);
+    assert_eq!(
+        generation.summary.value(root, true),
+        rac_engine::output::portfolio_summary_value(
+            &rac_engine::portfolio::portfolio_from_corpus(root, &fresh_items, true)
+        ),
+        "summary generation must equal a fresh portfolio reduction"
+    );
+    let scope_signature = |rows: Vec<rac_engine::retrieve::ScopeRow>| {
+        rows.into_iter()
+            .map(|row| (row.id, row.title, row.status, row.path, row.scope_entries))
+            .collect::<Vec<_>>()
+    };
+    assert_eq!(
+        scope_signature(generation.scope.rows()),
+        scope_signature(rac_engine::retrieve::scope_rows_from_items(&fresh_items)),
+        "scope generation must equal fresh scope rows"
+    );
+    let fresh_live: Vec<String> = build_derived_index(root, true)
+        .live_decision_paths
+        .into_iter()
+        .map(|path| {
+            Path::new(&path)
+                .strip_prefix(root)
+                .unwrap()
+                .to_string_lossy()
+                .into_owned()
+        })
+        .collect();
+    assert_eq!(generation.scope.live_paths(), fresh_live);
     let relationship_signature = |edges: Vec<rac_engine::relationships::Relationship>| {
         edges
             .into_iter()

--- a/rust/rac-mcp/src/tools.rs
+++ b/rust/rac-mcp/src/tools.rs
@@ -184,7 +184,7 @@ pub fn find_decisions_tool(
             Some(TrackerModel::Delta(generation)) => {
                 rac_engine::retrieve::scope_lookup_value(
                     &rac_engine::retrieve::decisions_for_path_with_rows(
-                        &generation.derived.scope_rows,
+                        &generation.scope.rows(),
                         root,
                         p,
                     ),
@@ -204,8 +204,8 @@ pub fn find_decisions_tool(
             topic,
         ),
         Some(TrackerModel::Delta(generation)) => rac_engine::read_model::find_decisions_in(
-            &generation.derived.index_entries,
-            &generation.derived.live_decision_paths,
+            &generation.search.entries(&generation.graph),
+            &generation.scope.live_paths(),
             topic,
         ),
         None => find_decisions(root, topic, true),
@@ -311,7 +311,7 @@ pub fn get_summary(root: &str, model: Option<&TrackerModel>, budget: i64) -> Str
         let summary = match model {
             TrackerModel::View(reader) => reader.portfolio_summary().unwrap_or(Value::Null),
             TrackerModel::Snapshot(derived) => derived.portfolio_summary.clone(),
-            TrackerModel::Delta(generation) => generation.derived.portfolio_summary.clone(),
+            TrackerModel::Delta(generation) => generation.summary.value(root, true),
         };
         if let Value::Object(mut payload) = summary {
             let empty = payload
@@ -471,6 +471,12 @@ mod tests {
             graph: rac_engine::delta_generation::GraphGeneration::from_items(
                 items.iter().map(|item| ("decision.md", item)),
                 &IdentityGeneration::from_items(items.iter().map(|item| ("decision.md", item))),
+            ),
+            scope: rac_engine::delta_generation::ScopeGeneration::from_items(
+                items.iter().map(|item| ("decision.md", item)),
+            ),
+            summary: rac_engine::delta_generation::SummaryGeneration::from_items(
+                items.iter().map(|item| ("decision.md", item)),
             ),
             derived: stale_derived,
         }));


### PR DESCRIPTION
## Summary
- add ADR-119 P6.5 immutable-base scope rows and live-decision membership with changed-document overlays
- add immutable validated portfolio projections so parsing, validation, completeness, and attention classification stay change-bound
- publish scope and summary state atomically with document, identity, search, and graph generations
- route preview path-scope lookup, topic live-decision filtering, and `get_summary` through the new generations
- extend fresh-build mutation referees to exact scope rows, live paths, and complete portfolio JSON

## Performance boundary
- staged generations share compacted scope, live-decision, and validated portfolio bases
- only changed document projections are rebuilt
- exact portfolio JSON still performs a corpus-linear reduction over compact validated rows because relationship integrity, orphan counts, ordering, and health are global
- the complete derived model remains the correctness referee; default serving remains unchanged

## Validation
- `cargo test --workspace`
- `cargo test --workspace --release`
- `cargo clippy --release --no-deps -- -D warnings`
- ADR-119 native validation
- generated agent-rule drift check
- live-corpus validity, determinism, cache/no-cache equality, and freshness invariants

Closes #369
