### PR TITLE
(engine) Prepare v0.26.0 release

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -28,7 +28,7 @@ checksum = "3f8ebf5827e4ac4fd5946560e6a99776ea73b596d80898f357007317a7141e47"
 
 [[package]]
 name = "asdecided-core"
-version = "0.25.1"
+version = "0.26.0"
 dependencies = [
  "globset",
  "inotify",
@@ -127,14 +127,14 @@ checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "decided"
-version = "0.25.1"
+version = "0.26.0"
 dependencies = [
  "asdecided-core",
 ]
 
 [[package]]
 name = "decided-mcp"
-version = "0.25.1"
+version = "0.26.0"
 dependencies = [
  "asdecided-core",
  "serde",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["rac-engine", "decided", "decided-mcp"]
 
 [workspace.package]
-version = "0.25.1"
+version = "0.26.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/asdecided/core"

--- a/rust/decided/Cargo.toml
+++ b/rust/decided/Cargo.toml
@@ -12,4 +12,4 @@ categories = ["command-line-utilities", "development-tools"]
 publish = ["crates-io"]
 
 [dependencies]
-rac-engine = { package = "asdecided-core", version = "=0.25.1", path = "../rac-engine" }
+rac-engine = { package = "asdecided-core", version = "=0.26.0", path = "../rac-engine" }


### PR DESCRIPTION
## Outcome

Prepares v0.26.0 as the minor release for deterministic decision-to-code enforcement.

## Changes

- bumps the Rust workspace from 0.25.1 to 0.26.0
- updates the exact `decided` dependency on `asdecided-core`
- refreshes all three workspace package entries in `Cargo.lock`

## Release capability

The release carries the merged Sentry stack from #395–#397:

- `decided sentry` and `decided gate --code`
- deterministic pattern and import constraints
- native blocking CI and SARIF output
- 20/121 live decisions explicitly classified (16.53% corpus adoption)
- 20/20 eligible decisions constrained (100% eligible coverage)
- 46 active deterministic rules
- no embeddings, model call, network service, or LLM judge

## Verification

- `cargo metadata --locked --no-deps --format-version 1`
- `cargo test --workspace --locked`
- full-tree `decided sentry`: pass, 0 findings
