### PR TITLE
(mcp) Validate JSON-RPC request envelopes

### DIFF
--- a/rust/decided-mcp/src/http.rs
+++ b/rust/decided-mcp/src/http.rs
@@ -403,18 +403,14 @@ fn route_post(
             );
         }
     };
-    let Some(method) = message.get("method").and_then(Value::as_str) else {
-        return json_response(
-            "400 Bad Request",
-            "{\"jsonrpc\":\"2.0\",\"id\":null,\"error\":{\"code\":-32600,\
-\"message\":\"Invalid Request\"}}"
-                .to_string(),
-        );
-    };
-    let id_json = message
-        .get("id")
-        .and_then(|id| serde_json::to_string(id).ok())
-        .unwrap_or_else(|| "null".to_string());
+    let id_json = protocol::request_id_json(&message);
+    if let Err(frame) = protocol::validate_request_envelope(&message, &id_json) {
+        return json_response("400 Bad Request", frame);
+    }
+    let method = message
+        .get("method")
+        .and_then(Value::as_str)
+        .expect("envelope validator requires a method");
     let era = match http_era(req, &message, &id_json) {
         Ok(era) => era,
         Err(response) => return response,

--- a/rust/decided-mcp/src/main.rs
+++ b/rust/decided-mcp/src/main.rs
@@ -175,11 +175,18 @@ fn serve(
             out.flush().ok();
             continue;
         };
-        let id = message.get("id");
-        let Some(id) = id else {
+        let id_present = message.get("id").is_some();
+        let id_json = protocol::request_id_json(&message);
+        if let Err(frame) = protocol::validate_request_envelope(&message, &id_json) {
+            if id_present {
+                writeln!(out, "{frame}").ok();
+                out.flush().ok();
+            }
+            continue;
+        }
+        if !id_present {
             continue; // notification (e.g. notifications/initialized): no response
-        };
-        let id_json = serde_json::to_string(id).unwrap_or_else(|_| "null".to_string());
+        }
         // stdio has no per-request principal; attribution stays the recorder's
         // locally resolved identity (ADR-098).
         let era = match protocol::era_for_stdio(method, &message) {

--- a/rust/decided-mcp/src/protocol.rs
+++ b/rust/decided-mcp/src/protocol.rs
@@ -35,8 +35,49 @@ pub fn requested_version(message: &Value) -> Option<&str> {
         .and_then(Value::as_str)
 }
 
+/// Return a request ID only when it is safe to echo under JSON-RPC. Invalid
+/// IDs are represented as `null` in the invalid-request response rather than
+/// reflecting an object, array, boolean, or null value back to the client.
+pub fn request_id_json(message: &Value) -> String {
+    message
+        .get("id")
+        .filter(|id| valid_request_id(id))
+        .and_then(|id| serde_json::to_string(id).ok())
+        .unwrap_or_else(|| "null".to_string())
+}
+
+/// Validate the JSON-RPC request envelope before either protocol era dispatches
+/// it. Both transports share this gate so current and legacy tools cannot
+/// accidentally accept a non-2.0 envelope or a non-scalar request ID.
+pub fn validate_request_envelope(message: &Value, id_json: &str) -> Result<(), String> {
+    let Some(object) = message.as_object() else {
+        return Err(invalid_request_frame(id_json));
+    };
+    if object.get("jsonrpc").and_then(Value::as_str) != Some("2.0") {
+        return Err(invalid_request_frame(id_json));
+    }
+    if object.get("method").and_then(Value::as_str).is_none() {
+        return Err(invalid_request_frame(id_json));
+    }
+    if let Some(id) = object.get("id") {
+        if !valid_request_id(id) {
+            return Err(invalid_request_frame("null"));
+        }
+    }
+    if let Some(params) = object.get("params") {
+        if !params.is_object() && !params.is_array() {
+            return Err(invalid_request_frame(id_json));
+        }
+    }
+    Ok(())
+}
+
+fn valid_request_id(id: &Value) -> bool {
+    id.is_string() || id.as_i64().is_some() || id.as_u64().is_some()
+}
+
 pub fn era_for_stdio(method: &str, message: &Value) -> Result<Era, String> {
-    if method == "initialize" {
+    if method == "initialize" && requested_version(message) != Some(CURRENT_PROTOCOL_VERSION) {
         return Ok(Era::Legacy);
     }
     match requested_version(message) {
@@ -226,6 +267,10 @@ fn invalid_params_frame(id_json: &str, detail: &str) -> String {
     error_frame(id_json, -32602, "Invalid params", json!({ "detail": detail }))
 }
 
+pub fn invalid_request_frame(id_json: &str) -> String {
+    error_frame(id_json, -32600, "Invalid Request", Value::Null)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -245,6 +290,22 @@ mod tests {
             }
         });
         assert_eq!(era_for_stdio("tools/list", &request), Ok(Era::Current));
+    }
+
+    #[test]
+    fn current_initialize_is_not_treated_as_legacy() {
+        let request = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "_meta": {
+                    PROTOCOL_VERSION_META_KEY: CURRENT_PROTOCOL_VERSION,
+                    CLIENT_CAPABILITIES_META_KEY: {}
+                }
+            }
+        });
+        assert_eq!(era_for_stdio("initialize", &request), Ok(Era::Current));
     }
 
     #[test]

--- a/rust/decided-mcp/tests/http_transport.rs
+++ b/rust/decided-mcp/tests/http_transport.rs
@@ -209,6 +209,22 @@ fn current_http_rejects_legacy_header_with_current_body_metadata() {
 }
 
 #[test]
+fn current_http_rejects_invalid_jsonrpc_envelope() {
+    let _guard = serial_http_test();
+    let server = Server::start("http-envelope");
+    let request = json!({
+        "jsonrpc": "1.0",
+        "id": {"object": true},
+        "method": "server/discover",
+        "params": {"_meta": current_meta()}
+    });
+    let (status, response) = server.post(&request, "server/discover", None);
+    assert_eq!(status, "HTTP/1.1 400 Bad Request");
+    assert_eq!(response.pointer("/error/code"), Some(&json!(-32600)));
+    assert_eq!(response.pointer("/id"), Some(&json!(null)));
+}
+
+#[test]
 fn current_http_unknown_rpc_uses_404_and_method_not_found() {
     let _guard = serial_http_test();
     let server = Server::start("http-unknown");

--- a/rust/decided-mcp/tests/protocol_2026.rs
+++ b/rust/decided-mcp/tests/protocol_2026.rs
@@ -191,6 +191,29 @@ fn current_requests_require_client_capabilities_metadata() {
 }
 
 #[test]
+fn current_initialize_and_invalid_envelopes_use_current_validation() {
+    let initialize = json!({
+        "jsonrpc": "2.0",
+        "id": "initialize",
+        "method": "initialize",
+        "params": {"_meta": current_meta()}
+    });
+    let invalid = json!({
+        "jsonrpc": "1.0",
+        "id": {"object": true},
+        "method": "server/discover",
+        "params": {"_meta": current_meta()}
+    });
+    let frames = run_stdio(
+        "current-envelope",
+        &[initialize.to_string(), invalid.to_string()],
+    );
+    assert_eq!(parse(&frames[0]).pointer("/error/code"), Some(&json!(-32601)));
+    assert_eq!(parse(&frames[1]).pointer("/error/code"), Some(&json!(-32600)));
+    assert_eq!(parse(&frames[1]).pointer("/id"), Some(&json!(null)));
+}
+
+#[test]
 fn tool_schemas_are_json_schema_2020_12_compatible_and_local() {
     let list: serde_json::Value =
         serde_json::from_str(include_str!("../src/tools_list_result.json")).unwrap();


### PR DESCRIPTION
## Summary

- add one shared JSON-RPC envelope validator used by HTTP and stdio;
- require JSON-RPC 2.0, string/integer IDs, string methods, and object/array params;
- return `-32600` with a null ID for invalid IDs/envelopes;
- route current-era stdio `initialize` through current validation instead of the legacy shortcut;
- add HTTP and stdio regressions for malformed envelopes and current initialize.

This closes #409 and completes the request-boundary slice tracked by #418.

## Validation

- `cargo test -p decided-mcp`
- `cargo clippy -p decided-mcp --all-targets -- -D warnings`
- `git diff --check`

