### PR TITLE
docs(governance): publish sustainability and continuity posture

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,60 @@
+# Project Governance and Continuity
+
+## Stewardship
+
+AsDecided core is currently solo-maintained by Tom Ballard
+([@tcballard](https://github.com/tcballard)). It is not governed by a
+foundation, steering committee, or employer, and there is no governance board
+to imply otherwise. The maintainer has final responsibility for accepting
+changes and publishing releases.
+
+Material product and engineering choices are recorded as reviewable artifacts
+under [`decisions/`](decisions/). Contributions follow
+[`CONTRIBUTING.md`](CONTRIBUTING.md), including the Developer Certificate of
+Origin. Opening an issue or pull request does not create a commitment to merge
+it or to respond within a particular time.
+
+The language-neutral contract has its own governance policy in
+[`asdecided/spec`](https://github.com/asdecided/spec/blob/main/GOVERNANCE.md).
+Core is the reference implementation, but the published specification and
+conformance fixtures are the compatibility authority.
+
+## Support and releases
+
+Support is best-effort. There is no paid support contract, guaranteed response
+time, or fix-time SLA attached to this open-source repository. Security reports
+are the exception to the general response posture: the
+[`SECURITY.md`](SECURITY.md) policy targets acknowledgment within five business
+days, while explicitly not promising a fix deadline.
+
+Only the current stable release is supported. Releases are demand-led rather
+than scheduled to a fixed calendar: a release is published when a coherent
+change set has passed the repository's test, contract, and release gates. The
+project may publish quickly when a protocol or security change requires it,
+but does not promise a regular cadence.
+
+## Continuity and adopter control
+
+AsDecided is designed so adoption does not create a hosted-service dependency:
+
+- the core implementation is available under the Apache-2.0 license;
+- the specification, schemas, and conformance fixtures are published in
+  [`asdecided/spec`](https://github.com/asdecided/spec);
+- decision corpora remain ordinary Markdown and configuration in the adopter's
+  own git repositories;
+- the native engine runs locally, with no required account, hosted index, or
+  outbound network service; and
+- derived caches are disposable and can be rebuilt from the repository.
+
+These properties provide practical continuity if maintenance slows or stops:
+an adopter can pin a release, retain and read its corpus without AsDecided, or
+fork the Apache-2.0 implementation and validate it against the public contract.
+They are not a formal source-escrow arrangement and do not substitute for a
+commercial support agreement.
+
+## Changes to this policy
+
+Changes to this file use the normal pull-request process. A change that alters
+project stewardship, compatibility authority, licensing, or the support
+posture should also be recorded in the decision corpus so the public statement
+and the project's operating record change together.

--- a/README.md
+++ b/README.md
@@ -112,3 +112,11 @@ tag; it is not maintained or run in normal CI.
 ## License
 
 Apache-2.0. See [LICENSE](LICENSE) and [NOTICE](NOTICE).
+
+## Governance and continuity
+
+AsDecided core is solo-maintained and supported on a best-effort basis. The
+project does not depend on a hosted service: adopters keep their Markdown
+corpus in their own git repository, while the Apache-2.0 implementation and
+language-neutral specification remain public. See [GOVERNANCE.md](GOVERNANCE.md)
+for the maintainer, release, support, and continuity posture.

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -1,4 +1,9 @@
-# Governance: the enforcement policy & `decided gate`
+# Enforcement Policy and `decided gate`
+
+This page describes how a repository governs findings produced by AsDecided.
+It is not the governance policy for the AsDecided project itself; see
+[`GOVERNANCE.md`](https://github.com/asdecided/core/blob/main/GOVERNANCE.md)
+for project stewardship, support, release cadence, and continuity.
 
 `decided gate` is AsDecided's single enforcement entry point. It runs validation,
 relationship integrity, and review over a corpus, then classifies every finding

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,7 +49,7 @@ nav:
   - Artifacts: artifacts.md
   - Relationships: relationships.md
   - Validation: validation.md
-  - Governance: governance.md
+  - Enforcement Policy: governance.md
   - Security: security.md
   - OKF Profile: okf-profile.md
   - Repository Workflow: repo-workflow.md

--- a/rust/decided-mcp/tests/docs_contract.rs
+++ b/rust/decided-mcp/tests/docs_contract.rs
@@ -424,3 +424,37 @@ fn public_docs_and_recipes_do_not_reintroduce_retired_surfaces() {
         );
     }
 }
+
+#[test]
+fn project_governance_states_the_support_and_continuity_contract() {
+    let root = repo_root();
+    let governance =
+        fs::read_to_string(root.join("GOVERNANCE.md")).expect("read project governance");
+    let normalized = governance.split_whitespace().collect::<Vec<_>>().join(" ");
+
+    for required in [
+        "solo-maintained",
+        "Support is best-effort",
+        "five business days",
+        "Only the current stable release is supported",
+        "demand-led rather than scheduled",
+        "Apache-2.0",
+        "asdecided/spec",
+        "no required account, hosted index, or outbound network service",
+        "not a formal source-escrow arrangement",
+    ] {
+        assert!(
+            normalized.contains(required),
+            "GOVERNANCE.md omits required public posture {required:?}"
+        );
+    }
+
+    let enforcement =
+        fs::read_to_string(root.join("docs/governance.md")).expect("read enforcement policy");
+    assert!(enforcement.starts_with("# Enforcement Policy"));
+    assert!(enforcement.contains("GOVERNANCE.md"));
+
+    let readme = fs::read_to_string(root.join("README.md")).expect("read README");
+    assert!(readme.contains("## Governance and continuity"));
+    assert!(readme.contains("[GOVERNANCE.md](GOVERNANCE.md)"));
+}


### PR DESCRIPTION
## Summary

Closes DEP-11 from the enterprise deployability review.

- add a root project-governance statement that names the solo-maintainer model without inventing a board or foundation
- state the best-effort support, current-stable-only support, and demand-led release posture
- document practical continuity through Apache-2.0, the public spec and conformance fixtures, local git-owned corpora, no hosted dependency, and rebuildable caches
- distinguish those properties from formal source escrow or a commercial support agreement
- rename the existing docs navigation/page from Governance to Enforcement Policy and cross-link the real project governance policy
- pin the public claims in the native docs-contract suite

## Validation

- `git diff --check`
- `rustfmt --edition 2021 --check decided-mcp/tests/docs_contract.rs`
- `cargo test -p decided-mcp --test docs_contract --release` (3 passed)

## Notes

The repository-wide `cargo fmt --all --check` reports pre-existing formatting drift across untouched Rust files; the changed Rust test itself passes `rustfmt --check`.