### PR TITLE
ci(release): enforce changelog entries before publish

### DIFF
--- a/.github/workflows/crates-publish.yml
+++ b/.github/workflows/crates-publish.yml
@@ -13,6 +13,16 @@ permissions:
   id-token: write
 
 jobs:
+  changelog:
+    name: Verify release changelog
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: v${{ inputs.version }}
+      - name: Require one matching SemVer entry
+        run: ./scripts/verify-release-changelog.sh "${{ inputs.version }}"
+
   verification:
     name: Full native release battery
     uses: ./.github/workflows/rust-spike.yml
@@ -22,7 +32,7 @@ jobs:
       contents: read
 
   publish:
-    needs: verification
+    needs: [verification, changelog]
     runs-on: ubuntu-latest
     environment: crates.io
     steps:

--- a/.github/workflows/mcp-registry-publish.yml
+++ b/.github/workflows/mcp-registry-publish.yml
@@ -13,6 +13,16 @@ permissions:
   id-token: write
 
 jobs:
+  changelog:
+    name: Verify release changelog
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: v${{ inputs.version }}
+      - name: Require one matching SemVer entry
+        run: ./scripts/verify-release-changelog.sh "${{ inputs.version }}"
+
   verification:
     name: Full native release battery
     uses: ./.github/workflows/rust-spike.yml
@@ -22,7 +32,7 @@ jobs:
       contents: read
 
   publish:
-    needs: verification
+    needs: [verification, changelog]
     runs-on: ubuntu-latest
     environment: mcp-registry
     steps:

--- a/.github/workflows/native-publish.yml
+++ b/.github/workflows/native-publish.yml
@@ -10,6 +10,18 @@ permissions:
   attestations: write
 
 jobs:
+  changelog:
+    name: Verify release changelog
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.release.tag_name }}
+      - name: Require one matching SemVer entry
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: ./scripts/verify-release-changelog.sh "$RELEASE_TAG"
+
   verification:
     name: Full native release battery
     uses: ./.github/workflows/rust-spike.yml
@@ -20,7 +32,7 @@ jobs:
 
   metadata:
     name: Generate release notices
-    needs: verification
+    needs: [verification, changelog]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -161,7 +173,7 @@ jobs:
           subject-path: dist/asdecided-${{ github.event.release.tag_name }}-sbom.cdx.json
 
   image:
-    needs: [verification, metadata]
+    needs: [verification, changelog, metadata]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -12,6 +12,16 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  release-changelog:
+    name: release changelog contract
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Verify current version has one changelog entry
+        run: |
+          VERSION="$(cargo metadata --manifest-path rust/Cargo.toml --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "decided") | .version')"
+          ./scripts/verify-release-changelog.sh "$VERSION"
+
   # Watchkeeper dogfood (v0.12.3): every pull request here gets a product
   # knowledge review from the local action in source mode — which is also
   # the live end-to-end test of action.yml itself.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ details, release history over commit history.
 
 ## Unreleased
 
+- Release publishing now fails closed unless the exact SemVer has one unique
+  changelog entry. The same check runs on pull requests and before native,
+  crates.io, or MCP Registry publication.
+- Backfilled the native-release history from v0.24.0 through v0.26.0 from the
+  published GitHub release notes and folded the previously untagged
+  "warm by default" notes into the v0.23.0 release that ultimately shipped
+  them.
+
 ## v0.26.2 — 2026-08-01
 
 - Corrected official MCP Registry publishing to use its supported OCI package
@@ -39,6 +47,59 @@ details, release history over commit history.
   for a signed local Pilot App Store submission.
 - Documented direct Cargo installation for both native executables and the
   official Scoop installation path for Windows.
+
+## v0.26.0 — 2026-07-30
+
+- Made Sentry operational across the native engine and CI: `decided sentry`
+  checks accepted decisions' deterministic source constraints, while
+  `decided gate --code` composes those findings into the merge gate.
+- Added blocking SARIF reporting for required patterns, forbidden patterns,
+  and bounded import checks without embeddings, model calls, network judges,
+  or an LLM escape hatch.
+- Published separate corpus-adoption and eligible-enforcement coverage so
+  decisions that still require human review remain explicit rather than being
+  counted as machine-enforced.
+
+## v0.25.1 — 2026-07-29
+
+- Updated `decided export --okf` to Google OKF v0.2, including its versioned
+  bundle identity, lifecycle projection, deterministic generator metadata,
+  git-derived generation time, and structural relationship export.
+- Kept the old OKF v0.1 shape only as a bounded retirement fixture and removed
+  an unnecessary whole-corpus HTML render from Markdown bundle generation.
+- Preserved the trust boundary: governance links and accepted decisions are
+  not promoted into fabricated sources, verification actors, attestations, or
+  trust tiers.
+
+## v0.25.0 — 2026-07-29
+
+- Added MCP `2026-07-28` discovery and per-request protocol metadata while
+  retaining bounded compatibility with initialize-based `2025-11-25` clients.
+- Added standard MCP HTTP routing headers and errors, explicit result types,
+  cache hints, and JSON Schema 2020-12-compatible tool schemas.
+- Kept the same six read-only tools and preserved corpus freshness, response
+  budgets, mandatory HTTP auditing, and proxy-owned authentication.
+
+## v0.24.1 — 2026-07-28
+
+- Published the native CLI to crates.io so Rust users can install it with
+  `cargo install decided`; the internal implementation crate is published as
+  `asdecided-core` while `decided` remains the supported product interface.
+- Made Cargo package metadata authoritative for source builds, aligned package
+  licensing with Apache-2.0, and added tokenless trusted publishing for
+  subsequent crates.io releases.
+- Continued shipping `decided` and `decided-mcp` together in native Linux,
+  Apple Silicon macOS, and Windows archives.
+
+## v0.24.0 — 2026-07-27
+
+- Introduced Sentry, the deterministic code-side enforcement layer, through
+  `decided sentry` and `decided gate --code`.
+- Added decision-declared forbidden patterns, required patterns, and import
+  boundaries over pull-request diffs or full source trees, with deterministic
+  SARIF and explicit enforcement coverage.
+- Moved Herald rendering to native Rust and shipped native `decided` and
+  `decided-mcp` archives for Linux, Apple Silicon macOS, and Windows.
 
 ## v0.23.1 — 2026-07-24
 
@@ -100,7 +161,7 @@ of dying on one hostile file. Both engines converge on the identical finding:
 the native engine's former oracle-crash divergence marker for this class is
 retired, pinned by new mainline parity cases.
 
-## v0.23.0 — the "warm by default" release
+**Also included: the previously untagged "warm by default" work.**
 
 **The cache is on by default** (ADR-112, supersedes ADR-110). `rac find`,
 `rac validate`, and `rac mcp` now reuse the persistent derived-index and

--- a/scripts/verify-release-changelog.sh
+++ b/scripts/verify-release-changelog.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "usage: $0 <vX.Y.Z|X.Y.Z> [CHANGELOG.md]" >&2
+  exit 2
+}
+
+[[ $# -ge 1 && $# -le 2 ]] || usage
+
+requested="${1#refs/tags/}"
+requested="${requested#v}"
+changelog="${2:-CHANGELOG.md}"
+
+semver_component='(0|[1-9][0-9]*)'
+if [[ ! "$requested" =~ ^${semver_component}\.${semver_component}\.${semver_component}$ ]]; then
+  echo "release version must be SemVer vX.Y.Z or X.Y.Z, got: $1" >&2
+  exit 1
+fi
+
+if [[ ! -r "$changelog" ]]; then
+  echo "changelog is not readable: $changelog" >&2
+  exit 1
+fi
+
+heading="## v${requested}"
+entry_count="$({
+  awk -v heading="$heading" '
+    index($0, heading) == 1 {
+      suffix = substr($0, length(heading) + 1)
+      if (suffix == "" || suffix ~ /^[[:space:]]/) count++
+    }
+    END { print count + 0 }
+  ' "$changelog"
+})"
+
+if [[ "$entry_count" != "1" ]]; then
+  echo "$changelog must contain exactly one '$heading' entry; found $entry_count" >&2
+  exit 1
+fi
+
+duplicates="$({
+  awk '
+    /^## v[0-9]+\.[0-9]+\.[0-9]+([[:space:]]|$)/ { count[$2]++ }
+    END { for (version in count) if (count[version] > 1) print version }
+  ' "$changelog" | sort
+})"
+
+if [[ -n "$duplicates" ]]; then
+  echo "duplicate release headings in $changelog:" >&2
+  echo "$duplicates" >&2
+  exit 1
+fi
+
+echo "changelog entry verified: v${requested}"


### PR DESCRIPTION
## Summary

Closes DEP-20 from the enterprise deployability review.

- backfill v0.24.0, v0.24.1, v0.25.0, v0.25.1, and v0.26.0 from their published GitHub release notes
- remove the duplicate v0.23.0 heading by folding the previously untagged warm-by-default notes into the v0.23.0 release that ultimately contained them
- add one fail-closed SemVer/changelog verifier shared by pull-request and release workflows
- require the verifier before native artifacts, crates.io packages, or MCP Registry metadata can publish
- reject malformed CalVer-style inputs and duplicate version headings

## Validation

- `bash -n scripts/verify-release-changelog.sh`
- `shellcheck scripts/verify-release-changelog.sh`
- `./scripts/verify-release-changelog.sh v0.26.2`
- confirmed `2026.06.5` is rejected
- `actionlint .github/workflows/pr-checks.yml .github/workflows/native-publish.yml .github/workflows/crates-publish.yml .github/workflows/mcp-registry-publish.yml`
- `git diff --check`

## Decision alignment

This restores ADR-111's existing requirement that no release publish with a malformed version or missing changelog entry; it does not introduce a new release policy.