### PR TITLE
fix(engine): close public guidance drift

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -122,6 +122,26 @@ jobs:
           fi
           echo "AsDecided Sentry passed."
 
+  # Keep public commands and generated agent guidance tied to the native
+  # distribution. This job runs for docs-only changes too; rust-spike's path
+  # filter is intentionally limited to engine/spec changes.
+  guidance-drift:
+    name: public docs and guidance drift
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Build native AsDecided
+        working-directory: rust
+        run: cargo build --release --locked -p decided
+
+      - name: Check generated agent guidance
+        run: rust/target/release/decided export decisions/ --agent-rules --check
+
+      - name: Check public command and MCP contracts
+        working-directory: rust
+        run: cargo test -p decided-mcp --test docs_contract --release
+
   mcp-distribution:
     name: mcp distribution metadata
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ The toolchain is pinned by `rust/rust-toolchain.toml`.
 
 ```bash
 git clone https://github.com/asdecided/core.git
-cd rac-core/rust
+cd core/rust
 rustup show
 cargo build --workspace --locked
 ```
@@ -50,7 +50,7 @@ Follow `decisions/prompts/rac-agent-commit-guidelines.md`:
 
 ## License and sign-off
 
-RAC is licensed under Apache-2.0. Contributions must carry a
+AsDecided is licensed under Apache-2.0. Contributions must carry a
 [Developer Certificate of Origin](https://developercertificate.org/) sign-off:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -35,9 +35,10 @@ scoop install asdecided
 Native `decided` and `decided-mcp` archives are also published on
 [GitHub Releases](https://github.com/asdecided/core/releases).
 
-`rac-core` is no longer distributed through PyPI. Python API consumers should
-use [`asdecided/sdk`](https://github.com/asdecided/sdk), which is a
-client SDK rather than a second engine implementation.
+Python API consumers should use the
+[`asdecided/sdk`](https://github.com/asdecided/sdk) client SDK. It talks to the
+native engine; this repository does not ship a second Python engine or a PyPI
+package.
 
 ## Start a repository
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,12 +1,13 @@
 # CLI Reference
 
-RAC ships a single command, `rac`, with twenty-two subcommands. This page documents each
-one: its purpose, inputs, outputs, and exit codes.
+AsDecided ships the native `decided` CLI and the separate `decided-mcp` server.
+This page documents the supported CLI commands, their inputs, outputs, and exit
+codes.
 
 ```bash
-rac <command> [arguments] [options]
+decided <command> [arguments] [options]
 decided --version
-rac <command> --help
+decided <command> --help
 ```
 
 ## Conventions
@@ -19,7 +20,7 @@ These apply across every command.
 - **Standard input** — `validate`, `inspect`, and `improve` accept `-` in place of a
   file to read Markdown from stdin (e.g. `cat file.md | decided validate -`).
 - **Recursion** — directory commands (`validate`, `stats`, `inspect`,
-  `relationships`, `review`, `portfolio`, `index`, `explorer`) recurse into
+  `relationships`, `review`, `portfolio`, and `index`) recurse into
   subdirectories by default. Pass `--top-level`
   to scan only the immediate directory. `--recursive` is accepted explicitly for
   clarity but is already the default.
@@ -130,7 +131,7 @@ Corpus references
 
 This is the engine seam the generated Claude Code pre-edit hook pipes proposed
 content into; see [Agent integration](governance.md#agent-integration-context-supply-and-enforcement).
-Validation stays in `rac` — the hook computes nothing
+Validation stays in `decided` — the hook computes nothing
 ([ADR-067](https://github.com/asdecided/core/blob/main/decisions/decisions/adr-067-agent-integration-boundary.md),
 [ADR-063](https://github.com/asdecided/core/blob/main/decisions/decisions/adr-063-non-python-clients-are-thin.md)).
 
@@ -190,68 +191,23 @@ sections, and a list of files that matched no schema (not errors — see
 
 ---
 
-## ingest
+## Ingestion boundary
 
-Convert a document (DOCX, PDF, HTML, PPTX, XLSX, or Markdown) into RAC-compatible
-Markdown.
+The native engine does not expose an `ingest` subcommand. Initial corpus
+creation from DOCX, PDF, HTML, PPTX, XLSX, or note-tool exports belongs in the
+ancillary Python connectors repository:
+[`asdecided/connectors`](https://github.com/asdecided/connectors).
 
-- **Input:** `decided ingest <file>` — the source document.
-- **Options:** `-o, --output <path>` (write to a file; errors if it exists unless
-  `--force`) · `--stdout` (explicit stdout, the default) · `--force` · `--json`
-- **Exit codes:** `0` success · `1` conversion failed · `2` unsupported type / file not found / output exists without `--force`
-
-```bash
-decided ingest spec.docx                 # preview Markdown on stdout
-decided ingest spec.docx -o spec.md      # write to a file
-decided ingest report.pdf -o report.md --force
-```
-
-Document ingestion is no longer shipped by `rac-core`. Use the ancillary
-Python ingestion connector when creating an initial corpus.
-
-### Note-tool exports (Obsidian, Logseq, Notion, Roam)
-
-Point `decided ingest` at a **note-tool export** and it normalises the whole graph —
-each note becomes a RAC-shaped draft, and the link graph you already drew is
-carried in as **candidate `## Related` references** rather than flattened to
-plain text. Obsidian, Logseq, Notion, and Roam are supported today; the
-converters need no extra to install.
-
-- **Input:** `decided ingest <dir>` — an export directory (an Obsidian vault, a
-  Logseq graph, or a Notion "Markdown & CSV" export) — or `decided ingest <graph>.json`
-  for a Roam JSON export. The tool is auto-detected; force a directory's with
-  `--from obsidian|logseq|notion|roam`. Logseq's `pages/` and `journals/` notes
-  are walked, its `[[page links]]` resolve like Obsidian's, and block references
-  (`((id))`) and `key:: value` properties are preserved verbatim. Notion pages
-  use standard Markdown links (resolved the same way); its database CSVs are
-  reported and skipped, since Notion exports each row as its own page. Roam's
-  single JSON graph is parsed and each page's block tree is flattened to outliner
-  Markdown, with `[[page links]]` resolved and block references left verbatim.
-- **Output:** `-o <dir>` writes one draft per note (mirroring the vault's
-  structure) and **never overwrites an existing file** — pass `--force` to
-  replace. Without `-o`, a summary previews what would convert and what needs
-  review. `--json` emits the full structured result.
+Those connectors produce reviewable Markdown drafts. Once the drafts are in
+your repository, use the native CLI to inspect and validate them:
 
 ```bash
-decided ingest ./my-vault                    # preview: notes, resolved links, ambiguities
-decided ingest ./my-vault -o drafts/         # write reviewable drafts
-decided ingest ./my-export --from obsidian -o drafts/
+decided inspect draft.md
+decided validate draft.md
 ```
 
-What the normaliser does, deterministically and offline (identical export →
-byte-identical drafts, nothing dropped):
-
-- **Wikilinks → candidates.** A resolved `[[Note]]` becomes an inline Markdown
-  link, and its target is added to a clearly-marked candidate `## Related`
-  section — a suggestion for you to promote, never an edge the tool asserts.
-  Ambiguous (`[[Name]]` matching two notes) and unresolved links are left inline
-  and listed for review, never guessed.
-- **Frontmatter and unmapped content are preserved verbatim**, so you review a
-  complete, faithful draft.
-
-The drafts are for **human review**: promote the candidate links and finalise the
-artifact frontmatter, then `decided validate`. This is an import step, not an
-auto-commit.
+Ingestion is deliberately outside the engine's normal runtime and CI surface;
+the native CLI remains the deterministic validator, index, and MCP server.
 
 ---
 
@@ -677,15 +633,15 @@ materialized read-only via `git archive` (ADR-043): nothing mutates your
 repository, and only the corpus subpath is extracted.
 
 ```bash
-decided watchkeeper rac --base main
+decided watchkeeper decisions/ --base main
 ```
 
 ```text
 RAC Watchkeeper
 ===============
 
-Directory:  rac
-Comparing:  main → rac
+Directory:  decisions/
+Comparing:  main → decisions/
 
 Changed Artifacts
 -----------------
@@ -776,7 +732,7 @@ which the runner turns into inline annotations. `--no-annotate` suppresses
 the stderr stream:
 
 ```bash
-decided watchkeeper rac --base "origin/$GITHUB_BASE_REF" --format github > "$GITHUB_STEP_SUMMARY"
+decided watchkeeper decisions/ --base "origin/$GITHUB_BASE_REF" --format github > "$GITHUB_STEP_SUMMARY"
 ```
 
 The `--json` form is a stable contract (`schema_version: "1"`) with `base`,
@@ -903,148 +859,21 @@ export; the canonical `id` is what makes the round-trip reliable.
 
 ---
 
-## explorer
+## Explorer (retired)
 
-Launch the interactive terminal Explorer — browse every artifact, read it in
-full, assess repository health, and reach anything through the `/` command
-palette, without memorizing RAC commands. One persistent workspace frame: a
-navigation sidebar of type-tagged artifacts on the left, a context panel
-that swaps views on the right, and a status line of key hints with the
-health chip — under the rac-lantern theme by default. Pressing `/` summons
-the palette (v0.8.8): an input with a live, navigable suggestion menu below
-it. The workspace is live (v0.8.9): Explorer watches the repository and
-reloads itself when artifacts change on disk.
+The former interactive Explorer was a presentation surface, not an engine
+capability. It is retired and is not shipped by the native distribution. Use
+these deterministic commands instead:
 
-Explorer is a presentation layer over the same services the CLI uses: everything
-it shows is also available through `decided portfolio`, `decided index`, `decided resolve`,
-`decided find`, and friends (ADR-015). It never edits artifacts (ADR-024).
+- `decided portfolio decisions/` for a corpus inventory.
+- `decided index decisions/` to inspect the derived index.
+- `decided find "topic" decisions/` for deterministic search.
+- `decided inspect <file>` and `decided review decisions/` for health and
+  completeness.
 
-- **Input:** `decided explorer [directory]` — defaults to `decisions/` when present
-  (ADR-018), else the current directory; scanned recursively for `*.md`.
-- **Options:** `--top-level` · `--recursive` (no `--json`: the surface is interactive)
-- **Keys:** `/` summons the command palette from anywhere · `↑ ↓` navigate ·
-  `Enter` select · `Tab` cycle panels · `Esc` back (palette → dismiss;
-  context → view history; otherwise → home) · `h` health · `r` reload ·
-  `f` filter results by type · `?` help · `q` quit. Single-letter shortcuts
-  are suspended while you type in the palette.
-- **Palette (`/`):** empty input offers the artifacts you opened most
-  recently in this repository (Enter reopens one) above the full command
-  list; a command prefix filters them (Enter completes argument-taking
-  commands into the input); any other text shows live artifact matches —
-  Enter quick-opens the highlighted one — plus a "search all results" row.
-  Commands: `open <ref>` · `find <query> [type]` · `browse [type]` ·
-  `list [type]` · `health` · `stats` · `recommendations` · `new <type> <path>` ·
-  `import <source> [target]` · `relationships <ref>` · `resume` ·
-  `schema [type]` · `settings` · `home` · `help` · `quit` — anything else is
-  a search, resolved with `decided resolve` / `decided find` semantics. Full results render in the context panel (the layout
-  never jumps), where `f` narrows artifact results by type — all → each type
-  present → all. `/browse <type>` lists that type in the results panel in
-  every grouping mode; bare `/browse` focuses the sidebar. `/schema` lists
-  the registered artifact types; `/schema decision` renders the type's
-  expected sections, the same facts `decided schema` reports.
-- **Sidebar:** every artifact under "Artifacts", mirroring the repository's
-  directory structure by default — directories as collapsible nodes (name
-  with a trailing `/` and an artifact count), nested exactly as on disk.
-  The `artifact_grouping` setting cycles `folders` | `type` | `flat`. Rows
-  carry a colour-coded type tag (`REQ` `ADR` `RMP` `PRM` `DSG`) beside the
-  title, invalid artifacts are marked `✗`, and the highlighted artifact's
-  status chip shows in the panel border. `e` opens the highlighted artifact
-  in your editor. Expansion and cursor survive reloads — nested directories
-  included — and opening an artifact reveals it along its filesystem path;
-  the sidebar hides below 80 columns.
-- **Artifact context:** opening an artifact shows four tabs — **Content**
-  (the document's rendered Markdown, read-only — the default; it takes the
-  keyboard, scrolls with `j`/`k`/PgUp/PgDn, and artifact references inside
-  the text open in place, so the corpus reads like a wiki), **Inspection**
-  (status, completeness, and the artifact's validation diagnostics — the
-  same issues `decided validate` reports), **Links** (the knowledge graph as
-  text — a dependency chain to what the artifact relates to, an Impact
-  Analysis block naming what a change may affect, and a lineage chain;
-  connected artifacts open on Enter, so the graph traverses one hop at a
-  time and `Esc` unwinds), and **Findings** (the artifact's
-  recommendations, plus an Improvement group from the improve service —
-  one suggestion per missing section, with the schema's guidance question
-  as the action). Inspection, Links, and Findings carry count badges; `g`
-  jumps to Links; `←`/`→` switch tabs.
-- **Health:** `h` or `/health` opens the health view — Core's score with a text
-  label, the Completeness / Relationships / Validation / Coverage areas, and a
-  prioritized attention list whose items open the affected artifact on its
-  Inspection tab, where the diagnostics explain the finding.
-- **Recommendations:** `/recommendations` (or `r` from the health view) presents
-  Core's review findings grouped by category (Validation, Relationships,
-  Repository Health, Quality), each with its impact, a suggested `rac` command,
-  and navigation to the affected artifact's Findings tab. Advisory only —
-  Explorer applies nothing. `x` exports them to a Markdown file (preview,
-  then confirm).
-- **Actions:** `e` opens the current artifact in your editor — the `editor`
-  setting, then `$VISUAL` / `$EDITOR`; terminal editors (vim, nvim, emacs,
-  nano, …) run with the Explorer suspended and resume it on exit; guidance
-  is shown when nothing is configured (Explorer never edits, ADR-024).
-  `/import <source> [target]` converts a document via the ingest service,
-  previews the Markdown, and writes it only after you confirm with `y`
-  (never overwriting). Long conversions report progress.
-  `/new <type> <path>` starts an artifact from its canonical template: the
-  preview shows the sections with the ID noted as assigned on write, `y`
-  confirms, and the write goes through the same Core service as `decided new` —
-  the ID is minted against the repository index, existing files refuse,
-  missing directories refuse, and an uninitialized repository points you at
-  `decided init`. On success the Explorer reloads and opens the new artifact,
-  ready for `e`; bare `/new` lists the creatable types.
-- **Stats:** `/stats` opens a portfolio dashboard — per-type counts with
-  validity, requirement/metric/risk totals, decision status and category
-  breakdowns, and relationship counts — the same facts `decided stats` reports,
-  collected off the UI thread on request.
-- **Portfolio list:** `/list` opens a sortable table of every artifact — type
-  tag, id, status, link count, recency, and title. `/list <type>` (for example
-  `/list decision`) scopes it to one artifact type, and `/list <text>` (anything
-  that is not a type) runs a fuzzy name search; `s` cycles the sort (type,
-  recency, links, status, id), `f` the status filter (all, invalid, valid), and
-  `ctrl+f` focuses the same name search live in the box. Enter opens the
-  highlighted artifact. The type scope, status filter, and name search compose,
-  and the header names whichever are active. Recency is git-derived (ADR-045),
-  so the column fills from a worker after the table is on screen.
-- **Live reload:** Explorer compares the corpus files on disk every two
-  seconds (paths and mtimes only — no parsing) and reloads when something
-  changed: the sidebar keeps its expansion and cursor, the open artifact
-  keeps its tab and scroll position, and the health chip updates. The
-  watcher holds while a terminal editor owns the screen and rescans the
-  moment Explorer resumes, so a saved edit shows immediately; an open
-  artifact that disappears falls back home. `r` still reloads on demand.
-- **First run:** onboarding derives from repository content (existing, empty, or
-  invalid repository) and is skipped for returning users; a lantern-carrying
-  mascot animates in the welcome, empty, and loading states (static with
-  `animations = off`, hidden with `mascot = off` — no information is lost).
-  Selecting the mascot (a click, or keyboard focus then Enter) returns a small
-  response inline — an acknowledgement, an occasional reminder, gentle guidance
-  toward existing commands, and one rare line — with no popup and nothing
-  hidden behind it; turn it off independently with `mascot_interaction = off`.
-  One optional editor step follows the welcome: Enter accepts (an empty
-  value keeps the `$VISUAL`/`$EDITOR` fallback), typing sets the `editor`
-  preference, Esc skips — `/settings` can change it any time.
-- **Settings & continuity:** `/settings` changes everything in place — theme
-  (three curated RAC themes ship: `rac-lantern`, the dark default;
-  `rac-parchment`, a light companion — warm paper, dark ink, the lantern amber
-  deepened to read on light; and `rac-high-contrast` — pure-white ink on true
-  black for maximum legibility. Enter cycles them and every other Textual theme
-  with live preview; all meaning survives any palette, and the artifact type
-  tags re-tune their hue to the active theme so they stay legible on light or
-  dark), mascot, animations, mascot interaction, artifact grouping
-  (`folders` default), workspace layout (`frame` default — the tree sidebar plus
-  a swapping context region — or `split`, a master-detail layout where the
-  portfolio list drives a persistent reading pane; switching applies live), and
-  the editor command —
-  persisted to `$XDG_CONFIG_HOME/decisions/explorer.json` (no login, cloud, or
-  sync). Explorer remembers recently opened repositories plus the last
-  artifact and view per repository (under `$XDG_STATE_HOME/decisions/`); `.` or
-  `/resume` takes you back to where you were.
-- **Exit codes:** `0` session quit · `2` not a directory, or the `explorer` extra is
-  not installed
+The native CLI and MCP server are the supported delivery surfaces.
 
-Explorer is retired and is not part of the native product.
-
----
-
-## mcp
+## decided-mcp
 
 Serve AsDecided repository knowledge to coding agents over MCP. The native
 server exposes six read-only tools; client configuration, response budgets,
@@ -1593,79 +1422,43 @@ decided migrate metadata decisions/ --json
 
 ## skill
 
-Install or list the bundled Claude Code agent skills. Three skills are
-bundled: `rac-artifacts` (author and maintain artifacts), `rac-review`
-(corpus review and triage), and `rac-ingest` (legacy document conversion).
-Skill content ships with the distribution as package resources, so
-installation works from an installed wheel without this repository, network
-access, or AI involvement.
+Install or list the four bundled Claude Code agent skills. They are embedded in
+the native distribution and require no Python runtime or network access.
 
 - **Input:** `decided skill install [name]` — with no name, every bundled skill;
-  with a name, exactly that skill. `decided skill list` — enumerate the bundle.
+  with a name, exactly that skill. `decided skill list` enumerates the bundle.
 - **Options:** `--dir PATH` (target project directory; default: current
   directory; install only) · `--json`
 - **Exit codes:** `0` installed / listed · `1` a target skill file already
-  exists (never overwritten), or a packaged skill resource is missing
-  (broken installation) · `2` `--dir` is not a directory, or an unknown
-  skill name (the available skills are listed)
+  exists (never overwritten), or a packaged resource is missing · `2`
+  `--dir` is not a directory, or the skill name is unknown.
 
-`decided skill install` writes each skill to
-`.claude/skills/<name>/SKILL.md` under the target directory — the documented
-Claude Code project-level discovery path — creating parent directories as
-needed. An existing skill file is never overwritten. The no-name form is
-all-or-nothing: every target path is checked first, and if any exists the
-command refuses with exit `1`, reports the existing path(s), and writes
-nothing. To add a single missing skill alongside ones already installed,
-name it: `decided skill install rac-review`.
+The current skills are:
+
+- `decided-artifacts` — author and maintain artifacts.
+- `decided-review` — review and triage a corpus.
+- `decided-import` — reformat one existing Markdown document with review.
+- `decided-capture` — capture one new decision or requirement by interview.
 
 ```bash
-decided skill install                       # all bundled skills, current project
-decided skill install rac-review            # one skill by name
-decided skill install --dir ../app --json   # into another project
-decided skill list                          # what is bundled
+decided skill install
+decided skill install decided-artifacts
+decided skill install --dir ../app --json
+decided skill list
 ```
 
-```text
-Bundled agent skills:
-
-- rac-artifacts  Author and maintain RAC Markdown artifacts with the rac CLI.
-- rac-review     Review a RAC corpus and work findings worst-first.
-- rac-ingest     Convert legacy documents into valid, linked RAC artifacts.
-```
-
-The install `--json` form reports one entry per installed skill:
-
-```json
-{
-  "schema_version": "1",
-  "installed": true,
-  "skills": [
-    {
-      "skill": "rac-artifacts",
-      "path": ".claude/skills/rac-artifacts/SKILL.md"
-    },
-    {
-      "skill": "rac-review",
-      "path": ".claude/skills/rac-review/SKILL.md"
-    },
-    {
-      "skill": "rac-ingest",
-      "path": ".claude/skills/rac-ingest/SKILL.md"
-    }
-  ]
-}
-```
-
----
+The installed files live at `.claude/skills/<name>/SKILL.md`. Existing files
+are never overwritten; the all-skills form checks every destination before it
+writes anything.
 
 ## hook
 
 Install or list the bundled git hooks. Two hooks are bundled: `post-commit`
 (an advisory write-cadence nudge that prints when the corpus has gone quiet and
 **never blocks** a commit) and `pre-commit` (validates staged Markdown
-artifacts and blocks the commit on errors). Hook scripts ship with the
-distribution as package resources, so installation works from an installed
-wheel without this repository.
+artifacts and blocks the commit on errors). Hook scripts ship with the native
+distribution as package resources, so installation works without this
+repository.
 
 - **Input:** `decided hook install` — install one hook. `decided hook list` —
   enumerate the bundle.

--- a/docs/ecosystem.md
+++ b/docs/ecosystem.md
@@ -1,20 +1,20 @@
-# Ecosystem
+# AsDecided ecosystem
 
-Things that consume RAC artifacts or the RAC engine. Every entry is
+Things that consume AsDecided artifacts or the native engine. Every entry is
 real and verified at the time of listing: it exists at the cited
 location and works against a released engine version. There are no
 planned or placeholder entries.
 
 | Name | What it is | Where |
 | --- | --- | --- |
-| RAC dogfood corpus | This repository's own product knowledge — requirements, decisions, roadmaps, prompts, designs — validated in CI by the engine it specifies | [`decisions/`](https://github.com/asdecided/core/tree/main/decisions/) |
-| `rac-artifacts` Claude Code skill | A project-level agent skill that teaches Claude Code to create, validate, and update RAC artifacts using the `rac` CLI | [`.claude/skills/rac-artifacts/`](https://github.com/asdecided/core/blob/main/.claude/skills/rac-artifacts/SKILL.md) |
+| AsDecided dogfood corpus | This repository's own product knowledge — requirements, decisions, roadmaps, prompts, designs — validated in CI by the engine it specifies | [`decisions/`](https://github.com/asdecided/core/tree/main/decisions/) |
+| `decided-artifacts` Claude Code skill | A bundled project-level agent skill that teaches Claude Code to create, validate, and update AsDecided artifacts using the `decided` CLI | [`rust/rac-engine/assets/skills/decided-artifacts/`](https://github.com/asdecided/core/blob/main/rust/rac-engine/assets/skills/decided-artifacts/SKILL.md) |
 | MCP grounding example | A runnable demo showing an agent connected to AsDecided over MCP respecting a recorded decision that an unconnected agent violates | [`examples/guide/`](https://github.com/asdecided/core/blob/main/examples/guide/demo.md) |
-| Amp setup | A worked setup connecting Sourcegraph's Amp to RAC — it reads the generated `AGENTS.md` natively and queries the `asdecided` MCP server | [`examples/amp/`](https://github.com/asdecided/core/blob/main/examples/amp/README.md) |
-| Claude Code setup | A worked setup connecting Claude Code to RAC — the generated `CLAUDE.md`, the `asdecided` MCP server, the `rac-artifacts` skill, and the optional pre-edit veto hook | [`examples/claude-code/`](https://github.com/asdecided/core/blob/main/examples/claude-code/README.md) |
-| Codex setup | A worked setup connecting OpenAI Codex to RAC — it reads the generated `AGENTS.md` and queries the `asdecided` MCP server via `config.toml` | [`examples/codex/`](https://github.com/asdecided/core/blob/main/examples/codex/README.md) |
-| Cursor setup | A worked setup connecting Cursor to RAC — it reads the generated `AGENTS.md` and queries the `asdecided` MCP server via `.cursor/mcp.json` | [`examples/cursor/`](https://github.com/asdecided/core/blob/main/examples/cursor/README.md) |
-| GitHub Copilot setup | A worked setup connecting Copilot in VS Code to RAC — the generated `.github/copilot-instructions.md` plus the `asdecided` MCP server in agent mode | [`examples/copilot/`](https://github.com/asdecided/core/blob/main/examples/copilot/README.md) |
+| Amp setup | A worked setup connecting Sourcegraph's Amp to AsDecided — it reads the generated `AGENTS.md` natively and queries the `asdecided` MCP server | [`examples/amp/`](https://github.com/asdecided/core/blob/main/examples/amp/README.md) |
+| Claude Code setup | A worked setup connecting Claude Code to AsDecided — the generated `CLAUDE.md`, the `asdecided` MCP server, the `decided-artifacts` skill, and the optional pre-edit veto hook | [`examples/claude-code/`](https://github.com/asdecided/core/blob/main/examples/claude-code/README.md) |
+| Codex setup | A worked setup connecting OpenAI Codex to AsDecided — it reads the generated `AGENTS.md` and queries the `asdecided` MCP server via `config.toml` | [`examples/codex/`](https://github.com/asdecided/core/blob/main/examples/codex/README.md) |
+| Cursor setup | A worked setup connecting Cursor to AsDecided — it reads the generated `AGENTS.md` and queries the `asdecided` MCP server via `.cursor/mcp.json` | [`examples/cursor/`](https://github.com/asdecided/core/blob/main/examples/cursor/README.md) |
+| GitHub Copilot setup | A worked setup connecting Copilot in VS Code to AsDecided — the generated `.github/copilot-instructions.md` plus the `asdecided` MCP server in agent mode | [`examples/copilot/`](https://github.com/asdecided/core/blob/main/examples/copilot/README.md) |
 
 ## Adding an entry
 
@@ -23,18 +23,19 @@ An entry is one row in the table above. The criteria:
 - The thing exists — on disk in this repository or at a stated
   external location — and can be inspected; intentions and
   works-in-progress are not listed.
-- It consumes RAC artifacts or the RAC engine against a released
+- It consumes AsDecided artifacts or the native engine against a released
   version.
 - The row states what it is and where it lives, in one line.
 
 Entries are added by a pull request changing the single table row.
-The project's contribution policy is pending; until it is published,
-external additions cannot yet be accepted.
+Contributions follow [`CONTRIBUTING.md`](https://github.com/asdecided/core/blob/main/CONTRIBUTING.md)
+and the Developer Certificate of Origin; external additions are welcome via
+pull request.
 
 ### Harness integration recipes
 
 A harness integration (a worked `examples/<client>/` setup connecting a
-coding agent to RAC) follows a template and a verification gate — see the
+coding agent to AsDecided) follows a template and a verification gate — see the
 [integration recipes authoring guide](integration-recipes.md). A recipe is
 listed here **only after it is smoke-tested against a released engine
 version** by running the grounding demo ([`examples/guide/`](https://github.com/asdecided/core/blob/main/examples/guide/demo.md))

--- a/docs/integration-recipes.md
+++ b/docs/integration-recipes.md
@@ -1,6 +1,6 @@
-# Integration recipes — authoring guide
+# AsDecided integration recipes — authoring guide
 
-RAC meets a coding agent on two surfaces it does not own: a generated
+AsDecided meets a coding agent on two surfaces it does not own: a generated
 agent-instructions file the agent reads (the **push**), and the `asdecided` MCP server
 the agent connects to for live retrieval (the **pull**). Because both are standard
 surfaces, connecting a new harness is **documentation, not engine work** — a worked
@@ -28,7 +28,7 @@ template (ADR-021).
 
 A recipe README has these parts, in this order:
 
-1. **Title and framing** — `# RAC with <Client>`, then one line naming the two
+1. **Title and framing** — `# AsDecided with <Client>`, then one line naming the two
    surfaces (the context file the client reads, and the `asdecided` MCP server).
 2. **Prerequisites** — `brew install asdecided/tap/asdecided-core` and a corpus under `decisions/`.
 3. **Context file (the push)** — `decided export decisions/ --agent-rules`, and which

--- a/docs/org-grounding.md
+++ b/docs/org-grounding.md
@@ -52,7 +52,8 @@ Nothing about it is special to the engine. What makes it work is editorial:
 
 - **Curate the live constraints, not the archive.** A few hundred binding,
   current decisions ground agents better than ten thousand imported pages.
-  Seed it with [`decided ingest`](cli.md#ingest) from what already exists, and
+  Seed it with an ingestion connector from
+  [`asdecided/connectors`](https://github.com/asdecided/connectors), then
   promote only what an owner ratifies as live.
 - **Govern it like code.** Changes land by pull request behind required
   review; use `CODEOWNERS` on `decisions/decisions/` so every standard has an

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -122,11 +122,11 @@ A composite GitHub Action wraps `decided validate --sarif` and uploads the resul
 GitHub Code Scanning, so findings annotate the pull request inline. The decision
 behind it is
 [ADR-058](https://github.com/asdecided/core/blob/main/decisions/decisions/adr-058-validation-github-action.md);
-it is a thin wrapper — the `rac` CLI stays the source of truth.
+it is a thin wrapper — the `decided` CLI stays the source of truth.
 
 ```yaml
-# .github/workflows/rac.yml
-name: RAC
+# .github/workflows/asdecided.yml
+name: AsDecided
 on: [pull_request]
 permissions:
   contents: read
@@ -141,8 +141,8 @@ jobs:
           path: decisions/
 ```
 
-Inputs: `path` (default `rac`), `upload-sarif` (default `true`), `sarif-file`,
-`rac-version` (pin a release), and `install-from` (`pypi` or `source`). Errors
+Inputs: `path` (default `decisions`), `upload-sarif` (default `true`), and
+`sarif-file`. Errors
 fail the check; warnings — including findings downgraded in `.decided/config.yaml` —
 annotate without failing, so a legacy repo can adopt the gate green on day one and
 tighten over time.
@@ -159,15 +159,15 @@ surface — see [Watchkeeper](watchkeeper.md).)
 
 To carry the whole contract into one required check, `decided gate` composes
 validation, relationship integrity, and review into a single enforced verdict
-under the corpus **enforcement policy**, and emits one combined SARIF document
-(v0.21.14). The `pr-gate-action` runs it and uploads that single SARIF to Code
-Scanning under one category (`rac-gate`), failing when any finding is *blocking*.
+under the corpus **enforcement policy**, and emits one combined SARIF document.
+The `pr-gate-action` runs it and uploads that single SARIF to Code Scanning
+under one category (`decided-gate`), failing when any finding is *blocking*.
 It is the same thin wrapper — the engine decides what is blocking, the action
 computes nothing ([ADR-063](https://github.com/asdecided/core/blob/main/decisions/decisions/adr-063-non-python-clients-are-thin.md)):
 
 ```yaml
-# .github/workflows/rac.yml
-name: RAC
+# .github/workflows/asdecided.yml
+name: AsDecided
 on: [pull_request]
 permissions:
   contents: read
@@ -182,9 +182,9 @@ jobs:
           path: decisions/
 ```
 
-Inputs mirror `validate-action`: `path` (default `rac`), `upload-sarif` (default
-`true`), `sarif-dir` (default `rac-sarif`, now one `gate.sarif`), `rac-version`,
-and `install-from` (`pypi` or `source`).
+Inputs mirror `validate-action`: `path` (default `decisions`),
+`upload-sarif` (default `true`), and `sarif-dir` (default `decided-sarif`, with
+one `gate.sarif` output).
 
 `decided gate <dir>` is also runnable locally — `--json` and `--sarif` produce the
 machine contracts, the exit code is `0` when nothing is blocking and `1`

--- a/docs/watchkeeper.md
+++ b/docs/watchkeeper.md
@@ -14,7 +14,7 @@ only network use in CI is installing the package.
 ## The command
 
 ```bash
-decided watchkeeper rac --base main
+decided watchkeeper decisions/ --base main
 ```
 
 See the [CLI reference](cli.md#watchkeeper) for every flag, the finding
@@ -59,7 +59,7 @@ On every pull request that touches your corpus you get:
 
 | Input | Default | Meaning |
 | --- | --- | --- |
-| `path` | `rac` | Corpus directory to compare |
+| `path` | `decisions` | Corpus directory to compare |
 | `base` | `''` | Base revision; empty resolves to `origin/<PR base branch>` |
 | `fail-on` | `error` | `error` · `warning` · `none` (report, never fail) |
 | `annotate` | `true` | Emit inline annotations |
@@ -77,7 +77,7 @@ jobs:
   watchkeeper:
     uses: asdecided/core/.github/workflows/watchkeeper.yml@<release-tag>
     with:
-      path: rac
+      path: decisions
 ```
 
 It wires up the full-history checkout and passes every input through to

--- a/examples/_recipe-template/README.md
+++ b/examples/_recipe-template/README.md
@@ -9,9 +9,9 @@ change the wording of section 3 (Enforcement) — it is fixed by ADR-067 so the
 boundary reads identically across every recipe. Delete these HTML comments as you
 go; a finished recipe carries none of them.
 -->
-# RAC with <Client>
+# AsDecided with <Client>
 
-[<Client>](<client-url>) consumes RAC on two surfaces — a generated context file
+[<Client>](<client-url>) consumes AsDecided on two surfaces — a generated context file
 <Client> reads, and the `asdecided` MCP server it connects to. A stranger can reproduce
 this from the file alone.
 
@@ -21,7 +21,7 @@ this from the file alone.
 brew install asdecided/tap/asdecided-core   # the `decided` CLI and the `decided-mcp` server
 ```
 
-A repository with a RAC corpus under `decisions/` (run `decided quickstart`, or use this
+A repository with an AsDecided corpus under `decisions/` (run `decided quickstart`, or use this
 repository's own `decisions/`).
 
 ## 1. Context file (the push)
@@ -73,7 +73,7 @@ every call and never writes to the repo.
 
 <!-- FIXED WORDING (ADR-067). Only swap <Client> for the harness name; change nothing
 else in this section so the boundary reads identically across every recipe. -->
-RAC supplies context and enforces *after* the edit (ADR-067). There is no platform
+AsDecided supplies context and enforces *after* the edit (ADR-067). There is no platform
 API to veto a <Client> agent edit before it lands, so <Client> relies on the
 post-edit guard: `decided validate` / `decided relationships --validate` and the GitHub
 Action / pre-merge gate, the same as any contributor. (A pre-edit veto is
@@ -94,6 +94,6 @@ unconnected run violates: [`examples/guide/`](../guide/demo.md).
 | CI gate | `decided validate` · `decided relationships --validate` | Enforces on every PR |
 
 <!-- Before this recipe is listed in docs/ecosystem.md it MUST be smoke-tested against
-a released rac-core version (docs/integration-recipes.md, the verification gate).
+a released AsDecided core version (docs/integration-recipes.md, the verification gate).
 Until then, keep the marker below and stay off the ecosystem table. -->
 <!-- TODO: verify against <Client> <version> before listing in docs/ecosystem.md -->

--- a/examples/claude-code/README.md
+++ b/examples/claude-code/README.md
@@ -1,4 +1,4 @@
-# RAC with Claude Code
+# AsDecided with Claude Code
 
 [Claude Code](https://docs.anthropic.com/en/docs/claude-code) is AsDecided's most
 integrated client — it gets the two surfaces every client gets (a generated
@@ -12,7 +12,7 @@ bundled authoring **skill** and the only platform seam that allows a real
 brew install asdecided/tap/asdecided-core   # the `decided` CLI and the `decided-mcp` server
 ```
 
-A repository with a RAC corpus under `decisions/` (run `decided quickstart`, or use this
+A repository with an AsDecided corpus under `decisions/` (run `decided quickstart`, or use this
 repository's own `decisions/`).
 
 ## 1. `CLAUDE.md` — context every session (the push)
@@ -49,30 +49,30 @@ on every call and never writes to the repo.
 ## 3. The authoring skill (Claude-Code-specific)
 
 ```bash
-decided skill install rac-artifacts
+decided skill install decided-artifacts
 ```
 
 Installs a project skill that teaches Claude Code to create, validate, and
-update RAC artifacts with the `rac` CLI (it only touches the `decisions/` subtree).
-`decided skill list` shows the bundled skills (`rac-artifacts`, `rac-import`,
-`rac-ingest`, `rac-review`).
+update AsDecided artifacts with the `decided` CLI (it only touches the
+`decisions/` subtree). `decided skill list` shows the bundled skills
+(`decided-artifacts`, `decided-capture`, `decided-import`, `decided-review`).
 
 ## 4. Enforcement — two seams
 
-RAC supplies context and enforces *after* the edit (ADR-067); it does not rewrite
+AsDecided supplies context and enforces *after* the edit (ADR-067); it does not rewrite
 Claude Code's loop. Two optional guards:
 
 - **Git hook (any client).** `decided hook install --style pre-commit` validates
   staged artifacts on commit (`--style post-commit` is an advisory cadence
   nudge that never blocks). This is a *git* hook, not a Claude Code hook.
 - **Pre-edit veto (Claude-Code-only).** Claude Code's `PreToolUse` hook is the
-  one platform seam that can block an edit *before* it lands. The RAC VS Code /
+  one platform seam that can block an edit *before* it lands. The AsDecided VS Code /
   Cursor extension generates it ("RAC: Enable Claude Code pre-edit hook"), or you
   can register it by hand in `.claude/settings.json` under `hooks.PreToolUse`:
   it pipes the proposed content to `decided validate - --corpus decisions/` and **blocks
   (exit 2)** only on a structural finding — a reference to a retired or missing
   decision, or a malformed artifact — and **fails open** on any internal error.
-  All validation stays in `rac`; the hook computes nothing (ADR-063, ADR-067).
+  All validation stays in `decided`; the hook computes nothing (ADR-063, ADR-067).
 
 Either way, the CI / PR gate (`decided validate`, `decided relationships --validate`)
 remains the backstop, regardless of which agent edited.
@@ -89,6 +89,6 @@ unconnected run violates: [`examples/guide/`](../guide/demo.md).
 | --- | --- | --- |
 | `CLAUDE.md` | `decided export decisions/ --agent-rules` | Reads it every session |
 | `asdecided` MCP | `claude mcp add asdecided -- decided-mcp --root .` | Calls `find_decisions` / `get_related` on demand |
-| Skill | `decided skill install rac-artifacts` | Authors artifacts with the `rac` CLI |
+| Skill | `decided skill install decided-artifacts` | Authors artifacts with the `decided` CLI |
 | Pre-edit veto | `.claude/settings.json` → `PreToolUse` → `decided validate - --corpus decisions/` | Blocks an edit that contradicts a decision |
 | CI gate | `decided validate` · `decided relationships --validate` | Enforces on every PR |

--- a/rust/decided-mcp/tests/docs_contract.rs
+++ b/rust/decided-mcp/tests/docs_contract.rs
@@ -19,6 +19,82 @@ fn repo_root() -> PathBuf {
         .to_path_buf()
 }
 
+const SUPPORTED_DECIDED_COMMANDS: &[&str] = &[
+    "validate",
+    "diff",
+    "stats",
+    "inspect",
+    "improve",
+    "schema",
+    "relationships",
+    "rename",
+    "review",
+    "doctor",
+    "coverage",
+    "gate",
+    "watchkeeper",
+    "portfolio",
+    "index",
+    "export",
+    "mcp-stats",
+    "telemetry",
+    "usage",
+    "new",
+    "templates",
+    "init",
+    "quickstart",
+    "resolve",
+    "find",
+    "decisions-for",
+    "eval",
+    "migrate",
+    "skill",
+    "hook",
+    "retrieve",
+    "sentry",
+    "herald",
+];
+
+fn documented_decided_command(line: &str) -> Option<&str> {
+    let line = line.trim();
+    let line = line
+        .strip_prefix("$ ")
+        .or_else(|| line.strip_prefix("> "))
+        .unwrap_or(line);
+    let mut words = line.split_whitespace();
+    if words.next()? != "decided" {
+        return None;
+    }
+    let command = words.next()?;
+    if command.starts_with('<') || command.starts_with('-') {
+        return None;
+    }
+    Some(command.trim_matches('`'))
+}
+
+fn assert_fenced_commands_are_supported(root: &Path, relative: &str) {
+    let path = root.join(relative);
+    let text = fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("read command contract surface {relative}: {error}"));
+    let mut in_fence = false;
+    for (line_number, line) in text.lines().enumerate() {
+        if line.trim_start().starts_with("```") {
+            in_fence = !in_fence;
+            continue;
+        }
+        if !in_fence {
+            continue;
+        }
+        let Some(command) = documented_decided_command(line) else {
+            continue;
+        };
+        assert!(
+            SUPPORTED_DECIDED_COMMANDS.contains(&command),
+            "{relative}:{line_number}: documented unsupported decided subcommand {command:?}"
+        );
+    }
+}
+
 #[test]
 fn guide_documents_the_native_surface_and_starts_the_example_server() {
     let root = repo_root();
@@ -149,6 +225,9 @@ fn public_docs_and_recipes_do_not_reintroduce_retired_surfaces() {
         "docs/ecosystem.md",
         "docs/governance.md",
         "docs/relationships.md",
+        "docs/org-grounding.md",
+        "docs/validation.md",
+        "docs/watchkeeper.md",
         "examples/_recipe-template/README.md",
         "examples/amp/README.md",
         "examples/claude-code/README.md",
@@ -162,6 +241,10 @@ fn public_docs_and_recipes_do_not_reintroduce_retired_surfaces() {
         "examples/opencode/README.md",
         "examples/windsurf/README.md",
         "examples/zed/README.md",
+        "rust/rac-engine/assets/skills/decided-artifacts/SKILL.md",
+        "rust/rac-engine/assets/skills/decided-capture/SKILL.md",
+        "rust/rac-engine/assets/skills/decided-import/SKILL.md",
+        "rust/rac-engine/assets/skills/decided-review/SKILL.md",
     ];
     let banned = [
         "--telemetry",
@@ -173,6 +256,16 @@ fn public_docs_and_recipes_do_not_reintroduce_retired_surfaces() {
         "mcpServers.lore",
         "examples/guide/rac",
         ".rac/",
+        "decided ingest ",
+        "decided-ingest",
+        "decided explorer ",
+        "rac-artifacts",
+        "rac-review",
+        "rac-import",
+        "rac-ingest",
+        "rac-core",
+        "pip install",
+        "`rac` CLI",
     ];
     for relative in surfaces {
         let path = root.join(relative);
@@ -184,6 +277,41 @@ fn public_docs_and_recipes_do_not_reintroduce_retired_surfaces() {
                 "{relative} reintroduces retired surface {needle:?}"
             );
         }
+    }
+
+    for relative in [
+        "README.md",
+        "CONTRIBUTING.md",
+        "docs/artifacts.md",
+        "docs/cli.md",
+        "docs/context-cost.md",
+        "docs/governance.md",
+        "docs/index.md",
+        "docs/integration-recipes.md",
+        "docs/mcp.md",
+        "docs/okf-profile.md",
+        "docs/org-grounding.md",
+        "docs/quickstart.md",
+        "docs/repo-workflow.md",
+        "docs/relationships.md",
+        "docs/security.md",
+        "docs/validation.md",
+        "docs/watchkeeper.md",
+        "examples/_recipe-template/README.md",
+        "examples/amp/README.md",
+        "examples/claude-code/README.md",
+        "examples/cline/README.md",
+        "examples/codex/README.md",
+        "examples/copilot/README.md",
+        "examples/cursor/README.md",
+        "examples/guide/demo.md",
+        "examples/obey-demo/README.md",
+        "examples/omnigent/README.md",
+        "examples/opencode/README.md",
+        "examples/windsurf/README.md",
+        "examples/zed/README.md",
+    ] {
+        assert_fenced_commands_are_supported(&root, relative);
     }
 
     let index = fs::read_to_string(root.join("docs/index.md")).expect("read docs index");

--- a/rust/rac-engine/assets/skills/decided-artifacts/SKILL.md
+++ b/rust/rac-engine/assets/skills/decided-artifacts/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: decided-artifacts
-description: Author and maintain RAC (requirements-as-code) Markdown artifacts — requirements, decisions, roadmaps, prompts, designs — using the decided CLI. Use when asked to create, read, validate, update, or link AsDecided (RAC) artifacts in a project's decisions/ directory.
+description: Author and maintain AsDecided Markdown artifacts — requirements, decisions, roadmaps, prompts, designs — using the decided CLI. Use when asked to create, read, validate, update, or link artifacts in a project's decisions/ directory.
 ---
 
 # RAC artifacts

--- a/rust/rac-engine/assets/skills/decided-capture/SKILL.md
+++ b/rust/rac-engine/assets/skills/decided-capture/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: decided-capture
-description: Capture a NEW decision or requirement from a conversation (an interview) into ONE valid RAC (requirements-as-code) artifact — you interview and propose, the human ratifies, `decided validate` closes, and promotion into the trusted corpus is by pull request reviewed by someone other than the author. Use when a user wants to record a fresh decision or requirement into AsDecided (a project's decisions/ directory) by talking it through rather than importing a document. For an existing document use decided-import; for bulk conversion use decided-ingest.
+description: Capture a NEW decision or requirement from a conversation (an interview) into ONE valid AsDecided artifact — you interview and propose, the human ratifies, `decided validate` closes, and promotion into the trusted corpus is by pull request reviewed by someone other than the author. Use when a user wants to record a fresh decision or requirement into AsDecided (a project's decisions/ directory) by talking it through rather than importing a document. For an existing document use decided-import; for bulk conversion use an external ingestion connector.
 ---
 
 # RAC interview capture
@@ -153,7 +153,7 @@ Never open-and-self-approve, and never merge the author's own capture for them.
 
 - Reformatting an **existing document** into an artifact — use `decided-import`.
 - Bulk or batch conversion, directory crawling, or "migrate my whole wiki" — use
-  `decided-ingest`.
+  an external AsDecided ingestion connector.
 - Inferring relationships by scanning the repository — only the links the author
   names, each confirmed.
 - Inventing context, consequences, rationale, or requirements the author did not

--- a/rust/rac-engine/assets/skills/decided-import/SKILL.md
+++ b/rust/rac-engine/assets/skills/decided-import/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: decided-import
-description: Reformat ONE existing document (a decision, requirement, design, roadmap, or prompt) into ONE valid RAC (requirements-as-code) artifact, with a mandatory human-review step before any file is written and `decided validate` as the deterministic close. Use when a user wants to add or import a single existing decision or document into AsDecided (a project's decisions/ directory). Single-document only — for multi-format or bulk conversion use the decided-ingest skill.
+description: Reformat ONE existing Markdown document (a decision, requirement, design, roadmap, or prompt) into ONE valid AsDecided artifact, with a mandatory human-review step before any file is written and `decided validate` as the deterministic close. Use when a user wants to add or import a single existing document into AsDecided (a project's decisions/ directory). Single-document only — for rich documents or bulk conversion use an external AsDecided ingestion connector.
 ---
 
 # RAC single-document import
@@ -13,8 +13,9 @@ adds AI to the AsDecided core — it runs in the coding agent and uses the `deci
 
 - **One document in, one artifact out.** If asked to import a directory, a
   whole wiki, or several documents at once, stop and explain that this skill
-  handles exactly one document → one artifact by design. For multi-format or
-  bulk conversion, point the user to the `decided-ingest` skill.
+  handles exactly one Markdown document → one artifact by design. For rich
+  documents or bulk conversion, point the user to an external AsDecided
+  ingestion connector.
 - **The schema is not yours to invent.** Read the real shape with
   `decided schema <type>` (and `decided schema` for the list of recognised types).
   Use the real section names, the real five artifact types, and the real
@@ -41,17 +42,12 @@ not obvious, what kind of decision or requirement it represents. If they offer
 more than one document or a directory, apply the single-document constraint
 above before going further.
 
-## 2. Convert (only if not already Markdown)
+## 2. Get Markdown (if the source is rich text)
 
-```bash
-decided ingest decision.docx          # preview Markdown on stdout
-```
-
-`decided ingest <file>` converts DOCX / PDF / HTML / PPTX / XLSX / Markdown to
-Markdown text, preserving structure — it does not judge whether the result is a
-valid artifact. Pasted Markdown needs no conversion. Rich formats need the
-optional extras (`pip install 'decided-core[ingest]'`, `[ingest-pdf]`,
-`[ingest-office]`); the command names the missing extra when one is needed.
+The native engine does not ingest DOCX, PDF, HTML, PPTX, or XLSX. Ask the user
+to run an external AsDecided ingestion connector and provide the resulting
+Markdown for review. Pasted Markdown needs no conversion. This skill never
+installs Python packages or silently changes the source document.
 
 ## 3. Choose the type and read its real schema
 
@@ -133,7 +129,8 @@ fill a missing recommended section. If the artifact links to others, finish with
 ## Out of scope
 
 - Bulk or batch import, directory crawling, or "migrate my whole wiki" (one
-  document → one artifact only; use `decided-ingest` for broader conversion).
+  Markdown document → one artifact only; use an external ingestion connector
+  for broader conversion).
 - Inferring relationships by scanning the repository — only the links the source
   document itself names, each confirmed by the user.
 - Auto-committing the new artifact without the human-review step.

--- a/rust/rac-engine/src/commands.rs
+++ b/rust/rac-engine/src/commands.rs
@@ -603,7 +603,7 @@ fn read_markdown_input(target: &str, command: &str) -> Result<String, i32> {
     let suffix = py_suffix_lower(target);
     if suffix != ".md" && suffix != ".markdown" {
         return Err(usage_error(&format!(
-            "{command} expects a Markdown file; convert it first with: decided ingest {target}"
+            "{command} expects a Markdown file; convert {target} first with an AsDecided ingestion connector"
         )));
     }
     match std::fs::read(target) {
@@ -716,8 +716,8 @@ pub fn cmd_relationships(args: &RelationshipsArgs) -> i32 {
             .unwrap_or_default();
         if suffix != ".md" && suffix != ".markdown" {
             return usage_error(&format!(
-                "relationships expects a Markdown file or directory; \
-                 convert it first with: decided ingest {}",
+                "relationships expects a Markdown file or directory: {}; \
+                 convert it first with an AsDecided ingestion connector",
                 args.path
             ));
         }


### PR DESCRIPTION
## Summary

Closes the next enterprise deployability slice from DEP-03/DEP-09: make the
public guidance describe the native AsDecided distribution, then make that
claim self-checking in CI.

## What changed

- rewrote the CLI reference's retired `explorer` and unimplemented `ingest`
  sections around the supported native boundary; initial rich-document
  conversion now points to `asdecided/connectors`
- removed stale RAC/Python-era install commands and skill names from the
  README, contribution guide, recipes, examples, ecosystem page, validation
  and Watchkeeper docs, and bundled skills
- corrected native action inputs, SARIF category names, repository paths, and
  Apache-2.0 wording
- stopped native error messages from recommending the nonexistent `decided
  ingest` command
- extended the MCP docs contract test to scan public fenced `decided` commands
  against the shipped command surface and reject retired identifiers
- added a PR-wide guidance-drift job that runs the generated agent-rule check
  and the expanded docs/MCP contract, including for docs-only changes

## Validation

- `cargo test --manifest-path rust/Cargo.toml --workspace --release`
- `rust/target/release/decided export decisions/ --agent-rules --check`
- `cargo test --manifest-path rust/Cargo.toml -p decided-mcp --test docs_contract --release`
- `actionlint .github/workflows/*.yml`
- `git diff --check`

All release-mode workspace tests passed, including 2 docs-contract tests and
the CLI generated-guidance test.
