### PR TITLE
docs(readme): point documentation link at canonical site

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ read-only to agents over MCP.
 No embeddings, model call, hosted index, or Python runtime is required. The
 same repository state produces the same answer.
 
-[Product site](https://asdecided.com/) · [Documentation](https://docs.asdecided.com/start-here/) · [Canonical sources](https://asdecided.com/sources) · [Changelog](https://asdecided.com/changelog)
+[Product site](https://asdecided.com/) · [Documentation](https://asdecided.com/docs/start-here/) · [Canonical sources](https://asdecided.com/sources) · [Changelog](https://asdecided.com/changelog)
 
 ## Install
 


### PR DESCRIPTION
## Summary

- replace the obsolete `https://docs.asdecided.com/start-here/` README link
- point readers to the canonical documentation route at `https://asdecided.com/docs/start-here/`

## Why

The documentation now lives under the main AsDecided site. Keeping the Core README on the canonical route avoids sending users and crawlers through the legacy documentation hostname.

## Validation

- confirmed the canonical documentation URL returns HTTP 200
- confirmed Core contains no remaining `docs.asdecided.com` references
- ran `git diff --check`