### PR TITLE
perf(engine): cut over S1 delta freshness

### DIFF
--- a/docs/scale.md
+++ b/docs/scale.md
@@ -37,7 +37,7 @@ the corresponding scale tier is promoted:
 
 | tier | corpus | release objective |
 | --- | ---: | --- |
-| S1 | 5,000 | production baseline and default delta cutover |
+| S1 | 5,000 | production baseline; delta is the default freshness lifecycle |
 | S2 | 10,000 | preserve the S1 interactive budget where practical |
 | S3 | 25,000 | mutation publication comfortably below 500 ms |
 | S4 | 50,000 | bounded incremental publication and compaction |

--- a/rac/decisions/adr-119-base-plus-delta-serving-generations.md
+++ b/rac/decisions/adr-119-base-plus-delta-serving-generations.md
@@ -153,6 +153,16 @@ not require satisfying speculative 100,000-artifact latency targets. Higher
 tiers must repeat the same correctness, lifecycle, and memory evidence before
 their performance promises are published.
 
+P6.8 completes S1 adoption. The complete lifecycle peaked at 593 MiB RSS for
+delta versus 466 MiB for snapshot, passing the S1 limits of 768 MiB and 1.5
+times snapshot. A three-round release-mode soak performed 100 unchanged reads
+and 21 certified lifecycle transitions with zero validity, determinism,
+freshness, cache/no-cache, or persisted-segment divergence. The repeated valid
+corpus matrix measured 17.60 ms warm p95, 104.76-140.08 ms mutation p95, and
+1.44 s threshold compaction versus 1.50 s for snapshot. The normal constructor
+therefore selects delta; `new_snapshot` remains the explicit rollback path for
+the initial soak release.
+
 ## Alternatives Considered
 
 ### Mutate the currently served structures in place

--- a/rust/P6-SCALE-CERTIFICATION.md
+++ b/rust/P6-SCALE-CERTIFICATION.md
@@ -4,7 +4,7 @@ Date: 2026-07-22
 
 Decision: ADR-119
 
-Result: **certified for a 5,000-artifact production envelope; cutover pending**
+Result: **certified and cut over for the 5,000-artifact production envelope**
 
 ## Purpose
 
@@ -66,9 +66,8 @@ target/release/examples/p6_scale snapshot CORPUS CACHE_DIR 7
 target/release/examples/p6_scale delta CORPUS CACHE_DIR 7
 ```
 
-For the remaining 5,000-file memory gate, run the same commands under macOS
-`/usr/bin/time -l` and record `maximum resident set size`. This run did not
-capture trustworthy peak RSS, so gate 5 is explicitly unresolved.
+Peak RSS is measured by running the same complete lifecycle command under
+macOS `/usr/bin/time -l` and recording `maximum resident set size`.
 
 ## Results
 
@@ -145,11 +144,41 @@ Each tier requires correctness invariants, peak-RSS evidence, and the complete
 lifecycle matrix. Demand or a clearly reusable architectural improvement—not
 the existence of the next round number—triggers work on a higher tier.
 
+## S1 cutover certification
+
+Issue #375 repeated the complete 5,000-file matrix on a regenerated,
+validation-clean seed-1234 corpus before changing the production constructor.
+
+| lifecycle operation | snapshot | delta | S1 gate |
+|---|---:|---:|---|
+| cold | 983.42 ms | 2272.48 ms | measured, non-interactive |
+| warm p95 | 10.69 ms | 17.60 ms | pass: <=25 ms |
+| edit p95 | 513.60 ms | 140.08 ms | pass: <=150 ms |
+| add p95 | 552.60 ms | 127.69 ms | pass: <=150 ms |
+| delete p95 | 894.60 ms | 114.68 ms | pass: <=150 ms |
+| rename p95 | 526.84 ms | 104.76 ms | pass: <=150 ms |
+| threshold compaction | 1502.16 ms | 1440.16 ms | pass: delta 4.1% faster |
+| maximum resident set | 466 MiB | 593 MiB | pass |
+
+The S1 memory budget is at most 768 MiB peak RSS and at most 1.5 times the
+snapshot lifecycle. Delta used 1.27 times snapshot RSS, incurred no swaps, and
+remained 175 MiB below the absolute budget.
+
+The release-mode `p6_soak` certification then ran 100 unchanged reads and 21
+certified transitions over three rounds, including edit, restore, add, delete,
+rename, rename-back, threshold compaction, and first edit after compaction. It
+reported zero validity, determinism, freshness, cache/no-cache, or persisted
+segment byte-equality divergence. The first post-compaction edit parsed one
+file.
+
+With every S1 gate satisfied, `FreshnessTracker::new()` now selects the delta
+lifecycle used by normal MCP serving. `FreshnessTracker::new_snapshot()` keeps
+the established snapshot implementation as an explicit rollback path for the
+initial soak release.
+
 ## Verdict
 
 P6's architecture and correctness work is complete, and S1 is certified on
-latency and correctness. Default cutover is now blocked only on the 5,000-file
-peak-RSS measurement and bounded soak, not on speculative 100,000-file demand.
-Keep `FreshnessTracker::new_delta_preview` explicit until those two gates pass.
-After cutover, preserve the higher-scale matrix as roadmap and regression
-evidence rather than a release blocker.
+latency, memory, lifecycle safety, and correctness. Delta is the production
+default; snapshot is the explicit rollback path. Preserve the higher-scale
+matrix as roadmap and regression evidence rather than a release blocker.

--- a/rust/rac-engine/examples/p6_scale.rs
+++ b/rust/rac-engine/examples/p6_scale.rs
@@ -55,9 +55,9 @@ fn main() {
     let file_count = rac_engine::walk::find_markdown_files(&root_text, true).len();
     let threshold = file_count.saturating_add(iterations).saturating_add(10);
     let mut tracker = if mode == "delta" {
-        FreshnessTracker::new_delta_preview(cache.clone(), &root_text, Some(threshold))
-    } else {
         FreshnessTracker::new(cache.clone(), &root_text, Some(threshold))
+    } else {
+        FreshnessTracker::new_snapshot(cache.clone(), &root_text, Some(threshold))
     };
 
     let cold_ms = timed_read(&mut tracker, true);
@@ -98,9 +98,9 @@ fn main() {
     }
 
     let mut compact_tracker = if mode == "delta" {
-        FreshnessTracker::new_delta_preview(cache.join("compact"), &root_text, Some(1))
-    } else {
         FreshnessTracker::new(cache.join("compact"), &root_text, Some(1))
+    } else {
+        FreshnessTracker::new_snapshot(cache.join("compact"), &root_text, Some(1))
     };
     timed_read(&mut compact_tracker, true);
     fs::write(&target, &edited).expect("write compaction edit");

--- a/rust/rac-engine/examples/p6_soak.rs
+++ b/rust/rac-engine/examples/p6_soak.rs
@@ -1,0 +1,277 @@
+//! ADR-119 S1 bounded lifecycle soak and byte-equality certification.
+//!
+//! Run against a disposable generated corpus:
+//!
+//! `p6_soak <corpus> <cache-root> [rounds]`
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use rac_engine::derived::{build_derived_index, DerivedIndex, SCHEMA_VERSION};
+use rac_engine::freshness::{FreshnessTracker, TrackerModel};
+use rac_engine::index_store::{store_dir, write_store};
+use serde_json::json;
+
+fn first_markdown(root: &Path) -> PathBuf {
+    rac_engine::walk::find_markdown_files(&root.to_string_lossy(), true)
+        .into_iter()
+        .next()
+        .map(|entry| root.join(entry.components.join("/")))
+        .expect("corpus must contain at least one markdown file")
+}
+
+fn store_hashes(cache: &Path, key: &str) -> Vec<(String, String)> {
+    let mut hashes: Vec<(String, String)> = fs::read_dir(store_dir(cache, key))
+        .expect("read persisted store")
+        .map(|entry| {
+            let entry = entry.expect("read store entry");
+            let bytes = fs::read(entry.path()).expect("read store segment");
+            (
+                entry.file_name().to_string_lossy().into_owned(),
+                rac_engine::sha256::hexdigest(&bytes),
+            )
+        })
+        .collect();
+    hashes.sort();
+    hashes
+}
+
+fn assert_valid(root: &str) {
+    let items = rac_engine::relationships::corpus_items(root, true);
+    for item in &items {
+        let Some(spec) = item.spec else {
+            continue;
+        };
+        let issues = rac_engine::validate::validate(&item.artifact, None, Some(&spec.name));
+        assert!(
+            !rac_engine::validate::has_errors(&issues),
+            "{} must remain valid: {issues:?}",
+            item.path
+        );
+    }
+    let relationships = rac_engine::relationships::validate_relationships(root, true);
+    assert!(
+        relationships.ok(),
+        "relationship validation must remain clean: {:?}",
+        relationships.issues
+    );
+}
+
+fn certify_generation(
+    tracker: &mut FreshnessTracker,
+    verify: bool,
+    root: &str,
+    tracker_cache: &Path,
+    referee_root: &Path,
+    stage: &str,
+) {
+    let materialized: Option<DerivedIndex> = match tracker.read_model(verify) {
+        TrackerModel::Delta(generation) => Some(generation.materialize_derived(root, true)),
+        TrackerModel::View(_) => None,
+        TrackerModel::Snapshot(_) => panic!("S1 delta soak served a snapshot at {stage}"),
+    };
+    let key = tracker
+        .corpus_hash()
+        .expect("fresh generation must have a corpus hash")
+        .to_string();
+    let candidate_cache = referee_root.join(stage).join("candidate");
+    let fresh_cache = referee_root.join(stage).join("fresh");
+    let _ = fs::remove_dir_all(&candidate_cache);
+    let _ = fs::remove_dir_all(&fresh_cache);
+
+    let fresh = build_derived_index(root, true);
+    assert!(write_store(&fresh_cache, &key, SCHEMA_VERSION, &fresh));
+    let candidate_cache = if let Some(candidate) = materialized {
+        assert!(write_store(
+            &candidate_cache,
+            &key,
+            SCHEMA_VERSION,
+            &candidate,
+        ));
+        candidate_cache.as_path()
+    } else {
+        tracker_cache
+    };
+    assert_eq!(
+        store_hashes(candidate_cache, &key),
+        store_hashes(&fresh_cache, &key),
+        "persisted segments diverged from a fresh no-cache derivation at {stage}"
+    );
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() < 3 {
+        eprintln!("usage: p6_soak <corpus> <cache-root> [rounds]");
+        std::process::exit(2);
+    }
+    let corpus = PathBuf::from(&args[1]);
+    let cache_root = PathBuf::from(&args[2]);
+    let rounds: usize = args
+        .get(3)
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(3);
+    let root = corpus.to_string_lossy().into_owned();
+    let mutation_cache = cache_root.join("mutation");
+    let referee_root = cache_root.join("referees");
+    let _ = fs::remove_dir_all(&cache_root);
+    fs::create_dir_all(&cache_root).expect("create soak cache");
+    assert_valid(&root);
+
+    let mut tracker = FreshnessTracker::new(
+        mutation_cache.clone(),
+        &root,
+        Some(rounds.saturating_mul(16).saturating_add(100)),
+    );
+    certify_generation(
+        &mut tracker,
+        true,
+        &root,
+        &mutation_cache,
+        &referee_root,
+        "cold",
+    );
+    let mut warm_reads = 0;
+    for _ in 0..100 {
+        tracker.read_model(false);
+        warm_reads += 1;
+    }
+
+    let target = first_markdown(&corpus);
+    let original = fs::read(&target).expect("read mutation target");
+    let mut transitions = 0;
+    for round in 0..rounds {
+        let mut edited = original.clone();
+        edited.extend_from_slice(format!("\n<!-- p6-soak-{round} -->\n").as_bytes());
+        fs::write(&target, &edited).expect("write edit");
+        certify_generation(
+            &mut tracker,
+            true,
+            &root,
+            &mutation_cache,
+            &referee_root,
+            &format!("round-{round}-edit"),
+        );
+        assert_eq!(tracker.last_parse_files(), 1);
+        transitions += 1;
+
+        fs::write(&target, &original).expect("restore edit");
+        certify_generation(
+            &mut tracker,
+            true,
+            &root,
+            &mutation_cache,
+            &referee_root,
+            &format!("round-{round}-restore"),
+        );
+        assert_eq!(tracker.last_parse_files(), 1);
+        transitions += 1;
+
+        let added = corpus.join(format!("p6-soak-added-{round}.md"));
+        let added_text = format!(
+            "---\nschema_version: 1\nid: RAC-Z9SCAE{round:06}\ntype: decision\n---\n# Soak {round}\n\n## Context\n\nBounded soak.\n\n## Decision\n\nCertify.\n\n## Consequences\n\nEvidence.\n\n## Status\n\nAccepted\n"
+        );
+        fs::write(&added, added_text).expect("write added artifact");
+        certify_generation(
+            &mut tracker,
+            true,
+            &root,
+            &mutation_cache,
+            &referee_root,
+            &format!("round-{round}-add"),
+        );
+        assert_eq!(tracker.last_parse_files(), 1);
+        transitions += 1;
+
+        fs::remove_file(&added).expect("delete added artifact");
+        certify_generation(
+            &mut tracker,
+            true,
+            &root,
+            &mutation_cache,
+            &referee_root,
+            &format!("round-{round}-delete"),
+        );
+        assert_eq!(tracker.last_parse_files(), 0);
+        transitions += 1;
+
+        let renamed = target.with_extension(format!("soak-{round}.md"));
+        fs::rename(&target, &renamed).expect("rename target");
+        certify_generation(
+            &mut tracker,
+            true,
+            &root,
+            &mutation_cache,
+            &referee_root,
+            &format!("round-{round}-rename"),
+        );
+        assert_eq!(tracker.last_parse_files(), 1);
+        transitions += 1;
+        fs::rename(&renamed, &target).expect("restore target name");
+        certify_generation(
+            &mut tracker,
+            true,
+            &root,
+            &mutation_cache,
+            &referee_root,
+            &format!("round-{round}-rename-back"),
+        );
+        assert_eq!(tracker.last_parse_files(), 1);
+        transitions += 1;
+    }
+
+    let compaction_cache = cache_root.join("compaction");
+    let compaction_referees = cache_root.join("compaction-referees");
+    let mut compact = FreshnessTracker::new(compaction_cache.clone(), &root, Some(1));
+    certify_generation(
+        &mut compact,
+        true,
+        &root,
+        &compaction_cache,
+        &compaction_referees,
+        "compact-cold",
+    );
+    let mut edited = original.clone();
+    edited.extend_from_slice(b"\n<!-- p6-soak-compaction -->\n");
+    fs::write(&target, &edited).expect("write compaction edit");
+    certify_generation(
+        &mut compact,
+        true,
+        &root,
+        &compaction_cache,
+        &compaction_referees,
+        "compact-edit",
+    );
+    assert_eq!(compact.last_parse_files(), 1);
+    assert_eq!(compact.delta_size(), 0);
+    fs::write(&target, &original).expect("write first post-compaction edit");
+    certify_generation(
+        &mut compact,
+        true,
+        &root,
+        &compaction_cache,
+        &compaction_referees,
+        "compact-post-edit",
+    );
+    assert_eq!(compact.last_parse_files(), 1);
+    assert_eq!(compact.delta_size(), 0);
+    assert_valid(&root);
+
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&json!({
+            "schema_version": "1",
+            "files": rac_engine::walk::find_markdown_files(&root, true).len(),
+            "rounds": rounds,
+            "warm_reads": warm_reads,
+            "certified_transitions": transitions + 3,
+            "valid": true,
+            "deterministic": true,
+            "fresh": true,
+            "cache_no_cache_equal": true,
+            "persisted_segments_byte_equal": true,
+            "post_compaction_parse_files": compact.last_parse_files(),
+        }))
+        .unwrap()
+    );
+}

--- a/rust/rac-engine/src/freshness.rs
+++ b/rust/rac-engine/src/freshness.rs
@@ -27,7 +27,7 @@ use crate::relationships::CorpusItem;
 pub enum TrackerModel {
     View(MmapIndexReader),
     Snapshot(DerivedIndex),
-    /// P6 preview generation. The document overlay is immutable for the
+    /// P6 production generation. The document overlay is immutable for the
     /// lifetime of this served model and is published only after every
     /// incremental projection has been staged successfully.
     Delta(Box<DeltaGeneration>),
@@ -49,9 +49,8 @@ pub struct FreshnessTracker {
     /// advances for mutation-window snapshots that have not compacted.
     serving_generation: u64,
     delta_paths: HashSet<String>,
-    /// Present only for the opt-in P6 preview. Default serving retains the
-    /// established snapshot lifecycle until the later delta slices pass the
-    /// referee and scale gates.
+    /// Present for the production P6 delta lifecycle. The explicit snapshot
+    /// fallback leaves these absent.
     delta_documents: Option<DeltaDocuments>,
     delta_identity: Option<IdentityGeneration>,
     delta_search: Option<SearchGeneration>,
@@ -68,14 +67,20 @@ pub struct FreshnessTracker {
 }
 
 impl FreshnessTracker {
+    /// Production S1 freshness: immutable base plus cumulative delta.
     pub fn new(cache_dir: PathBuf, root: &str, threshold: Option<usize>) -> Self {
+        Self::new_delta(cache_dir, root, threshold, true)
+    }
+
+    /// Explicit rollback path retained for the first S1 soak release.
+    pub fn new_snapshot(cache_dir: PathBuf, root: &str, threshold: Option<usize>) -> Self {
         Self::new_with_watcher(cache_dir, root, threshold, true)
     }
 
     /// Force the authoritative stat rung. Used by fallback/parity tests and
     /// remains the behavior on platforms without a synchronous watcher.
     pub fn new_stat(cache_dir: PathBuf, root: &str, threshold: Option<usize>) -> Self {
-        Self::new_with_watcher(cache_dir, root, threshold, false)
+        Self::new_delta(cache_dir, root, threshold, false)
     }
 
     fn new_with_watcher(
@@ -110,15 +115,13 @@ impl FreshnessTracker {
         }
     }
 
-    /// Opt in to the P6 generation preview. This is intentionally a
-    /// separate constructor so normal MCP serving cannot adopt the preview by
-    /// accident.
-    pub fn new_delta_preview(
+    fn new_delta(
         cache_dir: PathBuf,
         root: &str,
         threshold: Option<usize>,
+        watcher_enabled: bool,
     ) -> Self {
-        let mut tracker = Self::new_with_watcher(cache_dir, root, threshold, true);
+        let mut tracker = Self::new_with_watcher(cache_dir, root, threshold, watcher_enabled);
         tracker.delta_documents = Some(DeltaDocuments::empty());
         tracker.delta_identity = Some(IdentityGeneration::empty());
         tracker.delta_search = Some(SearchGeneration::empty());
@@ -148,7 +151,7 @@ impl FreshnessTracker {
             .map_or_else(|| self.delta_paths.len(), DeltaDocuments::delta_len)
     }
 
-    pub fn delta_preview_enabled(&self) -> bool {
+    pub fn delta_enabled(&self) -> bool {
         self.delta_documents.is_some()
     }
 
@@ -206,7 +209,7 @@ impl FreshnessTracker {
         if !cold {
             let recompute_started = crate::timing::start();
             if self.delta_documents.is_some() {
-                self.rebuild_delta_preview(&changed);
+                self.rebuild_delta(&changed);
             } else {
                 self.apply(&changed);
                 self.rebuild_model();
@@ -223,7 +226,7 @@ impl FreshnessTracker {
         // phases feed the RAC_TIMING scorecard (ADR-107).
         let parse_start = std::time::Instant::now();
         if self.delta_documents.is_some() {
-            self.rebuild_delta_preview(&changed);
+            self.rebuild_delta(&changed);
         } else {
             self.apply(&changed);
         }
@@ -363,7 +366,7 @@ impl FreshnessTracker {
 
     /// Build a complete candidate generation from staged overlays, then swap
     /// every serving field only after all projections succeed.
-    fn rebuild_delta_preview(&mut self, changed: &BTreeSet<String>) {
+    fn rebuild_delta(&mut self, changed: &BTreeSet<String>) {
         let current: HashSet<&str> = self.manifest.iter().map(|(rel, _)| rel.as_str()).collect();
         let root = PathBuf::from(&self.root_str);
         let present: Vec<PathBuf> = changed
@@ -396,32 +399,32 @@ impl FreshnessTracker {
                 let identity = self
                     .delta_identity
                     .as_ref()
-                    .expect("preview identity")
+                    .expect("delta identity")
                     .stage(changed, &parsed);
                 let search = self
                     .delta_search
                     .as_ref()
-                    .expect("preview search")
+                    .expect("delta search")
                     .stage(changed, &parsed);
                 let graph = self
                     .delta_graph
                     .as_ref()
-                    .expect("preview graph")
+                    .expect("delta graph")
                     .stage(changed, &parsed, &identity);
                 let scope = self
                     .delta_scope
                     .as_ref()
-                    .expect("preview scope")
+                    .expect("delta scope")
                     .stage(changed, &parsed);
                 let summary = self
                     .delta_summary
                     .as_ref()
-                    .expect("preview summary")
+                    .expect("delta summary")
                     .stage(changed, &parsed);
                 let documents = self
                     .delta_documents
                     .as_ref()
-                    .expect("preview documents")
+                    .expect("delta documents")
                     .stage(changed, parsed);
                 (documents, identity, search, graph, scope, summary)
             } else {
@@ -582,23 +585,23 @@ impl FreshnessTracker {
             documents.promote(ordered_paths);
             self.delta_identity
                 .as_mut()
-                .expect("preview identity")
+                .expect("delta identity")
                 .promote();
             self.delta_search
                 .as_mut()
-                .expect("preview search")
+                .expect("delta search")
                 .promote();
             self.delta_graph
                 .as_mut()
-                .expect("preview graph")
+                .expect("delta graph")
                 .promote();
             self.delta_scope
                 .as_mut()
-                .expect("preview scope")
+                .expect("delta scope")
                 .promote();
             self.delta_summary
                 .as_mut()
-                .expect("preview summary")
+                .expect("delta summary")
                 .promote();
             // P6 removes snapshot shedding for its parsed document base so
             // the first post-compaction edit remains change-bound.

--- a/rust/rac-engine/tests/freshness_tracker.rs
+++ b/rust/rac-engine/tests/freshness_tracker.rs
@@ -28,7 +28,7 @@ fn base_delta_compaction_lifecycle() {
 
     // Threshold 2: the second delta path triggers compaction — observable
     // without a 10k-file corpus.
-    let mut tracker = FreshnessTracker::new(cache.clone(), &root, Some(2));
+    let mut tracker = FreshnessTracker::new_snapshot(cache.clone(), &root, Some(2));
     #[cfg(target_os = "linux")]
     assert_eq!(tracker.mode(), "inotify");
     #[cfg(not(target_os = "linux"))]
@@ -79,7 +79,7 @@ fn base_delta_compaction_lifecycle() {
             assert_eq!(derived.index_entries.len(), 2);
         }
         TrackerModel::View(_) => panic!("one change below threshold must serve the snapshot"),
-        TrackerModel::Delta(_) => panic!("default tracker must not serve the P6 preview"),
+        TrackerModel::Delta(_) => panic!("snapshot fallback must not serve delta generations"),
     }
     assert_eq!(tracker.serving_generation(), 4);
 
@@ -124,9 +124,11 @@ fn detection_barrier_catches_immediate_nested_mutation() {
     fs::create_dir_all(&nested).unwrap();
     fs::write(nested.join("adr-2-two.md"), DOC.replace("ADR-1", "ADR-2")).unwrap();
     match tracker.read_model(false) {
-        TrackerModel::Snapshot(derived) => assert_eq!(derived.index_entries.len(), 2),
+        TrackerModel::Delta(delta) => {
+            assert_eq!(delta.materialize_derived(&root, true).index_entries.len(), 2)
+        }
         TrackerModel::View(_) => panic!("nested mutation must open the delta window"),
-        TrackerModel::Delta(_) => panic!("default tracker must not serve the P6 preview"),
+        TrackerModel::Snapshot(_) => panic!("default tracker must serve the delta generation"),
     }
     assert!(tracker.last_detect_scanned());
     assert_eq!(tracker.serving_generation(), generation + 1);
@@ -157,9 +159,11 @@ fn watcher_setup_and_runtime_failure_degrade_to_stat() {
     tracker.read_model(false);
     fs::remove_dir_all(&corpus).unwrap();
     match tracker.read_model(false) {
-        TrackerModel::Snapshot(derived) => assert!(derived.index_entries.is_empty()),
-        TrackerModel::View(_) => panic!("root removal must be served as an empty snapshot"),
-        TrackerModel::Delta(_) => panic!("default tracker must not serve the P6 preview"),
+        TrackerModel::Delta(delta) => {
+            assert!(delta.materialize_derived(&root, true).index_entries.is_empty())
+        }
+        TrackerModel::View(_) => panic!("root removal must open an empty delta generation"),
+        TrackerModel::Snapshot(_) => panic!("default tracker must serve the delta generation"),
     }
     assert_eq!(tracker.mode(), "stat");
     assert!(tracker.last_detect_scanned());
@@ -185,7 +189,7 @@ fn store_hashes(cache_dir: &Path, corpus_hash: &str) -> Vec<(String, String)> {
 
 fn assert_delta_matches_fresh(model: &TrackerModel, root: &str, tag: &str) {
     let TrackerModel::Delta(generation) = model else {
-        panic!("expected a preview delta generation");
+        panic!("expected a delta generation");
     };
     let candidate_cache = scratch(&format!("{tag}-candidate"));
     let fresh_cache = scratch(&format!("{tag}-fresh"));
@@ -206,7 +210,7 @@ fn assert_delta_matches_fresh(model: &TrackerModel, root: &str, tag: &str) {
     assert_eq!(
         store_hashes(&candidate_cache, key),
         store_hashes(&fresh_cache, key),
-        "preview generation must be byte-identical to a fresh derivation"
+        "delta generation must be byte-identical to a fresh derivation"
     );
     let fresh_items = rac_engine::relationships::corpus_items(root, true);
     assert_eq!(
@@ -326,15 +330,15 @@ fn assert_delta_matches_fresh(model: &TrackerModel, root: &str, tag: &str) {
 }
 
 #[test]
-fn delta_preview_stages_mutations_compacts_and_keeps_parsed_base() {
+fn default_delta_stages_mutations_compacts_and_keeps_parsed_base() {
     let corpus = scratch("p6-corpus");
     let cache = scratch("p6-cache");
     fs::write(corpus.join("adr-1-base.md"), DOC).unwrap();
     fs::write(corpus.join("adr-2-two.md"), DOC.replace("ADR-1", "ADR-2")).unwrap();
     let root = corpus.to_string_lossy().into_owned();
-    let mut tracker = FreshnessTracker::new_delta_preview(cache.clone(), &root, Some(3));
+    let mut tracker = FreshnessTracker::new(cache.clone(), &root, Some(3));
 
-    assert!(tracker.delta_preview_enabled());
+    assert!(tracker.delta_enabled());
     assert!(matches!(tracker.read_model(false), TrackerModel::View(_)));
     assert_eq!(tracker.base_generation(), 1);
     assert_eq!(tracker.delta_base_documents(), 2);
@@ -351,7 +355,7 @@ fn delta_preview_stages_mutations_compacts_and_keeps_parsed_base() {
     let base = tracker.base_generation();
     let model = tracker.read_model(false);
     let TrackerModel::Delta(generation) = model else {
-        panic!("one edit must open the preview delta");
+        panic!("one edit must open the delta generation");
     };
     assert_eq!(generation.base_generation, base);
     assert_eq!(generation.serving_generation, serving);

--- a/rust/tools/gen_corpus.py
+++ b/rust/tools/gen_corpus.py
@@ -151,7 +151,7 @@ def bullets(rng):
 def reqs_body(rng):
     lines = []
     for i in range(1, rng.randint(3, 6)):
-        lines.append(f"- [REQ-{i:03d}] The system must {sentence(rng).lower()}")
+        lines.append(f"- [REQ-{i:03d}] The system MUST {sentence(rng).lower()}")
     return "\n".join(lines)
 
 


### PR DESCRIPTION
Closes #375

## Summary
- certify the 5,000-artifact lifecycle against explicit latency, memory, compaction, and correctness gates
- add a bounded release-mode soak that proves validity, freshness, determinism, cache/no-cache equality, and persisted-segment byte equality
- make base-plus-delta the normal `FreshnessTracker::new()` lifecycle used by MCP
- retain `FreshnessTracker::new_snapshot()` as the explicit rollback path for the initial soak release
- repair the deterministic corpus generator so requirements remain valid under the current BCP 14 contract

## S1 evidence
- delta peak RSS: 593 MiB vs snapshot 466 MiB (1.27x; budget <=768 MiB and <=1.5x)
- warm p95: 17.60 ms
- mutation p95: 104.76-140.08 ms
- compaction: 1440.16 ms delta vs 1502.16 ms snapshot
- soak: 100 warm reads, 21 certified transitions, zero divergence, one parsed file after compaction

## Verification
- cargo test --workspace
- cargo test -p rac-engine --test freshness_tracker
- cargo test -p rac-mcp
- cargo clippy -p rac-engine --release --lib --example p6_scale --example p6_soak --test freshness_tracker --no-deps -- -D warnings
- release `p6_scale` snapshot/delta matrix over valid seed-1234 5k corpus
- release `p6_soak` over valid seed-1234 5k corpus, 3 rounds
- `/usr/bin/time -l` complete lifecycle RSS measurements
- ADR-119 validation
- git diff --check