### PR TITLE
(engine) Audit performance and freshness Sentry eligibility

### DIFF
--- a/decisions/decisions/adr-103-unified-derived-read-model.md
+++ b/decisions/decisions/adr-103-unified-derived-read-model.md
@@ -147,3 +147,22 @@ Architecture
   live-decision scope semantics; only its data-supply path is unified.
 - ADR-002: content addressing and lossless serialisation keep the two added
   structures deterministic and byte-identical across runs and platforms.
+
+## Code Constraints
+
+```yaml
+version: 1
+eligibility: eligible
+reason: "The unified serving model and its persisted projections have concrete native source and parity-test anchors."
+rules:
+  - id: derived-index-keeps-summary-and-scope
+    kind: require_pattern
+    path_glob: "rust/rac-engine/src/derived.rs"
+    pattern: '(?s)pub struct DerivedIndex.*pub portfolio_summary: Value.*pub scope_rows: Vec<ScopeRow>'
+    message: "The canonical derived read model must retain portfolio and decision-scope projections."
+  - id: mapped-store-keeps-summary-and-scope-parity
+    kind: require_pattern
+    path_glob: "rust/rac-engine/tests/index_store_vectors.rs"
+    pattern: '(?s)reader\.scope_rows\(\).*reader\.portfolio_summary\(\)'
+    message: "The mapped-store parity suite must continue to cover both unified projections."
+```

--- a/decisions/decisions/adr-104-persistent-mmap-index-store.md
+++ b/decisions/decisions/adr-104-persistent-mmap-index-store.md
@@ -236,3 +236,22 @@ sufficient for its prefix-range mechanism and its byte-parity reconstruction.
   disposable, never authoritative; deleting it costs only latency.
 - ADR-002: content addressing and lossless, deterministic serialisation keep the
   store byte-identical across runs and platforms.
+
+## Code Constraints
+
+```yaml
+version: 1
+eligibility: eligible
+reason: "The read-only mapped-store dependency and fail-closed corruption battery are deterministic repository properties."
+rules:
+  - id: index-store-remains-memory-mapped
+    kind: require_pattern
+    path_glob: "rust/rac-engine/src/index_store.rs"
+    pattern: 'use memmap2::Mmap;'
+    message: "The persistent native index must retain its memory-mapped read path."
+  - id: index-store-keeps-fail-closed-open-tests
+    kind: require_pattern
+    path_glob: "rust/rac-engine/tests/index_store_vectors.rs"
+    pattern: '(?s)open_store\(cache_dir, "0"\.repeat\(64\).*open_store\(cache_dir, corpus_hash, SCHEMA_VERSION\)\.is_some\(\)'
+    message: "The store suite must continue to reject invalid stores before accepting a valid one."
+```

--- a/decisions/decisions/adr-105-event-sourced-serving-freshness.md
+++ b/decisions/decisions/adr-105-event-sourced-serving-freshness.md
@@ -230,3 +230,22 @@ while giving the same completed-writes-are-visible guarantee.
   the tracker can change only latency, never an answer.
 - ADR-002: content confirmation on every flagged path keeps the freshness key a
   pure function of the corpus bytes, byte-identical across runs and platforms.
+
+## Code Constraints
+
+```yaml
+version: 1
+eligibility: eligible
+reason: "The request-boundary detection ladder and its authoritative fallback are directly testable."
+rules:
+  - id: tracker-keeps-bounded-stable-scan-barrier
+    kind: require_pattern
+    path_glob: "rust/rac-engine/src/freshness.rs"
+    pattern: '(?s)for _ in 0\.\.3.*prepare_scan\(\).*acknowledge_if_stable'
+    message: "Freshness detection must retain its bounded scan-and-event barrier."
+  - id: tracker-keeps-stat-and-verify-floor
+    kind: require_pattern
+    path_glob: "rust/rac-engine/tests/freshness_tracker.rs"
+    pattern: 'stat_fallback_and_verify_never_trust_clean_events'
+    message: "The freshness suite must retain the authoritative stat and verify fallback contract."
+```

--- a/decisions/decisions/adr-106-incremental-validation.md
+++ b/decisions/decisions/adr-106-incremental-validation.md
@@ -227,3 +227,22 @@ ADR-032 and ADR-105 reject it: mtime alone is an unreliable invalidation signal
 that selects which files to content-confirm; content hashing remains the truth, and
 the one case the prefilter alone can miss (S5) is named, pinned, and caught by
 `--verify`.
+
+## Code Constraints
+
+```yaml
+version: 1
+eligibility: eligible
+reason: "Incremental validation and the explicit content-confirmation floor have stable command and regression-test anchors."
+rules:
+  - id: engine-keeps-incremental-directory-validation
+    kind: require_pattern
+    path_glob: "rust/rac-engine/src/commands.rs"
+    pattern: 'pub fn validate_directory_incremental'
+    message: "The native engine must retain its incremental directory-validation path."
+  - id: verify-keeps-stat-preserving-rewrite-coverage
+    kind: require_pattern
+    path_glob: "rust/rac-engine/tests/incremental_validate.rs"
+    pattern: 's5_stat_preserving_rewrite_is_the_accepted_miss_and_verify_catches_it'
+    message: "The verify floor must remain pinned against stat-preserving rewrites."
+```

--- a/decisions/decisions/adr-107-parallel-cold-build.md
+++ b/decisions/decisions/adr-107-parallel-cold-build.md
@@ -168,3 +168,22 @@ module-level worker is the portable, state-clean choice the constraint demands.
 - ADR-104
 - ADR-105
 - ADR-106
+
+## Code Constraints
+
+```yaml
+version: 1
+eligibility: eligible
+reason: "Parallel construction and its serial fault floor are named native paths with byte-parity tests."
+rules:
+  - id: native-build-keeps-bounded-rayon-pool
+    kind: require_pattern
+    path_glob: "rust/rac-engine/src/parallel_build.rs"
+    pattern: '(?s)rayon::ThreadPoolBuilder::new\(\).*num_threads\(n_workers\)'
+    message: "The native cold build must retain its explicitly bounded worker pool."
+  - id: parallel-fault-keeps-serial-floor
+    kind: require_pattern
+    path_glob: "rust/rac-engine/tests/parallel_build.rs"
+    pattern: 'a fault must land on the serial floor'
+    message: "A parallel worker failure must remain covered by the serial fallback test."
+```

--- a/decisions/decisions/adr-108-term-range-partitioned-parallel-merge.md
+++ b/decisions/decisions/adr-108-term-range-partitioned-parallel-merge.md
@@ -139,3 +139,22 @@ parse fan-out already is.
 ## Related Roadmaps
 
 - rebuild-scale
+
+## Code Constraints
+
+```yaml
+version: 1
+eligibility: eligible
+reason: "Indexed parallel collection and worker-count-invariant store bytes expose the deterministic merge boundary."
+rules:
+  - id: parallel-fragments-preserve-input-order
+    kind: require_pattern
+    path_glob: "rust/rac-engine/src/parallel_build.rs"
+    pattern: '(?s)paths\s*\.par_iter\(\).*collect::<Vec<DocFragment>>\(\)'
+    message: "Parallel document fragments must continue to collect in canonical input order."
+  - id: merge-output-remains-worker-invariant
+    kind: require_pattern
+    path_glob: "rust/rac-engine/tests/parallel_build.rs"
+    pattern: 'store bytes must be worker-count-invariant'
+    message: "The persisted merge result must remain byte-identical across worker counts."
+```

--- a/decisions/decisions/adr-109-tag-search-tier-and-facet.md
+++ b/decisions/decisions/adr-109-tag-search-tier-and-facet.md
@@ -123,3 +123,22 @@ tier is lexical only.
 ## Related Roadmaps
 
 - candidate-discovery
+
+## Code Constraints
+
+```yaml
+version: 1
+eligibility: eligible
+reason: "The indexed tag field, scoring tier, and store-format gate are explicit native constants."
+rules:
+  - id: index-store-keeps-tags-field
+    kind: require_pattern
+    path_glob: "rust/rac-engine/src/index_store.rs"
+    pattern: 'pub const FIELDS: \[&str; 6\] = \["id", "title", "path", "heading", "body", "tags"\];'
+    message: "Tags must remain a persisted and searchable index field."
+  - id: tag-tier-keeps-format-version-gate
+    kind: require_pattern
+    path_glob: "rust/rac-engine/src/index_format.rs"
+    pattern: 'pub const SEGMENT_FORMAT_VERSION: u16 = 4;'
+    message: "The tag-aware store format must remain explicitly version-gated unless the decision is amended."
+```

--- a/decisions/decisions/adr-112-cache-on-by-default.md
+++ b/decisions/decisions/adr-112-cache-on-by-default.md
@@ -185,3 +185,22 @@ one-shot path serves.
 - warm-by-default
 - candidate-discovery
 - single-node-scale-residuals
+
+## Code Constraints
+
+```yaml
+version: 1
+eligibility: eligible
+reason: "The default cache posture and explicit rollback flags are deterministic CLI properties."
+rules:
+  - id: find-and-validate-default-cache-on
+    kind: require_pattern
+    path_glob: "rust/rac-engine/src/cli.rs"
+    pattern: '(?s)let mut cache = true;.*let mut cache = true;'
+    message: "The native validate and find paths must continue to default to the engineered cache."
+  - id: cli-keeps-no-cache-escape-hatch
+    kind: require_pattern
+    path_glob: "rust/rac-engine/src/cli.rs"
+    pattern: '"--no-cache" => cache = false'
+    message: "The CLI must retain the explicit no-cache rollback path."
+```

--- a/decisions/decisions/adr-114-native-index-workspace-dependencies.md
+++ b/decisions/decisions/adr-114-native-index-workspace-dependencies.md
@@ -97,3 +97,22 @@ Technical
 - ADR-107
 - ADR-108
 - ADR-112
+
+## Code Constraints
+
+```yaml
+version: 1
+eligibility: eligible
+reason: "The audited mapped-store dependency and target-specific watcher dependency are exact manifest boundaries."
+rules:
+  - id: engine-keeps-reviewed-memmap-dependency
+    kind: require_pattern
+    path_glob: "rust/rac-engine/Cargo.toml"
+    pattern: '(?m)^memmap2 = "0\.9"$'
+    message: "The mapped store must retain the reviewed memmap2 dependency line."
+  - id: inotify-remains-linux-only-and-minimal
+    kind: require_pattern
+    path_glob: "rust/rac-engine/Cargo.toml"
+    pattern: '(?s)\[target\.\x27cfg\(target_os = "linux"\)\x27\.dependencies\].*inotify = \{ version = "0\.11", default-features = false \}'
+    message: "The event accelerator must remain Linux-only with default async features disabled."
+```

--- a/decisions/decisions/adr-118-native-event-freshness-acceleration.md
+++ b/decisions/decisions/adr-118-native-event-freshness-acceleration.md
@@ -98,3 +98,27 @@ the stat/content differ remains truth.
 - ADR-105
 - ADR-114
 - ADR-116
+
+## Code Constraints
+
+```yaml
+version: 1
+eligibility: eligible
+reason: "Linux watcher scope, overflow degradation, and platform fallback are explicit native implementation boundaries."
+rules:
+  - id: watcher-remains-linux-targeted
+    kind: require_pattern
+    path_glob: "rust/rac-engine/src/freshness_watch.rs"
+    pattern: '#\[cfg\(target_os = "linux"\)\]'
+    message: "The native event accelerator must remain explicitly Linux-targeted."
+  - id: watcher-overflow-never-asserts-clean
+    kind: require_pattern
+    path_glob: "rust/rac-engine/src/freshness_watch.rs"
+    pattern: 'EventMask::Q_OVERFLOW'
+    message: "Queue overflow must remain a dirty signal that falls back to authoritative scanning."
+  - id: tracker-keeps-mode-and-fallback-regression
+    kind: require_pattern
+    path_glob: "rust/rac-engine/tests/freshness_tracker.rs"
+    pattern: 'watcher_setup_and_runtime_failure_degrade_to_stat'
+    message: "Watcher setup and runtime failures must continue to degrade to the stat rung."
+```

--- a/decisions/decisions/adr-119-base-plus-delta-serving-generations.md
+++ b/decisions/decisions/adr-119-base-plus-delta-serving-generations.md
@@ -189,3 +189,22 @@ total corpus size, contradicting the change-bound target.
 - ADR-107
 - ADR-116
 - ADR-118
+
+## Code Constraints
+
+```yaml
+version: 1
+eligibility: eligible
+reason: "The production constructor, immutable generation type, and lifecycle parity test make the publication boundary enforceable."
+rules:
+  - id: production-tracker-defaults-to-delta
+    kind: require_pattern
+    path_glob: "rust/rac-engine/src/freshness.rs"
+    pattern: '(?s)pub fn new\(.*Self::new_delta\(cache_dir, root, threshold, true\)'
+    message: "The production tracker must continue to select base-plus-delta serving."
+  - id: delta-lifecycle-keeps-parity-coverage
+    kind: require_pattern
+    path_glob: "rust/rac-engine/tests/freshness_tracker.rs"
+    pattern: 'default_delta_stages_mutations_compacts_and_keeps_parsed_base'
+    message: "The delta lifecycle must remain covered across mutation, compaction, and retained-base behavior."
+```

--- a/decisions/designs/sentry-eligibility-classification.md
+++ b/decisions/designs/sentry-eligibility-classification.md
@@ -64,6 +64,20 @@ ADR-121, and ADR-122. These decisions govern the trust boundary, deterministic
 evaluation, agent integration, merge gating, shared specs, Rust CI authority,
 MCP compatibility, and truthful OKF export.
 
+### Tranche-two scope
+
+The second tranche covers ADR-103, ADR-104, ADR-105, ADR-106, ADR-107, ADR-108,
+ADR-109, ADR-112, ADR-114, ADR-118, and ADR-119. These decisions form the
+native performance and freshness spine: one derived read model, mapped
+persistence, bounded freshness detection, incremental validation, deterministic
+parallel construction, indexed tags, cache defaults, constrained dependencies,
+Linux event acceleration, and atomic base-plus-delta generations.
+
+The tranche raises explicit corpus adoption to 20 of 121 live decisions
+(16.53%). All 20 explicitly eligible decisions carry active rules, for 100%
+eligible coverage and 46 deterministic rules. The remaining 101 decisions stay
+visibly unclassified pending later review.
+
 ## Constraints
 
 - Classification is explicit; absent sections remain unclassified.


### PR DESCRIPTION
## Summary

- classify the eleven accepted decisions forming the native performance and freshness spine
- add 23 deterministic rules for the unified read model, mapped store, freshness ladder, incremental validation, parallel construction, tags, cache defaults, dependencies, Linux events, and delta generations
- record tranche-two scope and measured coverage in the governing Sentry audit design

This is intentionally stacked on #396, which is itself stacked on #395. Merge base-to-tip.

## Coverage after this tranche

- corpus adoption: 20/121 decisions (16.53%)
- eligible enforcement: 20/20 decisions (100%)
- active deterministic rules: 46
- unclassified decisions: 101

No decision was inferred as ineligible and no rule uses semantic or model-based judgement.

## Validation

- `decided validate`: 437 valid, 0 invalid; OKF v0.2 conformant
- relationship validation: 2,634 checked, 0 issues
- Sentry full-tree: pass, 0 findings
- Sentry diff mode against tranche one commit: pass, 0 findings
- `cargo test --workspace --locked`: pass
