### PR TITLE
chore(engine): prepare v0.23.1 native patch release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ details, release history over commit history.
 
 ## Unreleased
 
+## v0.23.1 — 2026-07-24
+
+- Fixed native Windows compilation by using portable filesystem metadata,
+  limiting permission changes and symlink inspection to Unix platforms.
+- Added a Windows workspace compile check to CI so native Windows support
+  remains a release gate.
+
 ## v0.23.0 — 2026-07-24
 
 **AsDecided is now the product and runtime surface.** The supported native


### PR DESCRIPTION
## Summary

- record the portable Windows filesystem fix in v0.23.1
- record the new Windows workspace compile gate
- leave Unreleased ready for subsequent work

## Release intent

After this PR is merged, publish v0.23.1 from the merge commit and update the `decided` and `rac-full` Homebrew formulas to the patch release.

## Verification

- `git diff --check`
- PR checks, including the Windows workspace compile gate