### PR TITLE
(engine) Align the OKF carrier profile with v0.2

### DIFF
--- a/decisions/decisions/adr-122-okf-v0-2-carrier-profile.md
+++ b/decisions/decisions/adr-122-okf-v0-2-carrier-profile.md
@@ -1,0 +1,124 @@
+---
+schema_version: 1
+id: RAC-KX9H2M7Q4V8C
+type: decision
+---
+# ADR-122: OKF v0.2 Is a Truthful Derived Carrier
+
+## Status
+
+Accepted
+
+## Category
+
+Architecture
+
+## Context
+
+ADR-048 adopted Google's Open Knowledge Format as an informative carrier
+profile and pinned the derived export to OKF v0.1. Google has now published OKF
+v0.2. The new revision keeps Markdown plus YAML frontmatter as its carrier but
+makes provenance, trust, freshness, lifecycle, and deterministic attestation
+first-class optional conventions.
+
+OKF v0.2 also supersedes two v0.1 shapes that AsDecided's exporter currently
+uses: a timestamp-style history projection is replaced by `generated`, and body
+`# Citations` are replaced by frontmatter `sources` for genuine derivation.
+
+AsDecided has related concepts, but they are not interchangeable:
+
+- Git recency is evidence of when an artifact changed, not proof that its claims
+  were verified.
+- `Verified By` relationships point to external tests or traces, not actors who
+  confirmed a concept against a source.
+- Structural relationships preserve navigation and integrity, but they do not
+  necessarily assert that one artifact derives from another.
+- AsDecided lifecycle values are type-specific and stricter than OKF's
+  `draft | stable | deprecated` carrier vocabulary.
+
+A mechanical field rename would therefore claim provenance or trust the
+authoritative corpus does not record.
+
+## Decision
+
+AsDecided updates its informative export profile to OKF v0.2 as a truthful
+derived carrier. This decision supersedes ADR-048 only where that decision pins
+the profile to v0.1 or adopts the v0.1 timestamp and citation conventions; its
+informative-dependency and no-loosening boundaries remain in force.
+
+1. The root generated `index.md` declares `okf_version: "0.2"`.
+2. Every exported concept retains its mapped OKF type and stable AsDecided ID,
+   and adds a safely encoded display title.
+3. Git's last meaningful content commit may populate `generated.at`.
+   `generated.by` identifies the deterministic AsDecided exporter, not the
+   original author.
+4. AsDecided lifecycle maps conservatively: proposed work becomes `draft`,
+   retired or superseded work becomes `deprecated`, and other valid live states
+   become `stable`.
+5. Resolved structural relationships remain ordinary Markdown links under
+   `# Related concepts`. They MUST NOT be mislabeled as `sources`.
+6. `sources`, `verified`, `stale_after`, and Attested Computation fields are
+   emitted only when an authoritative AsDecided contract carries equivalent
+   semantics. This release does not invent them from proximity, Git history, or
+   external verification edges.
+7. Core remains stricter than OKF when reading its authoritative corpus.
+   Unknown OKF concept types and optional-field absence remain acceptable to
+   general OKF consumers; they do not expand AsDecided's own artifact registry.
+8. The migration is network-free and fixture-driven. OKF v0.1 remains a
+   documented compatibility input, but new exports target v0.2 only.
+
+## Consequences
+
+### Positive
+
+- New exports declare the current OKF revision and stop emitting a superseded
+  citations convention.
+- Trust and provenance retain their meaning instead of becoming marketing
+  labels inferred from unrelated evidence.
+- AsDecided's strict write-time guarantees remain unchanged.
+- The exporter remains deterministic, local, and independent of Google tooling.
+
+### Negative
+
+- OKF consumers expecting the old generated `# Citations` section must follow
+  standard related-concept links instead.
+- The derived bundle does not populate every optional v0.2 family until the
+  authoritative corpus has equivalent data.
+- The carrier profile must keep tracking a pre-1.0 upstream specification.
+
+## Alternatives Considered
+
+### Copy every new OKF field into AsDecided frontmatter
+
+Rejected. It would make an informative export format part of the authoritative
+artifact schema and duplicate existing lifecycle and relationship contracts.
+
+### Infer trust from accepted status and `Verified By`
+
+Rejected. Review status, executable verification, and source confirmation are
+different claims. Conflating them would overstate trust.
+
+### Stay pinned to v0.1
+
+Rejected. New exports would knowingly use superseded conventions and miss the
+versioned interoperability surface.
+
+## Related Decisions
+
+- adr-007
+- adr-016
+- adr-045
+- adr-048
+- adr-049
+- adr-065
+- adr-066
+- adr-096
+- adr-120
+
+## Related Requirements
+
+- asdecided-okf-v0-2-carrier
+
+## Related Designs
+
+- okf-v0-2-export-projection

--- a/decisions/designs/okf-v0-2-export-projection.md
+++ b/decisions/designs/okf-v0-2-export-projection.md
@@ -1,0 +1,91 @@
+---
+schema_version: 1
+id: RAC-KX9K7P2T5Y9F
+type: design
+---
+# OKF v0.2 Export Projection
+
+## Context
+
+The native exporter already builds a deterministic derived tree from one
+validated AsDecided corpus walk plus Git recency. OKF v0.2 changes the carrier
+envelope but does not justify a second parser or a network dependency.
+
+## User Need
+
+An operator should be able to export current OKF bundles for other tools without
+changing the authoritative AsDecided artifacts or overstating their provenance
+and trust.
+
+## Design
+
+### Root index
+
+The generated root `index.md` starts with:
+
+```yaml
+---
+okf_version: "0.2"
+---
+```
+
+The existing progressive-disclosure body and deterministic type ordering remain.
+
+### Concept envelope
+
+Each generated concept carries:
+
+```yaml
+---
+type: ADR
+id: RAC-EXAMPLE
+title: "ADR-001: Example"
+status: stable
+generated:
+  by: asdecided/0.25.0
+  at: 2026-07-29T06:00:00+00:00
+tags: [example]
+---
+```
+
+`generated` is omitted when Git cannot supply a valid last commit. YAML string
+values that can contain punctuation are encoded deterministically as JSON-style
+quoted scalars, which YAML accepts.
+
+### Lifecycle
+
+Comparison is ASCII case-insensitive after trimming:
+
+| AsDecided status | OKF status |
+| --- | --- |
+| `Proposed`, `Draft` | `draft` |
+| `Retired`, `Superseded`, `Deprecated`, `Obsolete` | `deprecated` |
+| any other non-empty valid status | `stable` |
+| absent/unknown | omit |
+
+The mapping is a carrier simplification only. It never feeds back into Core.
+
+### Relationships and provenance
+
+Resolved outgoing relationships render under `# Related concepts` using
+bundle-relative links. The exporter does not populate `sources`: relationship
+edges express governance and navigation, not necessarily derivation.
+
+No `verified`, `stale_after`, source credibility, executor, or attester field is
+generated in this release. Future projections require an authoritative semantic
+source and a new governed change.
+
+### Compatibility
+
+The v0.1 exporter shape remains captured as a small retirement fixture and
+documented for consumers. There is no dual-output flag: new `--okf` exports are
+v0.2, avoiding an indefinitely maintained second exporter.
+
+## Related Decisions
+
+- adr-048
+- adr-122
+
+## Related Requirements
+
+- asdecided-okf-v0-2-carrier

--- a/decisions/requirements/asdecided-okf-v0-2-carrier.md
+++ b/decisions/requirements/asdecided-okf-v0-2-carrier.md
@@ -1,0 +1,75 @@
+---
+schema_version: 1
+id: RAC-KX9J5N8R3W6D
+type: requirement
+---
+# Requirement: OKF v0.2 Carrier Alignment
+
+## Status
+
+Accepted
+
+## Problem
+
+AsDecided exports an informative OKF v0.1 bundle. OKF v0.2 supersedes the
+export's timestamp and citations conventions and adds versioned lifecycle,
+provenance, trust, freshness, and deterministic attestation families. Merely
+changing the displayed conformance version would produce a misleading carrier;
+copying every optional field would weaken the semantic boundaries of the
+authoritative AsDecided corpus.
+
+## Requirements
+
+- [REQ-000] This requirement MUST supersede the v0.1 version, timestamp, and citation clauses of `rac-okf-carrier-profile` while retaining its informative-dependency and no-loosening constraints.
+- [REQ-001] `decided export --okf` MUST emit a bundle-root `index.md` declaring `okf_version: "0.2"`.
+- [REQ-002] Every exported concept MUST retain its mapped OKF `type`, stable AsDecided `id`, safely encoded `title`, and tags when present.
+- [REQ-003] When Git supplies a valid last-content timestamp, the export MUST emit `generated.by` as the versioned AsDecided exporter and `generated.at` as that timestamp; it MUST NOT describe the exporter as the original author.
+- [REQ-004] Exported lifecycle MUST map proposed states to `draft`, retired or superseded states to `deprecated`, and other valid live states to `stable`.
+- [REQ-005] Resolved structural relationships MUST remain deterministic Markdown links under `# Related concepts` and MUST NOT be emitted as OKF `sources` unless an authoritative derivation contract exists.
+- [REQ-006] The exporter MUST NOT infer `verified`, trust tier, `stale_after`, source credibility, or attestation from acceptance status, Git history, proximity, or AsDecided `Verified By` edges.
+- [REQ-007] The authoritative AsDecided validator and relationship gate MUST retain their existing strict behavior; OKF's permissive consumer rules MUST NOT expand the registered AsDecided artifact types.
+- [REQ-008] New OKF exports MUST target v0.2 only, while tests and documentation MUST explain the bounded v0.1 compatibility fallback for existing consumers.
+- [REQ-009] Verification MUST be deterministic, network-free, and fixture-driven, including lifecycle, generated metadata, relationship links, safe YAML strings, and absence of invented trust fields.
+
+## Success Metrics
+
+- A generated bundle satisfies the mandatory OKF v0.2 structure.
+- Repeated exports of the same corpus and Git history are byte-identical.
+- Existing non-OKF workspace tests and live-corpus invariants remain green.
+- No production dependency on Google code or tooling is added.
+
+## Risks
+
+- Downstream consumers may rely on the old `# Citations` heading. The release
+  notes and profile document the migration to standard related-concept links.
+- Lifecycle projection may erase type-specific nuance. The original AsDecided
+  artifact remains authoritative and its stable ID is preserved.
+- Optional v0.2 fields may appear incomplete. Their absence is preferable to
+  fabricating trust or provenance, and is explicitly conformant with OKF v0.2.
+
+## Assumptions
+
+- OKF v0.2 remains an informative, pre-1.0 carrier dependency.
+- Git timestamps are available only as derived recency evidence.
+- AsDecided's structural relationships are not automatically provenance edges.
+
+## Related Decisions
+
+- adr-048
+- adr-122
+
+## Related Designs
+
+- okf-v0-2-export-projection
+
+## Related Requirements
+
+- rac-okf-carrier-profile
+
+## Related Tickets
+
+- asdecided/core#392
+
+## Verified By
+
+- rust/rac-engine/tests/okf_v02.rs

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -827,7 +827,7 @@ modes; the default writes the viewer JSON payload to stdout. Exports are build
 artifacts — existing output is overwritten.
 
 - **Input:** `decided export [directory]` — scanned recursively for `*.md` (default: current directory).
-- **Modes:** *(default)* viewer JSON to stdout · `--html` (self-contained Portal file) · `--okf` (OKF v0.1 Markdown bundle) · `--documents` (JSONL for memory/RAG backends) · `--graph` (typed node+edge JSON for graph backends) · `--agent-rules` (per-client agent-context files; see its own behaviour)
+- **Modes:** *(default)* viewer JSON to stdout · `--html` (self-contained Portal file) · `--okf` (OKF v0.2 Markdown bundle) · `--documents` (JSONL for memory/RAG backends) · `--graph` (typed node+edge JSON for graph backends) · `--agent-rules` (per-client agent-context files; see its own behaviour)
 - **Options:** `--out <path>` (only `--html`/`--okf`/`--agent-rules`; the stdout modes are pipeable) · `--json` (no-op for the default mode)
 - **Exit codes:** `0` success · `2` not a directory, or `--out` given to a stdout mode
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -72,19 +72,19 @@ Comparison sources, verified 2026-06-12:
 
 Google's Open Knowledge Format (OKF) standardises the *carrier* — a Git tree of Markdown with YAML front matter — and is deliberately permissive: consumers must not reject a bundle for missing fields, unknown types, or broken links. OKF says *"if you can `cat` it, you can read it."* RAC says *"and CI guarantees the file is well-formed, the decision is consistent, and nothing points at a superseded artifact."* OKF is read-time interchange; RAC is **write-time enforcement** — deterministic, cross-artifact validation (referential integrity, status-consistency, illegal-edge detection) that fails your build before bad knowledge lands. A RAC repo *is* a conformant OKF bundle (`decided export --okf`), so you get the interchange for free and keep the enforcement OKF leaves out (ADR-048, ADR-049).
 
-| Dimension | AsDecided / RAC | OKF (v0.1 Draft) |
+| Dimension | AsDecided / RAC | OKF v0.2 |
 | --- | --- | --- |
 | Validation time | Write-time: `decided validate` and `decided relationships --validate` fail CI before the knowledge lands | Read-time: consumers "MUST NOT reject a bundle" for missing optional fields or unknown `type`, and "MUST tolerate broken links" |
 | Links | Typed `## Related` structural references, resolved and validated — broken, ambiguous, superseded-target, and unsupported edges are errors | Untyped: the relationship kind "is conveyed by the surrounding prose, not by the link itself" |
 | `type` field | Five enumerated types that drive classification and validation | A free string — "Type values are not registered centrally" |
 | Cross-artifact checks | Referential integrity, status-consistency, edge-legality — enforced deterministically in CI | None defined; consumption is permissive by design |
-| Maturity | Governed corpus; CLI and MCP output is a stability-tested contract | "Version 0.1 — Draft"; a single-vendor (Google Cloud) initiative |
+| Maturity | Governed corpus; CLI and MCP output is a stability-tested contract | Pre-1.0, openly specified Google Cloud initiative with optional provenance, trust, freshness, lifecycle, and deterministic attestation conventions |
 | Interoperability | `decided export --okf` emits a conformant OKF bundle | The shared carrier RAC writes |
 
 <!--
-OKF comparison source, verified 2026-06-14:
+OKF comparison source, verified 2026-07-29:
 - OKF — https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md
-  (SPEC.md, "Version 0.1 — Draft"): consumers "MUST NOT reject a bundle because
+  (SPEC.md, "Version 0.2"): consumers "MUST NOT reject a bundle because
   of: Missing optional frontmatter fields / Unknown `type` values / Unknown
   additional frontmatter keys" and "MUST tolerate broken links"; the relationship
   kind "is conveyed by the surrounding prose, not by the link itself"; "Type

--- a/docs/okf-profile.md
+++ b/docs/okf-profile.md
@@ -1,164 +1,145 @@
 # OKF Profile
 
-RAC stores product knowledge the same way [Google Cloud's Open Knowledge Format
-(OKF)](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
-does — a Git tree of Markdown files with YAML front matter. This page is RAC's
-**informative profile** of OKF **v0.1 Draft**: it defines how a RAC repository
-presents itself as a conformant OKF bundle. It is a derived, interoperability
-view; RAC Core and `decided validate` remain the source of truth, and adopting this
-profile loosens none of RAC's guarantees. The decision behind it is
-[ADR-048](https://github.com/asdecided/core/blob/main/decisions/decisions/adr-048-okf-carrier-profile.md),
-scoped by the `rac-okf-carrier-profile` requirement.
+AsDecided can project an authoritative decision corpus into [Google Cloud's
+Open Knowledge Format (OKF)
+v0.2](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md):
+a portable Git tree of Markdown files with YAML frontmatter.
 
-> The key words MUST, SHOULD, and MAY in this document are to be interpreted as
-> described in BCP 14 (RFC 2119, RFC 8174) when, and only when, they appear in
-> all capitals.
+This is an **informative carrier profile**. AsDecided remains the source of
+truth and keeps its stricter write-time validation, typed relationships, and
+lifecycle rules. The export never feeds back into the corpus and requires no
+Google code, package, service, or network call. The governing decisions are
+[ADR-048](https://github.com/asdecided/core/blob/main/decisions/decisions/adr-048-okf-carrier-profile.md)
+and
+[ADR-122](https://github.com/asdecided/core/blob/main/decisions/decisions/adr-122-okf-v0-2-carrier-profile.md).
 
 ## Producing a bundle
-
-`decided export <dir> --okf` writes the bundle described here:
 
 ```bash
 decided export decisions/ --okf --out okf-bundle/
 ```
 
-It emits one Markdown file per typed artifact (front matter projecting the OKF
-`type`), plus a generated `index.md` and `log.md`, mirroring the corpus layout.
-The bundle is a derived build artifact, parallel to `decided export --json` and
-`--html`; it never feeds back into RAC.
+The command emits one concept file per typed artifact, preserving the corpus
+layout, plus generated root `index.md` and `log.md` files. New exports target
+OKF v0.2 only.
 
-Each bundle artifact also carries OKF's descriptive fields where RAC has them
-(ADR-050): `tags` projected from the source frontmatter (a RAC artifact MAY
-declare `tags: [...]`), and `created`/`updated` derived from git history — first
-and last commit. Timestamps are never stored in the source frontmatter; recency
-is git-derived (ADR-045), so the source stays date-free while the bundle is fully
-timestamped. RAC does not project a frontmatter `title` (it derives from the H1)
-or a `description`.
-
-## Type mapping (normative)
-
-Every RAC artifact carries a `type` in its front matter. In the OKF bundle view
-each artifact MUST present a non-empty OKF `type`, mapped from its RAC `type`:
-
-| RAC `type`    | OKF `type`    |
-| ------------- | ------------- |
-| `requirement` | `Requirement` |
-| `decision`    | `ADR`         |
-| `roadmap`     | `Roadmap`     |
-| `prompt`      | `Prompt`      |
-| `design`      | `Design`      |
-
-The RAC `type` is authoritative; the OKF `type` is derived from it. A RAC
-artifact MUST NOT present an empty or unmapped OKF `type`.
-
-### Worked example
-
-A RAC decision artifact:
+The root index declares the profile explicitly:
 
 ```yaml
 ---
-schema_version: 1
-id: RAC-KV2KWK55FC49
-type: decision
+okf_version: "0.2"
 ---
-# ADR-048: OKF as an Informative Carrier Profile
 ```
 
-presents, in the OKF bundle view, as `type: ADR` — the same file, the same body,
-a derived front-matter projection.
+## Concept projection
 
-## Checking conformance (write-time gate)
+Each concept preserves the stable AsDecided ID and body while projecting the
+carrier fields:
 
-Conformance is enforced, not just produced on export. Running `decided validate` over
-a corpus checks OKF v0.1 conformance as part of the run (ADR-048, ADR-049):
+```yaml
+---
+type: ADR
+id: "RAC-KV2KWK55FC49"
+title: "ADR-048: OKF as an Informative Carrier Profile"
+status: stable
+generated:
+  by: asdecided/0.25.0
+  at: 2026-07-29T11:00:00+01:00
+tags: ["interoperability"]
+---
+```
+
+- `title` and `tags` are safely encoded YAML strings.
+- `generated.at` is the last meaningful Git commit time, when available.
+- `generated.by` identifies the versioned deterministic exporter. It does not
+  claim that AsDecided authored the underlying knowledge.
+- `generated` is omitted when Git cannot supply a valid timestamp.
+- `description` remains absent because AsDecided has no equivalent canonical
+  field.
+
+### Type mapping
+
+| AsDecided `type` | OKF `type` |
+| --- | --- |
+| `requirement` | `Requirement` |
+| `decision` | `ADR` |
+| `roadmap` | `Roadmap` |
+| `prompt` | `Prompt` |
+| `design` | `Design` |
+
+Unknown documents remain outside the derived export. OKF consumers must tolerate
+unknown types, but that permissive read rule does not expand AsDecided's
+authoritative artifact registry.
+
+### Lifecycle mapping
+
+OKF v0.2 has a deliberately small lifecycle vocabulary. The projection is:
+
+| AsDecided status | OKF `status` |
+| --- | --- |
+| `Proposed`, `Draft` | `draft` |
+| `Retired`, `Superseded`, `Deprecated`, `Obsolete` | `deprecated` |
+| other valid non-empty live states | `stable` |
+| absent or unknown | omitted |
+
+The source artifact retains the full type-specific lifecycle meaning.
+
+## Relationships are not provenance
+
+Resolved AsDecided relationships are emitted as deterministic Markdown links
+under `# Related concepts`. They are not emitted as OKF `sources`: a governance
+or navigation edge does not necessarily mean the target was a source for the
+concept.
+
+For the same reason, this profile does not infer:
+
+- `verified` or a trust tier from an accepted status;
+- verification actors from AsDecided `Verified By` test and trace paths;
+- `stale_after` from Git recency;
+- source credibility from relationship proximity; or
+- executor or attester fields without an authoritative Attested Computation.
+
+Those optional v0.2 fields can be added only when the AsDecided corpus carries
+equivalent semantics. Their absence is valid OKF and is more truthful than
+invented provenance.
+
+## Generated navigation
+
+- `index.md` declares `okf_version: "0.2"` and provides progressive disclosure
+  by artifact type.
+- `log.md` groups concepts by their last Git commit date, newest first.
+- Both are derived output and must not be hand-maintained as authoritative
+  corpus state.
+
+## Checking conformance
+
+`decided validate` keeps a stricter AsDecided profile gate:
 
 ```bash
 decided validate decisions/
-# … PASS  decisions/ — N artifact(s) checked: N valid, 0 invalid. OKF v0.1: conformant.
+# … PASS decisions/ — N artifact(s) checked: N valid, 0 invalid. OKF v0.2: conformant.
 ```
 
-The check is deterministic and per-artifact. It reports, with a file-named,
-fixable diagnostic, and fails the `validate` exit code:
+It fails on mapped artifacts that cannot be represented or collide with the
+reserved generated `index.md` and `log.md` paths. Relationship integrity remains
+the responsibility of `decided relationships --validate`. General OKF v0.2
+consumers are more permissive: optional fields, unknown types, broken links, and
+a missing index are not rejection conditions.
 
-| Code | Meaning |
-| --- | --- |
-| `okf-unmapped-type` | a typed artifact whose `type` has no OKF mapping (it would be silently dropped from the bundle) |
-| `okf-reserved-filename-collision` | a typed artifact named `index.md` or `log.md`, which OKF reserves for generated entry points |
+## Migrating from the v0.1 profile
 
-Untyped documents are excluded (ADR-010): they are legitimately skipped and the
-bundle already omits them, so an `index.md`/`log.md` that is an untyped entry
-point is recognized, never flagged. Referential integrity ("links resolve") stays
-with `decided relationships --validate`. The directory `validate` JSON carries an
-additive `okf` section (ADR-007). Per ADR-052, `rac-core` — the OKF-superset
-frontmatter envelope (`schema_version`, `id`, `type`, `relationships`, `tags`) —
-is defined in code and enforced this way; RAC ships no JSON Schema `rac-core` file
-and takes no schema-validation dependency.
+New exports make two intentional changes:
 
-## Conventions (recommended)
+- `created` and `updated` are replaced by v0.2 `generated`; and
+- generated `# Citations` are replaced by `# Related concepts`.
 
-Where RAC has gaps, a RAC repository SHOULD adopt the following OKF conventions.
-Each is a derived output generated from the corpus, never a hand-maintained
-source file.
-
-### `index.md` — progressive disclosure
-
-An OKF bundle SHOULD ship an `index.md` entry point that discloses the corpus in
-layers: an overview, then the artifact types, then individual artifacts. It is
-the front door for a human or agent that has never seen the bundle.
-
-```markdown
-# Knowledge Index
-
-## Decisions
-- [ADR-048: OKF as an Informative Carrier Profile](decisions/decisions/adr-048-okf-carrier-profile.md)
-  — RAC adopts OKF as an informative carrier profile and derived export target.
-
-## Requirements
-- [REQ-OKF-Carrier-Profile](decisions/requirements/rac-okf-carrier-profile.md)
-  — conformance, derived bundle export, and the no-loosening invariant.
-```
-
-### `log.md` — date-grouped history
-
-An OKF bundle SHOULD ship a `log.md` recording how the corpus evolved, grouped
-by date, newest-first. RAC derives this from Git history of the `decisions/` tree
-(consistent with ADR-045: recency is derived from Git, not stored in front
-matter), so it never drifts from reality.
-
-```markdown
-# Log
-
-## 2026-06-14
-- Added ADR-048 (OKF as an informative carrier profile).
-- Added REQ-OKF-Carrier-Profile (conformance, profile, and bundle export).
-```
-
-### `# Citations` — body references
-
-Where a RAC artifact wants a human-facing list of what it draws on, it SHOULD use
-a `# Citations` body section. This complements — and never replaces — RAC's typed
-`## Related <Type>` structural references, which remain the machine-resolved,
-validated edges (see [relationships](relationships.md) and ADR-016). In the
-derived OKF view, each resolved structural relationship also appears as a body
-link, so the relationship survives for permissive OKF consumers.
-
-```markdown
-# Citations
-
-- [ADR-016: Relationships as Explicit Structural References](decisions/decisions/adr-016-relationships-as-structural-references.md)
-- [ADR-007: JSON Contract Stability](decisions/decisions/adr-007-json-contract-stability.md)
-```
-
-## Status of this profile
-
-The dependency on OKF is **informative and pinned to OKF v0.1**. RAC takes no
-code, package, or network dependency on OKF or Google tooling. OKF is a pre-1.0,
-single-vendor draft; if it diverges materially at 1.0, RAC can re-pin or drop the
-profile without touching Core. Promoting the OKF bundle to a frozen RAC contract
-(alongside the JSON/Portal export) would extend RAC's stability obligations and
-is therefore a future, separately recorded ADR — not a change to this page.
+An existing consumer can temporarily fall back from `generated.at` to legacy
+`updated`, and can continue parsing legacy `# Citations`, while it adopts v0.2.
+AsDecided does not maintain a dual-output flag; the small v0.1 retirement
+fixture exists only to keep that migration explicit and bounded.
 
 ## See also
 
-- [relationships.md](relationships.md) — how RAC's typed structural references work.
-- [artifacts.md](artifacts.md) — artifact types and identity.
+- [Relationships](relationships.md)
+- [Artifacts](artifacts.md)
+- [Validation](validation.md)

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -2,7 +2,7 @@
 
 `decided validate` is RAC's write-time gate: it fails when any artifact carries an
 error-severity finding, and (over a directory) when the corpus is not a
-conformant OKF v0.1 bundle. Two features make that gate adoptable in CI on a
+conformant OKF v0.2 bundle. Two features make that gate adoptable in CI on a
 real, pre-existing repository.
 
 ## Per-type standards checks

--- a/rust/PORT-CONTRACT.d/21-okf-v0-2.md
+++ b/rust/PORT-CONTRACT.d/21-okf-v0-2.md
@@ -1,0 +1,45 @@
+# 21 — OKF v0.2 derived carrier
+
+This addendum supersedes only the OKF artifact and index byte shape in
+addendum 17. It does not restore the retired Python oracle as a live authority.
+ADR-122 and `asdecided-okf-v0-2-carrier` govern the new native contract.
+
+## Root index
+
+`index.md` begins exactly:
+
+```yaml
+---
+okf_version: "0.2"
+---
+```
+
+The existing progressive-disclosure body, ordering, collision behavior, and
+terminal newline remain unchanged.
+
+## Concept frontmatter
+
+Each generated concept emits, in order:
+
+1. mapped `type`;
+2. safely encoded stable `id`;
+3. safely encoded `title`;
+4. projected OKF lifecycle `status`, when known;
+5. `generated.by` as `asdecided/<CARGO_PKG_VERSION>` and `generated.at` as the
+   validated last Git commit timestamp, when available; and
+6. tags as a deterministic JSON-style sequence accepted by YAML.
+
+Legacy `created` and `updated` fields are not emitted. First-commit recency
+remains available to the log join but is not projected as v0.2 provenance.
+
+## Relationships and non-inference
+
+Resolved outgoing structural edges render under `# Related concepts`.
+They never populate `sources`. The exporter does not synthesize `verified`,
+trust, `stale_after`, source credibility, executor, or attester fields.
+
+## Compatibility boundary
+
+New exports are v0.2-only. The v0.1 shape is retained as one small retirement
+fixture for migration tests and documentation, not as a second implementation
+or runtime flag.

--- a/rust/rac-engine/src/commands.rs
+++ b/rust/rac-engine/src/commands.rs
@@ -1218,11 +1218,10 @@ pub fn cmd_export(args: &ExportArgs) -> i32 {
         )));
         return EXIT_OK;
     }
-    let export = crate::export::build_corpus_export(&args.directory, output::rac_version());
-
-    // OKF bundle (ADR-048): a derived tree written under out, sorted-path
-    // order; recency feeds created/updated and log.md (ADR-045).
+    // OKF consumes source Markdown directly, so its projection skips the
+    // unrelated HTML rendering used by the viewer export.
     if args.okf {
+        let export = crate::export::build_okf_export(&args.directory, output::rac_version());
         let recency = crate::okf::artifact_recency(&args.directory, &export);
         let bundle = match crate::okf::render_okf_bundle(&export, &recency, &args.directory) {
             Ok(bundle) => bundle,
@@ -1254,6 +1253,7 @@ pub fn cmd_export(args: &ExportArgs) -> i32 {
         ));
         return EXIT_OK;
     }
+    let export = crate::export::build_corpus_export(&args.directory, output::rac_version());
 
     // JSON is the default mode: the payload is the product (--json a no-op).
     if !args.html {

--- a/rust/rac-engine/src/export.rs
+++ b/rust/rac-engine/src/export.rs
@@ -131,7 +131,11 @@ impl CorpusExport {
     }
 }
 
-pub fn build_corpus_export(directory: &str, rac_version: String) -> CorpusExport {
+fn build_corpus_export_inner(
+    directory: &str,
+    rac_version: String,
+    include_body_html: bool,
+) -> CorpusExport {
     let items = corpus_items(directory, true);
     let canonical = canonical_by_path(&items);
 
@@ -150,7 +154,11 @@ pub fn build_corpus_export(directory: &str, rac_version: String) -> CorpusExport
             status: status(&it.artifact, spec),
             title,
             path: it.path.clone(),
-            body_html: crate::mdhtml::render(&body_markdown(&it.path)),
+            body_html: if include_body_html {
+                crate::mdhtml::render(&body_markdown(&it.path))
+            } else {
+                String::new()
+            },
             tags: tags_of(&it.artifact),
         });
     }
@@ -177,6 +185,16 @@ pub fn build_corpus_export(directory: &str, rac_version: String) -> CorpusExport
         artifacts,
         relationships: edges,
     }
+}
+
+pub fn build_corpus_export(directory: &str, rac_version: String) -> CorpusExport {
+    build_corpus_export_inner(directory, rac_version, true)
+}
+
+/// OKF consumes the source Markdown body directly. Avoid an irrelevant HTML
+/// render over the whole corpus on this path.
+pub fn build_okf_export(directory: &str, rac_version: String) -> CorpusExport {
+    build_corpus_export_inner(directory, rac_version, false)
 }
 
 // --- documents JSONL ---------------------------------------------------------

--- a/rust/rac-engine/src/okf.rs
+++ b/rust/rac-engine/src/okf.rs
@@ -3,9 +3,9 @@
 //!
 //! A derived tree of Markdown files: one per typed artifact at its path
 //! relative to the exported corpus root, plus generated `index.md` and
-//! `log.md`. `created`/`updated` derive from git commit times with the
-//! committer's stored offset preserved (`%cI`, ADR-045); when git cannot
-//! answer, the fields are omitted and `log.md` degrades to a placeholder.
+//! `log.md`. OKF v0.2 `generated.at` derives from the last git commit time
+//! with the committer's stored offset preserved (`%cI`, ADR-045); when git
+//! cannot answer, `generated` is omitted and `log.md` degrades to a placeholder.
 
 use std::collections::BTreeMap;
 use std::collections::HashMap;
@@ -95,35 +95,54 @@ fn body(path: &str) -> String {
     py_strip(&split_frontmatter(&text).body).to_string()
 }
 
-/// `_artifact_file(art, citations, created, updated)`.
+fn yaml_string(value: &str) -> String {
+    serde_json::to_string(value).expect("serializing a Rust string cannot fail")
+}
+
+fn okf_status(status: &str) -> Option<&'static str> {
+    match status.trim().to_ascii_lowercase().as_str() {
+        "" | "unknown" => None,
+        "proposed" | "draft" => Some("draft"),
+        "retired" | "superseded" | "deprecated" | "obsolete" => Some("deprecated"),
+        _ => Some("stable"),
+    }
+}
+
+/// One v0.2 concept file. Structural relationships are navigation links, not
+/// provenance, so they deliberately do not populate `sources`.
 fn artifact_file(
     art: &ExportArtifact,
-    citations: &[(String, String)],
-    created: Option<&str>,
+    related: &[(String, String)],
     updated: Option<&str>,
 ) -> String {
     let mut lines = vec![
         "---".to_string(),
         format!("type: {}", okf_type(&art.artifact_type)),
-        format!("id: {}", art.id),
+        format!("id: {}", yaml_string(&art.id)),
+        format!("title: {}", yaml_string(&art.title)),
     ];
-    if let Some(created) = created {
-        lines.push(format!("created: {created}"));
+    if let Some(status) = okf_status(&art.status) {
+        lines.push(format!("status: {status}"));
     }
     if let Some(updated) = updated {
-        lines.push(format!("updated: {updated}"));
+        lines.push("generated:".to_string());
+        lines.push(format!("  by: asdecided/{}", env!("CARGO_PKG_VERSION")));
+        lines.push(format!("  at: {updated}"));
     }
     if !art.tags.is_empty() {
-        lines.push(format!("tags: [{}]", art.tags.join(", ")));
+        lines.push(format!(
+            "tags: {}",
+            serde_json::to_string(&art.tags).expect("serializing tags cannot fail")
+        ));
     }
     lines.push("---".to_string());
     lines.push(String::new());
     lines.push(body(&art.path));
-    if !citations.is_empty() {
+    if !related.is_empty() {
         lines.push(String::new());
-        lines.push("# Citations".to_string());
+        lines.push("# Related concepts".to_string());
         lines.push(String::new());
-        for (title, path) in citations {
+        for (title, path) in related {
             lines.push(format!("- [{title}]({path})"));
         }
     }
@@ -132,9 +151,9 @@ fn artifact_file(
     out
 }
 
-/// `_citations(art, export, by_id, rel)` — resolved outgoing relationships
+/// Resolved outgoing relationships
 /// as `(title, bundle path)` pairs, in relationship order.
-fn citations(
+fn related_concepts(
     art: &ExportArtifact,
     export: &CorpusExport,
     by_id: &HashMap<&str, &ExportArtifact>,
@@ -158,6 +177,10 @@ fn index(export: &CorpusExport, rel: &HashMap<&str, String>) -> String {
     let count = export.artifact_count();
     let noun = if count == 1 { "artifact" } else { "artifacts" };
     let mut lines = vec![
+        "---".to_string(),
+        "okf_version: \"0.2\"".to_string(),
+        "---".to_string(),
+        String::new(),
         format!("# {} \u{2014} Knowledge Index", export.corpus_name),
         String::new(),
         format!(
@@ -261,11 +284,10 @@ pub fn render_okf_bundle(
             ));
         }
         let record = recency_by_path.get(art.path.as_str());
-        let created = record.and_then(|r| r.first_committed.as_deref());
         let updated = record.and_then(|r| r.last_committed.as_deref());
         files.insert(
             key,
-            artifact_file(art, &citations(art, export, &by_id, &rel), created, updated),
+            artifact_file(art, &related_concepts(art, export, &by_id, &rel), updated),
         );
     }
     files.insert(INDEX_PATH.to_string(), index(export, &rel));

--- a/rust/rac-engine/src/output.rs
+++ b/rust/rac-engine/src/output.rs
@@ -374,10 +374,10 @@ pub fn render_validate_dir_human(result: &DirectoryValidation) -> String {
     );
     if let Some(okf) = &result.okf {
         if okf.ok() {
-            summary.push_str(" OKF v0.1: conformant.");
+            summary.push_str(" OKF v0.2: conformant.");
         } else {
             summary.push_str(&format!(
-                " OKF v0.1: {} conformance issue(s).",
+                " OKF v0.2: {} conformance issue(s).",
                 okf.findings.len()
             ));
         }

--- a/rust/rac-engine/tests/fixtures/okf_v01_legacy.md
+++ b/rust/rac-engine/tests/fixtures/okf_v01_legacy.md
@@ -1,0 +1,13 @@
+---
+type: ADR
+id: RAC-LEGACY
+created: 2026-01-01T00:00:00+00:00
+updated: 2026-01-02T00:00:00+00:00
+tags: [legacy]
+---
+
+# Legacy concept
+
+# Citations
+
+- [Related concept](related.md)

--- a/rust/rac-engine/tests/okf_v02.rs
+++ b/rust/rac-engine/tests/okf_v02.rs
@@ -1,0 +1,112 @@
+use std::fs;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use rac_engine::export::{CorpusExport, ExportArtifact, ExportRelationship};
+use rac_engine::okf::{render_okf_bundle, ArtifactRecency};
+
+static NEXT_DIR: AtomicUsize = AtomicUsize::new(0);
+
+fn fixture_dir() -> PathBuf {
+    let suffix = NEXT_DIR.fetch_add(1, Ordering::Relaxed);
+    std::env::temp_dir().join(format!("asdecided-okf-v02-{}-{suffix}", std::process::id()))
+}
+
+fn artifact(path: String, id: &str, status: &str, title: &str, tags: &[&str]) -> ExportArtifact {
+    ExportArtifact {
+        id: id.to_string(),
+        aliases: vec![id.to_string()],
+        artifact_type: "decision".to_string(),
+        status: status.to_string(),
+        title: title.to_string(),
+        path,
+        body_html: String::new(),
+        tags: tags.iter().map(|tag| (*tag).to_string()).collect(),
+    }
+}
+
+#[test]
+fn exports_truthful_okf_v02_carrier() {
+    let root = fixture_dir();
+    fs::create_dir_all(&root).unwrap();
+    let first = root.join("first.md");
+    let second = root.join("second.md");
+    fs::write(&first, "---\ntype: decision\n---\n# First\n").unwrap();
+    fs::write(&second, "---\ntype: decision\n---\n# Second\n").unwrap();
+
+    let export = CorpusExport {
+        corpus_name: "Test corpus".to_string(),
+        rac_version: "0.25.0".to_string(),
+        artifacts: vec![
+            artifact(
+                first.to_string_lossy().into_owned(),
+                "RAC-01JY4M8X2QZ7",
+                "Proposed",
+                "First: \"quoted\"",
+                &["safe", "colon: value"],
+            ),
+            artifact(
+                second.to_string_lossy().into_owned(),
+                "RAC-01JY4M8X2QZ8",
+                "Superseded",
+                "Second",
+                &[],
+            ),
+        ],
+        relationships: vec![ExportRelationship {
+            from: "RAC-01JY4M8X2QZ7".to_string(),
+            to: "RAC-01JY4M8X2QZ8".to_string(),
+            edge_type: "related decisions".to_string(),
+        }],
+    };
+    let recency = vec![
+        ArtifactRecency {
+            path: first.to_string_lossy().into_owned(),
+            first_committed: Some("2026-07-28T10:00:00+01:00".to_string()),
+            last_committed: Some("2026-07-29T11:00:00+01:00".to_string()),
+        },
+        ArtifactRecency {
+            path: second.to_string_lossy().into_owned(),
+            first_committed: None,
+            last_committed: None,
+        },
+    ];
+
+    let bundle = render_okf_bundle(&export, &recency, root.to_str().unwrap()).unwrap();
+    let index = &bundle["index.md"];
+    assert!(index.starts_with("---\nokf_version: \"0.2\"\n---\n"));
+
+    let first_out = &bundle["first.md"];
+    assert!(first_out.contains("title: \"First: \\\"quoted\\\"\""));
+    assert!(first_out.contains("status: draft"));
+    assert!(first_out.contains("generated:\n  by: asdecided/"));
+    assert!(first_out.contains("  at: 2026-07-29T11:00:00+01:00"));
+    assert!(first_out.contains("tags: [\"safe\",\"colon: value\"]"));
+    assert!(first_out.contains("# Related concepts\n\n- [Second](second.md)"));
+
+    for invented in [
+        "sources:",
+        "verified:",
+        "stale_after:",
+        "attester:",
+        "created:",
+        "updated:",
+        "# Citations",
+    ] {
+        assert!(!first_out.contains(invented), "must not emit {invented}");
+    }
+
+    let second_out = &bundle["second.md"];
+    assert!(second_out.contains("status: deprecated"));
+    assert!(!second_out.contains("generated:"));
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn retains_v01_shape_only_as_a_retirement_fixture() {
+    let legacy = include_str!("fixtures/okf_v01_legacy.md");
+    assert!(legacy.contains("updated:"));
+    assert!(legacy.contains("# Citations"));
+    assert!(!legacy.contains("okf_version: \"0.2\""));
+}


### PR DESCRIPTION
Closes #392.

## Outcome

Aligns AsDecided's informative carrier export with Google's OKF v0.2 while keeping the authoritative corpus stricter and avoiding invented provenance or trust.

## What changed

- records ADR-122, the v0.2 requirement, and the native projection design
- declares `okf_version: "0.2"` in the generated root index
- projects stable ID, safely encoded title and tags, conservative lifecycle, and versioned `generated` metadata
- renders structural edges under `# Related concepts` instead of mislabelling them as provenance `sources`
- deliberately does not infer `verified`, trust tier, `stale_after`, source credibility, executor, or attester fields
- retains one small v0.1 retirement fixture with focused migration tests
- skips irrelevant HTML rendering on the OKF path
- updates the validation label, CLI reference, comparison page, public profile, and native port contract

## Evidence

- `cargo test --workspace` — pass, including MCP loopback transport tests outside the filesystem sandbox
- `decided validate decisions` — 432 valid, 0 invalid; OKF v0.2 conformant
- `decided relationships decisions --validate` — 2,612 checked, 0 issues
- live dogfood export — 432 artifacts and 2,658 relationships
- exported tree scan — no invented provenance/trust fields and no legacy `created`, `updated`, or `# Citations`

Upstream profile: https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md
