### PR TITLE
ci(engine): enforce dependency supply-chain policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: /rust
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      rust-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: /rac-localview
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      npm-dependencies:
+        patterns:
+          - "*"

--- a/.github/workflows/rust-spike.yml
+++ b/.github/workflows/rust-spike.yml
@@ -18,12 +18,16 @@ on:
     paths:
       - "rust/**"
       - "decisions/**"
+      - "deny.toml"
+      - ".github/dependabot.yml"
       - ".github/workflows/rust-spike.yml"
   push:
     branches: [main]
     paths:
       - "rust/**"
       - "decisions/**"
+      - "deny.toml"
+      - ".github/dependabot.yml"
       - ".github/workflows/rust-spike.yml"
 
 jobs:
@@ -169,3 +173,19 @@ jobs:
           python rust/tools/live_corpus_invariants.py \
             --engine rust/target/release/decided \
             --corpus decisions
+
+  dependency-policy:
+    name: dependency policy (cargo-deny)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      # deny.toml bans outbound HTTP/TLS/async stacks, restricts sources to
+      # crates.io, and checks the RustSec advisory and license databases.
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          manifest-path: rust/Cargo.toml
+          arguments: --all-features --locked

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,10 +1,11 @@
 # Security Model
 
-This document describes the trust and threat model for **RAC Core** and the
-**AsDecided** read-only MCP server in this repository. It is scoped to that surface:
-it explains what the read-only guarantee does and does not protect, and how to
-report a vulnerability. It deliberately does **not** promise a vulnerability-
-response SLA, a content sanitizer, or any automated per-artifact trust verdict.
+This document describes the trust and threat model for the native **AsDecided**
+engine and read-only MCP server in this repository. It explains what the
+read-only guarantee does and does not protect, and how to report a
+vulnerability. We target an acknowledgment within **five business days**;
+that is an acknowledgment target, not a fix-time SLA. This policy does not
+promise a content sanitizer or any automated per-artifact trust verdict.
 
 ## Trust model
 
@@ -67,9 +68,50 @@ RAC never sanitizes, rewrites, redacts, or filters artifact content. The
 trust boundary stays human PR review (ADR-065); the aids inform that review,
 they do not replace it.
 
+## Supported versions
+
+AsDecided is maintained on a latest-release basis. The current stable release
+is the supported security target; older minor lines, prereleases, snapshots,
+and the archived `python-engine-final` snapshot are not supported. If a report
+affects an older release, upgrade to the current stable release before
+requesting a backport.
+
+| Version | Security support |
+| --- | --- |
+| Current stable release | Investigated; fixes are best-effort and may require an upgrade to a newer release |
+| Older minor releases | Not supported; upgrade to current stable |
+| Prereleases, snapshots, and archived Python engine | Not supported |
+
 ## Reporting a vulnerability
 
 Report suspected vulnerabilities privately through GitHub's **"Report a
 vulnerability"** flow on this repository's **Security** tab (private security
-advisories). Please do not open a public issue for a security report. This is
-the report channel; it does not carry a response-time commitment.
+advisories). Please do not open a public issue for a security report. Include
+the affected version or commit, operating system, a minimal reproduction, and
+the impact you observed; redact secrets and personal data.
+
+We aim to acknowledge a report within five business days. We do not promise a
+fix deadline: this is a solo-maintained open-source project, and a fix may
+require a release or an upgrade path. We will keep the advisory private while
+we assess it and will coordinate disclosure with the reporter where practical.
+
+## Advisories and identifiers
+
+For a confirmed vulnerability with material security impact, we intend to
+publish a GitHub Security Advisory and request a CVE through GitHub's CVE
+Numbering Authority when the issue is eligible. Not every report qualifies for
+a CVE; the advisory and release notes will explain the affected versions,
+severity, mitigations, and fixed version when one exists.
+
+## Safe harbor for good-faith research
+
+Security research is welcome when it is conducted against a local copy,
+disposable test corpus, or another system you are authorized to test. Please
+avoid accessing data that is not yours, exfiltrating secrets, degrading
+availability, modifying another person's repository, social engineering, or
+automated high-volume scanning of public infrastructure. Stop testing and
+contact us if you encounter real user data or a service-impacting condition.
+
+We will not initiate legal action for good-faith research that follows these
+guidelines. We ask researchers to allow reasonable time for assessment and
+coordinated disclosure before making details public.

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,76 @@
+# AsDecided dependency policy.
+#
+# The native engine is deliberately local-first: outbound HTTP, TLS, async
+# runtimes, and cryptographic client stacks are not part of the workspace.
+# Keep this file small and explicit so a dependency addition cannot silently
+# change that boundary.
+
+[graph]
+all-features = true
+
+[advisories]
+version = 2
+# A direct serde_yaml dependency remains while the native YAML compatibility
+# layer is migrated. It is archived upstream but has no matching RustSec
+# advisory in the database used by this check; keep the migration visible in
+# review rather than silently treating it as healthy. `derivative` is
+# transitive; `workspace` keeps direct additions blocking while retaining
+# visibility for transitive maintenance notices.
+unmaintained = "workspace"
+ignore = [
+    { id = "RUSTSEC-2024-0421", reason = "idna 0.3 is pulled transitively by mdurl for local Markdown HTML rendering; AsDecided never resolves hosts, fetches URLs, or performs network authorization. Revisit if URL fetching is ever added." },
+]
+
+[licenses]
+version = 2
+confidence-threshold = 0.8
+allow = [
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "ISC",
+    "MIT",
+    "Unicode-3.0",
+    "Unlicense",
+    "Zlib",
+]
+unused-allowed-license = "warn"
+
+[licenses.private]
+ignore = false
+
+[bans]
+# Existing duplicate versions are warnings while Dependabot works through the
+# graph. A newly introduced wildcard dependency is not acceptable.
+multiple-versions = "warn"
+wildcards = "deny"
+deny = [
+    # Outbound HTTP clients and transport stacks.
+    { crate = "reqwest", reason = "AsDecided core has no outbound network client; fronting infrastructure owns network egress." },
+    { crate = "ureq", reason = "AsDecided core has no outbound network client; fronting infrastructure owns network egress." },
+    { crate = "isahc", reason = "AsDecided core has no outbound network client; fronting infrastructure owns network egress." },
+    { crate = "curl", reason = "AsDecided core has no outbound network client; fronting infrastructure owns network egress." },
+    { crate = "curl-sys", reason = "AsDecided core has no outbound network client; fronting infrastructure owns network egress." },
+    { crate = "hyper", reason = "AsDecided core uses a bounded std::net listener rather than an async HTTP stack." },
+    { crate = "hyper-util", reason = "AsDecided core uses a bounded std::net listener rather than an async HTTP stack." },
+    { crate = "surf", reason = "AsDecided core has no outbound network client; fronting infrastructure owns network egress." },
+    { crate = "attohttpc", reason = "AsDecided core has no outbound network client; fronting infrastructure owns network egress." },
+    { crate = "awc", reason = "AsDecided core has no outbound network client; fronting infrastructure owns network egress." },
+    { crate = "http-client", reason = "AsDecided core has no outbound network client; fronting infrastructure owns network egress." },
+    # TLS/crypto and async runtime dependencies would create a new network
+    # boundary in a binary that is intentionally no-egress and proxy-terminated.
+    { crate = "native-tls", reason = "Transit encryption belongs to the fronting proxy, not the native engine." },
+    { crate = "openssl", reason = "The native workspace intentionally carries no cryptographic client stack." },
+    { crate = "openssl-sys", reason = "The native workspace intentionally carries no cryptographic client stack." },
+    { crate = "rustls", reason = "The native workspace intentionally carries no cryptographic client stack." },
+    { crate = "rustls-native-certs", reason = "The native workspace intentionally carries no cryptographic client stack." },
+    { crate = "rustls-pemfile", reason = "The native workspace intentionally carries no cryptographic client stack." },
+    { crate = "rustls-webpki", reason = "The native workspace intentionally carries no cryptographic client stack." },
+    { crate = "tokio", reason = "The native engine is synchronous and deliberately avoids an async runtime." },
+    { crate = "async-std", reason = "The native engine is synchronous and deliberately avoids an async runtime." },
+]
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []

--- a/docs/security.md
+++ b/docs/security.md
@@ -26,6 +26,9 @@ The shipped implementation is the Cargo workspace under `rust/`. Review
 `rust/Cargo.lock` for its resolved dependency graph. The Python package,
 Python dependency manifest, and Python engine were retired from this
 repository; the final snapshot is preserved at `python-engine-final`.
+CI enforces [`deny.toml`](https://github.com/asdecided/core/blob/main/deny.toml)
+with `cargo-deny` for RustSec advisories, accepted licenses, crates.io-only
+sources, and the no-egress dependency ban list.
 
 ## Verification
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -39,6 +39,16 @@ CI also runs contract certification against `asdecided-spec` and live-corpus
 invariants. This is a self-attested open-source security posture, not a
 third-party certification.
 
+## Vulnerability handling
+
+Report suspected vulnerabilities through the private-advisory flow described
+in the repository's [`SECURITY.md`](https://github.com/asdecided/core/blob/main/SECURITY.md).
+We target acknowledgment within five business days, support the current
+stable release on a latest-release basis, and do not promise a fix-time SLA.
+Confirmed material issues may receive a GitHub Security Advisory and a CVE
+request when eligible. The policy also includes a good-faith research safe
+harbor and coordinated-disclosure guidance.
+
 ## Release verification
 
 Each native release carries a `SHA256SUMS` file, a CycloneDX SBOM, and GitHub


### PR DESCRIPTION
## Summary

Implements DEP-10 from the enterprise deployability review: dependency
updates are now surfaced automatically, and the native Rust workspace has a
reviewable supply-chain policy enforced in CI.

## What changed

- add root `deny.toml` covering RustSec advisories, accepted SPDX licenses,
  crates.io-only sources, wildcard dependencies, and a no-egress ban list
- ban outbound HTTP clients, TLS/crypto stacks, and async runtimes so the
  native no-egress/synchronous boundary is CI-enforced rather than only
  documented
- document the existing `serde_yaml` direct-dependency exception and the
  transitive `derivative` maintenance disposition
- add weekly Dependabot updates for Cargo, GitHub Actions, and the
  `rac-localview` npm package
- add `cargo-deny` to the reusable Rust contract workflow, which is inherited
  by native, crates.io, and MCP Registry release verification
- document the policy on the public security posture page

## Validation

- `python3` TOML parse of `deny.toml`
- lockfile assertion that no banned dependency names are present
- `actionlint .github/workflows/*.yml`
- `git diff --check`

The local environment could not run `cargo-deny` itself because crates.io DNS
was unavailable; the hosted job is the authoritative advisory/license/source
check and will fetch its pinned tool and RustSec database.
