### PR TITLE
fix(engine): make native release compile on Windows

### DIFF
--- a/.github/workflows/rust-spike.yml
+++ b/.github/workflows/rust-spike.yml
@@ -17,6 +17,24 @@ on:
       - ".github/workflows/rust-spike.yml"
 
 jobs:
+  windows-compile:
+    name: Windows native compile
+    runs-on: windows-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install rust toolchain (pinned by rust/rust-toolchain.toml)
+        run: rustup show
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rust
+
+      - name: Check native workspace
+        working-directory: rust
+        run: cargo check --workspace --locked
+
   rust-contract:
     name: Rust contract + live-corpus invariants
     runs-on: ubuntu-latest

--- a/rust/rac-engine/src/derived_cache.rs
+++ b/rust/rac-engine/src/derived_cache.rs
@@ -50,10 +50,14 @@ pub fn default_cache_dir() -> PathBuf {
 // ---------------------------------------------------------------------------
 
 fn stat_pair(path: &Path) -> Option<(u64, u64)> {
-    use std::os::unix::fs::MetadataExt;
     let meta = std::fs::metadata(path).ok()?;
-    let mtime_ns = (meta.mtime() as i128) * 1_000_000_000 + i128::from(meta.mtime_nsec());
-    Some((meta.len(), mtime_ns as u64))
+    let mtime_ns = meta
+        .modified()
+        .ok()?
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()?
+        .as_nanos() as u64;
+    Some((meta.len(), mtime_ns))
 }
 
 /// Diff the corpus against `prev_manifest` by stat, content-confirming

--- a/rust/rac-engine/src/hook.rs
+++ b/rust/rac-engine/src/hook.rs
@@ -98,11 +98,12 @@ pub fn install_hook(target_dir: &str, style: &str) -> Result<InstalledHook, Hook
     std::fs::write(dest, content)
         .map_err(|e| HookInstallError::Io(format!("{e}: {dest_display}")))?;
     // dest.chmod(dest.stat().st_mode | S_IXUSR | S_IXGRP | S_IXOTH)
-    let mode = std::fs::metadata(dest)
-        .map_err(|e| HookInstallError::Io(format!("{e}: {dest_display}")))?
-        .permissions();
+    #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
+        let mode = std::fs::metadata(dest)
+            .map_err(|e| HookInstallError::Io(format!("{e}: {dest_display}")))?
+            .permissions();
         let new_mode = mode.mode() | 0o111;
         std::fs::set_permissions(dest, std::fs::Permissions::from_mode(new_mode))
             .map_err(|e| HookInstallError::Io(format!("{e}: {dest_display}")))?;

--- a/rust/rac-engine/src/revisions.rs
+++ b/rust/rac-engine/src/revisions.rs
@@ -278,12 +278,14 @@ fn extract_tar(data: &[u8], target: &Path) {
                             let _ = std::fs::write(&dest, body);
                         }
                         b'2' => {
-                            let link = cstr_field(&header[157..257]);
                             if let Some(parent) = dest.parent() {
                                 let _ = std::fs::create_dir_all(parent);
                             }
                             #[cfg(unix)]
-                            let _ = std::os::unix::fs::symlink(&link, &dest);
+                            {
+                                let link = cstr_field(&header[157..257]);
+                                let _ = std::os::unix::fs::symlink(&link, &dest);
+                            }
                         }
                         _ => {} // hardlinks/devices: never in git archives
                     }


### PR DESCRIPTION
## Root cause

The first v0.23.0 native release exposed unconditional Unix filesystem APIs in the Rust engine. Windows failed on MetadataExt/PermissionsExt before packaging.

## Fix

- derive mtime nanoseconds through portable std::fs::Metadata::modified
- apply executable permission bits only on Unix
- scope symlink target parsing to Unix alongside symlink creation

## Verification

- rac-engine release suite: pass
- local Windows target reached native dependency compilation; the host lacks the MinGW compiler needed to complete cross-checking
- GitHub's windows-latest release job is the authoritative Windows build gate