### PR TITLE
feat(engine): add source-aware corpus identity substrate

### DIFF
--- a/decisions/designs/corpus-federation-mechanism.md
+++ b/decisions/designs/corpus-federation-mechanism.md
@@ -145,6 +145,19 @@ unsupported transitive declaration, and a stale digest are distinct stable
 error findings. No parent artifact enters the effective corpus until all four
 checks pass.
 
+The version-one byte contract is fixed. The hash begins with the ASCII domain
+separator `asdecided-corpus-digest-v1\0`. Every following value is framed as a
+one-byte tag, an unsigned 64-bit big-endian byte length, and the exact value
+bytes. Tag `0x01` carries the UTF-8 parent source, tag `0x02` carries the exact
+governing config bytes, and each Markdown file contributes tag `0x03` with its
+corpus-relative POSIX UTF-8 path followed by tag `0x04` with its exact content
+bytes. Files are ordered by those path bytes. No newline, Unicode, YAML, or
+Markdown normalisation occurs. The operator surface is the read-only command
+`decided corpus digest --root <parent-root> --corpus <parent-corpus>`; it reads
+the source from the bounded parent config and prints `sha256:` followed by 64
+lowercase hexadecimal characters. The command never edits the manifest or
+parent and never performs network I/O.
+
 ### One source-aware read model
 
 The engine introduces source-aware equivalents of its path-only concepts:
@@ -221,6 +234,12 @@ An absent, ambiguous, cross-type, retired-rationale, or parent-to-parent
 mapping is a validation error. There is no implicit child-wins or parent-wins
 rule.
 
+All three override operands are canonical IDs. `parent` is qualified; `with`
+and `rationale` are canonical local IDs and do not accept aliases. An override
+redirects only the parent's canonical ID in the effective unqualified view;
+it does not turn the parent's legacy or title aliases into aliases of the
+replacement.
+
 ### Validation semantics
 
 The parent is validated as a source corpus before overlay. A structural or
@@ -261,11 +280,24 @@ They do not copy artifact bodies, excerpts, override mappings, or the full
 response provenance. Because ADR-127 pins the current path-only shape, ADR-141
 must amend that decision explicitly before these fields ship.
 
+Public `path` values remain corpus-relative paths within the artifact's owning
+source; they never expose or encode the vendored or submodule checkout path.
+The accompanying `source` disambiguates equal paths across layers. Federated
+CLI and MCP records carry `source`, `layer`, and `pin` in their existing
+provenance object, with `pin` present only for inherited records. Export
+records carry the same facts in their projection-specific metadata. A
+repository without a manifest retains its existing shapes byte for byte.
+
 Default reads use the effective combined corpus. Human-facing diagnostic and
 export commands may request `--local-only` to inspect the child layer. MCP and
 enforcement do not expose a local-only bypass: an agent connected to a
 federated repository and `decided gate --code` both receive inherited
 governance.
+
+The first increment exposes `--local-only` on viewer, documents, and graph
+exports. Other human diagnostic reads may adopt the same projection later;
+they are not required for the first implementation and must never weaken MCP,
+routing, or enforcement.
 
 ### Code scope and enforcement
 

--- a/decisions/requirements/corpus-source-identity.md
+++ b/decisions/requirements/corpus-source-identity.md
@@ -7,7 +7,7 @@ type: requirement
 
 ## Status
 
-Proposed
+Accepted
 
 Classification: `[internal]` — merge N corpora with zero collisions and give
 federated artifacts one source identity across every surface. Feature E of the

--- a/rust/decided-mcp/src/graph.rs
+++ b/rust/decided-mcp/src/graph.rs
@@ -191,6 +191,9 @@ impl GraphView {
             artifact_id: artifact_id.to_string(),
             outcome: OUTCOME_RESOLVED,
             artifact: Some(ResolvedArtifact {
+                key: entry.key.clone(),
+                artifact_path: entry.artifact_path.clone(),
+                origin: entry.origin.clone(),
                 id: entry.id.clone(),
                 artifact_type: entry.artifact_type.clone(),
                 title: entry.title.clone(),
@@ -406,6 +409,9 @@ impl GraphView {
 
 fn identity_projection(entry: &IndexEntry) -> IndexEntry {
     IndexEntry {
+        key: entry.key.clone(),
+        artifact_path: entry.artifact_path.clone(),
+        origin: entry.origin.clone(),
         id: entry.id.clone(),
         artifact_type: entry.artifact_type.clone(),
         title: entry.title.clone(),

--- a/rust/rac-engine/src/corpus.rs
+++ b/rust/rac-engine/src/corpus.rs
@@ -1,0 +1,327 @@
+//! Stable corpus and artifact identity for the source-aware read model.
+//!
+//! Stable identity deliberately excludes checkout paths. Runtime filesystem
+//! locators are separate types so moving an otherwise identical checkout
+//! cannot alter an [`ArtifactKey`] or [`ArtifactPath`] (ADR-135/ADR-138).
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::scaffold::{load_repository_identity, ScaffoldError};
+
+/// Whether an artifact belongs to the writable child or a read-only parent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Layer {
+    Local,
+    Inherited,
+}
+
+impl Layer {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Local => "local",
+            Self::Inherited => "inherited",
+        }
+    }
+
+    pub const fn is_writable(self) -> bool {
+        matches!(self, Self::Local)
+    }
+}
+
+/// Stable identity and provenance shared by every artifact in one layer.
+///
+/// `pin` and `alias` are absent for the local layer. An inherited layer has
+/// both: the full verified digest and the child-local readable alias.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct CorpusLayer {
+    pub source: String,
+    pub layer: Layer,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pin: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub alias: Option<String>,
+}
+
+impl CorpusLayer {
+    pub fn local(source: impl Into<String>) -> Self {
+        Self {
+            source: source.into(),
+            layer: Layer::Local,
+            pin: None,
+            alias: None,
+        }
+    }
+
+    pub fn inherited(
+        source: impl Into<String>,
+        alias: impl Into<String>,
+        pin: impl Into<String>,
+    ) -> Self {
+        Self {
+            source: source.into(),
+            layer: Layer::Inherited,
+            pin: Some(pin.into()),
+            alias: Some(alias.into()),
+        }
+    }
+
+    pub fn origin(&self) -> ArtifactOrigin {
+        ArtifactOrigin {
+            source: self.source.clone(),
+            layer: self.layer,
+            pin: self.pin.clone(),
+            alias: self.alias.clone(),
+        }
+    }
+}
+
+/// Stable global artifact identity: `(source, canonical_id)`.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct ArtifactKey {
+    pub source: String,
+    pub canonical_id: String,
+}
+
+impl ArtifactKey {
+    pub fn new(source: impl Into<String>, canonical_id: impl Into<String>) -> Self {
+        Self {
+            source: source.into(),
+            canonical_id: canonical_id.into(),
+        }
+    }
+}
+
+/// Stable global path identity: `(source, corpus-relative path)`.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct ArtifactPath {
+    pub source: String,
+    pub relative_path: String,
+}
+
+impl ArtifactPath {
+    pub fn new(source: impl Into<String>, relative_path: impl Into<String>) -> Self {
+        Self {
+            source: source.into(),
+            relative_path: relative_path.into(),
+        }
+    }
+}
+
+/// Stable provenance attached to a parsed or derived artifact.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct ArtifactOrigin {
+    pub source: String,
+    pub layer: Layer,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pin: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub alias: Option<String>,
+}
+
+impl ArtifactOrigin {
+    pub fn key(&self, canonical_id: impl Into<String>) -> ArtifactKey {
+        ArtifactKey::new(self.source.clone(), canonical_id)
+    }
+
+    pub fn path(&self, relative_path: impl Into<String>) -> ArtifactPath {
+        ArtifactPath::new(self.source.clone(), relative_path)
+    }
+}
+
+impl From<&ArtifactOrigin> for CorpusLayer {
+    fn from(origin: &ArtifactOrigin) -> Self {
+        Self {
+            source: origin.source.clone(),
+            layer: origin.layer,
+            pin: origin.pin.clone(),
+            alias: origin.alias.clone(),
+        }
+    }
+}
+
+/// Runtime-only filesystem location of one corpus layer.
+///
+/// These paths must never be serialized as stable identity or used as a
+/// deterministic tie-break. Federation verification owns canonicalisation;
+/// this substrate only keeps the already-selected locations distinct from
+/// provenance.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PhysicalCorpusLocator {
+    pub repository_root: PathBuf,
+    pub corpus_root: PathBuf,
+}
+
+impl PhysicalCorpusLocator {
+    pub fn new(repository_root: impl Into<PathBuf>, corpus_root: impl Into<PathBuf>) -> Self {
+        Self {
+            repository_root: repository_root.into(),
+            corpus_root: corpus_root.into(),
+        }
+    }
+
+    pub fn local(corpus_root: impl Into<PathBuf>) -> Self {
+        let corpus_root = corpus_root.into();
+        Self::new(repository_root_for(&corpus_root), corpus_root)
+    }
+}
+
+/// Runtime-only filesystem location of one artifact.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PhysicalArtifactLocator {
+    pub corpus: PhysicalCorpusLocator,
+    pub path: PathBuf,
+}
+
+impl PhysicalArtifactLocator {
+    pub fn new(corpus: PhysicalCorpusLocator, path: impl Into<PathBuf>) -> Self {
+        Self {
+            corpus,
+            path: path.into(),
+        }
+    }
+}
+
+/// The exact non-federated source derivation shared by exports and the local
+/// source-aware layer: explicit `corpus.source`, then lower-case
+/// `repository_key`, then the released directory-basename fallback.
+pub fn compatible_corpus_source(directory: &str) -> Result<String, ScaffoldError> {
+    let Some(identity) = load_repository_identity(directory)? else {
+        return Ok(compatible_corpus_name(directory));
+    };
+    if let Some(source) = identity.corpus_source {
+        return Ok(source);
+    }
+    if let Some(repository_key) = identity.repository_key {
+        return Ok(repository_key
+            .strip_suffix('\n')
+            .unwrap_or(&repository_key)
+            .to_ascii_lowercase());
+    }
+    Ok(compatible_corpus_name(directory))
+}
+
+/// Build the dormant single local layer without making configuration errors
+/// newly observable on legacy read paths. Strict federation loading uses its
+/// own fallible verification gate before composition.
+pub fn compatible_local_layer(directory: &str) -> CorpusLayer {
+    let source =
+        compatible_corpus_source(directory).unwrap_or_else(|_| compatible_corpus_name(directory));
+    CorpusLayer::local(source)
+}
+
+pub(crate) fn compatible_corpus_name(directory: &str) -> String {
+    let normalized = crate::walk::normalize_root(directory);
+    let trimmed = normalized.trim_end_matches('/');
+    let name = trimmed.rsplit('/').next().unwrap_or("");
+    if name.is_empty() || name == "." || name == ".." {
+        directory.to_string()
+    } else {
+        name.to_string()
+    }
+}
+
+fn repository_root_for(corpus_root: &Path) -> PathBuf {
+    let start = if corpus_root.is_dir() {
+        corpus_root
+    } else {
+        corpus_root.parent().unwrap_or(corpus_root)
+    };
+    crate::validate::repository_root(&start.to_string_lossy())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn composite_keys_order_by_source_then_local_identity() {
+        let mut keys = [
+            ArtifactKey::new("zeta/standards", "ADR-001"),
+            ArtifactKey::new("acme/app", "ADR-002"),
+            ArtifactKey::new("acme/app", "ADR-001"),
+        ];
+        keys.sort();
+        assert_eq!(
+            keys.iter()
+                .map(|key| (key.source.as_str(), key.canonical_id.as_str()))
+                .collect::<Vec<_>>(),
+            vec![
+                ("acme/app", "ADR-001"),
+                ("acme/app", "ADR-002"),
+                ("zeta/standards", "ADR-001"),
+            ]
+        );
+
+        let mut paths = [
+            ArtifactPath::new("zeta/standards", "a.md"),
+            ArtifactPath::new("acme/app", "z.md"),
+            ArtifactPath::new("acme/app", "a.md"),
+        ];
+        paths.sort();
+        assert_eq!(paths[0], ArtifactPath::new("acme/app", "a.md"));
+        assert_eq!(paths[2], ArtifactPath::new("zeta/standards", "a.md"));
+    }
+
+    #[test]
+    fn provenance_serde_is_stable_and_omits_absent_local_fields() {
+        assert_eq!(
+            serde_json::to_string(&ArtifactKey::new("acme/app", "APP-001")).unwrap(),
+            r#"{"source":"acme/app","canonical_id":"APP-001"}"#
+        );
+        assert_eq!(
+            serde_json::to_string(&ArtifactPath::new("acme/app", "decisions/adr-001.md")).unwrap(),
+            r#"{"source":"acme/app","relative_path":"decisions/adr-001.md"}"#
+        );
+        let local = CorpusLayer::local("acme/app").origin();
+        assert_eq!(
+            serde_json::to_string(&local).unwrap(),
+            r#"{"source":"acme/app","layer":"local"}"#
+        );
+        assert_eq!(
+            serde_json::from_str::<ArtifactOrigin>(r#"{"source":"acme/app","layer":"local"}"#)
+                .unwrap(),
+            local
+        );
+
+        let inherited =
+            CorpusLayer::inherited("acme/standards", "standards", "sha256:0123456789abcdef")
+                .origin();
+        assert_eq!(
+            serde_json::to_string(&inherited).unwrap(),
+            r#"{"source":"acme/standards","layer":"inherited","pin":"sha256:0123456789abcdef","alias":"standards"}"#
+        );
+        assert_eq!(
+            serde_json::from_str::<ArtifactOrigin>(&serde_json::to_string(&inherited).unwrap())
+                .unwrap(),
+            inherited
+        );
+    }
+
+    #[test]
+    fn stable_identity_does_not_include_clone_location() {
+        let layer =
+            CorpusLayer::inherited("acme/standards", "standards", "sha256:0123456789abcdef");
+        let left = PhysicalArtifactLocator::new(
+            PhysicalCorpusLocator::new("/clone-a", "/clone-a/vendor/standards/decisions"),
+            "/clone-a/vendor/standards/decisions/decisions/adr-001.md",
+        );
+        let right = PhysicalArtifactLocator::new(
+            PhysicalCorpusLocator::new("/clone-b", "/clone-b/vendor/standards/decisions"),
+            "/clone-b/vendor/standards/decisions/decisions/adr-001.md",
+        );
+
+        assert_ne!(left, right);
+        assert_eq!(
+            layer.origin().key("ADR-001"),
+            ArtifactKey::new("acme/standards", "ADR-001")
+        );
+        assert_eq!(
+            layer.origin().path("decisions/adr-001.md"),
+            ArtifactPath::new("acme/standards", "decisions/adr-001.md")
+        );
+        assert!(!serde_json::to_string(&layer).unwrap().contains("clone-"));
+    }
+}

--- a/rust/rac-engine/src/delta_generation.rs
+++ b/rust/rac-engine/src/delta_generation.rs
@@ -37,6 +37,8 @@ use crate::retrieve::{scope_rows_from_items, ScopeRow};
 #[derive(Clone)]
 pub struct IdentityRow {
     pub entry: IndexEntry,
+    pub artifact_path: crate::corpus::ArtifactPath,
+    pub origin: crate::corpus::ArtifactOrigin,
     pub status: String,
 }
 
@@ -44,6 +46,8 @@ impl IdentityRow {
     fn from_item(item: &CorpusItem) -> Self {
         Self {
             entry: identity_entry_from_item(item),
+            artifact_path: item.artifact_path.clone(),
+            origin: item.origin.clone(),
             status: artifact_status(&item.artifact),
         }
     }
@@ -169,6 +173,26 @@ impl IdentityGeneration {
             return None;
         }
         self.base.get(path).map(|row| row.status.as_str())
+    }
+
+    pub fn artifact_path_for_path(&self, path: &str) -> Option<&crate::corpus::ArtifactPath> {
+        if let Some(row) = self.upserts.get(path) {
+            return Some(&row.artifact_path);
+        }
+        if self.tombstones.contains(path) {
+            return None;
+        }
+        self.base.get(path).map(|row| &row.artifact_path)
+    }
+
+    pub fn origin_for_path(&self, path: &str) -> Option<&crate::corpus::ArtifactOrigin> {
+        if let Some(row) = self.upserts.get(path) {
+            return Some(&row.origin);
+        }
+        if self.tombstones.contains(path) {
+            return None;
+        }
+        self.base.get(path).map(|row| &row.origin)
     }
 
     pub fn entries(&self) -> Vec<IndexEntry> {
@@ -444,31 +468,38 @@ fn resolve_graph_row(row: &ValidationRow, identity: &IdentityGeneration) -> Vec<
     for (section, targets) in &row.edges {
         let external = edge_spec(section).is_some_and(|spec| spec.external);
         for target in targets {
-            let (resolved_path, issue) = if external {
-                (None, None)
+            let (resolved_path, resolved_artifact, issue) = if external {
+                (None, None, None)
             } else {
                 let result = identity.resolve(target);
                 match result.outcome {
-                    OUTCOME_NOT_FOUND => (None, Some(ISSUE_TARGET_NOT_FOUND.to_string())),
-                    OUTCOME_DUPLICATE => (None, Some(ISSUE_TARGET_AMBIGUOUS.to_string())),
+                    OUTCOME_NOT_FOUND => {
+                        (None, None, Some(ISSUE_TARGET_NOT_FOUND.to_string()))
+                    }
+                    OUTCOME_DUPLICATE => {
+                        (None, None, Some(ISSUE_TARGET_AMBIGUOUS.to_string()))
+                    }
                     OUTCOME_RESOLVED => {
                         let path = result
                             .artifact
                             .expect("resolved identity has artifact")
                             .path;
                         if path == row.path {
-                            (None, Some(ISSUE_SELF_REFERENCE.to_string()))
+                            (None, None, Some(ISSUE_SELF_REFERENCE.to_string()))
                         } else {
-                            (Some(path), None)
+                            let artifact_path = identity.artifact_path_for_path(&path).cloned();
+                            (Some(path), artifact_path, None)
                         }
                     }
                     _ => unreachable!("identity resolution outcome"),
                 }
             };
             edges.push(Relationship {
+                source_artifact: Some(row.artifact_path.clone()),
                 source_path: row.path.clone(),
                 relationship: section.clone(),
                 target: target.clone(),
+                resolved_artifact,
                 resolved_path,
                 issue,
             });
@@ -1196,7 +1227,45 @@ impl DeltaGeneration {
     /// validation and is therefore suitable for durable compaction.
     pub fn materialize_derived(&self, directory: &str, recursive: bool) -> DerivedIndex {
         let (index_entries, field_tokens) = self.search.entries_and_fields(&self.graph);
+        let compatibility_layer = crate::corpus::compatible_local_layer(directory);
+        let source_artifacts: Vec<crate::derived::SourceAwareArtifact> = index_entries
+            .iter()
+            .map(|entry| {
+                let path = self
+                    .identity
+                    .artifact_path_for_path(&entry.path)
+                    .cloned()
+                    .unwrap_or_else(|| {
+                        crate::corpus::ArtifactPath::new(
+                            compatibility_layer.source.clone(),
+                            entry.path.clone(),
+                        )
+                    });
+                let origin = self
+                    .identity
+                    .origin_for_path(&entry.path)
+                    .cloned()
+                    .unwrap_or_else(|| compatibility_layer.origin());
+                crate::derived::SourceAwareArtifact {
+                    key: origin.key(entry.id.clone()),
+                    path,
+                    origin,
+                    display_path: entry.path.clone(),
+                }
+            })
+            .collect();
+        let mut layers: Vec<crate::corpus::CorpusLayer> = source_artifacts
+            .iter()
+            .map(|artifact| crate::corpus::CorpusLayer::from(&artifact.origin))
+            .collect();
+        layers.sort();
+        layers.dedup();
+        if layers.is_empty() {
+            layers.push(compatibility_layer);
+        }
         DerivedIndex {
+            layers,
+            source_artifacts,
             index_entries,
             field_tokens,
             relationships: self.graph.relationships(),
@@ -1219,11 +1288,7 @@ mod tests {
         let text = DOC.replace("ADR-1", id).replace("Accepted", status);
         let artifact = crate::parse::parse_text(&text, path);
         let spec = crate::spec::spec_for(&crate::classify::classify(&artifact).artifact_type);
-        CorpusItem {
-            path: path.to_string(),
-            artifact,
-            spec,
-        }
+        CorpusItem::compatible_local_file(path, artifact, spec)
     }
 
     fn tagged_item(path: &str, id: &str, status: &str, tag: &str) -> CorpusItem {
@@ -1237,11 +1302,7 @@ mod tests {
             );
         let artifact = crate::parse::parse_text(&text, path);
         let spec = crate::spec::spec_for(&crate::classify::classify(&artifact).artifact_type);
-        CorpusItem {
-            path: path.to_string(),
-            artifact,
-            spec,
-        }
+        CorpusItem::compatible_local_file(path, artifact, spec)
     }
 
     fn related_item(path: &str, id: &str, target: &str) -> CorpusItem {
@@ -1250,11 +1311,7 @@ mod tests {
         );
         let artifact = crate::parse::parse_text(&text, path);
         let spec = crate::spec::spec_for(&crate::classify::classify(&artifact).artifact_type);
-        CorpusItem {
-            path: path.to_string(),
-            artifact,
-            spec,
-        }
+        CorpusItem::compatible_local_file(path, artifact, spec)
     }
 
     fn scoped_item(path: &str, id: &str, status: &str, scope: Option<&str>) -> CorpusItem {
@@ -1267,11 +1324,7 @@ mod tests {
             .replace("\n## Status", &format!("{scope}\n\n## Status"));
         let artifact = crate::parse::parse_text(&text, path);
         let spec = crate::spec::spec_for(&crate::classify::classify(&artifact).artifact_type);
-        CorpusItem {
-            path: path.to_string(),
-            artifact,
-            spec,
-        }
+        CorpusItem::compatible_local_file(path, artifact, spec)
     }
 
     fn scope_signature(rows: Vec<ScopeRow>) -> Vec<(String, String, String, String, Vec<String>)> {

--- a/rust/rac-engine/src/derived.rs
+++ b/rust/rac-engine/src/derived.rs
@@ -7,6 +7,7 @@
 
 use serde_json::Value;
 
+use crate::corpus::{ArtifactKey, ArtifactOrigin, ArtifactPath, CorpusLayer};
 use crate::relationships::{corpus_items, relationships_from_corpus, CorpusItem, Relationship};
 use crate::resolve::{entry_from_item, field_tokens_of, is_live_decision, FieldTokens, IndexEntry};
 use crate::retrieve::{scope_rows_from_items, ScopeRow};
@@ -16,8 +17,24 @@ pub const SCHEMA_VERSION: &str = "3";
 
 pub(crate) const DECISION_TYPE: &str = "decision";
 
+/// The source-aware identity projection parallel to the existing searchable
+/// rows. It remains in memory while the frozen v1 store is the compatibility
+/// format; the versioned store cutover will persist these exact values.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourceAwareArtifact {
+    pub key: ArtifactKey,
+    pub path: ArtifactPath,
+    pub origin: ArtifactOrigin,
+    /// Released display path retained independently from stable path identity.
+    pub display_path: String,
+}
+
 /// The expensive derived structures for one corpus snapshot.
 pub struct DerivedIndex {
+    /// Stable layer identities represented in this generation.
+    pub layers: Vec<CorpusLayer>,
+    /// Per-document source identity in the same order as `index_entries`.
+    pub source_artifacts: Vec<SourceAwareArtifact>,
     /// Repository index rows in walk (sorted-path) order — docid order.
     pub index_entries: Vec<IndexEntry>,
     /// Per-entry BM25F field-token vectors, parallel to `index_entries`.
@@ -54,6 +71,24 @@ pub fn build_derived_index_from_items(
         })
         .collect();
     let field_tokens: Vec<FieldTokens> = index_entries.iter().map(field_tokens_of).collect();
+    let source_artifacts: Vec<SourceAwareArtifact> = items
+        .iter()
+        .map(|item| SourceAwareArtifact {
+            key: item.key.clone(),
+            path: item.artifact_path.clone(),
+            origin: item.origin.clone(),
+            display_path: item.path.clone(),
+        })
+        .collect();
+    let mut layers: Vec<CorpusLayer> = items
+        .iter()
+        .map(|item| CorpusLayer::from(&item.origin))
+        .collect();
+    layers.sort();
+    layers.dedup();
+    if layers.is_empty() {
+        layers.push(crate::corpus::compatible_local_layer(directory));
+    }
     let live_decision_paths: Vec<String> = items
         .iter()
         .filter(|item| {
@@ -64,6 +99,8 @@ pub fn build_derived_index_from_items(
         .collect();
     let summary = crate::portfolio::portfolio_from_corpus(directory, items, recursive);
     DerivedIndex {
+        layers,
+        source_artifacts,
         index_entries,
         field_tokens,
         relationships,

--- a/rust/rac-engine/src/export.rs
+++ b/rust/rac-engine/src/export.rs
@@ -8,7 +8,7 @@ use crate::pycompat::py_strip;
 use crate::relationships::{
     corpus_items, edge_spec, relationships_from_corpus, CorpusItem,
 };
-use crate::scaffold::{load_repository_identity, ScaffoldError};
+use crate::scaffold::ScaffoldError;
 use crate::spec::ArtifactSpec;
 use crate::validate::load_ticketing_provider;
 
@@ -23,6 +23,12 @@ const DOCUMENTS_SCHEMA: &str =
     include_str!("../assets/schemas/export-documents-v1.schema.json");
 const GRAPH_SCHEMA: &str = include_str!("../assets/schemas/export-graph-v1.schema.json");
 
+/// Released display name; unlike source identity, this remains tied to the
+/// caller's directory spelling.
+fn corpus_name(directory: &str) -> String {
+    crate::corpus::compatible_corpus_name(directory)
+}
+
 /// Return the packaged Draft 2020-12 contract for an export projection.
 ///
 /// These bytes are the public resource surfaced by `decided export --schema`;
@@ -36,35 +42,11 @@ pub fn export_schema(name: &str) -> Option<&'static str> {
     }
 }
 
-/// `_corpus_name(directory)`.
-fn corpus_name(directory: &str) -> String {
-    let normalized = crate::walk::normalize_root(directory);
-    let trimmed = normalized.trim_end_matches('/');
-    let name = trimmed.rsplit('/').next().unwrap_or("");
-    if name.is_empty() || name == "." || name == ".." {
-        directory.to_string()
-    } else {
-        name.to_string()
-    }
-}
-
 /// The one non-federated source derivation shared by every JSON projection:
 /// explicit `corpus.source`, then the lower-case repository key, then the
 /// released directory-basename fallback (ADR-135).
 pub fn corpus_source(directory: &str) -> Result<String, ScaffoldError> {
-    let Some(identity) = load_repository_identity(directory)? else {
-        return Ok(corpus_name(directory));
-    };
-    if let Some(source) = identity.corpus_source {
-        return Ok(source);
-    }
-    if let Some(repository_key) = identity.repository_key {
-        return Ok(repository_key
-            .strip_suffix('\n')
-            .unwrap_or(&repository_key)
-            .to_ascii_lowercase());
-    }
-    Ok(corpus_name(directory))
+    crate::corpus::compatible_corpus_source(directory)
 }
 
 fn first_line(raw: &str) -> String {

--- a/rust/rac-engine/src/freshness.rs
+++ b/rust/rac-engine/src/freshness.rs
@@ -310,7 +310,8 @@ impl FreshnessTracker {
                     self.items.remove(rel); // removed
                 }
             }
-            let (parsed, workers) = crate::parallel_build::parallel_parse_paths(&present);
+            let (parsed, workers) =
+                crate::parallel_build::parallel_parse_paths(&self.root_str, &present);
             self.last_parse_workers = workers;
             self.last_parse_files = present.len();
             for item in parsed {
@@ -333,7 +334,8 @@ impl FreshnessTracker {
     fn reparse_full(&mut self) {
         let root = PathBuf::from(&self.root_str);
         let paths: Vec<PathBuf> = self.manifest.iter().map(|(rel, _)| root.join(rel)).collect();
-        let (parsed, workers) = crate::parallel_build::parallel_parse_paths(&paths);
+        let (parsed, workers) =
+            crate::parallel_build::parallel_parse_paths(&self.root_str, &paths);
         self.last_parse_workers = workers;
         self.last_parse_files = paths.len();
         self.items = parsed
@@ -374,7 +376,8 @@ impl FreshnessTracker {
             .filter(|rel| current.contains(rel.as_str()))
             .map(|rel| root.join(rel))
             .collect();
-        let (parsed, workers) = crate::parallel_build::parallel_parse_paths(&present);
+        let (parsed, workers) =
+            crate::parallel_build::parallel_parse_paths(&self.root_str, &present);
         self.last_parse_workers = workers;
         self.last_parse_files = present.len();
         let parsed: BTreeMap<String, CorpusItem> = parsed
@@ -490,7 +493,8 @@ impl FreshnessTracker {
             .iter()
             .map(|(rel, _)| root.join(rel))
             .collect();
-        let (parsed, workers) = crate::parallel_build::parallel_parse_paths(&paths);
+        let (parsed, workers) =
+            crate::parallel_build::parallel_parse_paths(&self.root_str, &paths);
         self.last_parse_workers = workers;
         self.last_parse_files = paths.len();
         let parsed: BTreeMap<String, CorpusItem> = parsed

--- a/rust/rac-engine/src/index_store.rs
+++ b/rust/rac-engine/src/index_store.rs
@@ -540,6 +540,9 @@ impl MmapIndexReader {
         let aliases = reader.text_list()?;
         let tags = reader.text_list()?;
         Ok(IndexEntry {
+            key: None,
+            artifact_path: None,
+            origin: None,
             id,
             artifact_type,
             title,
@@ -563,6 +566,9 @@ impl MmapIndexReader {
         let inbound = reader.u32()?;
         let sections = self.read_sections(docid)?;
         Ok(IndexEntry {
+            key: None,
+            artifact_path: None,
+            origin: None,
             id,
             artifact_type,
             title,
@@ -773,9 +779,11 @@ impl MmapIndexReader {
         let mut result = Vec::with_capacity(count.min(1 << 20) as usize);
         for _ in 0..count {
             result.push(Relationship {
+                source_artifact: None,
                 source_path: reader.text()?,
                 relationship: reader.text()?,
                 target: reader.text()?,
+                resolved_artifact: None,
                 resolved_path: reader.opt_text()?,
                 issue: reader.opt_text()?,
             });

--- a/rust/rac-engine/src/lib.rs
+++ b/rust/rac-engine/src/lib.rs
@@ -46,6 +46,7 @@ pub mod walk;
 pub mod parse;
 pub mod classify;
 pub mod identity;
+pub mod corpus;
 pub mod validate;
 pub mod relationships;
 pub mod diff;

--- a/rust/rac-engine/src/parallel_build.rs
+++ b/rust/rac-engine/src/parallel_build.rs
@@ -16,6 +16,9 @@
 
 use std::path::PathBuf;
 
+use crate::corpus::{
+    compatible_local_layer, ArtifactOrigin, PhysicalArtifactLocator, PhysicalCorpusLocator,
+};
 use crate::derived::{build_derived_index_from_items, DerivedIndex, DECISION_TYPE};
 use crate::relationships::{relationships_from_corpus, CorpusItem};
 use crate::resolve::{entry_from_item, field_tokens_of, is_live_decision, IndexEntry};
@@ -80,17 +83,24 @@ struct DocFragment {
     scope_row: Option<ScopeRow>,
 }
 
-fn fragment_for(path_display: &str) -> DocFragment {
+fn fragment_for(
+    entry: &crate::walk::WalkEntry,
+    origin: &ArtifactOrigin,
+    physical_corpus: &PhysicalCorpusLocator,
+) -> DocFragment {
     if std::env::var_os(FAULT_ENV).is_some() {
         panic!("parallel-build worker fault (injected)");
     }
-    let artifact = crate::parse::parse_file(path_display);
+    let artifact = crate::parse::parse_file(&entry.display);
     let spec = crate::spec::spec_for(&crate::classify::classify(&artifact).artifact_type);
-    let item = CorpusItem {
-        path: path_display.to_string(),
+    let item = CorpusItem::new(
+        entry.display.clone(),
+        entry.rel(),
         artifact,
         spec,
-    };
+        origin.clone(),
+        PhysicalArtifactLocator::new(physical_corpus.clone(), entry.abs.clone()),
+    );
     let index_entry = entry_from_item(&item, 0);
     let field_tokens = field_tokens_of(&index_entry);
     let live = item.spec.map(|s| s.name == DECISION_TYPE).unwrap_or(false)
@@ -106,7 +116,12 @@ fn fragment_for(path_display: &str) -> DocFragment {
 }
 
 /// Fan the parse + per-doc derive across `n_workers`, or None on any fault.
-fn fragments_parallel(paths: &[String], n_workers: usize) -> Option<Vec<DocFragment>> {
+fn fragments_parallel(
+    entries: &[crate::walk::WalkEntry],
+    n_workers: usize,
+    origin: &ArtifactOrigin,
+    physical_corpus: &PhysicalCorpusLocator,
+) -> Option<Vec<DocFragment>> {
     let pool = rayon::ThreadPoolBuilder::new()
         .num_threads(n_workers)
         .build()
@@ -114,9 +129,9 @@ fn fragments_parallel(paths: &[String], n_workers: usize) -> Option<Vec<DocFragm
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         pool.install(|| {
             use rayon::prelude::*;
-            paths
+            entries
                 .par_iter()
-                .map(|path| fragment_for(path))
+                .map(|entry| fragment_for(entry, origin, physical_corpus))
                 .collect::<Vec<DocFragment>>()
         })
     }));
@@ -130,6 +145,7 @@ fn fragments_parallel(paths: &[String], n_workers: usize) -> Option<Vec<DocFragm
 fn reproduce(fragments: Vec<DocFragment>, directory: &str, recursive: bool) -> DerivedIndex {
     let mut items = Vec::with_capacity(fragments.len());
     let mut index_entries = Vec::with_capacity(fragments.len());
+    let mut source_artifacts = Vec::with_capacity(fragments.len());
     let mut field_tokens = Vec::with_capacity(fragments.len());
     let mut live_decision_paths = Vec::new();
     let mut scope_rows = Vec::new();
@@ -140,6 +156,12 @@ fn reproduce(fragments: Vec<DocFragment>, directory: &str, recursive: bool) -> D
         if let Some(row) = fragment.scope_row {
             scope_rows.push(row);
         }
+        source_artifacts.push(crate::derived::SourceAwareArtifact {
+            key: fragment.item.key.clone(),
+            path: fragment.item.artifact_path.clone(),
+            origin: fragment.item.origin.clone(),
+            display_path: fragment.item.path.clone(),
+        });
         items.push(fragment.item);
         index_entries.push(fragment.index_entry);
         field_tokens.push(fragment.field_tokens);
@@ -156,7 +178,18 @@ fn reproduce(fragments: Vec<DocFragment>, directory: &str, recursive: bool) -> D
         entry.inbound_count = inbound.get(entry.path.as_str()).copied().unwrap_or(0);
     }
     let summary = crate::portfolio::portfolio_from_corpus(directory, &items, recursive);
+    let mut layers: Vec<crate::corpus::CorpusLayer> = items
+        .iter()
+        .map(|item| crate::corpus::CorpusLayer::from(&item.origin))
+        .collect();
+    layers.sort();
+    layers.dedup();
+    if layers.is_empty() {
+        layers.push(crate::corpus::compatible_local_layer(directory));
+    }
     DerivedIndex {
+        layers,
+        source_artifacts,
         index_entries,
         field_tokens,
         relationships,
@@ -174,13 +207,12 @@ pub fn build_derived_index_parallel(
     workers: Option<usize>,
 ) -> (DerivedIndex, BuildStats) {
     let t0 = std::time::Instant::now();
-    let paths: Vec<String> = crate::walk::find_markdown_files(directory, recursive)
-        .into_iter()
-        .map(|e| e.display)
-        .collect();
-    let n_workers = resolve_workers(workers, paths.len());
+    let entries = crate::walk::find_markdown_files(directory, recursive);
+    let n_workers = resolve_workers(workers, entries.len());
+    let origin = compatible_local_layer(directory).origin();
+    let physical_corpus = PhysicalCorpusLocator::local(directory);
     let fragments = if n_workers > 1 {
-        fragments_parallel(&paths, n_workers)
+        fragments_parallel(&entries, n_workers, &origin, &physical_corpus)
     } else {
         None
     };
@@ -233,7 +265,10 @@ pub fn emit_build_timing(stats: &BuildStats) {
 /// The paths type alias for the freshness tracker's explicit-list parse
 /// (INDEX-PLAN B6): parse a known path list through the one true per-file
 /// path, parallel when it pays; entries in list order.
-pub fn parallel_parse_paths(paths: &[PathBuf]) -> (Vec<CorpusItem>, usize) {
+pub fn parallel_parse_paths(root: &str, paths: &[PathBuf]) -> (Vec<CorpusItem>, usize) {
+    let corpus_root = PathBuf::from(root);
+    let origin = compatible_local_layer(root).origin();
+    let physical_corpus = PhysicalCorpusLocator::local(&corpus_root);
     let displays: Vec<String> = paths
         .iter()
         .map(|p| p.to_string_lossy().into_owned())
@@ -245,11 +280,21 @@ pub fn parallel_parse_paths(paths: &[PathBuf]) -> (Vec<CorpusItem>, usize) {
             let artifact = crate::parse::parse_file(path);
             let spec =
                 crate::spec::spec_for(&crate::classify::classify(&artifact).artifact_type);
-            CorpusItem {
-                path: path.clone(),
+            let relative_path = PathBuf::from(path)
+                .strip_prefix(&corpus_root)
+                .unwrap_or_else(|_| std::path::Path::new(path))
+                .iter()
+                .map(|part| part.to_string_lossy())
+                .collect::<Vec<_>>()
+                .join("/");
+            CorpusItem::new(
+                path.clone(),
+                relative_path,
                 artifact,
                 spec,
-            }
+                origin.clone(),
+                PhysicalArtifactLocator::new(physical_corpus.clone(), path),
+            )
         })
         .collect();
     let workers = std::thread::available_parallelism()

--- a/rust/rac-engine/src/parallel_build.rs
+++ b/rust/rac-engine/src/parallel_build.rs
@@ -117,7 +117,7 @@ fn fragment_for(
 
 /// Fan the parse + per-doc derive across `n_workers`, or None on any fault.
 fn fragments_parallel(
-    entries: &[crate::walk::WalkEntry],
+    paths: &[crate::walk::WalkEntry],
     n_workers: usize,
     origin: &ArtifactOrigin,
     physical_corpus: &PhysicalCorpusLocator,
@@ -129,7 +129,7 @@ fn fragments_parallel(
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         pool.install(|| {
             use rayon::prelude::*;
-            entries
+            paths
                 .par_iter()
                 .map(|entry| fragment_for(entry, origin, physical_corpus))
                 .collect::<Vec<DocFragment>>()

--- a/rust/rac-engine/src/portfolio.rs
+++ b/rust/rac-engine/src/portfolio.rs
@@ -5,7 +5,7 @@
 use crate::classify::missing_sections;
 use crate::pycompat::py_round;
 use crate::relationships::{
-    summary_from_rows, validation_from_rows, validation_row, CorpusItem, RelationshipSummary,
+    summary_from_rows, validation_from_rows, CorpusItem, RelationshipSummary,
     ValidationRow, ISSUE_SELF_REFERENCE, ISSUE_TARGET_AMBIGUOUS, ISSUE_TARGET_NOT_FOUND,
 };
 use crate::validate::{apply_overrides, has_errors, load_overrides, py_title, validate, SeverityOverrides};
@@ -99,7 +99,7 @@ pub fn portfolio_row(item: &CorpusItem) -> PortfolioRow {
         .spec
         .map(|s| s.name.clone())
         .unwrap_or_else(|| "unknown".to_string());
-    let vrow = validation_row(&path, &item.artifact, item.spec);
+    let vrow = crate::relationships::validation_row_from_item(item);
     match item.spec {
         None => PortfolioRow {
             path,

--- a/rust/rac-engine/src/relationships.rs
+++ b/rust/rac-engine/src/relationships.rs
@@ -10,6 +10,10 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 use crate::classify::classify;
+use crate::corpus::{
+    compatible_local_layer, ArtifactKey, ArtifactOrigin, ArtifactPath,
+    PhysicalArtifactLocator, PhysicalCorpusLocator,
+};
 use crate::identity::{artifact_identifier, artifact_identifiers, strip_list_marker};
 use crate::parse::{parse_file, Artifact};
 use crate::pycompat::{py_casefold, py_splitlines, py_strip};
@@ -265,6 +269,9 @@ fn is_retired(artifact: &Artifact, spec: &ArtifactSpec) -> bool {
 
 #[derive(Debug, Clone)]
 pub struct ValidationRow {
+    pub key: ArtifactKey,
+    pub artifact_path: ArtifactPath,
+    pub origin: ArtifactOrigin,
     pub path: String,
     /// Artifact type name, or None for an Unknown/untyped document.
     pub spec_name: Option<String>,
@@ -282,10 +289,56 @@ pub fn validation_row(
     artifact: &Artifact,
     spec: Option<&ArtifactSpec>,
 ) -> ValidationRow {
+    let parent = std::path::Path::new(path)
+        .parent()
+        .and_then(std::path::Path::to_str)
+        .unwrap_or(".");
+    let layer = compatible_local_layer(parent);
+    let origin = layer.origin();
+    let relative_path = std::path::Path::new(path)
+        .file_name()
+        .and_then(std::ffi::OsStr::to_str)
+        .unwrap_or(path);
     let identifiers = artifact_identifiers(artifact, spec, path);
     let canonical_id = artifact_identifier(artifact, spec, path);
+    validation_row_with_identity(
+        path,
+        artifact,
+        spec,
+        origin.key(canonical_id),
+        origin.path(relative_path),
+        origin,
+        identifiers,
+    )
+}
+
+pub(crate) fn validation_row_from_item(item: &CorpusItem) -> ValidationRow {
+    validation_row_with_identity(
+        &item.path,
+        &item.artifact,
+        item.spec,
+        item.key.clone(),
+        item.artifact_path.clone(),
+        item.origin.clone(),
+        artifact_identifiers(&item.artifact, item.spec, &item.path),
+    )
+}
+
+fn validation_row_with_identity(
+    path: &str,
+    artifact: &Artifact,
+    spec: Option<&ArtifactSpec>,
+    key: ArtifactKey,
+    artifact_path: ArtifactPath,
+    origin: ArtifactOrigin,
+    identifiers: Vec<String>,
+) -> ValidationRow {
+    let canonical_id = key.canonical_id.clone();
     match spec {
         None => ValidationRow {
+            key,
+            artifact_path,
+            origin,
             path: path.to_string(),
             spec_name: None,
             canonical_id,
@@ -295,6 +348,9 @@ pub fn validation_row(
             edges: Vec::new(),
         },
         Some(spec) => ValidationRow {
+            key,
+            artifact_path,
+            origin,
             path: path.to_string(),
             spec_name: Some(spec.name.clone()),
             canonical_id,
@@ -911,11 +967,7 @@ pub fn build_relationship_report(directory: &str, recursive: bool) -> Relationsh
 pub fn build_relationship_report_file(path: &str) -> RelationshipReport {
     let artifact = parse_file(path);
     let spec = spec_for(&classify(&artifact).artifact_type);
-    let items = vec![CorpusItem {
-        path: path.to_string(),
-        artifact,
-        spec,
-    }];
+    let items = vec![CorpusItem::compatible_local_file(path, artifact, spec)];
     build_report(path, items, false)
 }
 
@@ -923,12 +975,68 @@ pub fn build_relationship_report_file(path: &str) -> RelationshipReport {
 // Corpus entry points
 // ---------------------------------------------------------------------------
 
-/// One parsed + classified item: `(display path, artifact, spec)`.
+/// One parsed + classified item with stable identity and a separate runtime
+/// locator. `path` remains the released display string.
 #[derive(Clone)]
 pub struct CorpusItem {
+    pub key: ArtifactKey,
+    pub artifact_path: ArtifactPath,
+    pub origin: ArtifactOrigin,
+    pub locator: PhysicalArtifactLocator,
     pub path: String,
     pub artifact: Artifact,
     pub spec: Option<&'static ArtifactSpec>,
+}
+
+impl CorpusItem {
+    pub fn new(
+        path: String,
+        relative_path: String,
+        artifact: Artifact,
+        spec: Option<&'static ArtifactSpec>,
+        origin: ArtifactOrigin,
+        locator: PhysicalArtifactLocator,
+    ) -> Self {
+        let canonical_id = artifact_identifier(&artifact, spec, &path);
+        Self {
+            key: origin.key(canonical_id),
+            artifact_path: origin.path(relative_path),
+            origin,
+            locator,
+            path,
+            artifact,
+            spec,
+        }
+    }
+
+    /// Compatibility constructor for single-file and synthetic validation
+    /// seams that do not begin with a corpus walk.
+    pub fn compatible_local_file(
+        path: &str,
+        artifact: Artifact,
+        spec: Option<&'static ArtifactSpec>,
+    ) -> Self {
+        let file = std::path::Path::new(path);
+        let corpus_root = file.parent().unwrap_or_else(|| std::path::Path::new("."));
+        let corpus_root_text = corpus_root.to_string_lossy();
+        let origin = compatible_local_layer(&corpus_root_text).origin();
+        let relative_path = file
+            .file_name()
+            .and_then(std::ffi::OsStr::to_str)
+            .unwrap_or(path)
+            .to_string();
+        Self::new(
+            path.to_string(),
+            relative_path,
+            artifact,
+            spec,
+            origin,
+            PhysicalArtifactLocator::new(
+                PhysicalCorpusLocator::local(corpus_root),
+                file,
+            ),
+        )
+    }
 }
 
 /// `_corpus_items(directory, recursive)` — the sorted-path walk, parsed and
@@ -941,16 +1049,22 @@ pub struct CorpusItem {
 /// Rendering stays sequential over the ordered results.
 pub fn corpus_items(directory: &str, recursive: bool) -> Vec<CorpusItem> {
     use rayon::prelude::*;
+    let origin = compatible_local_layer(directory).origin();
+    let physical_corpus = PhysicalCorpusLocator::local(directory);
     find_markdown_files(directory, recursive)
         .into_par_iter()
         .map(|entry| {
+            let relative_path = entry.rel();
             let artifact = parse_file(&entry.display);
             let spec = spec_for(&classify(&artifact).artifact_type);
-            CorpusItem {
-                path: entry.display,
+            CorpusItem::new(
+                entry.display,
+                relative_path,
                 artifact,
                 spec,
-            }
+                origin.clone(),
+                PhysicalArtifactLocator::new(physical_corpus.clone(), entry.abs),
+            )
         })
         .collect()
 }
@@ -958,7 +1072,7 @@ pub fn corpus_items(directory: &str, recursive: bool) -> Vec<CorpusItem> {
 fn rows_from_items(items: &[CorpusItem]) -> Vec<ValidationRow> {
     items
         .iter()
-        .map(|item| validation_row(&item.path, &item.artifact, item.spec))
+        .map(validation_row_from_item)
         .collect()
 }
 
@@ -991,7 +1105,7 @@ pub fn validate_document_against_corpus(
         if py_casefold(&ident) == proposed_ident {
             continue; // the on-disk counterpart of the document being edited
         }
-        rows.push(validation_row(&item.path, &item.artifact, item.spec));
+        rows.push(validation_row_from_item(item));
     }
     rows.push(validation_row(source_path, artifact, spec));
     let result = validation_from_rows(directory, &rows, recursive);
@@ -1017,9 +1131,15 @@ pub fn validate_document_against_corpus(
 /// uniquely to another artifact.
 #[derive(Debug, Clone)]
 pub struct Relationship {
+    /// Stable source-aware endpoint. `None` only when reconstructed from the
+    /// pre-federation v1 persistent store; the v2 cutover owns its codec.
+    pub source_artifact: Option<ArtifactPath>,
     pub source_path: String,
     pub relationship: String,
     pub target: String,
+    /// Stable resolved endpoint, present for a uniquely resolved internal
+    /// edge built from the in-memory read model.
+    pub resolved_artifact: Option<ArtifactPath>,
     pub resolved_path: Option<String>,
     pub issue: Option<String>,
 }
@@ -1031,15 +1151,21 @@ pub fn resolve_relationships(
     index: &ResolutionIndex,
 ) -> Vec<Relationship> {
     let mut out = Vec::new();
+    let artifact_paths: HashMap<&str, &ArtifactPath> = rows
+        .iter()
+        .map(|row| (row.path.as_str(), &row.artifact_path))
+        .collect();
     for row in rows {
         for (section, refs) in &row.edges {
             let external = edge_spec(section).is_some_and(|e| e.external);
             for reference in refs {
                 if external {
                     out.push(Relationship {
+                        source_artifact: Some(row.artifact_path.clone()),
                         source_path: row.path.clone(),
                         relationship: section.clone(),
                         target: reference.clone(),
+                        resolved_artifact: None,
                         resolved_path: None,
                         issue: None,
                     });
@@ -1057,10 +1183,16 @@ pub fn resolve_relationships(
                         (None, Some(ISSUE_SELF_REFERENCE.to_string()))
                     }
                 };
+                let resolved_artifact = resolved
+                    .as_deref()
+                    .and_then(|path| artifact_paths.get(path).copied())
+                    .cloned();
                 out.push(Relationship {
+                    source_artifact: Some(row.artifact_path.clone()),
                     source_path: row.path.clone(),
                     relationship: section.clone(),
                     target: reference.clone(),
+                    resolved_artifact,
                     resolved_path: resolved,
                     issue,
                 });

--- a/rust/rac-engine/src/rename.rs
+++ b/rust/rac-engine/src/rename.rs
@@ -15,7 +15,7 @@ use std::path::{Path, PathBuf};
 
 use crate::pycompat::{py_casefold, py_is_space, py_splitlines, py_strip};
 use crate::relationships::{
-    corpus_items, resolution_index_from_rows, validation_row, CorpusItem, ValidationRow,
+    corpus_items, resolution_index_from_rows, CorpusItem, ValidationRow,
 };
 use crate::spec::RELATIONSHIP_SECTIONS;
 
@@ -719,7 +719,7 @@ pub fn compute_rename(
     let items = corpus_items(directory, recursive);
     let rows: Vec<ValidationRow> = items
         .iter()
-        .map(|item| validation_row(&item.path, &item.artifact, item.spec))
+        .map(crate::relationships::validation_row_from_item)
         .collect();
     let index = resolution_index_from_rows(&rows);
     let mut targets: Vec<&str> = index

--- a/rust/rac-engine/src/resolve.rs
+++ b/rust/rac-engine/src/resolve.rs
@@ -19,12 +19,13 @@
 
 use std::collections::{HashMap, HashSet};
 
+use crate::corpus::{ArtifactKey, ArtifactOrigin, ArtifactPath};
 use crate::identity::{artifact_identifier, artifact_identifiers};
 use crate::markdown::SearchSection;
 use crate::parse::Artifact;
 use crate::pycompat::{first_nonempty_line, py_casefold, py_round, py_strip};
 use crate::relationships::{
-    corpus_items, edge_spec, resolution_index_from_rows, validation_row, CorpusItem,
+    corpus_items, edge_spec, resolution_index_from_rows, validation_row_from_item, CorpusItem,
 };
 use crate::spec::spec_for;
 
@@ -116,6 +117,11 @@ fn tf(term: &str, tokens: &[String]) -> i64 {
 /// One searchable row of the repository index.
 #[derive(Debug, Clone)]
 pub struct IndexEntry {
+    /// Source-aware identity is present for in-memory rows. The frozen v1
+    /// store reconstructs `None` until the versioned v2 codec cutover.
+    pub key: Option<ArtifactKey>,
+    pub artifact_path: Option<ArtifactPath>,
+    pub origin: Option<ArtifactOrigin>,
     pub id: String,
     pub artifact_type: String,
     pub title: Option<String>,
@@ -139,6 +145,9 @@ pub(crate) fn identity_entry_from_item(item: &CorpusItem) -> IndexEntry {
         .map(|s| s.name.clone())
         .unwrap_or_else(|| "unknown".to_string());
     IndexEntry {
+        key: Some(item.key.clone()),
+        artifact_path: Some(item.artifact_path.clone()),
+        origin: Some(item.origin.clone()),
         id: artifact_identifier(&item.artifact, item.spec, &item.path),
         artifact_type,
         title: item.artifact.product.title.clone(),
@@ -170,7 +179,7 @@ pub(crate) fn entry_from_item(item: &CorpusItem, inbound: i64) -> IndexEntry {
 fn inbound_counts(items: &[CorpusItem]) -> HashMap<String, i64> {
     let rows: Vec<_> = items
         .iter()
-        .map(|item| validation_row(&item.path, &item.artifact, item.spec))
+        .map(validation_row_from_item)
         .collect();
     let index = resolution_index_from_rows(&rows);
     let mut counts: HashMap<String, i64> = HashMap::new();
@@ -212,6 +221,9 @@ pub fn index_from_items(items: &[CorpusItem]) -> Vec<IndexEntry> {
 /// One resolved artifact / search match (`ResolvedArtifact`).
 #[derive(Debug, Clone)]
 pub struct ResolvedArtifact {
+    pub key: Option<ArtifactKey>,
+    pub artifact_path: Option<ArtifactPath>,
+    pub origin: Option<ArtifactOrigin>,
     pub id: String,
     pub artifact_type: String,
     pub title: Option<String>,
@@ -270,6 +282,9 @@ pub struct ResolutionResult {
 
 pub(crate) fn resolved_from_entry(entry: &IndexEntry) -> ResolvedArtifact {
     ResolvedArtifact {
+        key: entry.key.clone(),
+        artifact_path: entry.artifact_path.clone(),
+        origin: entry.origin.clone(),
         id: entry.id.clone(),
         artifact_type: entry.artifact_type.clone(),
         title: entry.title.clone(),
@@ -1036,6 +1051,9 @@ pub(crate) fn rank_and_build(
             let fused_raw = fused[index];
             let bm25_raw = bm25_scores[index];
             ResolvedArtifact {
+                key: entry.key.clone(),
+                artifact_path: entry.artifact_path.clone(),
+                origin: entry.origin.clone(),
                 id: entry.id.clone(),
                 artifact_type: entry.artifact_type.clone(),
                 title: entry.title.clone(),
@@ -1145,6 +1163,9 @@ mod tests {
 
     fn test_entry(id: &str, title: &str, path: &str, body: &str, inbound: i64) -> IndexEntry {
         IndexEntry {
+            key: None,
+            artifact_path: None,
+            origin: None,
             id: id.to_string(),
             artifact_type: "decision".to_string(),
             title: Some(title.to_string()),
@@ -1322,6 +1343,9 @@ mod tests {
     #[test]
     fn persisted_field_matching_preserves_tiers_and_snippets() {
         let entry = IndexEntry {
+            key: None,
+            artifact_path: None,
+            origin: None,
             id: "RAC-EXAMPLE1234".to_string(),
             artifact_type: "requirement".to_string(),
             title: Some("Search latency".to_string()),

--- a/rust/rac-engine/src/sentry.rs
+++ b/rust/rac-engine/src/sentry.rs
@@ -307,11 +307,11 @@ fn parse_document(item: &CorpusItem) -> Result<Option<ConstraintDocument>, Box<S
 /// not require a repository tree and therefore fail the ordinary corpus gate
 /// even when code enforcement was not requested.
 pub fn validate_artifact(artifact: &Artifact) -> Vec<Issue> {
-    let item = CorpusItem {
-        path: String::new(),
-        artifact: artifact.clone(),
-        spec: spec_for("decision"),
-    };
+    let item = CorpusItem::compatible_local_file(
+        "",
+        artifact.clone(),
+        spec_for("decision"),
+    );
     match parse_document(&item) {
         Err(finding) => vec![Issue::new("error", finding.code, finding.message, None)],
         _ => Vec::new(),

--- a/rust/rac-engine/tests/index_store_vectors.rs
+++ b/rust/rac-engine/tests/index_store_vectors.rs
@@ -248,6 +248,8 @@ fn corruption_gates(cache_dir: &Path, corpus_hash: &str, seg_dir: &Path) {
     // A same-hash rewrite over a CORRUPT store replaces it (self-heal).
     fs::write(&target, &original[..10]).unwrap();
     let derived = rac_engine::derived::DerivedIndex {
+        layers: Vec::new(),
+        source_artifacts: Vec::new(),
         index_entries: Vec::new(),
         field_tokens: Vec::new(),
         relationships: Vec::new(),

--- a/rust/rac-engine/tests/source_aware_substrate.rs
+++ b/rust/rac-engine/tests/source_aware_substrate.rs
@@ -1,0 +1,190 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use rac_engine::corpus::{ArtifactKey, ArtifactPath, Layer};
+use rac_engine::identity::{artifact_identifier, artifact_identifiers};
+
+const DECISION: &str = r#"---
+schema_version: 1
+id: APP-KWJ4VMKVSS65
+type: decision
+---
+# ADR-001: Keep It Local
+
+## Status
+
+Accepted
+
+## Context
+
+The fixture needs one decision.
+
+## Decision
+
+Keep the released projection exact.
+
+## Consequences
+
+The source-aware fields remain internal.
+"#;
+
+const REQUIREMENT: &str = r#"---
+schema_version: 1
+id: APP-KWJ8S53D06CH
+type: requirement
+---
+# Requirement: Preserve Identity
+
+## Status
+
+Accepted
+
+## Problem
+
+Endpoints need stable source-aware paths.
+
+## Requirements
+
+- [REQ-001] The endpoint MUST retain its corpus source.
+
+## Related Decisions
+
+- APP-KWJ4VMKVSS65
+"#;
+
+fn scratch(tag: &str) -> PathBuf {
+    let unique = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let root =
+        std::env::temp_dir().join(format!("asdecided-{tag}-{}-{unique}", std::process::id()));
+    fs::create_dir_all(root.join(".decided")).unwrap();
+    fs::create_dir_all(root.join("decisions")).unwrap();
+    fs::write(
+        root.join(".decided/config.yaml"),
+        "repository_key: APP\ncorpus:\n  source: acme/app\n",
+    )
+    .unwrap();
+    fs::write(root.join("decisions/adr-001.md"), DECISION).unwrap();
+    root
+}
+
+fn corpus_arg(root: &Path) -> String {
+    root.join("decisions").to_string_lossy().into_owned()
+}
+
+#[test]
+fn stable_identity_survives_equivalent_clone_roots() {
+    let left_root = scratch("clone-a");
+    let right_root = scratch("clone-b");
+    let left = rac_engine::relationships::corpus_items(&corpus_arg(&left_root), true);
+    let right = rac_engine::relationships::corpus_items(&corpus_arg(&right_root), true);
+
+    assert_eq!(left.len(), 1);
+    assert_eq!(right.len(), 1);
+    assert_eq!(left[0].origin, right[0].origin);
+    assert_eq!(
+        left[0].key,
+        ArtifactKey::new("acme/app", "APP-KWJ4VMKVSS65")
+    );
+    assert_eq!(left[0].key, right[0].key);
+    assert_eq!(
+        left[0].artifact_path,
+        ArtifactPath::new("acme/app", "adr-001.md")
+    );
+    assert_eq!(left[0].artifact_path, right[0].artifact_path);
+    assert_eq!(left[0].origin.layer, Layer::Local);
+    assert_ne!(left[0].locator.path, right[0].locator.path);
+
+    let _ = fs::remove_dir_all(left_root);
+    let _ = fs::remove_dir_all(right_root);
+}
+
+#[test]
+fn no_manifest_keeps_the_released_index_projection_byte_exact() {
+    let root = scratch("parity");
+    assert!(!root.join(".decided/corpus.md").exists());
+    let directory = corpus_arg(&root);
+    let items = rac_engine::relationships::corpus_items(&directory, true);
+
+    // This is the complete path-only projection used before the source-aware
+    // substrate. It intentionally does not inspect the new identity fields.
+    let legacy = rac_engine::index::RepositoryIndex {
+        directory: directory.clone(),
+        recursive: true,
+        artifacts: items
+            .iter()
+            .map(|item| rac_engine::index::IndexEntry {
+                id: artifact_identifier(&item.artifact, item.spec, &item.path),
+                artifact_type: rac_engine::classify::classify(&item.artifact).artifact_type,
+                title: item.artifact.product.title.clone(),
+                path: item.path.clone(),
+                aliases: artifact_identifiers(&item.artifact, item.spec, &item.path),
+            })
+            .collect(),
+    };
+    let source_aware = rac_engine::index::build_repository_index(&directory, true);
+
+    assert_eq!(
+        rac_engine::output::render_index_json(&source_aware),
+        rac_engine::output::render_index_json(&legacy)
+    );
+    assert_eq!(
+        rac_engine::output::render_index_human(&source_aware),
+        rac_engine::output::render_index_human(&legacy)
+    );
+
+    let derived = rac_engine::derived::build_derived_index(&directory, true);
+    assert_eq!(derived.layers.len(), 1);
+    assert_eq!(derived.layers[0].source, "acme/app");
+    assert_eq!(derived.source_artifacts.len(), derived.index_entries.len());
+    assert_eq!(derived.source_artifacts[0].key, items[0].key);
+    assert_eq!(derived.source_artifacts[0].path, items[0].artifact_path);
+    assert_eq!(derived.index_entries[0].key, Some(items[0].key.clone()));
+    assert_eq!(
+        derived.index_entries[0].artifact_path,
+        Some(items[0].artifact_path.clone())
+    );
+    let resolved =
+        rac_engine::resolve::resolve_in_index(&derived.index_entries, "APP-KWJ4VMKVSS65")
+            .artifact
+            .expect("source-aware resolved artifact");
+    assert_eq!(resolved.key, Some(items[0].key.clone()));
+    assert_eq!(resolved.origin, Some(items[0].origin.clone()));
+
+    // The frozen v1 codec remains untouched in this substrate-only change.
+    assert_eq!(rac_engine::index_store::STORE_LAYOUT_VERSION, "v1");
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn validation_and_relationships_retain_source_aware_endpoints() {
+    let root = scratch("relationships");
+    fs::write(root.join("decisions/req-002.md"), REQUIREMENT).unwrap();
+    let directory = corpus_arg(&root);
+    let items = rac_engine::relationships::corpus_items(&directory, true);
+    let rows = rac_engine::relationships::rows_from_corpus_items(&items);
+
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].key.source, "acme/app");
+    assert_eq!(rows[1].artifact_path.source, "acme/app");
+    assert!(rows.iter().all(|row| row.origin.layer == Layer::Local));
+
+    let relationships = rac_engine::relationships::relationships_from_corpus(&items);
+    let edge = relationships
+        .iter()
+        .find(|edge| edge.relationship == "related_decisions")
+        .expect("related decision edge");
+    assert_eq!(
+        edge.source_artifact,
+        Some(ArtifactPath::new("acme/app", "req-002.md"))
+    );
+    assert_eq!(
+        edge.resolved_artifact,
+        Some(ArtifactPath::new("acme/app", "adr-001.md"))
+    );
+
+    let _ = fs::remove_dir_all(root);
+}


### PR DESCRIPTION
## What changed

- freezes the approved v1 parent-digest, path/provenance, and override operand contracts
- adds typed local/inherited corpus layers, source-aware artifact keys and paths, and runtime-only physical locators
- threads source identity through corpus items, validation rows, relationship endpoints, resolver results, derived/delta generations, freshness state, Sentry, and the MCP graph projection
- corrects the already-shipped `corpus-source-identity` requirement to Accepted
- leaves the v1 persistent-store bytes and every no-manifest public output unchanged

## Why

ADR-135 and ADR-138 require federation to begin with one source-aware identity substrate shared by every later consumer. This PR establishes that substrate without activating parent-manifest behavior or creating an alternate resolver.

Part of #270.

## Validation

- `cargo test --workspace`: 205 passed, 0 failed, 1 ignored differential driver
- `cargo clippy --workspace --all-targets -- -D warnings`
- persistent-store oracle goldens unchanged
- `decided validate decisions/`: 462 valid, 0 invalid, 12 skipped
- `decided relationships decisions/ --validate`: 2,931 checked, 0 issues
- gate: 0 blocking findings; 134 existing advisories
- `git diff --check`

## Stack

Base PR in the corpus-federation implementation stack. Public federation activation remains deliberately dormant until the complete stack is coherent.