### PR TITLE
feat(federation): verify materialised parent corpora

### DIFF
--- a/decisions/designs/corpus-federation-mechanism.md
+++ b/decisions/designs/corpus-federation-mechanism.md
@@ -145,6 +145,19 @@ unsupported transitive declaration, and a stale digest are distinct stable
 error findings. No parent artifact enters the effective corpus until all four
 checks pass.
 
+The version-one byte contract is fixed. The hash begins with the ASCII domain
+separator `asdecided-corpus-digest-v1\0`. Every following value is framed as a
+one-byte tag, an unsigned 64-bit big-endian byte length, and the exact value
+bytes. Tag `0x01` carries the UTF-8 parent source, tag `0x02` carries the exact
+governing config bytes, and each Markdown file contributes tag `0x03` with its
+corpus-relative POSIX UTF-8 path followed by tag `0x04` with its exact content
+bytes. Files are ordered by those path bytes. No newline, Unicode, YAML, or
+Markdown normalisation occurs. The operator surface is the read-only command
+`decided corpus digest --root <parent-root> --corpus <parent-corpus>`; it reads
+the source from the bounded parent config and prints `sha256:` followed by 64
+lowercase hexadecimal characters. The command never edits the manifest or
+parent and never performs network I/O.
+
 ### One source-aware read model
 
 The engine introduces source-aware equivalents of its path-only concepts:
@@ -221,6 +234,12 @@ An absent, ambiguous, cross-type, retired-rationale, or parent-to-parent
 mapping is a validation error. There is no implicit child-wins or parent-wins
 rule.
 
+All three override operands are canonical IDs. `parent` is qualified; `with`
+and `rationale` are canonical local IDs and do not accept aliases. An override
+redirects only the parent's canonical ID in the effective unqualified view;
+it does not turn the parent's legacy or title aliases into aliases of the
+replacement.
+
 ### Validation semantics
 
 The parent is validated as a source corpus before overlay. A structural or
@@ -261,11 +280,24 @@ They do not copy artifact bodies, excerpts, override mappings, or the full
 response provenance. Because ADR-127 pins the current path-only shape, ADR-141
 must amend that decision explicitly before these fields ship.
 
+Public `path` values remain corpus-relative paths within the artifact's owning
+source; they never expose or encode the vendored or submodule checkout path.
+The accompanying `source` disambiguates equal paths across layers. Federated
+CLI and MCP records carry `source`, `layer`, and `pin` in their existing
+provenance object, with `pin` present only for inherited records. Export
+records carry the same facts in their projection-specific metadata. A
+repository without a manifest retains its existing shapes byte for byte.
+
 Default reads use the effective combined corpus. Human-facing diagnostic and
 export commands may request `--local-only` to inspect the child layer. MCP and
 enforcement do not expose a local-only bypass: an agent connected to a
 federated repository and `decided gate --code` both receive inherited
 governance.
+
+The first increment exposes `--local-only` on viewer, documents, and graph
+exports. Other human diagnostic reads may adopt the same projection later;
+they are not required for the first implementation and must never weaken MCP,
+routing, or enforcement.
 
 ### Code scope and enforcement
 

--- a/decisions/requirements/corpus-source-identity.md
+++ b/decisions/requirements/corpus-source-identity.md
@@ -7,7 +7,7 @@ type: requirement
 
 ## Status
 
-Proposed
+Accepted
 
 Classification: `[internal]` — merge N corpora with zero collisions and give
 federated artifacts one source identity across every surface. Feature E of the

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -34,6 +34,44 @@ These apply across every command.
 
 ---
 
+## corpus digest
+
+Calculate the canonical pin for a parent corpus that is already materialised
+on disk. The command is read-only: it does not clone, fetch, update, write, or
+repin the parent.
+
+```bash
+decided corpus digest --root vendor/standards --corpus decisions
+```
+
+`--root` is the parent repository root and bounds configuration discovery to
+exactly `<root>/.decided/config.yaml`; the command never inherits a config from
+an ancestor. `--corpus` is a relative directory below that root. The config
+must declare an explicit valid `corpus.source`. On success stdout is exactly a
+full lowercase pin followed by a newline:
+
+```text
+sha256:899d5cdfa52b90a157b018dceb20f4f2901e0d56c91b089c12286c0b8b7b3325
+```
+
+Digest version 1 hashes the fixed domain bytes
+`asdecided-corpus-digest-v1\0`, then length-framed records. Each record is a
+one-byte tag, an unsigned 64-bit big-endian byte length, and the raw payload:
+
+1. tag `0x01`: parent `corpus.source` UTF-8 bytes;
+2. tag `0x02`: exact governing `.decided/config.yaml` bytes; then
+3. for every discovered Markdown file in corpus-relative POSIX UTF-8 path
+   order, tag `0x03` for the path bytes and tag `0x04` for its exact content
+   bytes.
+
+Checkout location, timestamps, filesystem iteration order, hidden paths, and
+non-`.md` files do not enter the digest. Absolute or `..` corpus paths, path
+escape, and traversed symlinks are rejected with stable `parent-corpus-*`
+errors. Exit `0` means the digest was calculated; exit `1` means the bounded
+materialisation could not be safely snapshotted.
+
+---
+
 ## validate
 
 Validate an artifact — or every artifact in a directory — for structural and

--- a/rust/decided-mcp/src/graph.rs
+++ b/rust/decided-mcp/src/graph.rs
@@ -191,6 +191,9 @@ impl GraphView {
             artifact_id: artifact_id.to_string(),
             outcome: OUTCOME_RESOLVED,
             artifact: Some(ResolvedArtifact {
+                key: entry.key.clone(),
+                artifact_path: entry.artifact_path.clone(),
+                origin: entry.origin.clone(),
                 id: entry.id.clone(),
                 artifact_type: entry.artifact_type.clone(),
                 title: entry.title.clone(),
@@ -406,6 +409,9 @@ impl GraphView {
 
 fn identity_projection(entry: &IndexEntry) -> IndexEntry {
     IndexEntry {
+        key: entry.key.clone(),
+        artifact_path: entry.artifact_path.clone(),
+        origin: entry.origin.clone(),
         id: entry.id.clone(),
         artifact_type: entry.artifact_type.clone(),
         title: entry.title.clone(),

--- a/rust/decided-mcp/tests/docs_contract.rs
+++ b/rust/decided-mcp/tests/docs_contract.rs
@@ -54,6 +54,7 @@ const SUPPORTED_DECIDED_COMMANDS: &[&str] = &[
     "retrieve",
     "sentry",
     "herald",
+    "corpus",
 ];
 
 fn documented_decided_command(line: &str) -> Option<&str> {

--- a/rust/decided/tests/cli.rs
+++ b/rust/decided/tests/cli.rs
@@ -171,3 +171,87 @@ fn export_rejects_an_invalid_configured_corpus_source() {
 
     fs::remove_dir_all(root).expect("remove CLI smoke corpus");
 }
+
+#[test]
+fn corpus_digest_prints_the_canonical_read_only_pin() {
+    let root = scratch_root();
+    fs::create_dir_all(root.join(".decided")).unwrap();
+    fs::create_dir_all(root.join("decisions/sub")).unwrap();
+    fs::write(
+        root.join(".decided/config.yaml"),
+        b"repository_key: STD\ncorpus:\n  source: acme/standards\n",
+    )
+    .unwrap();
+    fs::write(root.join("decisions/a.md"), b"alpha\n").unwrap();
+    fs::write(root.join("decisions/sub/b.md"), b"beta\r\n").unwrap();
+    fs::write(root.join("decisions/ignored.MD"), b"ignored\n").unwrap();
+    let before_config = fs::read(root.join(".decided/config.yaml")).unwrap();
+    let before_a = fs::read(root.join("decisions/a.md")).unwrap();
+    let root_text = root.to_string_lossy().into_owned();
+
+    let output = run(&[
+        "corpus",
+        "digest",
+        "--root",
+        &root_text,
+        "--corpus",
+        "decisions",
+    ]);
+    assert!(
+        output.status.success(),
+        "stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        output.stdout,
+        b"sha256:899d5cdfa52b90a157b018dceb20f4f2901e0d56c91b089c12286c0b8b7b3325\n"
+    );
+    assert!(output.stderr.is_empty());
+    assert_eq!(fs::read(root.join(".decided/config.yaml")).unwrap(), before_config);
+    assert_eq!(fs::read(root.join("decisions/a.md")).unwrap(), before_a);
+
+    fs::remove_dir_all(root).expect("remove CLI digest corpus");
+}
+
+#[test]
+fn corpus_digest_bounds_config_and_rejects_escaping_corpus_paths() {
+    let root = scratch_root();
+    fs::create_dir_all(root.join("parent/decisions")).unwrap();
+    fs::write(root.join("parent/decisions/a.md"), b"alpha\n").unwrap();
+    fs::create_dir_all(root.join(".decided")).unwrap();
+    fs::write(
+        root.join(".decided/config.yaml"),
+        b"repository_key: CHILD\ncorpus:\n  source: acme/child\n",
+    )
+    .unwrap();
+    let parent = root.join("parent").to_string_lossy().into_owned();
+
+    let missing = run(&[
+        "corpus",
+        "digest",
+        "--root",
+        &parent,
+        "--corpus",
+        "decisions",
+    ]);
+    assert_eq!(missing.status.code(), Some(1));
+    assert!(
+        String::from_utf8_lossy(&missing.stderr).contains("parent-corpus-config-missing")
+    );
+
+    let escaping = run(&[
+        "corpus",
+        "digest",
+        "--root",
+        &parent,
+        "--corpus",
+        "../decisions",
+    ]);
+    assert_eq!(escaping.status.code(), Some(1));
+    assert!(
+        String::from_utf8_lossy(&escaping.stderr).contains("parent-corpus-path-escape")
+    );
+
+    fs::remove_dir_all(root).expect("remove CLI digest corpus");
+}

--- a/rust/rac-engine/src/cli.rs
+++ b/rust/rac-engine/src/cli.rs
@@ -5,16 +5,16 @@
 //! (decision 9) — stdout stays byte-identical (empty on errors).
 
 use crate::commands::{
-    cmd_coverage, cmd_decisions_for, cmd_diagnose, cmd_diff, cmd_doctor, cmd_eval, cmd_export,
-    cmd_find, cmd_gate, cmd_herald, cmd_hook, cmd_improve, cmd_index, cmd_init, cmd_inspect,
-    cmd_mcp_stats, cmd_migrate, cmd_new, cmd_portfolio, cmd_quickstart, cmd_relationships,
-    cmd_rename, cmd_resolve, cmd_retrieve, cmd_review, cmd_schema, cmd_sentry, cmd_skill,
-    cmd_stats, cmd_telemetry, cmd_templates, cmd_usage, cmd_validate, CoverageArgs,
-    DecisionsForArgs, DiagnoseArgs, DiffArgs, DoctorArgs, EvalArgs, ExportArgs, FindArgs,
-    GateArgs, HeraldArgs, HookArgs, ImproveArgs, IndexArgs, InitArgs, InspectArgs, McpStatsArgs,
-    MigrateArgs, NewArgs, PortfolioArgs, QuickstartArgs, RelationshipsArgs, RenameArgs,
-    ResolveArgs, RetrieveArgs, ReviewArgs, SchemaArgs, SentryArgs, SkillArgs, StatsArgs,
-    TelemetryArgs, TemplatesArgs, UsageArgs, ValidateArgs, WatchkeeperArgs,
+    cmd_corpus_digest, cmd_coverage, cmd_decisions_for, cmd_diagnose, cmd_diff, cmd_doctor,
+    cmd_eval, cmd_export, cmd_find, cmd_gate, cmd_herald, cmd_hook, cmd_improve, cmd_index,
+    cmd_init, cmd_inspect, cmd_mcp_stats, cmd_migrate, cmd_new, cmd_portfolio, cmd_quickstart,
+    cmd_relationships, cmd_rename, cmd_resolve, cmd_retrieve, cmd_review, cmd_schema, cmd_sentry,
+    cmd_skill, cmd_stats, cmd_telemetry, cmd_templates, cmd_usage, cmd_validate,
+    CorpusDigestArgs, CoverageArgs, DecisionsForArgs, DiagnoseArgs, DiffArgs, DoctorArgs, EvalArgs,
+    ExportArgs, FindArgs, GateArgs, HeraldArgs, HookArgs, ImproveArgs, IndexArgs, InitArgs,
+    InspectArgs, McpStatsArgs, MigrateArgs, NewArgs, PortfolioArgs, QuickstartArgs,
+    RelationshipsArgs, RenameArgs, ResolveArgs, RetrieveArgs, ReviewArgs, SchemaArgs, SentryArgs,
+    SkillArgs, StatsArgs, TelemetryArgs, TemplatesArgs, UsageArgs, ValidateArgs, WatchkeeperArgs,
 };
 use crate::commands::cmd_watchkeeper;
 use crate::output::rac_version;
@@ -156,7 +156,10 @@ fn run_dispatch(args: &[String]) -> u8 {
     // Native-only additions dispatch but are deliberately NOT in SUBCOMMANDS:
     // the retired Python oracle's `invalid choice` bytes remain pinned by the
     // bounded compatibility suite.
-    if !matches!(first.as_str(), "retrieve" | "sentry" | "herald" | "diagnose")
+    if !matches!(
+        first.as_str(),
+        "retrieve" | "sentry" | "herald" | "diagnose" | "corpus"
+    )
         && !SUBCOMMANDS.contains(&first.as_str())
     {
         return argparse_error("decided", &invalid_choice_message(first));
@@ -232,6 +235,7 @@ fn run_dispatch(args: &[String]) -> u8 {
         "quickstart" => run_quickstart(&rest),
         "rename" => run_rename(&rest),
         "migrate" => run_migrate(&rest),
+        "corpus" => run_corpus(&rest),
         other => {
             eprintln!("decided-rs: subcommand '{other}' is not yet implemented");
             2
@@ -276,6 +280,78 @@ fn take_opt_value(
             &format!("argument {flag}: expected one argument"),
         )),
     }
+}
+
+fn run_corpus(rest: &[&String]) -> u8 {
+    let prog = "decided corpus";
+    let mut action: Option<String> = None;
+    let mut root: Option<String> = None;
+    let mut corpus: Option<String> = None;
+    let mut extras: Vec<String> = Vec::new();
+    let mut positional_only = false;
+
+    let mut i = 0;
+    while i < rest.len() {
+        let arg = rest[i].as_str();
+        if positional_only || arg == "-" || !arg.starts_with('-') {
+            if action.is_none() {
+                if arg != "digest" {
+                    return argparse_error(
+                        prog,
+                        &format!(
+                            "argument action: invalid choice: '{arg}' (choose from 'digest')"
+                        ),
+                    );
+                }
+                action = Some(arg.to_string());
+            } else {
+                extras.push(arg.to_string());
+            }
+            i += 1;
+            continue;
+        }
+        match arg {
+            "--" => positional_only = true,
+            other if other == "--root" || other.starts_with("--root=") => {
+                match take_opt_value(prog, "--root", other, rest, &mut i) {
+                    Ok(value) => root = Some(value),
+                    Err(code) => return code,
+                }
+            }
+            other if other == "--corpus" || other.starts_with("--corpus=") => {
+                match take_opt_value(prog, "--corpus", other, rest, &mut i) {
+                    Ok(value) => corpus = Some(value),
+                    Err(code) => return code,
+                }
+            }
+            other => extras.push(other.to_string()),
+        }
+        i += 1;
+    }
+
+    if action.is_none() {
+        return argparse_error(prog, "the following arguments are required: action");
+    }
+    if root.is_none() || corpus.is_none() {
+        let missing = match (root.is_none(), corpus.is_none()) {
+            (true, true) => "--root, --corpus",
+            (true, false) => "--root",
+            (false, true) => "--corpus",
+            (false, false) => unreachable!(),
+        };
+        return argparse_error(
+            prog,
+            &format!("the following arguments are required: {missing}"),
+        );
+    }
+    if !extras.is_empty() {
+        return unrecognized(&extras);
+    }
+
+    cmd_corpus_digest(&CorpusDigestArgs {
+        root: root.expect("checked above"),
+        corpus: corpus.expect("checked above"),
+    }) as u8
 }
 
 fn run_validate(rest: &[&String]) -> u8 {

--- a/rust/rac-engine/src/commands.rs
+++ b/rust/rac-engine/src/commands.rs
@@ -2244,6 +2244,27 @@ pub fn cmd_rename(args: &RenameArgs) -> i32 {
     EXIT_OK
 }
 
+pub struct CorpusDigestArgs {
+    pub root: String,
+    pub corpus: String,
+}
+
+/// Read-only operator calculation for the canonical parent corpus pin. The
+/// implementation consumes only local bytes below `root` and cannot write,
+/// fetch, refresh, or repin anything.
+pub fn cmd_corpus_digest(args: &CorpusDigestArgs) -> i32 {
+    match crate::federation::calculate_parent_digest(&args.root, &args.corpus) {
+        Ok(result) => {
+            emit(result.digest);
+            EXIT_OK
+        }
+        Err(error) => {
+            eprintln!("decided: {error}");
+            EXIT_VALIDATION_FAILED
+        }
+    }
+}
+
 pub struct TelemetryArgs {
     /// Validated positional choice; argparse default is `status`.
     pub action: String,

--- a/rust/rac-engine/src/corpus.rs
+++ b/rust/rac-engine/src/corpus.rs
@@ -1,0 +1,327 @@
+//! Stable corpus and artifact identity for the source-aware read model.
+//!
+//! Stable identity deliberately excludes checkout paths. Runtime filesystem
+//! locators are separate types so moving an otherwise identical checkout
+//! cannot alter an [`ArtifactKey`] or [`ArtifactPath`] (ADR-135/ADR-138).
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::scaffold::{load_repository_identity, ScaffoldError};
+
+/// Whether an artifact belongs to the writable child or a read-only parent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Layer {
+    Local,
+    Inherited,
+}
+
+impl Layer {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Local => "local",
+            Self::Inherited => "inherited",
+        }
+    }
+
+    pub const fn is_writable(self) -> bool {
+        matches!(self, Self::Local)
+    }
+}
+
+/// Stable identity and provenance shared by every artifact in one layer.
+///
+/// `pin` and `alias` are absent for the local layer. An inherited layer has
+/// both: the full verified digest and the child-local readable alias.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct CorpusLayer {
+    pub source: String,
+    pub layer: Layer,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pin: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub alias: Option<String>,
+}
+
+impl CorpusLayer {
+    pub fn local(source: impl Into<String>) -> Self {
+        Self {
+            source: source.into(),
+            layer: Layer::Local,
+            pin: None,
+            alias: None,
+        }
+    }
+
+    pub fn inherited(
+        source: impl Into<String>,
+        alias: impl Into<String>,
+        pin: impl Into<String>,
+    ) -> Self {
+        Self {
+            source: source.into(),
+            layer: Layer::Inherited,
+            pin: Some(pin.into()),
+            alias: Some(alias.into()),
+        }
+    }
+
+    pub fn origin(&self) -> ArtifactOrigin {
+        ArtifactOrigin {
+            source: self.source.clone(),
+            layer: self.layer,
+            pin: self.pin.clone(),
+            alias: self.alias.clone(),
+        }
+    }
+}
+
+/// Stable global artifact identity: `(source, canonical_id)`.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct ArtifactKey {
+    pub source: String,
+    pub canonical_id: String,
+}
+
+impl ArtifactKey {
+    pub fn new(source: impl Into<String>, canonical_id: impl Into<String>) -> Self {
+        Self {
+            source: source.into(),
+            canonical_id: canonical_id.into(),
+        }
+    }
+}
+
+/// Stable global path identity: `(source, corpus-relative path)`.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct ArtifactPath {
+    pub source: String,
+    pub relative_path: String,
+}
+
+impl ArtifactPath {
+    pub fn new(source: impl Into<String>, relative_path: impl Into<String>) -> Self {
+        Self {
+            source: source.into(),
+            relative_path: relative_path.into(),
+        }
+    }
+}
+
+/// Stable provenance attached to a parsed or derived artifact.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct ArtifactOrigin {
+    pub source: String,
+    pub layer: Layer,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pin: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub alias: Option<String>,
+}
+
+impl ArtifactOrigin {
+    pub fn key(&self, canonical_id: impl Into<String>) -> ArtifactKey {
+        ArtifactKey::new(self.source.clone(), canonical_id)
+    }
+
+    pub fn path(&self, relative_path: impl Into<String>) -> ArtifactPath {
+        ArtifactPath::new(self.source.clone(), relative_path)
+    }
+}
+
+impl From<&ArtifactOrigin> for CorpusLayer {
+    fn from(origin: &ArtifactOrigin) -> Self {
+        Self {
+            source: origin.source.clone(),
+            layer: origin.layer,
+            pin: origin.pin.clone(),
+            alias: origin.alias.clone(),
+        }
+    }
+}
+
+/// Runtime-only filesystem location of one corpus layer.
+///
+/// These paths must never be serialized as stable identity or used as a
+/// deterministic tie-break. Federation verification owns canonicalisation;
+/// this substrate only keeps the already-selected locations distinct from
+/// provenance.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PhysicalCorpusLocator {
+    pub repository_root: PathBuf,
+    pub corpus_root: PathBuf,
+}
+
+impl PhysicalCorpusLocator {
+    pub fn new(repository_root: impl Into<PathBuf>, corpus_root: impl Into<PathBuf>) -> Self {
+        Self {
+            repository_root: repository_root.into(),
+            corpus_root: corpus_root.into(),
+        }
+    }
+
+    pub fn local(corpus_root: impl Into<PathBuf>) -> Self {
+        let corpus_root = corpus_root.into();
+        Self::new(repository_root_for(&corpus_root), corpus_root)
+    }
+}
+
+/// Runtime-only filesystem location of one artifact.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PhysicalArtifactLocator {
+    pub corpus: PhysicalCorpusLocator,
+    pub path: PathBuf,
+}
+
+impl PhysicalArtifactLocator {
+    pub fn new(corpus: PhysicalCorpusLocator, path: impl Into<PathBuf>) -> Self {
+        Self {
+            corpus,
+            path: path.into(),
+        }
+    }
+}
+
+/// The exact non-federated source derivation shared by exports and the local
+/// source-aware layer: explicit `corpus.source`, then lower-case
+/// `repository_key`, then the released directory-basename fallback.
+pub fn compatible_corpus_source(directory: &str) -> Result<String, ScaffoldError> {
+    let Some(identity) = load_repository_identity(directory)? else {
+        return Ok(compatible_corpus_name(directory));
+    };
+    if let Some(source) = identity.corpus_source {
+        return Ok(source);
+    }
+    if let Some(repository_key) = identity.repository_key {
+        return Ok(repository_key
+            .strip_suffix('\n')
+            .unwrap_or(&repository_key)
+            .to_ascii_lowercase());
+    }
+    Ok(compatible_corpus_name(directory))
+}
+
+/// Build the dormant single local layer without making configuration errors
+/// newly observable on legacy read paths. Strict federation loading uses its
+/// own fallible verification gate before composition.
+pub fn compatible_local_layer(directory: &str) -> CorpusLayer {
+    let source =
+        compatible_corpus_source(directory).unwrap_or_else(|_| compatible_corpus_name(directory));
+    CorpusLayer::local(source)
+}
+
+pub(crate) fn compatible_corpus_name(directory: &str) -> String {
+    let normalized = crate::walk::normalize_root(directory);
+    let trimmed = normalized.trim_end_matches('/');
+    let name = trimmed.rsplit('/').next().unwrap_or("");
+    if name.is_empty() || name == "." || name == ".." {
+        directory.to_string()
+    } else {
+        name.to_string()
+    }
+}
+
+fn repository_root_for(corpus_root: &Path) -> PathBuf {
+    let start = if corpus_root.is_dir() {
+        corpus_root
+    } else {
+        corpus_root.parent().unwrap_or(corpus_root)
+    };
+    crate::validate::repository_root(&start.to_string_lossy())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn composite_keys_order_by_source_then_local_identity() {
+        let mut keys = [
+            ArtifactKey::new("zeta/standards", "ADR-001"),
+            ArtifactKey::new("acme/app", "ADR-002"),
+            ArtifactKey::new("acme/app", "ADR-001"),
+        ];
+        keys.sort();
+        assert_eq!(
+            keys.iter()
+                .map(|key| (key.source.as_str(), key.canonical_id.as_str()))
+                .collect::<Vec<_>>(),
+            vec![
+                ("acme/app", "ADR-001"),
+                ("acme/app", "ADR-002"),
+                ("zeta/standards", "ADR-001"),
+            ]
+        );
+
+        let mut paths = [
+            ArtifactPath::new("zeta/standards", "a.md"),
+            ArtifactPath::new("acme/app", "z.md"),
+            ArtifactPath::new("acme/app", "a.md"),
+        ];
+        paths.sort();
+        assert_eq!(paths[0], ArtifactPath::new("acme/app", "a.md"));
+        assert_eq!(paths[2], ArtifactPath::new("zeta/standards", "a.md"));
+    }
+
+    #[test]
+    fn provenance_serde_is_stable_and_omits_absent_local_fields() {
+        assert_eq!(
+            serde_json::to_string(&ArtifactKey::new("acme/app", "APP-001")).unwrap(),
+            r#"{"source":"acme/app","canonical_id":"APP-001"}"#
+        );
+        assert_eq!(
+            serde_json::to_string(&ArtifactPath::new("acme/app", "decisions/adr-001.md")).unwrap(),
+            r#"{"source":"acme/app","relative_path":"decisions/adr-001.md"}"#
+        );
+        let local = CorpusLayer::local("acme/app").origin();
+        assert_eq!(
+            serde_json::to_string(&local).unwrap(),
+            r#"{"source":"acme/app","layer":"local"}"#
+        );
+        assert_eq!(
+            serde_json::from_str::<ArtifactOrigin>(r#"{"source":"acme/app","layer":"local"}"#)
+                .unwrap(),
+            local
+        );
+
+        let inherited =
+            CorpusLayer::inherited("acme/standards", "standards", "sha256:0123456789abcdef")
+                .origin();
+        assert_eq!(
+            serde_json::to_string(&inherited).unwrap(),
+            r#"{"source":"acme/standards","layer":"inherited","pin":"sha256:0123456789abcdef","alias":"standards"}"#
+        );
+        assert_eq!(
+            serde_json::from_str::<ArtifactOrigin>(&serde_json::to_string(&inherited).unwrap())
+                .unwrap(),
+            inherited
+        );
+    }
+
+    #[test]
+    fn stable_identity_does_not_include_clone_location() {
+        let layer =
+            CorpusLayer::inherited("acme/standards", "standards", "sha256:0123456789abcdef");
+        let left = PhysicalArtifactLocator::new(
+            PhysicalCorpusLocator::new("/clone-a", "/clone-a/vendor/standards/decisions"),
+            "/clone-a/vendor/standards/decisions/decisions/adr-001.md",
+        );
+        let right = PhysicalArtifactLocator::new(
+            PhysicalCorpusLocator::new("/clone-b", "/clone-b/vendor/standards/decisions"),
+            "/clone-b/vendor/standards/decisions/decisions/adr-001.md",
+        );
+
+        assert_ne!(left, right);
+        assert_eq!(
+            layer.origin().key("ADR-001"),
+            ArtifactKey::new("acme/standards", "ADR-001")
+        );
+        assert_eq!(
+            layer.origin().path("decisions/adr-001.md"),
+            ArtifactPath::new("acme/standards", "decisions/adr-001.md")
+        );
+        assert!(!serde_json::to_string(&layer).unwrap().contains("clone-"));
+    }
+}

--- a/rust/rac-engine/src/delta_generation.rs
+++ b/rust/rac-engine/src/delta_generation.rs
@@ -37,6 +37,8 @@ use crate::retrieve::{scope_rows_from_items, ScopeRow};
 #[derive(Clone)]
 pub struct IdentityRow {
     pub entry: IndexEntry,
+    pub artifact_path: crate::corpus::ArtifactPath,
+    pub origin: crate::corpus::ArtifactOrigin,
     pub status: String,
 }
 
@@ -44,6 +46,8 @@ impl IdentityRow {
     fn from_item(item: &CorpusItem) -> Self {
         Self {
             entry: identity_entry_from_item(item),
+            artifact_path: item.artifact_path.clone(),
+            origin: item.origin.clone(),
             status: artifact_status(&item.artifact),
         }
     }
@@ -169,6 +173,26 @@ impl IdentityGeneration {
             return None;
         }
         self.base.get(path).map(|row| row.status.as_str())
+    }
+
+    pub fn artifact_path_for_path(&self, path: &str) -> Option<&crate::corpus::ArtifactPath> {
+        if let Some(row) = self.upserts.get(path) {
+            return Some(&row.artifact_path);
+        }
+        if self.tombstones.contains(path) {
+            return None;
+        }
+        self.base.get(path).map(|row| &row.artifact_path)
+    }
+
+    pub fn origin_for_path(&self, path: &str) -> Option<&crate::corpus::ArtifactOrigin> {
+        if let Some(row) = self.upserts.get(path) {
+            return Some(&row.origin);
+        }
+        if self.tombstones.contains(path) {
+            return None;
+        }
+        self.base.get(path).map(|row| &row.origin)
     }
 
     pub fn entries(&self) -> Vec<IndexEntry> {
@@ -444,31 +468,38 @@ fn resolve_graph_row(row: &ValidationRow, identity: &IdentityGeneration) -> Vec<
     for (section, targets) in &row.edges {
         let external = edge_spec(section).is_some_and(|spec| spec.external);
         for target in targets {
-            let (resolved_path, issue) = if external {
-                (None, None)
+            let (resolved_path, resolved_artifact, issue) = if external {
+                (None, None, None)
             } else {
                 let result = identity.resolve(target);
                 match result.outcome {
-                    OUTCOME_NOT_FOUND => (None, Some(ISSUE_TARGET_NOT_FOUND.to_string())),
-                    OUTCOME_DUPLICATE => (None, Some(ISSUE_TARGET_AMBIGUOUS.to_string())),
+                    OUTCOME_NOT_FOUND => {
+                        (None, None, Some(ISSUE_TARGET_NOT_FOUND.to_string()))
+                    }
+                    OUTCOME_DUPLICATE => {
+                        (None, None, Some(ISSUE_TARGET_AMBIGUOUS.to_string()))
+                    }
                     OUTCOME_RESOLVED => {
                         let path = result
                             .artifact
                             .expect("resolved identity has artifact")
                             .path;
                         if path == row.path {
-                            (None, Some(ISSUE_SELF_REFERENCE.to_string()))
+                            (None, None, Some(ISSUE_SELF_REFERENCE.to_string()))
                         } else {
-                            (Some(path), None)
+                            let artifact_path = identity.artifact_path_for_path(&path).cloned();
+                            (Some(path), artifact_path, None)
                         }
                     }
                     _ => unreachable!("identity resolution outcome"),
                 }
             };
             edges.push(Relationship {
+                source_artifact: Some(row.artifact_path.clone()),
                 source_path: row.path.clone(),
                 relationship: section.clone(),
                 target: target.clone(),
+                resolved_artifact,
                 resolved_path,
                 issue,
             });
@@ -1196,7 +1227,45 @@ impl DeltaGeneration {
     /// validation and is therefore suitable for durable compaction.
     pub fn materialize_derived(&self, directory: &str, recursive: bool) -> DerivedIndex {
         let (index_entries, field_tokens) = self.search.entries_and_fields(&self.graph);
+        let compatibility_layer = crate::corpus::compatible_local_layer(directory);
+        let source_artifacts: Vec<crate::derived::SourceAwareArtifact> = index_entries
+            .iter()
+            .map(|entry| {
+                let path = self
+                    .identity
+                    .artifact_path_for_path(&entry.path)
+                    .cloned()
+                    .unwrap_or_else(|| {
+                        crate::corpus::ArtifactPath::new(
+                            compatibility_layer.source.clone(),
+                            entry.path.clone(),
+                        )
+                    });
+                let origin = self
+                    .identity
+                    .origin_for_path(&entry.path)
+                    .cloned()
+                    .unwrap_or_else(|| compatibility_layer.origin());
+                crate::derived::SourceAwareArtifact {
+                    key: origin.key(entry.id.clone()),
+                    path,
+                    origin,
+                    display_path: entry.path.clone(),
+                }
+            })
+            .collect();
+        let mut layers: Vec<crate::corpus::CorpusLayer> = source_artifacts
+            .iter()
+            .map(|artifact| crate::corpus::CorpusLayer::from(&artifact.origin))
+            .collect();
+        layers.sort();
+        layers.dedup();
+        if layers.is_empty() {
+            layers.push(compatibility_layer);
+        }
         DerivedIndex {
+            layers,
+            source_artifacts,
             index_entries,
             field_tokens,
             relationships: self.graph.relationships(),
@@ -1219,11 +1288,7 @@ mod tests {
         let text = DOC.replace("ADR-1", id).replace("Accepted", status);
         let artifact = crate::parse::parse_text(&text, path);
         let spec = crate::spec::spec_for(&crate::classify::classify(&artifact).artifact_type);
-        CorpusItem {
-            path: path.to_string(),
-            artifact,
-            spec,
-        }
+        CorpusItem::compatible_local_file(path, artifact, spec)
     }
 
     fn tagged_item(path: &str, id: &str, status: &str, tag: &str) -> CorpusItem {
@@ -1237,11 +1302,7 @@ mod tests {
             );
         let artifact = crate::parse::parse_text(&text, path);
         let spec = crate::spec::spec_for(&crate::classify::classify(&artifact).artifact_type);
-        CorpusItem {
-            path: path.to_string(),
-            artifact,
-            spec,
-        }
+        CorpusItem::compatible_local_file(path, artifact, spec)
     }
 
     fn related_item(path: &str, id: &str, target: &str) -> CorpusItem {
@@ -1250,11 +1311,7 @@ mod tests {
         );
         let artifact = crate::parse::parse_text(&text, path);
         let spec = crate::spec::spec_for(&crate::classify::classify(&artifact).artifact_type);
-        CorpusItem {
-            path: path.to_string(),
-            artifact,
-            spec,
-        }
+        CorpusItem::compatible_local_file(path, artifact, spec)
     }
 
     fn scoped_item(path: &str, id: &str, status: &str, scope: Option<&str>) -> CorpusItem {
@@ -1267,11 +1324,7 @@ mod tests {
             .replace("\n## Status", &format!("{scope}\n\n## Status"));
         let artifact = crate::parse::parse_text(&text, path);
         let spec = crate::spec::spec_for(&crate::classify::classify(&artifact).artifact_type);
-        CorpusItem {
-            path: path.to_string(),
-            artifact,
-            spec,
-        }
+        CorpusItem::compatible_local_file(path, artifact, spec)
     }
 
     fn scope_signature(rows: Vec<ScopeRow>) -> Vec<(String, String, String, String, Vec<String>)> {

--- a/rust/rac-engine/src/derived.rs
+++ b/rust/rac-engine/src/derived.rs
@@ -7,6 +7,7 @@
 
 use serde_json::Value;
 
+use crate::corpus::{ArtifactKey, ArtifactOrigin, ArtifactPath, CorpusLayer};
 use crate::relationships::{corpus_items, relationships_from_corpus, CorpusItem, Relationship};
 use crate::resolve::{entry_from_item, field_tokens_of, is_live_decision, FieldTokens, IndexEntry};
 use crate::retrieve::{scope_rows_from_items, ScopeRow};
@@ -16,8 +17,24 @@ pub const SCHEMA_VERSION: &str = "3";
 
 pub(crate) const DECISION_TYPE: &str = "decision";
 
+/// The source-aware identity projection parallel to the existing searchable
+/// rows. It remains in memory while the frozen v1 store is the compatibility
+/// format; the versioned store cutover will persist these exact values.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourceAwareArtifact {
+    pub key: ArtifactKey,
+    pub path: ArtifactPath,
+    pub origin: ArtifactOrigin,
+    /// Released display path retained independently from stable path identity.
+    pub display_path: String,
+}
+
 /// The expensive derived structures for one corpus snapshot.
 pub struct DerivedIndex {
+    /// Stable layer identities represented in this generation.
+    pub layers: Vec<CorpusLayer>,
+    /// Per-document source identity in the same order as `index_entries`.
+    pub source_artifacts: Vec<SourceAwareArtifact>,
     /// Repository index rows in walk (sorted-path) order — docid order.
     pub index_entries: Vec<IndexEntry>,
     /// Per-entry BM25F field-token vectors, parallel to `index_entries`.
@@ -54,6 +71,24 @@ pub fn build_derived_index_from_items(
         })
         .collect();
     let field_tokens: Vec<FieldTokens> = index_entries.iter().map(field_tokens_of).collect();
+    let source_artifacts: Vec<SourceAwareArtifact> = items
+        .iter()
+        .map(|item| SourceAwareArtifact {
+            key: item.key.clone(),
+            path: item.artifact_path.clone(),
+            origin: item.origin.clone(),
+            display_path: item.path.clone(),
+        })
+        .collect();
+    let mut layers: Vec<CorpusLayer> = items
+        .iter()
+        .map(|item| CorpusLayer::from(&item.origin))
+        .collect();
+    layers.sort();
+    layers.dedup();
+    if layers.is_empty() {
+        layers.push(crate::corpus::compatible_local_layer(directory));
+    }
     let live_decision_paths: Vec<String> = items
         .iter()
         .filter(|item| {
@@ -64,6 +99,8 @@ pub fn build_derived_index_from_items(
         .collect();
     let summary = crate::portfolio::portfolio_from_corpus(directory, items, recursive);
     DerivedIndex {
+        layers,
+        source_artifacts,
         index_entries,
         field_tokens,
         relationships,

--- a/rust/rac-engine/src/export.rs
+++ b/rust/rac-engine/src/export.rs
@@ -8,7 +8,7 @@ use crate::pycompat::py_strip;
 use crate::relationships::{
     corpus_items, edge_spec, relationships_from_corpus, CorpusItem,
 };
-use crate::scaffold::{load_repository_identity, ScaffoldError};
+use crate::scaffold::ScaffoldError;
 use crate::spec::ArtifactSpec;
 use crate::validate::load_ticketing_provider;
 
@@ -23,6 +23,12 @@ const DOCUMENTS_SCHEMA: &str =
     include_str!("../assets/schemas/export-documents-v1.schema.json");
 const GRAPH_SCHEMA: &str = include_str!("../assets/schemas/export-graph-v1.schema.json");
 
+/// Released display name; unlike source identity, this remains tied to the
+/// caller's directory spelling.
+fn corpus_name(directory: &str) -> String {
+    crate::corpus::compatible_corpus_name(directory)
+}
+
 /// Return the packaged Draft 2020-12 contract for an export projection.
 ///
 /// These bytes are the public resource surfaced by `decided export --schema`;
@@ -36,35 +42,11 @@ pub fn export_schema(name: &str) -> Option<&'static str> {
     }
 }
 
-/// `_corpus_name(directory)`.
-fn corpus_name(directory: &str) -> String {
-    let normalized = crate::walk::normalize_root(directory);
-    let trimmed = normalized.trim_end_matches('/');
-    let name = trimmed.rsplit('/').next().unwrap_or("");
-    if name.is_empty() || name == "." || name == ".." {
-        directory.to_string()
-    } else {
-        name.to_string()
-    }
-}
-
 /// The one non-federated source derivation shared by every JSON projection:
 /// explicit `corpus.source`, then the lower-case repository key, then the
 /// released directory-basename fallback (ADR-135).
 pub fn corpus_source(directory: &str) -> Result<String, ScaffoldError> {
-    let Some(identity) = load_repository_identity(directory)? else {
-        return Ok(corpus_name(directory));
-    };
-    if let Some(source) = identity.corpus_source {
-        return Ok(source);
-    }
-    if let Some(repository_key) = identity.repository_key {
-        return Ok(repository_key
-            .strip_suffix('\n')
-            .unwrap_or(&repository_key)
-            .to_ascii_lowercase());
-    }
-    Ok(corpus_name(directory))
+    crate::corpus::compatible_corpus_source(directory)
 }
 
 fn first_line(raw: &str) -> String {

--- a/rust/rac-engine/src/federation.rs
+++ b/rust/rac-engine/src/federation.rs
@@ -1,0 +1,1351 @@
+//! Verified, offline parent-corpus materialisation (ADR-133 through ADR-135).
+//!
+//! This module owns only the declaration and byte-snapshot boundary. It does
+//! not compose artifacts, resolve relationships, or give any read consumer a
+//! second directory-overlay path. A successful [`verify_parent`] call returns
+//! the exact config and Markdown bytes which were hashed, so later stages can
+//! parse the verified snapshot without re-reading mutable parent files.
+
+use serde::Deserialize;
+use std::fmt;
+use std::path::{Component, Path, PathBuf};
+
+use crate::markdown::consumed_events;
+use crate::sha256::Sha256;
+
+pub const MANIFEST_RELATIVE_PATH: &str = ".decided/corpus.md";
+pub const CONFIG_RELATIVE_PATH: &str = ".decided/config.yaml";
+pub const DIGEST_PREFIX: &str = "sha256:";
+
+/// Fixed domain bytes for parent-corpus digest version 1.
+///
+/// The complete v1 preimage is:
+///
+/// ```text
+/// "asdecided-corpus-digest-v1\0"
+/// frame(0x01, source UTF-8)
+/// frame(0x02, raw .decided/config.yaml bytes)
+/// for each corpus-relative path in UTF-8 byte order:
+///   frame(0x03, path UTF-8)
+///   frame(0x04, raw file bytes)
+/// ```
+///
+/// A frame is its one-byte tag, an unsigned 64-bit big-endian payload length,
+/// and the payload. Tags plus explicit lengths make every tuple boundary
+/// unambiguous; locations, metadata, and timestamps never enter the preimage.
+pub const DIGEST_V1_DOMAIN: &[u8] = b"asdecided-corpus-digest-v1\0";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ParentCorpusErrorCode {
+    MalformedManifest,
+    MultipleParents,
+    MaterialisationMissing,
+    ParentCorpusMissing,
+    ParentConfigMissing,
+    ChildConfigMissing,
+    InvalidConfig,
+    ChildSourceMissing,
+    ParentSourceMissing,
+    SourceMismatch,
+    SourceCollision,
+    PathEscape,
+    SymlinkTraversal,
+    TransitiveInheritance,
+    SnapshotFailed,
+    DigestMismatch,
+}
+
+impl ParentCorpusErrorCode {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::MalformedManifest => "parent-corpus-malformed-manifest",
+            Self::MultipleParents => "parent-corpus-multiple-parents",
+            Self::MaterialisationMissing => "parent-corpus-materialisation-missing",
+            Self::ParentCorpusMissing => "parent-corpus-missing",
+            Self::ParentConfigMissing => "parent-corpus-config-missing",
+            Self::ChildConfigMissing => "parent-corpus-child-config-missing",
+            Self::InvalidConfig => "parent-corpus-config-invalid",
+            Self::ChildSourceMissing => "parent-corpus-child-source-missing",
+            Self::ParentSourceMissing => "parent-corpus-source-missing",
+            Self::SourceMismatch => "parent-corpus-source-mismatch",
+            Self::SourceCollision => "parent-corpus-source-collision",
+            Self::PathEscape => "parent-corpus-path-escape",
+            Self::SymlinkTraversal => "parent-corpus-symlink-traversal",
+            Self::TransitiveInheritance => "parent-corpus-transitive-inheritance",
+            Self::SnapshotFailed => "parent-corpus-snapshot-failed",
+            Self::DigestMismatch => "parent-corpus-digest-mismatch",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParentCorpusError {
+    pub code: ParentCorpusErrorCode,
+    pub message: String,
+    pub path: Option<PathBuf>,
+}
+
+impl ParentCorpusError {
+    fn new(code: ParentCorpusErrorCode, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+            path: None,
+        }
+    }
+
+    fn at(
+        code: ParentCorpusErrorCode,
+        path: impl Into<PathBuf>,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            code,
+            message: message.into(),
+            path: Some(path.into()),
+        }
+    }
+
+    pub const fn stable_code(&self) -> &'static str {
+        self.code.as_str()
+    }
+}
+
+impl fmt::Display for ParentCorpusError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}: {}", self.stable_code(), self.message)
+    }
+}
+
+impl std::error::Error for ParentCorpusError {}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawParentDeclaration {
+    version: u32,
+    alias: String,
+    source: String,
+    root: String,
+    corpus: String,
+    digest: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParentDeclaration {
+    pub version: u32,
+    pub alias: String,
+    pub source: String,
+    pub root: String,
+    pub corpus: String,
+    pub digest: String,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CorpusManifest {
+    pub path: PathBuf,
+    pub bytes: Vec<u8>,
+    pub inherits: ParentDeclaration,
+    /// Parsed but not interpreted here. Override resolution belongs to the
+    /// central composition layer; retaining the value prevents a second
+    /// Markdown section parser from drifting from this manifest boundary.
+    pub overrides: Option<serde_yaml::Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SnapshotFile {
+    pub relative_path: String,
+    pub absolute_path: PathBuf,
+    pub bytes: Vec<u8>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParentDigest {
+    pub source: String,
+    pub config_path: PathBuf,
+    pub config_bytes: Vec<u8>,
+    pub corpus_root: PathBuf,
+    pub files: Vec<SnapshotFile>,
+    /// Full `sha256:<64 lowercase hex>` value.
+    pub digest: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerifiedParent {
+    pub manifest_path: PathBuf,
+    pub manifest_bytes: Vec<u8>,
+    pub declaration: ParentDeclaration,
+    pub child_repository_root: PathBuf,
+    pub child_source: String,
+    pub materialisation_root: PathBuf,
+    pub corpus_root: PathBuf,
+    pub config_path: PathBuf,
+    pub config_bytes: Vec<u8>,
+    pub files: Vec<SnapshotFile>,
+    /// The verified, full `sha256:<64 lowercase hex>` pin.
+    pub digest: String,
+    /// Parsed but not interpreted by the materialisation boundary.
+    pub overrides: Option<serde_yaml::Value>,
+}
+
+impl VerifiedParent {
+    /// True when `path` resolves inside the read-only materialisation subtree.
+    /// Local walks use this predicate to prevent the same Markdown byte from
+    /// entering both the child and inherited layers.
+    pub fn contains_materialised_path(&self, path: &Path) -> bool {
+        canonical_or_absolute(path).is_some_and(|candidate| {
+            candidate == self.materialisation_root
+                || candidate.starts_with(&self.materialisation_root)
+        })
+    }
+
+    /// Remove entries that resolve beneath the verified parent subtree.
+    pub fn exclude_materialisation<T, F>(&self, entries: Vec<T>, path_of: F) -> Vec<T>
+    where
+        F: Fn(&T) -> &Path,
+    {
+        entries
+            .into_iter()
+            .filter(|entry| !self.contains_materialised_path(path_of(entry)))
+            .collect()
+    }
+}
+
+fn malformed(path: &Path, reason: impl Into<String>) -> ParentCorpusError {
+    ParentCorpusError::at(
+        ParentCorpusErrorCode::MalformedManifest,
+        path,
+        format!(
+            "malformed federation manifest {}: {}",
+            path.display(),
+            reason.into()
+        ),
+    )
+}
+
+fn normalize_newlines(text: &str) -> String {
+    text.replace("\r\n", "\n").replace('\r', "\n")
+}
+
+fn is_top_level_atx_h2(lines: &[&str], line: i64) -> bool {
+    if line < 0 {
+        return false;
+    }
+    let Some(raw) = lines.get(line as usize) else {
+        return false;
+    };
+    let indent = raw.bytes().take_while(|byte| *byte == b' ').count();
+    if indent > 3 {
+        return false;
+    }
+    let rest = &raw[indent..];
+    rest.starts_with("## ") || rest.starts_with("##\t")
+}
+
+fn is_top_level_heading(lines: &[&str], line: i64) -> bool {
+    if line < 0 {
+        return false;
+    }
+    let index = line as usize;
+    let Some(raw) = lines.get(index) else {
+        return false;
+    };
+    let indent = raw.bytes().take_while(|byte| *byte == b' ').count();
+    if indent > 3 {
+        return false;
+    }
+    let rest = &raw[indent..];
+    if rest.starts_with('#') {
+        return true;
+    }
+    // Top-level Setext heading. Container-prefixed underlines do not match.
+    lines.get(index + 1).is_some_and(|underline| {
+        let indent = underline.bytes().take_while(|byte| *byte == b' ').count();
+        if indent > 3 {
+            return false;
+        }
+        let underline = underline[indent..].trim_end();
+        !underline.is_empty()
+            && (underline.bytes().all(|byte| byte == b'=')
+                || underline.bytes().all(|byte| byte == b'-'))
+    })
+}
+
+fn heading_sections(text: &str, name: &str) -> Vec<(usize, usize)> {
+    let events = consumed_events(text);
+    let lines: Vec<&str> = text.lines().collect();
+    let mut sections = Vec::new();
+    for (index, event) in events.iter().enumerate() {
+        if !event.heading
+            || event.tag != "h2"
+            || event.content != name
+            || !is_top_level_atx_h2(&lines, event.line)
+        {
+            continue;
+        }
+        let start = event.line.max(0) as usize + 1;
+        let end = events[index + 1..]
+            .iter()
+            .find(|next| {
+                next.heading
+                    && next.line >= 0
+                    && matches!(next.tag, "h1" | "h2")
+                    && is_top_level_heading(&lines, next.line)
+            })
+            .map_or_else(|| text.lines().count(), |next| next.line as usize);
+        sections.push((start, end));
+    }
+    sections
+}
+
+fn reject_misspelled_operational_headings(
+    path: &Path,
+    text: &str,
+) -> Result<(), ParentCorpusError> {
+    let lines: Vec<&str> = text.lines().collect();
+    for event in consumed_events(text) {
+        if !event.heading || event.tag != "h2" || !is_top_level_atx_h2(&lines, event.line) {
+            continue;
+        }
+        if (event.content.eq_ignore_ascii_case("inherits") && event.content != "inherits")
+            || (event.content.eq_ignore_ascii_case("overrides") && event.content != "overrides")
+        {
+            return Err(malformed(
+                path,
+                format!(
+                    "federation heading must use exact lowercase spelling: ## {}",
+                    event.content.to_ascii_lowercase()
+                ),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn fence_open(line: &str) -> Option<(u8, usize, &str)> {
+    let indent = line.bytes().take_while(|byte| *byte == b' ').count();
+    if indent > 3 {
+        return None;
+    }
+    let rest = &line[indent..];
+    let marker = *rest.as_bytes().first()?;
+    if marker != b'`' && marker != b'~' {
+        return None;
+    }
+    let count = rest.bytes().take_while(|byte| *byte == marker).count();
+    if count < 3 {
+        return None;
+    }
+    Some((marker, count, rest[count..].trim()))
+}
+
+fn fence_close(line: &str, marker: u8, count: usize) -> bool {
+    let indent = line.bytes().take_while(|byte| *byte == b' ').count();
+    if indent > 3 {
+        return false;
+    }
+    let rest = &line[indent..];
+    let seen = rest.bytes().take_while(|byte| *byte == marker).count();
+    seen >= count && rest[seen..].trim().is_empty()
+}
+
+fn fenced_yaml_blocks(
+    path: &Path,
+    text: &str,
+    start: usize,
+    end: usize,
+) -> Result<Vec<String>, ParentCorpusError> {
+    let lines: Vec<&str> = text.lines().collect();
+    let mut blocks = Vec::new();
+    let mut index = start;
+    while index < end.min(lines.len()) {
+        let Some((marker, count, info)) = fence_open(lines[index]) else {
+            index += 1;
+            continue;
+        };
+        let content_start = index + 1;
+        index += 1;
+        while index < end.min(lines.len()) && !fence_close(lines[index], marker, count) {
+            index += 1;
+        }
+        if index >= end.min(lines.len()) {
+            return Err(malformed(path, "unterminated fenced block"));
+        }
+        if info == "yaml" {
+            blocks.push(lines[content_start..index].join("\n"));
+        }
+        index += 1;
+    }
+    Ok(blocks)
+}
+
+fn valid_alias(alias: &str) -> bool {
+    let bytes = alias.as_bytes();
+    !bytes.is_empty()
+        && (bytes[0].is_ascii_lowercase() || bytes[0].is_ascii_digit())
+        && (bytes[bytes.len() - 1].is_ascii_lowercase() || bytes[bytes.len() - 1].is_ascii_digit())
+        && bytes.iter().all(|byte| {
+            byte.is_ascii_lowercase() || byte.is_ascii_digit() || matches!(byte, b'-' | b'_' | b'.')
+        })
+}
+
+fn validate_relative_path(value: &str, field: &str) -> Result<(), String> {
+    let path = Path::new(value);
+    if value.is_empty() {
+        return Err(format!("'{field}' must be a non-empty relative path"));
+    }
+    if path.is_absolute() {
+        return Err(format!("'{field}' must not be absolute"));
+    }
+    for component in path.components() {
+        match component {
+            Component::ParentDir => return Err(format!("'{field}' must not contain '..'")),
+            Component::Prefix(_) | Component::RootDir => {
+                return Err(format!("'{field}' must be repository-relative"))
+            }
+            Component::Normal(_) | Component::CurDir => {}
+        }
+    }
+    Ok(())
+}
+
+fn parse_declaration(path: &Path, yaml: &str) -> Result<ParentDeclaration, ParentCorpusError> {
+    let value: serde_yaml::Value = serde_yaml::from_str(yaml).map_err(|error| {
+        malformed(
+            path,
+            format!("## inherits YAML must be one mapping: {error}"),
+        )
+    })?;
+    if value.as_sequence().is_some_and(|parents| parents.len() > 1) {
+        return Err(ParentCorpusError::at(
+            ParentCorpusErrorCode::MultipleParents,
+            path,
+            "the first federation increment accepts exactly one direct parent mapping",
+        ));
+    }
+    if !value.is_mapping() {
+        return Err(malformed(path, "## inherits YAML must be one mapping"));
+    }
+    let raw: RawParentDeclaration = serde_yaml::from_value(value).map_err(|error| {
+        malformed(
+            path,
+            format!("## inherits YAML must be one mapping: {error}"),
+        )
+    })?;
+    if raw.version != 1 {
+        return Err(malformed(
+            path,
+            format!("unsupported inheritance manifest version: {}", raw.version),
+        ));
+    }
+    if !valid_alias(&raw.alias) {
+        return Err(malformed(
+            path,
+            "'alias' must be a lowercase local name containing only letters, digits, '.', '_', or '-'",
+        ));
+    }
+    if !crate::scaffold::valid_corpus_source(&raw.source) {
+        return Err(malformed(
+            path,
+            "'source' must be a lower-case slash-namespaced corpus identity",
+        ));
+    }
+    validate_relative_path(&raw.root, "root")
+        .map_err(|reason| ParentCorpusError::at(ParentCorpusErrorCode::PathEscape, path, reason))?;
+    validate_relative_path(&raw.corpus, "corpus")
+        .map_err(|reason| ParentCorpusError::at(ParentCorpusErrorCode::PathEscape, path, reason))?;
+    let hash = raw.digest.strip_prefix(DIGEST_PREFIX).unwrap_or("");
+    if hash.len() != 64
+        || !hash
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return Err(malformed(
+            path,
+            "'digest' must be sha256: followed by exactly 64 lowercase hexadecimal characters",
+        ));
+    }
+    Ok(ParentDeclaration {
+        version: raw.version,
+        alias: raw.alias,
+        source: raw.source,
+        root: raw.root,
+        corpus: raw.corpus,
+        digest: raw.digest,
+    })
+}
+
+/// Parse the fixed operational manifest. Absence means no parent; presence is
+/// strict and cannot be partially interpreted.
+pub fn load_manifest(repository_root: &Path) -> Result<Option<CorpusManifest>, ParentCorpusError> {
+    let path = repository_root.join(MANIFEST_RELATIVE_PATH);
+    let metadata = match std::fs::symlink_metadata(&path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(ParentCorpusError::at(
+                ParentCorpusErrorCode::MalformedManifest,
+                &path,
+                format!(
+                    "cannot inspect federation manifest {}: {error}",
+                    path.display()
+                ),
+            ));
+        }
+    };
+    ensure_no_symlink_components(repository_root, &path)?;
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        return Err(ParentCorpusError::at(
+            ParentCorpusErrorCode::SymlinkTraversal,
+            &path,
+            format!(
+                "federation manifest must be a regular file: {}",
+                path.display()
+            ),
+        ));
+    }
+    let bytes = std::fs::read(&path).map_err(|error| {
+        ParentCorpusError::at(
+            ParentCorpusErrorCode::MalformedManifest,
+            &path,
+            format!(
+                "cannot read federation manifest {}: {error}",
+                path.display()
+            ),
+        )
+    })?;
+    let raw = std::str::from_utf8(&bytes)
+        .map_err(|_| malformed(&path, "manifest must be valid UTF-8"))?;
+    let text = normalize_newlines(raw);
+    reject_misspelled_operational_headings(&path, &text)?;
+
+    let inherits = heading_sections(&text, "inherits");
+    if inherits.len() > 1 {
+        return Err(ParentCorpusError::at(
+            ParentCorpusErrorCode::MultipleParents,
+            &path,
+            "the first federation increment accepts exactly one ## inherits declaration",
+        ));
+    }
+    let Some((start, end)) = inherits.first().copied() else {
+        return Err(malformed(
+            &path,
+            "missing exact lowercase heading '## inherits'",
+        ));
+    };
+    let blocks = fenced_yaml_blocks(&path, &text, start, end)?;
+    if blocks.len() > 1 {
+        return Err(ParentCorpusError::at(
+            ParentCorpusErrorCode::MultipleParents,
+            &path,
+            "## inherits must contain exactly one fenced YAML mapping",
+        ));
+    }
+    let Some(yaml) = blocks.first() else {
+        return Err(malformed(
+            &path,
+            "## inherits must contain exactly one fenced yaml block",
+        ));
+    };
+    let inherits = parse_declaration(&path, yaml)?;
+
+    let override_sections = heading_sections(&text, "overrides");
+    if override_sections.len() > 1 {
+        return Err(malformed(&path, "## overrides may appear at most once"));
+    }
+    let overrides = if let Some((start, end)) = override_sections.first().copied() {
+        let blocks = fenced_yaml_blocks(&path, &text, start, end)?;
+        if blocks.len() != 1 {
+            return Err(malformed(
+                &path,
+                "## overrides must contain exactly one fenced yaml block",
+            ));
+        }
+        let value: serde_yaml::Value = serde_yaml::from_str(&blocks[0]).map_err(|error| {
+            malformed(
+                &path,
+                format!("## overrides YAML must be one mapping: {error}"),
+            )
+        })?;
+        if !value.is_mapping() {
+            return Err(malformed(&path, "## overrides YAML must be one mapping"));
+        }
+        Some(value)
+    } else {
+        None
+    };
+
+    Ok(Some(CorpusManifest {
+        path,
+        bytes,
+        inherits,
+        overrides,
+    }))
+}
+
+fn lexical_components(path: &Path) -> Result<Vec<&std::ffi::OsStr>, ()> {
+    let mut out = Vec::new();
+    for component in path.components() {
+        match component {
+            Component::Normal(value) => out.push(value),
+            Component::CurDir => {}
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => return Err(()),
+        }
+    }
+    Ok(out)
+}
+
+fn checked_relative_join(
+    boundary: &Path,
+    relative: &str,
+    field: &str,
+) -> Result<PathBuf, ParentCorpusError> {
+    let components = lexical_components(Path::new(relative)).map_err(|_| {
+        ParentCorpusError::new(
+            ParentCorpusErrorCode::PathEscape,
+            format!("parent {field} must be a relative path without '..': {relative}"),
+        )
+    })?;
+    if components.is_empty() && relative != "." {
+        return Err(ParentCorpusError::new(
+            ParentCorpusErrorCode::PathEscape,
+            format!("parent {field} must be a non-empty relative path"),
+        ));
+    }
+    let mut joined = boundary.to_path_buf();
+    for component in components {
+        joined.push(component);
+    }
+    Ok(joined)
+}
+
+fn ensure_no_symlink_components(boundary: &Path, target: &Path) -> Result<(), ParentCorpusError> {
+    let relative = target.strip_prefix(boundary).map_err(|_| {
+        ParentCorpusError::at(
+            ParentCorpusErrorCode::PathEscape,
+            target,
+            format!(
+                "parent path escapes repository boundary: {}",
+                target.display()
+            ),
+        )
+    })?;
+    let mut current = boundary.to_path_buf();
+    for component in relative.components() {
+        let Component::Normal(value) = component else {
+            continue;
+        };
+        current.push(value);
+        match std::fs::symlink_metadata(&current) {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                return Err(ParentCorpusError::at(
+                    ParentCorpusErrorCode::SymlinkTraversal,
+                    &current,
+                    format!("parent path traverses a symlink: {}", current.display()),
+                ));
+            }
+            Ok(_) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(error) => {
+                return Err(ParentCorpusError::at(
+                    ParentCorpusErrorCode::SnapshotFailed,
+                    &current,
+                    format!("cannot inspect parent path {}: {error}", current.display()),
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn canonical_confined(
+    boundary: &Path,
+    candidate: &Path,
+    missing_code: ParentCorpusErrorCode,
+    kind: &str,
+) -> Result<PathBuf, ParentCorpusError> {
+    ensure_no_symlink_components(boundary, candidate)?;
+    let canonical = std::fs::canonicalize(candidate).map_err(|error| {
+        ParentCorpusError::at(
+            missing_code,
+            candidate,
+            format!(
+                "parent {kind} is unavailable at {}: {error}",
+                candidate.display()
+            ),
+        )
+    })?;
+    if canonical != boundary && !canonical.starts_with(boundary) {
+        return Err(ParentCorpusError::at(
+            ParentCorpusErrorCode::PathEscape,
+            candidate,
+            format!(
+                "parent {kind} escapes repository boundary: {}",
+                candidate.display()
+            ),
+        ));
+    }
+    Ok(canonical)
+}
+
+fn canonical_or_absolute(path: &Path) -> Option<PathBuf> {
+    if let Ok(canonical) = std::fs::canonicalize(path) {
+        return Some(canonical);
+    }
+    if path.is_absolute() {
+        Some(path.to_path_buf())
+    } else {
+        std::env::current_dir().ok().map(|cwd| cwd.join(path))
+    }
+}
+
+fn snapshot_directory(
+    corpus_root: &Path,
+    directory: &Path,
+    components: &mut Vec<String>,
+    output: &mut Vec<SnapshotFile>,
+) -> Result<(), ParentCorpusError> {
+    let entries = std::fs::read_dir(directory).map_err(|error| {
+        ParentCorpusError::at(
+            ParentCorpusErrorCode::SnapshotFailed,
+            directory,
+            format!(
+                "cannot read parent corpus directory {}: {error}",
+                directory.display()
+            ),
+        )
+    })?;
+    let mut entries = entries.collect::<Result<Vec<_>, _>>().map_err(|error| {
+        ParentCorpusError::at(
+            ParentCorpusErrorCode::SnapshotFailed,
+            directory,
+            format!(
+                "cannot enumerate parent corpus directory {}: {error}",
+                directory.display()
+            ),
+        )
+    })?;
+    entries.sort_by_key(|entry| entry.file_name());
+
+    for entry in entries {
+        // Match the engine's corpus discovery boundary: paths which cannot be
+        // represented as UTF-8 are not discovered as artifacts and therefore
+        // do not enter the digest.
+        let Ok(name) = entry.file_name().into_string() else {
+            continue;
+        };
+        if name.starts_with('.') {
+            continue;
+        }
+        let path = entry.path();
+        let metadata = std::fs::symlink_metadata(&path).map_err(|error| {
+            ParentCorpusError::at(
+                ParentCorpusErrorCode::SnapshotFailed,
+                &path,
+                format!(
+                    "cannot inspect parent corpus entry {}: {error}",
+                    path.display()
+                ),
+            )
+        })?;
+        if metadata.file_type().is_symlink() {
+            if name.ends_with(".md") {
+                return Err(ParentCorpusError::at(
+                    ParentCorpusErrorCode::SymlinkTraversal,
+                    &path,
+                    format!(
+                        "parent Markdown artifact must not be a symlink: {}",
+                        path.display()
+                    ),
+                ));
+            }
+            // A symlinked directory is never traversed and therefore cannot
+            // contribute bytes to the snapshot.
+            continue;
+        }
+        components.push(name.clone());
+        if metadata.is_dir() {
+            snapshot_directory(corpus_root, &path, components, output)?;
+        } else if name.ends_with(".md") {
+            if !metadata.is_file() {
+                return Err(ParentCorpusError::at(
+                    ParentCorpusErrorCode::SnapshotFailed,
+                    &path,
+                    format!(
+                        "parent Markdown artifact is not a regular file: {}",
+                        path.display()
+                    ),
+                ));
+            }
+            let canonical = std::fs::canonicalize(&path).map_err(|error| {
+                ParentCorpusError::at(
+                    ParentCorpusErrorCode::SnapshotFailed,
+                    &path,
+                    format!("cannot resolve parent artifact {}: {error}", path.display()),
+                )
+            })?;
+            if !canonical.starts_with(corpus_root) {
+                return Err(ParentCorpusError::at(
+                    ParentCorpusErrorCode::PathEscape,
+                    &path,
+                    format!("parent artifact escapes corpus root: {}", path.display()),
+                ));
+            }
+            let bytes = std::fs::read(&canonical).map_err(|error| {
+                ParentCorpusError::at(
+                    ParentCorpusErrorCode::SnapshotFailed,
+                    &path,
+                    format!("cannot read parent artifact {}: {error}", path.display()),
+                )
+            })?;
+            output.push(SnapshotFile {
+                relative_path: components.join("/"),
+                absolute_path: canonical,
+                bytes,
+            });
+        }
+        components.pop();
+    }
+    Ok(())
+}
+
+fn write_frame(hasher: &mut Sha256, tag: u8, payload: &[u8]) {
+    hasher.update(&[tag]);
+    hasher.update(&(payload.len() as u64).to_be_bytes());
+    hasher.update(payload);
+}
+
+/// Pure digest over an already captured byte snapshot. File order at the API
+/// boundary is ignored; paths are always folded in canonical UTF-8 order.
+pub fn digest_snapshot(source: &str, config_bytes: &[u8], files: &[SnapshotFile]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(DIGEST_V1_DOMAIN);
+    write_frame(&mut hasher, 0x01, source.as_bytes());
+    write_frame(&mut hasher, 0x02, config_bytes);
+    let mut files: Vec<&SnapshotFile> = files.iter().collect();
+    files.sort_by_key(|file| file.relative_path.as_str());
+    for file in files {
+        write_frame(&mut hasher, 0x03, file.relative_path.as_bytes());
+        write_frame(&mut hasher, 0x04, &file.bytes);
+    }
+    format!("{DIGEST_PREFIX}{}", hasher.hexdigest())
+}
+
+fn read_bounded_source(config_path: &Path) -> Result<(String, Vec<u8>), ParentCorpusError> {
+    let bytes = std::fs::read(config_path).map_err(|error| {
+        ParentCorpusError::at(
+            ParentCorpusErrorCode::InvalidConfig,
+            config_path,
+            format!(
+                "cannot read parent config {}: {error}",
+                config_path.display()
+            ),
+        )
+    })?;
+    let text = std::str::from_utf8(&bytes).map_err(|_| {
+        ParentCorpusError::at(
+            ParentCorpusErrorCode::InvalidConfig,
+            config_path,
+            format!(
+                "parent config must be valid UTF-8: {}",
+                config_path.display()
+            ),
+        )
+    })?;
+    // Parse the exact file rather than ancestor-walking: the materialisation
+    // root is the provenance boundary chosen by the manifest/operator.
+    let identity = crate::scaffold::parse_identity_config(&config_path.to_string_lossy(), text)
+        .map_err(|error| {
+            ParentCorpusError::at(
+                ParentCorpusErrorCode::InvalidConfig,
+                config_path,
+                error.message().to_string(),
+            )
+        })?;
+    let source = identity.corpus_source.ok_or_else(|| {
+        ParentCorpusError::at(
+            ParentCorpusErrorCode::ParentSourceMissing,
+            config_path,
+            format!(
+                "parent config {} must declare an explicit corpus.source",
+                config_path.display()
+            ),
+        )
+    })?;
+    Ok((source, bytes))
+}
+
+fn snapshot_at(root: &Path, corpus_relative: &str) -> Result<ParentDigest, ParentCorpusError> {
+    let root_input = if root.is_absolute() {
+        root.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .map_err(|error| {
+                ParentCorpusError::new(
+                    ParentCorpusErrorCode::SnapshotFailed,
+                    format!("cannot determine current directory: {error}"),
+                )
+            })?
+            .join(root)
+    };
+    if std::fs::symlink_metadata(&root_input)
+        .is_ok_and(|metadata| metadata.file_type().is_symlink())
+    {
+        return Err(ParentCorpusError::at(
+            ParentCorpusErrorCode::SymlinkTraversal,
+            &root_input,
+            format!(
+                "parent materialisation root must not be a symlink: {}",
+                root_input.display()
+            ),
+        ));
+    }
+    let root = std::fs::canonicalize(&root_input).map_err(|error| {
+        ParentCorpusError::at(
+            ParentCorpusErrorCode::MaterialisationMissing,
+            &root_input,
+            format!(
+                "parent materialisation is unavailable at {}: {error}",
+                root_input.display()
+            ),
+        )
+    })?;
+    if !root.is_dir() {
+        return Err(ParentCorpusError::at(
+            ParentCorpusErrorCode::MaterialisationMissing,
+            &root,
+            format!(
+                "parent materialisation is not a directory: {}",
+                root.display()
+            ),
+        ));
+    }
+    validate_relative_path(corpus_relative, "corpus")
+        .map_err(|reason| ParentCorpusError::new(ParentCorpusErrorCode::PathEscape, reason))?;
+
+    let config_candidate = root.join(CONFIG_RELATIVE_PATH);
+    let config_path = canonical_confined(
+        &root,
+        &config_candidate,
+        ParentCorpusErrorCode::ParentConfigMissing,
+        "config",
+    )?;
+    if !config_path.is_file() {
+        return Err(ParentCorpusError::at(
+            ParentCorpusErrorCode::ParentConfigMissing,
+            &config_path,
+            format!(
+                "parent config is not a regular file: {}",
+                config_path.display()
+            ),
+        ));
+    }
+    let corpus_candidate = checked_relative_join(&root, corpus_relative, "corpus")?;
+    let corpus_root = canonical_confined(
+        &root,
+        &corpus_candidate,
+        ParentCorpusErrorCode::ParentCorpusMissing,
+        "corpus",
+    )?;
+    if !corpus_root.is_dir() {
+        return Err(ParentCorpusError::at(
+            ParentCorpusErrorCode::ParentCorpusMissing,
+            &corpus_root,
+            format!(
+                "parent corpus is not a directory: {}",
+                corpus_root.display()
+            ),
+        ));
+    }
+
+    let (source, config_bytes) = read_bounded_source(&config_path)?;
+    let mut files = Vec::new();
+    snapshot_directory(&corpus_root, &corpus_root, &mut Vec::new(), &mut files)?;
+    // Directory recursion is already component-sorted. Pin this explicitly so
+    // a future traversal refactor cannot alter the digest contract.
+    files.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
+    let digest = digest_snapshot(&source, &config_bytes, &files);
+    Ok(ParentDigest {
+        source,
+        config_path,
+        config_bytes,
+        corpus_root,
+        files,
+        digest,
+    })
+}
+
+/// Calculate a parent pin from a bounded materialisation root and a relative
+/// corpus directory. This is the pure operator surface behind
+/// `decided corpus digest`; it never writes, fetches, or updates a pin.
+pub fn calculate_parent_digest(
+    root: impl AsRef<Path>,
+    corpus_relative: &str,
+) -> Result<ParentDigest, ParentCorpusError> {
+    snapshot_at(root.as_ref(), corpus_relative)
+}
+
+fn exact_config_source(
+    config_path: &Path,
+    missing_config: ParentCorpusErrorCode,
+    missing_source: ParentCorpusErrorCode,
+    owner: &str,
+) -> Result<String, ParentCorpusError> {
+    if !config_path.is_file() {
+        return Err(ParentCorpusError::at(
+            missing_config,
+            config_path,
+            format!("{owner} config is missing: {}", config_path.display()),
+        ));
+    }
+    let identity =
+        crate::scaffold::read_identity_config(&config_path.to_string_lossy()).map_err(|error| {
+            ParentCorpusError::at(
+                ParentCorpusErrorCode::InvalidConfig,
+                config_path,
+                error.message().to_string(),
+            )
+        })?;
+    identity.corpus_source.ok_or_else(|| {
+        ParentCorpusError::at(
+            missing_source,
+            config_path,
+            format!("{owner} config must declare an explicit corpus.source"),
+        )
+    })
+}
+
+/// Verify the optional direct parent rooted at `child_repository_root`.
+/// Nothing from the parent is returned until containment, topology, source,
+/// and digest checks have all succeeded.
+pub fn verify_parent(
+    child_repository_root: impl AsRef<Path>,
+) -> Result<Option<VerifiedParent>, ParentCorpusError> {
+    let input = child_repository_root.as_ref();
+    let child_root = std::fs::canonicalize(input).map_err(|error| {
+        ParentCorpusError::at(
+            ParentCorpusErrorCode::PathEscape,
+            input,
+            format!(
+                "child repository root is unavailable at {}: {error}",
+                input.display()
+            ),
+        )
+    })?;
+    if !child_root.is_dir() {
+        return Err(ParentCorpusError::at(
+            ParentCorpusErrorCode::PathEscape,
+            &child_root,
+            format!(
+                "child repository root is not a directory: {}",
+                child_root.display()
+            ),
+        ));
+    }
+    let Some(manifest) = load_manifest(&child_root)? else {
+        return Ok(None);
+    };
+
+    let child_config = child_root.join(CONFIG_RELATIVE_PATH);
+    ensure_no_symlink_components(&child_root, &child_config)?;
+    let child_source = exact_config_source(
+        &child_config,
+        ParentCorpusErrorCode::ChildConfigMissing,
+        ParentCorpusErrorCode::ChildSourceMissing,
+        "child",
+    )?;
+
+    let materialisation_candidate =
+        checked_relative_join(&child_root, &manifest.inherits.root, "root")?;
+    let materialisation_root = canonical_confined(
+        &child_root,
+        &materialisation_candidate,
+        ParentCorpusErrorCode::MaterialisationMissing,
+        "materialisation",
+    )?;
+    if materialisation_root == child_root || !materialisation_root.is_dir() {
+        return Err(ParentCorpusError::at(
+            ParentCorpusErrorCode::PathEscape,
+            &materialisation_candidate,
+            "parent materialisation root must be a directory strictly inside the child repository",
+        ));
+    }
+
+    let parent_manifest_path = materialisation_root.join(MANIFEST_RELATIVE_PATH);
+    ensure_no_symlink_components(&materialisation_root, &parent_manifest_path)?;
+    if load_manifest(&materialisation_root)?.is_some() {
+        return Err(ParentCorpusError::at(
+            ParentCorpusErrorCode::TransitiveInheritance,
+            &parent_manifest_path,
+            format!(
+                "parent source '{}' declares its own inheritance; transitive federation is not supported",
+                manifest.inherits.source
+            ),
+        ));
+    }
+
+    let digest = snapshot_at(&materialisation_root, &manifest.inherits.corpus)?;
+    if digest.source != manifest.inherits.source {
+        return Err(ParentCorpusError::at(
+            ParentCorpusErrorCode::SourceMismatch,
+            &digest.config_path,
+            format!(
+                "manifest source '{}' does not match parent corpus.source '{}'",
+                manifest.inherits.source, digest.source
+            ),
+        ));
+    }
+    if child_source == digest.source {
+        return Err(ParentCorpusError::at(
+            ParentCorpusErrorCode::SourceCollision,
+            &manifest.path,
+            format!(
+                "child and parent must declare distinct corpus.source values; both are '{}'",
+                child_source
+            ),
+        ));
+    }
+    if digest.digest != manifest.inherits.digest {
+        return Err(ParentCorpusError::at(
+            ParentCorpusErrorCode::DigestMismatch,
+            &manifest.path,
+            format!(
+                "declared parent digest '{}' does not match verified digest '{}'",
+                manifest.inherits.digest, digest.digest
+            ),
+        ));
+    }
+
+    Ok(Some(VerifiedParent {
+        manifest_path: manifest.path,
+        manifest_bytes: manifest.bytes,
+        declaration: manifest.inherits,
+        child_repository_root: child_root,
+        child_source,
+        materialisation_root,
+        corpus_root: digest.corpus_root,
+        config_path: digest.config_path,
+        config_bytes: digest.config_bytes,
+        files: digest.files,
+        digest: digest.digest,
+        overrides: manifest.overrides,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    static COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+    fn scratch(name: &str) -> PathBuf {
+        let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+        let root = std::env::temp_dir().join(format!(
+            "asdecided-federation-{name}-{}-{n}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&root).unwrap();
+        root
+    }
+
+    fn write_parent(root: &Path) {
+        fs::create_dir_all(root.join(".decided")).unwrap();
+        fs::create_dir_all(root.join("decisions/sub")).unwrap();
+        fs::write(
+            root.join(".decided/config.yaml"),
+            b"repository_key: STD\ncorpus:\n  source: acme/standards\n",
+        )
+        .unwrap();
+        fs::write(root.join("decisions/a.md"), b"alpha\n").unwrap();
+        fs::write(root.join("decisions/sub/b.md"), b"beta\r\n").unwrap();
+        fs::write(root.join("decisions/ignored.MD"), b"ignored\n").unwrap();
+        fs::create_dir_all(root.join("decisions/.hidden")).unwrap();
+        fs::write(root.join("decisions/.hidden/secret.md"), b"hidden\n").unwrap();
+    }
+
+    fn write_child(root: &Path, digest: &str) {
+        fs::create_dir_all(root.join(".decided")).unwrap();
+        fs::write(
+            root.join(".decided/config.yaml"),
+            b"repository_key: APP\ncorpus:\n  source: acme/app\n",
+        )
+        .unwrap();
+        fs::write(
+            root.join(".decided/corpus.md"),
+            format!(
+                "# Corpus\n\n## inherits\n\n```yaml\nversion: 1\nalias: standards\nsource: acme/standards\nroot: vendor/standards\ncorpus: decisions\ndigest: {digest}\n```\n"
+            ),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn digest_v1_known_vector_and_exact_snapshot() {
+        let root = scratch("digest-vector");
+        write_parent(&root);
+        let result = calculate_parent_digest(&root, "decisions").unwrap();
+        assert_eq!(result.source, "acme/standards");
+        assert_eq!(
+            result
+                .files
+                .iter()
+                .map(|file| file.relative_path.as_str())
+                .collect::<Vec<_>>(),
+            ["a.md", "sub/b.md"]
+        );
+        assert_eq!(result.files[1].bytes, b"beta\r\n");
+        assert_eq!(
+            result.digest,
+            "sha256:899d5cdfa52b90a157b018dceb20f4f2901e0d56c91b089c12286c0b8b7b3325"
+        );
+        let mut reversed = result.files.clone();
+        reversed.reverse();
+        assert_eq!(
+            digest_snapshot(&result.source, &result.config_bytes, &reversed),
+            result.digest
+        );
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn manifest_requires_exact_lowercase_heading_and_one_mapping() {
+        let root = scratch("manifest");
+        fs::create_dir_all(root.join(".decided")).unwrap();
+        fs::write(
+            root.join(".decided/corpus.md"),
+            "# Corpus\n\n## Inherits\n\n```yaml\nversion: 1\n```\n",
+        )
+        .unwrap();
+        let error = load_manifest(&root).unwrap_err();
+        assert_eq!(error.code, ParentCorpusErrorCode::MalformedManifest);
+        assert!(error.message.contains("exact lowercase"));
+
+        fs::write(
+            root.join(".decided/corpus.md"),
+            "# Corpus\n\n## inherits\n\n```yaml\nversion: 1\n```\n\n```yaml\nversion: 1\n```\n",
+        )
+        .unwrap();
+        assert_eq!(
+            load_manifest(&root).unwrap_err().code,
+            ParentCorpusErrorCode::MultipleParents
+        );
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn verifies_one_direct_parent_and_excludes_its_tree() {
+        let child = scratch("verify");
+        let parent = child.join("vendor/standards");
+        write_parent(&parent);
+        let pin = calculate_parent_digest(&parent, "decisions")
+            .unwrap()
+            .digest;
+        write_child(&child, &pin);
+        let verified = verify_parent(&child).unwrap().unwrap();
+        assert_eq!(verified.digest, pin);
+        assert_eq!(verified.child_source, "acme/app");
+        assert!(verified.contains_materialised_path(&parent.join("decisions/a.md")));
+        assert!(!verified.contains_materialised_path(&child.join("local.md")));
+        let entries = vec![child.join("local.md"), parent.join("decisions/a.md")];
+        let retained = verified.exclude_materialisation(entries, |path| path.as_path());
+        assert_eq!(retained, [child.join("local.md")]);
+        fs::remove_dir_all(child).unwrap();
+    }
+
+    #[test]
+    fn stale_pin_and_source_mismatch_are_distinct() {
+        let child = scratch("mismatch");
+        let parent = child.join("vendor/standards");
+        write_parent(&parent);
+        let pin = calculate_parent_digest(&parent, "decisions")
+            .unwrap()
+            .digest;
+        write_child(&child, &pin);
+        fs::write(parent.join("decisions/a.md"), b"changed\n").unwrap();
+        assert_eq!(
+            verify_parent(&child).unwrap_err().code,
+            ParentCorpusErrorCode::DigestMismatch
+        );
+
+        write_child(
+            &child,
+            &calculate_parent_digest(&parent, "decisions")
+                .unwrap()
+                .digest,
+        );
+        let manifest = fs::read_to_string(child.join(".decided/corpus.md"))
+            .unwrap()
+            .replace("source: acme/standards", "source: acme/other");
+        fs::write(child.join(".decided/corpus.md"), manifest).unwrap();
+        assert_eq!(
+            verify_parent(&child).unwrap_err().code,
+            ParentCorpusErrorCode::SourceMismatch
+        );
+        fs::remove_dir_all(child).unwrap();
+    }
+
+    #[test]
+    fn transitive_parent_is_rejected_before_overlay() {
+        let child = scratch("transitive");
+        let parent = child.join("vendor/standards");
+        write_parent(&parent);
+        let pin = calculate_parent_digest(&parent, "decisions")
+            .unwrap()
+            .digest;
+        write_child(&child, &pin);
+        fs::write(
+            parent.join(".decided/corpus.md"),
+            "# Corpus\n\n## inherits\n\n```yaml\nversion: 1\nalias: upstream\nsource: acme/upstream\nroot: vendor/upstream\ncorpus: decisions\ndigest: sha256:0000000000000000000000000000000000000000000000000000000000000000\n```\n",
+        )
+        .unwrap();
+        assert_eq!(
+            verify_parent(&child).unwrap_err().code,
+            ParentCorpusErrorCode::TransitiveInheritance
+        );
+        fs::remove_dir_all(child).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlinked_materialisation_and_artifact_are_rejected() {
+        use std::os::unix::fs::symlink;
+
+        let child = scratch("symlink-root");
+        let outside = scratch("outside");
+        write_parent(&outside);
+        fs::create_dir_all(child.join("vendor")).unwrap();
+        symlink(&outside, child.join("vendor/standards")).unwrap();
+        write_child(
+            &child,
+            &calculate_parent_digest(&outside, "decisions")
+                .unwrap()
+                .digest,
+        );
+        assert_eq!(
+            verify_parent(&child).unwrap_err().code,
+            ParentCorpusErrorCode::SymlinkTraversal
+        );
+        fs::remove_dir_all(&child).unwrap();
+        fs::remove_dir_all(&outside).unwrap();
+
+        let root = scratch("symlink-file");
+        write_parent(&root);
+        fs::write(root.join("target.md"), "target").unwrap();
+        symlink("../target.md", root.join("decisions/link.md")).unwrap();
+        assert_eq!(
+            calculate_parent_digest(&root, "decisions")
+                .unwrap_err()
+                .code,
+            ParentCorpusErrorCode::SymlinkTraversal
+        );
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn no_manifest_is_inert() {
+        let root = scratch("no-manifest");
+        assert!(verify_parent(&root).unwrap().is_none());
+        fs::remove_dir_all(root).unwrap();
+    }
+}

--- a/rust/rac-engine/src/freshness.rs
+++ b/rust/rac-engine/src/freshness.rs
@@ -310,7 +310,8 @@ impl FreshnessTracker {
                     self.items.remove(rel); // removed
                 }
             }
-            let (parsed, workers) = crate::parallel_build::parallel_parse_paths(&present);
+            let (parsed, workers) =
+                crate::parallel_build::parallel_parse_paths(&self.root_str, &present);
             self.last_parse_workers = workers;
             self.last_parse_files = present.len();
             for item in parsed {
@@ -333,7 +334,8 @@ impl FreshnessTracker {
     fn reparse_full(&mut self) {
         let root = PathBuf::from(&self.root_str);
         let paths: Vec<PathBuf> = self.manifest.iter().map(|(rel, _)| root.join(rel)).collect();
-        let (parsed, workers) = crate::parallel_build::parallel_parse_paths(&paths);
+        let (parsed, workers) =
+            crate::parallel_build::parallel_parse_paths(&self.root_str, &paths);
         self.last_parse_workers = workers;
         self.last_parse_files = paths.len();
         self.items = parsed
@@ -374,7 +376,8 @@ impl FreshnessTracker {
             .filter(|rel| current.contains(rel.as_str()))
             .map(|rel| root.join(rel))
             .collect();
-        let (parsed, workers) = crate::parallel_build::parallel_parse_paths(&present);
+        let (parsed, workers) =
+            crate::parallel_build::parallel_parse_paths(&self.root_str, &present);
         self.last_parse_workers = workers;
         self.last_parse_files = present.len();
         let parsed: BTreeMap<String, CorpusItem> = parsed
@@ -490,7 +493,8 @@ impl FreshnessTracker {
             .iter()
             .map(|(rel, _)| root.join(rel))
             .collect();
-        let (parsed, workers) = crate::parallel_build::parallel_parse_paths(&paths);
+        let (parsed, workers) =
+            crate::parallel_build::parallel_parse_paths(&self.root_str, &paths);
         self.last_parse_workers = workers;
         self.last_parse_files = paths.len();
         let parsed: BTreeMap<String, CorpusItem> = parsed

--- a/rust/rac-engine/src/index_store.rs
+++ b/rust/rac-engine/src/index_store.rs
@@ -540,6 +540,9 @@ impl MmapIndexReader {
         let aliases = reader.text_list()?;
         let tags = reader.text_list()?;
         Ok(IndexEntry {
+            key: None,
+            artifact_path: None,
+            origin: None,
             id,
             artifact_type,
             title,
@@ -563,6 +566,9 @@ impl MmapIndexReader {
         let inbound = reader.u32()?;
         let sections = self.read_sections(docid)?;
         Ok(IndexEntry {
+            key: None,
+            artifact_path: None,
+            origin: None,
             id,
             artifact_type,
             title,
@@ -773,9 +779,11 @@ impl MmapIndexReader {
         let mut result = Vec::with_capacity(count.min(1 << 20) as usize);
         for _ in 0..count {
             result.push(Relationship {
+                source_artifact: None,
                 source_path: reader.text()?,
                 relationship: reader.text()?,
                 target: reader.text()?,
+                resolved_artifact: None,
                 resolved_path: reader.opt_text()?,
                 issue: reader.opt_text()?,
             });

--- a/rust/rac-engine/src/lib.rs
+++ b/rust/rac-engine/src/lib.rs
@@ -34,6 +34,7 @@
 //! - `watchkeeper`: the watchkeeper report and review verdict.
 //! - `output`: human/JSON/SARIF renderers per command.
 //! - `commands`: CLI command entry points (argv already parsed).
+//! - `federation`: strict offline parent-manifest and byte-snapshot verification.
 //! - `cli`: argv parsing and exit codes matching the oracle's argparse
 //!   surface (PORT-CONTRACT.d/01).
 
@@ -76,6 +77,7 @@ pub mod sentry;
 pub mod doctor;
 pub mod mdhtml;
 pub mod export;
+pub mod federation;
 pub mod portal;
 pub mod agent_rules;
 pub mod okf;

--- a/rust/rac-engine/src/lib.rs
+++ b/rust/rac-engine/src/lib.rs
@@ -46,6 +46,7 @@ pub mod walk;
 pub mod parse;
 pub mod classify;
 pub mod identity;
+pub mod corpus;
 pub mod validate;
 pub mod relationships;
 pub mod diff;

--- a/rust/rac-engine/src/parallel_build.rs
+++ b/rust/rac-engine/src/parallel_build.rs
@@ -16,6 +16,9 @@
 
 use std::path::PathBuf;
 
+use crate::corpus::{
+    compatible_local_layer, ArtifactOrigin, PhysicalArtifactLocator, PhysicalCorpusLocator,
+};
 use crate::derived::{build_derived_index_from_items, DerivedIndex, DECISION_TYPE};
 use crate::relationships::{relationships_from_corpus, CorpusItem};
 use crate::resolve::{entry_from_item, field_tokens_of, is_live_decision, IndexEntry};
@@ -80,17 +83,24 @@ struct DocFragment {
     scope_row: Option<ScopeRow>,
 }
 
-fn fragment_for(path_display: &str) -> DocFragment {
+fn fragment_for(
+    entry: &crate::walk::WalkEntry,
+    origin: &ArtifactOrigin,
+    physical_corpus: &PhysicalCorpusLocator,
+) -> DocFragment {
     if std::env::var_os(FAULT_ENV).is_some() {
         panic!("parallel-build worker fault (injected)");
     }
-    let artifact = crate::parse::parse_file(path_display);
+    let artifact = crate::parse::parse_file(&entry.display);
     let spec = crate::spec::spec_for(&crate::classify::classify(&artifact).artifact_type);
-    let item = CorpusItem {
-        path: path_display.to_string(),
+    let item = CorpusItem::new(
+        entry.display.clone(),
+        entry.rel(),
         artifact,
         spec,
-    };
+        origin.clone(),
+        PhysicalArtifactLocator::new(physical_corpus.clone(), entry.abs.clone()),
+    );
     let index_entry = entry_from_item(&item, 0);
     let field_tokens = field_tokens_of(&index_entry);
     let live = item.spec.map(|s| s.name == DECISION_TYPE).unwrap_or(false)
@@ -106,7 +116,12 @@ fn fragment_for(path_display: &str) -> DocFragment {
 }
 
 /// Fan the parse + per-doc derive across `n_workers`, or None on any fault.
-fn fragments_parallel(paths: &[String], n_workers: usize) -> Option<Vec<DocFragment>> {
+fn fragments_parallel(
+    entries: &[crate::walk::WalkEntry],
+    n_workers: usize,
+    origin: &ArtifactOrigin,
+    physical_corpus: &PhysicalCorpusLocator,
+) -> Option<Vec<DocFragment>> {
     let pool = rayon::ThreadPoolBuilder::new()
         .num_threads(n_workers)
         .build()
@@ -114,9 +129,9 @@ fn fragments_parallel(paths: &[String], n_workers: usize) -> Option<Vec<DocFragm
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         pool.install(|| {
             use rayon::prelude::*;
-            paths
+            entries
                 .par_iter()
-                .map(|path| fragment_for(path))
+                .map(|entry| fragment_for(entry, origin, physical_corpus))
                 .collect::<Vec<DocFragment>>()
         })
     }));
@@ -130,6 +145,7 @@ fn fragments_parallel(paths: &[String], n_workers: usize) -> Option<Vec<DocFragm
 fn reproduce(fragments: Vec<DocFragment>, directory: &str, recursive: bool) -> DerivedIndex {
     let mut items = Vec::with_capacity(fragments.len());
     let mut index_entries = Vec::with_capacity(fragments.len());
+    let mut source_artifacts = Vec::with_capacity(fragments.len());
     let mut field_tokens = Vec::with_capacity(fragments.len());
     let mut live_decision_paths = Vec::new();
     let mut scope_rows = Vec::new();
@@ -140,6 +156,12 @@ fn reproduce(fragments: Vec<DocFragment>, directory: &str, recursive: bool) -> D
         if let Some(row) = fragment.scope_row {
             scope_rows.push(row);
         }
+        source_artifacts.push(crate::derived::SourceAwareArtifact {
+            key: fragment.item.key.clone(),
+            path: fragment.item.artifact_path.clone(),
+            origin: fragment.item.origin.clone(),
+            display_path: fragment.item.path.clone(),
+        });
         items.push(fragment.item);
         index_entries.push(fragment.index_entry);
         field_tokens.push(fragment.field_tokens);
@@ -156,7 +178,18 @@ fn reproduce(fragments: Vec<DocFragment>, directory: &str, recursive: bool) -> D
         entry.inbound_count = inbound.get(entry.path.as_str()).copied().unwrap_or(0);
     }
     let summary = crate::portfolio::portfolio_from_corpus(directory, &items, recursive);
+    let mut layers: Vec<crate::corpus::CorpusLayer> = items
+        .iter()
+        .map(|item| crate::corpus::CorpusLayer::from(&item.origin))
+        .collect();
+    layers.sort();
+    layers.dedup();
+    if layers.is_empty() {
+        layers.push(crate::corpus::compatible_local_layer(directory));
+    }
     DerivedIndex {
+        layers,
+        source_artifacts,
         index_entries,
         field_tokens,
         relationships,
@@ -174,13 +207,12 @@ pub fn build_derived_index_parallel(
     workers: Option<usize>,
 ) -> (DerivedIndex, BuildStats) {
     let t0 = std::time::Instant::now();
-    let paths: Vec<String> = crate::walk::find_markdown_files(directory, recursive)
-        .into_iter()
-        .map(|e| e.display)
-        .collect();
-    let n_workers = resolve_workers(workers, paths.len());
+    let entries = crate::walk::find_markdown_files(directory, recursive);
+    let n_workers = resolve_workers(workers, entries.len());
+    let origin = compatible_local_layer(directory).origin();
+    let physical_corpus = PhysicalCorpusLocator::local(directory);
     let fragments = if n_workers > 1 {
-        fragments_parallel(&paths, n_workers)
+        fragments_parallel(&entries, n_workers, &origin, &physical_corpus)
     } else {
         None
     };
@@ -233,7 +265,10 @@ pub fn emit_build_timing(stats: &BuildStats) {
 /// The paths type alias for the freshness tracker's explicit-list parse
 /// (INDEX-PLAN B6): parse a known path list through the one true per-file
 /// path, parallel when it pays; entries in list order.
-pub fn parallel_parse_paths(paths: &[PathBuf]) -> (Vec<CorpusItem>, usize) {
+pub fn parallel_parse_paths(root: &str, paths: &[PathBuf]) -> (Vec<CorpusItem>, usize) {
+    let corpus_root = PathBuf::from(root);
+    let origin = compatible_local_layer(root).origin();
+    let physical_corpus = PhysicalCorpusLocator::local(&corpus_root);
     let displays: Vec<String> = paths
         .iter()
         .map(|p| p.to_string_lossy().into_owned())
@@ -245,11 +280,21 @@ pub fn parallel_parse_paths(paths: &[PathBuf]) -> (Vec<CorpusItem>, usize) {
             let artifact = crate::parse::parse_file(path);
             let spec =
                 crate::spec::spec_for(&crate::classify::classify(&artifact).artifact_type);
-            CorpusItem {
-                path: path.clone(),
+            let relative_path = PathBuf::from(path)
+                .strip_prefix(&corpus_root)
+                .unwrap_or_else(|_| std::path::Path::new(path))
+                .iter()
+                .map(|part| part.to_string_lossy())
+                .collect::<Vec<_>>()
+                .join("/");
+            CorpusItem::new(
+                path.clone(),
+                relative_path,
                 artifact,
                 spec,
-            }
+                origin.clone(),
+                PhysicalArtifactLocator::new(physical_corpus.clone(), path),
+            )
         })
         .collect();
     let workers = std::thread::available_parallelism()

--- a/rust/rac-engine/src/parallel_build.rs
+++ b/rust/rac-engine/src/parallel_build.rs
@@ -117,7 +117,7 @@ fn fragment_for(
 
 /// Fan the parse + per-doc derive across `n_workers`, or None on any fault.
 fn fragments_parallel(
-    entries: &[crate::walk::WalkEntry],
+    paths: &[crate::walk::WalkEntry],
     n_workers: usize,
     origin: &ArtifactOrigin,
     physical_corpus: &PhysicalCorpusLocator,
@@ -129,7 +129,7 @@ fn fragments_parallel(
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         pool.install(|| {
             use rayon::prelude::*;
-            entries
+            paths
                 .par_iter()
                 .map(|entry| fragment_for(entry, origin, physical_corpus))
                 .collect::<Vec<DocFragment>>()

--- a/rust/rac-engine/src/portfolio.rs
+++ b/rust/rac-engine/src/portfolio.rs
@@ -5,7 +5,7 @@
 use crate::classify::missing_sections;
 use crate::pycompat::py_round;
 use crate::relationships::{
-    summary_from_rows, validation_from_rows, validation_row, CorpusItem, RelationshipSummary,
+    summary_from_rows, validation_from_rows, CorpusItem, RelationshipSummary,
     ValidationRow, ISSUE_SELF_REFERENCE, ISSUE_TARGET_AMBIGUOUS, ISSUE_TARGET_NOT_FOUND,
 };
 use crate::validate::{apply_overrides, has_errors, load_overrides, py_title, validate, SeverityOverrides};
@@ -99,7 +99,7 @@ pub fn portfolio_row(item: &CorpusItem) -> PortfolioRow {
         .spec
         .map(|s| s.name.clone())
         .unwrap_or_else(|| "unknown".to_string());
-    let vrow = validation_row(&path, &item.artifact, item.spec);
+    let vrow = crate::relationships::validation_row_from_item(item);
     match item.spec {
         None => PortfolioRow {
             path,

--- a/rust/rac-engine/src/relationships.rs
+++ b/rust/rac-engine/src/relationships.rs
@@ -10,6 +10,10 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 use crate::classify::classify;
+use crate::corpus::{
+    compatible_local_layer, ArtifactKey, ArtifactOrigin, ArtifactPath,
+    PhysicalArtifactLocator, PhysicalCorpusLocator,
+};
 use crate::identity::{artifact_identifier, artifact_identifiers, strip_list_marker};
 use crate::parse::{parse_file, Artifact};
 use crate::pycompat::{py_casefold, py_splitlines, py_strip};
@@ -265,6 +269,9 @@ fn is_retired(artifact: &Artifact, spec: &ArtifactSpec) -> bool {
 
 #[derive(Debug, Clone)]
 pub struct ValidationRow {
+    pub key: ArtifactKey,
+    pub artifact_path: ArtifactPath,
+    pub origin: ArtifactOrigin,
     pub path: String,
     /// Artifact type name, or None for an Unknown/untyped document.
     pub spec_name: Option<String>,
@@ -282,10 +289,56 @@ pub fn validation_row(
     artifact: &Artifact,
     spec: Option<&ArtifactSpec>,
 ) -> ValidationRow {
+    let parent = std::path::Path::new(path)
+        .parent()
+        .and_then(std::path::Path::to_str)
+        .unwrap_or(".");
+    let layer = compatible_local_layer(parent);
+    let origin = layer.origin();
+    let relative_path = std::path::Path::new(path)
+        .file_name()
+        .and_then(std::ffi::OsStr::to_str)
+        .unwrap_or(path);
     let identifiers = artifact_identifiers(artifact, spec, path);
     let canonical_id = artifact_identifier(artifact, spec, path);
+    validation_row_with_identity(
+        path,
+        artifact,
+        spec,
+        origin.key(canonical_id),
+        origin.path(relative_path),
+        origin,
+        identifiers,
+    )
+}
+
+pub(crate) fn validation_row_from_item(item: &CorpusItem) -> ValidationRow {
+    validation_row_with_identity(
+        &item.path,
+        &item.artifact,
+        item.spec,
+        item.key.clone(),
+        item.artifact_path.clone(),
+        item.origin.clone(),
+        artifact_identifiers(&item.artifact, item.spec, &item.path),
+    )
+}
+
+fn validation_row_with_identity(
+    path: &str,
+    artifact: &Artifact,
+    spec: Option<&ArtifactSpec>,
+    key: ArtifactKey,
+    artifact_path: ArtifactPath,
+    origin: ArtifactOrigin,
+    identifiers: Vec<String>,
+) -> ValidationRow {
+    let canonical_id = key.canonical_id.clone();
     match spec {
         None => ValidationRow {
+            key,
+            artifact_path,
+            origin,
             path: path.to_string(),
             spec_name: None,
             canonical_id,
@@ -295,6 +348,9 @@ pub fn validation_row(
             edges: Vec::new(),
         },
         Some(spec) => ValidationRow {
+            key,
+            artifact_path,
+            origin,
             path: path.to_string(),
             spec_name: Some(spec.name.clone()),
             canonical_id,
@@ -911,11 +967,7 @@ pub fn build_relationship_report(directory: &str, recursive: bool) -> Relationsh
 pub fn build_relationship_report_file(path: &str) -> RelationshipReport {
     let artifact = parse_file(path);
     let spec = spec_for(&classify(&artifact).artifact_type);
-    let items = vec![CorpusItem {
-        path: path.to_string(),
-        artifact,
-        spec,
-    }];
+    let items = vec![CorpusItem::compatible_local_file(path, artifact, spec)];
     build_report(path, items, false)
 }
 
@@ -923,12 +975,68 @@ pub fn build_relationship_report_file(path: &str) -> RelationshipReport {
 // Corpus entry points
 // ---------------------------------------------------------------------------
 
-/// One parsed + classified item: `(display path, artifact, spec)`.
+/// One parsed + classified item with stable identity and a separate runtime
+/// locator. `path` remains the released display string.
 #[derive(Clone)]
 pub struct CorpusItem {
+    pub key: ArtifactKey,
+    pub artifact_path: ArtifactPath,
+    pub origin: ArtifactOrigin,
+    pub locator: PhysicalArtifactLocator,
     pub path: String,
     pub artifact: Artifact,
     pub spec: Option<&'static ArtifactSpec>,
+}
+
+impl CorpusItem {
+    pub fn new(
+        path: String,
+        relative_path: String,
+        artifact: Artifact,
+        spec: Option<&'static ArtifactSpec>,
+        origin: ArtifactOrigin,
+        locator: PhysicalArtifactLocator,
+    ) -> Self {
+        let canonical_id = artifact_identifier(&artifact, spec, &path);
+        Self {
+            key: origin.key(canonical_id),
+            artifact_path: origin.path(relative_path),
+            origin,
+            locator,
+            path,
+            artifact,
+            spec,
+        }
+    }
+
+    /// Compatibility constructor for single-file and synthetic validation
+    /// seams that do not begin with a corpus walk.
+    pub fn compatible_local_file(
+        path: &str,
+        artifact: Artifact,
+        spec: Option<&'static ArtifactSpec>,
+    ) -> Self {
+        let file = std::path::Path::new(path);
+        let corpus_root = file.parent().unwrap_or_else(|| std::path::Path::new("."));
+        let corpus_root_text = corpus_root.to_string_lossy();
+        let origin = compatible_local_layer(&corpus_root_text).origin();
+        let relative_path = file
+            .file_name()
+            .and_then(std::ffi::OsStr::to_str)
+            .unwrap_or(path)
+            .to_string();
+        Self::new(
+            path.to_string(),
+            relative_path,
+            artifact,
+            spec,
+            origin,
+            PhysicalArtifactLocator::new(
+                PhysicalCorpusLocator::local(corpus_root),
+                file,
+            ),
+        )
+    }
 }
 
 /// `_corpus_items(directory, recursive)` — the sorted-path walk, parsed and
@@ -941,16 +1049,22 @@ pub struct CorpusItem {
 /// Rendering stays sequential over the ordered results.
 pub fn corpus_items(directory: &str, recursive: bool) -> Vec<CorpusItem> {
     use rayon::prelude::*;
+    let origin = compatible_local_layer(directory).origin();
+    let physical_corpus = PhysicalCorpusLocator::local(directory);
     find_markdown_files(directory, recursive)
         .into_par_iter()
         .map(|entry| {
+            let relative_path = entry.rel();
             let artifact = parse_file(&entry.display);
             let spec = spec_for(&classify(&artifact).artifact_type);
-            CorpusItem {
-                path: entry.display,
+            CorpusItem::new(
+                entry.display,
+                relative_path,
                 artifact,
                 spec,
-            }
+                origin.clone(),
+                PhysicalArtifactLocator::new(physical_corpus.clone(), entry.abs),
+            )
         })
         .collect()
 }
@@ -958,7 +1072,7 @@ pub fn corpus_items(directory: &str, recursive: bool) -> Vec<CorpusItem> {
 fn rows_from_items(items: &[CorpusItem]) -> Vec<ValidationRow> {
     items
         .iter()
-        .map(|item| validation_row(&item.path, &item.artifact, item.spec))
+        .map(validation_row_from_item)
         .collect()
 }
 
@@ -991,7 +1105,7 @@ pub fn validate_document_against_corpus(
         if py_casefold(&ident) == proposed_ident {
             continue; // the on-disk counterpart of the document being edited
         }
-        rows.push(validation_row(&item.path, &item.artifact, item.spec));
+        rows.push(validation_row_from_item(item));
     }
     rows.push(validation_row(source_path, artifact, spec));
     let result = validation_from_rows(directory, &rows, recursive);
@@ -1017,9 +1131,15 @@ pub fn validate_document_against_corpus(
 /// uniquely to another artifact.
 #[derive(Debug, Clone)]
 pub struct Relationship {
+    /// Stable source-aware endpoint. `None` only when reconstructed from the
+    /// pre-federation v1 persistent store; the v2 cutover owns its codec.
+    pub source_artifact: Option<ArtifactPath>,
     pub source_path: String,
     pub relationship: String,
     pub target: String,
+    /// Stable resolved endpoint, present for a uniquely resolved internal
+    /// edge built from the in-memory read model.
+    pub resolved_artifact: Option<ArtifactPath>,
     pub resolved_path: Option<String>,
     pub issue: Option<String>,
 }
@@ -1031,15 +1151,21 @@ pub fn resolve_relationships(
     index: &ResolutionIndex,
 ) -> Vec<Relationship> {
     let mut out = Vec::new();
+    let artifact_paths: HashMap<&str, &ArtifactPath> = rows
+        .iter()
+        .map(|row| (row.path.as_str(), &row.artifact_path))
+        .collect();
     for row in rows {
         for (section, refs) in &row.edges {
             let external = edge_spec(section).is_some_and(|e| e.external);
             for reference in refs {
                 if external {
                     out.push(Relationship {
+                        source_artifact: Some(row.artifact_path.clone()),
                         source_path: row.path.clone(),
                         relationship: section.clone(),
                         target: reference.clone(),
+                        resolved_artifact: None,
                         resolved_path: None,
                         issue: None,
                     });
@@ -1057,10 +1183,16 @@ pub fn resolve_relationships(
                         (None, Some(ISSUE_SELF_REFERENCE.to_string()))
                     }
                 };
+                let resolved_artifact = resolved
+                    .as_deref()
+                    .and_then(|path| artifact_paths.get(path).copied())
+                    .cloned();
                 out.push(Relationship {
+                    source_artifact: Some(row.artifact_path.clone()),
                     source_path: row.path.clone(),
                     relationship: section.clone(),
                     target: reference.clone(),
+                    resolved_artifact,
                     resolved_path: resolved,
                     issue,
                 });

--- a/rust/rac-engine/src/rename.rs
+++ b/rust/rac-engine/src/rename.rs
@@ -15,7 +15,7 @@ use std::path::{Path, PathBuf};
 
 use crate::pycompat::{py_casefold, py_is_space, py_splitlines, py_strip};
 use crate::relationships::{
-    corpus_items, resolution_index_from_rows, validation_row, CorpusItem, ValidationRow,
+    corpus_items, resolution_index_from_rows, CorpusItem, ValidationRow,
 };
 use crate::spec::RELATIONSHIP_SECTIONS;
 
@@ -719,7 +719,7 @@ pub fn compute_rename(
     let items = corpus_items(directory, recursive);
     let rows: Vec<ValidationRow> = items
         .iter()
-        .map(|item| validation_row(&item.path, &item.artifact, item.spec))
+        .map(crate::relationships::validation_row_from_item)
         .collect();
     let index = resolution_index_from_rows(&rows);
     let mut targets: Vec<&str> = index

--- a/rust/rac-engine/src/resolve.rs
+++ b/rust/rac-engine/src/resolve.rs
@@ -19,12 +19,13 @@
 
 use std::collections::{HashMap, HashSet};
 
+use crate::corpus::{ArtifactKey, ArtifactOrigin, ArtifactPath};
 use crate::identity::{artifact_identifier, artifact_identifiers};
 use crate::markdown::SearchSection;
 use crate::parse::Artifact;
 use crate::pycompat::{first_nonempty_line, py_casefold, py_round, py_strip};
 use crate::relationships::{
-    corpus_items, edge_spec, resolution_index_from_rows, validation_row, CorpusItem,
+    corpus_items, edge_spec, resolution_index_from_rows, validation_row_from_item, CorpusItem,
 };
 use crate::spec::spec_for;
 
@@ -116,6 +117,11 @@ fn tf(term: &str, tokens: &[String]) -> i64 {
 /// One searchable row of the repository index.
 #[derive(Debug, Clone)]
 pub struct IndexEntry {
+    /// Source-aware identity is present for in-memory rows. The frozen v1
+    /// store reconstructs `None` until the versioned v2 codec cutover.
+    pub key: Option<ArtifactKey>,
+    pub artifact_path: Option<ArtifactPath>,
+    pub origin: Option<ArtifactOrigin>,
     pub id: String,
     pub artifact_type: String,
     pub title: Option<String>,
@@ -139,6 +145,9 @@ pub(crate) fn identity_entry_from_item(item: &CorpusItem) -> IndexEntry {
         .map(|s| s.name.clone())
         .unwrap_or_else(|| "unknown".to_string());
     IndexEntry {
+        key: Some(item.key.clone()),
+        artifact_path: Some(item.artifact_path.clone()),
+        origin: Some(item.origin.clone()),
         id: artifact_identifier(&item.artifact, item.spec, &item.path),
         artifact_type,
         title: item.artifact.product.title.clone(),
@@ -170,7 +179,7 @@ pub(crate) fn entry_from_item(item: &CorpusItem, inbound: i64) -> IndexEntry {
 fn inbound_counts(items: &[CorpusItem]) -> HashMap<String, i64> {
     let rows: Vec<_> = items
         .iter()
-        .map(|item| validation_row(&item.path, &item.artifact, item.spec))
+        .map(validation_row_from_item)
         .collect();
     let index = resolution_index_from_rows(&rows);
     let mut counts: HashMap<String, i64> = HashMap::new();
@@ -212,6 +221,9 @@ pub fn index_from_items(items: &[CorpusItem]) -> Vec<IndexEntry> {
 /// One resolved artifact / search match (`ResolvedArtifact`).
 #[derive(Debug, Clone)]
 pub struct ResolvedArtifact {
+    pub key: Option<ArtifactKey>,
+    pub artifact_path: Option<ArtifactPath>,
+    pub origin: Option<ArtifactOrigin>,
     pub id: String,
     pub artifact_type: String,
     pub title: Option<String>,
@@ -270,6 +282,9 @@ pub struct ResolutionResult {
 
 pub(crate) fn resolved_from_entry(entry: &IndexEntry) -> ResolvedArtifact {
     ResolvedArtifact {
+        key: entry.key.clone(),
+        artifact_path: entry.artifact_path.clone(),
+        origin: entry.origin.clone(),
         id: entry.id.clone(),
         artifact_type: entry.artifact_type.clone(),
         title: entry.title.clone(),
@@ -1036,6 +1051,9 @@ pub(crate) fn rank_and_build(
             let fused_raw = fused[index];
             let bm25_raw = bm25_scores[index];
             ResolvedArtifact {
+                key: entry.key.clone(),
+                artifact_path: entry.artifact_path.clone(),
+                origin: entry.origin.clone(),
                 id: entry.id.clone(),
                 artifact_type: entry.artifact_type.clone(),
                 title: entry.title.clone(),
@@ -1145,6 +1163,9 @@ mod tests {
 
     fn test_entry(id: &str, title: &str, path: &str, body: &str, inbound: i64) -> IndexEntry {
         IndexEntry {
+            key: None,
+            artifact_path: None,
+            origin: None,
             id: id.to_string(),
             artifact_type: "decision".to_string(),
             title: Some(title.to_string()),
@@ -1322,6 +1343,9 @@ mod tests {
     #[test]
     fn persisted_field_matching_preserves_tiers_and_snippets() {
         let entry = IndexEntry {
+            key: None,
+            artifact_path: None,
+            origin: None,
             id: "RAC-EXAMPLE1234".to_string(),
             artifact_type: "requirement".to_string(),
             title: Some("Search latency".to_string()),

--- a/rust/rac-engine/src/scaffold.rs
+++ b/rust/rac-engine/src/scaffold.rs
@@ -209,7 +209,7 @@ fn valid_repository_key(key: &str) -> bool {
 /// A configured corpus source is a stable, lower-case, slash-namespaced
 /// identity such as `asdecided/core` (ADR-135). Each segment starts and ends
 /// with an ASCII letter or digit; `.`, `_`, and `-` are allowed internally.
-fn valid_corpus_source(source: &str) -> bool {
+pub(crate) fn valid_corpus_source(source: &str) -> bool {
     fn valid_segment(segment: &str) -> bool {
         let bytes = segment.as_bytes();
         let endpoint = |byte: u8| byte.is_ascii_lowercase() || byte.is_ascii_digit();
@@ -263,12 +263,13 @@ fn yaml_get<'a>(
 /// Read the two independent identity values from one config. Unknown sections
 /// remain additive; the recognised identity fields are strict so an invalid
 /// configured source can never silently fall through to another namespace.
-fn read_identity_config(config_path: &str) -> Result<RepositoryIdentityConfig, ScaffoldError> {
+pub(crate) fn parse_identity_config(
+    config_path: &str,
+    text: &str,
+) -> Result<RepositoryIdentityConfig, ScaffoldError> {
     use crate::frontmatter::Yaml;
 
-    let text = std::fs::read_to_string(config_path)
-        .map_err(|e| malformed_config(config_path, &format!("invalid YAML: {e}")))?;
-    let data = crate::frontmatter::yaml_load_config(&text)
+    let data = crate::frontmatter::yaml_load_config(text)
         .map_err(|problem| malformed_config(config_path, &format!("invalid YAML: {problem}")))?;
     let Yaml::Map(pairs) = data else {
         return Err(malformed_config(
@@ -330,6 +331,14 @@ fn read_identity_config(config_path: &str) -> Result<RepositoryIdentityConfig, S
         corpus_source,
         config_path: config_path.to_string(),
     })
+}
+
+pub(crate) fn read_identity_config(
+    config_path: &str,
+) -> Result<RepositoryIdentityConfig, ScaffoldError> {
+    let text = std::fs::read_to_string(config_path)
+        .map_err(|e| malformed_config(config_path, &format!("invalid YAML: {e}")))?;
+    parse_identity_config(config_path, &text)
 }
 
 /// `_read_config(config_path)` — strict read of one config file: YAML must

--- a/rust/rac-engine/src/sentry.rs
+++ b/rust/rac-engine/src/sentry.rs
@@ -307,11 +307,11 @@ fn parse_document(item: &CorpusItem) -> Result<Option<ConstraintDocument>, Box<S
 /// not require a repository tree and therefore fail the ordinary corpus gate
 /// even when code enforcement was not requested.
 pub fn validate_artifact(artifact: &Artifact) -> Vec<Issue> {
-    let item = CorpusItem {
-        path: String::new(),
-        artifact: artifact.clone(),
-        spec: spec_for("decision"),
-    };
+    let item = CorpusItem::compatible_local_file(
+        "",
+        artifact.clone(),
+        spec_for("decision"),
+    );
     match parse_document(&item) {
         Err(finding) => vec![Issue::new("error", finding.code, finding.message, None)],
         _ => Vec::new(),

--- a/rust/rac-engine/tests/federation_loader.rs
+++ b/rust/rac-engine/tests/federation_loader.rs
@@ -1,0 +1,265 @@
+use rac_engine::federation::{
+    calculate_parent_digest, load_manifest, verify_parent, ParentCorpusErrorCode,
+};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+fn scratch(name: &str) -> PathBuf {
+    let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+    let path = std::env::temp_dir().join(format!(
+        "asdecided-federation-integration-{name}-{}-{n}",
+        std::process::id()
+    ));
+    fs::create_dir_all(&path).unwrap();
+    path
+}
+
+fn parent_at(root: &Path, source: &str) {
+    fs::create_dir_all(root.join(".decided")).unwrap();
+    fs::create_dir_all(root.join("decisions/nested")).unwrap();
+    fs::write(
+        root.join(".decided/config.yaml"),
+        format!("repository_key: STD\ncorpus:\n  source: {source}\n"),
+    )
+    .unwrap();
+    fs::write(root.join("decisions/one.md"), b"one\n").unwrap();
+    fs::write(root.join("decisions/nested/two.md"), b"two\n").unwrap();
+}
+
+fn child_manifest(root: &Path, source: &str, pin: &str, parent_source: &str) {
+    fs::create_dir_all(root.join(".decided")).unwrap();
+    fs::write(
+        root.join(".decided/config.yaml"),
+        format!("repository_key: APP\ncorpus:\n  source: {source}\n"),
+    )
+    .unwrap();
+    fs::write(
+        root.join(".decided/corpus.md"),
+        format!(
+            "# Corpus\n\n## inherits\n\n```yaml\nversion: 1\nalias: standards\nsource: {parent_source}\nroot: vendor/standards\ncorpus: decisions\ndigest: {pin}\n```\n\n## overrides\n\n```yaml\nversion: 1\nitems: []\n```\n"
+        ),
+    )
+    .unwrap();
+}
+
+#[test]
+fn clone_location_and_metadata_do_not_change_the_pin() {
+    let first = scratch("clone-a");
+    let second = scratch("clone-b");
+    parent_at(&first, "acme/standards");
+    parent_at(&second, "acme/standards");
+
+    let first_pin = calculate_parent_digest(&first, "decisions").unwrap().digest;
+    let second_pin = calculate_parent_digest(&second, "decisions")
+        .unwrap()
+        .digest;
+    assert_eq!(first_pin, second_pin);
+
+    fs::remove_dir_all(first).unwrap();
+    fs::remove_dir_all(second).unwrap();
+}
+
+#[test]
+fn config_and_markdown_bytes_are_both_pin_inputs() {
+    let root = scratch("pin-inputs");
+    parent_at(&root, "acme/standards");
+    let original = calculate_parent_digest(&root, "decisions").unwrap().digest;
+
+    fs::write(root.join("decisions/one.md"), b"ONE\n").unwrap();
+    let content_changed = calculate_parent_digest(&root, "decisions").unwrap().digest;
+    assert_ne!(original, content_changed);
+
+    fs::write(root.join("decisions/one.md"), b"one\n").unwrap();
+    fs::write(
+        root.join(".decided/config.yaml"),
+        b"repository_key: STD\ncorpus:\n  source: acme/standards\n# reviewed\n",
+    )
+    .unwrap();
+    let config_changed = calculate_parent_digest(&root, "decisions").unwrap().digest;
+    assert_ne!(original, config_changed);
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn missing_materialisation_and_missing_corpus_are_distinct() {
+    let child = scratch("missing-materialisation");
+    fs::create_dir_all(child.join(".decided")).unwrap();
+    fs::write(
+        child.join(".decided/config.yaml"),
+        b"repository_key: APP\ncorpus:\n  source: acme/app\n",
+    )
+    .unwrap();
+    child_manifest(
+        &child,
+        "acme/app",
+        "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+        "acme/standards",
+    );
+    assert_eq!(
+        verify_parent(&child).unwrap_err().code,
+        ParentCorpusErrorCode::MaterialisationMissing
+    );
+
+    let parent = child.join("vendor/standards");
+    parent_at(&parent, "acme/standards");
+    fs::remove_dir_all(parent.join("decisions")).unwrap();
+    assert_eq!(
+        verify_parent(&child).unwrap_err().code,
+        ParentCorpusErrorCode::ParentCorpusMissing
+    );
+    fs::remove_dir_all(child).unwrap();
+}
+
+#[test]
+fn source_mismatch_and_source_collision_are_distinct() {
+    let child = scratch("sources");
+    let parent = child.join("vendor/standards");
+    parent_at(&parent, "acme/standards");
+    let pin = calculate_parent_digest(&parent, "decisions")
+        .unwrap()
+        .digest;
+
+    child_manifest(&child, "acme/app", &pin, "acme/other");
+    assert_eq!(
+        verify_parent(&child).unwrap_err().code,
+        ParentCorpusErrorCode::SourceMismatch
+    );
+
+    child_manifest(&child, "acme/standards", &pin, "acme/standards");
+    assert_eq!(
+        verify_parent(&child).unwrap_err().code,
+        ParentCorpusErrorCode::SourceCollision
+    );
+    fs::remove_dir_all(child).unwrap();
+}
+
+#[test]
+fn absolute_and_parent_relative_manifest_paths_never_load() {
+    let child = scratch("unsafe-paths");
+    fs::create_dir_all(child.join(".decided")).unwrap();
+    let manifest = |root: &str, corpus: &str| {
+        format!(
+            "# Corpus\n\n## inherits\n\n```yaml\nversion: 1\nalias: standards\nsource: acme/standards\nroot: {root}\ncorpus: {corpus}\ndigest: sha256:0000000000000000000000000000000000000000000000000000000000000000\n```\n"
+        )
+    };
+    fs::write(
+        child.join(".decided/corpus.md"),
+        manifest("/tmp/parent", "decisions"),
+    )
+    .unwrap();
+    assert_eq!(
+        load_manifest(&child).unwrap_err().code,
+        ParentCorpusErrorCode::PathEscape
+    );
+    fs::write(
+        child.join(".decided/corpus.md"),
+        manifest("vendor/standards", "../decisions"),
+    )
+    .unwrap();
+    assert_eq!(
+        load_manifest(&child).unwrap_err().code,
+        ParentCorpusErrorCode::PathEscape
+    );
+    fs::remove_dir_all(child).unwrap();
+}
+
+#[test]
+fn operational_headings_in_examples_do_not_declare_a_parent() {
+    let root = scratch("quoted-heading");
+    fs::create_dir_all(root.join(".decided")).unwrap();
+    fs::write(
+        root.join(".decided/corpus.md"),
+        "# Corpus\n\n```markdown\n## inherits\n```\n\n> ## inherits\n",
+    )
+    .unwrap();
+    let error = load_manifest(&root).unwrap_err();
+    assert_eq!(error.code, ParentCorpusErrorCode::MalformedManifest);
+    assert!(error.message.contains("missing exact lowercase"));
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn nested_headings_do_not_end_the_inherits_section() {
+    let root = scratch("nested-heading");
+    fs::create_dir_all(root.join(".decided")).unwrap();
+    fs::write(
+        root.join(".decided/corpus.md"),
+        "# Corpus\n\n## inherits\n\n> ## Example\n\n```yaml\nversion: 1\nalias: standards\nsource: acme/standards\nroot: vendor/standards\ncorpus: decisions\ndigest: sha256:0000000000000000000000000000000000000000000000000000000000000000\n```\n",
+    )
+    .unwrap();
+    let manifest = load_manifest(&root).unwrap().unwrap();
+    assert_eq!(manifest.inherits.alias, "standards");
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn a_verified_result_retains_manifest_and_snapshot_bytes() {
+    let child = scratch("retained-bytes");
+    let parent = child.join("vendor/standards");
+    parent_at(&parent, "acme/standards");
+    let calculated = calculate_parent_digest(&parent, "decisions").unwrap();
+    child_manifest(&child, "acme/app", &calculated.digest, "acme/standards");
+
+    let verified = verify_parent(&child).unwrap().unwrap();
+    assert_eq!(verified.config_bytes, calculated.config_bytes);
+    assert_eq!(verified.files, calculated.files);
+    assert_eq!(
+        verified
+            .files
+            .iter()
+            .find(|file| file.relative_path == "one.md")
+            .unwrap()
+            .bytes,
+        b"one\n"
+    );
+    assert!(verified.overrides.is_some());
+    assert_eq!(
+        verified.manifest_bytes,
+        fs::read(child.join(".decided/corpus.md")).unwrap()
+    );
+    fs::remove_dir_all(child).unwrap();
+}
+
+#[cfg(unix)]
+#[test]
+fn symlink_in_the_declared_corpus_path_is_rejected() {
+    use std::os::unix::fs::symlink;
+
+    let child = scratch("corpus-symlink");
+    let parent = child.join("vendor/standards");
+    fs::create_dir_all(parent.join(".decided")).unwrap();
+    fs::create_dir_all(parent.join("real-decisions")).unwrap();
+    fs::write(
+        parent.join(".decided/config.yaml"),
+        b"repository_key: STD\ncorpus:\n  source: acme/standards\n",
+    )
+    .unwrap();
+    symlink("real-decisions", parent.join("decisions")).unwrap();
+
+    let error = calculate_parent_digest(&parent, "decisions").unwrap_err();
+    assert_eq!(error.code, ParentCorpusErrorCode::SymlinkTraversal);
+    fs::remove_dir_all(child).unwrap();
+}
+
+#[cfg(unix)]
+#[test]
+fn symlinked_parent_config_is_rejected_before_reading_bytes() {
+    use std::os::unix::fs::symlink;
+
+    let root = scratch("config-symlink");
+    fs::create_dir_all(root.join(".decided")).unwrap();
+    fs::create_dir_all(root.join("decisions")).unwrap();
+    fs::write(
+        root.join("outside-config.yaml"),
+        b"repository_key: STD\ncorpus:\n  source: acme/standards\n",
+    )
+    .unwrap();
+    symlink("../outside-config.yaml", root.join(".decided/config.yaml")).unwrap();
+
+    let error = calculate_parent_digest(&root, "decisions").unwrap_err();
+    assert_eq!(error.code, ParentCorpusErrorCode::SymlinkTraversal);
+    fs::remove_dir_all(root).unwrap();
+}

--- a/rust/rac-engine/tests/index_store_vectors.rs
+++ b/rust/rac-engine/tests/index_store_vectors.rs
@@ -248,6 +248,8 @@ fn corruption_gates(cache_dir: &Path, corpus_hash: &str, seg_dir: &Path) {
     // A same-hash rewrite over a CORRUPT store replaces it (self-heal).
     fs::write(&target, &original[..10]).unwrap();
     let derived = rac_engine::derived::DerivedIndex {
+        layers: Vec::new(),
+        source_artifacts: Vec::new(),
         index_entries: Vec::new(),
         field_tokens: Vec::new(),
         relationships: Vec::new(),

--- a/rust/rac-engine/tests/source_aware_substrate.rs
+++ b/rust/rac-engine/tests/source_aware_substrate.rs
@@ -1,0 +1,190 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use rac_engine::corpus::{ArtifactKey, ArtifactPath, Layer};
+use rac_engine::identity::{artifact_identifier, artifact_identifiers};
+
+const DECISION: &str = r#"---
+schema_version: 1
+id: APP-KWJ4VMKVSS65
+type: decision
+---
+# ADR-001: Keep It Local
+
+## Status
+
+Accepted
+
+## Context
+
+The fixture needs one decision.
+
+## Decision
+
+Keep the released projection exact.
+
+## Consequences
+
+The source-aware fields remain internal.
+"#;
+
+const REQUIREMENT: &str = r#"---
+schema_version: 1
+id: APP-KWJ8S53D06CH
+type: requirement
+---
+# Requirement: Preserve Identity
+
+## Status
+
+Accepted
+
+## Problem
+
+Endpoints need stable source-aware paths.
+
+## Requirements
+
+- [REQ-001] The endpoint MUST retain its corpus source.
+
+## Related Decisions
+
+- APP-KWJ4VMKVSS65
+"#;
+
+fn scratch(tag: &str) -> PathBuf {
+    let unique = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let root =
+        std::env::temp_dir().join(format!("asdecided-{tag}-{}-{unique}", std::process::id()));
+    fs::create_dir_all(root.join(".decided")).unwrap();
+    fs::create_dir_all(root.join("decisions")).unwrap();
+    fs::write(
+        root.join(".decided/config.yaml"),
+        "repository_key: APP\ncorpus:\n  source: acme/app\n",
+    )
+    .unwrap();
+    fs::write(root.join("decisions/adr-001.md"), DECISION).unwrap();
+    root
+}
+
+fn corpus_arg(root: &Path) -> String {
+    root.join("decisions").to_string_lossy().into_owned()
+}
+
+#[test]
+fn stable_identity_survives_equivalent_clone_roots() {
+    let left_root = scratch("clone-a");
+    let right_root = scratch("clone-b");
+    let left = rac_engine::relationships::corpus_items(&corpus_arg(&left_root), true);
+    let right = rac_engine::relationships::corpus_items(&corpus_arg(&right_root), true);
+
+    assert_eq!(left.len(), 1);
+    assert_eq!(right.len(), 1);
+    assert_eq!(left[0].origin, right[0].origin);
+    assert_eq!(
+        left[0].key,
+        ArtifactKey::new("acme/app", "APP-KWJ4VMKVSS65")
+    );
+    assert_eq!(left[0].key, right[0].key);
+    assert_eq!(
+        left[0].artifact_path,
+        ArtifactPath::new("acme/app", "adr-001.md")
+    );
+    assert_eq!(left[0].artifact_path, right[0].artifact_path);
+    assert_eq!(left[0].origin.layer, Layer::Local);
+    assert_ne!(left[0].locator.path, right[0].locator.path);
+
+    let _ = fs::remove_dir_all(left_root);
+    let _ = fs::remove_dir_all(right_root);
+}
+
+#[test]
+fn no_manifest_keeps_the_released_index_projection_byte_exact() {
+    let root = scratch("parity");
+    assert!(!root.join(".decided/corpus.md").exists());
+    let directory = corpus_arg(&root);
+    let items = rac_engine::relationships::corpus_items(&directory, true);
+
+    // This is the complete path-only projection used before the source-aware
+    // substrate. It intentionally does not inspect the new identity fields.
+    let legacy = rac_engine::index::RepositoryIndex {
+        directory: directory.clone(),
+        recursive: true,
+        artifacts: items
+            .iter()
+            .map(|item| rac_engine::index::IndexEntry {
+                id: artifact_identifier(&item.artifact, item.spec, &item.path),
+                artifact_type: rac_engine::classify::classify(&item.artifact).artifact_type,
+                title: item.artifact.product.title.clone(),
+                path: item.path.clone(),
+                aliases: artifact_identifiers(&item.artifact, item.spec, &item.path),
+            })
+            .collect(),
+    };
+    let source_aware = rac_engine::index::build_repository_index(&directory, true);
+
+    assert_eq!(
+        rac_engine::output::render_index_json(&source_aware),
+        rac_engine::output::render_index_json(&legacy)
+    );
+    assert_eq!(
+        rac_engine::output::render_index_human(&source_aware),
+        rac_engine::output::render_index_human(&legacy)
+    );
+
+    let derived = rac_engine::derived::build_derived_index(&directory, true);
+    assert_eq!(derived.layers.len(), 1);
+    assert_eq!(derived.layers[0].source, "acme/app");
+    assert_eq!(derived.source_artifacts.len(), derived.index_entries.len());
+    assert_eq!(derived.source_artifacts[0].key, items[0].key);
+    assert_eq!(derived.source_artifacts[0].path, items[0].artifact_path);
+    assert_eq!(derived.index_entries[0].key, Some(items[0].key.clone()));
+    assert_eq!(
+        derived.index_entries[0].artifact_path,
+        Some(items[0].artifact_path.clone())
+    );
+    let resolved =
+        rac_engine::resolve::resolve_in_index(&derived.index_entries, "APP-KWJ4VMKVSS65")
+            .artifact
+            .expect("source-aware resolved artifact");
+    assert_eq!(resolved.key, Some(items[0].key.clone()));
+    assert_eq!(resolved.origin, Some(items[0].origin.clone()));
+
+    // The frozen v1 codec remains untouched in this substrate-only change.
+    assert_eq!(rac_engine::index_store::STORE_LAYOUT_VERSION, "v1");
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn validation_and_relationships_retain_source_aware_endpoints() {
+    let root = scratch("relationships");
+    fs::write(root.join("decisions/req-002.md"), REQUIREMENT).unwrap();
+    let directory = corpus_arg(&root);
+    let items = rac_engine::relationships::corpus_items(&directory, true);
+    let rows = rac_engine::relationships::rows_from_corpus_items(&items);
+
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].key.source, "acme/app");
+    assert_eq!(rows[1].artifact_path.source, "acme/app");
+    assert!(rows.iter().all(|row| row.origin.layer == Layer::Local));
+
+    let relationships = rac_engine::relationships::relationships_from_corpus(&items);
+    let edge = relationships
+        .iter()
+        .find(|edge| edge.relationship == "related_decisions")
+        .expect("related decision edge");
+    assert_eq!(
+        edge.source_artifact,
+        Some(ArtifactPath::new("acme/app", "req-002.md"))
+    );
+    assert_eq!(
+        edge.resolved_artifact,
+        Some(ArtifactPath::new("acme/app", "adr-001.md"))
+    );
+
+    let _ = fs::remove_dir_all(root);
+}


### PR DESCRIPTION
## Summary

- parse the operational `.decided/corpus.md` manifest with the exact lowercase `## inherits` and `## overrides` contract
- require one bounded, materialised, non-transitive parent with explicit distinct `corpus.source` identities
- reject absolute paths, traversal, path escape, and symlink traversal before composition
- verify a captured immutable parent snapshot with the versioned SHA-256 digest protocol
- add the read-only `decided corpus digest --root … --corpus …` operator command

## Stack

- Depends on #454
- Part of #270
- This slice verifies and snapshots the parent but does not activate federated reads

## Validation

- `cargo test --workspace --release --no-fail-fast`
- `cargo clippy -p asdecided-core --lib --tests -- -D warnings`
- `cargo clippy -p decided --all-targets -- -D warnings`
- `cargo clippy --workspace --release --no-deps -- -D warnings`
- federation loader integration tests: 10 passed
- `git diff --check`
