### PR TITLE
fix(engine): verify native releases before publishing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,7 @@
 *
 !rust/
 !rust/**
+!LICENSE
+!NOTICE
+!THIRD-PARTY-NOTICES
 rust/target/

--- a/.github/workflows/crates-publish.yml
+++ b/.github/workflows/crates-publish.yml
@@ -13,11 +13,22 @@ permissions:
   id-token: write
 
 jobs:
+  verification:
+    name: Full native release battery
+    uses: ./.github/workflows/rust-spike.yml
+    with:
+      ref: v${{ inputs.version }}
+    permissions:
+      contents: read
+
   publish:
+    needs: verification
     runs-on: ubuntu-latest
     environment: crates.io
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: v${{ inputs.version }}
       - name: Install pinned Rust toolchain
         working-directory: rust
         run: rustup show
@@ -51,6 +62,7 @@ jobs:
           REQUESTED_VERSION: ${{ inputs.version }}
         run: |
           for attempt in {1..30}; do
+            : "$attempt"
             if cargo info "asdecided-core@$REQUESTED_VERSION" --registry crates-io >/dev/null 2>&1; then
               exit 0
             fi

--- a/.github/workflows/mcp-registry-publish.yml
+++ b/.github/workflows/mcp-registry-publish.yml
@@ -13,7 +13,16 @@ permissions:
   id-token: write
 
 jobs:
+  verification:
+    name: Full native release battery
+    uses: ./.github/workflows/rust-spike.yml
+    with:
+      ref: v${{ inputs.version }}
+    permissions:
+      contents: read
+
   publish:
+    needs: verification
     runs-on: ubuntu-latest
     environment: mcp-registry
     steps:
@@ -36,6 +45,7 @@ jobs:
         run: |
           IMAGE="ghcr.io/asdecided/core:mcp-v$REQUESTED_VERSION"
           for attempt in {1..30}; do
+            : "$attempt"
             if docker manifest inspect "$IMAGE" >/dev/null 2>&1; then
               break
             fi

--- a/.github/workflows/native-publish.yml
+++ b/.github/workflows/native-publish.yml
@@ -6,9 +6,39 @@ on:
 
 permissions:
   contents: write
+  id-token: write
+  attestations: write
 
 jobs:
+  verification:
+    name: Full native release battery
+    uses: ./.github/workflows/rust-spike.yml
+    with:
+      ref: ${{ github.event.release.tag_name }}
+    permissions:
+      contents: read
+
+  metadata:
+    name: Generate release notices
+    needs: verification
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.release.tag_name }}
+      - name: Install pinned Rust toolchain
+        working-directory: rust
+        run: rustup show
+      - name: Generate Cargo dependency notices
+        run: ./scripts/generate-third-party-notices.sh
+      - uses: actions/upload-artifact@v4
+        with:
+          name: asdecided-third-party-notices
+          path: THIRD-PARTY-NOTICES
+          if-no-files-found: error
+
   binaries:
+    needs: [verification, metadata]
     strategy:
       fail-fast: false
       matrix:
@@ -31,6 +61,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.release.tag_name }}
+      - uses: actions/download-artifact@v4
+        with:
+          name: asdecided-third-party-notices
       - name: Install pinned Rust toolchain
         working-directory: rust
         run: rustup show
@@ -51,29 +86,97 @@ jobs:
           TARGET: ${{ matrix.target }}
         run: |
           mkdir -p dist
-          tar -C rust/target/release -czf "dist/asdecided-${TARGET}.tar.gz" decided decided-mcp
+          mkdir -p package
+          cp LICENSE NOTICE THIRD-PARTY-NOTICES package/
+          cp rust/target/release/decided rust/target/release/decided-mcp package/
+          tar -C package -czf "dist/asdecided-${TARGET}.tar.gz" .
       - name: Package Windows binaries
         if: matrix.archive == 'zip'
         shell: pwsh
         run: |
-          New-Item -ItemType Directory -Force dist | Out-Null
-          Compress-Archive -Path rust/target/release/decided.exe,rust/target/release/decided-mcp.exe -DestinationPath dist/asdecided-${{ matrix.target }}.zip
+          New-Item -ItemType Directory -Force dist,package | Out-Null
+          Copy-Item LICENSE,NOTICE,THIRD-PARTY-NOTICES -Destination package
+          Copy-Item rust/target/release/decided.exe,rust/target/release/decided-mcp.exe -Destination package
+          Compress-Archive -Path package\* -DestinationPath dist/asdecided-${{ matrix.target }}.zip
+      - name: Attest release archive
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: dist/asdecided-${{ matrix.target }}.${{ matrix.archive }}
       - name: Attach binaries to GitHub Release
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh release upload "${{ github.event.release.tag_name }}" dist/* --clobber
 
+  evidence:
+    name: Publish release verification pack
+    needs: binaries
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.release.tag_name }}
+      - name: Download release archives
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          mkdir -p dist
+          gh release download "$RELEASE_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --dir dist \
+            --pattern 'asdecided-*.tar.gz' \
+            --pattern 'asdecided-*.zip'
+      - name: Generate SHA256SUMS
+        working-directory: dist
+        run: sha256sum asdecided-*.tar.gz asdecided-*.zip > SHA256SUMS
+      - name: Attach SHA256SUMS
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: gh release upload "$RELEASE_TAG" dist/SHA256SUMS --repo "$GITHUB_REPOSITORY" --clobber
+      - name: Generate CycloneDX SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          path: rust
+          format: cyclonedx-json
+          output-file: dist/asdecided-${{ github.event.release.tag_name }}-sbom.cdx.json
+          upload-artifact: false
+      - name: Attach CycloneDX SBOM
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: gh release upload "$RELEASE_TAG" "dist/asdecided-${RELEASE_TAG}-sbom.cdx.json" --repo "$GITHUB_REPOSITORY" --clobber
+      - name: Attest SHA256SUMS
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: dist/SHA256SUMS
+      - name: Attest CycloneDX SBOM
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: dist/asdecided-${{ github.event.release.tag_name }}-sbom.cdx.json
+
   image:
+    needs: [verification, metadata]
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
+      id-token: write
     env:
       IMAGE: ghcr.io/asdecided/core
       TAG: ${{ github.event.release.tag_name }}
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.release.tag_name }}
+      - uses: actions/download-artifact@v4
+        with:
+          name: asdecided-third-party-notices
       - name: Build and smoke-test CLI image
         run: |
           docker build --target asdecided-cli --build-arg DECIDED_VERSION="$TAG" -t "$IMAGE:$TAG" -t "$IMAGE:latest" .
@@ -92,3 +195,14 @@ jobs:
           docker push "$IMAGE:latest"
           docker push "$IMAGE:mcp-$TAG"
           docker push "$IMAGE:mcp-latest"
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+      - name: Sign published images with GitHub OIDC
+        run: |
+          for reference in \
+            "$IMAGE:$TAG" \
+            "$IMAGE:latest" \
+            "$IMAGE:mcp-$TAG" \
+            "$IMAGE:mcp-latest"; do
+            cosign sign --yes "$reference"
+          done

--- a/.github/workflows/rust-spike.yml
+++ b/.github/workflows/rust-spike.yml
@@ -7,6 +7,13 @@ permissions:
   contents: read
 
 on:
+  workflow_call:
+    inputs:
+      ref:
+        description: "Revision to test when called from a release workflow."
+        type: string
+        required: false
+        default: ""
   pull_request:
     paths:
       - "rust/**"
@@ -26,6 +33,8 @@ jobs:
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Install rust toolchain (pinned by rust/rust-toolchain.toml)
         run: rustup show
@@ -62,6 +71,8 @@ jobs:
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Install rust toolchain (pinned by rust/rust-toolchain.toml)
         run: rustup show
@@ -98,6 +109,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - uses: actions/setup-python@v5
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /src/rust/target/release/decided /usr/local/bin/decided
 COPY --from=builder /src/rust/target/release/decided-mcp /usr/local/bin/decided-mcp
+COPY LICENSE NOTICE THIRD-PARTY-NOTICES /usr/share/doc/asdecided/
 
 WORKDIR /work
 

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-RAC (requirements-as-code)
+AsDecided
 Copyright 2026 Tom Ballard
 
 This product is licensed under the Apache License, Version 2.0 (see LICENSE).

--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -1,0 +1,12 @@
+AsDecided third-party notices
+============================
+
+The native release workflow regenerates this inventory from the locked Cargo
+dependency graph before packaging. The accompanying CycloneDX SBOM is the
+authoritative machine-readable record of dependency versions and license
+metadata for each release.
+
+This repository does not vendor third-party source code. Each dependency's
+license and notice text remains available from its upstream package source;
+the release archive and container image carry this inventory together with
+LICENSE and NOTICE.

--- a/docs/security.md
+++ b/docs/security.md
@@ -38,3 +38,36 @@ cargo clippy --workspace --all-targets -- -D warnings
 CI also runs contract certification against `asdecided-spec` and live-corpus
 invariants. This is a self-attested open-source security posture, not a
 third-party certification.
+
+## Release verification
+
+Each native release carries a `SHA256SUMS` file, a CycloneDX SBOM, and GitHub
+artifact-build attestations. Archives include `LICENSE`, `NOTICE`, and
+`THIRD-PARTY-NOTICES`; the same notices are present in the published container
+image at `/usr/share/doc/asdecided/`. The release workflow runs the full native
+Rust battery before building or publishing any archive, crate, image, or MCP
+Registry entry.
+
+After downloading an archive and the `SHA256SUMS` asset from the release, verify
+the bytes and provenance from a trusted checkout of this repository:
+
+```bash
+sha256sum -c SHA256SUMS
+gh attestation verify asdecided-x86_64-unknown-linux-gnu.tar.gz \
+  --repo asdecided/core
+```
+
+The SBOM is the `asdecided-<tag>-sbom.cdx.json` release asset. Verify a GHCR
+image's keyless signature with the GitHub Actions OIDC issuer and the exact
+release workflow identity:
+
+```bash
+cosign verify \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp \
+    'https://github.com/asdecided/core/.github/workflows/native-publish.yml@refs/tags/v.*' \
+  ghcr.io/asdecided/core:mcp-v<version>
+```
+
+The checksum, SBOM, and signature cover the published artifact; the source
+repository and locked Cargo graph remain the reviewable build inputs.

--- a/scripts/generate-third-party-notices.sh
+++ b/scripts/generate-third-party-notices.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUTPUT="${1:-$ROOT_DIR/THIRD-PARTY-NOTICES}"
+METADATA="$(mktemp)"
+trap 'rm -f "$METADATA"' EXIT
+
+cargo metadata \
+  --manifest-path "$ROOT_DIR/rust/Cargo.toml" \
+  --locked \
+  --format-version 1 > "$METADATA"
+
+mkdir -p "$(dirname "$OUTPUT")"
+{
+  cat <<'HEADER'
+AsDecided third-party notices
+============================
+
+The entries below are generated from the locked Cargo dependency graph for
+this release. The accompanying CycloneDX SBOM carries the same inventory in
+machine-readable form. This project does not vendor third-party source; the
+listed licenses and notices remain available from each upstream package.
+
+Dependencies
+------------
+HEADER
+  jq -r '
+    .packages[]
+    | select(.source != null)
+    | [
+        .name,
+        .version,
+        (.license // (if .license_file then "license file: " + .license_file else "license metadata unavailable" end)),
+        (.repository // "repository not recorded")
+      ]
+    | @tsv
+  ' "$METADATA" \
+    | sort -f \
+    | awk -F '\t' '{printf "- %s %s — %s — %s\n", $1, $2, $3, $4}'
+} > "$OUTPUT"


### PR DESCRIPTION
## Summary

Implements the first enterprise deployability slice from DEP-01/DEP-02:

- gates native archives, crates.io, container, and MCP Registry publishing on the full reusable Rust release battery;
- runs that battery against the exact release tag/version being published;
- packages `LICENSE`, `NOTICE`, and a generated `THIRD-PARTY-NOTICES` inventory with every native archive and image;
- attaches SHA256 checksums, a CycloneDX SBOM, and GitHub artifact-build attestations to native releases;
- signs the published CLI and MCP GHCR images with cosign keyless signing;
- documents verification commands and the zero-egress release evidence in `docs/security.md`.

## Validation

- `cargo test --manifest-path rust/Cargo.toml --workspace --release`
- `actionlint .github/workflows/native-publish.yml .github/workflows/crates-publish.yml .github/workflows/mcp-registry-publish.yml .github/workflows/rust-spike.yml`
- `bash -n scripts/generate-third-party-notices.sh`
- `shellcheck scripts/generate-third-party-notices.sh`
- `git diff --check`

The release workflow remains the owner of generated release metadata; the checked-in notice file is a safe source/container fallback, while the tagged release job regenerates the dependency inventory from the locked Cargo graph.
