### PR TITLE
(engine) Prepare v0.25.1 release

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -28,7 +28,7 @@ checksum = "3f8ebf5827e4ac4fd5946560e6a99776ea73b596d80898f357007317a7141e47"
 
 [[package]]
 name = "asdecided-core"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "globset",
  "inotify",
@@ -127,14 +127,14 @@ checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "decided"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "asdecided-core",
 ]
 
 [[package]]
 name = "decided-mcp"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "asdecided-core",
  "serde",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["rac-engine", "decided", "decided-mcp"]
 
 [workspace.package]
-version = "0.25.0"
+version = "0.25.1"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/asdecided/core"

--- a/rust/decided/Cargo.toml
+++ b/rust/decided/Cargo.toml
@@ -12,4 +12,4 @@ categories = ["command-line-utilities", "development-tools"]
 publish = ["crates-io"]
 
 [dependencies]
-rac-engine = { package = "asdecided-core", version = "=0.25.0", path = "../rac-engine" }
+rac-engine = { package = "asdecided-core", version = "=0.25.1", path = "../rac-engine" }


### PR DESCRIPTION
## Outcome

Prepares v0.25.1 as the patch release for the OKF v0.2 carrier alignment merged in #393.

## Changes

- bumps the Rust workspace from 0.25.0 to 0.25.1
- updates the exact `decided` dependency on `asdecided-core`
- refreshes all three workspace package entries in `Cargo.lock`

## Verification

- `cargo metadata --locked --no-deps --format-version 1`
- `cargo test --workspace`

The complete workspace passes, including Windows-covered source compatibility, MCP current/legacy protocol tests, loopback HTTP transport tests, live-corpus invariants, and the new OKF v0.2 fixtures.
