### PR TITLE
fix(distribution): make crates publishing retryable

### DIFF
--- a/.github/workflows/crates-publish.yml
+++ b/.github/workflows/crates-publish.yml
@@ -38,7 +38,13 @@ jobs:
         working-directory: rust
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.cargo-auth.outputs.token }}
-        run: cargo publish -p asdecided-core
+          REQUESTED_VERSION: ${{ inputs.version }}
+        run: |
+          if cargo info "asdecided-core@$REQUESTED_VERSION" --registry crates-io >/dev/null 2>&1; then
+            echo "asdecided-core $REQUESTED_VERSION is already published; skipping"
+          else
+            cargo publish -p asdecided-core
+          fi
       - name: Wait for engine crate to reach the index
         working-directory: rust
         env:
@@ -62,9 +68,21 @@ jobs:
         working-directory: rust
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.cargo-auth.outputs.token }}
-        run: cargo publish -p decided
+          REQUESTED_VERSION: ${{ inputs.version }}
+        run: |
+          if cargo info "decided@$REQUESTED_VERSION" --registry crates-io >/dev/null 2>&1; then
+            echo "decided $REQUESTED_VERSION is already published; skipping"
+          else
+            cargo publish -p decided
+          fi
       - name: Publish MCP crate
         working-directory: rust
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.cargo-auth.outputs.token }}
-        run: cargo publish -p decided-mcp
+          REQUESTED_VERSION: ${{ inputs.version }}
+        run: |
+          if cargo info "decided-mcp@$REQUESTED_VERSION" --registry crates-io >/dev/null 2>&1; then
+            echo "decided-mcp $REQUESTED_VERSION is already published; skipping"
+          else
+            cargo publish -p decided-mcp
+          fi


### PR DESCRIPTION
## Outcome

Makes the crates.io publication workflow safe to rerun after a partial release.

## Root cause

The first v0.26.2 run successfully published `asdecided-core` and `decided`, then crates.io rejected `decided-mcp` because that crate did not yet authorise the workflow's trusted-publishing identity. After adding the missing per-crate authorisation, rerunning the existing job would still fail at the first immutable version already present on crates.io.

## Change

Each upload step now queries crates.io for the exact requested package version. Existing immutable versions are reported and skipped; missing versions are published with the same short-lived trusted-publishing credential. Package dry-runs and the engine-index wait remain unchanged.

## Validation

- workflow YAML parses successfully
- `git diff --check`
- live crates.io predicates identify `asdecided-core@0.26.2` and `decided@0.26.2` as present
- the same predicate identifies `decided-mcp@0.26.2` as missing

This PR publishes nothing by itself. After merge, the v0.26.2 workflow can be retried to upload only the missing MCP crate.
