### PR TITLE
chore(release): prepare v0.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,25 @@ details, release history over commit history.
 
 ## Unreleased
 
+## v0.28.0 — 2026-08-09
+
+### Retrieval that preserves lexical relevance
+
+- Constrained relationship-graph ranking to lexical near-ties. A candidate
+  below 85% of the strongest BM25 match keeps its lexical score but receives no
+  graph boost. This prevents a well-connected but weak match from displacing a
+  more relevant decision.
+- Extended `find --explain` with the fixed graph-floor ratio and an `applied` or
+  `clamped` gate result. This makes the ranking decision visible without
+  changing the default `find` response.
+
+### Diagnose missed decisions
+
 - Added `decided diagnose` for deterministic, named-target explain-miss traces,
   including no-match, partial-match, filtering, outranked, and result-window
   truncation reasons.
-- Constrained relationship-graph ranking to lexical near-ties: candidates below
-  85% of the strongest BM25 match keep their lexical score but receive no graph
-  boost. `--explain` now reports the fixed ratio and whether the gate was
-  applied or clamped.
+- Reused the production tokeniser, filters, and ranking path for diagnosis, so
+  the trace explains the result that `find` actually produced.
 
 ## v0.27.0 — 2026-08-08
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -30,7 +30,7 @@ In CI, pin a release tag rather than `latest`, or pin by digest for
 immutable builds (the release run prints the pushed digest in its summary):
 
 ```bash
-docker pull ghcr.io/asdecided/core:v0.27.0
+docker pull ghcr.io/asdecided/core:v0.28.0
 docker pull ghcr.io/asdecided/core@sha256:<digest>
 ```
 
@@ -41,7 +41,7 @@ can run script steps):
 ```yaml
 rac-gate:
   image:
-    name: ghcr.io/asdecided/core:v0.27.0
+    name: ghcr.io/asdecided/core:v0.28.0
     entrypoint: [""]
   script:
     - decided gate decisions/
@@ -55,7 +55,7 @@ pipelines:
     '**':
       - step:
           name: decided gate
-          image: ghcr.io/asdecided/core:v0.27.0
+          image: ghcr.io/asdecided/core:v0.28.0
           script:
             - decided gate decisions/
 ```
@@ -64,7 +64,7 @@ Jenkins (declarative pipeline, docker agent):
 
 ```groovy
 pipeline {
-  agent { docker { image 'ghcr.io/asdecided/core:v0.27.0' } }
+  agent { docker { image 'ghcr.io/asdecided/core:v0.28.0' } }
   stages {
     stage('decided gate') {
       steps { sh 'decided gate decisions/' }

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -28,7 +28,7 @@ checksum = "3f8ebf5827e4ac4fd5946560e6a99776ea73b596d80898f357007317a7141e47"
 
 [[package]]
 name = "asdecided-core"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "globset",
  "inotify",
@@ -128,14 +128,14 @@ checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "decided"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "asdecided-core",
 ]
 
 [[package]]
 name = "decided-mcp"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "asdecided-core",
  "serde",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["rac-engine", "decided", "decided-mcp"]
 
 [workspace.package]
-version = "0.27.0"
+version = "0.28.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/asdecided/core"

--- a/rust/decided-mcp/Cargo.toml
+++ b/rust/decided-mcp/Cargo.toml
@@ -13,6 +13,6 @@ categories = ["command-line-utilities", "development-tools"]
 publish = ["crates-io"]
 
 [dependencies]
-rac-engine = { package = "asdecided-core", version = "=0.27.0", path = "../rac-engine" }
+rac-engine = { package = "asdecided-core", version = "=0.28.0", path = "../rac-engine" }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }

--- a/rust/decided/Cargo.toml
+++ b/rust/decided/Cargo.toml
@@ -13,4 +13,4 @@ categories = ["command-line-utilities", "development-tools"]
 publish = ["crates-io"]
 
 [dependencies]
-rac-engine = { package = "asdecided-core", version = "=0.27.0", path = "../rac-engine" }
+rac-engine = { package = "asdecided-core", version = "=0.28.0", path = "../rac-engine" }

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/asdecided/core",
     "source": "github"
   },
-  "version": "0.27.0",
+  "version": "0.28.0",
   "websiteUrl": "https://asdecided.com",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/asdecided/core:mcp-v0.27.0",
+      "identifier": "ghcr.io/asdecided/core:mcp-v0.28.0",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Outcome

Prepare AsDecided v0.28.0 as the release of the bounded graph-boost gate and named-target retrieval diagnostics delivered in #449.

## Changes

- align the Rust workspace, `decided`, `decided-mcp`, lockfile, and MCP Registry manifest on v0.28.0
- pin the public container quickstart to the v0.28.0 CLI image
- add the v0.28.0 changelog entry
- explain that graph popularity can only affect lexical near-ties
- document `decided diagnose` as the way to inspect why a named decision did or did not surface

## User impact

Relationship popularity can no longer promote a weak lexical match above a substantially stronger one. Authors can also run `decided diagnose` to see whether a target failed matching, was filtered, ranked lower, or fell outside the result budget.

## Deliberate exclusions

- This PR does not create the v0.28.0 tag or GitHub Release. Publication remains a separate approval after merge.
- Benchmark PR [asdecided/benchmarks#29](https://github.com/asdecided/benchmarks/pull/29) remains pinned to older released binaries until v0.28.0 artifacts and checksums exist.
- `THIRD-PARTY-NOTICES` is unchanged because the locked dependency graph did not change. The release workflow regenerates and packages it at the tag.

## Validation

- `./scripts/verify-release-changelog.sh v0.28.0`
- workspace, lockfile, dependency pins, Registry version, and OCI identifier alignment
- `decided validate decisions/` — 451 valid artifacts, 0 invalid
- `decided relationships decisions/ --validate` — 2,694 relationships, 0 issues
- JSON validation for `server.json`
- `git diff --check`

GitHub Actions is green. PR Checks run #503 passed the release changelog, Registry metadata, dogfood, public-documentation, and package gates. Rust workflow run #176 passed the release workspace tests, strict Clippy, dependency policy, live-corpus invariants, and macOS and Windows runtime smokes.

## After merge

Publish the GitHub Release tagged `v0.28.0`. The release event then runs the full native battery and publishes the native archives, SHA256SUMS, attestations, SBOM, signed container images, crates.io packages, and MCP Registry record. Once those assets exist, update benchmark PR #29 with the v0.28.0 checksums and workflow pins.