### PR TITLE
feat(engine): add Sentry enforcement and native Herald rendering

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -581,7 +581,8 @@ enforcement policy. The single enforcement entry point — one exit code, one SA
 document — used by the PR-gate Action.
 
 - **Input:** `decided gate <directory>` — scanned recursively for `*.md`.
-- **Options:** `--json` · `--sarif` (mutually exclusive) · `--top-level`
+- **Options:** `--json` · `--sarif` (mutually exclusive) · `--top-level` ·
+  `--code` · `--repository PATH` · `--base REF` · `--full`
 - **Exit codes:** `0` nothing blocking · `1` a blocking finding (or malformed
   `.decided/config.yaml`) · `2` not a directory
 
@@ -589,6 +590,7 @@ document — used by the PR-gate Action.
 decided gate decisions/                # human summary
 decided gate decisions/ --json         # stable JSON contract (schema_version "1")
 decided gate decisions/ --sarif        # one SARIF 2.1.0 document over all findings
+decided gate decisions/ --code --base origin/main  # include Sentry code checks
 ```
 
 Which findings block versus merely annotate is governed by an optional
@@ -599,6 +601,31 @@ lists of finding codes). With no policy, the gate's verdict is exactly
 `severity`, `enforcement`, `path`, `line`, `message`); `--sarif` emits one
 combined document for GitHub Code Scanning. See
 [Governance](governance.md) for the policy shape and fleet-readiness guidance.
+
+---
+
+## sentry
+
+Enforce the machine-checkable subset of live decisions against source code.
+Rules are declared in a decision artifact's versioned `## Code Constraints`
+YAML block. Enforcement is deterministic and offline: glob matching, regular
+expressions, and language-specific import extraction only—no model judge.
+
+- **Input:** `decided sentry <corpus-directory>`
+- **Options:** `--repository PATH` (default `.`) · `--base REF` (required for
+  diff enforcement) · `--full` (check the complete tree instead) · `--json` ·
+  `--sarif` (mutually exclusive) · `--top-level`
+- **Exit codes:** `0` no violations · `1` a malformed constraint or code
+  violation · `2` bad arguments, repository, or Git base
+
+```bash
+decided sentry decisions/ --base origin/main
+decided sentry decisions/ --full --json
+```
+
+Every report publishes `constrained_decisions / live_decisions` coverage.
+Coverage describes how much of the decision corpus has deterministic
+enforcement; it does not claim that prose-only decisions are enforced.
 
 ---
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1490,6 +1490,24 @@ The same lookup is available to agents over MCP as an additive optional `path`
 argument on the `find_decisions` tool (the five-tool surface is unchanged);
 `find_decisions` called with a `topic` is byte-identical to before.
 
+### Herald rendering
+
+`decided herald <directory>` turns a newline-delimited changed-path file into
+Herald's deterministic pull-request comment without Python:
+
+```bash
+decided herald decisions/ \
+  --paths-file changed-paths.txt \
+  --link-base https://github.com/owner/repo/blob/HEAD \
+  --max-inline 5 \
+  --out governing-decisions.md
+```
+
+`--github-output PATH` optionally appends `has_decisions=true|false` for a
+composite action output. The renderer deduplicates decisions and paths, sorts
+them, collapses overflow into a details element, and exits successfully for an
+ungoverned diff. It performs no enforcement; Herald reports facts only.
+
 
 ---
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -33,6 +33,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
+name = "bstr"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f7dc094d718f2e1c1559ad110e27eeaae14a5465d3d56dd6dbd793079fbd530"
+dependencies = [
+ "memchr",
+ "serde_core",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -171,6 +181,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "globset"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e47d37d2ae4464254884b60ab7071be2b876a9c35b696bd018ddcc76847309cd"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -248,6 +271,12 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "log"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "markdown-it"
@@ -343,12 +372,15 @@ dependencies = [
 name = "rac-engine"
 version = "0.0.1"
 dependencies = [
+ "globset",
  "inotify",
  "markdown-it",
  "memmap2",
  "rayon",
+ "regex",
  "serde",
  "serde_json",
+ "serde_yaml",
 ]
 
 [[package]]
@@ -421,6 +453,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -468,6 +506,19 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -558,6 +609,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "windows-link"

--- a/rust/rac-engine/Cargo.toml
+++ b/rust/rac-engine/Cargo.toml
@@ -11,6 +11,9 @@ serde_json = { version = "1", features = ["preserve_order"] }
 rayon = "1"
 memmap2 = "0.9"
 markdown-it = { version = "0.6.1", default-features = false }
+globset = "0.4"
+regex = "1"
+serde_yaml = "0.9"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 inotify = { version = "0.11", default-features = false }

--- a/rust/rac-engine/assets/spec/artifact-specs.json
+++ b/rust/rac-engine/assets/spec/artifact-specs.json
@@ -106,6 +106,7 @@
       ],
       "optional": [
         "supersedes",
+        "code constraints",
         "related requirements",
         "related roadmaps",
         "related designs",
@@ -134,6 +135,7 @@
       ],
       "descriptions": {
         "supersedes": "The artifact this one supersedes",
+        "code constraints": "Deterministic source-code rules that enforce the machine-checkable subset of this decision",
         "related requirements": "Requirement artifacts this artifact references",
         "related roadmaps": "Roadmap artifacts this artifact references",
         "related designs": "Design artifacts this artifact references",

--- a/rust/rac-engine/src/cli.rs
+++ b/rust/rac-engine/src/cli.rs
@@ -6,11 +6,11 @@
 
 use crate::commands::{
     cmd_coverage, cmd_decisions_for, cmd_diff, cmd_doctor, cmd_eval, cmd_export, cmd_find,
-    cmd_gate, cmd_hook, cmd_improve, cmd_index, cmd_init, cmd_inspect, cmd_mcp_stats, cmd_migrate,
+    cmd_gate, cmd_herald, cmd_hook, cmd_improve, cmd_index, cmd_init, cmd_inspect, cmd_mcp_stats, cmd_migrate,
     cmd_new, cmd_portfolio, cmd_quickstart, cmd_relationships, cmd_rename, cmd_resolve,
     cmd_retrieve, cmd_review, cmd_schema, cmd_sentry, cmd_skill, cmd_stats, cmd_telemetry,
     cmd_templates, cmd_usage, cmd_validate, CoverageArgs, DecisionsForArgs, DiffArgs, DoctorArgs,
-    EvalArgs, ExportArgs, FindArgs, GateArgs, HookArgs, ImproveArgs, IndexArgs, InitArgs,
+    EvalArgs, ExportArgs, FindArgs, GateArgs, HeraldArgs, HookArgs, ImproveArgs, IndexArgs, InitArgs,
     InspectArgs, McpStatsArgs, MigrateArgs, NewArgs, PortfolioArgs, QuickstartArgs,
     RelationshipsArgs, RenameArgs, ResolveArgs, RetrieveArgs, ReviewArgs, SchemaArgs, SentryArgs,
     SkillArgs, StatsArgs, TelemetryArgs, TemplatesArgs, UsageArgs, ValidateArgs, WatchkeeperArgs,
@@ -155,7 +155,7 @@ fn run_dispatch(args: &[String]) -> u8 {
     // Native-only additions dispatch but are deliberately NOT in SUBCOMMANDS:
     // the retired Python oracle's `invalid choice` bytes remain pinned by the
     // bounded compatibility suite.
-    if !matches!(first.as_str(), "retrieve" | "sentry")
+    if !matches!(first.as_str(), "retrieve" | "sentry" | "herald")
         && !SUBCOMMANDS.contains(&first.as_str())
     {
         return argparse_error("decided", &invalid_choice_message(first));
@@ -216,6 +216,7 @@ fn run_dispatch(args: &[String]) -> u8 {
         "decisions-for" => run_decisions_for(&rest),
         "gate" => run_gate(&rest),
         "sentry" => run_sentry(&rest),
+        "herald" => run_herald(&rest),
         "doctor" => run_doctor(&rest),
         "watchkeeper" => run_watchkeeper(&rest),
         "mcp-stats" => run_mcp_stats(&rest),
@@ -878,6 +879,82 @@ fn run_sentry(rest: &[&String]) -> u8 {
         full,
         json,
         sarif,
+        top_level,
+    }) as u8
+}
+
+fn run_herald(rest: &[&String]) -> u8 {
+    let prog = "decided herald";
+    let mut directory = None;
+    let mut paths_file = None;
+    let mut link_base = String::new();
+    let mut max_inline = 5i64;
+    let mut out = None;
+    let mut github_output = None;
+    let mut top_level = false;
+    let mut extras = Vec::new();
+    let mut i = 0;
+    while i < rest.len() {
+        let arg = rest[i].as_str();
+        if arg == "-" || !arg.starts_with('-') {
+            if directory.is_none() {
+                directory = Some(arg.to_string());
+            } else {
+                extras.push(arg.to_string());
+            }
+            i += 1;
+            continue;
+        }
+        match arg {
+            "--top-level" => top_level = true,
+            "--paths-file" | "--link-base" | "--max-inline" | "--out" | "--github-output" => {
+                i += 1;
+                if i >= rest.len() {
+                    return argparse_error(prog, &format!("argument {arg}: expected one argument"));
+                }
+                let value = rest[i].to_string();
+                match arg {
+                    "--paths-file" => paths_file = Some(value),
+                    "--link-base" => link_base = value,
+                    "--max-inline" => {
+                        max_inline = match value.parse() {
+                            Ok(value) => value,
+                            Err(_) => {
+                                return argparse_error(
+                                    prog,
+                                    &format!("argument --max-inline: invalid int value: '{value}'"),
+                                )
+                            }
+                        }
+                    }
+                    "--out" => out = Some(value),
+                    "--github-output" => github_output = Some(value),
+                    _ => unreachable!(),
+                }
+            }
+            other => extras.push(other.to_string()),
+        }
+        i += 1;
+    }
+    let Some(directory) = directory else {
+        return argparse_error(prog, "the following arguments are required: directory");
+    };
+    let Some(paths_file) = paths_file else {
+        return argparse_error(prog, "the following arguments are required: --paths-file");
+    };
+    let Some(out) = out else {
+        return argparse_error(prog, "the following arguments are required: --out");
+    };
+    if !extras.is_empty() {
+        return unrecognized(&extras);
+    }
+    cmd_herald(&HeraldArgs {
+        directory,
+        paths_file,
+        link_base,
+        max_inline,
+        out,
+        github_output,
         top_level,
     }) as u8
 }

--- a/rust/rac-engine/src/cli.rs
+++ b/rust/rac-engine/src/cli.rs
@@ -8,12 +8,12 @@ use crate::commands::{
     cmd_coverage, cmd_decisions_for, cmd_diff, cmd_doctor, cmd_eval, cmd_export, cmd_find,
     cmd_gate, cmd_hook, cmd_improve, cmd_index, cmd_init, cmd_inspect, cmd_mcp_stats, cmd_migrate,
     cmd_new, cmd_portfolio, cmd_quickstart, cmd_relationships, cmd_rename, cmd_resolve,
-    cmd_retrieve, cmd_review, cmd_schema, cmd_skill, cmd_stats, cmd_telemetry, cmd_templates,
-    cmd_usage, cmd_validate, CoverageArgs, DecisionsForArgs, DiffArgs, DoctorArgs, EvalArgs,
-    ExportArgs, FindArgs, GateArgs, HookArgs, ImproveArgs, IndexArgs, InitArgs, InspectArgs,
-    McpStatsArgs, MigrateArgs, NewArgs, PortfolioArgs, QuickstartArgs, RelationshipsArgs,
-    RenameArgs, ResolveArgs, RetrieveArgs, ReviewArgs, SchemaArgs, SkillArgs, StatsArgs,
-    TelemetryArgs, TemplatesArgs, UsageArgs, ValidateArgs, WatchkeeperArgs,
+    cmd_retrieve, cmd_review, cmd_schema, cmd_sentry, cmd_skill, cmd_stats, cmd_telemetry,
+    cmd_templates, cmd_usage, cmd_validate, CoverageArgs, DecisionsForArgs, DiffArgs, DoctorArgs,
+    EvalArgs, ExportArgs, FindArgs, GateArgs, HookArgs, ImproveArgs, IndexArgs, InitArgs,
+    InspectArgs, McpStatsArgs, MigrateArgs, NewArgs, PortfolioArgs, QuickstartArgs,
+    RelationshipsArgs, RenameArgs, ResolveArgs, RetrieveArgs, ReviewArgs, SchemaArgs, SentryArgs,
+    SkillArgs, StatsArgs, TelemetryArgs, TemplatesArgs, UsageArgs, ValidateArgs, WatchkeeperArgs,
 };
 use crate::commands::cmd_watchkeeper;
 use crate::output::rac_version;
@@ -152,11 +152,12 @@ fn run_dispatch(args: &[String]) -> u8 {
     if first.starts_with('-') {
         return argparse_error("decided", &format!("unrecognized arguments: {first}"));
     }
-    // `retrieve` (ADR-113, oracle-next 0.1.dev55+gf2091befd) dispatches but is
-    // deliberately NOT in SUBCOMMANDS: the mainline oracle's `invalid choice`
-    // message does not list it, and that message's bytes are pinned by the
-    // mainline parity suite (case `err-unknown-subcommand`).
-    if first != "retrieve" && !SUBCOMMANDS.contains(&first.as_str()) {
+    // Native-only additions dispatch but are deliberately NOT in SUBCOMMANDS:
+    // the retired Python oracle's `invalid choice` bytes remain pinned by the
+    // bounded compatibility suite.
+    if !matches!(first.as_str(), "retrieve" | "sentry")
+        && !SUBCOMMANDS.contains(&first.as_str())
+    {
         return argparse_error("decided", &invalid_choice_message(first));
     }
 
@@ -214,6 +215,7 @@ fn run_dispatch(args: &[String]) -> u8 {
         "coverage" => run_coverage(&rest),
         "decisions-for" => run_decisions_for(&rest),
         "gate" => run_gate(&rest),
+        "sentry" => run_sentry(&rest),
         "doctor" => run_doctor(&rest),
         "watchkeeper" => run_watchkeeper(&rest),
         "mcp-stats" => run_mcp_stats(&rest),
@@ -734,17 +736,23 @@ fn run_gate(rest: &[&String]) -> u8 {
     let mut json = false;
     let mut sarif = false;
     let mut top_level = false;
+    let mut code = false;
+    let mut repository = ".".to_string();
+    let mut base: Option<String> = None;
+    let mut full = false;
     let mut extras: Vec<String> = Vec::new();
     let mut positional_only = false;
 
-    for arg in rest {
-        let arg = arg.as_str();
+    let mut i = 0;
+    while i < rest.len() {
+        let arg = rest[i].as_str();
         if positional_only || arg == "-" || !arg.starts_with('-') {
             if directory.is_none() {
                 directory = Some(arg.to_string());
             } else {
                 extras.push(arg.to_string());
             }
+            i += 1;
             continue;
         }
         match arg {
@@ -763,10 +771,24 @@ fn run_gate(rest: &[&String]) -> u8 {
                 sarif = true;
             }
             "--top-level" => top_level = true,
+            "--code" => code = true,
+            "--full" => full = true,
+            "--repository" | "--base" => {
+                i += 1;
+                if i >= rest.len() {
+                    return argparse_error(prog, &format!("argument {arg}: expected one argument"));
+                }
+                if arg == "--repository" {
+                    repository = rest[i].to_string();
+                } else {
+                    base = Some(rest[i].to_string());
+                }
+            }
             // NO --recursive here (gate declares --top-level inline, not
             // scope_parent) — it bubbles to the top-level parser's error.
             other => extras.push(other.to_string()),
         }
+        i += 1;
     }
 
     // `directory` is a REQUIRED positional — unlike doctor/coverage.
@@ -779,6 +801,81 @@ fn run_gate(rest: &[&String]) -> u8 {
 
     cmd_gate(&GateArgs {
         directory,
+        json,
+        sarif,
+        top_level,
+        code,
+        repository,
+        base,
+        full,
+    }) as u8
+}
+
+fn run_sentry(rest: &[&String]) -> u8 {
+    let prog = "decided sentry";
+    let mut directory: Option<String> = None;
+    let mut repository = ".".to_string();
+    let mut base: Option<String> = None;
+    let mut full = false;
+    let mut json = false;
+    let mut sarif = false;
+    let mut top_level = false;
+    let mut extras = Vec::new();
+    let mut positional_only = false;
+    let mut i = 0;
+    while i < rest.len() {
+        let arg = rest[i].as_str();
+        if positional_only || arg == "-" || !arg.starts_with('-') {
+            if directory.is_none() {
+                directory = Some(arg.to_string());
+            } else {
+                extras.push(arg.to_string());
+            }
+            i += 1;
+            continue;
+        }
+        match arg {
+            "--" => positional_only = true,
+            "--json" => {
+                if let Some(code) = mutex_check(prog, "--json", "--sarif", sarif) {
+                    return code;
+                }
+                json = true;
+            }
+            "--sarif" => {
+                if let Some(code) = mutex_check(prog, "--sarif", "--json", json) {
+                    return code;
+                }
+                sarif = true;
+            }
+            "--full" => full = true,
+            "--top-level" => top_level = true,
+            "--repository" | "--base" => {
+                i += 1;
+                if i >= rest.len() {
+                    return argparse_error(prog, &format!("argument {arg}: expected one argument"));
+                }
+                if arg == "--repository" {
+                    repository = rest[i].to_string();
+                } else {
+                    base = Some(rest[i].to_string());
+                }
+            }
+            other => extras.push(other.to_string()),
+        }
+        i += 1;
+    }
+    let Some(directory) = directory else {
+        return argparse_error(prog, "the following arguments are required: directory");
+    };
+    if !extras.is_empty() {
+        return unrecognized(&extras);
+    }
+    cmd_sentry(&SentryArgs {
+        directory,
+        repository,
+        base,
+        full,
         json,
         sarif,
         top_level,

--- a/rust/rac-engine/src/commands.rs
+++ b/rust/rac-engine/src/commands.rs
@@ -983,6 +983,52 @@ pub fn cmd_sentry(args: &SentryArgs) -> i32 {
 }
 
 // ---------------------------------------------------------------------------
+// cmd_herald
+// ---------------------------------------------------------------------------
+
+pub struct HeraldArgs {
+    pub directory: String,
+    pub paths_file: String,
+    pub link_base: String,
+    pub max_inline: i64,
+    pub out: String,
+    pub github_output: Option<String>,
+    pub top_level: bool,
+}
+
+pub fn cmd_herald(args: &HeraldArgs) -> i32 {
+    if !Path::new(&args.directory).is_dir() {
+        return usage_error(&format!("not a directory: {}", args.directory));
+    }
+    let paths = match std::fs::read_to_string(&args.paths_file) {
+        Ok(text) => text.lines().map(str::trim).filter(|line| !line.is_empty()).map(str::to_string).collect::<Vec<_>>(),
+        Err(error) => return usage_error(&format!("could not read paths file {}: {error}", args.paths_file)),
+    };
+    let report = crate::herald::collect(&args.directory, &paths, !args.top_level);
+    let body = crate::herald::render(&report, &args.link_base, args.max_inline);
+    if let Err(error) = std::fs::write(&args.out, body) {
+        return usage_error(&format!("could not write Herald output {}: {error}", args.out));
+    }
+    let has_decisions = if report.has_decisions() { "true" } else { "false" };
+    if let Some(path) = &args.github_output {
+        use std::io::Write;
+        let result = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+            .and_then(|mut file| writeln!(file, "has_decisions={has_decisions}"));
+        if let Err(error) = result {
+            return usage_error(&format!("could not write command output {path}: {error}"));
+        }
+    }
+    emit(format!(
+        "{} governing decision(s); has_decisions={has_decisions}",
+        report.decisions.len()
+    ));
+    EXIT_OK
+}
+
+// ---------------------------------------------------------------------------
 // cmd_watchkeeper
 // ---------------------------------------------------------------------------
 

--- a/rust/rac-engine/src/commands.rs
+++ b/rust/rac-engine/src/commands.rs
@@ -893,6 +893,10 @@ pub struct GateArgs {
     pub json: bool,
     pub sarif: bool,
     pub top_level: bool,
+    pub code: bool,
+    pub repository: String,
+    pub base: Option<String>,
+    pub full: bool,
 }
 
 /// One enforcement entry point: validation + relationships + review under
@@ -904,7 +908,18 @@ pub fn cmd_gate(args: &GateArgs) -> i32 {
     if !Path::new(&args.directory).is_dir() {
         return usage_error(&format!("not a directory: {}", args.directory));
     }
-    let report = match crate::gate::build_gate(&args.directory, !args.top_level) {
+    if args.code && !args.full && args.base.is_none() {
+        return usage_error("a diff base is required for --code unless --full is supplied");
+    }
+    let report = match crate::gate::build_gate_with_code(
+        &args.directory,
+        !args.top_level,
+        args.code.then_some(crate::gate::CodeGateOptions {
+            repository: &args.repository,
+            base: args.base.as_deref(),
+            full_tree: args.full,
+        }),
+    ) {
         Ok(report) => report,
         Err(exc) => {
             eprintln!("decided: {}", exc.message());
@@ -917,6 +932,48 @@ pub fn cmd_gate(args: &GateArgs) -> i32 {
         emit(output::render_gate_json(&report));
     } else {
         emit(output::render_gate_human(&report));
+    }
+    if report.ok() {
+        EXIT_OK
+    } else {
+        EXIT_VALIDATION_FAILED
+    }
+}
+
+// ---------------------------------------------------------------------------
+// cmd_sentry
+// ---------------------------------------------------------------------------
+
+pub struct SentryArgs {
+    pub directory: String,
+    pub repository: String,
+    pub base: Option<String>,
+    pub full: bool,
+    pub json: bool,
+    pub sarif: bool,
+    pub top_level: bool,
+}
+
+pub fn cmd_sentry(args: &SentryArgs) -> i32 {
+    if !Path::new(&args.directory).is_dir() {
+        return usage_error(&format!("not a directory: {}", args.directory));
+    }
+    let report = match crate::sentry::analyze(
+        &args.directory,
+        &args.repository,
+        !args.top_level,
+        args.base.as_deref(),
+        args.full,
+    ) {
+        Ok(report) => report,
+        Err(message) => return usage_error(&message),
+    };
+    if args.sarif {
+        emit(output::render_sentry_sarif(&report));
+    } else if args.json {
+        emit(output::render_sentry_json(&report));
+    } else {
+        emit(output::render_sentry_human(&report));
     }
     if report.ok() {
         EXIT_OK

--- a/rust/rac-engine/src/gate.rs
+++ b/rust/rac-engine/src/gate.rs
@@ -27,6 +27,7 @@ pub const ENFORCEMENT_ADVISORY: &str = "advisory";
 pub const SOURCE_VALIDATE: &str = "validate";
 pub const SOURCE_RELATIONSHIPS: &str = "relationships";
 pub const SOURCE_REVIEW: &str = "review";
+pub const SOURCE_SENTRY: &str = "sentry";
 
 // ---------------------------------------------------------------------------
 // MalformedRepositoryConfig (decided.services.init)
@@ -287,6 +288,13 @@ pub struct GateReport {
     pub directory: String,
     pub recursive: bool,
     pub findings: Vec<GateFinding>,
+    pub code_coverage: Option<CodeCoverage>,
+}
+
+pub struct CodeCoverage {
+    pub live_decisions: usize,
+    pub constrained_decisions: usize,
+    pub percent: f64,
 }
 
 impl GateReport {
@@ -350,6 +358,20 @@ fn validate_findings(result: &DirectoryValidation) -> Vec<RawFinding> {
 /// review, then enforce the corpus policy. Findings the policy turns `off`
 /// are dropped; the rest sort by `(path, line or 0, source, code, message)`.
 pub fn build_gate(directory: &str, recursive: bool) -> Result<GateReport, MalformedConfig> {
+    build_gate_with_code(directory, recursive, None)
+}
+
+pub struct CodeGateOptions<'a> {
+    pub repository: &'a str,
+    pub base: Option<&'a str>,
+    pub full_tree: bool,
+}
+
+pub fn build_gate_with_code(
+    directory: &str,
+    recursive: bool,
+    code: Option<CodeGateOptions<'_>>,
+) -> Result<GateReport, MalformedConfig> {
     // The oracle raises from load_enforcement_policy first, then
     // load_overrides — mirror that order so a doubly-malformed config
     // reports the enforcement error.
@@ -363,6 +385,7 @@ pub fn build_gate(directory: &str, recursive: bool) -> Result<GateReport, Malfor
     let review: ReviewReport = review_from_portfolio(directory, portfolio, recursive);
 
     let mut findings: Vec<GateFinding> = Vec::new();
+    let mut code_coverage = None;
     let mut add = |source: &'static str,
                    code: String,
                    severity: String,
@@ -435,6 +458,46 @@ pub fn build_gate(directory: &str, recursive: bool) -> Result<GateReport, Malfor
         );
     }
 
+    if let Some(options) = code {
+        match crate::sentry::analyze(
+            directory,
+            options.repository,
+            recursive,
+            options.base,
+            options.full_tree,
+        ) {
+            Ok(report) => {
+                code_coverage = Some(CodeCoverage {
+                    live_decisions: report.live_decisions,
+                    constrained_decisions: report.constrained_decisions,
+                    percent: report.coverage_percent(),
+                });
+                for finding in report.findings {
+                    add(
+                        SOURCE_SENTRY,
+                        finding.code.to_string(),
+                        "error".to_string(),
+                        finding.path,
+                        finding.line,
+                        finding.message,
+                        ENFORCEMENT_BLOCKING,
+                    );
+                }
+            }
+            Err(message) => {
+                add(
+                    SOURCE_SENTRY,
+                    crate::sentry::INVALID_CONSTRAINT.to_string(),
+                    "error".to_string(),
+                    directory.to_string(),
+                    None,
+                    message,
+                    ENFORCEMENT_BLOCKING,
+                );
+            }
+        }
+    }
+
     findings.sort_by(|a, b| {
         a.path
             .cmp(&b.path)
@@ -447,5 +510,6 @@ pub fn build_gate(directory: &str, recursive: bool) -> Result<GateReport, Malfor
         directory: directory.to_string(),
         recursive,
         findings,
+        code_coverage,
     })
 }

--- a/rust/rac-engine/src/herald.rs
+++ b/rust/rac-engine/src/herald.rs
@@ -1,0 +1,205 @@
+//! Native deterministic renderer for Herald's governing-decisions PR comment.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::retrieve::decisions_for_path;
+
+pub const MARKER: &str = "<!-- lore-decisions-on-pr -->";
+const PATHS_SHOWN: usize = 3;
+
+#[derive(Debug)]
+pub struct HeraldDecision {
+    pub id: String,
+    pub title: String,
+    pub status: String,
+    pub path: String,
+    pub matching_entries: BTreeSet<String>,
+    pub changed_paths: BTreeSet<String>,
+}
+
+#[derive(Debug)]
+pub struct HeraldReport {
+    pub decisions: Vec<HeraldDecision>,
+}
+
+impl HeraldReport {
+    pub fn has_decisions(&self) -> bool {
+        !self.decisions.is_empty()
+    }
+}
+
+pub fn collect(corpus: &str, paths: &[String], recursive: bool) -> HeraldReport {
+    let mut merged: BTreeMap<String, HeraldDecision> = BTreeMap::new();
+    let changed: BTreeSet<&String> = paths
+        .iter()
+        .filter(|path| !path.trim().is_empty())
+        .collect();
+    for path in changed {
+        for decision in decisions_for_path(corpus, path, recursive).decisions {
+            let entry = merged
+                .entry(decision.id.clone())
+                .or_insert_with(|| HeraldDecision {
+                    id: decision.id,
+                    title: decision.title,
+                    status: decision.status,
+                    path: decision.path,
+                    matching_entries: BTreeSet::new(),
+                    changed_paths: BTreeSet::new(),
+                });
+            entry.matching_entries.insert(decision.matching_entry);
+            entry.changed_paths.insert(path.clone());
+        }
+    }
+    HeraldReport {
+        decisions: merged.into_values().collect(),
+    }
+}
+
+fn bullet(decision: &HeraldDecision, link_base: &str) -> String {
+    let scopes = decision
+        .matching_entries
+        .iter()
+        .map(|scope| format!("`{scope}`"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let paths: Vec<&String> = decision.changed_paths.iter().collect();
+    let mut changed = paths
+        .iter()
+        .take(PATHS_SHOWN)
+        .map(|path| format!("`{path}`"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let more = paths.len().saturating_sub(PATHS_SHOWN);
+    if more > 0 {
+        changed.push_str(&format!(" +{more} more"));
+    }
+    let link = if link_base.is_empty() {
+        decision.path.clone()
+    } else {
+        format!("{}/{}", link_base.trim_end_matches('/'), decision.path)
+    };
+    format!(
+        "- **[{} — {}]({})** ({}) — applies to {} — changed: {}",
+        decision.id, decision.title, link, decision.status, scopes, changed
+    )
+}
+
+pub fn render(report: &HeraldReport, link_base: &str, max_inline: i64) -> String {
+    if report.decisions.is_empty() {
+        return format!(
+            "{MARKER}\n### Decisions governing this change\n\n\
+             No recorded decisions govern the paths changed by this pull request.\n"
+        );
+    }
+    let count = report.decisions.len();
+    let plural = if count == 1 { "" } else { "s" };
+    let mut lines = vec![
+        MARKER.to_string(),
+        "### Decisions governing this change".to_string(),
+        String::new(),
+        format!(
+            "This pull request touches paths governed by {count} recorded decision{plural} — review recommended."
+        ),
+        String::new(),
+    ];
+    let inline_count = if max_inline > 0 {
+        (max_inline as usize).min(count)
+    } else {
+        count
+    };
+    lines.extend(
+        report.decisions[..inline_count]
+            .iter()
+            .map(|decision| bullet(decision, link_base)),
+    );
+    let rest = &report.decisions[inline_count..];
+    if !rest.is_empty() {
+        let rest_plural = if rest.len() == 1 { "" } else { "s" };
+        lines.push(String::new());
+        lines.push(format!(
+            "<details><summary>{} more governing decision{rest_plural}</summary>",
+            rest.len()
+        ));
+        lines.push(String::new());
+        lines.extend(rest.iter().map(|decision| bullet(decision, link_base)));
+        lines.push(String::new());
+        lines.push("</details>".to_string());
+    }
+    lines.push(String::new());
+    lines.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn decision(id: &str) -> HeraldDecision {
+        HeraldDecision {
+            id: id.to_string(),
+            title: format!("{id} title"),
+            status: "Accepted".to_string(),
+            path: format!("decisions/{id}.md"),
+            matching_entries: BTreeSet::from(["src/**".to_string()]),
+            changed_paths: BTreeSet::from([
+                "src/a.rs".to_string(),
+                "src/b.rs".to_string(),
+                "src/c.rs".to_string(),
+                "src/d.rs".to_string(),
+            ]),
+        }
+    }
+
+    #[test]
+    fn empty_state_is_stable() {
+        let body = render(&HeraldReport { decisions: vec![] }, "", 5);
+        assert!(body.starts_with(MARKER));
+        assert!(body.contains("No recorded decisions govern"));
+        assert!(body.ends_with('\n'));
+    }
+
+    #[test]
+    fn overflow_and_path_collapse_match_contract() {
+        let body = render(
+            &HeraldReport {
+                decisions: vec![decision("ADR-001"), decision("ADR-002")],
+            },
+            "https://example.com/blob/HEAD/",
+            1,
+        );
+        assert!(body.contains("<details><summary>1 more governing decision</summary>"));
+        assert!(body.contains("`src/a.rs`, `src/b.rs`, `src/c.rs` +1 more"));
+        assert!(body.contains("https://example.com/blob/HEAD/decisions/ADR-001.md"));
+    }
+
+    #[test]
+    fn collection_is_sorted_and_deduplicated_across_paths() {
+        let root = std::env::temp_dir().join(format!("decided-herald-{}", std::process::id()));
+        let corpus = root.join("decisions");
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(root.join(".decided")).unwrap();
+        fs::create_dir_all(&corpus).unwrap();
+        fs::write(root.join(".decided/config.yaml"), "repository_key: TEST\n").unwrap();
+        fs::write(
+            corpus.join("adr-001.md"),
+            "# Alpha rule\n\n## Status\n\nAccepted\n\n## Context\n\nContext.\n\n## Decision\n\nRule.\n\n## Consequences\n\nConsequence.\n\n## Applies To\n\n- src/**/*.rs\n",
+        )
+        .unwrap();
+        let report = collect(
+            corpus.to_str().unwrap(),
+            &[
+                "src/a.rs".to_string(),
+                "src/b.rs".to_string(),
+                "src/a.rs".to_string(),
+            ],
+            true,
+        );
+        assert_eq!(report.decisions.len(), 1);
+        assert_eq!(report.decisions[0].changed_paths.len(), 2);
+        assert_eq!(
+            report.decisions[0].matching_entries,
+            BTreeSet::from(["src/**/*.rs".to_string()])
+        );
+        fs::remove_dir_all(root).unwrap();
+    }
+}

--- a/rust/rac-engine/src/lib.rs
+++ b/rust/rac-engine/src/lib.rs
@@ -70,6 +70,7 @@ mod freshness_watch;
 pub mod coverage;
 pub mod review;
 pub mod gate;
+pub mod sentry;
 pub mod doctor;
 pub mod mdhtml;
 pub mod export;

--- a/rust/rac-engine/src/lib.rs
+++ b/rust/rac-engine/src/lib.rs
@@ -70,6 +70,7 @@ mod freshness_watch;
 pub mod coverage;
 pub mod review;
 pub mod gate;
+pub mod herald;
 pub mod sentry;
 pub mod doctor;
 pub mod mdhtml;

--- a/rust/rac-engine/src/output.rs
+++ b/rust/rac-engine/src/output.rs
@@ -35,6 +35,7 @@ use crate::resolve::{
     Evidence, Recency, ResolutionResult, ResolvedArtifact, SearchResult, OUTCOME_RESOLVED,
 };
 use crate::review::{ReviewIssue, ReviewReport};
+use crate::sentry::SentryReport;
 use crate::spec::{snake as spec_snake, spec_for, specs, ArtifactSpec};
 use crate::stats::PortfolioStats;
 use crate::validate::py_title;
@@ -2413,6 +2414,12 @@ pub fn render_gate_human(report: &GateReport) -> String {
         format!("Blocking:   {}", blocking.len()),
         format!("Advisory:   {}", advisory.len()),
     ];
+    if let Some(coverage) = &report.code_coverage {
+        lines.push(format!(
+            "Code coverage: {}/{} ({:.1}%)",
+            coverage.constrained_decisions, coverage.live_decisions, coverage.percent
+        ));
+    }
 
     let mut emit_group = |group: &[&GateFinding], title: &str, icon: &str| {
         if group.is_empty() {
@@ -2467,6 +2474,16 @@ pub fn render_gate_json(report: &GateReport) -> String {
         "findings".into(),
         Value::Array(report.findings.iter().map(gate_finding_value).collect()),
     );
+    if let Some(coverage) = &report.code_coverage {
+        payload.insert(
+            "code_coverage".into(),
+            json!({
+                "live_decisions": coverage.live_decisions,
+                "constrained_decisions": coverage.constrained_decisions,
+                "percent": coverage.percent,
+            }),
+        );
+    }
     dumps_indent2(&Value::Object(payload))
 }
 
@@ -2488,6 +2505,95 @@ pub fn render_gate_sarif(report: &GateReport) -> String {
         })
         .collect();
     sarif_document(results)
+}
+
+// --- sentry ------------------------------------------------------------------
+
+pub fn render_sentry_human(report: &SentryReport) -> String {
+    let mut lines = vec![
+        bold("Code Sentry"),
+        "===========".to_string(),
+        String::new(),
+        format!("Corpus:      {}", report.corpus),
+        format!("Repository:  {}", report.repository),
+        format!(
+            "Coverage:    {}/{} ({:.1}%)",
+            report.constrained_decisions,
+            report.live_decisions,
+            report.coverage_percent()
+        ),
+        format!("Violations:  {}", report.findings.len()),
+    ];
+    for finding in &report.findings {
+        lines.push(String::new());
+        lines.push(format!("  {} {}", red("\u{2717}"), loc(&finding.path, finding.line)));
+        lines.push(format!(
+            "      [{}] {}",
+            finding.rule_id.as_deref().unwrap_or(finding.code),
+            finding.message
+        ));
+        lines.push(format!("      decision: {}", finding.decision_path));
+    }
+    lines.push(String::new());
+    if report.ok() {
+        lines.push(green("\u{2713} Sentry passed."));
+    } else {
+        lines.push(red(&format!(
+            "\u{2717} Sentry failed \u{2014} {} finding(s).",
+            report.findings.len()
+        )));
+    }
+    lines.join("\n")
+}
+
+pub fn render_sentry_json(report: &SentryReport) -> String {
+    let findings: Vec<Value> = report
+        .findings
+        .iter()
+        .map(|finding| {
+            json!({
+                "code": finding.code,
+                "decision_path": finding.decision_path,
+                "rule_id": finding.rule_id,
+                "path": finding.path,
+                "line": finding.line,
+                "message": finding.message,
+            })
+        })
+        .collect();
+    dumps_indent2(&json!({
+        "schema_version": "1",
+        "corpus": report.corpus,
+        "repository": report.repository,
+        "base": report.base,
+        "full_tree": report.full_tree,
+        "ok": report.ok(),
+        "coverage": {
+            "live_decisions": report.live_decisions,
+            "constrained_decisions": report.constrained_decisions,
+            "percent": report.coverage_percent(),
+        },
+        "findings": findings,
+    }))
+}
+
+pub fn render_sentry_sarif(report: &SentryReport) -> String {
+    sarif_document(
+        report
+            .findings
+            .iter()
+            .map(|finding| SarifResult {
+                rule_id: finding.code.to_string(),
+                level: "error",
+                message: format!(
+                    "{} (decision: {})",
+                    finding.message, finding.decision_path
+                ),
+                uri: quote_uri(&finding.path),
+                line: finding.line,
+            })
+            .collect(),
+    )
 }
 
 // --- doctor ------------------------------------------------------------------

--- a/rust/rac-engine/src/sentry.rs
+++ b/rust/rac-engine/src/sentry.rs
@@ -1,0 +1,700 @@
+//! Deterministic decision-to-code enforcement.
+//!
+//! Constraints live in a decision artifact's `## Code Constraints` fenced
+//! YAML block. This module deliberately has no network or model integration:
+//! repository bytes, corpus bytes, and an optional git diff are the complete
+//! input.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Component, Path, PathBuf};
+use std::process::Command;
+
+use globset::Glob;
+use regex::Regex;
+use serde::Deserialize;
+
+use crate::parse::{Artifact, Issue};
+use crate::relationships::{corpus_items, CorpusItem};
+use crate::resolve::artifact_status;
+use crate::spec::spec_for;
+
+pub const CODE_VIOLATION: &str = "code-constraint-violation";
+pub const CODE_EMPTY_MATCH: &str = "code-constraint-empty-match";
+pub const CODE_UNSUPPORTED_LANGUAGE: &str = "code-constraint-unsupported-language";
+pub const MALFORMED_CONSTRAINTS: &str = "malformed-code-constraints";
+pub const UNSUPPORTED_VERSION: &str = "unsupported-code-constraints-version";
+pub const INVALID_CONSTRAINT: &str = "invalid-code-constraint";
+pub const DUPLICATE_RULE_ID: &str = "duplicate-code-constraint-id";
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ConstraintDocument {
+    version: u64,
+    rules: Vec<ConstraintRule>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ConstraintRule {
+    id: String,
+    kind: RuleKind,
+    path_glob: String,
+    pattern: String,
+    message: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum RuleKind {
+    ForbidPattern,
+    RequirePattern,
+    ForbidImport,
+}
+
+#[derive(Debug, Clone)]
+pub struct SentryFinding {
+    pub code: &'static str,
+    pub decision_path: String,
+    pub rule_id: Option<String>,
+    pub path: String,
+    pub line: Option<i64>,
+    pub message: String,
+}
+
+#[derive(Debug)]
+pub struct SentryReport {
+    pub corpus: String,
+    pub repository: String,
+    pub base: Option<String>,
+    pub full_tree: bool,
+    pub live_decisions: usize,
+    pub constrained_decisions: usize,
+    pub findings: Vec<SentryFinding>,
+}
+
+impl SentryReport {
+    pub fn ok(&self) -> bool {
+        self.findings.is_empty()
+    }
+
+    pub fn coverage_percent(&self) -> f64 {
+        if self.live_decisions == 0 {
+            0.0
+        } else {
+            self.constrained_decisions as f64 * 100.0 / self.live_decisions as f64
+        }
+    }
+}
+
+fn is_live_decision(item: &CorpusItem) -> bool {
+    if item.spec.map(|s| s.name.as_str()) != Some("decision") {
+        return false;
+    }
+    !matches!(
+        artifact_status(&item.artifact)
+            .trim()
+            .to_ascii_lowercase()
+            .as_str(),
+        "superseded" | "deprecated"
+    )
+}
+
+fn fenced_yaml(section: &str) -> Result<&str, &'static str> {
+    let trimmed = section.trim();
+    let body = trimmed
+        .strip_prefix("```yaml")
+        .or_else(|| trimmed.strip_prefix("```yml"))
+        .ok_or("expected exactly one fenced yaml block")?;
+    let body = body
+        .strip_suffix("```")
+        .ok_or("unterminated fenced yaml block")?;
+    if body.contains("\n```") {
+        return Err("expected exactly one fenced yaml block");
+    }
+    Ok(body.trim_matches('\n'))
+}
+
+fn valid_rule_id(id: &str) -> bool {
+    let mut chars = id.chars();
+    matches!(chars.next(), Some('a'..='z'))
+        && chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+        && !id.ends_with('-')
+        && !id.contains("--")
+}
+
+fn safe_glob(value: &str) -> bool {
+    !value.is_empty()
+        && !value.contains('\\')
+        && !Path::new(value).is_absolute()
+        && !Path::new(value)
+            .components()
+            .any(|part| part == Component::ParentDir)
+}
+
+fn raw_constraint_section(artifact: &Artifact) -> Result<Option<String>, &'static str> {
+    let text = match std::fs::read_to_string(&artifact.product.source_path) {
+        Ok(text) => text,
+        Err(_) => return Ok(artifact.section("code constraints").map(str::to_string)),
+    };
+    let heading = Regex::new(r"(?i)^##[ \t]+code[ \t]+constraints[ \t]*#*[ \t]*$").unwrap();
+    let any_h2 = Regex::new(r"^##(?:[ \t]|$)").unwrap();
+    let lines: Vec<&str> = text.lines().collect();
+    let starts: Vec<usize> = lines
+        .iter()
+        .enumerate()
+        .filter_map(|(index, line)| heading.is_match(line).then_some(index))
+        .collect();
+    match starts.as_slice() {
+        [] => Ok(None),
+        [_] => {
+            let start = starts[0] + 1;
+            let end = (start..lines.len())
+                .find(|index| any_h2.is_match(lines[*index]))
+                .unwrap_or(lines.len());
+            Ok(Some(lines[start..end].join("\n")))
+        }
+        _ => Err("more than one Code Constraints section"),
+    }
+}
+
+fn parse_document(item: &CorpusItem) -> Result<Option<ConstraintDocument>, Box<SentryFinding>> {
+    let section = raw_constraint_section(&item.artifact).map_err(|problem| {
+        Box::new(SentryFinding {
+            code: MALFORMED_CONSTRAINTS,
+            decision_path: item.path.clone(),
+            rule_id: None,
+            path: item.path.clone(),
+            line: None,
+            message: problem.to_string(),
+        })
+    })?;
+    let Some(section) = section else {
+        return Ok(None);
+    };
+    let yaml = fenced_yaml(&section).map_err(|problem| {
+        Box::new(SentryFinding {
+            code: MALFORMED_CONSTRAINTS,
+            decision_path: item.path.clone(),
+            rule_id: None,
+            path: item.path.clone(),
+            line: None,
+            message: problem.to_string(),
+        })
+    })?;
+    let document: ConstraintDocument = serde_yaml::from_str(yaml).map_err(|error| {
+        Box::new(SentryFinding {
+            code: MALFORMED_CONSTRAINTS,
+            decision_path: item.path.clone(),
+            rule_id: None,
+            path: item.path.clone(),
+            line: None,
+            message: format!("invalid code-constraint YAML: {error}"),
+        })
+    })?;
+    if document.version != 1 {
+        return Err(Box::new(SentryFinding {
+            code: UNSUPPORTED_VERSION,
+            decision_path: item.path.clone(),
+            rule_id: None,
+            path: item.path.clone(),
+            line: None,
+            message: format!(
+                "unsupported code-constraint version {}; supported version is 1",
+                document.version
+            ),
+        }));
+    }
+    if document.rules.is_empty() {
+        return Err(invalid(item, None, "rules must not be empty"));
+    }
+    let mut ids = BTreeSet::new();
+    for rule in &document.rules {
+        if !valid_rule_id(&rule.id) {
+            return Err(invalid(item, Some(&rule.id), "invalid rule id"));
+        }
+        if !ids.insert(rule.id.clone()) {
+            return Err(Box::new(SentryFinding {
+                code: DUPLICATE_RULE_ID,
+                decision_path: item.path.clone(),
+                rule_id: Some(rule.id.clone()),
+                path: item.path.clone(),
+                line: None,
+                message: format!("duplicate code-constraint id '{}'", rule.id),
+            }));
+        }
+        if !safe_glob(&rule.path_glob) {
+            return Err(invalid(
+                item,
+                Some(&rule.id),
+                "path_glob must be repository-relative and contain no '..' component",
+            ));
+        }
+        if Glob::new(&rule.path_glob).is_err() {
+            return Err(invalid(item, Some(&rule.id), "invalid path_glob"));
+        }
+        if rule.pattern.is_empty() || Regex::new(&rule.pattern).is_err() {
+            return Err(invalid(item, Some(&rule.id), "invalid regular expression"));
+        }
+        if rule
+            .message
+            .as_ref()
+            .is_some_and(|message| message.is_empty())
+        {
+            return Err(invalid(item, Some(&rule.id), "message must not be empty"));
+        }
+    }
+    Ok(Some(document))
+}
+
+/// Structural validation for `decided validate`: syntax and rule contracts do
+/// not require a repository tree and therefore fail the ordinary corpus gate
+/// even when code enforcement was not requested.
+pub fn validate_artifact(artifact: &Artifact) -> Vec<Issue> {
+    let item = CorpusItem {
+        path: String::new(),
+        artifact: artifact.clone(),
+        spec: spec_for("decision"),
+    };
+    match parse_document(&item) {
+        Err(finding) => vec![Issue::new("error", finding.code, finding.message, None)],
+        _ => Vec::new(),
+    }
+}
+
+fn invalid(item: &CorpusItem, rule_id: Option<&str>, message: &str) -> Box<SentryFinding> {
+    Box::new(SentryFinding {
+        code: INVALID_CONSTRAINT,
+        decision_path: item.path.clone(),
+        rule_id: rule_id.map(str::to_string),
+        path: item.path.clone(),
+        line: None,
+        message: message.to_string(),
+    })
+}
+
+fn collect_files(root: &Path, dir: &Path, output: &mut Vec<(String, PathBuf)>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    let mut entries: Vec<_> = entries.flatten().collect();
+    entries.sort_by_key(|entry| entry.file_name());
+    for entry in entries {
+        let path = entry.path();
+        let name = entry.file_name();
+        if name == ".git" {
+            continue;
+        }
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if file_type.is_dir() && !file_type.is_symlink() {
+            collect_files(root, &path, output);
+        } else if file_type.is_file() {
+            if let Ok(relative) = path.strip_prefix(root) {
+                output.push((relative.to_string_lossy().replace('\\', "/"), path));
+            }
+        }
+    }
+}
+
+fn changed_lines(
+    repository: &Path,
+    base: &str,
+) -> Result<BTreeMap<String, BTreeSet<usize>>, String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(repository)
+        .args(["diff", "--unified=0", "--no-ext-diff", base, "--"])
+        .output()
+        .map_err(|error| format!("could not run git diff: {error}"))?;
+    if !output.status.success() {
+        return Err(String::from_utf8_lossy(&output.stderr).trim().to_string());
+    }
+    let text = String::from_utf8_lossy(&output.stdout);
+    let mut result: BTreeMap<String, BTreeSet<usize>> = BTreeMap::new();
+    let mut path: Option<String> = None;
+    for line in text.lines() {
+        if let Some(value) = line.strip_prefix("+++ b/") {
+            path = Some(value.to_string());
+        } else if let Some(hunk) = line.strip_prefix("@@ -").and_then(|s| s.split(" +").nth(1)) {
+            let range = hunk.split(" @@").next().unwrap_or(hunk);
+            let mut fields = range.split(',');
+            let start = fields
+                .next()
+                .and_then(|v| v.parse::<usize>().ok())
+                .unwrap_or(0);
+            let count = fields
+                .next()
+                .and_then(|v| v.parse::<usize>().ok())
+                .unwrap_or(1);
+            if let Some(path) = &path {
+                result
+                    .entry(path.clone())
+                    .or_default()
+                    .extend(start..start.saturating_add(count));
+            }
+        }
+    }
+    Ok(result)
+}
+
+fn import_targets(extension: &str, text: &str) -> Option<Vec<(usize, String)>> {
+    let mut targets = Vec::new();
+    match extension {
+        "py" => {
+            let import = Regex::new(r"^\s*import\s+([A-Za-z0-9_., ]+)").unwrap();
+            let from = Regex::new(r"^\s*from\s+([A-Za-z0-9_.]+)\s+import\b").unwrap();
+            for (index, line) in text.lines().enumerate() {
+                if let Some(captures) = from.captures(line) {
+                    targets.push((index + 1, captures[1].to_string()));
+                } else if let Some(captures) = import.captures(line) {
+                    for target in captures[1].split(',') {
+                        targets.push((
+                            index + 1,
+                            target.split_whitespace().next().unwrap_or("").to_string(),
+                        ));
+                    }
+                }
+            }
+        }
+        "rs" => {
+            let use_re = Regex::new(r"^\s*use\s+([^;]+)").unwrap();
+            for (index, line) in text.lines().enumerate() {
+                if let Some(captures) = use_re.captures(line) {
+                    targets.push((index + 1, captures[1].trim().to_string()));
+                }
+            }
+        }
+        "js" | "jsx" | "ts" | "tsx" | "mjs" | "cjs" => {
+            let from = Regex::new(r#"\bfrom\s+['"]([^'"]+)['"]"#).unwrap();
+            let side_effect = Regex::new(r#"^\s*import\s+['"]([^'"]+)['"]"#).unwrap();
+            let require = Regex::new(r#"\brequire\(\s*['"]([^'"]+)['"]\s*\)"#).unwrap();
+            for (index, line) in text.lines().enumerate() {
+                for captures in from
+                    .captures_iter(line)
+                    .chain(side_effect.captures_iter(line))
+                    .chain(require.captures_iter(line))
+                {
+                    targets.push((index + 1, captures[1].to_string()));
+                }
+            }
+        }
+        _ => return None,
+    }
+    Some(targets)
+}
+
+pub fn analyze(
+    corpus: &str,
+    repository: &str,
+    recursive: bool,
+    base: Option<&str>,
+    full_tree: bool,
+) -> Result<SentryReport, String> {
+    let repository_path = Path::new(repository);
+    if !repository_path.is_dir() {
+        return Err(format!("not a directory: {repository}"));
+    }
+    if !full_tree && base.is_none() {
+        return Err("a diff base is required unless --full is supplied".to_string());
+    }
+    let changed = if full_tree {
+        None
+    } else {
+        Some(changed_lines(repository_path, base.unwrap())?)
+    };
+    let items = corpus_items(corpus, recursive);
+    let live: Vec<&CorpusItem> = items.iter().filter(|item| is_live_decision(item)).collect();
+    let mut documents = Vec::new();
+    let mut findings = Vec::new();
+    for item in &live {
+        match parse_document(item) {
+            Ok(Some(document)) => documents.push((*item, document)),
+            Ok(None) => {}
+            Err(finding) => findings.push(*finding),
+        }
+    }
+
+    let mut files = Vec::new();
+    collect_files(repository_path, repository_path, &mut files);
+    for (item, document) in &documents {
+        for rule in &document.rules {
+            let matcher = Glob::new(&rule.path_glob).unwrap().compile_matcher();
+            let selected: Vec<_> = files
+                .iter()
+                .filter(|(relative, _)| matcher.is_match(relative))
+                .filter(|(relative, _)| {
+                    full_tree
+                        || changed
+                            .as_ref()
+                            .is_some_and(|set| set.contains_key(relative))
+                })
+                .collect();
+            if matches!(rule.kind, RuleKind::RequirePattern) && selected.is_empty() {
+                findings.push(rule_finding(
+                    item,
+                    rule,
+                    CODE_EMPTY_MATCH,
+                    &item.path,
+                    None,
+                    format!("rule '{}' selected no files", rule.id),
+                ));
+                continue;
+            }
+            let pattern = Regex::new(&rule.pattern).unwrap();
+            for (relative, absolute) in selected {
+                let text = match std::fs::read_to_string(absolute) {
+                    Ok(text) => text,
+                    Err(_) => {
+                        findings.push(rule_finding(
+                            item,
+                            rule,
+                            CODE_UNSUPPORTED_LANGUAGE,
+                            relative,
+                            None,
+                            "selected source file is not readable UTF-8".to_string(),
+                        ));
+                        continue;
+                    }
+                };
+                match rule.kind {
+                    RuleKind::ForbidPattern => {
+                        let mut line_starts = vec![0usize];
+                        line_starts.extend(
+                            text.bytes()
+                                .enumerate()
+                                .filter_map(|(index, byte)| (byte == b'\n').then_some(index + 1)),
+                        );
+                        for matched in pattern.find_iter(&text) {
+                            let start_line =
+                                line_starts.partition_point(|start| *start <= matched.start());
+                            let end_offset = matched.end().saturating_sub(1);
+                            let end_line =
+                                line_starts.partition_point(|start| *start <= end_offset);
+                            let touches_change = full_tree
+                                || changed
+                                    .as_ref()
+                                    .and_then(|set| set.get(relative))
+                                    .is_some_and(|lines| {
+                                        (start_line..=end_line).any(|line| lines.contains(&line))
+                                    });
+                            if touches_change {
+                                findings.push(rule_finding(
+                                    item,
+                                    rule,
+                                    CODE_VIOLATION,
+                                    relative,
+                                    Some(start_line as i64),
+                                    rule.message.clone().unwrap_or_else(|| {
+                                        format!("forbidden pattern matched rule '{}'", rule.id)
+                                    }),
+                                ));
+                            }
+                        }
+                    }
+                    RuleKind::RequirePattern => {
+                        if !pattern.is_match(&text) {
+                            findings.push(rule_finding(
+                                item,
+                                rule,
+                                CODE_VIOLATION,
+                                relative,
+                                None,
+                                rule.message.clone().unwrap_or_else(|| {
+                                    format!("required pattern missing for rule '{}'", rule.id)
+                                }),
+                            ));
+                        }
+                    }
+                    RuleKind::ForbidImport => {
+                        let extension = absolute
+                            .extension()
+                            .and_then(|value| value.to_str())
+                            .unwrap_or("");
+                        let Some(imports) = import_targets(extension, &text) else {
+                            findings.push(rule_finding(
+                                item,
+                                rule,
+                                CODE_UNSUPPORTED_LANGUAGE,
+                                relative,
+                                None,
+                                format!("no deterministic import adapter for '.{extension}'"),
+                            ));
+                            continue;
+                        };
+                        for (line, target) in imports {
+                            if pattern.is_match(&target)
+                                && (full_tree
+                                    || changed
+                                        .as_ref()
+                                        .and_then(|set| set.get(relative))
+                                        .is_some_and(|lines| lines.contains(&line)))
+                            {
+                                findings.push(rule_finding(
+                                    item,
+                                    rule,
+                                    CODE_VIOLATION,
+                                    relative,
+                                    Some(line as i64),
+                                    rule.message.clone().unwrap_or_else(|| {
+                                        format!(
+                                            "forbidden import '{target}' matched rule '{}'",
+                                            rule.id
+                                        )
+                                    }),
+                                ));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    findings.sort_by(|a, b| {
+        a.path
+            .cmp(&b.path)
+            .then(a.line.unwrap_or(0).cmp(&b.line.unwrap_or(0)))
+            .then(a.decision_path.cmp(&b.decision_path))
+            .then(a.rule_id.cmp(&b.rule_id))
+    });
+    Ok(SentryReport {
+        corpus: corpus.to_string(),
+        repository: repository.to_string(),
+        base: base.map(str::to_string),
+        full_tree,
+        live_decisions: live.len(),
+        constrained_decisions: documents.len(),
+        findings,
+    })
+}
+
+fn rule_finding(
+    item: &CorpusItem,
+    rule: &ConstraintRule,
+    code: &'static str,
+    path: &str,
+    line: Option<i64>,
+    message: String,
+) -> SentryFinding {
+    SentryFinding {
+        code,
+        decision_path: item.path.clone(),
+        rule_id: Some(rule.id.clone()),
+        path: path.to_string(),
+        line,
+        message,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn rule_ids_are_kebab_case() {
+        assert!(valid_rule_id("no-hard-delete"));
+        assert!(!valid_rule_id("NoHardDelete"));
+        assert!(!valid_rule_id("no--delete"));
+    }
+
+    #[test]
+    fn import_adapters_extract_targets() {
+        assert_eq!(
+            import_targets("py", "from sqlalchemy.orm import Session\nimport httpx\n").unwrap(),
+            vec![(1, "sqlalchemy.orm".to_string()), (2, "httpx".to_string())]
+        );
+        assert_eq!(
+            import_targets("rs", "use crate::domain::User;\n").unwrap(),
+            vec![(1, "crate::domain::User".to_string())]
+        );
+    }
+
+    #[test]
+    fn full_tree_enforces_constraint_and_reports_coverage() {
+        let root = std::env::temp_dir().join(format!(
+            "decided-sentry-{}-{}",
+            std::process::id(),
+            std::thread::current().name().unwrap_or("test")
+        ));
+        let corpus = root.join("decisions");
+        let source = root.join("src");
+        fs::create_dir_all(&corpus).unwrap();
+        fs::create_dir_all(&source).unwrap();
+        fs::write(
+            corpus.join("adr-001.md"),
+            "# ADR-001: Retain users\n\n## Status\n\nAccepted\n\n## Context\n\nDeletion loses audit history.\n\n## Decision\n\nUse soft deletion.\n\n## Consequences\n\nRows remain recoverable.\n\n## Code Constraints\n\n```yaml\nversion: 1\nrules:\n  - id: no-hard-delete\n    kind: forbid_pattern\n    path_glob: \"src/**/*.sql\"\n    pattern: \"DELETE\\\\s+FROM\\\\s+users\"\n```\n",
+        )
+        .unwrap();
+        fs::write(source.join("users.sql"), "DELETE FROM users;\n").unwrap();
+
+        let report = analyze(
+            corpus.to_str().unwrap(),
+            root.to_str().unwrap(),
+            true,
+            None,
+            true,
+        )
+        .unwrap();
+        assert_eq!(report.live_decisions, 1);
+        assert_eq!(report.constrained_decisions, 1, "{:#?}", report.findings);
+        assert_eq!(report.findings.len(), 1);
+        assert_eq!(report.findings[0].code, CODE_VIOLATION);
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn diff_mode_reports_only_added_violation_lines() {
+        let root = std::env::temp_dir().join(format!("decided-sentry-diff-{}", std::process::id()));
+        let corpus = root.join("decisions");
+        let source = root.join("src");
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&corpus).unwrap();
+        fs::create_dir_all(&source).unwrap();
+        fs::write(
+            corpus.join("adr-001.md"),
+            "# ADR-001: Retain users\n\n## Status\n\nAccepted\n\n## Context\n\nDeletion loses audit history.\n\n## Decision\n\nUse soft deletion.\n\n## Consequences\n\nRows remain recoverable.\n\n## Code Constraints\n\n```yaml\nversion: 1\nrules:\n  - id: no-hard-delete\n    kind: forbid_pattern\n    path_glob: \"src/**/*.sql\"\n    pattern: \"DELETE\\\\s+FROM\\\\s+users\"\n```\n",
+        )
+        .unwrap();
+        fs::write(source.join("users.sql"), "SELECT * FROM users;\n").unwrap();
+        let git = |args: &[&str]| {
+            let status = Command::new("git")
+                .arg("-C")
+                .arg(&root)
+                .args(args)
+                .status()
+                .unwrap();
+            assert!(status.success(), "git {args:?}");
+        };
+        git(&["init", "-q"]);
+        git(&["add", "."]);
+        git(&[
+            "-c",
+            "user.name=As Decided",
+            "-c",
+            "user.email=tests@asdecided.com",
+            "commit",
+            "-qm",
+            "base",
+        ]);
+        fs::write(
+            source.join("users.sql"),
+            "SELECT * FROM users;\nDELETE FROM users;\n",
+        )
+        .unwrap();
+
+        let report = analyze(
+            corpus.to_str().unwrap(),
+            root.to_str().unwrap(),
+            true,
+            Some("HEAD"),
+            false,
+        )
+        .unwrap();
+        assert_eq!(report.findings.len(), 1);
+        assert_eq!(report.findings[0].line, Some(2));
+
+        fs::remove_dir_all(root).unwrap();
+    }
+}

--- a/rust/rac-engine/src/validate.rs
+++ b/rust/rac-engine/src/validate.rs
@@ -275,7 +275,10 @@ pub fn validate(
         &artifact_type,
     ));
     match artifact_type.as_str() {
-        "decision" => issues.extend(validate_decision(artifact)),
+        "decision" => {
+            issues.extend(validate_decision(artifact));
+            issues.extend(crate::sentry::validate_artifact(artifact));
+        }
         "roadmap" => issues.extend(validate_roadmap(artifact)),
         "prompt" => issues.extend(validate_prompt(artifact)),
         "design" => issues.extend(validate_design(artifact)),

--- a/rust/rac-engine/tests/vectors/spec.json
+++ b/rust/rac-engine/tests/vectors/spec.json
@@ -183,6 +183,7 @@
       ],
       "optional": [
         "supersedes",
+        "code constraints",
         "related requirements",
         "related roadmaps",
         "related designs",
@@ -219,6 +220,10 @@
         [
           "supersedes",
           "The artifact this one supersedes"
+        ],
+        [
+          "code constraints",
+          "Deterministic source-code rules that enforce the machine-checkable subset of this decision"
         ],
         [
           "related requirements",


### PR DESCRIPTION
## Summary

- add native Rust `decided sentry` and compose it into `decided gate --code`
- enforce `forbid_pattern`, `require_pattern`, and `forbid_import` deterministically
- support full-tree certification and added-line Git diff enforcement
- publish decision coverage in human/JSON output and violations as SARIF
- validate malformed constraint blocks during ordinary corpus validation
- provide Python, Rust, and JavaScript/TypeScript import adapters with no Python runtime or model judge
- move Herald collection, deduplication, sorting, and Markdown rendering into native `decided herald`

## Contract dependency

Depends on asdecided/spec#6. The vendored registry is intentionally advanced to that contract, so Guard 1 becomes green when the Spec PR merges.

## Validation

- `cargo test --workspace` (70 engine tests plus workspace/integration suites)
- `cargo clippy --workspace --no-deps -- -D warnings`
- `cargo check --workspace`
- full-tree Sentry CLI smoke
- real Git diff enforcement test
- native Herald deterministic rendering, overflow, deduplication, and empty-state tests

All local checks pass. This stays draft until the Spec dependency lands.