### PR TITLE
(engine) Make Sentry enforcement operational

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -71,3 +71,53 @@ jobs:
         with:
           path: decisions
           upload-sarif: ${{ !github.event.pull_request.head.repo.fork }}
+
+  # Sentry dogfood: accepted decisions can carry deterministic source-code
+  # constraints. Evaluate only the pull request diff against its base branch,
+  # upload the native engine's SARIF, and block on any violation. No model,
+  # embeddings, network judge, or second policy implementation is involved.
+  sentry:
+    name: sentry (dogfood, native)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Build native AsDecided
+        run: cargo build --release --locked -p decided
+        working-directory: rust
+
+      - name: Run Sentry (SARIF)
+        id: sentry
+        env:
+          BASE_REF: origin/${{ github.base_ref }}
+        run: |
+          set +e
+          mkdir -p decided-sarif
+          rust/target/release/decided sentry decisions \
+            --base "$BASE_REF" \
+            --sarif > decided-sarif/sentry.sarif
+          code=$?
+          echo "sentry exited $code"
+          echo "exit_code=$code" >> "$GITHUB_OUTPUT"
+
+      - name: Upload Sentry SARIF
+        if: ${{ always() && !github.event.pull_request.head.repo.fork }}
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: decided-sarif/sentry.sarif
+          category: decided-sentry
+
+      - name: Report result
+        env:
+          EXIT_CODE: ${{ steps.sentry.outputs.exit_code }}
+        run: |
+          if [ "$EXIT_CODE" != "0" ]; then
+            echo "::error::AsDecided Sentry failed (exit $EXIT_CODE) — see the Code Scanning annotations."
+            exit "$EXIT_CODE"
+          fi
+          echo "AsDecided Sentry passed."

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ client SDK rather than a second engine implementation.
 decided quickstart
 decided validate decisions/
 decided gate decisions/
+decided gate decisions/ --code --base origin/main
 ```
 
 New repositories use:

--- a/decisions/decisions/adr-065-artifact-content-untrusted.md
+++ b/decisions/decisions/adr-065-artifact-content-untrusted.md
@@ -125,6 +125,25 @@ Treat the read-only guarantee as sufficient.
 Naming artifact content as untrusted, with PR review as the boundary and a
 `doctor` flag as the aid, is selected.
 
+## Code Constraints
+
+```yaml
+version: 1
+eligibility: eligible
+reason: "The deterministic diagnostic and documented human-review boundary have concrete source anchors."
+rules:
+  - id: doctor-keeps-injection-diagnostic
+    kind: require_pattern
+    path_glob: "rust/rac-engine/src/doctor.rs"
+    pattern: 'CODE_INJECTION_CONTENT'
+    message: "The deterministic injection-style diagnostic must remain available."
+  - id: security-doc-keeps-review-boundary
+    kind: require_pattern
+    path_glob: "SECURITY.md"
+    pattern: '(?i)human review'
+    message: "Security documentation must retain human review as the trust boundary."
+```
+
 ## Related Decisions
 
 - adr-030

--- a/decisions/decisions/adr-066-deterministic-grounding-eval.md
+++ b/decisions/decisions/adr-066-deterministic-grounding-eval.md
@@ -121,6 +121,30 @@ Trust existing tests to catch retrieval regressions.
 
 Deterministic set-membership scoring over real tool output is selected.
 
+## Code Constraints
+
+```yaml
+version: 1
+eligibility: eligible
+reason: "The scored path has explicit dependency and hard-negative boundaries."
+rules:
+  - id: eval-has-no-network-client
+    kind: forbid_import
+    path_glob: "rust/rac-engine/src/eval.rs"
+    pattern: '^(reqwest|hyper|ureq)(::|$)'
+    message: "Grounding evaluation must remain local and network-free."
+  - id: eval-has-no-model-judge
+    kind: forbid_pattern
+    path_glob: "rust/rac-engine/src/eval.rs"
+    pattern: '(?i)llm[_ -]?judge|openai|anthropic|embedding'
+    message: "Grounding evaluation must not introduce a model or embedding judge."
+  - id: eval-keeps-hard-negatives
+    kind: require_pattern
+    path_glob: "rust/rac-engine/src/eval.rs"
+    pattern: 'must_not_return'
+    message: "The deterministic hard-negative contract must remain in the scored path."
+```
+
 ## Related Decisions
 
 - adr-002

--- a/decisions/decisions/adr-067-agent-integration-boundary.md
+++ b/decisions/decisions/adr-067-agent-integration-boundary.md
@@ -57,6 +57,30 @@ The boundary is firm. RAC will **not**:
 Generation lives in `rac` (Core); the extension orchestrates, registers MCP,
 watches for drift, and presents — it computes nothing (ADR-063).
 
+## Code Constraints
+
+```yaml
+version: 1
+eligibility: eligible
+reason: "Context projection and post-edit enforcement have deterministic engine and CI anchors."
+rules:
+  - id: core-keeps-agent-rules-generator
+    kind: require_pattern
+    path_glob: "rust/rac-engine/src/agent_rules.rs"
+    pattern: 'pub fn generate_agent_rules'
+    message: "Core must retain the engine-owned agent-context projection."
+  - id: agent-rules-has-no-model-client
+    kind: forbid_import
+    path_glob: "rust/rac-engine/src/agent_rules.rs"
+    pattern: '^(reqwest|hyper|ureq|openai|anthropic)(::|$)'
+    message: "Agent-context generation must remain deterministic and local."
+  - id: core-keeps-post-edit-sentry
+    kind: require_pattern
+    path_glob: ".github/workflows/pr-checks.yml"
+    pattern: 'decided sentry decisions'
+    message: "Core pull requests must retain deterministic post-edit code enforcement."
+```
+
 ## Consequences
 
 The engine stays deterministic, offline, no-telemetry, and authoritative — its

--- a/decisions/decisions/adr-075-required-merge-gate.md
+++ b/decisions/decisions/adr-075-required-merge-gate.md
@@ -173,6 +173,25 @@ output. Requiring them before merge keeps RAC's public contracts green on
 Review before v1.0.0, or sooner if `pr-checks.yml`'s job set changes materially
 or RAC accepts outside contributors who need a different gate.
 
+## Code Constraints
+
+```yaml
+version: 1
+eligibility: eligible
+reason: "The checked-in pull-request workflow is enforceable; GitHub branch-protection settings remain externally verified."
+rules:
+  - id: premerge-workflow-runs-on-prs
+    kind: require_pattern
+    path_glob: ".github/workflows/pr-checks.yml"
+    pattern: '(?m)^\s*pull_request:\s*$'
+    message: "The pre-merge tier must continue to run on pull requests."
+  - id: premerge-workflow-keeps-code-gate
+    kind: require_pattern
+    path_glob: ".github/workflows/pr-checks.yml"
+    pattern: '(?m)^\s*sentry:\s*$'
+    message: "The pre-merge tier must retain the blocking Sentry job."
+```
+
 ## Related Decisions
 
 - adr-027

--- a/decisions/decisions/adr-103-unified-derived-read-model.md
+++ b/decisions/decisions/adr-103-unified-derived-read-model.md
@@ -147,3 +147,22 @@ Architecture
   live-decision scope semantics; only its data-supply path is unified.
 - ADR-002: content addressing and lossless serialisation keep the two added
   structures deterministic and byte-identical across runs and platforms.
+
+## Code Constraints
+
+```yaml
+version: 1
+eligibility: eligible
+reason: "The unified serving model and its persisted projections have concrete native source and parity-test anchors."
+rules:
+  - id: derived-index-keeps-summary-and-scope
+    kind: require_pattern
+    path_glob: "rust/rac-engine/src/derived.rs"
+    pattern: '(?s)pub struct DerivedIndex.*pub portfolio_summary: Value.*pub scope_rows: Vec<ScopeRow>'
+    message: "The canonical derived read model must retain portfolio and decision-scope projections."
+  - id: mapped-store-keeps-summary-and-scope-parity
+    kind: require_pattern
+    path_glob: "rust/rac-engine/tests/index_store_vectors.rs"
+    pattern: '(?s)reader\.scope_rows\(\).*reader\.portfolio_summary\(\)'
+    message: "The mapped-store parity suite must continue to cover both unified projections."
+```

--- a/decisions/decisions/adr-104-persistent-mmap-index-store.md
+++ b/decisions/decisions/adr-104-persistent-mmap-index-store.md
@@ -236,3 +236,22 @@ sufficient for its prefix-range mechanism and its byte-parity reconstruction.
   disposable, never authoritative; deleting it costs only latency.
 - ADR-002: content addressing and lossless, deterministic serialisation keep the
   store byte-identical across runs and platforms.
+
+## Code Constraints
+
+```yaml
+version: 1
+eligibility: eligible
+reason: "The read-only mapped-store dependency and fail-closed corruption battery are deterministic repository properties."
+rules:
+  - id: index-store-remains-memory-mapped
+    kind: require_pattern
+    path_glob: "rust/rac-engine/src/index_store.rs"
+    pattern: 'use memmap2::Mmap;'
+    message: "The persistent native index must retain its memory-mapped read path."
+  - id: index-store-keeps-fail-closed-open-tests
+    kind: require_pattern
+    path_glob: "rust/rac-engine/tests/index_store_vectors.rs"
+    pattern: '(?s)open_store\(cache_dir, "0"\.repeat\(64\).*open_store\(cache_dir, corpus_hash, SCHEMA_VERSION\)\.is_some\(\)'
+    message: "The store suite must continue to reject invalid stores before accepting a valid one."
+```

--- a/decisions/decisions/adr-105-event-sourced-serving-freshness.md
+++ b/decisions/decisions/adr-105-event-sourced-serving-freshness.md
@@ -230,3 +230,22 @@ while giving the same completed-writes-are-visible guarantee.
   the tracker can change only latency, never an answer.
 - ADR-002: content confirmation on every flagged path keeps the freshness key a
   pure function of the corpus bytes, byte-identical across runs and platforms.
+
+## Code Constraints
+
+```yaml
+version: 1
+eligibility: eligible
+reason: "The request-boundary detection ladder and its authoritative fallback are directly testable."
+rules:
+  - id: tracker-keeps-bounded-stable-scan-barrier
+    kind: require_pattern
+    path_glob: "rust/rac-engine/src/freshness.rs"
+    pattern: '(?s)for _ in 0\.\.3.*prepare_scan\(\).*acknowledge_if_stable'
+    message: "Freshness detection must retain its bounded scan-and-event barrier."
+  - id: tracker-keeps-stat-and-verify-floor
+    kind: require_pattern
+    path_glob: "rust/rac-engine/tests/freshness_tracker.rs"
+    pattern: 'stat_fallback_and_verify_never_trust_clean_events'
+    message: "The freshness suite must retain the authoritative stat and verify fallback contract."
+```

--- a/decisions/decisions/adr-106-incremental-validation.md
+++ b/decisions/decisions/adr-106-incremental-validation.md
@@ -227,3 +227,22 @@ ADR-032 and ADR-105 reject it: mtime alone is an unreliable invalidation signal
 that selects which files to content-confirm; content hashing remains the truth, and
 the one case the prefilter alone can miss (S5) is named, pinned, and caught by
 `--verify`.
+
+## Code Constraints
+
+```yaml
+version: 1
+eligibility: eligible
+reason: "Incremental validation and the explicit content-confirmation floor have stable command and regression-test anchors."
+rules:
+  - id: engine-keeps-incremental-directory-validation
+    kind: require_pattern
+    path_glob: "rust/rac-engine/src/commands.rs"
+    pattern: 'pub fn validate_directory_incremental'
+    message: "The native engine must retain its incremental directory-validation path."
+  - id: verify-keeps-stat-preserving-rewrite-coverage
+    kind: require_pattern
+    path_glob: "rust/rac-engine/tests/incremental_validate.rs"
+    pattern: 's5_stat_preserving_rewrite_is_the_accepted_miss_and_verify_catches_it'
+    message: "The verify floor must remain pinned against stat-preserving rewrites."
+```

--- a/decisions/decisions/adr-107-parallel-cold-build.md
+++ b/decisions/decisions/adr-107-parallel-cold-build.md
@@ -168,3 +168,22 @@ module-level worker is the portable, state-clean choice the constraint demands.
 - ADR-104
 - ADR-105
 - ADR-106
+
+## Code Constraints
+
+```yaml
+version: 1
+eligibility: eligible
+reason: "Parallel construction and its serial fault floor are named native paths with byte-parity tests."
+rules:
+  - id: native-build-keeps-bounded-rayon-pool
+    kind: require_pattern
+    path_glob: "rust/rac-engine/src/parallel_build.rs"
+    pattern: '(?s)rayon::ThreadPoolBuilder::new\(\).*num_threads\(n_workers\)'
+    message: "The native cold build must retain its explicitly bounded worker pool."
+  - id: parallel-fault-keeps-serial-floor
+    kind: require_pattern
+    path_glob: "rust/rac-engine/tests/parallel_build.rs"
+    pattern: 'a fault must land on the serial floor'
+    message: "A parallel worker failure must remain covered by the serial fallback test."
+```

--- a/decisions/decisions/adr-108-term-range-partitioned-parallel-merge.md
+++ b/decisions/decisions/adr-108-term-range-partitioned-parallel-merge.md
@@ -139,3 +139,22 @@ parse fan-out already is.
 ## Related Roadmaps
 
 - rebuild-scale
+
+## Code Constraints
+
+```yaml
+version: 1
+eligibility: eligible
+reason: "Indexed parallel collection and worker-count-invariant store bytes expose the deterministic merge boundary."
+rules:
+  - id: parallel-fragments-preserve-input-order
+    kind: require_pattern
+    path_glob: "rust/rac-engine/src/parallel_build.rs"
+    pattern: '(?s)paths\s*\.par_iter\(\).*collect::<Vec<DocFragment>>\(\)'
+    message: "Parallel document fragments must continue to collect in canonical input order."
+  - id: merge-output-remains-worker-invariant
+    kind: require_pattern
+    path_glob: "rust/rac-engine/tests/parallel_build.rs"
+    pattern: 'store bytes must be worker-count-invariant'
+    message: "The persisted merge result must remain byte-identical across worker counts."
+```

--- a/decisions/decisions/adr-109-tag-search-tier-and-facet.md
+++ b/decisions/decisions/adr-109-tag-search-tier-and-facet.md
@@ -123,3 +123,22 @@ tier is lexical only.
 ## Related Roadmaps
 
 - candidate-discovery
+
+## Code Constraints
+
+```yaml
+version: 1
+eligibility: eligible
+reason: "The indexed tag field, scoring tier, and store-format gate are explicit native constants."
+rules:
+  - id: index-store-keeps-tags-field
+    kind: require_pattern
+    path_glob: "rust/rac-engine/src/index_store.rs"
+    pattern: 'pub const FIELDS: \[&str; 6\] = \["id", "title", "path", "heading", "body", "tags"\];'
+    message: "Tags must remain a persisted and searchable index field."
+  - id: tag-tier-keeps-format-version-gate
+    kind: require_pattern
+    path_glob: "rust/rac-engine/src/index_format.rs"
+    pattern: 'pub const SEGMENT_FORMAT_VERSION: u16 = 4;'
+    message: "The tag-aware store format must remain explicitly version-gated unless the decision is amended."
+```

--- a/decisions/decisions/adr-112-cache-on-by-default.md
+++ b/decisions/decisions/adr-112-cache-on-by-default.md
@@ -185,3 +185,22 @@ one-shot path serves.
 - warm-by-default
 - candidate-discovery
 - single-node-scale-residuals
+
+## Code Constraints
+
+```yaml
+version: 1
+eligibility: eligible
+reason: "The default cache posture and explicit rollback flags are deterministic CLI properties."
+rules:
+  - id: find-and-validate-default-cache-on
+    kind: require_pattern
+    path_glob: "rust/rac-engine/src/cli.rs"
+    pattern: '(?s)let mut cache = true;.*let mut cache = true;'
+    message: "The native validate and find paths must continue to default to the engineered cache."
+  - id: cli-keeps-no-cache-escape-hatch
+    kind: require_pattern
+    path_glob: "rust/rac-engine/src/cli.rs"
+    pattern: '"--no-cache" => cache = false'
+    message: "The CLI must retain the explicit no-cache rollback path."
+```

--- a/decisions/decisions/adr-114-native-index-workspace-dependencies.md
+++ b/decisions/decisions/adr-114-native-index-workspace-dependencies.md
@@ -97,3 +97,22 @@ Technical
 - ADR-107
 - ADR-108
 - ADR-112
+
+## Code Constraints
+
+```yaml
+version: 1
+eligibility: eligible
+reason: "The audited mapped-store dependency and target-specific watcher dependency are exact manifest boundaries."
+rules:
+  - id: engine-keeps-reviewed-memmap-dependency
+    kind: require_pattern
+    path_glob: "rust/rac-engine/Cargo.toml"
+    pattern: '(?m)^memmap2 = "0\.9"$'
+    message: "The mapped store must retain the reviewed memmap2 dependency line."
+  - id: inotify-remains-linux-only-and-minimal
+    kind: require_pattern
+    path_glob: "rust/rac-engine/Cargo.toml"
+    pattern: '(?s)\[target\.\x27cfg\(target_os = "linux"\)\x27\.dependencies\].*inotify = \{ version = "0\.11", default-features = false \}'
+    message: "The event accelerator must remain Linux-only with default async features disabled."
+```

--- a/decisions/decisions/adr-115-shared-artifact-spec-registry.md
+++ b/decisions/decisions/adr-115-shared-artifact-spec-registry.md
@@ -129,3 +129,17 @@ Architecture
 
 - rust/rac-engine/assets/spec/artifact-specs.json
 - rust/rac-engine/src/spec.rs
+
+## Code Constraints
+
+```yaml
+version: 1
+eligibility: eligible
+reason: "The native engine must embed the vendored language-neutral registry rather than recreate it in Rust."
+rules:
+  - id: rust-embeds-shared-artifact-registry
+    kind: require_pattern
+    path_glob: "rust/rac-engine/src/spec.rs"
+    pattern: 'include_str!\("../assets/spec/artifact-specs\.json"\)'
+    message: "The native engine must continue to consume the shared artifact registry bytes."
+```

--- a/decisions/decisions/adr-118-native-event-freshness-acceleration.md
+++ b/decisions/decisions/adr-118-native-event-freshness-acceleration.md
@@ -98,3 +98,27 @@ the stat/content differ remains truth.
 - ADR-105
 - ADR-114
 - ADR-116
+
+## Code Constraints
+
+```yaml
+version: 1
+eligibility: eligible
+reason: "Linux watcher scope, overflow degradation, and platform fallback are explicit native implementation boundaries."
+rules:
+  - id: watcher-remains-linux-targeted
+    kind: require_pattern
+    path_glob: "rust/rac-engine/src/freshness_watch.rs"
+    pattern: '#\[cfg\(target_os = "linux"\)\]'
+    message: "The native event accelerator must remain explicitly Linux-targeted."
+  - id: watcher-overflow-never-asserts-clean
+    kind: require_pattern
+    path_glob: "rust/rac-engine/src/freshness_watch.rs"
+    pattern: 'EventMask::Q_OVERFLOW'
+    message: "Queue overflow must remain a dirty signal that falls back to authoritative scanning."
+  - id: tracker-keeps-mode-and-fallback-regression
+    kind: require_pattern
+    path_glob: "rust/rac-engine/tests/freshness_tracker.rs"
+    pattern: 'watcher_setup_and_runtime_failure_degrade_to_stat'
+    message: "Watcher setup and runtime failures must continue to degrade to the stat rung."
+```

--- a/decisions/decisions/adr-119-base-plus-delta-serving-generations.md
+++ b/decisions/decisions/adr-119-base-plus-delta-serving-generations.md
@@ -189,3 +189,22 @@ total corpus size, contradicting the change-bound target.
 - ADR-107
 - ADR-116
 - ADR-118
+
+## Code Constraints
+
+```yaml
+version: 1
+eligibility: eligible
+reason: "The production constructor, immutable generation type, and lifecycle parity test make the publication boundary enforceable."
+rules:
+  - id: production-tracker-defaults-to-delta
+    kind: require_pattern
+    path_glob: "rust/rac-engine/src/freshness.rs"
+    pattern: '(?s)pub fn new\(.*Self::new_delta\(cache_dir, root, threshold, true\)'
+    message: "The production tracker must continue to select base-plus-delta serving."
+  - id: delta-lifecycle-keeps-parity-coverage
+    kind: require_pattern
+    path_glob: "rust/rac-engine/tests/freshness_tracker.rs"
+    pattern: 'default_delta_stages_mutations_compacts_and_keeps_parsed_base'
+    message: "The delta lifecycle must remain covered across mutation, compaction, and retained-base behavior."
+```

--- a/decisions/decisions/adr-120-rust-ci-contract-authority.md
+++ b/decisions/decisions/adr-120-rust-ci-contract-authority.md
@@ -83,6 +83,25 @@ would still freeze an intentionally evolving corpus.
 Rejected for this step. One bounded `rac-spec` certification remains until the
 recorded Rust cutover gates pass, then is removed explicitly.
 
+## Code Constraints
+
+```yaml
+version: 1
+eligibility: eligible
+reason: "The Rust CI authority is represented by named contract and live-corpus invariant steps."
+rules:
+  - id: rust-ci-keeps-contract-and-live-invariants
+    kind: require_pattern
+    path_glob: ".github/workflows/rust-spike.yml"
+    pattern: '(?s)sync_spec\.py.*conformance_certify\.py.*live_corpus_invariants\.py'
+    message: "Rust CI must retain contract synchronization, conformance certification, and live-corpus invariants."
+  - id: rust-ci-keeps-freshness-regression
+    kind: require_pattern
+    path_glob: ".github/workflows/rust-spike.yml"
+    pattern: 'freshness_tracker'
+    message: "Rust CI must retain the native freshness regression suite."
+```
+
 ## Related Decisions
 
 - ADR-063

--- a/decisions/decisions/adr-121-dual-era-mcp-protocol.md
+++ b/decisions/decisions/adr-121-dual-era-mcp-protocol.md
@@ -113,6 +113,30 @@ dependency-free wire layer during a breaking protocol transition would combine
 two risks and threaten the deterministic legacy contract. The protocol seam
 remains small enough to implement and test directly.
 
+## Code Constraints
+
+```yaml
+version: 1
+eligibility: eligible
+reason: "Both protocol eras and current discovery have stable implementation and test anchors."
+rules:
+  - id: current-protocol-keeps-discovery
+    kind: require_pattern
+    path_glob: "rust/decided-mcp/src/protocol.rs"
+    pattern: '"server/discover"'
+    message: "The current MCP era must retain server discovery."
+  - id: current-protocol-keeps-contract-tests
+    kind: require_pattern
+    path_glob: "rust/decided-mcp/tests/protocol_2026.rs"
+    pattern: 'current_client_discovers_native_server_without_initialize'
+    message: "The MCP 2026 discovery contract must remain pinned."
+  - id: legacy-protocol-keeps-byte-tests
+    kind: require_pattern
+    path_glob: "rust/decided-mcp/tests/protocol_legacy.rs"
+    pattern: 'legacy_2025_06_initialize_bytes_stay_pinned'
+    message: "The legacy MCP byte-compatibility fixture must remain pinned."
+```
+
 ## Related Decisions
 
 - adr-007

--- a/decisions/decisions/adr-122-okf-v0-2-carrier-profile.md
+++ b/decisions/decisions/adr-122-okf-v0-2-carrier-profile.md
@@ -103,6 +103,30 @@ different claims. Conflating them would overstate trust.
 Rejected. New exports would knowingly use superseded conventions and miss the
 versioned interoperability surface.
 
+## Code Constraints
+
+```yaml
+version: 1
+eligibility: eligible
+reason: "The carrier version, relationship projection, and no-invented-trust boundary are fixture-checkable."
+rules:
+  - id: okf-export-keeps-v02-version
+    kind: require_pattern
+    path_glob: "rust/rac-engine/src/okf.rs"
+    pattern: 'okf_version: \\"0\.2\\"'
+    message: "New OKF exports must continue to target v0.2."
+  - id: okf-export-keeps-related-concepts
+    kind: require_pattern
+    path_glob: "rust/rac-engine/src/okf.rs"
+    pattern: '# Related concepts'
+    message: "Structural relationships must remain ordinary related-concept links."
+  - id: okf-tests-guard-invented-trust
+    kind: require_pattern
+    path_glob: "rust/rac-engine/tests/okf_v02.rs"
+    pattern: '(?s)"sources:".*"verified:".*"stale_after:".*"attester:"'
+    message: "The OKF v0.2 fixture must continue to reject invented provenance and trust fields."
+```
+
 ## Related Decisions
 
 - adr-007

--- a/decisions/decisions/adr-123-deterministic-code-enforcement.md
+++ b/decisions/decisions/adr-123-deterministic-code-enforcement.md
@@ -51,8 +51,11 @@ Sentry evaluates its rules against repository bytes.
    import languages are blocking findings.
 6. Human, JSON, and SARIF reports are deterministic and include the governing
    Decision, rule, source path, line where available, and aggregate coverage.
-7. Coverage is honest: the report states constrained live Decisions divided by
-   all live Decisions. It never implies that unconstrained intent was checked.
+7. Reporting separates corpus adoption from eligible enforcement coverage.
+   Every live Decision is either explicitly `eligible`, explicitly
+   `ineligible` with a reason, or unclassified. The report publishes both
+   constrained/all-live adoption and constrained/eligible coverage, plus the
+   unclassified count and active rule count.
 8. The engine performs no model call, embedding lookup, network request, or
    semantic judgement. Nuanced decisions remain subject to human review.
 
@@ -60,6 +63,7 @@ Sentry evaluates its rules against repository bytes.
 
 ```yaml
 version: 1
+eligibility: eligible
 rules:
   - id: sentry-has-no-network-client
     kind: forbid_import

--- a/decisions/decisions/adr-123-deterministic-code-enforcement.md
+++ b/decisions/decisions/adr-123-deterministic-code-enforcement.md
@@ -1,0 +1,139 @@
+---
+schema_version: 1
+id: RAC-KXBD3T7Q9M2N
+type: decision
+---
+# ADR-123: Deterministic Decision-to-Code Enforcement
+
+## Status
+
+Accepted
+
+## Category
+
+Architecture
+
+## Context
+
+AsDecided already blocks malformed or inconsistent decision corpora and can
+show which decisions govern changed paths. That protects the record, but it
+does not prove that changed source code obeys the subset of decisions that can
+be checked mechanically.
+
+The gap matters most for concrete boundaries: forbidden dependencies, import
+directions, required integration points, and prohibited calls or statements.
+An accepted decision can say that hard deletion is forbidden while a pull
+request containing `DELETE FROM users` still passes a corpus-only gate.
+
+Some decision intent cannot be reduced to a deterministic source check.
+Pretending otherwise would replace review with false confidence. Adding an LLM
+judge would also violate ADR-066 and make enforcement depend on variable,
+networked interpretation.
+
+## Decision
+
+Accepted Decision artifacts MAY carry one versioned `## Code Constraints`
+YAML block. Core validates that block during ordinary corpus validation and
+Sentry evaluates its rules against repository bytes.
+
+1. Version 1 supports `forbid_pattern`, `require_pattern`, and
+   `forbid_import`, each with a stable rule ID, repository-relative path glob,
+   deterministic regular expression, and optional message.
+2. `decided sentry` is the dedicated enforcement command.
+   `decided gate --code` composes the same engine into the existing blocking
+   gate; neither surface reimplements policy.
+3. Pull-request enforcement evaluates changed source lines relative to an
+   explicit Git base. Full-tree certification is available through `--full`.
+4. A diff-scoped `require_pattern` applies only when the pull request changes
+   a matching file. Full-tree mode fails closed when its glob selects no file.
+5. Malformed constraint documents, unsupported versions, invalid globs or
+   regexes, duplicate rule IDs, unreadable selected source, and unsupported
+   import languages are blocking findings.
+6. Human, JSON, and SARIF reports are deterministic and include the governing
+   Decision, rule, source path, line where available, and aggregate coverage.
+7. Coverage is honest: the report states constrained live Decisions divided by
+   all live Decisions. It never implies that unconstrained intent was checked.
+8. The engine performs no model call, embedding lookup, network request, or
+   semantic judgement. Nuanced decisions remain subject to human review.
+
+## Code Constraints
+
+```yaml
+version: 1
+rules:
+  - id: sentry-has-no-network-client
+    kind: forbid_import
+    path_glob: "rust/rac-engine/src/sentry.rs"
+    pattern: "^(reqwest|hyper|ureq)(::|$)"
+    message: "Sentry must remain local and network-free."
+  - id: sentry-has-no-llm-judge
+    kind: forbid_pattern
+    path_glob: "rust/rac-engine/src/sentry.rs"
+    pattern: "(?i)llm[_ -]?judge|openai|anthropic"
+    message: "Sentry must not add an LLM judge or model-provider dependency."
+  - id: gate-composes-sentry-engine
+    kind: require_pattern
+    path_glob: "rust/rac-engine/src/gate.rs"
+    pattern: "crate::sentry::analyze"
+    message: "The code gate must compose the single Sentry engine."
+  - id: core-ci-runs-sentry
+    kind: require_pattern
+    path_glob: ".github/workflows/pr-checks.yml"
+    pattern: "decided sentry decisions"
+    message: "Core pull requests must run the blocking native Sentry check."
+```
+
+## Consequences
+
+### Positive
+
+- Concrete architectural decisions can now block violating code changes.
+- Enforcement is reproducible locally and in CI, with no hosted service.
+- Findings cite the governing record instead of presenting an unexplained
+  lint rule.
+- Published coverage separates what is machine-checkable from what still
+  requires judgement.
+
+### Negative
+
+- Regex and lightweight import adapters cover only a bounded class of intent.
+- Rule authors must maintain path globs as source layouts change.
+- Full-tree checks can expose pre-existing violations when a constraint is
+  first adopted.
+
+## Alternatives Considered
+
+### Use an LLM to judge every changed file against every Decision
+
+Rejected. Results would be variable, non-local, difficult to reproduce, and
+contrary to ADR-066.
+
+### Treat Herald proximity as enforcement
+
+Rejected. Governing-decision discovery is useful context, but an advisory
+comment neither evaluates nor blocks violating source.
+
+### Keep code policy in standalone linter configuration
+
+Rejected as the primary contract. A linter may execute a check, but separating
+the rule from its governing Decision loses rationale, status, and traceability.
+
+## Related Decisions
+
+- adr-005
+- adr-007
+- adr-049
+- adr-063
+- adr-065
+- adr-066
+- adr-067
+- adr-075
+- adr-120
+
+## Related Requirements
+
+- deterministic-decision-code-enforcement
+
+## Related Designs
+
+- sentry-code-constraint-evaluation

--- a/decisions/designs/sentry-code-constraint-evaluation.md
+++ b/decisions/designs/sentry-code-constraint-evaluation.md
@@ -26,6 +26,7 @@ section with one fenced YAML document:
 
 ```yaml
 version: 1
+eligibility: eligible
 rules:
   - id: no-hard-delete
     kind: forbid_pattern
@@ -34,9 +35,14 @@ rules:
     message: "ADR-014 requires recoverable account closure."
 ```
 
-Unknown document fields, unknown rule kinds, unsafe paths, invalid regexes,
-duplicate IDs, and empty rule sets are validation errors. Rule IDs use stable
-lowercase kebab-case.
+`eligibility` is `eligible` or `ineligible`. Existing v1 documents that predate
+the field remain `eligible` for compatibility. An eligible Decision may carry
+an empty rule list while its deterministic boundary is still being authored.
+An ineligible Decision carries no rules and must state a non-empty `reason`.
+No classification is inferred for Decisions without the section.
+
+Unknown document fields, unknown rule kinds, unsafe paths, invalid regexes, and
+duplicate IDs are validation errors. Rule IDs use stable lowercase kebab-case.
 
 ### Evaluation modes
 
@@ -65,8 +71,12 @@ SARIF renderers consume the same sorted findings.
 The report includes:
 
 - live Decision count;
+- classified and unclassified Decision counts;
+- explicitly eligible Decision count;
 - constrained live Decision count;
-- the resulting percentage;
+- active rule count;
+- constrained/all-live corpus adoption;
+- constrained/eligible enforcement coverage;
 - diff base or full-tree mode;
 - deterministic findings ordered by path, line, Decision, and rule.
 

--- a/decisions/designs/sentry-code-constraint-evaluation.md
+++ b/decisions/designs/sentry-code-constraint-evaluation.md
@@ -1,0 +1,120 @@
+---
+schema_version: 1
+id: RAC-KXBF5W9S3P7Q
+type: design
+---
+# Sentry Code-Constraint Evaluation
+
+## Context
+
+Core already parses the authoritative corpus once and owns the blocking gate.
+Decision-to-code checks should reuse those boundaries and produce stable
+findings without introducing a generic policy runtime or language server.
+
+## User Need
+
+A maintainer should be able to encode a concrete architectural boundary beside
+its rationale, run it locally, and receive the same blocking result in CI with
+an explicit statement of how much of the live Decision corpus is enforceable.
+
+## Design
+
+### Artifact contract
+
+An accepted Decision may contain exactly one second-level `Code Constraints`
+section with one fenced YAML document:
+
+```yaml
+version: 1
+rules:
+  - id: no-hard-delete
+    kind: forbid_pattern
+    path_glob: "src/**/*.sql"
+    pattern: "DELETE\\s+FROM\\s+users"
+    message: "ADR-014 requires recoverable account closure."
+```
+
+Unknown document fields, unknown rule kinds, unsafe paths, invalid regexes,
+duplicate IDs, and empty rule sets are validation errors. Rule IDs use stable
+lowercase kebab-case.
+
+### Evaluation modes
+
+Diff mode receives an explicit Git base and parses zero-context unified hunks.
+Forbidden patterns and imports report only matches intersecting added or
+modified lines. Required patterns evaluate each matching changed file; if the
+diff changes no matching file, the rule is out of scope for that run.
+
+Full mode walks the repository deterministically, excluding `.git`, and
+evaluates every file selected by each rule. A required-pattern rule whose glob
+matches no file is a blocking empty-match finding.
+
+### Import adapters
+
+Version 1 uses bounded deterministic adapters for Python, Rust, JavaScript, and
+TypeScript families. The adapter extracts literal import targets and applies
+the rule regex to those targets. A selected extension without an adapter
+produces an unsupported-language finding; it is never silently skipped.
+
+### Gate and reporting
+
+`decided sentry` calls the engine directly. `decided gate --code` calls the
+same function and appends its findings to the gate report. Human, JSON, and
+SARIF renderers consume the same sorted findings.
+
+The report includes:
+
+- live Decision count;
+- constrained live Decision count;
+- the resulting percentage;
+- diff base or full-tree mode;
+- deterministic findings ordered by path, line, Decision, and rule.
+
+### Core dogfood
+
+Core pull requests run `decided sentry decisions --base origin/<base>` after a
+full-history checkout. SARIF is uploaded under the distinct
+`decided-sentry` category and the native exit code remains blocking.
+
+## Constraints
+
+- No network request, model integration, embedding search, or LLM judge.
+- Constraint documents remain part of accepted Decision artifacts.
+- The Git diff and checked-out repository bytes are the entire code input.
+- Coverage describes declared deterministic rules, not semantic compliance.
+- Findings fail closed when inputs selected for evaluation cannot be checked.
+
+## Rationale
+
+The design deliberately resembles a small policy linter rather than a semantic
+reviewer. That narrower claim is reproducible, inspectable, and strong enough
+to turn concrete decisions into merge protection without weakening
+AsDecided's deterministic substrate.
+
+## Accessibility
+
+Every violation has a textual message and stable code. SARIF annotations are an
+additional navigation surface, not the only way to understand a failure.
+
+## Style Guidance
+
+Rule messages should state the governing boundary and remediation, not merely
+repeat that a regex matched. Path globs should be as narrow as the decision
+allows.
+
+## Open Questions
+
+- Which additional language import adapters have enough demand to justify a
+  versioned extension?
+- Should future releases support deterministic dependency-manifest rules as a
+  separate kind rather than expressing them as patterns?
+- What coverage threshold, if any, is useful once teams have observed their
+  baseline? Version 1 reports the number but does not gate on it.
+
+## Related Decisions
+
+- adr-123
+
+## Related Requirements
+
+- deterministic-decision-code-enforcement

--- a/decisions/designs/sentry-eligibility-classification.md
+++ b/decisions/designs/sentry-eligibility-classification.md
@@ -1,0 +1,117 @@
+---
+schema_version: 1
+id: RAC-KXBJ7Y3V5R9S
+type: design
+---
+# Sentry Eligibility Classification
+
+## Context
+
+ADR-123 separates all-live corpus adoption from explicitly eligible coverage.
+The classification process must now reduce the unclassified population without
+turning nuanced engineering intent into decorative regexes.
+
+## User Need
+
+A maintainer needs a credible answer to three different questions: which
+Decisions can be checked deterministically, which of those are actively
+constrained, and which still require classification or human review.
+
+## Design
+
+### Tranche selection
+
+Audit eight to twelve Decisions at a time. Prefer boundaries with commercial
+or operational leverage:
+
+1. security and trust;
+2. deterministic/no-network behavior;
+3. compatibility contracts;
+4. required merge protection;
+5. single-source registries and generated interfaces.
+
+Defer Decisions whose lifecycle is ambiguous or whose only possible rule would
+match wording rather than behavior.
+
+### Eligibility test
+
+A Decision is eligible when at least one obligation maps to a stable,
+repository-local property that Sentry can check using a narrow path glob and a
+deterministic pattern or import adapter.
+
+A Decision is ineligible when its binding content is product positioning,
+human judgement, delivery sequencing, an external setting, or another property
+with no honest repository-local proxy. The reason records that boundary.
+
+A partially enforceable Decision may be eligible, but its `reason` and rule
+messages must identify the enforced subset. External remainder—such as GitHub
+branch-protection configuration—stays explicitly outside the claim.
+
+### Rule quality
+
+- Prefer exact files over broad recursive globs.
+- Prefer named functions, fixtures, workflow steps, and embedded contract files
+  over prose tokens.
+- Use `forbid_import` for dependency boundaries.
+- Use `forbid_pattern` only for a concrete prohibited construct.
+- Use `require_pattern` for stable integration or test anchors.
+- Never add an LLM judge or semantic-scoring escape hatch.
+
+### Tranche-one scope
+
+The first tranche covers ADR-065, ADR-066, ADR-067, ADR-075, ADR-115, ADR-120,
+ADR-121, and ADR-122. These decisions govern the trust boundary, deterministic
+evaluation, agent integration, merge gating, shared specs, Rust CI authority,
+MCP compatibility, and truthful OKF export.
+
+### Tranche-two scope
+
+The second tranche covers ADR-103, ADR-104, ADR-105, ADR-106, ADR-107, ADR-108,
+ADR-109, ADR-112, ADR-114, ADR-118, and ADR-119. These decisions form the
+native performance and freshness spine: one derived read model, mapped
+persistence, bounded freshness detection, incremental validation, deterministic
+parallel construction, indexed tags, cache defaults, constrained dependencies,
+Linux event acceleration, and atomic base-plus-delta generations.
+
+The tranche raises explicit corpus adoption to 20 of 121 live decisions
+(16.53%). All 20 explicitly eligible decisions carry active rules, for 100%
+eligible coverage and 46 deterministic rules. The remaining 101 decisions stay
+visibly unclassified pending later review.
+
+## Constraints
+
+- Classification is explicit; absent sections remain unclassified.
+- A green full-tree run is required before a rule is proposed.
+- The audit does not alter Decision status or silently repair obsolete intent.
+- Coverage is an observation, never a target that justifies weak rules.
+
+## Rationale
+
+Small tranches make each eligibility judgement reviewable and allow the rule
+language to evolve from evidence. The first tranche exercises all three rule
+kinds across security, CI, protocol, and export boundaries without claiming
+semantic enforcement.
+
+## Accessibility
+
+Every rule carries a plain-language remediation message. Human and JSON reports
+retain counts and governing paths without requiring SARIF.
+
+## Style Guidance
+
+Rule IDs use stable kebab-case and name the boundary, not the implementation
+accident used to detect it.
+
+## Open Questions
+
+- Should a future report list unclassified Decision paths directly?
+- When should an eligible Decision with no rules become a blocking policy gap?
+- Which external settings merit a separate attestation mechanism?
+
+## Related Decisions
+
+- adr-123
+
+## Related Requirements
+
+- sentry-eligibility-audit

--- a/decisions/requirements/deterministic-decision-code-enforcement.md
+++ b/decisions/requirements/deterministic-decision-code-enforcement.md
@@ -26,9 +26,10 @@ deterministically without overstating coverage.
 - [REQ-006] Full-tree enforcement MUST evaluate every matching repository file and MUST fail when a required-pattern glob selects no file.
 - [REQ-007] `decided sentry` and `decided gate --code` MUST use the same enforcement engine and MUST return a blocking non-zero exit for violations or invalid constraints.
 - [REQ-008] Reports MUST be deterministic in human, JSON, and SARIF forms and MUST identify the governing Decision, rule ID, source path, line where available, and message.
-- [REQ-009] Reports MUST publish constrained-live-Decision coverage against all live Decisions and MUST NOT describe unconstrained decisions as enforced.
-- [REQ-010] Enforcement MUST remain local and MUST NOT use embeddings, model calls, an LLM judge, or a network service.
-- [REQ-011] Core pull requests MUST dogfood Sentry as a blocking check against the pull request base branch.
+- [REQ-009] Reports MUST label constrained/all-live as corpus adoption, MUST separately publish constrained/explicitly-eligible enforcement coverage, and MUST expose classified, unclassified, eligible, constrained, and active-rule counts.
+- [REQ-010] A Decision MUST be classifiable as `eligible` or `ineligible`; an ineligible Decision MUST state a reason and MUST NOT declare rules. A missing classification MUST remain visibly unclassified rather than being inferred.
+- [REQ-011] Enforcement MUST remain local and MUST NOT use embeddings, model calls, an LLM judge, or a network service.
+- [REQ-012] Core pull requests MUST dogfood Sentry as a blocking check against the pull request base branch.
 
 ## Success Metrics
 

--- a/decisions/requirements/deterministic-decision-code-enforcement.md
+++ b/decisions/requirements/deterministic-decision-code-enforcement.md
@@ -1,0 +1,76 @@
+---
+schema_version: 1
+id: RAC-KXBE4V8R2N6P
+type: requirement
+---
+# Requirement: Deterministic Decision-to-Code Enforcement
+
+## Status
+
+Accepted
+
+## Problem
+
+Corpus validation proves that engineering decisions are well-formed and linked,
+but not that changed source code obeys them. AsDecided needs a blocking,
+explainable check for the subset of decision intent that can be evaluated
+deterministically without overstating coverage.
+
+## Requirements
+
+- [REQ-001] Accepted Decision artifacts MUST be able to declare a versioned, machine-checkable code-constraint block without adding a second policy file.
+- [REQ-002] Version 1 MUST support deterministic forbidden-pattern, required-pattern, and forbidden-import rules scoped by repository-relative path globs.
+- [REQ-003] Constraint syntax MUST be validated by ordinary corpus validation, including version, unique stable rule ID, glob, regular expression, rule kind, and non-empty rule set.
+- [REQ-004] Pull-request enforcement MUST evaluate violations against an explicit Git diff base and MUST report only forbidden matches on changed lines.
+- [REQ-005] A diff-scoped required-pattern rule MUST apply to matching changed files and MUST NOT fail an unrelated change merely because its glob selects no changed file.
+- [REQ-006] Full-tree enforcement MUST evaluate every matching repository file and MUST fail when a required-pattern glob selects no file.
+- [REQ-007] `decided sentry` and `decided gate --code` MUST use the same enforcement engine and MUST return a blocking non-zero exit for violations or invalid constraints.
+- [REQ-008] Reports MUST be deterministic in human, JSON, and SARIF forms and MUST identify the governing Decision, rule ID, source path, line where available, and message.
+- [REQ-009] Reports MUST publish constrained-live-Decision coverage against all live Decisions and MUST NOT describe unconstrained decisions as enforced.
+- [REQ-010] Enforcement MUST remain local and MUST NOT use embeddings, model calls, an LLM judge, or a network service.
+- [REQ-011] Core pull requests MUST dogfood Sentry as a blocking check against the pull request base branch.
+
+## Success Metrics
+
+- A prohibited changed line fails locally and in pull-request CI with the same
+  governing Decision and rule.
+- An unrelated documentation-only diff does not fail a required-pattern rule.
+- Full-tree certification catches missing required files and existing
+  violations.
+- Repeated runs over identical corpus, repository, and base inputs are
+  byte-identical.
+- The report always exposes machine-enforceable coverage.
+
+## Risks
+
+- Regex rules can be written too broadly. Stable IDs, narrow globs, full-tree
+  certification, and code review keep each rule inspectable.
+- Lightweight import parsing may not cover every language construct.
+  Unsupported selected languages fail explicitly instead of being ignored.
+- Coverage may initially be low. Publishing the number is a feature: it keeps
+  the boundary between deterministic enforcement and human review visible.
+
+## Assumptions
+
+- The repository is available locally and a pull-request base revision has
+  been fetched.
+- Decision authors can distinguish checkable code boundaries from nuanced
+  intent.
+- Human review remains authoritative for decisions without a deterministic
+  constraint.
+
+## Related Decisions
+
+- adr-066
+- adr-120
+- adr-123
+
+## Related Designs
+
+- sentry-code-constraint-evaluation
+
+## Verified By
+
+- rust/rac-engine/src/sentry.rs
+- rust/rac-engine/src/gate.rs
+- .github/workflows/pr-checks.yml

--- a/decisions/requirements/sentry-eligibility-audit.md
+++ b/decisions/requirements/sentry-eligibility-audit.md
@@ -1,0 +1,66 @@
+---
+schema_version: 1
+id: RAC-KXBH6X2T4Q8R
+type: requirement
+---
+# Requirement: Sentry Eligibility Audit
+
+## Status
+
+Accepted
+
+## Problem
+
+Sentry can enforce deterministic decision-to-code rules, but most historical
+Decisions predate the eligibility contract. Treating every unclassified
+Decision as unenforced produces an honest adoption number but does not show
+which decisions are genuinely machine-checkable. Inferring eligibility in bulk
+would create false precision and weak rules.
+
+## Requirements
+
+- [REQ-001] Eligibility MUST be audited in bounded, reviewable tranches rather than one corpus-wide mechanical rewrite.
+- [REQ-002] Each classified Decision MUST state `eligibility: eligible` or `eligibility: ineligible`; an ineligible classification MUST carry a concrete reason.
+- [REQ-003] Eligible Decisions SHOULD land with at least one deterministic rule when a stable source anchor exists; an empty eligible rule set MUST remain visible as a coverage gap.
+- [REQ-004] Rules MUST enforce concrete repository properties, not paraphrase prose or approximate semantic intent.
+- [REQ-005] A partially enforceable Decision MAY be eligible when its enforceable boundary and externally verified remainder are stated honestly.
+- [REQ-006] Every tranche MUST pass full-tree Sentry, diff Sentry, corpus validation, relationship validation, and the native Rust test suite.
+- [REQ-007] Reports MUST retain corpus adoption, eligible coverage, active-rule count, and unclassified count as separate measurements.
+
+## Success Metrics
+
+- Each tranche reduces the unclassified count without weakening validation.
+- Every added rule passes full-tree certification before merge.
+- Eligible coverage does not increase through inferred or empty classifications.
+- Reviewers can trace each rule to one accepted Decision and one concrete source
+  boundary.
+
+## Risks
+
+- A rule can appear precise while enforcing only a superficial token.
+  Mitigation: narrow path globs, explicit messages, and full-tree tests.
+- Historical Decisions may describe retired implementation states.
+  Mitigation: exclude ambiguous cases from a tranche and resolve lifecycle
+  truth before classification.
+- Chasing a high percentage can reward low-value rules. Mitigation: prioritize
+  security, determinism, compatibility, and merge-protection boundaries.
+
+## Assumptions
+
+- Unclassified is a valid temporary state.
+- Human review remains authoritative for semantic and externally configured
+  policy.
+- The first tranche focuses on recent, high-confidence architectural Decisions.
+
+## Related Decisions
+
+- adr-066
+- adr-123
+
+## Related Designs
+
+- sentry-eligibility-classification
+
+## Verified By
+
+- rust/rac-engine/src/sentry.rs

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -627,6 +627,12 @@ Every report publishes `constrained_decisions / live_decisions` coverage.
 Coverage describes how much of the decision corpus has deterministic
 enforcement; it does not claim that prose-only decisions are enforced.
 
+In diff mode, `forbid_pattern` and `forbid_import` report only matches that
+intersect changed lines. `require_pattern` checks each matching file changed by
+the diff; if no matching file changed, that rule is outside the diff's scope.
+In `--full` mode every matching file is checked, and a `require_pattern` glob
+that selects no file is a blocking `code-constraint-empty-match` finding.
+
 ---
 
 ## watchkeeper

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -623,9 +623,16 @@ decided sentry decisions/ --base origin/main
 decided sentry decisions/ --full --json
 ```
 
-Every report publishes `constrained_decisions / live_decisions` coverage.
-Coverage describes how much of the decision corpus has deterministic
-enforcement; it does not claim that prose-only decisions are enforced.
+Every report separates two measurements:
+
+- **Corpus adoption:** constrained live Decisions divided by all live Decisions.
+- **Eligible coverage:** constrained Decisions divided by Decisions explicitly
+  classified as deterministically eligible.
+
+It also publishes classified, unclassified, eligible, constrained, and active
+rule counts. A Decision may declare `eligibility: ineligible` with a required
+reason and no rules. Decisions without a classification remain visibly
+unclassified; Sentry never infers eligibility from prose.
 
 In diff mode, `forbid_pattern` and `forbid_import` report only matches that
 intersect changed lines. `require_pattern` checks each matching file changed by

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -22,11 +22,20 @@ decided gate decisions/              # human summary; exit 0 if nothing blocking
 decided gate decisions/ --json       # stable JSON contract (ADR-007)
 decided gate decisions/ --sarif      # one SARIF 2.1.0 document over all findings
 decided gate decisions/ --top-level  # do not recurse into subdirectories
+decided gate decisions/ --code --base origin/main  # include changed-code constraints
 ```
 
 The exit code is the only enforcement signal: `0` when nothing is blocking, `1`
 when at least one finding is blocking. Advisory findings are reported (and
 annotated in SARIF) but never fail the gate.
+
+`--code` adds Sentry's deterministic decision-to-code checks to the same gate.
+Accepted Decisions declare bounded rules in a versioned `## Code Constraints`
+YAML block; the engine supports forbidden patterns, required patterns, and
+forbidden imports. The checks are repository- and diff-based—no embeddings,
+model call, network service, or LLM judge. Use `--full` instead of `--base` for
+whole-tree certification. Every report publishes the constrained-live-Decision
+coverage percentage so the machine-enforced boundary remains explicit.
 
 ## The `enforcement:` policy
 
@@ -144,8 +153,9 @@ policy change lands in one edit and is enforced everywhere the corpus is checked
 
 AI coding agents are the place a settled decision is most likely to be quietly
 re-litigated, because the agent never sees the corpus. RAC integrates with agents
-through two deterministic, engine-owned channels and enforces with structural
-validation — **not** a semantic verdict and **not** a cross-platform interceptor
+through deterministic, engine-owned channels and enforces both corpus structure
+and the explicitly declared machine-checkable subset of code constraints —
+**not** a general semantic verdict and **not** a cross-platform interceptor
 ([ADR-067](https://github.com/asdecided/core/blob/main/decisions/decisions/adr-067-agent-integration-boundary.md)):
 
 - **Context supply.** `decided export --agent-rules` generates committed,
@@ -153,8 +163,10 @@ validation — **not** a semantic verdict and **not** a cross-platform intercept
   `.github/copilot-instructions.md`) plus the `lore` MCP read tools. This reaches
   *every* agent — including Copilot — with zero per-developer setup.
 - **Post-edit enforcement.** The same structural diagnostics fire on
-  agent-written files exactly as on human edits: the editor's save-time
-  diagnostics, `decided validate`, and the `decided gate` PR check.
+  agent-written artifacts exactly as on human edits. `decided sentry` and
+  `decided gate --code` additionally block source changes that violate a
+  Decision's declared deterministic rules. Decisions without such rules remain
+  subject to human review, and the coverage report makes that boundary visible.
 
 No platform exposes a hook to inspect-and-veto a proposed agent edit before it
 lands — with **one** exception.

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -34,8 +34,10 @@ Accepted Decisions declare bounded rules in a versioned `## Code Constraints`
 YAML block; the engine supports forbidden patterns, required patterns, and
 forbidden imports. The checks are repository- and diff-based—no embeddings,
 model call, network service, or LLM judge. Use `--full` instead of `--base` for
-whole-tree certification. Every report publishes the constrained-live-Decision
-coverage percentage so the machine-enforced boundary remains explicit.
+whole-tree certification. Every report labels constrained/all-live as corpus
+adoption and separately publishes constrained/explicitly-eligible coverage,
+active rules, and the unclassified count so the machine-enforced boundary
+remains explicit.
 
 ## The `enforcement:` policy
 

--- a/rust/rac-engine/src/gate.rs
+++ b/rust/rac-engine/src/gate.rs
@@ -293,8 +293,13 @@ pub struct GateReport {
 
 pub struct CodeCoverage {
     pub live_decisions: usize,
+    pub classified_decisions: usize,
+    pub unclassified_decisions: usize,
+    pub eligible_decisions: usize,
     pub constrained_decisions: usize,
-    pub percent: f64,
+    pub active_rules: usize,
+    pub corpus_adoption_percent: f64,
+    pub eligible_coverage_percent: f64,
 }
 
 impl GateReport {
@@ -469,8 +474,13 @@ pub fn build_gate_with_code(
             Ok(report) => {
                 code_coverage = Some(CodeCoverage {
                     live_decisions: report.live_decisions,
+                    classified_decisions: report.classified_decisions,
+                    unclassified_decisions: report.unclassified_decisions(),
+                    eligible_decisions: report.eligible_decisions,
                     constrained_decisions: report.constrained_decisions,
-                    percent: report.coverage_percent(),
+                    active_rules: report.active_rules,
+                    corpus_adoption_percent: report.corpus_adoption_percent(),
+                    eligible_coverage_percent: report.eligible_coverage_percent(),
                 });
                 for finding in report.findings {
                     add(

--- a/rust/rac-engine/src/output.rs
+++ b/rust/rac-engine/src/output.rs
@@ -2416,8 +2416,18 @@ pub fn render_gate_human(report: &GateReport) -> String {
     ];
     if let Some(coverage) = &report.code_coverage {
         lines.push(format!(
-            "Code coverage: {}/{} ({:.1}%)",
-            coverage.constrained_decisions, coverage.live_decisions, coverage.percent
+            "Code adoption: {}/{} ({:.1}%)",
+            coverage.constrained_decisions,
+            coverage.live_decisions,
+            coverage.corpus_adoption_percent
+        ));
+        lines.push(format!(
+            "Eligible coverage: {}/{} ({:.1}%; {} rules, {} unclassified)",
+            coverage.constrained_decisions,
+            coverage.eligible_decisions,
+            coverage.eligible_coverage_percent,
+            coverage.active_rules,
+            coverage.unclassified_decisions
         ));
     }
 
@@ -2479,8 +2489,15 @@ pub fn render_gate_json(report: &GateReport) -> String {
             "code_coverage".into(),
             json!({
                 "live_decisions": coverage.live_decisions,
+                "classified_decisions": coverage.classified_decisions,
+                "unclassified_decisions": coverage.unclassified_decisions,
+                "eligible_decisions": coverage.eligible_decisions,
                 "constrained_decisions": coverage.constrained_decisions,
-                "percent": coverage.percent,
+                "active_rules": coverage.active_rules,
+                "percent": coverage.corpus_adoption_percent,
+                "metric": "corpus_adoption",
+                "corpus_adoption_percent": coverage.corpus_adoption_percent,
+                "eligible_coverage_percent": coverage.eligible_coverage_percent,
             }),
         );
     }
@@ -2517,11 +2534,24 @@ pub fn render_sentry_human(report: &SentryReport) -> String {
         format!("Corpus:      {}", report.corpus),
         format!("Repository:  {}", report.repository),
         format!(
-            "Coverage:    {}/{} ({:.1}%)",
+            "Corpus adoption: {}/{} ({:.1}%)",
             report.constrained_decisions,
             report.live_decisions,
-            report.coverage_percent()
+            report.corpus_adoption_percent()
         ),
+        format!(
+            "Eligibility:     {} eligible, {} constrained, {} unclassified",
+            report.eligible_decisions,
+            report.constrained_decisions,
+            report.unclassified_decisions()
+        ),
+        format!(
+            "Eligible coverage: {}/{} ({:.1}%)",
+            report.constrained_decisions,
+            report.eligible_decisions,
+            report.eligible_coverage_percent()
+        ),
+        format!("Active rules:    {}", report.active_rules),
         format!("Violations:  {}", report.findings.len()),
     ];
     for finding in &report.findings {
@@ -2570,8 +2600,15 @@ pub fn render_sentry_json(report: &SentryReport) -> String {
         "ok": report.ok(),
         "coverage": {
             "live_decisions": report.live_decisions,
+            "classified_decisions": report.classified_decisions,
+            "unclassified_decisions": report.unclassified_decisions(),
+            "eligible_decisions": report.eligible_decisions,
             "constrained_decisions": report.constrained_decisions,
-            "percent": report.coverage_percent(),
+            "active_rules": report.active_rules,
+            "percent": report.corpus_adoption_percent(),
+            "metric": "corpus_adoption",
+            "corpus_adoption_percent": report.corpus_adoption_percent(),
+            "eligible_coverage_percent": report.eligible_coverage_percent(),
         },
         "findings": findings,
     }))

--- a/rust/rac-engine/src/sentry.rs
+++ b/rust/rac-engine/src/sentry.rs
@@ -431,14 +431,21 @@ pub fn analyze(
                 })
                 .collect();
             if matches!(rule.kind, RuleKind::RequirePattern) && selected.is_empty() {
-                findings.push(rule_finding(
-                    item,
-                    rule,
-                    CODE_EMPTY_MATCH,
-                    &item.path,
-                    None,
-                    format!("rule '{}' selected no files", rule.id),
-                ));
+                // A diff-scoped gate only evaluates files changed by the pull
+                // request. An unrelated change is outside this rule's scope,
+                // not evidence that the required repository contract vanished.
+                // Full-tree certification remains fail-closed when the glob
+                // itself selects nothing.
+                if full_tree {
+                    findings.push(rule_finding(
+                        item,
+                        rule,
+                        CODE_EMPTY_MATCH,
+                        &item.path,
+                        None,
+                        format!("rule '{}' selected no files", rule.id),
+                    ));
+                }
                 continue;
             }
             let pattern = Regex::new(&rule.pattern).unwrap();
@@ -694,6 +701,59 @@ mod tests {
         .unwrap();
         assert_eq!(report.findings.len(), 1);
         assert_eq!(report.findings[0].line, Some(2));
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn diff_mode_skips_require_rule_when_no_matching_file_changed() {
+        let root =
+            std::env::temp_dir().join(format!("decided-sentry-require-{}", std::process::id()));
+        let corpus = root.join("decisions");
+        let source = root.join("src");
+        let docs = root.join("docs");
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&corpus).unwrap();
+        fs::create_dir_all(&source).unwrap();
+        fs::create_dir_all(&docs).unwrap();
+        fs::write(
+            corpus.join("adr-001.md"),
+            "# ADR-001: Audit entry point\n\n## Status\n\nAccepted\n\n## Context\n\nThe audit entry point is required.\n\n## Decision\n\nKeep it public.\n\n## Consequences\n\nCallers have one stable entry point.\n\n## Code Constraints\n\n```yaml\nversion: 1\nrules:\n  - id: audit-entry-point\n    kind: require_pattern\n    path_glob: \"src/audit.rs\"\n    pattern: \"pub fn audit\"\n```\n",
+        )
+        .unwrap();
+        fs::write(source.join("audit.rs"), "pub fn audit() {}\n").unwrap();
+        fs::write(docs.join("guide.md"), "Initial guide.\n").unwrap();
+        let git = |args: &[&str]| {
+            let status = Command::new("git")
+                .arg("-C")
+                .arg(&root)
+                .args(args)
+                .status()
+                .unwrap();
+            assert!(status.success(), "git {args:?}");
+        };
+        git(&["init", "-q"]);
+        git(&["add", "."]);
+        git(&[
+            "-c",
+            "user.name=As Decided",
+            "-c",
+            "user.email=tests@asdecided.com",
+            "commit",
+            "-qm",
+            "base",
+        ]);
+        fs::write(docs.join("guide.md"), "Updated guide.\n").unwrap();
+
+        let report = analyze(
+            corpus.to_str().unwrap(),
+            root.to_str().unwrap(),
+            true,
+            Some("HEAD"),
+            false,
+        )
+        .unwrap();
+        assert!(report.findings.is_empty(), "{:#?}", report.findings);
 
         fs::remove_dir_all(root).unwrap();
     }

--- a/rust/rac-engine/src/sentry.rs
+++ b/rust/rac-engine/src/sentry.rs
@@ -30,7 +30,24 @@ pub const DUPLICATE_RULE_ID: &str = "duplicate-code-constraint-id";
 #[serde(deny_unknown_fields)]
 struct ConstraintDocument {
     version: u64,
+    #[serde(default = "default_eligibility")]
+    eligibility: Eligibility,
+    #[serde(default)]
     rules: Vec<ConstraintRule>,
+    reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum Eligibility {
+    Eligible,
+    Ineligible,
+}
+
+fn default_eligibility() -> Eligibility {
+    // Compatibility with the v1 shape shipped in 0.25.1: a document that
+    // already carries rules was necessarily declaring itself eligible.
+    Eligibility::Eligible
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -68,7 +85,10 @@ pub struct SentryReport {
     pub base: Option<String>,
     pub full_tree: bool,
     pub live_decisions: usize,
+    pub classified_decisions: usize,
+    pub eligible_decisions: usize,
     pub constrained_decisions: usize,
+    pub active_rules: usize,
     pub findings: Vec<SentryFinding>,
 }
 
@@ -77,12 +97,25 @@ impl SentryReport {
         self.findings.is_empty()
     }
 
-    pub fn coverage_percent(&self) -> f64 {
+    pub fn corpus_adoption_percent(&self) -> f64 {
         if self.live_decisions == 0 {
             0.0
         } else {
             self.constrained_decisions as f64 * 100.0 / self.live_decisions as f64
         }
+    }
+
+    pub fn eligible_coverage_percent(&self) -> f64 {
+        if self.eligible_decisions == 0 {
+            0.0
+        } else {
+            self.constrained_decisions as f64 * 100.0 / self.eligible_decisions as f64
+        }
+    }
+
+    pub fn unclassified_decisions(&self) -> usize {
+        self.live_decisions
+            .saturating_sub(self.classified_decisions)
     }
 }
 
@@ -204,8 +237,32 @@ fn parse_document(item: &CorpusItem) -> Result<Option<ConstraintDocument>, Box<S
             ),
         }));
     }
-    if document.rules.is_empty() {
-        return Err(invalid(item, None, "rules must not be empty"));
+    if document.eligibility == Eligibility::Ineligible {
+        if !document.rules.is_empty() {
+            return Err(invalid(
+                item,
+                None,
+                "ineligible decisions must not declare rules",
+            ));
+        }
+        if document
+            .reason
+            .as_deref()
+            .map_or(true, |reason| reason.trim().is_empty())
+        {
+            return Err(invalid(
+                item,
+                None,
+                "ineligible decisions must state a non-empty reason",
+            ));
+        }
+    }
+    if document
+        .reason
+        .as_deref()
+        .is_some_and(|reason| reason.trim().is_empty())
+    {
+        return Err(invalid(item, None, "reason must not be empty"));
     }
     let mut ids = BTreeSet::new();
     for rule in &document.rules {
@@ -570,7 +627,22 @@ pub fn analyze(
         base: base.map(str::to_string),
         full_tree,
         live_decisions: live.len(),
-        constrained_decisions: documents.len(),
+        classified_decisions: documents.len(),
+        eligible_decisions: documents
+            .iter()
+            .filter(|(_, document)| document.eligibility == Eligibility::Eligible)
+            .count(),
+        constrained_decisions: documents
+            .iter()
+            .filter(|(_, document)| {
+                document.eligibility == Eligibility::Eligible && !document.rules.is_empty()
+            })
+            .count(),
+        active_rules: documents
+            .iter()
+            .filter(|(_, document)| document.eligibility == Eligibility::Eligible)
+            .map(|(_, document)| document.rules.len())
+            .sum(),
         findings,
     })
 }
@@ -633,6 +705,16 @@ mod tests {
             "# ADR-001: Retain users\n\n## Status\n\nAccepted\n\n## Context\n\nDeletion loses audit history.\n\n## Decision\n\nUse soft deletion.\n\n## Consequences\n\nRows remain recoverable.\n\n## Code Constraints\n\n```yaml\nversion: 1\nrules:\n  - id: no-hard-delete\n    kind: forbid_pattern\n    path_glob: \"src/**/*.sql\"\n    pattern: \"DELETE\\\\s+FROM\\\\s+users\"\n```\n",
         )
         .unwrap();
+        fs::write(
+            corpus.join("adr-002.md"),
+            "# ADR-002: Product language\n\n## Status\n\nAccepted\n\n## Context\n\nThe product needs a stable voice.\n\n## Decision\n\nUse direct language.\n\n## Consequences\n\nCopy remains subject to human review.\n\n## Code Constraints\n\n```yaml\nversion: 1\neligibility: ineligible\nreason: \"Product voice requires human review, not a source-code rule.\"\n```\n",
+        )
+        .unwrap();
+        fs::write(
+            corpus.join("adr-003.md"),
+            "# ADR-003: Unclassified\n\n## Status\n\nAccepted\n\n## Context\n\nThis historical decision has not been classified.\n\n## Decision\n\nKeep its status explicit.\n\n## Consequences\n\nSentry reports it as unclassified.\n",
+        )
+        .unwrap();
         fs::write(source.join("users.sql"), "DELETE FROM users;\n").unwrap();
 
         let report = analyze(
@@ -643,8 +725,14 @@ mod tests {
             true,
         )
         .unwrap();
-        assert_eq!(report.live_decisions, 1);
+        assert_eq!(report.live_decisions, 3);
+        assert_eq!(report.classified_decisions, 2);
+        assert_eq!(report.eligible_decisions, 1);
         assert_eq!(report.constrained_decisions, 1, "{:#?}", report.findings);
+        assert_eq!(report.active_rules, 1);
+        assert_eq!(report.unclassified_decisions(), 1);
+        assert!((report.corpus_adoption_percent() - 100.0 / 3.0).abs() < f64::EPSILON);
+        assert_eq!(report.eligible_coverage_percent(), 100.0);
         assert_eq!(report.findings.len(), 1);
         assert_eq!(report.findings[0].code, CODE_VIOLATION);
 

--- a/rust/rac-engine/src/sentry.rs
+++ b/rust/rac-engine/src/sentry.rs
@@ -248,7 +248,7 @@ fn parse_document(item: &CorpusItem) -> Result<Option<ConstraintDocument>, Box<S
         if document
             .reason
             .as_deref()
-            .map_or(true, |reason| reason.trim().is_empty())
+            .is_none_or(|reason| reason.trim().is_empty())
         {
             return Err(invalid(
                 item,


### PR DESCRIPTION
## Outcome

Makes deterministic decision-to-code enforcement operational in Core rather
than merely available as an engine command.

## What changed

- records ADR-123, its accepted requirement, and the evaluation design;
- adds four real `Code Constraints` that keep Sentry network-free,
  model-judge-free, composed into Gatekeeper, and running in Core CI;
- adds a blocking native Sentry PR job with distinct SARIF output;
- fixes `require_pattern` diff semantics so an unrelated change is out of
  scope instead of failing with `code-constraint-empty-match`;
- preserves fail-closed empty-match behavior for full-tree certification;
- documents the exact diff/full behavior and honest coverage boundary.

## Honest starting measurements

Core currently reports:

- **Corpus adoption:** 1 constrained / 121 live Decisions (**0.83%**)
- **Eligible enforcement coverage:** 1 constrained / 1 explicitly eligible
  Decision (**100%**)
- **Active rules:** 4
- **Unclassified:** 120

The 0.83% figure is deliberately labelled adoption, not enforcement coverage.
Sentry never infers that prose-only Decisions are eligible or enforced.

## Validation

- `cargo test --workspace --locked`
  - 71 engine unit tests passed
  - all integration, MCP 2026, legacy-protocol, and doc tests passed
- `cargo clippy --workspace --no-deps --locked -- -D warnings`
- `decided validate decisions`
  - 435 artifacts valid, 0 invalid
- `decided relationships decisions --validate`
  - 2,629 checked, 0 issues
- `decided sentry decisions --repository . --full --json`
  - pass; 0.83% corpus adoption, 100% eligible coverage, 4 active rules
- `decided sentry decisions --repository . --base origin/main --json`
  - pass on this PR diff
- `decided gate decisions --code --repository . --base origin/main --json`
  - 0 blocking findings

## Boundary

This remains deterministic and local: glob matching, regular expressions, and
bounded import adapters only. No embeddings, model call, network service, or
LLM-judge escape hatch.
