### PR TITLE
chore(engine): prepare v0.23.0 native release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ details, release history over commit history.
 
 ## Unreleased
 
+## v0.23.0 — 2026-07-24
+
 **AsDecided is now the product and runtime surface.** The supported native
 executables are `decided` and `decided-mcp`; there is no `rac` executable,
 Python CLI fallback, or `RAC_*` environment compatibility layer. New


### PR DESCRIPTION
## Summary

- cut the first native-only AsDecided release section
- retain an empty Unreleased section for subsequent changes

## Release boundary

After this PR is green and merged, publish v0.23.0 from its merge commit so the native release workflow can attach platform archives and publish the GHCR image.