### PR TITLE
feat(distribution): add Docker MCP catalog target

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 *
 !rust/
 !rust/**
+rust/target/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ details, release history over commit history.
 
 ## Unreleased
 
+- Added a dedicated native `decided-mcp` Docker build target for Docker's MCP
+  Catalog while preserving the existing CLI image as the default target. The
+  MCP image runs locally over a user-mounted repository with no network access.
 - Added crates.io packaging for the native CLI, making
   `cargo install decided` a supported installation path. The internal engine
   publishes first as `asdecided-core`; subsequent releases use short-lived

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,23 @@
-# Official native AsDecided container image.
+# Official native AsDecided container images.
 #
-# Local build:
-#   docker build -t rac .
+# CLI (the default target):
+#   docker build -t asdecided .
 #   docker run --rm -v "$PWD:/work" asdecided validate decisions/
+#
+# MCP server (used by the Docker MCP Catalog):
+#   docker build --target asdecided-mcp -t asdecided-mcp .
+#   docker run --rm -i -v "$PWD:/work" asdecided-mcp --root /work
 FROM rust:1.94-bookworm AS builder
 
 COPY rust /src/rust
 WORKDIR /src/rust
 RUN cargo build --release --locked -p decided -p decided-mcp
 
-FROM debian:bookworm-slim
+FROM debian:bookworm-slim AS runtime
 
 ARG DECIDED_VERSION=dev
-LABEL org.opencontainers.image.title="rac" \
-      org.opencontainers.image.description="RAC (Lore) requirements-as-code CLI" \
+LABEL org.opencontainers.image.title="AsDecided" \
+      org.opencontainers.image.description="Deterministic engineering decisions for coding agents" \
       org.opencontainers.image.source="https://github.com/asdecided/core" \
       org.opencontainers.image.licenses="Apache-2.0" \
       org.opencontainers.image.version="${DECIDED_VERSION}"
@@ -25,5 +29,11 @@ COPY --from=builder /src/rust/target/release/decided /usr/local/bin/decided
 COPY --from=builder /src/rust/target/release/decided-mcp /usr/local/bin/decided-mcp
 
 WORKDIR /work
+
+FROM runtime AS asdecided-mcp
+LABEL io.modelcontextprotocol.server.name="io.github.asdecided/core"
+ENTRYPOINT ["decided-mcp"]
+
+FROM runtime AS asdecided-cli
 ENTRYPOINT ["decided"]
 CMD ["--help"]

--- a/decisions/decisions/adr-126-docker-mcp-catalog-distribution.md
+++ b/decisions/decisions/adr-126-docker-mcp-catalog-distribution.md
@@ -1,0 +1,117 @@
+---
+schema_version: 1
+id: RAC-KYYC7HBFMRBA
+type: decision
+---
+# ADR-126: Package the Native MCP Server for Docker's MCP Catalog
+
+## Context
+
+ADR-124 publishes `decided-mcp` through Cargo and the official MCP Registry.
+That record is already the canonical public identity and package authority, but
+Docker's curated MCP Catalog is a separate downstream surface. Local entries in
+that catalog are built from a Dockerfile and must start an MCP server when the
+catalog probes the selected image.
+
+Core already has one Dockerfile, but its default image starts the `decided` CLI.
+Changing that default would silently break existing container users. Publishing
+another implementation or a hosted endpoint would also contradict the Rust
+cutover and the local-first trust boundary.
+
+## Decision
+
+AsDecided will add a dedicated `asdecided-mcp` build target to the existing
+root Dockerfile and submit that target to Docker's official MCP Catalog.
+
+- The target contains the same workspace-built `decided-mcp` binary as the
+  native release. It adds no Python, npm, wrapper, or hosted service.
+- The existing default Docker target remains the `decided` CLI. Docker's catalog
+  metadata selects `asdecided-mcp` explicitly.
+- The MCP image carries the canonical
+  `io.modelcontextprotocol.server.name=io.github.asdecided/core` label and starts
+  `decided-mcp` over stdio.
+- A user grants one repository directory as a volume. The catalog passes that
+  container path through `--root`; network access is disabled.
+- Docker may build, sign, scan, and publish the catalog image in its `mcp`
+  namespace. Cargo and the official MCP Registry remain the release and identity
+  authorities; the Docker listing is a downstream packaging surface.
+- GitHub's MCP Registry requires no second manifest: its published guidance says
+  downstream GitHub discovery consumes the official Registry record. A curated
+  GitHub feature request is outreach, not another source-controlled package.
+
+## Consequences
+
+Docker Desktop users gain a discoverable, isolated local installation without a
+second engine. The Docker-built option also adds Docker's image signing,
+provenance, SBOM, and update process.
+
+The root Dockerfile now has two public targets, and Docker's catalog pins a Core
+commit that its maintainers must review and periodically update. Filesystem
+access remains explicit, but users must understand that the selected repository
+is mounted into the container. Docker acceptance is external and cannot be
+treated as shipped until its maintainers merge the listing.
+
+## Status
+
+Accepted
+
+<!-- Choose one: Proposed | Accepted | Superseded | Deprecated -->
+<!-- Is this Proposed, Accepted, Superseded, or Deprecated? -->
+
+## Category
+
+Architecture
+
+<!-- Choose one: Architecture | Product | Process | Technical | Other -->
+<!-- Which area: Architecture, Product, Process, Technical, or Other? -->
+
+## Alternatives Considered
+
+### Replace the CLI container's default entrypoint
+
+Rejected because it would break an existing distribution surface merely to
+satisfy a catalog probe.
+
+### Publish a separately maintained image or wrapper repository
+
+Rejected because it creates a second release implementation and unnecessary
+repository surface. One multi-target Dockerfile keeps both binaries tied to the
+same workspace and commit.
+
+### Host a remote MCP endpoint
+
+Rejected because it would require corpus upload, tenancy, authentication, and
+storage decisions that AsDecided has not made.
+
+## Code Constraints
+
+```yaml
+version: 1
+eligibility: eligible
+reason: "The Docker MCP target and canonical identity have stable source anchors."
+rules:
+  - id: docker-keeps-dedicated-mcp-target
+    kind: require_pattern
+    path_glob: "Dockerfile"
+    pattern: 'FROM runtime AS asdecided-mcp'
+    message: "Docker catalog packaging must keep a dedicated MCP build target."
+  - id: docker-keeps-canonical-mcp-name
+    kind: require_pattern
+    path_glob: "Dockerfile"
+    pattern: 'io.modelcontextprotocol.server.name="io.github.asdecided/core"'
+    message: "The MCP image must retain the canonical public Registry identity."
+  - id: docker-keeps-native-mcp-entrypoint
+    kind: require_pattern
+    path_glob: "Dockerfile"
+    pattern: 'ENTRYPOINT \["decided-mcp"\]'
+    message: "The Docker catalog target must launch the native Rust MCP server."
+```
+
+## Related Decisions
+
+- adr-124
+- adr-121
+
+## Related Requirements
+
+- asdecided-public-mcp-distribution

--- a/decisions/designs/docker-mcp-catalog-packaging.md
+++ b/decisions/designs/docker-mcp-catalog-packaging.md
@@ -1,0 +1,95 @@
+---
+schema_version: 1
+id: RAC-KYYC7NNZE2ZR
+type: design
+---
+# Docker MCP Catalog Packaging
+
+## Context
+
+ADR-126 adds Docker's curated MCP Catalog as a downstream discovery surface for
+the native server selected by ADR-124. The catalog builds local servers from
+their source repository, probes them over stdio, and exposes configurable volume
+grants in Docker Desktop.
+
+## User Need
+
+A Docker Desktop user needs to select AsDecided, grant one local repository,
+and let an MCP client retrieve its recorded engineering decisions without
+installing Rust tooling or uploading the corpus.
+
+## Design
+
+The root Dockerfile builds both native executables once in a Rust builder stage,
+copies them into one minimal shared runtime, and exposes two final targets:
+
+1. `asdecided-cli` remains last and therefore preserves the existing default
+   `decided` entrypoint.
+2. `asdecided-mcp` adds the canonical MCP ownership label and replaces only the
+   entrypoint with `decided-mcp`.
+
+Docker catalog metadata selects `source.buildTarget: asdecided-mcp`. Its single
+`repository` parameter becomes a read-only-intent volume grant and the server is
+started with `--root` pointing at the mounted container path. The catalog entry
+sets `disableNetwork: true`, because repository retrieval requires no network.
+
+The catalog description says exactly what the server does: read-only access to
+deterministic engineering decisions in a local repository. It links to Core and
+uses the AsDecided organisation icon. It does not claim Docker acceptance until
+the upstream PR is merged.
+
+## Constraints
+
+- The default Dockerfile target must remain compatible with existing CLI use.
+- The catalog image must answer MCP `initialize` and `tools/list` over stdio.
+- The catalog must pin an immutable Core commit and select the named MCP target.
+- Repository access must be user-configured; no home-directory-wide implicit
+  mount is allowed.
+- The container must not require credentials, outbound network access, Python,
+  Node.js, or a model call.
+
+## Rationale
+
+A named final target is the smallest compatibility-preserving seam. Docker can
+build and inspect the MCP process it expects, while direct `docker build .`
+continues to produce the CLI image. Both derive from identical locked Rust
+sources and one runtime layer.
+
+## Alternatives
+
+- **Override the command in catalog metadata:** Docker's `run.command` appends
+  arguments to the image entrypoint; it does not replace `decided` with
+  `decided-mcp`.
+- **Make MCP the default image:** rejected as an avoidable CLI compatibility
+  break.
+- **Publish a pre-built AsDecided image:** deferred. Docker's own build path
+  provides signing, provenance, SBOMs, and automatic catalog updates without a
+  second image publication workflow in Core.
+
+## Accessibility
+
+The configuration is one clearly labelled path field and does not depend on an
+image, colour, or pointer-only interaction. Errors from an absent or invalid
+corpus remain textual MCP errors from the native server.
+
+## Style Guidance
+
+Use AsDecided as the product title and `decided-mcp` only for the executable.
+Prefer “local,” “read-only,” and “deterministic”; avoid “hosted,” “AI-powered,”
+or claims of enforcement beyond the server's retrieval tools.
+
+## Open Questions
+
+- Whether Docker's generated image exposes an independently useful version
+  label beyond the pinned Core commit.
+- Whether the catalog supports a read-only mount flag in addition to the server's
+  read-only MCP behavior; if it does, the upstream entry should adopt it.
+
+## Related Decisions
+
+- adr-126
+- adr-124
+
+## Related Requirements
+
+- asdecided-public-mcp-distribution

--- a/decisions/requirements/asdecided-public-mcp-distribution.md
+++ b/decisions/requirements/asdecided-public-mcp-distribution.md
@@ -30,6 +30,9 @@ line as every other distribution channel.
 - [REQ-005] Registry publication MUST wait until the exact crate version is retrievable from crates.io, then run the checksum-pinned official publisher's validation before publishing.
 - [REQ-006] Registry publication MUST be independently retryable without republishing or overwriting an immutable crate version.
 - [REQ-007] The public metadata MUST describe AsDecided as a local, read-only MCP server and MUST NOT imply a hosted corpus, remote index, model call, or write authority.
+- [REQ-008] The root Dockerfile MUST expose a dedicated `asdecided-mcp` build target that launches the native `decided-mcp` binary while preserving the existing CLI as the default target.
+- [REQ-009] A Docker MCP Catalog entry MUST select that named build target, pin an immutable Core commit, mount only a user-selected repository, pass its container path through `--root`, and disable network access.
+- [REQ-010] Secondary catalog metadata MUST retain `io.github.asdecided/core` as the canonical MCP identity and MUST remain downstream of the Cargo package and official MCP Registry record rather than becoming a second release authority.
 
 ## Acceptance Criteria
 
@@ -44,6 +47,10 @@ line as every other distribution channel.
   without attempting to publish any crate again.
 - Installing the listed crate exposes `decided-mcp`, which serves a local corpus
   over stdio with the same current protocol identity tested by ADR-121.
+- Building the Dockerfile's `asdecided-mcp` target and sending MCP `initialize`
+  and `tools/list` requests over stdio succeeds against a mounted fixture corpus.
+- Docker's registry validation and image build pass for metadata that pins a Core
+  commit containing the dedicated target.
 
 ## Success Metrics
 
@@ -70,6 +77,7 @@ line as every other distribution channel.
 ## Related Decisions
 
 - adr-124
+- adr-126
 - adr-121
 - adr-039
 


### PR DESCRIPTION
## Why

Docker's curated MCP Catalog builds local servers from their source repository and expects the selected image to start an MCP server. Core's existing Dockerfile starts the `decided` CLI, so the canonical Rust MCP server could not be submitted without either breaking that image or adding a dedicated target.

## What changed

- add an `asdecided-mcp` Docker target that starts the native `decided-mcp` binary over stdio
- retain `asdecided-cli` as the default final target, preserving existing container behavior
- add the canonical `io.github.asdecided/core` MCP image label
- exclude local Rust build output from the Docker context
- record ADR-126, the Docker packaging design, public-distribution requirements, and the Unreleased changelog entry

## Verification

- `cargo test --workspace --release` — passed
- `cargo clippy --workspace --all-targets -- -D warnings` — passed with the pinned Rust 1.94.1 toolchain
- `decided validate ../decisions` — 445 valid, 0 invalid
- `decided relationships ../decisions --validate` — 2,660 valid, 0 broken
- `decided gate decisions/ --code --full` — passed, nothing blocking
- `docker build --target asdecided-mcp -t asdecided-mcp:catalog-test .` — passed
- MCP `initialize` and `tools/list` over stdio against a read-only mounted Core corpus — passed; six tools returned
- default Docker target build plus `decided --version` — passed (`0.26.1`)

## Disclosure

`cargo fmt --all -- --check` currently reports pre-existing formatting drift across the Rust workspace on an unchanged fresh `main`; this PR changes no Rust source files and does not include unrelated mechanical formatting.
