### PR TITLE
(engine) Prepare v0.27.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,61 @@ details, release history over commit history.
 
 ## Unreleased
 
+## v0.27.0 — 2026-08-08
+
+### Hardened shared MCP serving
+
+- Hardened the HTTP transport against stalled and oversized requests, invalid
+  origins, conflicting protocol versions, malformed JSON-RPC envelopes, and
+  responses that exceed the engine's deterministic byte budgets.
+- Restored complete attributable audit records and made shared HTTP startup
+  fail closed when its mandatory audit sink is unavailable. The proxy remains
+  responsible for authenticating the asserted principal.
+- **Breaking for non-loopback HTTP deployments:** binding `decided-mcp` to a
+  public interface now requires the explicit `--behind-proxy` acknowledgement.
+  Loopback serving is unchanged. The deployment guide now specifies proxy TLS,
+  authentication, principal-header replacement, rate limits, network policy,
+  request bounds, and a read-only corpus mount.
+- Moved MCP compatibility to shared language-neutral vectors, added current
+  protocol discovery and request validation, and pinned the six-tool public
+  surface and documented launch commands to executable contract tests.
+- Confined rename staging and recovery to the corpus root, rejected symlinked
+  transaction paths, and made multi-file rename application transactional.
+
+### Verifiable release and dependency chain
+
+- Release publication now runs the complete native contract and live-corpus
+  battery at the release tag before any archive, image, crate, or Registry
+  record can publish.
+- Native releases now attach SHA256 checksums, GitHub build-provenance
+  attestations, an attested CycloneDX SBOM, and Apache-2.0 license and
+  third-party notices. Published container images are signed keylessly with
+  cosign through GitHub OIDC.
+- Added Dependabot coverage and a blocking `cargo-deny` policy for advisories,
+  licenses, sources, and banned outbound-network dependency families. This
+  turns the native engine's no-egress posture into a CI-enforced invariant.
 - Release publishing now fails closed unless the exact SemVer has one unique
-  changelog entry. The same check runs on pull requests and before native,
-  crates.io, or MCP Registry publication.
-- Backfilled the native-release history from v0.24.0 through v0.26.0 from the
-  published GitHub release notes and folded the previously untagged
-  "warm by default" notes into the v0.23.0 release that ultimately shipped
-  them.
+  changelog entry. The same contract runs on pull requests and before native,
+  crates.io, or MCP Registry publication. Historical entries from v0.24.0
+  through v0.26.0 were restored from their published releases.
+
+### Honest operating and trust posture
+
+- Replaced retired Python-era CLI, telemetry, tool-count, server-name, and
+  repository-layout guidance across public docs, recipes, generated agent
+  rules, examples, and the repository's own MCP configuration. Native
+  telemetry is now explicitly local-only with no sender or network side
+  channel.
+- Documented the artifact-content trust boundary for agents and operators:
+  records are treated as data, human pull-request review remains authoritative,
+  `decided doctor` and provenance are review aids rather than trust verdicts,
+  and the read-only server does not sanitize content.
+- Added a coordinated vulnerability-handling policy with a five-business-day
+  acknowledgement target, supported-version boundaries, GHSA/CVE handling, and
+  safe-harbor language.
+- Published the project's actual solo-maintainer, best-effort support,
+  demand-led release, and continuity posture without implying a foundation,
+  board, formal source escrow, or commercial SLA.
 
 ## v0.26.2 — 2026-08-01
 

--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -1,12 +1,80 @@
 AsDecided third-party notices
 ============================
 
-The native release workflow regenerates this inventory from the locked Cargo
-dependency graph before packaging. The accompanying CycloneDX SBOM is the
-authoritative machine-readable record of dependency versions and license
-metadata for each release.
+The entries below are generated from the locked Cargo dependency graph for
+this release. The accompanying CycloneDX SBOM carries the same inventory in
+machine-readable form. This project does not vendor third-party source; the
+listed licenses and notices remain available from each upstream package.
 
-This repository does not vendor third-party source code. Each dependency's
-license and notice text remains available from its upstream package source;
-the release archive and container image carry this inventory together with
-LICENSE and NOTICE.
+Dependencies
+------------
+- aho-corasick 1.1.4 — Unlicense OR MIT — https://github.com/BurntSushi/aho-corasick
+- argparse 0.2.2 — MIT — repository not recorded
+- ar_archive_writer 0.5.2 — Apache-2.0 WITH LLVM-exception — https://github.com/rust-lang/ar_archive_writer
+- bitflags 2.13.1 — MIT OR Apache-2.0 — https://github.com/bitflags/bitflags
+- bstr 1.13.0 — MIT OR Apache-2.0 — https://github.com/BurntSushi/bstr
+- cc 1.2.67 — MIT OR Apache-2.0 — https://github.com/rust-lang/cc-rs
+- cfg-if 1.0.4 — MIT OR Apache-2.0 — https://github.com/rust-lang/cfg-if
+- const_format 0.2.36 — Zlib — https://github.com/rodrimati1992/const_format_crates/
+- const_format_proc_macros 0.2.34 — Zlib — https://github.com/rodrimati1992/const_format_crates/
+- convert_case 0.4.0 — MIT — https://github.com/rutrum/convert-case
+- crossbeam-deque 0.8.7 — MIT OR Apache-2.0 — https://github.com/crossbeam-rs/crossbeam
+- crossbeam-epoch 0.9.20 — MIT OR Apache-2.0 — https://github.com/crossbeam-rs/crossbeam
+- crossbeam-utils 0.8.22 — MIT OR Apache-2.0 — https://github.com/crossbeam-rs/crossbeam
+- derivative 2.2.0 — MIT/Apache-2.0 — https://github.com/mcarton/rust-derivative
+- derive_more 0.99.20 — MIT — https://github.com/JelteF/derive_more
+- downcast-rs 1.2.1 — MIT/Apache-2.0 — https://github.com/marcianx/downcast-rs
+- either 1.16.0 — MIT OR Apache-2.0 — https://github.com/rayon-rs/either
+- entities 1.0.1 — MIT — https://github.com/p-jackson/entities
+- equivalent 1.0.2 — Apache-2.0 OR MIT — https://github.com/indexmap-rs/equivalent
+- find-msvc-tools 0.1.9 — MIT OR Apache-2.0 — https://github.com/rust-lang/cc-rs
+- globset 0.4.19 — Unlicense OR MIT — https://github.com/BurntSushi/ripgrep/tree/master/crates/globset
+- hashbrown 0.17.1 — MIT OR Apache-2.0 — https://github.com/rust-lang/hashbrown
+- html-escape 0.2.14 — MIT — https://github.com/magiclen/html-escape
+- idna 0.3.0 — MIT OR Apache-2.0 — https://github.com/servo/rust-url/
+- indexmap 2.14.0 — Apache-2.0 OR MIT — https://github.com/indexmap-rs/indexmap
+- inotify 0.11.4 — ISC — https://github.com/hannobraun/inotify-rs
+- inotify-sys 0.1.8 — ISC — https://github.com/hannobraun/inotify-sys
+- itoa 1.0.18 — MIT OR Apache-2.0 — https://github.com/dtolnay/itoa
+- konst 0.2.20 — Zlib — https://github.com/rodrimati1992/konst/
+- konst_macro_rules 0.2.19 — Zlib — https://github.com/rodrimati1992/konst/
+- libc 0.2.186 — MIT OR Apache-2.0 — https://github.com/rust-lang/libc
+- log 0.4.33 — MIT OR Apache-2.0 — https://github.com/rust-lang/log
+- markdown-it 0.6.1 — MIT — https://github.com/markdown-it-rust/markdown-it
+- mdurl 0.3.1 — MIT — https://github.com/rlidwka/mdurl.rs
+- memchr 2.8.3 — Unlicense OR MIT — https://github.com/BurntSushi/memchr
+- memmap2 0.9.11 — MIT OR Apache-2.0 — https://github.com/RazrFalcon/memmap2-rs
+- object 0.37.3 — Apache-2.0 OR MIT — https://github.com/gimli-rs/object
+- once_cell 1.21.4 — MIT OR Apache-2.0 — https://github.com/matklad/once_cell
+- proc-macro2 1.0.106 — MIT OR Apache-2.0 — https://github.com/dtolnay/proc-macro2
+- psm 0.1.31 — MIT OR Apache-2.0 — https://github.com/rust-lang/stacker/
+- quote 1.0.46 — MIT OR Apache-2.0 — https://github.com/dtolnay/quote
+- rayon 1.12.0 — MIT OR Apache-2.0 — https://github.com/rayon-rs/rayon
+- rayon-core 1.13.0 — MIT OR Apache-2.0 — https://github.com/rayon-rs/rayon
+- readonly 0.2.13 — MIT OR Apache-2.0 — https://github.com/dtolnay/readonly
+- regex 1.13.0 — MIT OR Apache-2.0 — https://github.com/rust-lang/regex
+- regex-automata 0.4.15 — MIT OR Apache-2.0 — https://github.com/rust-lang/regex
+- regex-syntax 0.8.11 — MIT OR Apache-2.0 — https://github.com/rust-lang/regex
+- rustc_version 0.4.1 — MIT OR Apache-2.0 — https://github.com/djc/rustc-version-rs
+- ryu 1.0.23 — Apache-2.0 OR BSL-1.0 — https://github.com/dtolnay/ryu
+- semver 1.0.28 — MIT OR Apache-2.0 — https://github.com/dtolnay/semver
+- serde 1.0.228 — MIT OR Apache-2.0 — https://github.com/serde-rs/serde
+- serde_core 1.0.228 — MIT OR Apache-2.0 — https://github.com/serde-rs/serde
+- serde_derive 1.0.228 — MIT OR Apache-2.0 — https://github.com/serde-rs/serde
+- serde_json 1.0.150 — MIT OR Apache-2.0 — https://github.com/serde-rs/json
+- serde_yaml 0.9.34+deprecated — MIT OR Apache-2.0 — https://github.com/dtolnay/serde-yaml
+- shlex 2.0.1 — MIT OR Apache-2.0 — https://github.com/comex/rust-shlex
+- stacker 0.1.24 — MIT OR Apache-2.0 — https://github.com/rust-lang/stacker
+- syn 1.0.109 — MIT OR Apache-2.0 — https://github.com/dtolnay/syn
+- syn 2.0.118 — MIT OR Apache-2.0 — https://github.com/dtolnay/syn
+- tinyvec 1.12.0 — Zlib OR Apache-2.0 OR MIT — https://github.com/Lokathor/tinyvec
+- tinyvec_macros 0.1.1 — MIT OR Apache-2.0 OR Zlib — https://github.com/Soveu/tinyvec_macros
+- unicode-bidi 0.3.18 — MIT OR Apache-2.0 — https://github.com/servo/unicode-bidi
+- unicode-general-category 0.6.0 — Apache-2.0 — https://github.com/yeslogic/unicode-general-category
+- unicode-ident 1.0.24 — (MIT OR Apache-2.0) AND Unicode-3.0 — https://github.com/dtolnay/unicode-ident
+- unicode-normalization 0.1.25 — MIT OR Apache-2.0 — https://github.com/unicode-rs/unicode-normalization
+- unicode-xid 0.2.6 — MIT OR Apache-2.0 — https://github.com/unicode-rs/unicode-xid
+- unsafe-libyaml 0.2.11 — MIT — https://github.com/dtolnay/unsafe-libyaml
+- windows-link 0.2.1 — MIT OR Apache-2.0 — https://github.com/microsoft/windows-rs
+- windows-sys 0.61.2 — MIT OR Apache-2.0 — https://github.com/microsoft/windows-rs
+- zmij 1.0.21 — MIT — https://github.com/dtolnay/zmij

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -30,7 +30,7 @@ In CI, pin a release tag rather than `latest`, or pin by digest for
 immutable builds (the release run prints the pushed digest in its summary):
 
 ```bash
-docker pull ghcr.io/asdecided/core:v0.26.2
+docker pull ghcr.io/asdecided/core:v0.27.0
 docker pull ghcr.io/asdecided/core@sha256:<digest>
 ```
 
@@ -41,7 +41,7 @@ can run script steps):
 ```yaml
 rac-gate:
   image:
-    name: ghcr.io/asdecided/core:v0.26.2
+    name: ghcr.io/asdecided/core:v0.27.0
     entrypoint: [""]
   script:
     - decided gate decisions/
@@ -55,7 +55,7 @@ pipelines:
     '**':
       - step:
           name: decided gate
-          image: ghcr.io/asdecided/core:v0.26.2
+          image: ghcr.io/asdecided/core:v0.27.0
           script:
             - decided gate decisions/
 ```
@@ -64,7 +64,7 @@ Jenkins (declarative pipeline, docker agent):
 
 ```groovy
 pipeline {
-  agent { docker { image 'ghcr.io/asdecided/core:v0.26.2' } }
+  agent { docker { image 'ghcr.io/asdecided/core:v0.27.0' } }
   stages {
     stage('decided gate') {
       steps { sh 'decided gate decisions/' }

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -28,7 +28,7 @@ checksum = "3f8ebf5827e4ac4fd5946560e6a99776ea73b596d80898f357007317a7141e47"
 
 [[package]]
 name = "asdecided-core"
-version = "0.26.2"
+version = "0.27.0"
 dependencies = [
  "globset",
  "inotify",
@@ -128,14 +128,14 @@ checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "decided"
-version = "0.26.2"
+version = "0.27.0"
 dependencies = [
  "asdecided-core",
 ]
 
 [[package]]
 name = "decided-mcp"
-version = "0.26.2"
+version = "0.27.0"
 dependencies = [
  "asdecided-core",
  "serde",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["rac-engine", "decided", "decided-mcp"]
 
 [workspace.package]
-version = "0.26.2"
+version = "0.27.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/asdecided/core"

--- a/rust/decided-mcp/Cargo.toml
+++ b/rust/decided-mcp/Cargo.toml
@@ -13,6 +13,6 @@ categories = ["command-line-utilities", "development-tools"]
 publish = ["crates-io"]
 
 [dependencies]
-rac-engine = { package = "asdecided-core", version = "=0.26.2", path = "../rac-engine" }
+rac-engine = { package = "asdecided-core", version = "=0.27.0", path = "../rac-engine" }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }

--- a/rust/decided/Cargo.toml
+++ b/rust/decided/Cargo.toml
@@ -13,4 +13,4 @@ categories = ["command-line-utilities", "development-tools"]
 publish = ["crates-io"]
 
 [dependencies]
-rac-engine = { package = "asdecided-core", version = "=0.26.2", path = "../rac-engine" }
+rac-engine = { package = "asdecided-core", version = "=0.27.0", path = "../rac-engine" }

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/asdecided/core",
     "source": "github"
   },
-  "version": "0.26.2",
+  "version": "0.27.0",
   "websiteUrl": "https://asdecided.com",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/asdecided/core:mcp-v0.26.2",
+      "identifier": "ghcr.io/asdecided/core:mcp-v0.27.0",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Outcome

Prepare AsDecided v0.27.0 as the first release of the completed MCP hardening and enterprise-deployability tranche.

## Changes

- align the Rust workspace, `decided`, `decided-mcp`, lockfile, and official MCP Registry manifest on v0.27.0
- pin the public container quickstart to the v0.27.0 CLI image
- publish release notes covering hardened shared MCP serving, verifiable release artifacts, dependency policy, corrected public guidance, vulnerability handling, artifact trust, and the honest maintainer/continuity posture
- regenerate the locked Cargo third-party notice inventory for the release

## Behavioural change

Non-loopback HTTP serving now requires the explicit `--behind-proxy` acknowledgement. Loopback serving is unchanged. The release notes and deployment-hardening guide call out the required proxy boundary.

## Deliberate exclusion

`distribution/pilot/pilot.app.yaml` remains pinned to v0.26.2. It carries immutable published URLs and hashes and must not move to v0.27.0 until those release assets exist.

## Validation

- `cargo test --workspace --release --locked`
- `cargo clippy --workspace --release --locked --no-deps -- -D warnings`
- `cargo publish --dry-run --locked --allow-dirty -p asdecided-core`
- package-boundary checks for `decided` and `decided-mcp`
- changelog, workspace, Registry version, and OCI identifier alignment
- native version output: `decided 0.27.0`
- live corpus: 451 valid, 0 invalid; 2,694 relationships, 0 issues
- Sentry: 27/27 eligible decisions constrained, 67 active rules, 0 violations
- `git diff --check`

After merge, publication remains a separate approval: create the v0.27.0 GitHub release, allow the gated release workflows to produce the verification pack, and verify those assets before downstream distribution moves.

Authored under my direction with Codex.