### PR TITLE
ci(release): automate downstream publication

### DIFF
--- a/.github/workflows/crates-publish.yml
+++ b/.github/workflows/crates-publish.yml
@@ -1,10 +1,16 @@
 name: Publish crates.io packages
 
 on:
+  workflow_call:
+    inputs:
+      version:
+        description: Exact workspace version to publish (X.Y.Z or vX.Y.Z)
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       version:
-        description: Exact workspace version to publish
+        description: Exact workspace version to publish (X.Y.Z or vX.Y.Z)
         required: true
         type: string
 
@@ -13,39 +19,68 @@ permissions:
   id-token: write
 
 jobs:
+  version:
+    name: Resolve release version
+    runs-on: ubuntu-latest
+    outputs:
+      number: ${{ steps.normalize.outputs.number }}
+      tag: ${{ steps.normalize.outputs.tag }}
+    steps:
+      - name: Normalize and validate version
+        id: normalize
+        env:
+          REQUESTED_VERSION: ${{ inputs.version }}
+        run: |
+          VERSION="$REQUESTED_VERSION"
+          case "$VERSION" in
+            v*|V*) VERSION="${VERSION:1}" ;;
+          esac
+          SEMVER_COMPONENT='(0|[1-9][0-9]*)'
+          if [[ ! "$VERSION" =~ ^${SEMVER_COMPONENT}\.${SEMVER_COMPONENT}\.${SEMVER_COMPONENT}$ ]]; then
+            echo "::error::release version must be SemVer X.Y.Z or vX.Y.Z, got: $REQUESTED_VERSION"
+            exit 1
+          fi
+          echo "number=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+
   changelog:
     name: Verify release changelog
+    needs: version
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
         with:
-          ref: v${{ inputs.version }}
+          ref: ${{ needs.version.outputs.tag }}
       - name: Require one matching SemVer entry
-        run: ./scripts/verify-release-changelog.sh "${{ inputs.version }}"
+        run: ./scripts/verify-release-changelog.sh "${{ needs.version.outputs.number }}"
 
   verification:
     name: Full native release battery
+    needs: version
     uses: ./.github/workflows/rust-spike.yml
     with:
-      ref: v${{ inputs.version }}
+      ref: ${{ needs.version.outputs.tag }}
     permissions:
       contents: read
 
   publish:
-    needs: [verification, changelog]
+    needs: [version, verification, changelog]
     runs-on: ubuntu-latest
     environment: crates.io
+    concurrency:
+      group: crates-publish-${{ needs.version.outputs.number }}
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v5
         with:
-          ref: v${{ inputs.version }}
+          ref: ${{ needs.version.outputs.tag }}
       - name: Install pinned Rust toolchain
         working-directory: rust
         run: rustup show
       - name: Verify requested version
         working-directory: rust
         env:
-          REQUESTED_VERSION: ${{ inputs.version }}
+          REQUESTED_VERSION: ${{ needs.version.outputs.number }}
         run: |
           PACKAGE_VERSION="$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "decided") | .version')"
           test "$REQUESTED_VERSION" = "$PACKAGE_VERSION"
@@ -59,7 +94,7 @@ jobs:
         working-directory: rust
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.cargo-auth.outputs.token }}
-          REQUESTED_VERSION: ${{ inputs.version }}
+          REQUESTED_VERSION: ${{ needs.version.outputs.number }}
         run: |
           if cargo info "asdecided-core@$REQUESTED_VERSION" --registry crates-io >/dev/null 2>&1; then
             echo "asdecided-core $REQUESTED_VERSION is already published; skipping"
@@ -69,7 +104,7 @@ jobs:
       - name: Wait for engine crate to reach the index
         working-directory: rust
         env:
-          REQUESTED_VERSION: ${{ inputs.version }}
+          REQUESTED_VERSION: ${{ needs.version.outputs.number }}
         run: |
           for attempt in {1..30}; do
             : "$attempt"
@@ -90,7 +125,7 @@ jobs:
         working-directory: rust
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.cargo-auth.outputs.token }}
-          REQUESTED_VERSION: ${{ inputs.version }}
+          REQUESTED_VERSION: ${{ needs.version.outputs.number }}
         run: |
           if cargo info "decided@$REQUESTED_VERSION" --registry crates-io >/dev/null 2>&1; then
             echo "decided $REQUESTED_VERSION is already published; skipping"
@@ -101,7 +136,7 @@ jobs:
         working-directory: rust
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.cargo-auth.outputs.token }}
-          REQUESTED_VERSION: ${{ inputs.version }}
+          REQUESTED_VERSION: ${{ needs.version.outputs.number }}
         run: |
           if cargo info "decided-mcp@$REQUESTED_VERSION" --registry crates-io >/dev/null 2>&1; then
             echo "decided-mcp $REQUESTED_VERSION is already published; skipping"

--- a/.github/workflows/mcp-registry-publish.yml
+++ b/.github/workflows/mcp-registry-publish.yml
@@ -1,10 +1,16 @@
 name: Publish to MCP Registry
 
 on:
+  workflow_call:
+    inputs:
+      version:
+        description: Exact released version to register (X.Y.Z or vX.Y.Z)
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       version:
-        description: Exact released version to register
+        description: Exact released version to register (X.Y.Z or vX.Y.Z)
         required: true
         type: string
 
@@ -13,35 +19,64 @@ permissions:
   id-token: write
 
 jobs:
+  version:
+    name: Resolve release version
+    runs-on: ubuntu-latest
+    outputs:
+      number: ${{ steps.normalize.outputs.number }}
+      tag: ${{ steps.normalize.outputs.tag }}
+    steps:
+      - name: Normalize and validate version
+        id: normalize
+        env:
+          REQUESTED_VERSION: ${{ inputs.version }}
+        run: |
+          VERSION="$REQUESTED_VERSION"
+          case "$VERSION" in
+            v*|V*) VERSION="${VERSION:1}" ;;
+          esac
+          SEMVER_COMPONENT='(0|[1-9][0-9]*)'
+          if [[ ! "$VERSION" =~ ^${SEMVER_COMPONENT}\.${SEMVER_COMPONENT}\.${SEMVER_COMPONENT}$ ]]; then
+            echo "::error::release version must be SemVer X.Y.Z or vX.Y.Z, got: $REQUESTED_VERSION"
+            exit 1
+          fi
+          echo "number=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+
   changelog:
     name: Verify release changelog
+    needs: version
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
         with:
-          ref: v${{ inputs.version }}
+          ref: ${{ needs.version.outputs.tag }}
       - name: Require one matching SemVer entry
-        run: ./scripts/verify-release-changelog.sh "${{ inputs.version }}"
+        run: ./scripts/verify-release-changelog.sh "${{ needs.version.outputs.number }}"
 
   verification:
     name: Full native release battery
+    needs: version
     uses: ./.github/workflows/rust-spike.yml
     with:
-      ref: v${{ inputs.version }}
+      ref: ${{ needs.version.outputs.tag }}
     permissions:
       contents: read
 
   publish:
-    needs: [verification, changelog]
+    needs: [version, verification, changelog]
     runs-on: ubuntu-latest
     environment: mcp-registry
+    concurrency:
+      group: mcp-registry-publish-${{ needs.version.outputs.number }}
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v5
         with:
-          ref: v${{ inputs.version }}
+          ref: ${{ needs.version.outputs.tag }}
       - name: Verify requested version and OCI metadata
         env:
-          REQUESTED_VERSION: ${{ inputs.version }}
+          REQUESTED_VERSION: ${{ needs.version.outputs.number }}
         run: |
           WORKSPACE_VERSION="$(cargo metadata --manifest-path rust/Cargo.toml --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "decided-mcp") | .version')"
           SERVER_VERSION="$(jq -r '.version' server.json)"
@@ -51,7 +86,7 @@ jobs:
           test "$PACKAGE_IDENTIFIER" = "ghcr.io/asdecided/core:mcp-v$REQUESTED_VERSION"
       - name: Verify MCP image is available and canonical
         env:
-          REQUESTED_VERSION: ${{ inputs.version }}
+          REQUESTED_VERSION: ${{ needs.version.outputs.number }}
         run: |
           IMAGE="ghcr.io/asdecided/core:mcp-v$REQUESTED_VERSION"
           for attempt in {1..30}; do

--- a/.github/workflows/native-publish.yml
+++ b/.github/workflows/native-publish.yml
@@ -218,3 +218,23 @@ jobs:
             "$IMAGE:mcp-latest"; do
             cosign sign --yes "$reference"
           done
+
+  crates:
+    name: Publish crates.io packages
+    needs: [evidence, image]
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/crates-publish.yml
+    with:
+      version: ${{ github.event.release.tag_name }}
+
+  mcp-registry:
+    name: Publish to MCP Registry
+    needs: [evidence, image]
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/mcp-registry-publish.yml
+    with:
+      version: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
## Summary

- call the protected crates.io and MCP Registry workflows automatically after the native release evidence and image jobs succeed
- keep both publisher workflows available through `workflow_dispatch` for recovery
- normalize `X.Y.Z`, `vX.Y.Z`, and `VX.Y.Z` inputs to one canonical release tag
- serialize publication attempts for the same package version

## Why

The v0.27.0 manual publication runs failed during checkout because each workflow prepended `v` to an input that already contained it. Publication should be part of one release graph, with the GitHub release as the normal entry point and manual dispatch as a recovery path.

## Safety

- crates.io and MCP Registry retain their existing protected environments and OIDC authentication
- both publishers retain their full native release battery and changelog gate
- neither publisher starts unless release archives, verification evidence, and signed OCI images complete successfully
- crates.io and MCP Registry run independently after that shared gate, so one registry outage does not block the other

## Validation

- parsed all three modified workflow files as YAML
- exercised normalization for prefixed and unprefixed v0.27.0 inputs
- confirmed malformed, incomplete, leading-zero, and double-prefixed inputs fail closed
- verified the v0.27.0 changelog contract
- ran `git diff --check`

## Current release

The corrected v0.27.0 recovery workflows were already dispatched manually. This automation applies to future releases.