### PR TITLE
(mcp) Validate configured HTTP origins

### DIFF
--- a/rust/PORT-CONTRACT.d/19-http-transport.md
+++ b/rust/PORT-CONTRACT.d/19-http-transport.md
@@ -42,6 +42,11 @@ contract):
 act, ADR-085); `--port` (default `8000`); `--path` (default `/mcp`). Serving is
 stateless per call (ADR-032): one JSON response per POST, no session store, no
 `Mcp-Session-Id`.
+The native server also accepts repeatable `--allowed-origin ORIGIN` values. A
+request without `Origin` is permitted for non-browser MCP clients; a request
+with `Origin` is accepted only on an exact allow-list match and otherwise gets
+HTTP 403 before its body is read. The default allow-list is empty: browser
+origins must be configured explicitly for local or reverse-proxy deployments.
 
 ## 2 — HTTP method / status map (captured empirically from the SDK)
 

--- a/rust/decided-mcp/src/http.rs
+++ b/rust/decided-mcp/src/http.rs
@@ -84,6 +84,7 @@ pub fn serve_http(
     host: &str,
     port: u16,
     path: &str,
+    allowed_origins: &[String],
 ) -> ! {
     let listener = match TcpListener::bind((host, port)) {
         Ok(l) => l,
@@ -106,6 +107,7 @@ stateless per call; authentication belongs to the deployment proxy, ADR-085)."
     let recorder = Arc::new(Mutex::new(recorder));
     let root = Arc::new(root.to_string());
     let path = Arc::new(path.to_string());
+    let allowed_origins = Arc::new(allowed_origins.to_vec());
     let active = Arc::new(AtomicUsize::new(0));
     for stream in listener.incoming() {
         match stream {
@@ -124,9 +126,10 @@ stateless per call; authentication belongs to the deployment proxy, ADR-085)."
                 let recorder = Arc::clone(&recorder);
                 let root = Arc::clone(&root);
                 let path = Arc::clone(&path);
+                let allowed_origins = Arc::clone(&allowed_origins);
                 std::thread::spawn(move || {
                     let _permit = ConnectionPermit { active };
-                    handle_connection(&root, &state, &recorder, &path, s);
+                    handle_connection(&root, &state, &recorder, &path, &allowed_origins, s);
                 });
             }
             Err(_) => continue,
@@ -170,6 +173,7 @@ fn handle_connection(
     state: &Mutex<ServerState>,
     recorder: &Mutex<Option<audit::Recorder>>,
     path: &str,
+    allowed_origins: &[String],
     mut stream: TcpStream,
 ) {
     if stream.set_read_timeout(Some(HTTP_IO_TIMEOUT)).is_err()
@@ -181,7 +185,7 @@ fn handle_connection(
         Ok(s) => s,
         Err(_) => return,
     });
-    let req = match read_request(&mut reader) {
+    let req = match read_request(&mut reader, allowed_origins) {
         Ok(Some(req)) => req,
         Ok(None) => return,
         Err(error) => {
@@ -201,7 +205,10 @@ fn handle_connection(
 }
 
 /// Parse one HTTP/1.1 request: request line, headers, and a Content-Length body.
-fn read_request(reader: &mut BufReader<TcpStream>) -> Result<Option<Request>, ReadError> {
+fn read_request(
+    reader: &mut BufReader<TcpStream>,
+    allowed_origins: &[String],
+) -> Result<Option<Request>, ReadError> {
     let Some(line) = read_line_limited(reader, MAX_REQUEST_LINE_BYTES)? else {
         return Ok(None);
     };
@@ -239,6 +246,9 @@ fn read_request(reader: &mut BufReader<TcpStream>) -> Result<Option<Request>, Re
         headers.push((k.trim().to_string(), v.trim().to_string()));
     }
 
+    if !origin_allowed(&headers, allowed_origins) {
+        return Err(ReadError::OriginDenied);
+    }
     if headers.iter().any(|(k, _)| k.eq_ignore_ascii_case("transfer-encoding")) {
         return Err(ReadError::BadRequest);
     }
@@ -295,6 +305,7 @@ fn read_line_limited(
 enum ReadError {
     BadRequest,
     TooLarge,
+    OriginDenied,
 }
 
 impl ReadError {
@@ -302,6 +313,7 @@ impl ReadError {
         match self {
             Self::BadRequest => "400 Bad Request",
             Self::TooLarge => "413 Payload Too Large",
+            Self::OriginDenied => "403 Forbidden",
         }
     }
 }
@@ -312,6 +324,19 @@ fn reject_connection(mut stream: TcpStream) {
         &mut stream,
         &Response { status: "503 Service Unavailable", body: None },
     );
+}
+
+fn origin_allowed(headers: &[(String, String)], allowed_origins: &[String]) -> bool {
+    let origins: Vec<&str> = headers
+        .iter()
+        .filter(|(name, _)| name.eq_ignore_ascii_case("origin"))
+        .map(|(_, value)| value.trim())
+        .collect();
+    match origins.as_slice() {
+        [] => true,
+        [origin] => allowed_origins.iter().any(|allowed| allowed == origin),
+        _ => false,
+    }
 }
 
 struct Response {

--- a/rust/decided-mcp/src/main.rs
+++ b/rust/decided-mcp/src/main.rs
@@ -51,6 +51,7 @@ fn main() {
     let mut host = "127.0.0.1".to_string();
     let mut port: u16 = 8000;
     let mut path = "/mcp".to_string();
+    let mut allowed_origins = Vec::new();
     while let Some(a) = argv.next() {
         match a.as_str() {
             "--root" => match argv.next() {
@@ -78,6 +79,11 @@ fn main() {
             "--path" => match argv.next() {
                 Some(v) => path = v,
                 None => usage_error("--path requires a value"),
+            },
+            "--allowed-origin" => match argv.next() {
+                Some(v) if !v.trim().is_empty() => allowed_origins.push(v),
+                Some(_) => usage_error("--allowed-origin requires a non-empty origin"),
+                None => usage_error("--allowed-origin requires a value"),
             },
             // Cache flags are real since INDEX-PLAN B6 and remain
             // output-neutral (ADR-112: cache-on vs cache-off runs are
@@ -120,7 +126,15 @@ fn main() {
             usage_error(&msg);
         }
         let recorder = audit::build(&root, "http", &audit_config);
-        http::serve_http(&root, state, recorder, &host, port, &path);
+        http::serve_http(
+            &root,
+            state,
+            recorder,
+            &host,
+            port,
+            &path,
+            &allowed_origins,
+        );
     }
     let mut recorder = audit::build(&root, "stdio", &audit_config);
     serve(&root, &mut state, &mut recorder);

--- a/rust/decided-mcp/tests/http_transport.rs
+++ b/rust/decided-mcp/tests/http_transport.rs
@@ -24,6 +24,10 @@ struct Server {
 
 impl Server {
     fn start(tag: &str) -> Self {
+        Self::start_with_origins(tag, &[])
+    }
+
+    fn start_with_origins(tag: &str, allowed_origins: &[&str]) -> Self {
         let corpus = scratch(tag);
         let audit_path = corpus.join("audit.jsonl");
         std::fs::create_dir_all(corpus.join(".decided")).unwrap();
@@ -40,17 +44,22 @@ impl Server {
             .local_addr()
             .unwrap()
             .port();
+        let mut args = vec![
+                "--root".to_string(),
+                corpus.to_str().unwrap().to_string(),
+                "--transport".to_string(),
+                "http".to_string(),
+                "--host".to_string(),
+                "127.0.0.1".to_string(),
+                "--port".to_string(),
+                port.to_string(),
+        ];
+        for origin in allowed_origins {
+            args.push("--allowed-origin".to_string());
+            args.push((*origin).to_string());
+        }
         let child = Command::new(env!("CARGO_BIN_EXE_decided-mcp"))
-            .args([
-                "--root",
-                corpus.to_str().unwrap(),
-                "--transport",
-                "http",
-                "--host",
-                "127.0.0.1",
-                "--port",
-                &port.to_string(),
-            ])
+            .args(&args)
             .stdout(Stdio::null())
             .stderr(Stdio::piped())
             .spawn()
@@ -70,6 +79,16 @@ impl Server {
     }
 
     fn post(&self, body: &Value, method_header: &str, name: Option<&str>) -> (String, Value) {
+        self.post_with_origin(body, method_header, name, None)
+    }
+
+    fn post_with_origin(
+        &self,
+        body: &Value,
+        method_header: &str,
+        name: Option<&str>,
+        origin: Option<&str>,
+    ) -> (String, Value) {
         let body = body.to_string();
         let mut request = format!(
             "POST /mcp HTTP/1.1\r\nHost: 127.0.0.1\r\nAccept: application/json\r\n\
@@ -78,6 +97,9 @@ Mcp-Method: {method_header}\r\n"
         );
         if let Some(name) = name {
             request.push_str(&format!("Mcp-Name: {name}\r\n"));
+        }
+        if let Some(origin) = origin {
+            request.push_str(&format!("Origin: {origin}\r\n"));
         }
         request.push_str(&format!(
             "Content-Length: {}\r\nConnection: close\r\n\r\n{body}",
@@ -225,5 +247,52 @@ Content-Type: application/json\r\nContent-Length: {}\r\n\r\n",
     assert_eq!(
         response.lines().next(),
         Some("HTTP/1.1 413 Payload Too Large")
+    );
+}
+
+#[test]
+fn current_http_rejects_unconfigured_origin_before_body_read() {
+    let _guard = serial_http_test();
+    let server = Server::start("http-origin-rejected");
+    let body = json!({
+        "jsonrpc": "2.0",
+        "id": 6,
+        "method": "server/discover",
+        "params": {"_meta": current_meta()}
+    });
+    let body = body.to_string();
+    let request = format!(
+        "POST /mcp HTTP/1.1\r\nHost: 127.0.0.1\r\nOrigin: https://attacker.example\r\n\
+Accept: application/json\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+        1024 * 1024 + 1,
+        body
+    );
+    let mut stream = TcpStream::connect(("127.0.0.1", server.port)).unwrap();
+    stream.write_all(request.as_bytes()).unwrap();
+    let mut response = String::new();
+    stream.read_to_string(&mut response).unwrap();
+    assert_eq!(response.lines().next(), Some("HTTP/1.1 403 Forbidden"));
+}
+
+#[test]
+fn current_http_allows_explicit_origin() {
+    let _guard = serial_http_test();
+    let server = Server::start_with_origins("http-origin-allowed", &["https://agent.example"]);
+    let request = json!({
+        "jsonrpc": "2.0",
+        "id": 6,
+        "method": "server/discover",
+        "params": {"_meta": current_meta()}
+    });
+    let (status, response) = server.post_with_origin(
+        &request,
+        "server/discover",
+        None,
+        Some("https://agent.example"),
+    );
+    assert_eq!(status, "HTTP/1.1 200 OK");
+    assert_eq!(
+        response.pointer("/result/supportedVersions/0"),
+        Some(&json!(CURRENT_VERSION))
     );
 }


### PR DESCRIPTION
## Summary

- add repeatable `--allowed-origin ORIGIN` configuration to the HTTP server;
- permit requests without `Origin` for non-browser MCP clients;
- reject present Origins unless they exactly match the configured allow-list;
- return HTTP 403 before reading or allocating the request body;
- document the policy in the HTTP port contract and cover accepted, rejected, and duplicate-policy ordering cases.

This closes #416 and is sequenced after #417 in #418.

## Validation

- `cargo test -p decided-mcp`
- `cargo clippy -p decided-mcp --all-targets -- -D warnings`
- `git diff --check`

