### PR TITLE
(engine) Support MCP 2026-07-28 dual-era protocol

### DIFF
--- a/decisions/decisions/adr-121-dual-era-mcp-protocol.md
+++ b/decisions/decisions/adr-121-dual-era-mcp-protocol.md
@@ -1,0 +1,135 @@
+---
+schema_version: 1
+id: RAC-MCP20260728A
+type: decision
+---
+# ADR-121: Dual-Era MCP Protocol Compatibility
+
+## Status
+
+Accepted
+
+## Category
+
+Architecture
+
+## Context
+
+AsDecided `v0.24.1` implements MCP's initialize-based lifecycle through
+protocol revision `2025-06-18`. MCP `2026-07-28` is a breaking revision: it
+removes the initialize handshake from the new era, moves version and client
+metadata onto each request, requires `server/discover`, standardizes HTTP
+routing headers, and adds caching hints to cacheable results.
+
+The existing native server is already stateless at the application boundary.
+Its read-only tools, per-call corpus freshness, and session-free HTTP
+implementation match the new protocol's architectural direction. Its wire
+contract does not: a strict `2026-07-28` client cannot discover the server, and
+the current generic unknown-method response is not a conforming downgrade
+signal.
+
+AsDecided also has installed clients that still use the legacy lifecycle.
+Replacing that lifecycle outright would turn a protocol upgrade into an
+avoidable compatibility break.
+
+## Decision
+
+`decided-mcp` supports two explicit MCP protocol eras from one deterministic
+request processor.
+
+- **Legacy era.** Initialize-based clients continue to negotiate
+  `2024-11-05`, `2025-03-26`, `2025-06-18`, or `2025-11-25`. Existing
+  `2025-06-18` fixtures remain authoritative for legacy byte compatibility.
+- **Current era.** Clients select `2026-07-28` through per-request protocol
+  metadata. The server implements `server/discover`; no initialize handshake
+  or MCP session identifier is used for this era.
+- **Transport selects framing, not semantics.** stdio reads the protocol
+  revision from request `_meta`; HTTP reads and cross-checks the
+  `MCP-Protocol-Version`, `Mcp-Method`, and applicable `Mcp-Name` headers.
+  Both transports dispatch to the same read-only tool implementation.
+- **Conforming failure enables safe fallback.** Unsupported versions, missing
+  required metadata, header/body mismatch, and unknown methods use the
+  revision-defined error codes and HTTP statuses. The server never silently
+  claims a newer revision while serving legacy framing.
+- **Cache hints describe the existing truth.** Static tool, prompt, and
+  resource lists carry explicit `ttlMs` and `cacheScope` values in
+  `2026-07-28`; legacy result bytes stay unchanged.
+- **The surface does not expand.** Tasks, Apps, roots, sampling, write tools,
+  and engine-owned authentication remain out of scope. JSON Schema 2020-12
+  acceptance broadens what a valid tool schema may express without adding a
+  tool or increasing response authority.
+- **Protocol identity stops inheriting Python SDK identity.** The current-era
+  discovery response identifies `decided-mcp` with the AsDecided package
+  version. The historical `lore` / `1.28.1` identity remains only inside the
+  pinned legacy compatibility response.
+
+## Consequences
+
+### Positive
+
+- Strict current clients can use AsDecided without a downgrade, while older
+  clients remain supported.
+- The stateless design chosen in ADR-032 and ADR-098 becomes protocol-native
+  rather than merely implementation-local.
+- HTTP gateways can route and audit calls from standard headers without
+  inspecting JSON bodies.
+- Compatibility is an explicit matrix with fixtures and conformance tests,
+  not an accidental property of one client SDK.
+
+### Negative
+
+- The server carries two lifecycle paths and revision-aware response framing.
+- Legacy byte parity prevents immediately removing historical SDK-shaped
+  identity and list payloads.
+- HTTP validation becomes stricter for current-era callers.
+
+### Risks
+
+- A shared dispatcher could accidentally add current-era fields to legacy
+  responses. Mitigation: immutable legacy fixtures and byte-for-byte tests.
+- A client could send conflicting protocol metadata and HTTP headers.
+  Mitigation: reject disagreement deterministically before tool dispatch.
+- Upstream protocol interpretation could drift. Mitigation: vendor small,
+  language-neutral contract fixtures and run the official MCP conformance
+  scenarios where supported.
+
+## Alternatives Considered
+
+### Replace the legacy lifecycle with `2026-07-28`
+
+This is simpler internally but breaks installed clients and contradicts the
+published compatibility contract.
+
+### Stay on `2025-06-18` and rely on client fallback
+
+Fallback is not guaranteed for clients pinned to the current revision, and
+AsDecided's current unknown-method and HTTP status behavior is not a reliable
+conforming fallback signal.
+
+### Adopt an MCP SDK as the Rust server implementation
+
+An SDK may eventually reduce protocol maintenance, but replacing the
+dependency-free wire layer during a breaking protocol transition would combine
+two risks and threaten the deterministic legacy contract. The protocol seam
+remains small enough to implement and test directly.
+
+## Related Decisions
+
+- adr-007
+- adr-029
+- adr-030
+- adr-032
+- adr-065
+- adr-066
+- adr-084
+- adr-085
+- adr-098
+- adr-120
+
+## Related Requirements
+
+- asdecided-mcp-2026-protocol
+
+## Related Designs
+
+- mcp-2026-dual-era-wire-contract

--- a/decisions/designs/mcp-2026-dual-era-wire-contract.md
+++ b/decisions/designs/mcp-2026-dual-era-wire-contract.md
@@ -1,0 +1,189 @@
+---
+schema_version: 1
+id: RAC-MCP20260728C
+type: design
+---
+# MCP 2026 Dual-Era Wire Contract
+
+## Context
+
+`decided-mcp` currently owns a deliberately small, dependency-free JSON-RPC
+wire layer. One processor serves newline-delimited stdio and single-response
+HTTP, preserving Python-oracle bytes for the legacy surface. MCP
+`2026-07-28` replaces the initialize lifecycle with per-request negotiation and
+adds transport-level requirements without changing AsDecided's tool semantics.
+
+## User Need
+
+An agent host should connect to AsDecided using either the established MCP
+lifecycle or the current revision and receive the same deterministic,
+read-only grounding answers. Operators should be able to upgrade clients
+without coordinating an all-at-once AsDecided migration.
+
+## Design
+
+### 1. Protocol seam
+
+Introduce a small protocol module between transport parsing and tool dispatch.
+It owns:
+
+- protocol revision constants and era classification;
+- extraction of namespaced request metadata;
+- `server/discover` and legacy `initialize` envelopes;
+- standard JSON-RPC protocol errors;
+- cache hints for current-era list results.
+
+Tool implementations remain unaware of protocol revisions.
+
+### 2. Revision matrix
+
+| Selected revision | Lifecycle | Version carrier | Identity |
+| --- | --- | --- | --- |
+| `2024-11-05` through `2025-11-25` | `initialize` / `initialized` | `params.protocolVersion` during initialize | pinned legacy `lore` / `1.28.1` |
+| `2026-07-28` | `server/discover`, then independent requests | namespaced request `_meta`; HTTP header cross-check | `decided-mcp` / package version |
+
+Legacy initialize never negotiates `2026-07-28`. Current-era requests never
+require or create a session.
+
+### 3. stdio flow
+
+1. Parse one newline-delimited JSON-RPC value.
+2. If the method is `server/discover`, return the current discovery result.
+3. Otherwise classify the request from
+   `_meta["io.modelcontextprotocol/protocolVersion"]`.
+4. Validate the selected revision and required per-request
+   `clientCapabilities` before dispatch.
+5. Dispatch valid tool requests through the existing shared processor.
+6. Write diagnostics to stderr; keep only explicitly pinned legacy notification
+   bytes.
+
+A client receiving `-32601` from an older server can fall back to initialize.
+The upgraded server responds to discovery directly.
+
+### 4. HTTP flow
+
+For a `2026-07-28` POST:
+
+1. Require `MCP-Protocol-Version: 2026-07-28`.
+2. Require `Mcp-Method` and compare it with JSON-RPC `method`.
+3. For `tools/call`, compare `Mcp-Name` with `params.name`.
+4. Compare the header revision with request `_meta`.
+5. Return `400` plus a structured protocol error on revision or header
+   validation failure.
+6. Return `404` plus `-32601` for an unknown RPC.
+7. Return one JSON response; emit no session identifier.
+
+Legacy HTTP requests retain their existing transport behavior and audit
+precondition.
+
+### 5. Cache policy
+
+| Result | `ttlMs` | `cacheScope` | Reason |
+| --- | ---: | --- | --- |
+| `tools/list` | 86,400,000 | `public` | fixed by the installed binary |
+| `prompts/list` | 86,400,000 | `public` | fixed empty surface |
+| `resources/list` | 0 | `private` | conservative default for future corpus-backed resources |
+
+Only current-era envelopes carry these fields. A binary upgrade naturally
+invalidates process-local list caches. Every current-era successful result also
+carries `resultType: "complete"` as required by the final schema.
+
+### 6. Errors
+
+Protocol errors are generated centrally with stable data:
+
+- `-32020` Header mismatch
+- `-32022` Unsupported protocol version, including a `supported` list
+- `-32601` Method not found
+- existing JSON parse and invalid-request errors remain standard JSON-RPC
+
+Tool argument failures continue as tool execution errors so agents can
+self-correct. No current AsDecided RPC requires a client capability, so the
+server does not manufacture a `-32021` path without a real capability boundary.
+
+### 7. Test topology
+
+- Keep current legacy oracle fixtures unchanged.
+- Add small language-neutral JSON request/response fixtures for discovery,
+  revision selection, cache hints, and errors.
+- Run stdio process tests and direct protocol-unit tests.
+- Run HTTP socket tests for headers, statuses, audit gating, and parity.
+- Add an optional official conformance runner job only after it can be pinned
+  deterministically; local CI must not fetch moving protocol data.
+
+## Constraints
+
+- No new MCP tools or write authority.
+- No engine-owned OAuth, authentication, sessions, Tasks, Apps, roots, or
+  sampling.
+- No external `$ref` dereferencing in tool schemas.
+- No model call or probabilistic judge in validation.
+- Legacy `2025-06-18` bytes stay frozen.
+- HTTP remains mandatory-audit-on.
+
+## Rationale
+
+A protocol seam isolates breaking wire evolution from stable product
+semantics. Dual-era support matches how official SDKs migrate while retaining
+AsDecided's stronger deterministic contract. Small fixtures are reviewable and
+can later move into `asdecided/spec` without coupling Rust CI to another
+implementation.
+
+## Alternatives
+
+### Fork the whole request processor by protocol revision
+
+This minimizes conditionals but duplicates tool dispatch, audit, freshness,
+and serialization logic, making semantic drift likely.
+
+### Replace the wire layer with a prerelease SDK
+
+This delegates conformance but makes legacy byte parity and release stability
+dependent on a larger moving dependency. Reconsider after the Rust SDK's
+current-protocol release is stable and parity can be demonstrated.
+
+### Emit current-era fields to every client
+
+This is simpler but breaks the frozen legacy contract and can surprise clients
+that validate older result schemas.
+
+## Accessibility
+
+Not applicable to this machine-to-machine surface. Human-facing errors remain
+plain, actionable text and do not rely on color or terminal formatting.
+
+## Style Guidance
+
+- Keep protocol names and header casing identical to the MCP specification.
+- Prefer explicit revision names over “latest”.
+- Describe compatibility as verified behavior, never as SDK affiliation.
+- Keep wire fixtures compact enough to review directly.
+
+## Open Questions
+
+- Whether the official MCP Rust SDK can replace the bespoke wire layer after
+  its stable `2026-07-28` release without breaking legacy fixtures.
+- Whether `tools/list` should eventually use a shorter TTL when dynamic
+  extension tools exist; the current six-tool binary surface is static.
+
+## Related Requirements
+
+- asdecided-mcp-2026-protocol
+- rac-mcp-http-transport
+- rac-mcp-surface-budget
+
+## Related Decisions
+
+- adr-032
+- adr-066
+- adr-098
+- adr-120
+- adr-121
+
+## Related Roadmaps
+
+- lore-at-team-scale
+
+## Related Tickets
+
+- asdecided/core#389

--- a/decisions/requirements/asdecided-mcp-2026-protocol.md
+++ b/decisions/requirements/asdecided-mcp-2026-protocol.md
@@ -1,0 +1,92 @@
+---
+schema_version: 1
+id: RAC-MCP20260728B
+type: requirement
+---
+# Requirement: MCP 2026-07-28 Protocol Compatibility
+
+## Status
+
+Accepted
+
+## Problem
+
+The native AsDecided MCP server is stateless and read-only, but its wire
+contract ends at MCP `2025-06-18`. It cannot answer the mandatory
+`server/discover` request, does not enforce the current HTTP routing headers,
+and does not emit current-era caching hints or protocol errors. Clients pinned
+to `2026-07-28` therefore cannot use AsDecided reliably, while removing the
+legacy lifecycle would break existing installations.
+
+## Requirements
+
+- [REQ-001] `decided-mcp` MUST implement `server/discover` and advertise `2026-07-28`, its read-only capabilities, and its real package identity.
+- [REQ-002] Every `2026-07-28` request MUST carry the selected protocol revision and `clientCapabilities` in namespaced request `_meta`; HTTP requests MUST additionally carry `MCP-Protocol-Version`.
+- [REQ-003] Current-era HTTP POST requests MUST carry `Mcp-Method` and, where the RPC names a tool or resource, the corresponding `Mcp-Name`; a mismatch with the JSON-RPC body MUST fail before dispatch.
+- [REQ-004] The server MUST return the revision-defined errors for header mismatch (`-32020`), unsupported protocol version (`-32022`), and unknown method (`-32601`); no AsDecided RPC currently requires a client capability that would justify `-32021`.
+- [REQ-005] An unknown current-era HTTP method MUST return HTTP `404`; malformed or revision-invalid current-era requests MUST return HTTP `400` with a structured JSON-RPC error.
+- [REQ-006] `server/discover`, `tools/list`, `prompts/list`, and `resources/list` results MUST include `resultType`, non-negative `ttlMs`, and an explicit `cacheScope` for `2026-07-28`; every other successful current-era result MUST include `resultType`.
+- [REQ-007] Tool input and output schemas MUST be valid JSON Schema 2020-12, MUST retain the object-root input constraint, and MUST NOT dereference external references.
+- [REQ-008] Initialize-based clients MUST continue to negotiate `2024-11-05`, `2025-03-26`, `2025-06-18`, or `2025-11-25`; the pinned `2025-06-18` response and tool payload fixtures MUST remain byte-identical.
+- [REQ-009] stdio and HTTP MUST dispatch identical valid tool calls to the same implementation and return semantically identical tool results.
+- [REQ-010] The six-tool read-only surface, corpus freshness behavior, response budgets, mandatory HTTP audit posture, and proxy-owned authentication boundary MUST remain unchanged.
+- [REQ-011] New-protocol diagnostics MUST use stderr or structured protocol errors rather than the deprecated MCP logging capability; legacy parse-error compatibility MAY retain its pinned notification.
+- [REQ-012] CI MUST exercise legacy and current protocol scenarios without a model call, embeddings, or network-dependent assertions.
+
+## Success Metrics
+
+- A strict `2026-07-28` conformance client discovers the server and completes
+  `tools/list` and representative `tools/call` requests over stdio and HTTP.
+- All pre-existing MCP compatibility fixtures remain green.
+- Protocol tests produce identical results across repeated runs.
+
+## Risks
+
+- Dual-era branching creates response drift. Mitigation: revision-specific
+  envelope tests around one shared tool dispatcher.
+- Strict HTTP validation exposes previously tolerated malformed clients.
+  Mitigation: strictness applies only when the caller selects `2026-07-28`;
+  legacy handling remains available.
+- Cache hints hide corpus changes. Mitigation: only static list surfaces receive
+  positive TTLs; corpus-dependent reads use zero TTL or remain uncached.
+
+## Assumptions
+
+- MCP `2026-07-28` is the published current specification.
+- Official clients retain a legacy fallback path during the ecosystem
+  transition.
+- AsDecided does not require Tasks, Apps, roots, sampling, or protocol-level
+  sessions to provide deterministic decision grounding.
+
+## Related Decisions
+
+- adr-007
+- adr-029
+- adr-030
+- adr-032
+- adr-065
+- adr-066
+- adr-084
+- adr-085
+- adr-098
+- adr-120
+- adr-121
+
+## Related Designs
+
+- mcp-2026-dual-era-wire-contract
+
+## Related Requirements
+
+- rac-mcp-http-transport
+- rac-mcp-surface-budget
+
+## Related Tickets
+
+- asdecided/core#389
+
+## Verified By
+
+- rust/decided-mcp/tests/protocol_2026.rs
+- rust/decided-mcp/tests/protocol_legacy.rs
+- rust/decided-mcp/tests/http_transport.rs

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -12,6 +12,26 @@ brew install asdecided/tap/asdecided-core
 
 No Python runtime or extra is needed.
 
+## Protocol compatibility
+
+`decided-mcp` supports both MCP lifecycle eras:
+
+- existing clients can continue using the initialize-based revisions through
+  `2025-11-25`;
+- current clients can use the stateless `2026-07-28` revision through
+  `server/discover` and per-request metadata.
+
+No configuration change is required for stdio clients: a current host discovers
+the current revision, while an older host follows the established initialize
+flow. The six read-only tools and their grounding results are the same in both
+eras.
+
+For shared HTTP deployments, current clients send
+`MCP-Protocol-Version`, `Mcp-Method`, and the applicable `Mcp-Name` headers.
+AsDecided validates these before dispatch and never creates an MCP session.
+Authentication remains the responsibility of the fronting deployment proxy;
+the engine's mandatory HTTP audit posture is unchanged.
+
 ## 2. Configure your client
 
 Replace `/path/to/your/repo` with the absolute path to the directory that

--- a/rust/PORT-CONTRACT.d/20-mcp-2026-protocol.md
+++ b/rust/PORT-CONTRACT.d/20-mcp-2026-protocol.md
@@ -1,0 +1,106 @@
+# 20 — MCP `2026-07-28`: dual-era protocol contract
+
+Scope: the current MCP wire revision served by `decided-mcp` over stdio and
+HTTP. Addendum 10 remains authoritative for legacy stdio bytes; addendum 19
+remains authoritative for legacy HTTP behavior. This addendum records the
+current-era extension selected by ADR-121.
+
+Normative upstream artifact: the immutable MCP JSON schema at
+`modelcontextprotocol/modelcontextprotocol`, tag `2026-07-28`,
+`schema/2026-07-28/schema.json`.
+
+## 0 — Compatibility matrix
+
+| Era | Revisions | Lifecycle | Identity |
+| --- | --- | --- | --- |
+| Legacy | `2024-11-05`, `2025-03-26`, `2025-06-18`, `2025-11-25` | `initialize` / `initialized` | pinned `lore` / `1.28.1` |
+| Current | `2026-07-28` | `server/discover`; metadata on every request | `decided-mcp` / Cargo package version |
+
+Legacy frames do not gain current-era fields. In particular, the
+`2025-06-18` initialize and tools/list bytes in addendum 10 remain frozen.
+
+## 1 — Required request metadata
+
+Every current-era request carries:
+
+```json
+{
+  "_meta": {
+    "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+    "io.modelcontextprotocol/clientCapabilities": {}
+  }
+}
+```
+
+`io.modelcontextprotocol/clientInfo` is accepted but not trusted and does not
+change behavior. Missing or malformed required metadata is `-32602 Invalid
+params`.
+
+## 2 — Discovery
+
+`server/discover` is mandatory and returns:
+
+- `resultType: "complete"`
+- `supportedVersions: ["2026-07-28"]`
+- the tools, prompts, and resources capabilities AsDecided serves
+- `serverInfo.name: "decided-mcp"` and the Cargo package version
+- `ttlMs: 86400000`, `cacheScope: "public"`
+- concise instructions describing the read-only grounding surface
+
+The discovery result advertises per-request-metadata revisions. Legacy
+initialize revisions remain available through the legacy fallback lifecycle
+and are not mixed into `supportedVersions`.
+
+## 3 — Successful results
+
+Every current-era successful result has `resultType: "complete"`.
+
+Cacheable lists additionally carry:
+
+| Method | `ttlMs` | `cacheScope` |
+| --- | ---: | --- |
+| `tools/list` | `86400000` | `public` |
+| `prompts/list` | `86400000` | `public` |
+| `resources/list` | `0` | `private` |
+
+The six tool definitions and their order are the same as the legacy pinned
+surface. Their schemas are a valid JSON Schema 2020-12 subset; input roots
+remain objects and external `$ref` values are forbidden.
+
+Current `tools/call` results retain `content`, `structuredContent`, and
+`isError`, with `resultType` added. Tool argument and execution failures remain
+tool results so an agent can self-correct.
+
+## 4 — Removed current-era methods
+
+`initialize`, `ping`, and other methods absent from the `2026-07-28` client
+request union return `-32601 Method not found`. Their legacy behavior remains
+available only in the legacy era.
+
+## 5 — HTTP headers and statuses
+
+Every current-era HTTP POST requires:
+
+- `MCP-Protocol-Version: 2026-07-28`
+- `Mcp-Method: <JSON-RPC method>`
+- `Mcp-Name: <params.name>` for `tools/call`
+
+Header values are compared with the JSON-RPC body before dispatch. Missing or
+conflicting values return HTTP 400 with `-32020 Header mismatch`. Unsupported
+versions return HTTP 400 with `-32022 Unsupported protocol version`. Unknown
+RPCs return HTTP 404 with `-32601 Method not found`.
+
+No response carries `Mcp-Session-Id`; one request can be served by any process
+instance.
+
+## 6 — Verification
+
+- `decided-mcp/tests/protocol_legacy.rs`: frozen initialize/list compatibility
+- `decided-mcp/tests/protocol_2026.rs`: discovery, metadata, results, caching,
+  errors, and schema subset
+- `decided-mcp/tests/http_transport.rs`: current headers, statuses, discovery,
+  and tool calls over a real TCP server
+
+The full AsDecided corpus is validated separately. The official MCP conformance
+runner may be pinned in CI after its current server scenarios cover a partial,
+read-only server without requiring unadvertised capabilities.

--- a/rust/decided-mcp/src/http.rs
+++ b/rust/decided-mcp/src/http.rs
@@ -23,7 +23,7 @@ use std::net::{TcpListener, TcpStream};
 
 use serde_json::Value;
 
-use crate::{audit, process_request, ServerState};
+use crate::{audit, process_request, protocol, ServerState};
 
 /// Prove a working audit sink for HTTP serving (ADR-084 fail-loud). Audit must
 /// be enabled in `.decided/config.yaml` and its resolved path writable, or the
@@ -238,17 +238,115 @@ fn route_post(
                 .to_string(),
         );
     };
+    let id_json = message
+        .get("id")
+        .and_then(|id| serde_json::to_string(id).ok())
+        .unwrap_or_else(|| "null".to_string());
+    let era = match http_era(req, &message, &id_json) {
+        Ok(era) => era,
+        Err(response) => return response,
+    };
+    if era == protocol::Era::Current {
+        if let Err(response) = validate_current_headers(req, &message, method, &id_json) {
+            return response;
+        }
+        if let Err(frame) = protocol::validate_current_metadata(&message, &id_json) {
+            return json_response("400 Bad Request", frame);
+        }
+    }
     // A notification (no id) is acknowledged with 202 and no body (ADR-032:
     // nothing to return; the read-only server holds no session to advance).
-    let Some(id) = message.get("id") else {
+    if message.get("id").is_none() {
         return Response { status: "202 Accepted", body: None };
-    };
+    }
     // Attribution rides X-AsDecided-Principal (ADR-098): recorded by audit, never an
     // access-control input — the response is identical whatever it says.
     let principal = req.header("x-asdecided-principal");
-    let id_json = serde_json::to_string(id).unwrap_or_else(|_| "null".to_string());
-    let frame = process_request(root, state, method, &id_json, &message, recorder.as_mut(), principal);
-    json_response("200 OK", frame)
+    let frame = process_request(
+        root,
+        state,
+        era,
+        &id_json,
+        &message,
+        recorder.as_mut(),
+        principal,
+    );
+    let status = if era == protocol::Era::Current
+        && !protocol::current_method_supported(method)
+    {
+        "404 Not Found"
+    } else {
+        "200 OK"
+    };
+    json_response(status, frame)
+}
+
+fn http_era(req: &Request, message: &Value, id_json: &str) -> Result<protocol::Era, Response> {
+    let header_version = req.header("mcp-protocol-version");
+    let metadata_version = protocol::requested_version(message);
+    match header_version {
+        Some(protocol::CURRENT_PROTOCOL_VERSION) => Ok(protocol::Era::Current),
+        Some(version) if protocol::LEGACY_PROTOCOL_VERSIONS.contains(&version) => {
+            Ok(protocol::Era::Legacy)
+        }
+        Some(version) => Err(json_response(
+            "400 Bad Request",
+            protocol::unsupported_protocol_frame(message.get("id"), Some(version)),
+        )),
+        None if metadata_version == Some(protocol::CURRENT_PROTOCOL_VERSION) => Err(json_response(
+            "400 Bad Request",
+            protocol::header_mismatch_frame(
+                id_json,
+                "MCP-Protocol-Version",
+                Some(protocol::CURRENT_PROTOCOL_VERSION),
+                None,
+            ),
+        )),
+        None => Ok(protocol::Era::Legacy),
+    }
+}
+
+fn validate_current_headers(
+    req: &Request,
+    message: &Value,
+    method: &str,
+    id_json: &str,
+) -> Result<(), Response> {
+    let metadata_version = protocol::requested_version(message);
+    if metadata_version != Some(protocol::CURRENT_PROTOCOL_VERSION) {
+        return Err(json_response(
+            "400 Bad Request",
+            protocol::header_mismatch_frame(
+                id_json,
+                "MCP-Protocol-Version",
+                Some(protocol::CURRENT_PROTOCOL_VERSION),
+                metadata_version,
+            ),
+        ));
+    }
+    let method_header = req.header("mcp-method");
+    if method_header != Some(method) {
+        return Err(json_response(
+            "400 Bad Request",
+            protocol::header_mismatch_frame(id_json, "Mcp-Method", Some(method), method_header),
+        ));
+    }
+    if method == "tools/call" {
+        let expected_name = message.pointer("/params/name").and_then(Value::as_str);
+        let actual_name = req.header("mcp-name");
+        if expected_name.is_none() || actual_name != expected_name {
+            return Err(json_response(
+                "400 Bad Request",
+                protocol::header_mismatch_frame(
+                    id_json,
+                    "Mcp-Name",
+                    expected_name,
+                    actual_name,
+                ),
+            ));
+        }
+    }
+    Ok(())
 }
 
 fn respond(writer: &mut TcpStream, resp: &Response) {

--- a/rust/decided-mcp/src/main.rs
+++ b/rust/decided-mcp/src/main.rs
@@ -11,6 +11,7 @@ mod args;
 mod audit;
 mod graph;
 mod http;
+mod protocol;
 mod provenance;
 mod sidecar;
 mod tools;
@@ -19,17 +20,6 @@ use args::{Arg, Kind, Param};
 use rac_engine::budget;
 use serde_json::{json, Map, Value};
 use std::io::{BufRead, Write};
-
-/// Pinned `serverInfo.version` (contract landmine, §3): the oracle emits the
-/// bundled **Python `mcp` SDK package version** (`mcp==1.28.1`), not the decided
-/// product version. Byte parity requires the same literal.
-const SDK_VERSION: &str = "1.28.1";
-const SERVER_NAME: &str = "lore";
-
-/// Protocol versions the pinned SDK negotiates; anything else falls back to
-/// the latest. The harness pins its requests to 2025-06-18.
-const SUPPORTED_PROTOCOL_VERSIONS: [&str; 3] = ["2024-11-05", "2025-03-26", "2025-06-18"];
-const LATEST_PROTOCOL_VERSION: &str = "2025-06-18";
 
 /// The pinned `tools/list` result — the captured ORACLE-NEXT bytes, embedded
 /// verbatim (schemas, descriptions, pydantic-shaped titles incl. the
@@ -178,7 +168,23 @@ fn serve(
         let id_json = serde_json::to_string(id).unwrap_or_else(|_| "null".to_string());
         // stdio has no per-request principal; attribution stays the recorder's
         // locally resolved identity (ADR-098).
-        let frame = process_request(root, state, method, &id_json, &message, recorder.as_mut(), None);
+        let era = match protocol::era_for_stdio(method, &message) {
+            Ok(era) => era,
+            Err(frame) => {
+                writeln!(out, "{frame}").ok();
+                out.flush().ok();
+                continue;
+            }
+        };
+        if era == protocol::Era::Current {
+            if let Err(frame) = protocol::validate_current_metadata(&message, &id_json) {
+                writeln!(out, "{frame}").ok();
+                out.flush().ok();
+                continue;
+            }
+        }
+        let frame =
+            process_request(root, state, era, &id_json, &message, recorder.as_mut(), None);
         writeln!(out, "{frame}").ok();
         out.flush().ok();
     }
@@ -191,55 +197,65 @@ fn serve(
 pub(crate) fn process_request(
     root: &str,
     state: &mut ServerState,
-    method: &str,
+    era: protocol::Era,
     id_json: &str,
     message: &Value,
     recorder: Option<&mut audit::Recorder>,
     principal: Option<&str>,
 ) -> String {
-    match method {
-        "initialize" => initialize_frame(id_json, message),
-        "ping" => format!("{{\"jsonrpc\":\"2.0\",\"id\":{id_json},\"result\":{{}}}}"),
-        "tools/list" => {
+    let method = message
+        .get("method")
+        .and_then(Value::as_str)
+        .expect("transport validates method before dispatch");
+    match (era, method) {
+        (protocol::Era::Legacy, "initialize") => {
+            protocol::legacy_initialize_frame(id_json, message)
+        }
+        (protocol::Era::Current, "server/discover") => protocol::discover_frame(id_json),
+        (protocol::Era::Current, "initialize") => {
+            protocol::method_not_found_frame(id_json, method)
+        }
+        (protocol::Era::Legacy, "ping") => {
+            format!("{{\"jsonrpc\":\"2.0\",\"id\":{id_json},\"result\":{{}}}}")
+        }
+        (protocol::Era::Current, "tools/list") => {
+            protocol::current_tools_list_frame(id_json, TOOLS_LIST_RESULT)
+        }
+        (protocol::Era::Legacy, "tools/list") => {
             format!("{{\"jsonrpc\":\"2.0\",\"id\":{id_json},\"result\":{TOOLS_LIST_RESULT}}}")
         }
-        "prompts/list" => {
+        (protocol::Era::Current, "prompts/list") => {
+            protocol::current_empty_list_frame(id_json, "prompts", true)
+        }
+        (protocol::Era::Legacy, "prompts/list") => {
             format!("{{\"jsonrpc\":\"2.0\",\"id\":{id_json},\"result\":{{\"prompts\":[]}}}}")
         }
-        "resources/list" => {
+        (protocol::Era::Current, "resources/list") => {
+            protocol::current_empty_list_frame(id_json, "resources", false)
+        }
+        (protocol::Era::Legacy, "resources/list") => {
             format!("{{\"jsonrpc\":\"2.0\",\"id\":{id_json},\"result\":{{\"resources\":[]}}}}")
         }
-        "tools/call" => tools_call_frame(root, state, id_json, message, recorder, principal),
-        _ => format!(
+        (_, "tools/call") => {
+            tools_call_frame(root, state, era, id_json, message, recorder, principal)
+        }
+        (protocol::Era::Current, _) => protocol::method_not_found_frame(id_json, method),
+        (protocol::Era::Legacy, _) => format!(
             "{{\"jsonrpc\":\"2.0\",\"id\":{id_json},\"error\":{{\"code\":-32602,\"message\":\"Invalid request parameters\",\"data\":\"\"}}}}"
         ),
     }
-}
-
-fn initialize_frame(id_json: &str, message: &Value) -> String {
-    let requested = message
-        .pointer("/params/protocolVersion")
-        .and_then(Value::as_str)
-        .unwrap_or(LATEST_PROTOCOL_VERSION);
-    let version = if SUPPORTED_PROTOCOL_VERSIONS.contains(&requested) {
-        requested
-    } else {
-        LATEST_PROTOCOL_VERSION
-    };
-    format!(
-        "{{\"jsonrpc\":\"2.0\",\"id\":{id_json},\"result\":{{\"protocolVersion\":\"{version}\",\
-\"capabilities\":{{\"experimental\":{{}},\"prompts\":{{\"listChanged\":false}},\
-\"resources\":{{\"subscribe\":false,\"listChanged\":false}},\
-\"tools\":{{\"listChanged\":false}}}},\
-\"serverInfo\":{{\"name\":\"{SERVER_NAME}\",\"version\":\"{SDK_VERSION}\"}}}}}}"
-    )
 }
 
 /// Serialize the tools/call result envelope (§5). Success duplicates the
 /// payload under `structuredContent.result` (the handlers return `str` and an
 /// outputSchema exists — landmine 1); SDK-text errors ride `isError:true`
 /// with no `structuredContent`.
-fn call_result_frame(id_json: &str, text: &str, is_error: bool) -> String {
+fn call_result_frame(
+    era: protocol::Era,
+    id_json: &str,
+    text: &str,
+    is_error: bool,
+) -> String {
     let mut content_item = Map::new();
     content_item.insert("type".to_string(), json!("text"));
     content_item.insert("text".to_string(), json!(text));
@@ -254,6 +270,9 @@ fn call_result_frame(id_json: &str, text: &str, is_error: bool) -> String {
         result.insert("structuredContent".to_string(), Value::Object(structured));
     }
     result.insert("isError".to_string(), json!(is_error));
+    if era == protocol::Era::Current {
+        result.insert("resultType".to_string(), json!("complete"));
+    }
     let result_json = serde_json::to_string(&Value::Object(result)).expect("serializable");
     format!("{{\"jsonrpc\":\"2.0\",\"id\":{id_json},\"result\":{result_json}}}")
 }
@@ -261,6 +280,7 @@ fn call_result_frame(id_json: &str, text: &str, is_error: bool) -> String {
 fn tools_call_frame(
     root: &str,
     state: &mut ServerState,
+    era: protocol::Era,
     id_json: &str,
     message: &Value,
     recorder: Option<&mut audit::Recorder>,
@@ -281,8 +301,8 @@ fn tools_call_frame(
     );
     let serialize_started = rac_engine::timing::start();
     let frame = match dispatched {
-        Ok(payload) => call_result_frame(id_json, &payload, false),
-        Err(text) => call_result_frame(id_json, &text, true),
+        Ok(payload) => call_result_frame(era, id_json, &payload, false),
+        Err(text) => call_result_frame(era, id_json, &text, true),
     };
     rac_engine::timing::emit_since(
         "mcp.response_serialize",

--- a/rust/decided-mcp/src/protocol.rs
+++ b/rust/decided-mcp/src/protocol.rs
@@ -1,0 +1,288 @@
+//! MCP wire-revision handling.
+//!
+//! Tool semantics deliberately do not live here. This module owns only the
+//! dual-era lifecycle, revision metadata, cache hints, and protocol errors
+//! recorded by ADR-121.
+
+use serde_json::{json, Value};
+
+pub const CURRENT_PROTOCOL_VERSION: &str = "2026-07-28";
+pub const LATEST_LEGACY_PROTOCOL_VERSION: &str = "2025-11-25";
+pub const LEGACY_PROTOCOL_VERSIONS: [&str; 4] = [
+    "2024-11-05",
+    "2025-03-26",
+    "2025-06-18",
+    LATEST_LEGACY_PROTOCOL_VERSION,
+];
+pub const PROTOCOL_VERSION_META_KEY: &str = "io.modelcontextprotocol/protocolVersion";
+pub const CLIENT_CAPABILITIES_META_KEY: &str =
+    "io.modelcontextprotocol/clientCapabilities";
+
+const SERVER_NAME: &str = "decided-mcp";
+const DAY_MS: u64 = 86_400_000;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Era {
+    Legacy,
+    Current,
+}
+
+pub fn requested_version(message: &Value) -> Option<&str> {
+    message
+        .pointer("/params/_meta")
+        .and_then(Value::as_object)
+        .and_then(|meta| meta.get(PROTOCOL_VERSION_META_KEY))
+        .and_then(Value::as_str)
+}
+
+pub fn era_for_stdio(method: &str, message: &Value) -> Result<Era, String> {
+    if method == "initialize" {
+        return Ok(Era::Legacy);
+    }
+    match requested_version(message) {
+        Some(CURRENT_PROTOCOL_VERSION) => Ok(Era::Current),
+        Some(version) if LEGACY_PROTOCOL_VERSIONS.contains(&version) => Ok(Era::Legacy),
+        Some(version) => Err(unsupported_protocol_frame(
+            message.get("id"),
+            Some(version),
+        )),
+        None if method == "server/discover" => Ok(Era::Current),
+        None => Ok(Era::Legacy),
+    }
+}
+
+pub fn legacy_initialize_frame(id_json: &str, message: &Value) -> String {
+    let requested = message
+        .pointer("/params/protocolVersion")
+        .and_then(Value::as_str)
+        .unwrap_or(LATEST_LEGACY_PROTOCOL_VERSION);
+    let version = if LEGACY_PROTOCOL_VERSIONS.contains(&requested) {
+        requested
+    } else {
+        LATEST_LEGACY_PROTOCOL_VERSION
+    };
+    format!(
+        "{{\"jsonrpc\":\"2.0\",\"id\":{id_json},\"result\":{{\"protocolVersion\":\"{version}\",\
+\"capabilities\":{{\"experimental\":{{}},\"prompts\":{{\"listChanged\":false}},\
+\"resources\":{{\"subscribe\":false,\"listChanged\":false}},\
+\"tools\":{{\"listChanged\":false}}}},\
+\"serverInfo\":{{\"name\":\"lore\",\"version\":\"1.28.1\"}}}}}}"
+    )
+}
+
+pub fn discover_frame(id_json: &str) -> String {
+    let result = json!({
+        "resultType": "complete",
+        "ttlMs": DAY_MS,
+        "cacheScope": "public",
+        "supportedVersions": [CURRENT_PROTOCOL_VERSION],
+        "capabilities": {
+            "tools": {
+                "listChanged": false,
+            },
+            "prompts": {
+                "listChanged": false,
+            },
+            "resources": {
+                "subscribe": false,
+                "listChanged": false,
+            },
+        },
+        "serverInfo": {
+            "name": SERVER_NAME,
+            "version": env!("CARGO_PKG_VERSION"),
+            "description": "Read-only AsDecided decision grounding server",
+        },
+        "instructions": "Use the read-only tools to ground engineering work in the repository decision corpus.",
+    });
+    result_frame(id_json, result)
+}
+
+pub fn current_tools_list_frame(id_json: &str, legacy_result: &str) -> String {
+    let mut result: Value =
+        serde_json::from_str(legacy_result).expect("embedded tools/list result must be valid JSON");
+    let object = result
+        .as_object_mut()
+        .expect("embedded tools/list result must be an object");
+    object.insert("ttlMs".to_string(), json!(DAY_MS));
+    object.insert("cacheScope".to_string(), json!("public"));
+    object.insert("resultType".to_string(), json!("complete"));
+    result_frame(id_json, result)
+}
+
+pub fn current_empty_list_frame(id_json: &str, field: &str, public: bool) -> String {
+    let mut result = serde_json::Map::new();
+    result.insert(field.to_string(), json!([]));
+    result.insert("ttlMs".to_string(), json!(if public { DAY_MS } else { 0 }));
+    result.insert(
+        "cacheScope".to_string(),
+        json!(if public { "public" } else { "private" }),
+    );
+    result.insert("resultType".to_string(), json!("complete"));
+    result_frame(id_json, Value::Object(result))
+}
+
+pub fn method_not_found_frame(id_json: &str, method: &str) -> String {
+    error_frame(
+        id_json,
+        -32601,
+        "Method not found",
+        json!({ "method": method }),
+    )
+}
+
+pub fn header_mismatch_frame(
+    id_json: &str,
+    header: &str,
+    expected: Option<&str>,
+    actual: Option<&str>,
+) -> String {
+    error_frame(
+        id_json,
+        -32020,
+        "Header mismatch",
+        json!({
+            "header": header,
+            "expected": expected,
+            "actual": actual,
+        }),
+    )
+}
+
+pub fn unsupported_protocol_frame(id: Option<&Value>, requested: Option<&str>) -> String {
+    let id_json = id
+        .and_then(|id| serde_json::to_string(id).ok())
+        .unwrap_or_else(|| "null".to_string());
+    error_frame(
+        &id_json,
+        -32022,
+        "Unsupported protocol version",
+        json!({
+            "requested": requested.unwrap_or(""),
+            "supported": [CURRENT_PROTOCOL_VERSION],
+        }),
+    )
+}
+
+pub fn validate_current_metadata(message: &Value, id_json: &str) -> Result<(), String> {
+    let Some(meta) = message
+        .pointer("/params/_meta")
+        .and_then(Value::as_object)
+    else {
+        return Err(invalid_params_frame(
+            id_json,
+            "Current protocol requests require params._meta",
+        ));
+    };
+    if meta
+        .get(PROTOCOL_VERSION_META_KEY)
+        .and_then(Value::as_str)
+        != Some(CURRENT_PROTOCOL_VERSION)
+    {
+        return Err(invalid_params_frame(
+            id_json,
+            "Current protocol requests require protocolVersion metadata",
+        ));
+    }
+    if !meta
+        .get(CLIENT_CAPABILITIES_META_KEY)
+        .is_some_and(Value::is_object)
+    {
+        return Err(invalid_params_frame(
+            id_json,
+            "Current protocol requests require clientCapabilities metadata",
+        ));
+    }
+    Ok(())
+}
+
+pub fn current_method_supported(method: &str) -> bool {
+    matches!(
+        method,
+        "server/discover"
+            | "tools/list"
+            | "prompts/list"
+            | "resources/list"
+            | "tools/call"
+    )
+}
+
+fn result_frame(id_json: &str, result: Value) -> String {
+    let result_json = serde_json::to_string(&result).expect("protocol result must serialize");
+    format!("{{\"jsonrpc\":\"2.0\",\"id\":{id_json},\"result\":{result_json}}}")
+}
+
+fn error_frame(id_json: &str, code: i64, message: &str, data: Value) -> String {
+    let error = json!({
+        "code": code,
+        "message": message,
+        "data": data,
+    });
+    let error_json = serde_json::to_string(&error).expect("protocol error must serialize");
+    format!("{{\"jsonrpc\":\"2.0\",\"id\":{id_json},\"error\":{error_json}}}")
+}
+
+fn invalid_params_frame(id_json: &str, detail: &str) -> String {
+    error_frame(id_json, -32602, "Invalid params", json!({ "detail": detail }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn current_metadata_selects_current_era() {
+        let mut meta = serde_json::Map::new();
+        meta.insert(
+            PROTOCOL_VERSION_META_KEY.to_string(),
+            json!(CURRENT_PROTOCOL_VERSION),
+        );
+        let request = json!({
+            "id": 1,
+            "method": "tools/list",
+            "params": {
+                "_meta": Value::Object(meta),
+            }
+        });
+        assert_eq!(era_for_stdio("tools/list", &request), Ok(Era::Current));
+    }
+
+    #[test]
+    fn discovery_identifies_native_server() {
+        let frame: Value = serde_json::from_str(&discover_frame("1")).unwrap();
+        assert_eq!(
+            frame.pointer("/result/supportedVersions/0"),
+            Some(&json!(CURRENT_PROTOCOL_VERSION))
+        );
+        assert_eq!(
+            frame.pointer("/result/serverInfo/name"),
+            Some(&json!("decided-mcp"))
+        );
+    }
+
+    #[test]
+    fn cache_hints_do_not_mutate_legacy_input() {
+        let legacy = r#"{"tools":[]}"#;
+        let frame: Value =
+            serde_json::from_str(&current_tools_list_frame("1", legacy)).unwrap();
+        assert_eq!(frame.pointer("/result/ttlMs"), Some(&json!(DAY_MS)));
+        assert_eq!(
+            frame.pointer("/result/cacheScope"),
+            Some(&json!("public"))
+        );
+        assert_eq!(legacy, r#"{"tools":[]}"#);
+    }
+
+    #[test]
+    fn unsupported_version_lists_both_eras() {
+        let request = json!({"id": 7});
+        let frame: Value =
+            serde_json::from_str(&unsupported_protocol_frame(request.get("id"), Some("2099-01-01")))
+                .unwrap();
+        assert_eq!(frame.pointer("/error/code"), Some(&json!(-32022)));
+        assert_eq!(
+            frame.pointer("/error/data/supported/0"),
+            Some(&json!(CURRENT_PROTOCOL_VERSION))
+        );
+    }
+}

--- a/rust/decided-mcp/tests/common/mod.rs
+++ b/rust/decided-mcp/tests/common/mod.rs
@@ -1,0 +1,73 @@
+#![allow(dead_code)]
+
+use serde_json::Value;
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+pub const CURRENT_VERSION: &str = "2026-07-28";
+pub const VERSION_META_KEY: &str = "io.modelcontextprotocol/protocolVersion";
+
+pub fn scratch(tag: &str) -> PathBuf {
+    let directory = std::env::temp_dir().join(format!(
+        "decided-mcp-protocol-{tag}-{}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&directory);
+    std::fs::create_dir_all(&directory).expect("create scratch corpus");
+    std::fs::write(
+        directory.join("decision.md"),
+        "---\nschema_version: 1\nid: FIX-MCP20260728\ntype: decision\n---\n\
+# Protocol fixture\n\n## Status\n\nAccepted\n\n## Category\n\nTechnical\n\n\
+## Context\n\nA protocol fixture is required.\n\n## Decision\n\nKeep it deterministic.\n\n\
+## Consequences\n\nProtocol tests stay local.\n",
+    )
+    .expect("write fixture artifact");
+    directory
+}
+
+pub fn run_stdio(tag: &str, requests: &[String]) -> Vec<String> {
+    let corpus = scratch(tag);
+    let mut child = Command::new(env!("CARGO_BIN_EXE_decided-mcp"))
+        .arg("--root")
+        .arg(&corpus)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn decided-mcp");
+    {
+        let stdin = child.stdin.as_mut().expect("child stdin");
+        for request in requests {
+            writeln!(stdin, "{request}").expect("write request");
+        }
+    }
+    drop(child.stdin.take());
+    let output = child.wait_with_output().expect("wait for decided-mcp");
+    let _ = std::fs::remove_dir_all(corpus);
+    assert!(
+        output.status.success(),
+        "decided-mcp failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout)
+        .expect("UTF-8 stdout")
+        .lines()
+        .map(str::to_string)
+        .collect()
+}
+
+pub fn parse(frame: &str) -> Value {
+    serde_json::from_str(frame).expect("valid JSON-RPC frame")
+}
+
+pub fn current_meta() -> Value {
+    serde_json::json!({
+        VERSION_META_KEY: CURRENT_VERSION,
+        "io.modelcontextprotocol/clientInfo": {
+            "name": "asdecided-conformance",
+            "version": "1.0.0"
+        },
+        "io.modelcontextprotocol/clientCapabilities": {}
+    })
+}

--- a/rust/decided-mcp/tests/http_transport.rs
+++ b/rust/decided-mcp/tests/http_transport.rs
@@ -1,0 +1,179 @@
+mod common;
+
+use common::{current_meta, parse, scratch, CURRENT_VERSION};
+use serde_json::{json, Value};
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::process::{Child, Command, Stdio};
+use std::sync::{Mutex, MutexGuard};
+use std::time::Duration;
+
+static HTTP_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+fn serial_http_test() -> MutexGuard<'static, ()> {
+    HTTP_TEST_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+struct Server {
+    child: Child,
+    corpus: std::path::PathBuf,
+    port: u16,
+}
+
+impl Server {
+    fn start(tag: &str) -> Self {
+        let corpus = scratch(tag);
+        let audit_path = corpus.join("audit.jsonl");
+        std::fs::create_dir_all(corpus.join(".decided")).unwrap();
+        std::fs::write(
+            corpus.join(".decided/config.yaml"),
+            format!(
+                "audit:\n  enabled: true\n  path: {}\n",
+                audit_path.display()
+            ),
+        )
+        .unwrap();
+        let port = TcpListener::bind(("127.0.0.1", 0))
+            .unwrap()
+            .local_addr()
+            .unwrap()
+            .port();
+        let child = Command::new(env!("CARGO_BIN_EXE_decided-mcp"))
+            .args([
+                "--root",
+                corpus.to_str().unwrap(),
+                "--transport",
+                "http",
+                "--host",
+                "127.0.0.1",
+                "--port",
+                &port.to_string(),
+            ])
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn HTTP server");
+        let server = Self {
+            child,
+            corpus,
+            port,
+        };
+        for _ in 0..100 {
+            if TcpStream::connect(("127.0.0.1", port)).is_ok() {
+                return server;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        panic!("HTTP server did not start");
+    }
+
+    fn post(&self, body: &Value, method_header: &str, name: Option<&str>) -> (String, Value) {
+        let body = body.to_string();
+        let mut request = format!(
+            "POST /mcp HTTP/1.1\r\nHost: 127.0.0.1\r\nAccept: application/json\r\n\
+Content-Type: application/json\r\nMCP-Protocol-Version: {CURRENT_VERSION}\r\n\
+Mcp-Method: {method_header}\r\n"
+        );
+        if let Some(name) = name {
+            request.push_str(&format!("Mcp-Name: {name}\r\n"));
+        }
+        request.push_str(&format!(
+            "Content-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            body.len()
+        ));
+        let mut stream = TcpStream::connect(("127.0.0.1", self.port)).unwrap();
+        stream.write_all(request.as_bytes()).unwrap();
+        let mut response = String::new();
+        stream.read_to_string(&mut response).unwrap();
+        let (headers, body) = response.split_once("\r\n\r\n").unwrap();
+        let status = headers.lines().next().unwrap().to_string();
+        (status, parse(body))
+    }
+}
+
+impl Drop for Server {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+        let _ = std::fs::remove_dir_all(&self.corpus);
+    }
+}
+
+#[test]
+fn current_http_discovery_is_sessionless() {
+    let _guard = serial_http_test();
+    let server = Server::start("http-discover");
+    let request = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "server/discover",
+        "params": {"_meta": current_meta()}
+    });
+    let (status, response) = server.post(&request, "server/discover", None);
+    assert_eq!(status, "HTTP/1.1 200 OK");
+    assert_eq!(
+        response.pointer("/result/supportedVersions/0"),
+        Some(&json!(CURRENT_VERSION))
+    );
+}
+
+#[test]
+fn current_http_rejects_header_body_mismatch() {
+    let _guard = serial_http_test();
+    let server = Server::start("http-mismatch");
+    let request = json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "tools/list",
+        "params": {"_meta": current_meta()}
+    });
+    let (status, response) = server.post(&request, "resources/list", None);
+    assert_eq!(status, "HTTP/1.1 400 Bad Request");
+    assert_eq!(response.pointer("/error/code"), Some(&json!(-32020)));
+}
+
+#[test]
+fn current_http_unknown_rpc_uses_404_and_method_not_found() {
+    let _guard = serial_http_test();
+    let server = Server::start("http-unknown");
+    let request = json!({
+        "jsonrpc": "2.0",
+        "id": 3,
+        "method": "unknown/current",
+        "params": {"_meta": current_meta()}
+    });
+    let (status, response) = server.post(&request, "unknown/current", None);
+    assert_eq!(status, "HTTP/1.1 404 Not Found");
+    assert_eq!(response.pointer("/error/code"), Some(&json!(-32601)));
+}
+
+#[test]
+fn current_http_tool_call_requires_name_and_returns_current_result() {
+    let _guard = serial_http_test();
+    let server = Server::start("http-tool-call");
+    let request = json!({
+        "jsonrpc": "2.0",
+        "id": 4,
+        "method": "tools/call",
+        "params": {
+            "name": "get_summary",
+            "arguments": {},
+            "_meta": current_meta()
+        }
+    });
+    let (missing_status, missing_response) = server.post(&request, "tools/call", None);
+    assert_eq!(missing_status, "HTTP/1.1 400 Bad Request");
+    assert_eq!(
+        missing_response.pointer("/error/code"),
+        Some(&json!(-32020))
+    );
+
+    let (status, response) = server.post(&request, "tools/call", Some("get_summary"));
+    assert_eq!(status, "HTTP/1.1 200 OK");
+    assert_eq!(
+        response.pointer("/result/resultType"),
+        Some(&json!("complete"))
+    );
+}

--- a/rust/decided-mcp/tests/protocol_2026.rs
+++ b/rust/decided-mcp/tests/protocol_2026.rs
@@ -1,0 +1,203 @@
+mod common;
+
+use common::{current_meta, parse, run_stdio, CURRENT_VERSION};
+use serde_json::json;
+
+fn assert_schema_subset(schema: &serde_json::Value) {
+    let object = schema.as_object().expect("schema is an object");
+    if let Some(kind) = object.get("type") {
+        let kind = kind.as_str().expect("type is a string");
+        assert!(
+            matches!(
+                kind,
+                "null"
+                    | "boolean"
+                    | "object"
+                    | "array"
+                    | "number"
+                    | "string"
+                    | "integer"
+            ),
+            "valid JSON Schema type: {kind}"
+        );
+    }
+    if let Some(properties) = object.get("properties") {
+        for property in properties
+            .as_object()
+            .expect("properties is an object")
+            .values()
+        {
+            assert_schema_subset(property);
+        }
+    }
+    if let Some(items) = object.get("items") {
+        assert_schema_subset(items);
+    }
+    if let Some(any_of) = object.get("anyOf") {
+        let alternatives = any_of.as_array().expect("anyOf is an array");
+        assert!(!alternatives.is_empty(), "anyOf has an alternative");
+        alternatives.iter().for_each(assert_schema_subset);
+    }
+    if let Some(required) = object.get("required") {
+        assert!(
+            required
+                .as_array()
+                .expect("required is an array")
+                .iter()
+                .all(serde_json::Value::is_string),
+            "required contains only property names"
+        );
+    }
+    if let Some(reference) = object.get("$ref").and_then(serde_json::Value::as_str) {
+        assert!(
+            reference.starts_with('#'),
+            "external references are not allowed: {reference}"
+        );
+    }
+}
+
+#[test]
+fn current_client_discovers_native_server_without_initialize() {
+    let request = json!({
+        "jsonrpc": "2.0",
+        "id": "discover",
+        "method": "server/discover",
+        "params": {"_meta": current_meta()}
+    });
+    let frames = run_stdio("current-discover", &[request.to_string()]);
+    let response = parse(&frames[0]);
+    assert_eq!(
+        response.pointer("/result/supportedVersions/0"),
+        Some(&json!(CURRENT_VERSION))
+    );
+    assert_eq!(
+        response.pointer("/result/serverInfo/name"),
+        Some(&json!("decided-mcp"))
+    );
+    assert_eq!(
+        response.pointer("/result/serverInfo/version"),
+        Some(&json!(env!("CARGO_PKG_VERSION")))
+    );
+    assert_eq!(
+        response.pointer("/result/resultType"),
+        Some(&json!("complete"))
+    );
+    assert_eq!(
+        response.pointer("/result/cacheScope"),
+        Some(&json!("public"))
+    );
+    assert!(
+        response
+            .pointer("/result/ttlMs")
+            .and_then(|value| value.as_u64())
+            .is_some()
+    );
+}
+
+#[test]
+fn current_lists_include_required_cache_hints() {
+    let requests = ["tools/list", "prompts/list", "resources/list"]
+        .iter()
+        .enumerate()
+        .map(|(index, method)| {
+            json!({
+                "jsonrpc": "2.0",
+                "id": index + 1,
+                "method": method,
+                "params": {"_meta": current_meta()}
+            })
+            .to_string()
+        })
+        .collect::<Vec<_>>();
+    let frames = run_stdio("current-cache", &requests);
+    for frame in frames {
+        let response = parse(&frame);
+        assert!(
+            response
+                .pointer("/result/ttlMs")
+                .and_then(|value| value.as_u64())
+                .is_some()
+        );
+        assert!(matches!(
+            response
+                .pointer("/result/cacheScope")
+                .and_then(|value| value.as_str()),
+            Some("public" | "private")
+        ));
+    }
+}
+
+#[test]
+fn current_unknown_method_and_version_return_conforming_errors() {
+    let unknown = json!({
+        "jsonrpc": "2.0",
+        "id": 7,
+        "method": "unknown/current",
+        "params": {"_meta": current_meta()}
+    });
+    let unsupported = json!({
+        "jsonrpc": "2.0",
+        "id": 8,
+        "method": "tools/list",
+        "params": {
+            "_meta": {
+                "io.modelcontextprotocol/protocolVersion": "2099-01-01"
+            }
+        }
+    });
+    let frames = run_stdio(
+        "current-errors",
+        &[unknown.to_string(), unsupported.to_string()],
+    );
+    assert_eq!(parse(&frames[0]).pointer("/error/code"), Some(&json!(-32601)));
+    assert_eq!(parse(&frames[1]).pointer("/error/code"), Some(&json!(-32022)));
+}
+
+#[test]
+fn current_tool_results_include_result_type() {
+    let request = json!({
+        "jsonrpc": "2.0",
+        "id": 9,
+        "method": "tools/call",
+        "params": {
+            "name": "get_summary",
+            "arguments": {},
+            "_meta": current_meta()
+        }
+    });
+    let frames = run_stdio("current-call", &[request.to_string()]);
+    let response = parse(&frames[0]);
+    assert_eq!(
+        response.pointer("/result/resultType"),
+        Some(&json!("complete"))
+    );
+    assert!(response.pointer("/result/content").is_some());
+}
+
+#[test]
+fn current_requests_require_client_capabilities_metadata() {
+    let request = json!({
+        "jsonrpc": "2.0",
+        "id": 10,
+        "method": "tools/list",
+        "params": {
+            "_meta": {
+                "io.modelcontextprotocol/protocolVersion": CURRENT_VERSION
+            }
+        }
+    });
+    let frames = run_stdio("current-metadata", &[request.to_string()]);
+    assert_eq!(parse(&frames[0]).pointer("/error/code"), Some(&json!(-32602)));
+}
+
+#[test]
+fn tool_schemas_are_json_schema_2020_12_compatible_and_local() {
+    let list: serde_json::Value =
+        serde_json::from_str(include_str!("../src/tools_list_result.json")).unwrap();
+    for tool in list["tools"].as_array().unwrap() {
+        let input = &tool["inputSchema"];
+        assert_eq!(input["type"], "object", "tool input root stays an object");
+        assert_schema_subset(input);
+        assert_schema_subset(&tool["outputSchema"]);
+    }
+}

--- a/rust/decided-mcp/tests/protocol_legacy.rs
+++ b/rust/decided-mcp/tests/protocol_legacy.rs
@@ -1,0 +1,63 @@
+mod common;
+
+use common::{parse, run_stdio};
+use serde_json::json;
+
+#[test]
+fn legacy_2025_06_initialize_bytes_stay_pinned() {
+    let request = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-06-18",
+            "capabilities": {},
+            "clientInfo": {"name": "legacy-test", "version": "1.0.0"}
+        }
+    });
+    let frames = run_stdio("legacy-init", &[request.to_string()]);
+    assert_eq!(
+        frames,
+        [concat!(
+            "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"protocolVersion\":\"2025-06-18\",",
+            "\"capabilities\":{\"experimental\":{},\"prompts\":{\"listChanged\":false},",
+            "\"resources\":{\"subscribe\":false,\"listChanged\":false},",
+            "\"tools\":{\"listChanged\":false}},",
+            "\"serverInfo\":{\"name\":\"lore\",\"version\":\"1.28.1\"}}}"
+        )]
+    );
+}
+
+#[test]
+fn legacy_clients_can_negotiate_2025_11_25() {
+    let request = json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-11-25",
+            "capabilities": {},
+            "clientInfo": {"name": "legacy-test", "version": "1.0.0"}
+        }
+    });
+    let frames = run_stdio("legacy-latest", &[request.to_string()]);
+    assert_eq!(
+        parse(&frames[0]).pointer("/result/protocolVersion"),
+        Some(&json!("2025-11-25"))
+    );
+}
+
+#[test]
+fn legacy_list_result_does_not_gain_current_cache_fields() {
+    let request = json!({
+        "jsonrpc": "2.0",
+        "id": 3,
+        "method": "tools/list",
+        "params": {}
+    });
+    let frames = run_stdio("legacy-list", &[request.to_string()]);
+    let response = parse(&frames[0]);
+    assert!(response.pointer("/result/tools").is_some());
+    assert!(response.pointer("/result/ttlMs").is_none());
+    assert!(response.pointer("/result/cacheScope").is_none());
+}


### PR DESCRIPTION
## What changed

- add ADR-121, a requirement artifact, and a wire-contract design for MCP `2026-07-28`
- support the new stateless `server/discover` lifecycle and required per-request metadata
- enforce current HTTP routing headers and revision-defined errors/statuses
- add current-era result/cache metadata without changing frozen legacy response bytes
- retain initialize-based compatibility through `2025-11-25`
- document the public compatibility model

Closes #389.

## Why

MCP `2026-07-28` removes initialization from the current lifecycle and requires discovery, request metadata, routing headers, result typing, and cache hints. AsDecided is already stateless and read-only, so this change adds a narrow revision-aware wire seam while leaving the six tools and their authority unchanged.

## Dogfooding

The change is governed by:

- `ADR-121: Dual-Era MCP Protocol Compatibility`
- `Requirement: MCP 2026-07-28 Protocol Compatibility`
- `MCP 2026 Dual-Era Wire Contract`
- `PORT-CONTRACT.d/20-mcp-2026-protocol.md`

The requirement is linked to #389 and its `Verified By` section names the executable integration suites.

## Validation

- `decided validate decisions` — 430 valid, 0 invalid; OKF v0.1 conformant
- `cargo test --workspace` — pass
- `cargo clippy --workspace --all-targets -- -D warnings` — pass
- `cargo test -p decided-mcp` — 20 tests pass
- actual stdio requests and responses from the built binary validate against the immutable final MCP `2026-07-28` JSON schema
- `git diff --check` — pass

The official new-era conformance runner is currently published as an alpha; this PR does not add a network-dependent alpha runner to CI.
