### PR TITLE
docs: normalize canonical site links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,7 +134,7 @@ forks the comment degrades to the step summary. A thin client over
 ships in the CI delivery repo as
 `asdecided/ci/herald/github` beside Watchkeeper, Gatekeeper, and
 Registrar, and is documented on the new
-[Decisions on PRs](https://asdecided.github.io/core/decisions-on-pr/)
+[Decisions on PRs](https://asdecided.com/docs/vendor/core/decisions-on-pr/)
 page.
 
 **The org grounding plane** (ADR-117). One org-standards corpus behind the
@@ -144,7 +144,7 @@ wires a repository to it: the `lore-org` streamable-HTTP entry is ensured in
 `.mcp.json` and `.cursor/mcp.json`, on fresh **and** already-initialized
 repositories, merging into existing files (only the `lore-org` key is
 touched, nothing you wrote is removed) and writing nothing on an unchanged
-re-run. The new [Org Grounding](https://asdecided.github.io/core/org-grounding/)
+re-run. The new [Org Grounding](https://asdecided.com/docs/vendor/core/org-grounding/)
 page is the operator runbook: the org corpus, the shared-server recipe, fleet
 wiring, boundaries, and the federation handoff (ADR-089 stays untouched — no
 cross-corpus resolution enters the engine). The `rac init --json` contract
@@ -273,7 +273,7 @@ as candidate relationships.
   shared HTTP serving blocks a call if the audit sink write fails
   (ADR-098). stdio behaviour is unchanged.
 - **Operator guide for the shared server.** A new
-  [Shared Server](https://asdecided.github.io/core/shared-server/) doc
+  [Shared Server](https://asdecided.com/docs/vendor/core/shared-server/) doc
   covers when to run one, the container and authenticating-proxy recipe, keeping
   the checkout current with `main`, and where observability lives — the whole
   topology is deployment wrapper around an unchanged, database-free engine.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,7 @@ site_name: AsDecided
 site_description: >-
   Give your coding agent the decisions your team already made — typed
   Markdown artifacts in your repo, served over MCP.
-site_url: https://asdecided.github.io/core/
+site_url: https://asdecided.com/docs/vendor/core/
 repo_url: https://github.com/asdecided/core
 repo_name: asdecided/core
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/asdecided/core"
 homepage = "https://asdecided.com"
+documentation = "https://asdecided.com/docs/vendor/core/quickstart/"
 
 [profile.release]
 lto = "thin"

--- a/rust/decided-mcp/Cargo.toml
+++ b/rust/decided-mcp/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
+documentation.workspace = true
 description = "Read-only MCP access to deterministic engineering decisions"
 readme = "README.md"
 keywords = ["mcp", "decisions", "architecture", "agents", "offline"]

--- a/rust/decided/Cargo.toml
+++ b/rust/decided/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
+documentation.workspace = true
 description = "Engineering decisions your agents can follow"
 readme = "README.md"
 keywords = ["decisions", "architecture", "agents", "cli", "offline"]

--- a/rust/rac-engine/Cargo.toml
+++ b/rust/rac-engine/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
+documentation.workspace = true
 description = "Deterministic, offline engine for validating and enforcing engineering decisions"
 readme = "README.md"
 keywords = ["decisions", "architecture", "agents", "validation", "cli"]


### PR DESCRIPTION
## Summary

- make the canonical website documentation base explicit in MkDocs and current changelog links
- publish the canonical documentation URL through all three Cargo packages
- retain GitHub as the source and release evidence location

## Validation

- confirmed every added `asdecided.com` destination returns HTTP 200
- parsed all four Cargo manifests and verified workspace inheritance
- `git diff --check`

Rust tooling was not available in the workspace, so `cargo metadata` was not run.
