### PR TITLE
feat(export): publish machine-readable contract schemas

### DIFF
--- a/.github/workflows/rust-spike.yml
+++ b/.github/workflows/rust-spike.yml
@@ -131,6 +131,12 @@ jobs:
         working-directory: rust
         run: cargo build --release --locked
 
+      - name: Install export-schema test dependency
+        run: python -m pip install --disable-pip-version-check -r rust/tools/export-schema-requirements.txt
+
+      - name: Export-schema contracts
+        run: python rust/tools/export_schema_contracts.py --engine rust/target/release/decided
+
       # Keep the Linux-only event-watch correctness gate independently visible
       # before the broader workspace suite.
       - name: Freshness tracker (Linux inotify + stat fallback)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ details, release history over commit history.
 
 ## Unreleased
 
+- Added versioned Draft 2020-12 schemas for the viewer, documents, and graph
+  export contracts. `decided export --schema <viewer|documents|graph>` emits
+  the packaged schema bytes offline, and CI now checks fixture and live-corpus
+  exports for contract and field-set drift.
+
 ## v0.28.0 — 2026-08-09
 
 ### Retrieval that preserves lexical relevance

--- a/decisions/requirements/rac-export-contract-schemas.md
+++ b/decisions/requirements/rac-export-contract-schemas.md
@@ -16,45 +16,45 @@ exports in CI.
 
 ## Problem
 
-ADR-007 promises that RAC's JSON outputs are stable, additive contracts —
+ADR-007 promises that AsDecided's JSON outputs are stable, additive contracts —
 but nothing checks that promise. No schema artifact exists for any export
 projection; the `--documents` and `--graph` modes are absent even from the
 prose viewer contract. An enterprise platform that wants to build on the
 export surface must reverse-engineer the emitting code and re-verify it on
 every upgrade. A published, versioned, machine-readable schema per
-projection lets a consumer validate exports in its own CI, and lets RAC's
+projection lets a consumer validate exports in its own CI, and lets AsDecided's
 CI prove that emitted shapes and published contracts never drift apart.
 
 ## Requirements
 
-- [REQ-001] RAC MUST publish JSON Schema (draft 2020-12) files for the three export projections — the viewer JSON payload, a single documents JSONL record, and the graph JSON object — as packaged resources, one schema file per projection, each identifying the projection's `schema_version` (ADR-007).
-- [REQ-002] An additive `rac export --schema <viewer|documents|graph>` mode MUST print the packaged schema to stdout, offline and byte-identical to the packaged resource, without altering any existing export mode's behaviour (ADR-002, ADR-007, ADR-011).
+- [REQ-001] AsDecided MUST publish JSON Schema (draft 2020-12) files for the three export projections — the viewer JSON payload, a single documents JSONL record, and the graph JSON object — as packaged resources, one schema file per projection, each identifying the projection's `schema_version` (ADR-007).
+- [REQ-002] An additive `decided export --schema <viewer|documents|graph>` mode MUST print the packaged schema to stdout, offline and byte-identical to the packaged resource, without altering any existing export mode's behaviour (ADR-002, ADR-007, ADR-011).
 - [REQ-003] Each schema MUST require and type every field the projection currently emits while leaving objects open to additive extension, so the schema pins the minimum contract a consumer may rely on and an unknown extra field never fails validation (ADR-007).
-- [REQ-004] CI MUST validate real exports against the schemas — golden fixtures and a dogfood export of the repository corpus for all three modes — using a test-only schema-validation dependency; the engine's runtime dependency set MUST be unchanged (ADR-086).
+- [REQ-004] CI MUST validate real exports against the schemas — golden fixtures and a dogfood export of the repository corpus for all three modes — using a CI-only schema-validation dependency; the Rust engine's runtime dependency set MUST be unchanged (ADR-086).
 - [REQ-005] A drift guard MUST fail CI when the emitted shape and the packaged schema diverge in either direction: a field added to the code without a schema update, or a schema field the code no longer emits.
 - [REQ-006] The documents and graph projections MUST be documented on a contracts page with the schema files as the source of truth, and the viewer schema MUST be reconciled with the existing viewer contract rather than redefined against it.
 - [REQ-007] Removing or retyping a schema-required field MUST be defined as a breaking change requiring a `schema_version` bump, and that rule MUST be recorded on the contracts page (ADR-007, ADR-063).
 
 ## Acceptance Criteria
 
-- Every line of `rac export --documents` over a fixture corpus validates
+- Every line of `decided export --documents` over a fixture corpus validates
   against the documents record schema; the graph and default JSON outputs
   validate against theirs.
-- `rac export --schema documents` output parses as a valid draft 2020-12
+- `decided export --schema documents` output parses as a valid draft 2020-12
   schema and is byte-identical across two runs and to the packaged file; an
   unknown mode argument exits with the usage error code.
 - A test that deletes a required key from a synthetic payload fails schema
   validation, proving the schema is load-bearing rather than vacuous.
 - A payload carrying an extra unknown field still validates, pinning the
   additive tolerance.
-- The runtime dependency set is unchanged; the schema-validation library
-  appears only in the development extra.
+- The runtime dependency set is unchanged; the schema-validation library is
+  pinned only in the CI contract-test requirements.
 
 ## Success Metrics
 
-- A downstream platform validates RAC exports in its own CI using only the
-  published schema files, with no reference to RAC's source code.
-- Shape drift between code and contract is caught by RAC's CI before
+- A downstream platform validates AsDecided exports in its own CI using only
+  the published schema files, with no reference to AsDecided's source code.
+- Shape drift between code and contract is caught by AsDecided's CI before
   release, not by a consumer after one.
 
 ## Risks

--- a/decisions/requirements/rac-export-contract-schemas.md
+++ b/decisions/requirements/rac-export-contract-schemas.md
@@ -7,7 +7,7 @@ type: requirement
 
 ## Status
 
-Proposed
+Accepted
 
 Classification: `[internal]` — make the export contracts machine-checkable.
 Feature A of the `corpus-sync` programme: published JSON Schema files for

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -806,7 +806,7 @@ modes; the default writes the viewer JSON payload to stdout. Exports are build
 artifacts — existing output is overwritten.
 
 - **Input:** `decided export [directory]` — scanned recursively for `*.md` (default: current directory).
-- **Modes:** *(default)* viewer JSON to stdout · `--html` (self-contained Portal file) · `--okf` (OKF v0.2 Markdown bundle) · `--documents` (JSONL for memory/RAG backends) · `--graph` (typed node+edge JSON for graph backends) · `--agent-rules` (per-client agent-context files; see its own behaviour)
+- **Modes:** *(default)* viewer JSON to stdout · `--html` (self-contained Portal file) · `--okf` (OKF v0.2 Markdown bundle) · `--documents` (JSONL for memory/RAG backends) · `--graph` (typed node+edge JSON for graph backends) · `--schema <viewer|documents|graph>` (the packaged JSON Schema, without reading a corpus) · `--agent-rules` (per-client agent-context files; see its own behaviour)
 - **Options:** `--out <path>` (only `--html`/`--okf`/`--agent-rules`; the stdout modes are pipeable) · `--json` (no-op for the default mode)
 - **Exit codes:** `0` success · `2` not a directory, or `--out` given to a stdout mode
 
@@ -814,8 +814,13 @@ artifacts — existing output is overwritten.
 decided export decisions/                      # viewer JSON to stdout
 decided export decisions/ --documents          # JSONL, one record per artifact
 decided export decisions/ --graph              # typed node+edge graph
+decided export --schema documents              # Draft 2020-12 record schema
 decided export decisions/ --html --out asdecided.html
 ```
+
+The three machine-readable payload contracts, compatibility rules, and direct
+schema links are documented on the [Export contracts](export-contracts.md)
+page.
 
 ### Exporting to external memory / RAG / graph backends
 

--- a/docs/export-contracts.md
+++ b/docs/export-contracts.md
@@ -1,0 +1,71 @@
+# Export contracts
+
+AsDecided publishes Draft 2020-12 JSON Schemas for every JSON export
+projection. The schemas describe the minimum v1 contract a consumer can rely
+on, and the CLI prints the packaged files without reading a corpus or using the
+network:
+
+```sh
+decided export --schema viewer
+decided export --schema documents
+decided export --schema graph
+```
+
+The emitted bytes are exactly the packaged resources:
+
+- [viewer export v1](https://github.com/asdecided/core/blob/main/rust/rac-engine/assets/schemas/export-viewer-v1.schema.json)
+- [documents record v1](https://github.com/asdecided/core/blob/main/rust/rac-engine/assets/schemas/export-documents-v1.schema.json)
+- [graph export v1](https://github.com/asdecided/core/blob/main/rust/rac-engine/assets/schemas/export-graph-v1.schema.json)
+
+Those files are the machine-readable source of truth. CI validates exports of
+both a fixed fixture corpus and AsDecided's own decision corpus against them. A
+separate field-set guard also requires the producer and schema to name exactly
+the same current fields.
+
+## Viewer object
+
+The default `decided export` projection is one JSON object containing:
+
+- `schema_version`
+- `corpus`: `name`, `rac_version`, and `artifact_count`
+- `artifacts[]`: `id`, `aliases`, `type`, `status`, `title`, `path`, and
+  `body_html`
+- `relationships[]`: `from`, `to`, and the flattened `relates-to` `type`
+
+The viewer schema is reconciled with the existing Portal input contract. The
+committed demonstration payload's additive `corpus.sample` field remains valid,
+although Core does not emit that field.
+
+## Documents records
+
+`decided export --documents` is JSON Lines, not one enclosing JSON array. Each
+non-empty line is independently validated against the documents schema and
+contains:
+
+- `schema_version`, `id`, `type`, `status`, `title`, and Markdown `text`
+- `metadata`: `path`, `aliases`, `tags`, and `source`
+
+The schema describes one line. A consumer should split the UTF-8 stream on line
+boundaries and validate each record separately.
+
+## Graph object
+
+`decided export --graph` is one JSON object containing `schema_version`,
+`source`, `nodes`, and `edges`. Nodes carry `id`, `type`, `status`, and `title`.
+Edges carry `source`, `target`, `type`, `directed`, `resolved`, `external`, and
+nullable `provider` provenance.
+
+The graph edge `type` is the engine's real relationship kind. It is not the
+viewer projection's flattened `relates-to` value.
+
+## Compatibility rule
+
+All schema objects allow unknown additional properties. This is intentional:
+an additive producer release must remain readable by an existing consumer.
+Consumers should ignore fields they do not understand.
+
+Every field emitted today is nevertheless declared and required. Removing a
+required field, changing its type incompatibly, or changing its meaning is a
+breaking contract change and requires a `schema_version` bump plus a new
+versioned schema file. Adding a field requires updating the current schema and
+its producer drift test in the same change.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,7 @@ nav:
   - Deployment Hardening: deployment-hardening.md
   - Org Grounding: org-grounding.md
   - CLI Reference: cli.md
+  - Export Contracts: export-contracts.md
   - Context Cost: context-cost.md
   - Scale & Performance: scale.md
   - Watchkeeper: watchkeeper.md

--- a/rust/decided/tests/cli.rs
+++ b/rust/decided/tests/cli.rs
@@ -122,3 +122,29 @@ fn generated_agent_rules_are_in_sync_with_the_decision_corpus() {
         String::from_utf8_lossy(&output.stderr)
     );
 }
+
+#[test]
+fn export_schema_prints_the_packaged_resource_exactly() {
+    let output = run(&["export", "--schema", "documents"]);
+    assert!(
+        output.status.success(),
+        "stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        output.stdout,
+        include_bytes!("../../rac-engine/assets/schemas/export-documents-v1.schema.json")
+    );
+}
+
+#[test]
+fn export_schema_rejects_an_unknown_projection() {
+    let output = run(&["export", "--schema", "unknown"]);
+    assert_eq!(output.status.code(), Some(2));
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("invalid choice: 'unknown'"),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}

--- a/rust/rac-engine/assets/schemas/export-documents-v1.schema.json
+++ b/rust/rac-engine/assets/schemas/export-documents-v1.schema.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "AsDecided documents export record v1",
+  "description": "One JSON Lines record emitted by decided export --documents.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "id",
+    "type",
+    "status",
+    "title",
+    "text",
+    "metadata"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "1"
+    },
+    "id": {
+      "type": "string"
+    },
+    "type": {
+      "type": "string"
+    },
+    "status": {
+      "type": "string"
+    },
+    "title": {
+      "type": "string"
+    },
+    "text": {
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object",
+      "required": [
+        "path",
+        "aliases",
+        "tags",
+        "source"
+      ],
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "aliases": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "source": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/rust/rac-engine/assets/schemas/export-graph-v1.schema.json
+++ b/rust/rac-engine/assets/schemas/export-graph-v1.schema.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "AsDecided graph export v1",
+  "description": "The typed node-and-edge object emitted by decided export --graph.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "source",
+    "nodes",
+    "edges"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "1"
+    },
+    "source": {
+      "type": "string"
+    },
+    "nodes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "id",
+          "type",
+          "status",
+          "title"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": true
+      }
+    },
+    "edges": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "source",
+          "target",
+          "type",
+          "directed",
+          "resolved",
+          "external",
+          "provider"
+        ],
+        "properties": {
+          "source": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "directed": {
+            "type": "boolean"
+          },
+          "resolved": {
+            "type": "boolean"
+          },
+          "external": {
+            "type": "boolean"
+          },
+          "provider": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "additionalProperties": true
+      }
+    }
+  },
+  "additionalProperties": true
+}

--- a/rust/rac-engine/assets/schemas/export-viewer-v1.schema.json
+++ b/rust/rac-engine/assets/schemas/export-viewer-v1.schema.json
@@ -1,0 +1,106 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "AsDecided viewer export v1",
+  "description": "The default JSON object emitted by decided export.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "corpus",
+    "artifacts",
+    "relationships"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "1"
+    },
+    "corpus": {
+      "type": "object",
+      "required": [
+        "name",
+        "rac_version",
+        "artifact_count"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "rac_version": {
+          "type": "string"
+        },
+        "artifact_count": {
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "additionalProperties": true
+    },
+    "artifacts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "id",
+          "aliases",
+          "type",
+          "status",
+          "title",
+          "path",
+          "body_html"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "aliases": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "type": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "body_html": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": true
+      }
+    },
+    "relationships": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "from",
+          "to",
+          "type"
+        ],
+        "properties": {
+          "from": {
+            "type": "string"
+          },
+          "to": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "const": "relates-to"
+          }
+        },
+        "additionalProperties": true
+      }
+    }
+  },
+  "additionalProperties": true
+}

--- a/rust/rac-engine/src/cli.rs
+++ b/rust/rac-engine/src/cli.rs
@@ -2076,6 +2076,8 @@ fn run_export(rest: &[&String]) -> u8 {
     let mut json = false;
     let mut html = false;
     let mut okf = false;
+    let mut schema: Option<String> = None;
+    let mut schema_mode = false;
     let mut documents = false;
     let mut graph = false;
     let mut agent_rules = false;
@@ -2139,6 +2141,44 @@ fn run_export(rest: &[&String]) -> u8 {
                     return c;
                 }
             }
+            "--schema" => {
+                if let Err(FlagError(c)) =
+                    set_mode("--schema", &mut schema_mode, &mut last_mode)
+                {
+                    return c;
+                }
+                i += 1;
+                match rest.get(i) {
+                    Some(v) if is_export_schema_choice(v) => schema = Some(v.to_string()),
+                    Some(v) if !v.starts_with('-') => {
+                        return argparse_error(
+                            prog,
+                            &format!(
+                                "argument --schema: invalid choice: '{v}' (choose from 'viewer', 'documents', 'graph')"
+                            ),
+                        )
+                    }
+                    _ => return argparse_error(prog, "argument --schema: expected one argument"),
+                }
+            }
+            other if other.starts_with("--schema=") => {
+                if let Err(FlagError(c)) =
+                    set_mode("--schema", &mut schema_mode, &mut last_mode)
+                {
+                    return c;
+                }
+                let value = &other["--schema=".len()..];
+                if is_export_schema_choice(value) {
+                    schema = Some(value.to_string());
+                } else {
+                    return argparse_error(
+                        prog,
+                        &format!(
+                            "argument --schema: invalid choice: '{value}' (choose from 'viewer', 'documents', 'graph')"
+                        ),
+                    );
+                }
+            }
             "--agent-rules" => {
                 if let Err(FlagError(c)) =
                     set_mode("--agent-rules", &mut agent_rules, &mut last_mode)
@@ -2193,6 +2233,7 @@ fn run_export(rest: &[&String]) -> u8 {
     cmd_export(&ExportArgs {
         directory: directory.unwrap_or_else(|| ".".to_string()),
         json,
+        schema,
         graph,
         documents,
         html,
@@ -2206,6 +2247,10 @@ fn run_export(rest: &[&String]) -> u8 {
 
 fn is_client_choice(v: &str) -> bool {
     matches!(v, "claude" | "agents" | "cursor" | "copilot")
+}
+
+fn is_export_schema_choice(v: &str) -> bool {
+    crate::export::EXPORT_SCHEMA_NAMES.contains(&v)
 }
 
 fn run_schema(rest: &[&String]) -> u8 {

--- a/rust/rac-engine/src/commands.rs
+++ b/rust/rac-engine/src/commands.rs
@@ -42,6 +42,14 @@ fn emit(text: String) {
     let _ = stdout.flush();
 }
 
+fn emit_exact(text: &str) {
+    use std::io::Write;
+    let payload = crate::pycompat::encode_stdout_surrogateescape(text);
+    let mut stdout = std::io::stdout().lock();
+    let _ = stdout.write_all(&payload);
+    let _ = stdout.flush();
+}
+
 // ---------------------------------------------------------------------------
 // Service results (decided.services.validate)
 // ---------------------------------------------------------------------------
@@ -1175,6 +1183,7 @@ pub fn cmd_review(args: &ReviewArgs) -> i32 {
 pub struct ExportArgs {
     pub directory: String,
     pub json: bool,
+    pub schema: Option<String>,
     pub graph: bool,
     pub documents: bool,
     pub html: bool,
@@ -1186,7 +1195,7 @@ pub struct ExportArgs {
 }
 
 pub fn cmd_export(args: &ExportArgs) -> i32 {
-    if !Path::new(&args.directory).is_dir() {
+    if args.schema.is_none() && !Path::new(&args.directory).is_dir() {
         return usage_error(&format!("not a directory: {}", args.directory));
     }
     // Agent-rules is a distinct mode (ADR-067) owning --out/--client/--check
@@ -1205,6 +1214,15 @@ pub fn cmd_export(args: &ExportArgs) -> i32 {
     }
     if args.out.is_some() && !(args.html || args.okf) {
         return usage_error("--out requires --html or --okf (--json writes to stdout)");
+    }
+    if let Some(name) = &args.schema {
+        let Some(schema) = crate::export::export_schema(name) else {
+            return usage_error(&format!(
+                "unknown export schema: {name} (choose from viewer, documents, graph)"
+            ));
+        };
+        emit_exact(schema);
+        return EXIT_OK;
     }
     if args.documents {
         emit(output::render_documents_jsonl(

--- a/rust/rac-engine/src/export.rs
+++ b/rust/rac-engine/src/export.rs
@@ -14,6 +14,27 @@ use crate::validate::load_ticketing_provider;
 pub const EDGE_TYPE: &str = "relates-to";
 pub const STATUS_ABSENT: &str = "unknown";
 
+pub const EXPORT_SCHEMA_NAMES: [&str; 3] = ["viewer", "documents", "graph"];
+
+const VIEWER_SCHEMA: &str =
+    include_str!("../assets/schemas/export-viewer-v1.schema.json");
+const DOCUMENTS_SCHEMA: &str =
+    include_str!("../assets/schemas/export-documents-v1.schema.json");
+const GRAPH_SCHEMA: &str = include_str!("../assets/schemas/export-graph-v1.schema.json");
+
+/// Return the packaged Draft 2020-12 contract for an export projection.
+///
+/// These bytes are the public resource surfaced by `decided export --schema`;
+/// keep the CLI write exact so consumers can compare them directly.
+pub fn export_schema(name: &str) -> Option<&'static str> {
+    match name {
+        "viewer" => Some(VIEWER_SCHEMA),
+        "documents" => Some(DOCUMENTS_SCHEMA),
+        "graph" => Some(GRAPH_SCHEMA),
+        _ => None,
+    }
+}
+
 /// `_corpus_name(directory)`.
 fn corpus_name(directory: &str) -> String {
     let trimmed = directory.trim_end_matches('/');

--- a/rust/tools/export-schema-requirements.txt
+++ b/rust/tools/export-schema-requirements.txt
@@ -1,0 +1,1 @@
+jsonschema==4.26.0

--- a/rust/tools/export_schema_contracts.py
+++ b/rust/tools/export_schema_contracts.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Validate packaged export schemas against fixture and live-corpus output."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCHEMA_DIR = ROOT / "rust" / "rac-engine" / "assets" / "schemas"
+SCHEMA_PATHS = {
+    "viewer": SCHEMA_DIR / "export-viewer-v1.schema.json",
+    "documents": SCHEMA_DIR / "export-documents-v1.schema.json",
+    "graph": SCHEMA_DIR / "export-graph-v1.schema.json",
+}
+
+
+def run(engine: Path, *args: str) -> subprocess.CompletedProcess[bytes]:
+    return subprocess.run(
+        [str(engine), *args],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+    )
+
+
+def successful(engine: Path, *args: str) -> bytes:
+    result = run(engine, *args)
+    if result.returncode != 0:
+        raise AssertionError(
+            f"{' '.join(args)} exited {result.returncode}: "
+            f"{result.stderr.decode('utf-8', errors='replace')}"
+        )
+    return result.stdout
+
+
+def object_keys(value: Any, schema: dict[str, Any], label: str) -> None:
+    if not isinstance(value, dict):
+        raise AssertionError(f"{label} is not an object")
+    properties = set(schema["properties"])
+    required = set(schema["required"])
+    if required != properties:
+        raise AssertionError(
+            f"{label} schema does not require every declared property: "
+            f"required={sorted(required)}, properties={sorted(properties)}"
+        )
+    emitted = set(value)
+    if emitted != properties:
+        raise AssertionError(
+            f"{label} producer/schema drift: "
+            f"emitted={sorted(emitted)}, properties={sorted(properties)}"
+        )
+
+
+def validate_shapes(
+    viewer: dict[str, Any],
+    documents: list[dict[str, Any]],
+    graph: dict[str, Any],
+    schemas: dict[str, dict[str, Any]],
+) -> None:
+    viewer_schema = schemas["viewer"]
+    object_keys(viewer, viewer_schema, "viewer")
+    object_keys(viewer["corpus"], viewer_schema["properties"]["corpus"], "viewer.corpus")
+    artifact_schema = viewer_schema["properties"]["artifacts"]["items"]
+    for index, artifact in enumerate(viewer["artifacts"]):
+        object_keys(artifact, artifact_schema, f"viewer.artifacts[{index}]")
+    relationship_schema = viewer_schema["properties"]["relationships"]["items"]
+    for index, relationship in enumerate(viewer["relationships"]):
+        object_keys(
+            relationship,
+            relationship_schema,
+            f"viewer.relationships[{index}]",
+        )
+
+    document_schema = schemas["documents"]
+    for index, document in enumerate(documents):
+        object_keys(document, document_schema, f"documents[{index}]")
+        object_keys(
+            document["metadata"],
+            document_schema["properties"]["metadata"],
+            f"documents[{index}].metadata",
+        )
+
+    graph_schema = schemas["graph"]
+    object_keys(graph, graph_schema, "graph")
+    node_schema = graph_schema["properties"]["nodes"]["items"]
+    for index, node in enumerate(graph["nodes"]):
+        object_keys(node, node_schema, f"graph.nodes[{index}]")
+    edge_schema = graph_schema["properties"]["edges"]["items"]
+    for index, edge in enumerate(graph["edges"]):
+        object_keys(edge, edge_schema, f"graph.edges[{index}]")
+
+
+def load_exports(
+    engine: Path, corpus: Path
+) -> tuple[dict[str, Any], list[dict[str, Any]], dict[str, Any]]:
+    corpus_text = str(corpus)
+    viewer = json.loads(successful(engine, "export", corpus_text))
+    document_bytes = successful(engine, "export", corpus_text, "--documents")
+    documents = [json.loads(line) for line in document_bytes.splitlines() if line]
+    graph = json.loads(successful(engine, "export", corpus_text, "--graph"))
+    return viewer, documents, graph
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--engine", required=True, type=Path)
+    args = parser.parse_args()
+    engine = args.engine.resolve()
+
+    schemas = {
+        name: json.loads(path.read_text(encoding="utf-8"))
+        for name, path in SCHEMA_PATHS.items()
+    }
+    validators: dict[str, Draft202012Validator] = {}
+    for name, schema in schemas.items():
+        Draft202012Validator.check_schema(schema)
+        validators[name] = Draft202012Validator(schema)
+
+        packaged = SCHEMA_PATHS[name].read_bytes()
+        first = successful(engine, "export", "--schema", name)
+        second = successful(engine, "export", f"--schema={name}")
+        if first != packaged or second != packaged:
+            raise AssertionError(f"--schema {name} did not emit the packaged bytes exactly")
+
+    unknown = run(engine, "export", "--schema", "unknown")
+    if unknown.returncode != 2:
+        raise AssertionError(f"unknown schema exited {unknown.returncode}, expected 2")
+
+    fixture = ROOT / "rust" / "fixtures" / "closure" / "export" / "proj" / "rac"
+    live = ROOT / "decisions"
+    for label, corpus in (("fixture", fixture), ("live", live)):
+        viewer, documents, graph = load_exports(engine, corpus)
+        validators["viewer"].validate(viewer)
+        for document in documents:
+            validators["documents"].validate(document)
+        validators["graph"].validate(graph)
+        validate_shapes(viewer, documents, graph, schemas)
+        if not documents:
+            raise AssertionError(f"{label} documents export was unexpectedly empty")
+
+    sample = json.loads(
+        (ROOT / "rac-localview" / "src" / "viewer" / "sample" / "lore-export.sample.json")
+        .read_text(encoding="utf-8")
+    )
+    validators["viewer"].validate(sample)
+
+    _, fixture_documents, _ = load_exports(engine, fixture)
+    missing_key = copy.deepcopy(fixture_documents[0])
+    del missing_key["id"]
+    if validators["documents"].is_valid(missing_key):
+        raise AssertionError("documents schema accepted a record missing required id")
+
+    additive = copy.deepcopy(fixture_documents[0])
+    additive["future_field"] = {"accepted": True}
+    additive["metadata"]["future_metadata"] = "accepted"
+    if not validators["documents"].is_valid(additive):
+        raise AssertionError("documents schema rejected additive fields")
+
+    print("export schemas: fixture, viewer sample, and live corpus conform")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #256.

## What changed

- packages Draft 2020-12 schemas for the viewer object, one documents JSONL record, and the graph object
- adds `decided export --schema <viewer|documents|graph>` with exact packaged-byte output and no corpus read
- adds fixture, Portal-sample, and live-corpus schema validation in CI
- adds a bidirectional field-set guard, plus negative missing-key and additive-field cases
- publishes an export-contracts documentation page and updates the CLI reference and changelog
- refreshes the existing requirement's retired Python-era command and dependency wording and records Tom's acceptance of the contract

## Why

ADR-007 makes export JSON a stable additive contract, but consumers previously had to infer those contracts from emitting code. This makes the three existing projections machine-checkable without changing their payloads or the Rust engine's runtime dependency set.

## Compatibility

All schema objects remain open to additive fields. Every field emitted today is declared and required. Removing or incompatibly retyping one requires a `schema_version` bump and a new versioned schema file.

## Validation

- `cargo test --workspace --release`
- `cargo clippy --release --no-deps -- -D warnings`
- `python rust/tools/export_schema_contracts.py --engine …`
  - fixed fixture: viewer, documents, graph
  - Portal sample: viewer
  - live `decisions/` corpus: viewer, documents, graph
  - exact schema bytes, unknown-mode exit 2, missing-required-key rejection, additive-field tolerance, field-set parity
- `mkdocs build --strict`
- `decided validate decisions/`: 462 valid, 0 invalid, 12 skipped
- `decided relationships decisions/ --validate`: 2,929 checked, 0 issues
- `decided gate decisions/`: 0 blocking, 134 advisory
- `decided review decisions/`: advisory backlog retained (473 issues), health 95
- `git diff --check`
