### PR TITLE
perf(engine): add P6.6 delta-native compaction

### DIFF
--- a/rac/decisions/adr-119-base-plus-delta-serving-generations.md
+++ b/rac/decisions/adr-119-base-plus-delta-serving-generations.md
@@ -83,6 +83,14 @@ relationship integrity, orphan counts, global ordering, and health scoring are
 corpus-global. Preview scope lookup, topic-mode live-decision filtering, and
 summary reads consume these generations rather than the complete referee.
 
+P6.6 implements item 5. The served delta generation no longer owns or builds a
+fresh whole-corpus `DerivedIndex`. Compaction assembles the persisted bundle
+directly from the published search rows/field vectors, graph edges and inbound
+counts, scope/live-decision rows, and validated portfolio projections. Fresh
+whole-corpus derivation remains only in bounded certification tests. Failed
+writes or failed reopen still leave the complete in-memory delta generation
+served unchanged.
+
 No slice becomes the default until mutation referees show byte-identical output
 against a fresh whole-corpus rebuild and scale tests show bounded regression.
 
@@ -115,6 +123,12 @@ rename, and compaction. Staging shares validated portfolio and scope bases and
 rebuilds only changed document projections. The final compact-row portfolio
 reduction remains corpus-linear; scale gates must measure it before the full
 referee can be removed or preview serving becomes the default.
+
+P6.6 removes that referee from runtime mutation publication. Certification now
+serializes a delta-native materialization beside a fresh rebuild and compares
+every persisted segment byte-for-byte across edit, delete, rename, compaction,
+and first-edit-after-compaction transitions. Below-threshold mutations perform
+no full corpus parse, validation, or derived-index build.
 
 The first slice does not claim mutation-latency improvement for derivation: it
 still materializes live documents and rebuilds all derived structures. Its

--- a/rust/rac-engine/src/delta_generation.rs
+++ b/rust/rac-engine/src/delta_generation.rs
@@ -9,8 +9,8 @@
 //! resolution over the overlay. P6.3 adds token rows, postings, filters, and
 //! exact global search statistics. P6.4 adds relationship rows, reverse target
 //! buckets, resolved edges, and inbound counts. P6.5 adds scope/live-decision
-//! rows and validated portfolio projections. The complete derived model remains
-//! as the mutation referee until durable compaction and default-adoption gates.
+//! rows and validated portfolio projections. P6.6 materializes durable store
+//! segments from those projections; fresh derivation remains test-only.
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::sync::Arc;
@@ -656,6 +656,25 @@ impl SearchGeneration {
             .collect()
     }
 
+    fn entries_and_fields(&self, graph: &GraphGeneration) -> (Vec<IndexEntry>, Vec<FieldTokens>) {
+        let inbound = graph.inbound_counts();
+        let mut entries = Vec::new();
+        let mut fields = Vec::new();
+        for path in self
+            .base
+            .keys()
+            .chain(self.upserts.keys())
+            .collect::<BTreeSet<_>>()
+        {
+            let Some(row) = self.row(path) else { continue };
+            let mut entry = row.entry.clone();
+            entry.inbound_count = inbound.get(&entry.path).copied().unwrap_or(0);
+            entries.push(entry);
+            fields.push(row.fields.clone());
+        }
+        (entries, fields)
+    }
+
     fn row(&self, path: &str) -> Option<&SearchRow> {
         self.upserts.get(path).map(AsRef::as_ref).or_else(|| {
             (!self.tombstones.contains(path))
@@ -806,9 +825,9 @@ fn postings_for(rows: &BTreeMap<String, Arc<SearchRow>>) -> BTreeMap<String, Vec
 #[derive(Clone, Default)]
 pub struct ScopeGeneration {
     base_scope: Arc<BTreeMap<String, Arc<ScopeRow>>>,
-    base_live: Arc<BTreeSet<String>>,
+    base_live: Arc<BTreeMap<String, String>>,
     scope_upserts: BTreeMap<String, Arc<ScopeRow>>,
-    live_upserts: BTreeSet<String>,
+    live_upserts: BTreeMap<String, String>,
     tombstones: BTreeSet<String>,
 }
 
@@ -819,10 +838,10 @@ impl ScopeGeneration {
 
     pub fn from_items<'a>(items: impl IntoIterator<Item = (&'a str, &'a CorpusItem)>) -> Self {
         let mut scope = BTreeMap::new();
-        let mut live = BTreeSet::new();
+        let mut live = BTreeMap::new();
         for (path, item) in items {
             if is_live_decision_item(item) {
-                live.insert(path.to_string());
+                live.insert(path.to_string(), item.path.clone());
             }
             if let Some(row) = scope_row(item) {
                 scope.insert(path.to_string(), Arc::new(row));
@@ -832,7 +851,7 @@ impl ScopeGeneration {
             base_scope: Arc::new(scope),
             base_live: Arc::new(live),
             scope_upserts: BTreeMap::new(),
-            live_upserts: BTreeSet::new(),
+            live_upserts: BTreeMap::new(),
             tombstones: BTreeSet::new(),
         }
     }
@@ -848,17 +867,17 @@ impl ScopeGeneration {
             next.live_upserts.remove(path);
             if let Some(item) = parsed.get(path) {
                 if is_live_decision_item(item) {
-                    next.live_upserts.insert(path.clone());
+                    next.live_upserts.insert(path.clone(), item.path.clone());
                 }
                 if let Some(row) = scope_row(item) {
                     next.scope_upserts.insert(path.clone(), Arc::new(row));
                 }
-                if next.base_scope.contains_key(path) || next.base_live.contains(path) {
+                if next.base_scope.contains_key(path) || next.base_live.contains_key(path) {
                     next.tombstones.insert(path.clone());
                 } else {
                     next.tombstones.remove(path);
                 }
-            } else if next.base_scope.contains_key(path) || next.base_live.contains(path) {
+            } else if next.base_scope.contains_key(path) || next.base_live.contains_key(path) {
                 next.tombstones.insert(path.clone());
             } else {
                 next.tombstones.remove(path);
@@ -877,14 +896,14 @@ impl ScopeGeneration {
         for path in self.scope_upserts.keys() {
             scope.remove(path);
         }
-        for path in self.live_upserts.iter() {
+        for path in self.live_upserts.keys() {
             live.remove(path);
         }
         for (path, row) in &self.scope_upserts {
             scope.insert(path.clone(), Arc::clone(row));
         }
-        for path in &self.live_upserts {
-            live.insert(path.clone());
+        for (path, display_path) in &self.live_upserts {
+            live.insert(path.clone(), display_path.clone());
         }
         self.base_scope = Arc::new(scope);
         self.base_live = Arc::new(live);
@@ -912,15 +931,18 @@ impl ScopeGeneration {
 
     pub fn live_paths(&self) -> Vec<String> {
         self.base_live
-            .iter()
-            .chain(self.live_upserts.iter())
-            .filter(|path| {
-                self.live_upserts.contains(*path)
-                    || (!self.tombstones.contains(*path) && self.base_live.contains(*path))
-            })
-            .cloned()
+            .keys()
+            .chain(self.live_upserts.keys())
             .collect::<BTreeSet<_>>()
             .into_iter()
+            .filter_map(|path| {
+                self.live_upserts.get(path).or_else(|| {
+                    (!self.tombstones.contains(path))
+                        .then(|| self.base_live.get(path))
+                        .flatten()
+                })
+            })
+            .cloned()
             .collect()
     }
 
@@ -1157,7 +1179,23 @@ pub struct DeltaGeneration {
     pub graph: GraphGeneration,
     pub scope: ScopeGeneration,
     pub summary: SummaryGeneration,
-    pub derived: DerivedIndex,
+}
+
+impl DeltaGeneration {
+    /// Assemble the persisted/read-model bundle from the already-published
+    /// incremental projections. This performs no parsing or artifact
+    /// validation and is therefore suitable for durable compaction.
+    pub fn materialize_derived(&self, directory: &str, recursive: bool) -> DerivedIndex {
+        let (index_entries, field_tokens) = self.search.entries_and_fields(&self.graph);
+        DerivedIndex {
+            index_entries,
+            field_tokens,
+            relationships: self.graph.relationships(),
+            live_decision_paths: self.scope.live_paths(),
+            portfolio_summary: self.summary.value(directory, recursive),
+            scope_rows: self.scope.rows(),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/rust/rac-engine/src/freshness.rs
+++ b/rust/rac-engine/src/freshness.rs
@@ -6,7 +6,7 @@
 //! provide a synchronous barrier, otherwise the stat-manifest scan. Events
 //! never compute the changed set: any dirty or uncertain signal falls back to
 //! the authoritative scan. Whatever the rung, the served read-model is
-//! re-derived from the tracker's incrementally maintained parsed snapshot,
+//! built from the tracker's incrementally maintained generations,
 //! byte-identical to a fresh whole-corpus walk at the current corpus state.
 
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
@@ -28,8 +28,8 @@ pub enum TrackerModel {
     View(MmapIndexReader),
     Snapshot(DerivedIndex),
     /// P6 preview generation. The document overlay is immutable for the
-    /// lifetime of this served model and is published only after its complete
-    /// derived referee has been built.
+    /// lifetime of this served model and is published only after every
+    /// incremental projection has been staged successfully.
     Delta(Box<DeltaGeneration>),
 }
 
@@ -361,8 +361,8 @@ impl FreshnessTracker {
         self.serving_generation += 1;
     }
 
-    /// Build a complete candidate generation from a staged document overlay,
-    /// then swap every serving field only after derivation succeeds.
+    /// Build a complete candidate generation from staged overlays, then swap
+    /// every serving field only after all projections succeed.
     fn rebuild_delta_preview(&mut self, changed: &BTreeSet<String>) {
         let current: HashSet<&str> = self.manifest.iter().map(|(rel, _)| rel.as_str()).collect();
         let root = PathBuf::from(&self.root_str);
@@ -447,7 +447,6 @@ impl FreshnessTracker {
             } else {
                 self.full_delta_candidate()
             };
-        let ordered_items = candidate.ordered_items(ordered_paths.iter().map(String::as_str));
         let hash = corpus_hash_from_complete_manifest(&self.manifest);
         let serving_generation = self.serving_generation + 1;
         let generation = DeltaGeneration {
@@ -459,7 +458,6 @@ impl FreshnessTracker {
             graph: graph_candidate.clone(),
             scope: scope_candidate.clone(),
             summary: summary_candidate.clone(),
-            derived: build_derived_index_from_items(&self.root_str, &ordered_items, true),
         };
 
         self.delta_documents = Some(candidate);
@@ -540,7 +538,10 @@ impl FreshnessTracker {
         let derived_owned;
         let derived = match &self.model {
             Some(TrackerModel::Snapshot(derived)) => derived,
-            Some(TrackerModel::Delta(generation)) => &generation.derived,
+            Some(TrackerModel::Delta(generation)) => {
+                derived_owned = generation.materialize_derived(&self.root_str, true);
+                &derived_owned
+            }
             _ => {
                 derived_owned =
                     build_derived_index_from_items(&self.root_str, &self.ordered_items(), true);

--- a/rust/rac-engine/tests/freshness_tracker.rs
+++ b/rust/rac-engine/tests/freshness_tracker.rs
@@ -190,11 +190,12 @@ fn assert_delta_matches_fresh(model: &TrackerModel, root: &str, tag: &str) {
     let candidate_cache = scratch(&format!("{tag}-candidate"));
     let fresh_cache = scratch(&format!("{tag}-fresh"));
     let key = "referee";
+    let materialized = generation.materialize_derived(root, true);
     assert!(write_store(
         &candidate_cache,
         key,
         SCHEMA_VERSION,
-        &generation.derived,
+        &materialized,
     ));
     assert!(write_store(
         &fresh_cache,
@@ -228,13 +229,6 @@ fn assert_delta_matches_fresh(model: &TrackerModel, root: &str, tag: &str) {
     let fresh_live: Vec<String> = build_derived_index(root, true)
         .live_decision_paths
         .into_iter()
-        .map(|path| {
-            Path::new(&path)
-                .strip_prefix(root)
-                .unwrap()
-                .to_string_lossy()
-                .into_owned()
-        })
         .collect();
     assert_eq!(generation.scope.live_paths(), fresh_live);
     let relationship_signature = |edges: Vec<rac_engine::relationships::Relationship>| {

--- a/rust/rac-mcp/src/tools.rs
+++ b/rust/rac-mcp/src/tools.rs
@@ -416,6 +416,7 @@ pub fn retrieve_grounding(
             )
         }
         Some(TrackerModel::Delta(generation)) => {
+            let derived = generation.materialize_derived(root, true);
             rac_engine::retrieve::retrieve_grounding_from_derived(
                 root,
                 task,
@@ -423,7 +424,7 @@ pub fn retrieve_grounding(
                 top_k,
                 effective,
                 live_only,
-                &generation.derived,
+                &derived,
             )
         }
         None => rac_engine::retrieve::retrieve_grounding(
@@ -454,8 +455,6 @@ mod tests {
         let path = root.join("decision.md");
         std::fs::write(&path, decision("RAC-111111111111")).unwrap();
         let root_str = root.to_string_lossy().into_owned();
-        let stale_derived = rac_engine::derived::build_derived_index(&root_str, true);
-
         std::fs::write(&path, decision("RAC-222222222222")).unwrap();
         let items = rac_engine::relationships::corpus_items(&root_str, true);
         let identity =
@@ -478,7 +477,6 @@ mod tests {
             summary: rac_engine::delta_generation::SummaryGeneration::from_items(
                 items.iter().map(|item| ("decision.md", item)),
             ),
-            derived: stale_derived,
         }));
 
         assert_eq!(


### PR DESCRIPTION
## Summary
- remove the fresh whole-corpus `DerivedIndex` from served P6 delta generations
- materialize exact index entries, field vectors, relationships, live-decision paths, portfolio JSON, and scope rows from published incremental projections
- use delta-native materialization for durable compaction and grounding reads
- retain fresh whole-corpus derivation only in bounded byte-certification tests
- correct live-decision generations to carry canonical display paths rather than overlay keys

## Performance boundary
- below-threshold preview mutations no longer parse, validate, or derive the full corpus
- compaction performs serialization-oriented materialization from existing projections without reparsing or artifact validation
- failed writes or reopen continue serving the complete in-memory delta generation
- default serving remains unchanged pending scale and adoption gates

## Validation
- `cargo test --workspace`
- `cargo test --workspace --release`
- `cargo clippy --release --no-deps -- -D warnings`
- delta-native versus fresh store-segment byte equality across edit/delete/rename/compaction
- ADR-119 validation and generated agent-rule drift
- live-corpus validity, determinism, cache/no-cache equality, and freshness invariants

Closes #371
