### PR TITLE
Sharpen the public README front door (engine)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,14 @@
 
 **Engineering decisions your agents can follow. Build, as decided.**
 
-AsDecided keeps requirements, decisions, designs, roadmaps, and prompts as
-typed Markdown in your repository. Its native Rust engine validates that
-knowledge, retrieves relevant decisions deterministically, and serves it
-read-only to agents over MCP.
+AsDecided is a local system of record for the product decisions behind your
+code. It keeps requirements, decisions, designs, roadmaps, and prompts as typed
+Markdown, rejects broken knowledge before it lands, and serves the current
+record read-only to coding agents over MCP.
 
-No embeddings, model call, hosted index, or Python runtime is required. The
-same repository state produces the same answer.
+The engine is native Rust. Retrieval is deterministic: no embeddings, model
+call, hosted index, or Python runtime, and the same repository state produces
+the same answer. [Read the documentation](https://asdecided.github.io/core/).
 
 ## Install
 
@@ -72,7 +73,7 @@ refuses to overwrite either destination.
 
 Rust is the product engine and the only CLI/MCP runtime in this repository.
 The authoritative language-neutral compatibility fixtures live in
-[`asdecided-spec`](https://github.com/asdecided/spec). Live-corpus validation is
+[`asdecided/spec`](https://github.com/asdecided/spec). Live-corpus validation is
 based on validity, determinism, freshness, and cache/no-cache equality.
 
 Document ingestion remains an ancillary Python connector rather than part of


### PR DESCRIPTION
## Summary

- reposition the README opening around AsDecided as a local system of record
- make native Rust and deterministic retrieval explicit
- link directly to the public documentation
- correct the specification repository label to `asdecided/spec`

## Why

The existing README described the implementation accurately, but its opening
did not establish the product value quickly enough for a first-time visitor.
This gives the repository a clearer public front door without changing the
underlying product contract.

## Validation

- `git diff --check`
- README front-door audit passed
- documentation-only change
