### PR TITLE
feat(mcp): require proxy acknowledgement for public binds

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -888,6 +888,9 @@ decided-mcp --root /path/to/repo \
 - **`--root PATH`** — repository root to serve (default: current directory)
 - **`--transport {stdio,http}`** — MCP transport (default: `stdio`)
 - **`--host HOST`** — HTTP bind host (default: `127.0.0.1`)
+- **`--behind-proxy`** — explicitly acknowledge a non-loopback HTTP bind;
+  required when `--host` is not loopback. This does not authenticate the
+  endpoint; put an authenticating TLS proxy in front ([deployment hardening](deployment-hardening.md)).
 - **`--port PORT`** — HTTP bind port (default: `8000`)
 - **`--path PATH`** — HTTP endpoint path (default: `/mcp`)
 - **`--budget N`** — maximum response size in characters (minimum `128`)

--- a/docs/deployment-hardening.md
+++ b/docs/deployment-hardening.md
@@ -1,0 +1,71 @@
+# Deployment Hardening
+
+The native HTTP transport is a read-only, unauthenticated server for one
+checkout. It is loopback-only by default. A non-loopback bind is a deliberate
+deployment choice: `decided-mcp` requires the explicit `--behind-proxy` flag as
+an acknowledgement that an authenticating TLS proxy fronts the process.
+
+The flag is **not** authentication, encryption, or an authorization policy. It
+only prevents an accidental `0.0.0.0` launch from looking like a safe default.
+The engine still follows the proxy-owned authentication boundary in
+[ADR-085](https://github.com/asdecided/core/blob/main/decisions/decisions/adr-085-enterprise-configuration-not-mode.md)
+and the shared-server contract in
+[ADR-098](https://github.com/asdecided/core/blob/main/decisions/decisions/adr-098-shared-http-mcp-serving.md).
+
+## Preflight checklist
+
+Before exposing a shared endpoint, verify every item:
+
+- [ ] **Private engine network:** bind the engine only on a private interface
+  reachable by the proxy. Never publish the engine port directly to the
+  internet.
+- [ ] **Explicit acknowledgement:** use `--behind-proxy` for a non-loopback
+  host. Keep the default loopback bind for local or single-user use.
+- [ ] **TLS at the edge:** terminate TLS at the proxy; redirect or reject
+  plaintext public traffic. The engine has no TLS or certificate store.
+- [ ] **Authentication at the edge:** authenticate callers at the proxy and
+  overwrite `X-AsDecided-Principal` with the identity it verified. Strip any
+  client-supplied copy before proxying; the engine records attribution but does
+  not authenticate it.
+- [ ] **Origin and rate controls:** apply an allowlist for browser origins and
+  rate/connection limits at the proxy. The engine's request and connection
+  caps are a second boundary, not a replacement for edge policy.
+- [ ] **Read-only corpus:** mount the checkout read-only into the engine
+  container. Only a reviewed pull to `main` may change knowledge; keep-current
+  pulls belong in a separate sidecar or job.
+- [ ] **Audit is durable:** enable the committed `audit:` stanza, place the
+  JSONL on a writable persistent volume, and fail deployment if the sink is
+  unavailable. Rotate and ship it with the organisation's normal log system.
+- [ ] **No credentials in the engine:** keep proxy credentials, registry tokens,
+  and collector credentials out of the corpus container and its environment.
+- [ ] **Operational logs:** collect stderr from `decided-mcp` and the proxy;
+  keep the audit stream and edge access logs together for incident review.
+- [ ] **Freshness is observable:** monitor the checkout update job and alert if
+  the server is serving an old `main` revision. The engine cannot pull or
+  authenticate a git remote for you.
+
+## Reference launch
+
+This is the shape for a private container network with a proxy in front:
+
+```bash
+decided-mcp --root /corpus \
+  --transport http \
+  --host 0.0.0.0 \
+  --behind-proxy \
+  --port 8000 \
+  --path /mcp
+```
+
+The proxy should be the only public listener. It terminates TLS, authenticates
+the caller, overwrites `X-AsDecided-Principal`, applies origin/rate policy, and
+forwards only the MCP path to the private engine address. See the
+[shared-server recipe](shared-server.md) for the checkout, audit, and proxy
+topology.
+
+## What this checklist does not change
+
+The engine remains read-only and stateless. It does not grow SSO, RBAC,
+credential handling, a `/metrics` endpoint, or a content trust verdict. Those
+boundaries are intentional; the deployment wrapper supplies the controls that
+belong at the edge.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -376,6 +376,10 @@ decided-mcp --root /path/to/your/repo --transport http --host 127.0.0.1 --port 8
 - **`--host` / `--port` / `--path`** — where the HTTP server binds and serves
   (defaults `127.0.0.1`, `8000`, `/mcp`). It binds to loopback by default;
   exposing it to a network is a deliberate deployment choice.
+- **`--behind-proxy`** — required when `--host` is non-loopback. This is an
+  explicit deployment acknowledgement, not authentication; put an
+  authenticating TLS proxy in front and follow the
+  [deployment hardening checklist](deployment-hardening.md).
 
 The HTTP transport is **serving-layer only**: the six tools are unchanged, the
 server re-reads the repository per call (no cache, no session state), and an

--- a/docs/shared-server.md
+++ b/docs/shared-server.md
@@ -63,7 +63,7 @@ as an explicit affirmation.
 docker run --rm --entrypoint decided-mcp -p 8000:8000 -v "$PWD:/corpus:ro" \
   ghcr.io/asdecided/core:latest \
   --root /corpus --transport http \
-  --host 0.0.0.0 --port 8000
+  --host 0.0.0.0 --behind-proxy --port 8000
 ```
 
 HTTP serving is **mandatory audit-on**: the server refuses to start without a
@@ -78,8 +78,11 @@ audit:
 ```
 
 No secrets belong in this container: it holds no credentials, terminates no TLS,
-and authenticates nobody. Bind it to the proxy's network, never to the public
-internet.
+and authenticates nobody. `--behind-proxy` is an explicit acknowledgement of
+that deployment shape, not an authentication mechanism. Bind it to the proxy's
+private network, never to the public internet. Complete the
+[deployment hardening checklist](deployment-hardening.md) before putting the
+endpoint into service.
 
 ## 4. The authenticating proxy
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,6 +40,7 @@ nav:
   - Quickstart: quickstart.md
   - MCP Server: mcp.md
   - Shared Server: shared-server.md
+  - Deployment Hardening: deployment-hardening.md
   - Org Grounding: org-grounding.md
   - CLI Reference: cli.md
   - Context Cost: context-cost.md

--- a/rust/decided-mcp/src/main.rs
+++ b/rust/decided-mcp/src/main.rs
@@ -41,6 +41,25 @@ fn usage_error(msg: &str) -> ! {
     std::process::exit(2);
 }
 
+fn is_loopback_host(host: &str) -> bool {
+    host.eq_ignore_ascii_case("localhost")
+        || host
+            .parse::<std::net::IpAddr>()
+            .is_ok_and(|address| address.is_loopback())
+}
+
+fn non_loopback_bind_error(transport: &str, host: &str, behind_proxy: bool) -> Option<String> {
+    if transport == "http" && !behind_proxy && !is_loopback_host(host) {
+        Some(format!(
+            "non-loopback HTTP bind {host:?} requires explicit --behind-proxy acknowledgement; \
+             put an authenticating TLS proxy in front of the server and review \
+             docs/deployment-hardening.md before exposing it"
+        ))
+    } else {
+        None
+    }
+}
+
 fn main() {
     let mut argv = std::env::args().skip(1);
     let mut root = ".".to_string();
@@ -49,6 +68,7 @@ fn main() {
     // the streamable-HTTP transport (mandatory audit-on, loopback by default).
     let mut transport = "stdio".to_string();
     let mut host = "127.0.0.1".to_string();
+    let mut behind_proxy = false;
     let mut port: u16 = 8000;
     let mut path = "/mcp".to_string();
     let mut server_budget = budget::DEFAULT_BUDGET;
@@ -70,6 +90,7 @@ fn main() {
                 Some(v) => host = v,
                 None => usage_error("--host requires a value"),
             },
+            "--behind-proxy" => behind_proxy = true,
             "--port" => match argv.next() {
                 Some(v) => match v.parse::<u16>() {
                     Ok(p) => port = p,
@@ -105,6 +126,9 @@ fn main() {
             "--cache" => cache = true,
             other => usage_error(&format!("unrecognized argument: {other}")),
         }
+    }
+    if let Some(message) = non_loopback_bind_error(&transport, &host, behind_proxy) {
+        usage_error(&message);
     }
     if !std::path::Path::new(&root).is_dir() {
         usage_error(&format!("not a directory: {root}"));
@@ -598,6 +622,26 @@ fn dispatch(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn loopback_host_detection_is_conservative() {
+        assert!(is_loopback_host("127.0.0.1"));
+        assert!(is_loopback_host("::1"));
+        assert!(is_loopback_host("localhost"));
+        assert!(is_loopback_host("LOCALHOST"));
+        assert!(!is_loopback_host("0.0.0.0"));
+        assert!(!is_loopback_host("::"));
+        assert!(!is_loopback_host("knowledge.internal"));
+    }
+
+    #[test]
+    fn non_loopback_http_requires_explicit_proxy_acknowledgement() {
+        assert!(non_loopback_bind_error("http", "0.0.0.0", false).is_some());
+        assert!(non_loopback_bind_error("http", "::", false).is_some());
+        assert!(non_loopback_bind_error("http", "0.0.0.0", true).is_none());
+        assert!(non_loopback_bind_error("http", "127.0.0.1", false).is_none());
+        assert!(non_loopback_bind_error("stdio", "0.0.0.0", false).is_none());
+    }
 
     const DECISION: &str = "---\nschema_version: 1\nid: FIX-0DEC1GRAPH00\ntype: decision\n---\n# Graph Decision\n\n## Context\n\nGraph context.\n\n## Decision\n\nKeep the graph indexed.\n\n## Consequences\n\nFast reads.\n\n## Status\n\nAccepted\n";
 

--- a/rust/decided-mcp/tests/docs_contract.rs
+++ b/rust/decided-mcp/tests/docs_contract.rs
@@ -124,6 +124,7 @@ fn guide_documents_the_native_surface_and_starts_the_example_server() {
         "provenance.status: Accepted",
         "decided doctor decisions/",
         "injection-style-content",
+        "--behind-proxy",
     ] {
         assert!(
             guide.contains(phrase),
@@ -247,6 +248,7 @@ fn public_docs_and_recipes_do_not_reintroduce_retired_surfaces() {
     let root = repo_root();
     let surfaces = [
         "docs/mcp.md",
+        "docs/deployment-hardening.md",
         "docs/cli.md",
         "docs/index.md",
         "docs/security.md",
@@ -347,6 +349,21 @@ fn public_docs_and_recipes_do_not_reintroduce_retired_surfaces() {
     let index = fs::read_to_string(root.join("docs/index.md")).expect("read docs index");
     assert!(index.contains("Apache-2.0 license"));
     assert!(index.contains("tree/main/decisions"));
+
+    let hardening = fs::read_to_string(root.join("docs/deployment-hardening.md"))
+        .expect("read deployment hardening checklist");
+    for phrase in [
+        "--behind-proxy",
+        "TLS at the edge",
+        "X-AsDecided-Principal",
+        "Read-only corpus",
+        "audit:",
+    ] {
+        assert!(
+            hardening.contains(phrase),
+            "deployment hardening checklist omits {phrase:?}"
+        );
+    }
 
     let mcp = fs::read_to_string(root.join(".mcp.json")).expect("read project MCP config");
     let mcp: Value = serde_json::from_str(&mcp).expect("project MCP config is JSON");


### PR DESCRIPTION
## Summary

- require `--behind-proxy` before any non-loopback HTTP bind
- add the public deployment-hardening checklist and link it from the MCP, CLI,
  and shared-server guides
- pin the new deployment contract in the docs test suite

## Why

The HTTP engine deliberately has no TLS or authentication; those controls live
in the deployment proxy under ADR-085/098. A prose warning was too easy to
miss, so a public bind now requires an explicit operator acknowledgement. The
flag does not authenticate or encrypt anything; it only makes the deployment
choice fail-loud and points operators at the checklist.

Loopback hosts (`127.0.0.1`, `::1`, and `localhost`) remain unchanged. stdio is
unchanged. The checklist covers private networking, TLS, proxy authentication,
principal-header overwriting, edge rate/origin controls, read-only corpus and
durable audit operation.

## Validation

- `cargo test -p decided-mcp --release`
- `cargo test -p decided-mcp --test docs_contract --release`
- runtime guard: non-loopback HTTP without `--behind-proxy` exits 2 with the
  actionable proxy message
- runtime acknowledgement path reaches the existing mandatory audit-on check
- `git diff --check`

`mkdocs` is not installed in this environment, so the site build itself was
not run locally; the page is included in `mkdocs.yml` and the docs contract
checks its required anchors.
