### PR TITLE
(engine) Prepare v0.25.0 release

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -28,7 +28,7 @@ checksum = "3f8ebf5827e4ac4fd5946560e6a99776ea73b596d80898f357007317a7141e47"
 
 [[package]]
 name = "asdecided-core"
-version = "0.24.1"
+version = "0.25.0"
 dependencies = [
  "globset",
  "inotify",
@@ -127,14 +127,14 @@ checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "decided"
-version = "0.24.1"
+version = "0.25.0"
 dependencies = [
  "asdecided-core",
 ]
 
 [[package]]
 name = "decided-mcp"
-version = "0.24.1"
+version = "0.25.0"
 dependencies = [
  "asdecided-core",
  "serde",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["rac-engine", "decided", "decided-mcp"]
 
 [workspace.package]
-version = "0.24.1"
+version = "0.25.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/asdecided/core"

--- a/rust/decided/Cargo.toml
+++ b/rust/decided/Cargo.toml
@@ -12,4 +12,4 @@ categories = ["command-line-utilities", "development-tools"]
 publish = ["crates-io"]
 
 [dependencies]
-rac-engine = { package = "asdecided-core", version = "=0.24.1", path = "../rac-engine" }
+rac-engine = { package = "asdecided-core", version = "=0.25.0", path = "../rac-engine" }


### PR DESCRIPTION
## What changed

- bump the Rust workspace packages from `0.24.1` to `0.25.0`
- keep the public `decided` crate pinned to the matching `asdecided-core` implementation version
- refresh the lockfile package versions

## Why

PR #390 added MCP `2026-07-28` support as a new compatibility surface while preserving legacy clients. This minor release packages that capability coherently as v0.25.0.

## Validation

- `decided validate decisions` — 430 valid, 0 invalid; OKF v0.1 conformant
- `cargo test --workspace` — pass
- `cargo clippy --workspace --all-targets -- -D warnings` — pass
- `git diff --check` — pass
