### PR TITLE
(mcp) Reject conflicting protocol versions

### DIFF
--- a/rust/decided-mcp/src/http.rs
+++ b/rust/decided-mcp/src/http.rs
@@ -457,16 +457,46 @@ fn route_post(
 fn http_era(req: &Request, message: &Value, id_json: &str) -> Result<protocol::Era, Response> {
     let header_version = req.header("mcp-protocol-version");
     let metadata_version = protocol::requested_version(message);
-    match header_version {
-        Some(protocol::CURRENT_PROTOCOL_VERSION) => Ok(protocol::Era::Current),
-        Some(version) if protocol::LEGACY_PROTOCOL_VERSIONS.contains(&version) => {
-            Ok(protocol::Era::Legacy)
+    if let Some(version) = header_version {
+        if version != protocol::CURRENT_PROTOCOL_VERSION
+            && !protocol::LEGACY_PROTOCOL_VERSIONS.contains(&version)
+        {
+            return Err(json_response(
+                "400 Bad Request",
+                protocol::unsupported_protocol_frame(message.get("id"), Some(version)),
+            ));
         }
-        Some(version) => Err(json_response(
-            "400 Bad Request",
-            protocol::unsupported_protocol_frame(message.get("id"), Some(version)),
-        )),
-        None if metadata_version == Some(protocol::CURRENT_PROTOCOL_VERSION) => Err(json_response(
+        if let Some(metadata) = metadata_version {
+            if metadata != version {
+                return Err(json_response(
+                    "400 Bad Request",
+                    protocol::header_mismatch_frame(
+                        id_json,
+                        "MCP-Protocol-Version",
+                        Some(version),
+                        Some(metadata),
+                    ),
+                ));
+            }
+        } else if version == protocol::CURRENT_PROTOCOL_VERSION {
+            return Err(json_response(
+                "400 Bad Request",
+                protocol::header_mismatch_frame(
+                    id_json,
+                    "MCP-Protocol-Version",
+                    Some(protocol::CURRENT_PROTOCOL_VERSION),
+                    None,
+                ),
+            ));
+        }
+        return Ok(if version == protocol::CURRENT_PROTOCOL_VERSION {
+            protocol::Era::Current
+        } else {
+            protocol::Era::Legacy
+        });
+    }
+    match metadata_version {
+        Some(protocol::CURRENT_PROTOCOL_VERSION) => Err(json_response(
             "400 Bad Request",
             protocol::header_mismatch_frame(
                 id_json,
@@ -474,6 +504,13 @@ fn http_era(req: &Request, message: &Value, id_json: &str) -> Result<protocol::E
                 Some(protocol::CURRENT_PROTOCOL_VERSION),
                 None,
             ),
+        )),
+        Some(version) if protocol::LEGACY_PROTOCOL_VERSIONS.contains(&version) => {
+            Ok(protocol::Era::Legacy)
+        }
+        Some(version) => Err(json_response(
+            "400 Bad Request",
+            protocol::unsupported_protocol_frame(message.get("id"), Some(version)),
         )),
         None => Ok(protocol::Era::Legacy),
     }

--- a/rust/decided-mcp/tests/http_transport.rs
+++ b/rust/decided-mcp/tests/http_transport.rs
@@ -79,7 +79,17 @@ impl Server {
     }
 
     fn post(&self, body: &Value, method_header: &str, name: Option<&str>) -> (String, Value) {
-        self.post_with_origin(body, method_header, name, None)
+        self.post_with_version_and_origin(body, method_header, name, CURRENT_VERSION, None)
+    }
+
+    fn post_with_version(
+        &self,
+        body: &Value,
+        method_header: &str,
+        name: Option<&str>,
+        version: &str,
+    ) -> (String, Value) {
+        self.post_with_version_and_origin(body, method_header, name, version, None)
     }
 
     fn post_with_origin(
@@ -89,10 +99,21 @@ impl Server {
         name: Option<&str>,
         origin: Option<&str>,
     ) -> (String, Value) {
+        self.post_with_version_and_origin(body, method_header, name, CURRENT_VERSION, origin)
+    }
+
+    fn post_with_version_and_origin(
+        &self,
+        body: &Value,
+        method_header: &str,
+        name: Option<&str>,
+        version: &str,
+        origin: Option<&str>,
+    ) -> (String, Value) {
         let body = body.to_string();
         let mut request = format!(
             "POST /mcp HTTP/1.1\r\nHost: 127.0.0.1\r\nAccept: application/json\r\n\
-Content-Type: application/json\r\nMCP-Protocol-Version: {CURRENT_VERSION}\r\n\
+Content-Type: application/json\r\nMCP-Protocol-Version: {version}\r\n\
 Mcp-Method: {method_header}\r\n"
         );
         if let Some(name) = name {
@@ -163,6 +184,26 @@ fn current_http_rejects_header_body_mismatch() {
         "params": {"_meta": current_meta()}
     });
     let (status, response) = server.post(&request, "resources/list", None);
+    assert_eq!(status, "HTTP/1.1 400 Bad Request");
+    assert_eq!(response.pointer("/error/code"), Some(&json!(-32020)));
+}
+
+#[test]
+fn current_http_rejects_legacy_header_with_current_body_metadata() {
+    let _guard = serial_http_test();
+    let server = Server::start("http-version-mismatch");
+    let request = json!({
+        "jsonrpc": "2.0",
+        "id": 11,
+        "method": "tools/list",
+        "params": {"_meta": current_meta()}
+    });
+    let (status, response) = server.post_with_version(
+        &request,
+        "tools/list",
+        None,
+        "2025-11-25",
+    );
     assert_eq!(status, "HTTP/1.1 400 Bad Request");
     assert_eq!(response.pointer("/error/code"), Some(&json!(-32020)));
 }


### PR DESCRIPTION
## Summary

- compare `MCP-Protocol-Version` with request `_meta` before selecting an era;
- reject current/legacy and legacy/current disagreement with the pinned `-32020` header-mismatch frame;
- reject unsupported versions from either carrier;
- preserve valid legacy requests and current requests;
- add a real HTTP regression for current body metadata paired with a legacy header.

This closes #412 and is sequenced after #416 in #418.

## Validation

- `cargo test -p decided-mcp`
- `cargo clippy -p decided-mcp --all-targets -- -D warnings`
- `git diff --check`

