### PR TITLE
(engine) Prepare v0.26.1 release

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -139,6 +139,11 @@ jobs:
           test "$(jq -r '.version' server.json)" = "$WORKSPACE_VERSION"
           test "$(jq -r '.packages[0].version' server.json)" = "$WORKSPACE_VERSION"
           grep -Fx "mcp-name: io.github.asdecided/core" rust/decided-mcp/README.md
-      - name: Package MCP crate
+      # A release PR can point at an exact engine version that does not exist on
+      # crates.io until the staged publish workflow runs. Listing the package
+      # still validates its include/exclude boundary without falsely requiring
+      # the unreleased dependency; crates-publish performs the full dry-run
+      # after publishing and indexing asdecided-core.
+      - name: Verify MCP crate package contents
         working-directory: rust
-        run: cargo publish --dry-run --locked -p decided-mcp
+        run: cargo package --list --locked -p decided-mcp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@ details, release history over commit history.
   release metadata, CI checkouts, and OCI publication now use the canonical
   AsDecided repository names. Stable `RAC-*` artifact IDs remain unchanged.
 
+## v0.26.1 — 2026-07-31
+
+- Published the native `decided-mcp` server as its own crates.io package and
+  added the canonical `io.github.asdecided/core` metadata and secretless GitHub
+  OIDC workflow for the official MCP Registry.
+- Added native Linux arm64 and macOS amd64 archives alongside Linux amd64,
+  macOS arm64, and Windows amd64, completing the four-platform asset set needed
+  for a signed local Pilot App Store submission.
+- Documented direct Cargo installation for both native executables and the
+  official Scoop installation path for Windows.
+
 ## v0.23.1 — 2026-07-24
 
 - Fixed native Windows compilation by using portable filesystem metadata,

--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ Rust users can install the `decided` CLI directly from crates.io:
 
 ```sh
 cargo install decided
+cargo install decided-mcp
+```
+
+Windows users can install both native executables through Scoop:
+
+```powershell
+scoop bucket add asdecided https://github.com/asdecided/scoop-bucket
+scoop install asdecided
 ```
 
 Native `decided` and `decided-mcp` archives are also published on
@@ -63,6 +71,8 @@ The migration moves `.rac/` to `.decided/` and `rac/` to `decisions/`. It
 refuses to overwrite either destination.
 
 ## MCP
+
+The official MCP Registry identity is `io.github.asdecided/core`.
 
 ```json
 {

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -28,7 +28,7 @@ checksum = "3f8ebf5827e4ac4fd5946560e6a99776ea73b596d80898f357007317a7141e47"
 
 [[package]]
 name = "asdecided-core"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "globset",
  "inotify",
@@ -127,14 +127,14 @@ checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "decided"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "asdecided-core",
 ]
 
 [[package]]
 name = "decided-mcp"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "asdecided-core",
  "serde",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["rac-engine", "decided", "decided-mcp"]
 
 [workspace.package]
-version = "0.26.0"
+version = "0.26.1"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/asdecided/core"

--- a/rust/decided-mcp/Cargo.toml
+++ b/rust/decided-mcp/Cargo.toml
@@ -12,6 +12,6 @@ categories = ["command-line-utilities", "development-tools"]
 publish = ["crates-io"]
 
 [dependencies]
-rac-engine = { package = "asdecided-core", version = "=0.26.0", path = "../rac-engine" }
+rac-engine = { package = "asdecided-core", version = "=0.26.1", path = "../rac-engine" }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }

--- a/rust/decided/Cargo.toml
+++ b/rust/decided/Cargo.toml
@@ -12,4 +12,4 @@ categories = ["command-line-utilities", "development-tools"]
 publish = ["crates-io"]
 
 [dependencies]
-rac-engine = { package = "asdecided-core", version = "=0.26.0", path = "../rac-engine" }
+rac-engine = { package = "asdecided-core", version = "=0.26.1", path = "../rac-engine" }

--- a/server.json
+++ b/server.json
@@ -7,14 +7,14 @@
     "url": "https://github.com/asdecided/core",
     "source": "github"
   },
-  "version": "0.26.0",
+  "version": "0.26.1",
   "websiteUrl": "https://asdecided.com",
   "packages": [
     {
       "registryType": "cargo",
       "registryBaseUrl": "https://crates.io",
       "identifier": "decided-mcp",
-      "version": "0.26.0",
+      "version": "0.26.1",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Outcome

Prepare As Decided v0.26.1 as a distribution-only patch release.

## Changes

- align the Rust workspace, `decided`, `decided-mcp`, lockfile, and MCP Registry manifest on v0.26.1
- document direct Cargo installation for both native executables
- document the official Scoop path for Windows
- record the crates.io, official MCP Registry, expanded native archive, and Pilot prerequisites in the changelog

This release does not change retrieval, validation, enforcement, or protocol behaviour.

## Validation

- `cargo test --workspace --locked`
- `cargo publish --dry-run --locked --allow-dirty -p asdecided-core`
- `mcp-publisher validate`
- live corpus: 443 valid, 0 invalid; 2,653 relationships, 0 issues
- Sentry: 22/22 eligible decisions constrained, 51 active rules, 0 violations
- version alignment and `git diff --check`

Authored under my direction with Codex.
