### PR TITLE
feat(mcp): serve verified federated corpora

### DIFF
--- a/rust/decided-mcp/src/audit.rs
+++ b/rust/decided-mcp/src/audit.rs
@@ -254,31 +254,37 @@ fn activation_message(recorder: &Recorder) -> String {
     )
 }
 
-/// Run `call`, record one audit event, and return the payload unchanged
-/// (ADR-084: audit is observability outside the response contract). With no
-/// recorder this is exactly `call()`. Under `on_write_error: block` a failed
-/// write refuses the call with a structured `audit-unavailable` error.
-pub fn observe(
+/// Result-preserving audit boundary for failures which happen before a tool
+/// can produce its structured payload (for example strict parent verification
+/// or composition). These failures still emit exactly one event with an empty
+/// returned set before the MCP layer serializes the error response.
+pub fn observe_result(
     recorder: Option<&mut Recorder>,
     request_principal: Option<&str>,
     tool: &str,
     args: Value,
-    call: impl FnOnce() -> String,
-) -> String {
+    call: impl FnOnce() -> Result<String, String>,
+) -> Result<String, String> {
     let Some(recorder) = recorder else {
         return call();
     };
     let stripped = request_principal.map(str::trim).filter(|s| !s.is_empty());
     let asserted = stripped.is_some();
-    let principal = stripped.map(str::to_string).unwrap_or_else(|| recorder.principal.clone());
+    let principal = stripped
+        .map(str::to_string)
+        .unwrap_or_else(|| recorder.principal.clone());
     let started = Instant::now();
-    let payload = call();
+    let result = call();
+    let (returned, result_outcome) = match &result {
+        Ok(payload) => (returned_records(payload), outcome(payload)),
+        Err(_) => (Vec::new(), "error"),
+    };
     let event = build_event(
         recorder,
         tool,
         args,
-        returned_records(&payload),
-        outcome(&payload),
+        returned,
+        result_outcome,
         started,
         &principal,
         asserted,
@@ -288,9 +294,11 @@ pub fn observe(
         err.insert("schema_version".into(), Value::String(SCHEMA_VERSION.into()));
         err.insert("error".into(), Value::String("audit-unavailable".into()));
         err.insert("tool".into(), Value::String(tool.into()));
-        return dumps_compact(&Value::Object(err));
+        // Preserve the established block-on-write wire behavior: the audit
+        // refusal is a structured tool payload, not the unrecorded result.
+        return Ok(dumps_compact(&Value::Object(err)));
     }
-    payload
+    result
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -338,6 +346,8 @@ fn outcome(payload: &str) -> &'static str {
 /// The audit schema deliberately keeps a small reference rather than copying
 /// result records: `id` is the stable identity, `resolved` records the
 /// resolution state, and `provenance.path` points back into the served corpus.
+/// Federated records add only the fixed source, layer, and pin identity fields
+/// authorised by ADR-141; response bodies and optional provenance stay out.
 /// The extractor covers every result collection emitted by the MCP tools. Raw
 /// outgoing relationship text is intentionally excluded because it can be an
 /// unresolved declaration rather than a returned artifact.
@@ -365,10 +375,16 @@ fn returned_records(payload: &str) -> Vec<Value> {
     }
     let mut seen = std::collections::HashSet::new();
     records.retain(|record| {
-        record
-            .get("id")
+        let Some(id) = record.get("id").and_then(Value::as_str) else {
+            return false;
+        };
+        let source = record
+            .get("provenance")
+            .and_then(Value::as_object)
+            .and_then(|provenance| provenance.get("source"))
             .and_then(Value::as_str)
-            .is_some_and(|id| seen.insert(id.to_string()))
+            .unwrap_or("");
+        seen.insert((source.to_string(), id.to_string()))
     });
     records
 }
@@ -379,11 +395,22 @@ fn returned_record(object: &Map<String, Value>) -> Option<Value> {
         .get("resolved")
         .and_then(Value::as_bool)
         .unwrap_or(true);
-    let provenance = object
-        .get("path")
-        .and_then(Value::as_str)
-        .map(|path| json!({ "path": path }))
-        .unwrap_or(Value::Null);
+    let mut provenance = Map::new();
+    if let Some(path) = object.get("path").and_then(Value::as_str) {
+        provenance.insert("path".to_string(), json!(path));
+    }
+    if let Some(response_provenance) = object.get("provenance").and_then(Value::as_object) {
+        for key in ["source", "layer", "pin"] {
+            if let Some(value) = response_provenance.get(key) {
+                provenance.insert(key.to_string(), value.clone());
+            }
+        }
+    }
+    let provenance = if provenance.is_empty() {
+        Value::Null
+    } else {
+        Value::Object(provenance)
+    };
     Some(json!({
         "id": id,
         "resolved": resolved,
@@ -501,6 +528,59 @@ mod tests {
         );
         assert!(!returned_records(&payload).iter().any(|item| item.to_string().contains("secret")));
         assert!(returned_records(r#"{"error":{"code":-1},"id":"A"}"#).is_empty());
+    }
+
+    #[test]
+    fn returned_records_keep_bounded_federation_identity_and_dedupe_by_source() {
+        let payload = json!({
+            "matches": [
+                {
+                    "id": "ADR-001",
+                    "path": "decisions/adr-001.md",
+                    "provenance": {
+                        "source": "acme/app",
+                        "layer": "local",
+                        "status": "Accepted",
+                        "status_history": ["must not enter audit"]
+                    }
+                },
+                {
+                    "id": "ADR-001",
+                    "path": "decisions/adr-001.md",
+                    "provenance": {
+                        "source": "acme/standards",
+                        "layer": "inherited",
+                        "pin": "sha256:0123",
+                        "evidence": "must not enter audit"
+                    }
+                }
+            ]
+        })
+        .to_string();
+        assert_eq!(
+            returned_records(&payload),
+            vec![
+                json!({
+                    "id": "ADR-001",
+                    "resolved": true,
+                    "provenance": {
+                        "path": "decisions/adr-001.md",
+                        "source": "acme/app",
+                        "layer": "local"
+                    }
+                }),
+                json!({
+                    "id": "ADR-001",
+                    "resolved": true,
+                    "provenance": {
+                        "path": "decisions/adr-001.md",
+                        "source": "acme/standards",
+                        "layer": "inherited",
+                        "pin": "sha256:0123"
+                    }
+                })
+            ]
+        );
     }
 
     #[test]

--- a/rust/decided-mcp/src/graph.rs
+++ b/rust/decided-mcp/src/graph.rs
@@ -2,6 +2,7 @@
 //! and adjacency indexes are built once per freshness generation, then reused
 //! by every graph call until the corpus changes.
 
+use rac_engine::corpus::{ArtifactKey, ArtifactOrigin, ArtifactPath, Layer};
 use rac_engine::freshness::TrackerModel;
 use rac_engine::relationships::{corpus_items, relationships_from_corpus, Relationship};
 use rac_engine::resolve::{index_from_items, IndexEntry, ResolutionResult, ResolvedArtifact};
@@ -26,6 +27,22 @@ fn relationship_order(section: &str) -> usize {
     RELATIONSHIP_SECTIONS.len()
 }
 
+fn stable_entry_order(left: &IndexEntry, right: &IndexEntry) -> std::cmp::Ordering {
+    left.artifact_path
+        .cmp(&right.artifact_path)
+        .then_with(|| left.path.cmp(&right.path))
+        .then_with(|| left.id.cmp(&right.id))
+}
+
+fn public_path(entry: &IndexEntry, federated: bool) -> String {
+    if federated {
+        if let Some(path) = &entry.artifact_path {
+            return path.relative_path.clone();
+        }
+    }
+    entry.path.clone()
+}
+
 pub struct OutgoingReferences {
     /// Section (snake_case) → raw stored targets, first-seen section order.
     pub by_section: Vec<(String, Vec<String>)>,
@@ -47,6 +64,8 @@ impl OutgoingReferences {
 }
 
 pub struct IncomingReference {
+    pub key: Option<ArtifactKey>,
+    pub origin: Option<ArtifactOrigin>,
     pub id: String,
     pub artifact_type: String,
     pub title: Option<String>,
@@ -61,6 +80,8 @@ pub struct IncomingReferences {
 }
 
 pub struct NeighborhoodNode {
+    pub key: Option<ArtifactKey>,
+    pub origin: Option<ArtifactOrigin>,
     pub id: String,
     pub artifact_type: String,
     pub title: Option<String>,
@@ -73,15 +94,21 @@ pub struct Neighborhood {
     pub truncated: bool,
 }
 
-/// Immutable graph projection for one logical corpus generation.
-pub struct GraphView {
-    entries: Vec<IndexEntry>,
+struct RelationshipProjection {
     relationships: Vec<Relationship>,
-    aliases: HashMap<String, Vec<usize>>,
-    entry_by_path: HashMap<String, usize>,
     outgoing_by_source: Vec<Vec<usize>>,
     incoming_by_target: Vec<Vec<usize>>,
     adjacency: Vec<Vec<(usize, usize)>>,
+}
+
+/// Immutable graph projection for one logical corpus generation.
+pub struct GraphView {
+    entries: Vec<IndexEntry>,
+    entry_by_path: HashMap<String, usize>,
+    entry_by_artifact_path: HashMap<ArtifactPath, usize>,
+    effective_graph: RelationshipProjection,
+    historical_graph: Option<RelationshipProjection>,
+    federated: bool,
 }
 
 impl GraphView {
@@ -111,37 +138,99 @@ impl GraphView {
         Self::new(index_from_items(&corpus), relationships_from_corpus(&corpus))
     }
 
+    pub fn from_composed(corpus: &rac_engine::composition::ComposedCorpus) -> Self {
+        Self::new_with_history(
+            corpus.identity_index(),
+            corpus.relationships(),
+            Some(corpus.catalog_relationships()),
+        )
+    }
+
     pub fn new(entries: Vec<IndexEntry>, relationships: Vec<Relationship>) -> Self {
-        let mut aliases: HashMap<String, Vec<usize>> = HashMap::new();
+        Self::new_with_history(entries, relationships, None)
+    }
+
+    fn new_with_history(
+        entries: Vec<IndexEntry>,
+        relationships: Vec<Relationship>,
+        historical_relationships: Option<Vec<Relationship>>,
+    ) -> Self {
         let mut entry_by_path = HashMap::with_capacity(entries.len());
+        let mut entry_by_artifact_path = HashMap::with_capacity(entries.len());
+        let federated = entries.iter().any(|entry| {
+            entry
+                .origin
+                .as_ref()
+                .is_some_and(|origin| origin.layer == Layer::Inherited)
+        });
         for (index, entry) in entries.iter().enumerate() {
             entry_by_path.insert(entry.path.clone(), index);
-            for alias in &entry.aliases {
-                let targets = aliases
-                    .entry(rac_engine::pycompat::py_casefold(alias))
-                    .or_default();
-                if !targets.contains(&index) {
-                    targets.push(index);
-                }
+            if let Some(path) = &entry.artifact_path {
+                entry_by_artifact_path.insert(path.clone(), index);
             }
         }
 
-        let mut outgoing_by_source = vec![Vec::new(); entries.len()];
-        let mut incoming_by_target = vec![Vec::new(); entries.len()];
-        let mut adjacency = vec![Vec::new(); entries.len()];
+        let effective_graph = Self::relationship_projection(
+            entries.len(),
+            &entry_by_path,
+            &entry_by_artifact_path,
+            relationships,
+        );
+        let historical_graph = historical_relationships.map(|relationships| {
+            Self::relationship_projection(
+                entries.len(),
+                &entry_by_path,
+                &entry_by_artifact_path,
+                relationships,
+            )
+        });
+
+        Self {
+            entries,
+            entry_by_path,
+            entry_by_artifact_path,
+            effective_graph,
+            historical_graph,
+            federated,
+        }
+    }
+
+    fn relationship_projection(
+        entry_count: usize,
+        entry_by_path: &HashMap<String, usize>,
+        entry_by_artifact_path: &HashMap<ArtifactPath, usize>,
+        relationships: Vec<Relationship>,
+    ) -> RelationshipProjection {
+        let mut outgoing_by_source = vec![Vec::new(); entry_count];
+        let mut incoming_by_target = vec![Vec::new(); entry_count];
+        let mut adjacency = vec![Vec::new(); entry_count];
         for (index, relationship) in relationships.iter().enumerate() {
-            let Some(&source_index) = entry_by_path.get(&relationship.source_path) else {
+            let source_index = relationship
+                .source_artifact
+                .as_ref()
+                .and_then(|path| entry_by_artifact_path.get(path))
+                .or_else(|| entry_by_path.get(&relationship.source_path))
+                .copied();
+            let Some(source_index) = source_index else {
                 continue;
             };
             outgoing_by_source[source_index].push(index);
-            let Some(target) = relationship.resolved_path.as_deref() else {
-                continue;
-            };
-            let Some(&target_index) = entry_by_path.get(target) else {
+            let target_index = relationship
+                .resolved_artifact
+                .as_ref()
+                .and_then(|path| entry_by_artifact_path.get(path))
+                .copied()
+                .or_else(|| {
+                    relationship
+                        .resolved_path
+                        .as_deref()
+                        .and_then(|path| entry_by_path.get(path).copied())
+                });
+            let Some(target_index) = target_index else {
                 continue;
             };
             incoming_by_target[target_index].push(index);
-            if relationship.source_path == target {
+            if source_index == target_index {
                 continue;
             }
             let rank = relationship_order(&relationship.relationship);
@@ -149,74 +238,50 @@ impl GraphView {
             adjacency[target_index].push((source_index, rank));
         }
 
-        Self {
-            entries,
+        RelationshipProjection {
             relationships,
-            aliases,
-            entry_by_path,
             outgoing_by_source,
             incoming_by_target,
             adjacency,
         }
     }
 
-    pub fn resolve(&self, artifact_id: &str) -> ResolutionResult {
-        use rac_engine::resolve::{OUTCOME_DUPLICATE, OUTCOME_NOT_FOUND, OUTCOME_RESOLVED};
-
-        let wanted = rac_engine::pycompat::py_casefold(rac_engine::pycompat::py_strip(artifact_id));
-        let matches = self.aliases.get(&wanted).map(Vec::as_slice).unwrap_or(&[]);
-        if matches.is_empty() {
-            return ResolutionResult {
-                artifact_id: artifact_id.to_string(),
-                outcome: OUTCOME_NOT_FOUND,
-                artifact: None,
-                duplicate_paths: Vec::new(),
-            };
-        }
-        if matches.len() > 1 {
-            let mut paths: Vec<String> = matches
-                .iter()
-                .map(|index| self.entries[*index].path.clone())
-                .collect();
-            paths.sort();
-            return ResolutionResult {
-                artifact_id: artifact_id.to_string(),
-                outcome: OUTCOME_DUPLICATE,
-                artifact: None,
-                duplicate_paths: paths,
-            };
-        }
-        let entry = &self.entries[matches[0]];
-        ResolutionResult {
-            artifact_id: artifact_id.to_string(),
-            outcome: OUTCOME_RESOLVED,
-            artifact: Some(ResolvedArtifact {
-                key: entry.key.clone(),
-                artifact_path: entry.artifact_path.clone(),
-                origin: entry.origin.clone(),
-                id: entry.id.clone(),
-                artifact_type: entry.artifact_type.clone(),
-                title: entry.title.clone(),
-                path: entry.path.clone(),
-                section: None,
-                snippet: None,
-                evidence: None,
-                recency: None,
-                tags: entry.tags.clone(),
-            }),
-            duplicate_paths: Vec::new(),
+    fn graph(&self, historical: bool) -> &RelationshipProjection {
+        if historical {
+            self.historical_graph
+                .as_ref()
+                .unwrap_or(&self.effective_graph)
+        } else {
+            &self.effective_graph
         }
     }
 
-    pub fn outgoing(&self, source_path: &str) -> OutgoingReferences {
+    fn entry_index(&self, artifact: &ResolvedArtifact) -> Option<usize> {
+        artifact
+            .artifact_path
+            .as_ref()
+            .and_then(|path| self.entry_by_artifact_path.get(path))
+            .copied()
+            .or_else(|| self.entry_by_path.get(&artifact.path).copied())
+    }
+
+    pub fn resolve(&self, artifact_id: &str) -> ResolutionResult {
+        rac_engine::resolve::resolve_in_index(&self.entries, artifact_id)
+    }
+
+    pub fn outgoing(
+        &self,
+        artifact: &ResolvedArtifact,
+        historical: bool,
+    ) -> OutgoingReferences {
+        let graph = self.graph(historical);
         let indexes = self
-            .entry_by_path
-            .get(source_path)
-            .map(|index| self.outgoing_by_source[*index].as_slice())
+            .entry_index(artifact)
+            .map(|index| graph.outgoing_by_source[index].as_slice())
             .unwrap_or(&[]);
         let mut by_section: Vec<(String, Vec<String>)> = Vec::new();
         for index in indexes.iter().take(MAX_RELATED_EDGES) {
-            let relationship = &self.relationships[*index];
+            let relationship = &graph.relationships[*index];
             match by_section
                 .iter_mut()
                 .find(|(section, _)| *section == relationship.relationship)
@@ -234,30 +299,42 @@ impl GraphView {
         }
     }
 
-    pub fn incoming(&self, target_path: &str) -> IncomingReferences {
-        let indexes = self
-            .entry_by_path
-            .get(target_path)
-            .map(|index| self.incoming_by_target[*index].as_slice())
+    pub fn incoming(
+        &self,
+        artifact: &ResolvedArtifact,
+        historical: bool,
+    ) -> IncomingReferences {
+        let graph = self.graph(historical);
+        let target_index = self.entry_index(artifact);
+        let indexes = target_index
+            .map(|index| graph.incoming_by_target[index].as_slice())
             .unwrap_or(&[]);
         let mut incoming = Vec::new();
         let mut total = 0usize;
         for index in indexes {
-            let relationship = &self.relationships[*index];
-            if relationship.source_path == target_path {
-                continue;
-            }
-            let Some(entry_index) = self.entry_by_path.get(&relationship.source_path) else {
+            let relationship = &graph.relationships[*index];
+            let entry_index = relationship
+                .source_artifact
+                .as_ref()
+                .and_then(|path| self.entry_by_artifact_path.get(path))
+                .or_else(|| self.entry_by_path.get(&relationship.source_path))
+                .copied();
+            let Some(entry_index) = entry_index else {
                 continue;
             };
+            if Some(entry_index) == target_index {
+                continue;
+            }
             total += 1;
             if incoming.len() < MAX_RELATED_EDGES {
-                let entry = &self.entries[*entry_index];
+                let entry = &self.entries[entry_index];
                 incoming.push(IncomingReference {
+                    key: entry.key.clone(),
+                    origin: entry.origin.clone(),
                     id: entry.id.clone(),
                     artifact_type: entry.artifact_type.clone(),
                     title: entry.title.clone(),
-                    path: relationship.source_path.clone(),
+                    path: public_path(entry, self.federated),
                     section: relationship.relationship.clone(),
                     target: relationship.target.clone(),
                 });
@@ -276,9 +353,15 @@ impl GraphView {
         }
     }
 
-    pub fn neighborhood(&self, origin_path: &str, depth: i64) -> Neighborhood {
+    pub fn neighborhood(
+        &self,
+        artifact: &ResolvedArtifact,
+        depth: i64,
+        historical: bool,
+    ) -> Neighborhood {
+        let graph = self.graph(historical);
         let depth = depth.clamp(0, MAX_TRAVERSAL_DEPTH);
-        let Some(&origin_index) = self.entry_by_path.get(origin_path) else {
+        let Some(origin_index) = self.entry_index(artifact) else {
             return Neighborhood {
                 nodes: Vec::new(),
                 truncated: false,
@@ -295,11 +378,14 @@ impl GraphView {
         for current_depth in 1..=depth {
             let mut next_frontier = Vec::new();
             let mut sorted_frontier = frontier.clone();
-            sorted_frontier.sort_by(|a, b| self.entries[*a].path.cmp(&self.entries[*b].path));
+            sorted_frontier.sort_by(|a, b| {
+                stable_entry_order(&self.entries[*a], &self.entries[*b])
+            });
             for entry_index in &sorted_frontier {
-                let mut neighbors = self.adjacency[*entry_index].clone();
+                let mut neighbors = graph.adjacency[*entry_index].clone();
                 neighbors.sort_by(|a, b| {
-                    (&self.entries[a.0].path, a.1).cmp(&(&self.entries[b.0].path, b.1))
+                    stable_entry_order(&self.entries[a.0], &self.entries[b.0])
+                        .then_with(|| a.1.cmp(&b.1))
                 });
                 neighbors.dedup();
                 for (neighbor_index, rank) in neighbors {
@@ -331,18 +417,21 @@ impl GraphView {
         }
 
         discovered.sort_by(|a, b| {
-            (a.0, a.1, &a.2, &self.entries[a.3].path)
-                .cmp(&(b.0, b.1, &b.2, &self.entries[b.3].path))
+            (a.0, a.1, &a.2)
+                .cmp(&(b.0, b.1, &b.2))
+                .then_with(|| stable_entry_order(&self.entries[a.3], &self.entries[b.3]))
         });
         let mut nodes: Vec<NeighborhoodNode> = discovered
             .into_iter()
             .map(|(hops, _rank, _id, entry_index)| {
                 let entry = &self.entries[entry_index];
                 NeighborhoodNode {
+                    key: entry.key.clone(),
+                    origin: entry.origin.clone(),
                     id: entry.id.clone(),
                     artifact_type: entry.artifact_type.clone(),
                     title: entry.title.clone(),
-                    path: entry.path.clone(),
+                    path: public_path(entry, self.federated),
                     hops,
                 }
             })
@@ -358,7 +447,11 @@ impl GraphView {
     }
 
     pub fn relationship_count(&self) -> usize {
-        self.relationships.len()
+        self.effective_graph.relationships.len()
+    }
+
+    pub fn is_federated(&self) -> bool {
+        self.federated
     }
 
     /// Approximate owned heap payload, excluding hash-table control bytes.
@@ -373,10 +466,19 @@ impl GraphView {
                     + entry.path.len()
                     + entry.aliases.iter().map(String::len).sum::<usize>()
                     + entry.tags.iter().map(String::len).sum::<usize>()
+                    + entry
+                        .artifact_path
+                        .as_ref()
+                        .map_or(0, |path| path.source.len() + path.relative_path.len())
+                    + entry.origin.as_ref().map_or(0, |origin| {
+                        origin.source.len()
+                            + origin.pin.as_ref().map_or(0, String::len)
+                            + origin.alias.as_ref().map_or(0, String::len)
+                    })
             })
             .sum();
-        let relationship_bytes: usize = self
-            .relationships
+        let relationship_bytes = |relationships: &[Relationship]| -> usize {
+            relationships
             .iter()
             .map(|relationship| {
                 relationship.source_path.len()
@@ -384,27 +486,141 @@ impl GraphView {
                     + relationship.target.len()
                     + relationship.resolved_path.as_ref().map_or(0, String::len)
                     + relationship.issue.as_ref().map_or(0, String::len)
+                    + relationship
+                        .source_artifact
+                        .as_ref()
+                        .map_or(0, |path| path.source.len() + path.relative_path.len())
+                    + relationship
+                        .resolved_artifact
+                        .as_ref()
+                        .map_or(0, |path| path.source.len() + path.relative_path.len())
             })
-            .sum();
-        let map_key_bytes = self.aliases.keys().map(String::len).sum::<usize>()
-            + self.entry_by_path.keys().map(String::len).sum::<usize>();
-        let vector_payload_bytes = self
+            .sum()
+        };
+        let relationship_bytes = relationship_bytes(&self.effective_graph.relationships)
+            + self.historical_graph.as_ref().map_or(0, |graph| {
+                relationship_bytes(&graph.relationships)
+            });
+        let map_key_bytes = self.entry_by_path.keys().map(String::len).sum::<usize>()
+            + self
+                .entry_by_artifact_path
+                .keys()
+                .map(|path| path.source.len() + path.relative_path.len())
+                .sum::<usize>();
+        let projection_payload = |graph: &RelationshipProjection| {
+            graph
             .outgoing_by_source
             .iter()
             .map(|indexes| indexes.len() * std::mem::size_of::<usize>())
             .sum::<usize>()
-            + self
+            + graph
                 .incoming_by_target
                 .iter()
                 .map(|indexes| indexes.len() * std::mem::size_of::<usize>())
                 .sum::<usize>()
-            + self
+            + graph
                 .adjacency
                 .iter()
                 .map(|neighbors| neighbors.len() * std::mem::size_of::<(usize, usize)>())
-                .sum::<usize>();
+                .sum::<usize>()
+        };
+        let vector_payload_bytes = projection_payload(&self.effective_graph)
+            + self
+                .historical_graph
+                .as_ref()
+                .map_or(0, projection_payload);
         entry_bytes + relationship_bytes + map_key_bytes + vector_payload_bytes
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rac_engine::corpus::{ArtifactKey, CorpusLayer};
+
+    fn entry(
+        layer: CorpusLayer,
+        id: &str,
+        relative_path: &str,
+        physical_path: &str,
+    ) -> IndexEntry {
+        let origin = layer.origin();
+        IndexEntry {
+            key: Some(ArtifactKey::new(&origin.source, id)),
+            artifact_path: Some(origin.path(relative_path)),
+            origin: Some(origin),
+            id: id.to_string(),
+            artifact_type: "Decision".to_string(),
+            title: None,
+            path: physical_path.to_string(),
+            aliases: vec![id.to_string()],
+            search_sections: Vec::new(),
+            inbound_count: 0,
+            tags: Vec::new(),
+        }
+    }
+
+    fn resolved(entry: &IndexEntry) -> ResolvedArtifact {
+        ResolvedArtifact {
+            key: entry.key.clone(),
+            artifact_path: entry.artifact_path.clone(),
+            origin: entry.origin.clone(),
+            id: entry.id.clone(),
+            artifact_type: entry.artifact_type.clone(),
+            title: entry.title.clone(),
+            path: entry.path.clone(),
+            section: None,
+            snippet: None,
+            evidence: None,
+            recency: None,
+            tags: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn source_aware_endpoints_do_not_alias_physical_or_display_paths() {
+        let parent = entry(
+            CorpusLayer::inherited("acme/standards", "standards", "sha256:0123"),
+            "ADR-PARENT",
+            "decisions/shared.md",
+            "/checkout/vendor/decisions/shared.md",
+        );
+        let local = entry(
+            CorpusLayer::local("acme/app"),
+            "ADR-LOCAL",
+            "decisions/shared.md",
+            "/checkout/decisions/shared.md",
+        );
+        let relationship = Relationship {
+            source_artifact: parent.artifact_path.clone(),
+            source_path: parent.path.clone(),
+            relationship: "depends_on".to_string(),
+            target: "ADR-LOCAL".to_string(),
+            resolved_artifact: local.artifact_path.clone(),
+            resolved_path: Some(local.path.clone()),
+            issue: None,
+        };
+        let parent_artifact = resolved(&parent);
+        let local_artifact = resolved(&local);
+        let view = GraphView::new(vec![parent, local], vec![relationship]);
+
+        assert!(view.is_federated());
+        assert_eq!(view.outgoing(&parent_artifact, false).total, 1);
+        assert_eq!(view.outgoing(&local_artifact, false).total, 0);
+
+        let incoming = view.incoming(&local_artifact, false);
+        assert_eq!(incoming.total, 1);
+        assert_eq!(incoming.items[0].id, "ADR-PARENT");
+        assert_eq!(incoming.items[0].path, "decisions/shared.md");
+        assert_eq!(
+            incoming.items[0]
+                .origin
+                .as_ref()
+                .map(|origin| origin.source.as_str()),
+            Some("acme/standards")
+        );
+    }
+
 }
 
 fn identity_projection(entry: &IndexEntry) -> IndexEntry {
@@ -429,13 +645,17 @@ fn identity_projection(entry: &IndexEntry) -> IndexEntry {
 #[derive(Default)]
 pub struct GraphCache {
     generation: Option<u64>,
+    federated_generation: Option<String>,
     view: Option<GraphView>,
     builds: u64,
 }
 
 impl GraphCache {
     pub fn view_for(&mut self, generation: u64, model: &TrackerModel) -> &GraphView {
-        if self.generation != Some(generation) || self.view.is_none() {
+        if self.generation != Some(generation)
+            || self.federated_generation.is_some()
+            || self.view.is_none()
+        {
             let started = rac_engine::timing::start();
             let replacement = GraphView::from_model(model);
             rac_engine::timing::emit_since(
@@ -449,9 +669,38 @@ impl GraphCache {
             );
             self.view = Some(replacement);
             self.generation = Some(generation);
+            self.federated_generation = None;
             self.builds += 1;
         }
         self.view.as_ref().expect("graph view built")
+    }
+
+    pub fn view_for_composed(
+        &mut self,
+        generation: &str,
+        corpus: &rac_engine::composition::ComposedCorpus,
+    ) -> &GraphView {
+        if self.federated_generation.as_deref() != Some(generation)
+            || self.generation.is_some()
+            || self.view.is_none()
+        {
+            let started = rac_engine::timing::start();
+            let replacement = GraphView::from_composed(corpus);
+            rac_engine::timing::emit_since(
+                "graph.view_build",
+                started,
+                &[
+                    ("entries", replacement.entry_count() as u64),
+                    ("relationships", replacement.relationship_count() as u64),
+                    ("payload_bytes", replacement.estimated_payload_bytes() as u64),
+                ],
+            );
+            self.view = Some(replacement);
+            self.generation = None;
+            self.federated_generation = Some(generation.to_string());
+            self.builds += 1;
+        }
+        self.view.as_ref().expect("federated graph view built")
     }
 
     #[cfg(test)]

--- a/rust/decided-mcp/src/main.rs
+++ b/rust/decided-mcp/src/main.rs
@@ -20,6 +20,7 @@ use args::{Arg, Kind, Param};
 use rac_engine::budget;
 use serde_json::{json, Map, Value};
 use std::io::{BufRead, Write};
+use std::path::{Path, PathBuf};
 
 /// The pinned `tools/list` result — the captured ORACLE-NEXT bytes, embedded
 /// verbatim (schemas, descriptions, pydantic-shaped titles incl. the
@@ -28,8 +29,64 @@ use std::io::{BufRead, Write};
 const TOOLS_LIST_RESULT: &str = include_str!("tools_list_result.json");
 
 pub(crate) struct ServerState {
+    repository_root: PathBuf,
+    federation_seen: bool,
     tracker: Option<rac_engine::freshness::FreshnessTracker>,
+    federated_tracker: Option<
+        rac_engine::derived_cache::FederatedCacheTracker<
+            rac_engine::composition::ComposedCorpus,
+        >,
+    >,
     graph_cache: graph::GraphCache,
+}
+
+enum RequestRead<'a> {
+    Legacy {
+        generation: Option<u64>,
+        model: Option<&'a rac_engine::freshness::TrackerModel>,
+    },
+    FederatedCached(
+        rac_engine::derived_cache::FederatedCacheRead<
+            'a,
+            rac_engine::composition::ComposedCorpus,
+        >,
+    ),
+    FederatedFresh {
+        generation: rac_engine::derived_cache::LogicalGeneration,
+        composed: Box<rac_engine::composition::ComposedCorpus>,
+    },
+}
+
+impl RequestRead<'_> {
+    fn legacy(&self) -> (Option<u64>, Option<&rac_engine::freshness::TrackerModel>) {
+        match self {
+            Self::Legacy { generation, model } => (*generation, *model),
+            _ => (None, None),
+        }
+    }
+
+    fn composed(&self) -> Option<&rac_engine::composition::ComposedCorpus> {
+        match self {
+            Self::FederatedCached(read) => Some(read.composed),
+            Self::FederatedFresh { composed, .. } => Some(composed),
+            Self::Legacy { .. } => None,
+        }
+    }
+
+    fn cached_model(&self) -> Option<&rac_engine::derived_cache::ReadModel> {
+        match self {
+            Self::FederatedCached(read) => Some(read.model),
+            _ => None,
+        }
+    }
+
+    fn logical_generation(&self) -> Option<&rac_engine::derived_cache::LogicalGeneration> {
+        match self {
+            Self::FederatedCached(read) => Some(read.generation),
+            Self::FederatedFresh { generation, .. } => Some(generation),
+            Self::Legacy { .. } => None,
+        }
+    }
 }
 
 /// The SDK's logging notification for an unparseable input line (§1) —
@@ -133,7 +190,10 @@ fn main() {
     if !std::path::Path::new(&root).is_dir() {
         usage_error(&format!("not a directory: {root}"));
     }
-    check_corpus(&root);
+    let mut federation_seen = false;
+    let topology = repository_topology(&root, None, &mut federation_seen)
+        .unwrap_or_else(|error| usage_error(&error));
+    check_corpus(&root, &topology);
     // Server-lifetime freshness (ADR-105/118): one tracker per server keeps
     // the derived read-model current through Linux inotify-clean detection or
     // the authoritative stat fallback, re-deriving only where files changed.
@@ -146,8 +206,18 @@ fn main() {
     } else {
         None
     };
+    let federated_tracker = if rac_engine::derived_cache::cache_enabled(cache) {
+        Some(rac_engine::derived_cache::FederatedCacheTracker::new(
+            rac_engine::derived_cache::default_cache_dir(),
+        ))
+    } else {
+        None
+    };
     let mut state = ServerState {
+        repository_root: topology.repository_root,
+        federation_seen,
         tracker,
+        federated_tracker,
         graph_cache: graph::GraphCache::default(),
     };
     // Audit recorder (ADR-084): built from the `.decided/config.yaml` audit stanza,
@@ -184,15 +254,122 @@ fn main() {
 }
 
 /// Startup diagnostic (stderr only; declared-normalized in parity, §0).
-fn check_corpus(root: &str) {
-    let entries = rac_engine::resolve::build_index(root, true);
-    if !entries.iter().any(|e| e.artifact_type != "unknown") {
+fn check_corpus(root: &str, topology: &RepositoryTopology) {
+    let has_artifacts = if topology.federated {
+        let generation = rac_engine::derived_cache::capture_logical_generation(
+            &topology.repository_root,
+            root,
+            true,
+        )
+        .unwrap_or_else(|error| usage_error(&error.to_string()));
+        let composed = rac_engine::derived_cache::compose_logical_generation(root, &generation)
+            .unwrap_or_else(|error| usage_error(&error.to_string()));
+        let has_artifacts = composed
+            .effective()
+            .any(|item| item.spec.is_some());
+        has_artifacts
+    } else {
+        rac_engine::resolve::build_index(root, true)
+            .iter()
+            .any(|entry| entry.artifact_type != "unknown")
+    };
+    if !has_artifacts {
         eprintln!(
             "decided-mcp: no AsDecided artifacts found under '{root}'. Point --root at a \
 directory containing RAC Markdown artifacts, or run 'decided init' to initialize \
 a new repository. The server is running; get_summary will report the empty state."
         );
     }
+}
+
+struct RepositoryTopology {
+    repository_root: PathBuf,
+    federated: bool,
+}
+
+fn marker_present(path: &Path) -> Result<bool, String> {
+    match std::fs::symlink_metadata(path) {
+        Ok(_) => Ok(true),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(format!(
+            "parent-corpus-malformed-manifest: cannot inspect repository topology {}: {error}",
+            path.display()
+        )),
+    }
+}
+
+/// Discover and then pin the repository topology used by one server.
+///
+/// Startup searches for either governing config or federation manifest. Each
+/// request supplies the pinned root, so removing config cannot make discovery
+/// jump to another ancestor and silently return to the single-corpus model.
+/// Manifest presence is inspected with `symlink_metadata`, then parsed by the
+/// strict loader; directories, symlinks (including dangling ones), and races
+/// therefore fail closed instead of masquerading as absence.
+fn repository_topology(
+    root: &str,
+    pinned_root: Option<&Path>,
+    federation_seen: &mut bool,
+) -> Result<RepositoryTopology, String> {
+    let repository_root = if let Some(pinned) = pinned_root {
+        pinned.to_path_buf()
+    } else {
+        let resolved = std::fs::canonicalize(root).map_err(|error| {
+            format!("cannot resolve MCP corpus root {}: {error}", Path::new(root).display())
+        })?;
+        let mut selected = None;
+        for ancestor in resolved.ancestors() {
+            let config = ancestor.join(rac_engine::federation::CONFIG_RELATIVE_PATH);
+            let manifest = ancestor.join(rac_engine::federation::MANIFEST_RELATIVE_PATH);
+            if marker_present(&config)? || marker_present(&manifest)? {
+                selected = Some(ancestor.to_path_buf());
+                break;
+            }
+        }
+        selected.unwrap_or(resolved)
+    };
+
+    let manifest_path = repository_root.join(rac_engine::federation::MANIFEST_RELATIVE_PATH);
+    let present = marker_present(&manifest_path)?;
+    if present {
+        // Presence itself is sticky. A malformed addition cannot be removed
+        // to make the next request fall back to a legacy corpus.
+        *federation_seen = true;
+    }
+    let manifest = rac_engine::federation::load_manifest(&repository_root)
+        .map_err(|error| error.to_string())?;
+    let federated = manifest.is_some();
+    if *federation_seen && !federated {
+        return Err(format!(
+            "parent-corpus-malformed-manifest: federation manifest disappeared after this server observed federation: {}",
+            manifest_path.display()
+        ));
+    }
+    if *federation_seen {
+        let config_path = repository_root.join(rac_engine::federation::CONFIG_RELATIVE_PATH);
+        let metadata = std::fs::symlink_metadata(&config_path).map_err(|error| {
+            format!(
+                "parent-corpus-child-config-missing: child config is unavailable after this server observed federation: {}: {error}",
+                config_path.display()
+            )
+        })?;
+        if metadata.file_type().is_symlink() {
+            return Err(format!(
+                "parent-corpus-symlink-traversal: child config must not be a symlink: {}",
+                config_path.display()
+            ));
+        }
+        if !metadata.is_file() {
+            return Err(format!(
+                "parent-corpus-child-config-missing: child config is not a regular file: {}",
+                config_path.display()
+            ));
+        }
+    }
+    Ok(RepositoryTopology {
+        repository_root,
+        federated,
+    })
 }
 
 fn serve(
@@ -437,6 +614,64 @@ fn a_bool(args: &[Arg], i: usize, default: bool) -> bool {
     }
 }
 
+fn read_request<'a>(
+    root: &str,
+    repository_root: &Path,
+    federation_seen: &mut bool,
+    tracker: &'a mut Option<rac_engine::freshness::FreshnessTracker>,
+    federated_tracker: &'a mut Option<
+        rac_engine::derived_cache::FederatedCacheTracker<
+            rac_engine::composition::ComposedCorpus,
+        >,
+    >,
+) -> Result<RequestRead<'a>, String> {
+    // Every recognized tool enters the same strict topology boundary after
+    // its allowlisted arguments have been normalized for audit. Cache-off
+    // skips persistence only; it never skips topology, parent verification,
+    // or exact-byte composition.
+    let topology = repository_topology(root, Some(repository_root), federation_seen)?;
+    if topology.federated {
+        match federated_tracker.as_mut() {
+            Some(tracker) => Ok(RequestRead::FederatedCached(
+                tracker
+                    .read_composed(&topology.repository_root, root, true)
+                    .map_err(|error| error.to_string())?,
+            )),
+            None => {
+                let generation = rac_engine::derived_cache::capture_logical_generation(
+                    &topology.repository_root,
+                    root,
+                    true,
+                )
+                .map_err(|error| error.to_string())?;
+                let composed = rac_engine::derived_cache::compose_logical_generation(
+                    root,
+                    &generation,
+                )
+                .map_err(|error| error.to_string())?;
+                Ok(RequestRead::FederatedFresh {
+                    generation,
+                    composed: Box::new(composed),
+                })
+            }
+        }
+    } else {
+        Ok(match tracker.as_mut() {
+            Some(tracker) => {
+                let (generation, model) = tracker.read_model_with_generation(false);
+                RequestRead::Legacy {
+                    generation: Some(generation),
+                    model: Some(model),
+                }
+            }
+            None => RequestRead::Legacy {
+                generation: None,
+                model: None,
+            },
+        })
+    }
+}
+
 fn dispatch(
     root: &str,
     state: &mut ServerState,
@@ -457,15 +692,13 @@ fn dispatch(
     ) {
         return Err(format!("Unknown tool: {name}"));
     }
-    // Freshen the read-model once per call (the corpus-change check every
-    // tool answer rides, ADR-105); without the tracker every arm re-walks.
-    let (generation, model) = match state.tracker.as_mut() {
-        Some(tracker) => {
-            let (generation, model) = tracker.read_model_with_generation(false);
-            (Some(generation), Some(model))
-        }
-        None => (None, None),
-    };
+    let ServerState {
+        repository_root,
+        federation_seen,
+        tracker,
+        federated_tracker,
+        graph_cache,
+    } = state;
     // Audit args mirror server.py's per-tool `observed(...)` shapes exactly
     // (insertion order = recorded key order): non-default arguments ride the
     // record only when supplied. `sidecar::observe` keeps the telemetry seam
@@ -481,11 +714,28 @@ fn dispatch(
             let effective = tools::effective_budget(server_budget, a_int(&a, 1, 0));
             budget::validate_call_budget(effective)?;
             let audit_args = json!({ "id": a_str(&a, 0, "") });
-            Ok(sidecar::observe(name, || {
-                audit::observe(recorder, principal, name, audit_args, || {
-                    tools::get_artifact(root, model, &a_str(&a, 0, ""), effective)
+            sidecar::observe(name, || {
+                audit::observe_result(recorder, principal, name, audit_args, || {
+                    let request = read_request(
+                        root,
+                        repository_root,
+                        federation_seen,
+                        tracker,
+                        federated_tracker,
+                    )?;
+                    let (_, model) = request.legacy();
+                    Ok(if let Some(corpus) = request.composed() {
+                        tools::get_artifact_composed(
+                            root,
+                            corpus,
+                            &a_str(&a, 0, ""),
+                            effective,
+                        )
+                    } else {
+                        tools::get_artifact(root, model, &a_str(&a, 0, ""), effective)
+                    })
                 })
-            }))
+            })
         }
         "search_artifacts" => {
             let params = [
@@ -509,19 +759,40 @@ fn dispatch(
                 m.insert("live_only".into(), Value::Bool(true));
             }
             let audit_args = Value::Object(m);
-            Ok(sidecar::observe(name, || {
-                audit::observe(recorder, principal, name, audit_args, || {
-                    tools::search_artifacts(
+            sidecar::observe(name, || {
+                audit::observe_result(recorder, principal, name, audit_args, || {
+                    let request = read_request(
                         root,
-                        model,
-                        &query,
-                        artifact_type.as_deref(),
-                        &tags,
-                        live_only,
-                        server_budget,
-                    )
+                        repository_root,
+                        federation_seen,
+                        tracker,
+                        federated_tracker,
+                    )?;
+                    let (_, model) = request.legacy();
+                    Ok(if let Some(corpus) = request.composed() {
+                        tools::search_artifacts_composed(
+                            root,
+                            request.cached_model(),
+                            corpus,
+                            &query,
+                            artifact_type.as_deref(),
+                            &tags,
+                            live_only,
+                            server_budget,
+                        )
+                    } else {
+                        tools::search_artifacts(
+                            root,
+                            model,
+                            &query,
+                            artifact_type.as_deref(),
+                            &tags,
+                            live_only,
+                            server_budget,
+                        )
+                    })
                 })
-            }))
+            })
         }
         "retrieve_grounding" => {
             let params = [
@@ -554,13 +825,27 @@ fn dispatch(
                 m.insert("live_only".into(), Value::Bool(false));
             }
             let audit_args = Value::Object(m);
-            Ok(sidecar::observe(name, || {
-                audit::observe(recorder, principal, name, audit_args, || {
-                    tools::retrieve_grounding(
-                        root, model, &task, &scope, top_k, effective, live_only,
-                    )
+            sidecar::observe(name, || {
+                audit::observe_result(recorder, principal, name, audit_args, || {
+                    let request = read_request(
+                        root,
+                        repository_root,
+                        federation_seen,
+                        tracker,
+                        federated_tracker,
+                    )?;
+                    let (_, model) = request.legacy();
+                    Ok(if let Some(corpus) = request.composed() {
+                        tools::retrieve_grounding_composed(
+                            root, corpus, &task, &scope, top_k, effective, live_only,
+                        )
+                    } else {
+                        tools::retrieve_grounding(
+                            root, model, &task, &scope, top_k, effective, live_only,
+                        )
+                    })
                 })
-            }))
+            })
         }
         "find_decisions" => {
             let params = [
@@ -576,11 +861,35 @@ fn dispatch(
                 m.insert("path".into(), Value::String(p.clone()));
             }
             let audit_args = Value::Object(m);
-            Ok(sidecar::observe(name, || {
-                audit::observe(recorder, principal, name, audit_args, || {
-                    tools::find_decisions_tool(root, model, &topic, path.as_deref(), server_budget)
+            sidecar::observe(name, || {
+                audit::observe_result(recorder, principal, name, audit_args, || {
+                    let request = read_request(
+                        root,
+                        repository_root,
+                        federation_seen,
+                        tracker,
+                        federated_tracker,
+                    )?;
+                    let (_, model) = request.legacy();
+                    Ok(if let Some(corpus) = request.composed() {
+                        tools::find_decisions_tool_composed(
+                            root,
+                            corpus,
+                            &topic,
+                            path.as_deref(),
+                            server_budget,
+                        )
+                    } else {
+                        tools::find_decisions_tool(
+                            root,
+                            model,
+                            &topic,
+                            path.as_deref(),
+                            server_budget,
+                        )
+                    })
                 })
-            }))
+            })
         }
         "get_related" => {
             let params = [
@@ -591,29 +900,74 @@ fn dispatch(
             let id = a_str(&a, 0, "");
             let depth = a_int(&a, 1, 1);
             let audit_args = json!({ "id": id.clone(), "depth": depth });
-            let fresh_graph;
-            let graph_view = match (generation, model) {
-                (Some(generation), Some(model)) => state.graph_cache.view_for(generation, model),
-                _ => {
-                    fresh_graph = graph::GraphView::fresh(root);
-                    &fresh_graph
-                }
-            };
-            Ok(sidecar::observe(name, || {
-                audit::observe(recorder, principal, name, audit_args, || {
-                    tools::get_related(graph_view, &id, depth, server_budget)
+            sidecar::observe(name, || {
+                audit::observe_result(recorder, principal, name, audit_args, || {
+                    let request = read_request(
+                        root,
+                        repository_root,
+                        federation_seen,
+                        tracker,
+                        federated_tracker,
+                    )?;
+                    let (generation, model) = request.legacy();
+                    let fresh_graph;
+                    let graph_view = if let (Some(corpus), Some(logical)) =
+                        (request.composed(), request.logical_generation())
+                    {
+                        graph_cache.view_for_composed(logical.cache_key(), corpus)
+                    } else {
+                        match (generation, model) {
+                            (Some(generation), Some(model)) => {
+                                graph_cache.view_for(generation, model)
+                            }
+                            _ => {
+                                fresh_graph = graph::GraphView::fresh(root);
+                                &fresh_graph
+                            }
+                        }
+                    };
+                    Ok(if let Some(corpus) = request.composed() {
+                        tools::get_related_composed(
+                            graph_view,
+                            corpus,
+                            &id,
+                            depth,
+                            server_budget,
+                        )
+                    } else {
+                        tools::get_related(graph_view, &id, depth, server_budget)
+                    })
                 })
-            }))
+            })
         }
         "get_summary" => {
             let params: [Param; 0] = [];
             args::validate(name, "get_summaryArguments", &params, arguments)?;
             let audit_args = json!({});
-            Ok(sidecar::observe(name, || {
-                audit::observe(recorder, principal, name, audit_args, || {
-                    tools::get_summary(root, model, server_budget)
+            sidecar::observe(name, || {
+                audit::observe_result(recorder, principal, name, audit_args, || {
+                    let request = read_request(
+                        root,
+                        repository_root,
+                        federation_seen,
+                        tracker,
+                        federated_tracker,
+                    )?;
+                    let (_, model) = request.legacy();
+                    Ok(if let (Some(corpus), Some(generation)) =
+                        (request.composed(), request.logical_generation())
+                    {
+                        tools::get_summary_composed(
+                            root,
+                            generation,
+                            corpus,
+                            server_budget,
+                        )
+                    } else {
+                        tools::get_summary(root, model, server_budget)
+                    })
                 })
-            }))
+            })
         }
         _ => unreachable!("known tool guard and dispatch arms must stay aligned"),
     }
@@ -664,11 +1018,14 @@ mod tests {
     #[test]
     fn unknown_tool_does_not_freshen_tracker() {
         let mut state = ServerState {
+            repository_root: PathBuf::from("/definitely-not-a-decided-corpus"),
+            federation_seen: false,
             tracker: Some(rac_engine::freshness::FreshnessTracker::new(
                 std::path::PathBuf::from("/definitely-not-a-decided-cache"),
                 "/definitely-not-a-decided-corpus",
                 None,
             )),
+            federated_tracker: None,
             graph_cache: graph::GraphCache::default(),
         };
         let result = dispatch(
@@ -692,11 +1049,14 @@ mod tests {
         std::fs::write(corpus.join("requirement-1.md"), requirement("FIX-0REQ1GRAPH00")).unwrap();
         let root = corpus.to_string_lossy().into_owned();
         let mut state = ServerState {
+            repository_root: corpus.clone(),
+            federation_seen: false,
             tracker: Some(rac_engine::freshness::FreshnessTracker::new(
                 cache.clone(),
                 &root,
                 Some(10),
             )),
+            federated_tracker: None,
             graph_cache: graph::GraphCache::default(),
         };
         let arguments = json!({"id": "FIX-0DEC1GRAPH00", "depth": 2});

--- a/rust/decided-mcp/src/sidecar.rs
+++ b/rust/decided-mcp/src/sidecar.rs
@@ -11,6 +11,6 @@
 //! remains a no-op around the read-only protocol.
 
 /// The no-op observation seam: time-and-record hooks would wrap `call` here.
-pub fn observe<F: FnOnce() -> String>(_tool: &str, call: F) -> String {
+pub fn observe<T, F: FnOnce() -> T>(_tool: &str, call: F) -> T {
     call()
 }

--- a/rust/decided-mcp/src/tools.rs
+++ b/rust/decided-mcp/src/tools.rs
@@ -18,6 +18,56 @@ use rac_engine::resolve::{
 };
 use serde_json::{json, Map, Value};
 
+fn fixed_origin(
+    origin: Option<&rac_engine::corpus::ArtifactOrigin>,
+    enabled: bool,
+) -> Option<Map<String, Value>> {
+    let origin = origin.filter(|_| enabled)?;
+    let mut provenance = Map::new();
+    provenance.insert("source".to_string(), json!(origin.source));
+    provenance.insert("layer".to_string(), json!(origin.layer.as_str()));
+    if let Some(pin) = &origin.pin {
+        provenance.insert("pin".to_string(), json!(pin));
+    }
+    Some(provenance)
+}
+
+fn attach_origin(
+    value: &mut Value,
+    origin: Option<&rac_engine::corpus::ArtifactOrigin>,
+    enabled: bool,
+) {
+    let Some(provenance) = fixed_origin(origin, enabled) else {
+        return;
+    };
+    if let Some(record) = value.as_object_mut() {
+        record.insert("provenance".to_string(), Value::Object(provenance));
+    }
+}
+
+fn composed_provenance(
+    corpus: &rac_engine::composition::ComposedCorpus,
+    key: Option<&rac_engine::corpus::ArtifactKey>,
+) -> Option<Map<String, Value>> {
+    let provenance = key.and_then(|key| corpus.provenance_for(key))?;
+    rac_engine::output::composed_provenance_value(&provenance)
+        .as_object()
+        .cloned()
+}
+
+fn attach_composed_provenance(
+    value: &mut Value,
+    corpus: &rac_engine::composition::ComposedCorpus,
+    key: Option<&rac_engine::corpus::ArtifactKey>,
+) {
+    let Some(provenance) = composed_provenance(corpus, key) else {
+        return;
+    };
+    if let Some(record) = value.as_object_mut() {
+        record.insert("provenance".to_string(), Value::Object(provenance));
+    }
+}
+
 /// The additive empty-corpus guidance the server layers over the summary.
 const EMPTY_GUIDANCE: &str = "This repository has no AsDecided artifacts yet. The user can create the \
 first one with `decided quickstart`, or with `decided init` then \
@@ -50,8 +100,35 @@ fn artifact_value(m: &ResolvedArtifact) -> Map<String, Value> {
     }
 }
 
-fn search_result_payload(result: &SearchResult) -> Value {
-    output::search_result_value(result, true)
+fn search_result_payload(result: &SearchResult, include_origin: bool) -> Value {
+    let mut payload = output::search_result_value(result, true);
+    if let Some(matches) = payload
+        .as_object_mut()
+        .and_then(|object| object.get_mut("matches"))
+        .and_then(Value::as_array_mut)
+    {
+        for (record, artifact) in matches.iter_mut().zip(&result.matches) {
+            attach_origin(record, artifact.origin.as_ref(), include_origin);
+        }
+    }
+    payload
+}
+
+fn composed_search_result_payload(
+    result: &SearchResult,
+    corpus: &rac_engine::composition::ComposedCorpus,
+) -> Value {
+    let mut payload = output::search_result_value(result, true);
+    if let Some(matches) = payload
+        .as_object_mut()
+        .and_then(|object| object.get_mut("matches"))
+        .and_then(Value::as_array_mut)
+    {
+        for (record, artifact) in matches.iter_mut().zip(&result.matches) {
+            attach_composed_provenance(record, corpus, artifact.key.as_ref());
+        }
+    }
+    payload
 }
 
 /// The per-call budget clamp (ADR-113): a call may only *lower* the server
@@ -113,14 +190,70 @@ pub fn get_artifact(
         payload.insert(k, v);
     }
     let status = artifact_status(&rac_engine::parse::parse_text(&content, &artifact.path));
-    let mut prov = Map::new();
+    let mut prov = fixed_origin(artifact.origin.as_ref(), false).unwrap_or_default();
     prov.insert("status".to_string(), json!(status));
-    for (k, v) in provenance::artifact_provenance(root, &artifact.path) {
-        prov.insert(k, v);
+    if artifact
+        .origin
+        .as_ref()
+        .is_none_or(|origin| origin.layer != rac_engine::corpus::Layer::Inherited)
+    {
+        for (k, v) in provenance::artifact_provenance(root, &artifact.path) {
+            prov.insert(k, v);
+        }
     }
     // Pinned key order: {schema_version, **artifact, content, provenance}.
     payload.insert("content".to_string(), json!(content));
     payload.insert("provenance".to_string(), Value::Object(prov));
+    serialize(&Value::Object(payload), budget)
+}
+
+pub fn get_artifact_composed(
+    root: &str,
+    corpus: &rac_engine::composition::ComposedCorpus,
+    artifact_id: &str,
+    budget: i64,
+) -> String {
+    let result = corpus.resolve_identity(artifact_id);
+    let Some(artifact) = result
+        .artifact
+        .as_ref()
+        .filter(|_| result.outcome == OUTCOME_RESOLVED)
+    else {
+        return serialize(&output::resolution_error_value(&result), budget);
+    };
+    let Some(key) = artifact.key.as_ref() else {
+        return serialize(&unreadable_payload(&artifact.id, &artifact.path), budget);
+    };
+    let Some(content) = corpus
+        .content(key)
+        .and_then(|bytes| String::from_utf8(bytes.to_vec()).ok())
+        .map(|text| text.replace("\r\n", "\n").replace('\r', "\n"))
+    else {
+        return serialize(&unreadable_payload(&artifact.id, &artifact.path), budget);
+    };
+    let mut payload = Map::new();
+    payload.insert("schema_version".to_string(), json!("1"));
+    for (key, value) in artifact_value(artifact) {
+        payload.insert(key, value);
+    }
+    payload.insert("content".to_string(), json!(content));
+
+    let mut provenance = composed_provenance(corpus, Some(key)).unwrap_or_default();
+    let status = corpus
+        .item(key)
+        .map(|item| artifact_status(&item.artifact))
+        .unwrap_or_default();
+    provenance.insert("status".to_string(), json!(status));
+    if let Some(item) = corpus
+        .item(key)
+        .filter(|item| item.origin.layer == rac_engine::corpus::Layer::Local)
+    {
+        let physical = item.locator.path.to_string_lossy();
+        for (name, value) in provenance::artifact_provenance(root, &physical) {
+            provenance.insert(name, value);
+        }
+    }
+    payload.insert("provenance".to_string(), Value::Object(provenance));
     serialize(&Value::Object(payload), budget)
 }
 
@@ -153,7 +286,52 @@ pub fn search_artifacts(
         }
     };
     rac_engine::commands::annotate_search_recency(&mut result.matches, root);
-    serialize(&search_result_payload(&result), budget)
+    serialize(
+        &search_result_payload(&result, false),
+        budget,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn search_artifacts_composed(
+    root: &str,
+    cached: Option<&rac_engine::derived_cache::ReadModel>,
+    corpus: &rac_engine::composition::ComposedCorpus,
+    query: &str,
+    artifact_type: Option<&str>,
+    tags: &[String],
+    live_only: bool,
+    budget: i64,
+) -> String {
+    let mut result = match cached {
+        Some(rac_engine::derived_cache::ReadModel::View(reader)) => {
+            rac_engine::read_model::store_search(
+                reader,
+                query,
+                artifact_type,
+                tags,
+                live_only,
+            )
+        }
+        Some(rac_engine::derived_cache::ReadModel::Fresh(derived)) => {
+            search_index_filtered(
+                &derived.index_entries,
+                query,
+                artifact_type,
+                tags,
+                live_only,
+            )
+        }
+        None => search_index_filtered(
+            &corpus.effective_index(),
+            query,
+            artifact_type,
+            tags,
+            live_only,
+        ),
+    };
+    rac_engine::commands::annotate_composed_search_recency(&mut result.matches, root, corpus);
+    serialize(&composed_search_result_payload(&result, corpus), budget)
 }
 
 pub fn find_decisions_tool(
@@ -165,32 +343,41 @@ pub fn find_decisions_tool(
 ) -> String {
     // Python truthiness: a non-empty `path` selects path mode.
     if let Some(p) = path.filter(|p| !p.is_empty()) {
+        let include_origin = false;
         // Path mode builds through the same read-model as every other tool
         // (ADR-103), served from precomputed scope rows.
         let payload = match model {
             Some(TrackerModel::View(reader)) => {
                 let rows = reader.scope_rows().unwrap_or_default();
-                rac_engine::retrieve::scope_lookup_value(
+                rac_engine::retrieve::scope_lookup_value_with_origin(
                     &rac_engine::retrieve::decisions_for_path_with_rows(&rows, root, p),
+                    include_origin,
                 )
             }
-            Some(TrackerModel::Snapshot(derived)) => rac_engine::retrieve::scope_lookup_value(
-                &rac_engine::retrieve::decisions_for_path_with_rows(
-                    &derived.scope_rows,
-                    root,
-                    p,
-                ),
-            ),
+            Some(TrackerModel::Snapshot(derived)) => {
+                rac_engine::retrieve::scope_lookup_value_with_origin(
+                    &rac_engine::retrieve::decisions_for_path_with_rows(
+                        &derived.scope_rows,
+                        root,
+                        p,
+                    ),
+                    include_origin,
+                )
+            }
             Some(TrackerModel::Delta(generation)) => {
-                rac_engine::retrieve::scope_lookup_value(
+                rac_engine::retrieve::scope_lookup_value_with_origin(
                     &rac_engine::retrieve::decisions_for_path_with_rows(
                         &generation.scope.rows(),
                         root,
                         p,
                     ),
+                    include_origin,
                 )
             }
-            None => rac_engine::retrieve::find_decisions_path_payload(root, p),
+            None => rac_engine::retrieve::scope_lookup_value_with_origin(
+                &rac_engine::retrieve::decisions_for_path(root, p, true),
+                include_origin,
+            ),
         };
         return serialize(&payload, budget);
     }
@@ -210,7 +397,45 @@ pub fn find_decisions_tool(
         ),
         None => find_decisions(root, topic, true),
     };
-    let mut payload = search_result_payload(&result);
+    let mut payload = search_result_payload(&result, false);
+    payload
+        .as_object_mut()
+        .expect("object")
+        .insert("filter".to_string(), json!("live-decisions"));
+    serialize(&payload, budget)
+}
+
+pub fn find_decisions_tool_composed(
+    root: &str,
+    corpus: &rac_engine::composition::ComposedCorpus,
+    topic: &str,
+    path: Option<&str>,
+    budget: i64,
+) -> String {
+    if let Some(path) = path.filter(|path| !path.is_empty()) {
+        let items: Vec<_> = corpus.effective().cloned().collect();
+        let rows = rac_engine::retrieve::scope_rows_from_items(&items);
+        let result = rac_engine::retrieve::decisions_for_path_with_rows(&rows, root, path);
+        return serialize(
+            &rac_engine::retrieve::scope_lookup_value_with_composed(&result, corpus),
+            budget,
+        );
+    }
+
+    let entries = corpus.effective_index();
+    let live: std::collections::HashSet<_> = corpus
+        .effective()
+        .filter(|item| {
+            item.spec.map(|spec| spec.name.as_str()) == Some("decision")
+                && rac_engine::resolve::is_live_decision(&item.artifact)
+        })
+        .map(|item| item.key.clone())
+        .collect();
+    let mut result = search_index_filtered(&entries, topic, Some("decision"), &[], false);
+    result
+        .matches
+        .retain(|artifact| artifact.key.as_ref().is_some_and(|key| live.contains(key)));
+    let mut payload = composed_search_result_payload(&result, corpus);
     payload
         .as_object_mut()
         .expect("object")
@@ -224,8 +449,31 @@ pub fn get_related(
     depth: i64,
     budget: i64,
 ) -> String {
+    get_related_inner(graph_view, None, artifact_id, depth, budget)
+}
+
+pub fn get_related_composed(
+    graph_view: &graph::GraphView,
+    corpus: &rac_engine::composition::ComposedCorpus,
+    artifact_id: &str,
+    depth: i64,
+    budget: i64,
+) -> String {
+    get_related_inner(graph_view, Some(corpus), artifact_id, depth, budget)
+}
+
+fn get_related_inner(
+    graph_view: &graph::GraphView,
+    corpus: Option<&rac_engine::composition::ComposedCorpus>,
+    artifact_id: &str,
+    depth: i64,
+    budget: i64,
+) -> String {
     let graph_started = rac_engine::timing::start();
-    let result = graph_view.resolve(artifact_id);
+    let result = corpus.map_or_else(
+        || graph_view.resolve(artifact_id),
+        |corpus| corpus.resolve_identity(artifact_id),
+    );
     let Some(artifact) = result
         .artifact
         .as_ref()
@@ -233,8 +481,15 @@ pub fn get_related(
     else {
         return serialize(&output::resolution_error_value(&result), budget);
     };
-    let outgoing = graph_view.outgoing(&artifact.path);
-    let incoming_result = graph_view.incoming(&artifact.path);
+    let include_origin = graph_view.is_federated();
+    let historical = corpus.is_some_and(|corpus| {
+        artifact
+            .key
+            .as_ref()
+            .is_some_and(|key| corpus.is_overridden(key))
+    });
+    let outgoing = graph_view.outgoing(artifact, historical);
+    let incoming_result = graph_view.incoming(artifact, historical);
     let incoming: Vec<Value> = incoming_result
         .items
         .iter()
@@ -250,7 +505,13 @@ pub fn get_related(
             ev.insert("relationship".to_string(), json!(r.section));
             ev.insert("target".to_string(), json!(r.target));
             m.insert("evidence".to_string(), Value::Object(ev));
-            Value::Object(m)
+            let mut value = Value::Object(m);
+            if let Some(corpus) = corpus {
+                attach_composed_provenance(&mut value, corpus, r.key.as_ref());
+            } else {
+                attach_origin(&mut value, r.origin.as_ref(), include_origin);
+            }
+            value
         })
         .collect();
     let mut payload = Map::new();
@@ -258,11 +519,17 @@ pub fn get_related(
     for (k, v) in artifact_value(artifact) {
         payload.insert(k, v);
     }
+    if let Some(provenance) = corpus
+        .and_then(|corpus| composed_provenance(corpus, artifact.key.as_ref()))
+        .or_else(|| fixed_origin(artifact.origin.as_ref(), include_origin))
+    {
+        payload.insert("provenance".to_string(), Value::Object(provenance));
+    }
     payload.insert("outgoing".to_string(), outgoing.to_value());
     payload.insert("incoming".to_string(), Value::Array(incoming));
     let mut neighborhood_truncated = false;
     if depth > 1 {
-        let hood = graph_view.neighborhood(&artifact.path, depth);
+        let hood = graph_view.neighborhood(artifact, depth, historical);
         let nodes: Vec<Value> = hood
             .nodes
             .iter()
@@ -274,7 +541,13 @@ pub fn get_related(
                 m.insert("title".to_string(), opt_str(&n.title));
                 m.insert("path".to_string(), json!(n.path));
                 m.insert("hops".to_string(), json!(n.hops));
-                Value::Object(m)
+                let mut value = Value::Object(m);
+                if let Some(corpus) = corpus {
+                    attach_composed_provenance(&mut value, corpus, n.key.as_ref());
+                } else {
+                    attach_origin(&mut value, n.origin.as_ref(), include_origin);
+                }
+                value
             })
             .collect();
         payload.insert("neighborhood".to_string(), Value::Array(nodes));
@@ -395,6 +668,42 @@ pub fn get_summary(root: &str, model: Option<&TrackerModel>, budget: i64) -> Str
     serialize(&Value::Object(payload), budget)
 }
 
+pub fn get_summary_composed(
+    root: &str,
+    generation: &rac_engine::derived_cache::LogicalGeneration,
+    corpus: &rac_engine::composition::ComposedCorpus,
+    budget: i64,
+) -> String {
+    let identity = generation
+        .identity()
+        .expect("federated request has generation identity");
+    let parent = generation
+        .verified_parent()
+        .expect("federated request has verified parent");
+    let items: Vec<_> = corpus.effective().cloned().collect();
+    let overrides = rac_engine::validate::overrides_from_config_bytes(&parent.child_config_bytes);
+    let summary = rac_engine::portfolio::portfolio_from_corpus_with_analysis(
+        &identity.child_corpus_path,
+        &items,
+        identity.recursive,
+        &overrides,
+        corpus.relationship_summary(),
+        corpus.validate_relationships(root, identity.recursive).ok(),
+    );
+    let mut payload = rac_engine::output::portfolio_summary_value(&summary);
+    if payload
+        .get("empty")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        payload
+            .as_object_mut()
+            .expect("portfolio payload is an object")
+            .insert("guidance".to_string(), json!(EMPTY_GUIDANCE));
+    }
+    serialize(&payload, budget)
+}
+
 pub fn retrieve_grounding(
     root: &str,
     model: Option<&TrackerModel>,
@@ -434,6 +743,28 @@ pub fn retrieve_grounding(
     serialize(&payload, effective)
 }
 
+pub fn retrieve_grounding_composed(
+    root: &str,
+    corpus: &rac_engine::composition::ComposedCorpus,
+    task: &str,
+    scope: &str,
+    top_k: i64,
+    effective: i64,
+    live_only: bool,
+) -> String {
+    let scope = if scope.is_empty() { None } else { Some(scope) };
+    let payload = rac_engine::retrieve::retrieve_grounding_from_composed(
+        root,
+        task,
+        scope,
+        top_k,
+        effective,
+        live_only,
+        corpus,
+    );
+    serialize(&payload, effective)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -444,6 +775,31 @@ mod tests {
         format!(
             "---\nschema_version: 1\nid: {id}\ntype: decision\n---\n# {id}: Identity\n\n## Context\n\nTest.\n\n## Decision\n\nKeep.\n\n## Consequences\n\nNone.\n\n## Status\n\nAccepted\n"
         )
+    }
+
+    #[test]
+    fn fixed_origin_is_additive_only_in_a_federated_context() {
+        let local = rac_engine::corpus::CorpusLayer::local("acme/app").origin();
+        assert!(fixed_origin(Some(&local), false).is_none());
+        assert_eq!(
+            Value::Object(fixed_origin(Some(&local), true).unwrap()),
+            json!({"source": "acme/app", "layer": "local"})
+        );
+
+        let inherited = rac_engine::corpus::CorpusLayer::inherited(
+            "acme/standards",
+            "standards",
+            "sha256:0123",
+        )
+        .origin();
+        assert_eq!(
+            Value::Object(fixed_origin(Some(&inherited), true).unwrap()),
+            json!({
+                "source": "acme/standards",
+                "layer": "inherited",
+                "pin": "sha256:0123"
+            })
+        );
     }
 
     #[test]

--- a/rust/decided-mcp/tests/federation.rs
+++ b/rust/decided-mcp/tests/federation.rs
@@ -1,0 +1,622 @@
+use serde_json::{json, Value};
+use std::fs;
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+fn scratch(tag: &str) -> PathBuf {
+    let sequence = COUNTER.fetch_add(1, Ordering::SeqCst);
+    let root = std::env::temp_dir().join(format!(
+        "decided-mcp-federation-{tag}-{}-{sequence}",
+        std::process::id()
+    ));
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(&root).expect("create federation scratch directory");
+    root
+}
+
+fn copy_tree(source: &Path, target: &Path) {
+    fs::create_dir_all(target).expect("create copied directory");
+    for entry in fs::read_dir(source).expect("read fixture directory") {
+        let entry = entry.expect("read fixture entry");
+        let destination = target.join(entry.file_name());
+        if entry.file_type().expect("fixture file type").is_dir() {
+            copy_tree(&entry.path(), &destination);
+        } else {
+            fs::copy(entry.path(), destination).expect("copy fixture file");
+        }
+    }
+}
+
+fn eval_fixture(tag: &str) -> PathBuf {
+    let target = scratch(tag);
+    let source = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../fixtures/eval/federation/child");
+    copy_tree(&source, &target);
+    target
+}
+
+fn request(id: usize, name: &str, arguments: Value) -> String {
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "method": "tools/call",
+        "params": {"name": name, "arguments": arguments}
+    })
+    .to_string()
+}
+
+fn run(root: &Path, extra_args: &[&str], requests: &[String]) -> Vec<Value> {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_decided-mcp"))
+        .arg("--root")
+        .arg(root)
+        .args(extra_args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn decided-mcp");
+    {
+        let stdin = child.stdin.as_mut().expect("server stdin");
+        for request in requests {
+            writeln!(stdin, "{request}").expect("write MCP request");
+        }
+    }
+    drop(child.stdin.take());
+    let output = child.wait_with_output().expect("wait for decided-mcp");
+    assert!(
+        output.status.success(),
+        "server failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout)
+        .expect("UTF-8 MCP output")
+        .lines()
+        .map(|line| serde_json::from_str(line).expect("JSON-RPC response"))
+        .collect()
+}
+
+fn tool_text(frame: &Value) -> &str {
+    frame
+        .pointer("/result/content/0/text")
+        .and_then(Value::as_str)
+        .expect("tool text")
+}
+
+fn tool_value(frame: &Value) -> Value {
+    serde_json::from_str(tool_text(frame)).expect("tool payload JSON")
+}
+
+fn spawn_live(root: &Path, extra_args: &[&str]) -> (Child, ChildStdin, BufReader<ChildStdout>) {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_decided-mcp"))
+        .arg("--root")
+        .arg(root)
+        .args(extra_args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn long-lived decided-mcp");
+    let stdin = child.stdin.take().expect("server stdin");
+    let stdout = BufReader::new(child.stdout.take().expect("server stdout"));
+    (child, stdin, stdout)
+}
+
+fn live_call(
+    stdin: &mut ChildStdin,
+    stdout: &mut BufReader<ChildStdout>,
+    call: &str,
+) -> Value {
+    writeln!(stdin, "{call}").expect("write MCP request");
+    stdin.flush().expect("flush MCP request");
+    let mut line = String::new();
+    stdout.read_line(&mut line).expect("read MCP response");
+    serde_json::from_str(line.trim()).expect("MCP response JSON")
+}
+
+fn finish_live(child: Child, stdin: ChildStdin, stdout: BufReader<ChildStdout>) {
+    drop(stdin);
+    drop(stdout);
+    let output = child.wait_with_output().expect("wait for long-lived server");
+    assert!(
+        output.status.success(),
+        "server failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn all_six_tools_share_one_verified_composition_with_or_without_cache() {
+    let repository = eval_fixture("six-tools");
+    let corpus = repository.join("decisions");
+    let requests = vec![
+        request(
+            1,
+            "get_artifact",
+            json!({"id": "standards::FEDEVAL-000000000001"}),
+        ),
+        request(
+            2,
+            "search_artifacts",
+            json!({"query": "quantum ledger compaction"}),
+        ),
+        request(
+            3,
+            "retrieve_grounding",
+            json!({"task": "quantum ledger compaction", "top_k": 3}),
+        ),
+        request(
+            4,
+            "find_decisions",
+            json!({"topic": "quantum ledger compaction"}),
+        ),
+        request(
+            5,
+            "get_related",
+            json!({"id": "standards::FEDEVAL-000000000002", "depth": 2}),
+        ),
+        request(6, "get_summary", json!({})),
+    ];
+
+    let uncached = run(&corpus, &["--no-cache"], &requests);
+    let cached = run(&corpus, &[], &requests);
+    assert_eq!(
+        uncached.iter().map(tool_text).collect::<Vec<_>>(),
+        cached.iter().map(tool_text).collect::<Vec<_>>()
+    );
+
+    let artifact = tool_value(&cached[0]);
+    assert_eq!(artifact["provenance"]["source"], json!("eval/standards"));
+    assert_eq!(artifact["provenance"]["layer"], json!("inherited"));
+    assert!(artifact["provenance"]["pin"]
+        .as_str()
+        .is_some_and(|pin| pin.starts_with("sha256:")));
+
+    let search = tool_value(&cached[1]);
+    assert_eq!(search["matches"][0]["id"], json!("FEDEVAL-000000000001"));
+    assert_eq!(
+        search["matches"][0]["provenance"]["source"],
+        json!("eval/standards")
+    );
+    assert!(search["matches"].as_array().unwrap().iter().any(|record| {
+        record["provenance"]["source"] == json!("eval/child")
+            && record.get("recency").is_some()
+    }));
+    assert!(search["matches"].as_array().unwrap().iter().all(|record| {
+        record["provenance"]["source"] != json!("eval/standards")
+            || record.get("recency").is_none()
+    }));
+    let grounding = tool_value(&cached[2]);
+    assert_eq!(
+        grounding["items"][0]["provenance"]["layer"],
+        json!("inherited")
+    );
+    assert_eq!(tool_value(&cached[5])["artifacts"]["total"], json!(41));
+    fs::remove_dir_all(repository).expect("remove six-tool fixture");
+}
+
+fn decision(id: &str, title: &str) -> String {
+    format!(
+        "---\nschema_version: 1\nid: {id}\ntype: decision\n---\n# {title}\n\n## Status\n\nAccepted\n\n## Context\n\nA reviewed context.\n\n## Decision\n\nKeep the reviewed rule.\n\n## Consequences\n\nThe rule is deterministic.\n"
+    )
+}
+
+fn decision_with_relationships(id: &str, title: &str, relationships: &str) -> String {
+    format!("{}\n{relationships}\n", decision(id, title))
+}
+
+fn override_fixture() -> PathBuf {
+    let child = scratch("override");
+    let parent = child.join("vendor/standards");
+    fs::create_dir_all(parent.join(".decided")).expect("parent config directory");
+    fs::create_dir_all(parent.join("decisions")).expect("parent corpus directory");
+    fs::create_dir_all(child.join(".decided")).expect("child config directory");
+    fs::create_dir_all(child.join("decisions")).expect("child corpus directory");
+    fs::write(
+        parent.join(".decided/config.yaml"),
+        "repository_key: STD\ncorpus:\n  source: acme/standards\n",
+    )
+    .expect("parent config");
+    fs::write(
+        parent.join("decisions/parent.md"),
+        decision_with_relationships(
+            "STD-01JY4M8X2QZ7",
+            "Parent Policy",
+            "## Related Decisions\n\n- STD-01JY4M8X2QZA",
+        ),
+    )
+    .expect("parent decision");
+    fs::write(
+        parent.join("decisions/target.md"),
+        decision("STD-01JY4M8X2QZA", "Retained Target"),
+    )
+    .expect("parent target decision");
+    fs::write(
+        child.join(".decided/config.yaml"),
+        "repository_key: APP\ncorpus:\n  source: acme/app\n",
+    )
+    .expect("child config");
+    fs::write(
+        child.join("decisions/replacement.md"),
+        decision("APP-01JY4M8X2QZ8", "Local Replacement"),
+    )
+    .expect("replacement decision");
+    fs::write(
+        child.join("decisions/rationale.md"),
+        decision("APP-01JY4M8X2QZ9", "Override Rationale"),
+    )
+    .expect("rationale decision");
+    let digest = rac_engine::federation::calculate_parent_digest(&parent, "decisions")
+        .expect("calculate parent digest")
+        .digest;
+    fs::write(
+        child.join(".decided/corpus.md"),
+        format!(
+            "# Corpus\n\n## inherits\n\n```yaml\nversion: 1\nalias: standards\nsource: acme/standards\nroot: vendor/standards\ncorpus: decisions\ndigest: {digest}\n```\n\n## overrides\n\n```yaml\nversion: 1\nitems:\n  - parent: standards::STD-01JY4M8X2QZ7\n    with: APP-01JY4M8X2QZ8\n    rationale: APP-01JY4M8X2QZ9\n```\n"
+        ),
+    )
+    .expect("child manifest");
+    child
+}
+
+fn alias_collision_fixture() -> PathBuf {
+    let child = scratch("alias-collision");
+    let parent = child.join("vendor/standards");
+    fs::create_dir_all(parent.join(".decided")).expect("parent config directory");
+    fs::create_dir_all(parent.join("decisions")).expect("parent corpus directory");
+    fs::create_dir_all(child.join(".decided")).expect("child config directory");
+    fs::create_dir_all(child.join("decisions")).expect("child corpus directory");
+    fs::write(
+        parent.join(".decided/config.yaml"),
+        "repository_key: STD\ncorpus:\n  source: acme/standards\n",
+    )
+    .expect("parent config");
+    fs::write(
+        parent.join("decisions/shared.md"),
+        decision("STD-01JY4M8X2QZ7", "Parent Shared Policy"),
+    )
+    .expect("parent shared decision");
+    fs::write(
+        child.join(".decided/config.yaml"),
+        "repository_key: APP\ncorpus:\n  source: acme/app\n",
+    )
+    .expect("child config");
+    fs::write(
+        child.join("decisions/shared.md"),
+        decision("APP-01JY4M8X2QZ8", "Local Shared Policy"),
+    )
+    .expect("local shared decision");
+    let digest = rac_engine::federation::calculate_parent_digest(&parent, "decisions")
+        .expect("calculate parent digest")
+        .digest;
+    fs::write(
+        child.join(".decided/corpus.md"),
+        format!(
+            "# Corpus\n\n## inherits\n\n```yaml\nversion: 1\nalias: standards\nsource: acme/standards\nroot: vendor/standards\ncorpus: decisions\ndigest: {digest}\n```\n"
+        ),
+    )
+    .expect("child manifest");
+    child
+}
+
+#[test]
+fn composed_exact_tools_share_source_aware_ambiguity_and_qualification() {
+    let repository = alias_collision_fixture();
+    let corpus = repository.join("decisions");
+    let frames = run(
+        &corpus,
+        &["--no-cache"],
+        &[
+            request(1, "get_artifact", json!({"id": "shared"})),
+            request(2, "get_related", json!({"id": "shared"})),
+            request(3, "get_artifact", json!({"id": "standards::shared"})),
+            request(
+                4,
+                "get_artifact",
+                json!({"id": "other::STD-01JY4M8X2QZ7"}),
+            ),
+            request(
+                5,
+                "get_artifact",
+                json!({"id": "standards::STD-01JY4M8X2QZ7"}),
+            ),
+        ],
+    );
+    let artifact_duplicate = tool_value(&frames[0]);
+    let related_duplicate = tool_value(&frames[1]);
+    let expected_paths = json!([
+        "acme/app::shared.md",
+        "acme/standards::shared.md"
+    ]);
+    assert_eq!(artifact_duplicate["error"], json!("duplicate"));
+    assert_eq!(related_duplicate["error"], json!("duplicate"));
+    assert_eq!(artifact_duplicate["paths"], expected_paths);
+    assert_eq!(related_duplicate["paths"], expected_paths);
+    assert_eq!(tool_value(&frames[2])["error"], json!("not-found"));
+    assert_eq!(tool_value(&frames[3])["error"], json!("not-found"));
+    assert_eq!(tool_value(&frames[4])["id"], json!("STD-01JY4M8X2QZ7"));
+    fs::remove_dir_all(repository).expect("remove alias collision fixture");
+}
+
+#[test]
+fn qualified_history_and_canonical_redirect_keep_complete_override_provenance() {
+    let repository = override_fixture();
+    let corpus = repository.join("decisions");
+    let frames = run(
+        &corpus,
+        &["--no-cache"],
+        &[
+            request(
+                1,
+                "get_artifact",
+                json!({"id": "standards::STD-01JY4M8X2QZ7"}),
+            ),
+            request(2, "get_artifact", json!({"id": "STD-01JY4M8X2QZ7"})),
+            request(3, "get_related", json!({"id": "STD-01JY4M8X2QZ7", "depth": 2})),
+            request(4, "get_related", json!({"id": "STD-01JY4M8X2QZA", "depth": 2})),
+            request(
+                5,
+                "get_related",
+                json!({"id": "standards::STD-01JY4M8X2QZ7", "depth": 2}),
+            ),
+        ],
+    );
+    let parent = tool_value(&frames[0]);
+    let replacement = tool_value(&frames[1]);
+    assert_eq!(parent["id"], json!("STD-01JY4M8X2QZ7"));
+    assert_eq!(parent["provenance"]["overrides"][0]["state"], json!("overridden"));
+    assert_eq!(replacement["id"], json!("APP-01JY4M8X2QZ8"));
+    let mapping = &replacement["provenance"]["overrides"][0];
+    assert_eq!(mapping["state"], json!("replacement"));
+    assert_eq!(mapping["parent"]["source"], json!("acme/standards"));
+    assert_eq!(mapping["replacement"]["source"], json!("acme/app"));
+    assert_eq!(mapping["rationale"]["id"], json!("APP-01JY4M8X2QZ9"));
+
+    let redirected_graph = tool_value(&frames[2]);
+    assert_eq!(redirected_graph["id"], json!("APP-01JY4M8X2QZ8"));
+    assert!(redirected_graph["outgoing"]
+        .get("related_decisions")
+        .is_none());
+
+    let target_graph = tool_value(&frames[3]);
+    assert!(target_graph["incoming"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .all(|entry| entry["id"] != json!("STD-01JY4M8X2QZ7")));
+
+    let parent_history = tool_value(&frames[4]);
+    assert_eq!(parent_history["id"], json!("STD-01JY4M8X2QZ7"));
+    assert_eq!(
+        parent_history["outgoing"]["related_decisions"],
+        json!(["STD-01JY4M8X2QZA"])
+    );
+    fs::remove_dir_all(repository).expect("remove override fixture");
+}
+
+#[test]
+fn tight_budgets_keep_parent_and_replacement_override_provenance_atomic() {
+    let repository = override_fixture();
+    let corpus = repository.join("decisions");
+    let mut requests = Vec::new();
+    let mut expectations = Vec::new();
+    for budget in [384, 512, 768] {
+        requests.push(request(
+            requests.len() + 1,
+            "get_artifact",
+            json!({"id": "standards::STD-01JY4M8X2QZ7", "budget": budget}),
+        ));
+        expectations.push((budget, "overridden"));
+        requests.push(request(
+            requests.len() + 1,
+            "get_artifact",
+            json!({"id": "STD-01JY4M8X2QZ7", "budget": budget}),
+        ));
+        expectations.push((budget, "replacement"));
+    }
+
+    let frames = run(&corpus, &["--no-cache"], &requests);
+    for (frame, (budget, state)) in frames.iter().zip(expectations) {
+        let text = tool_text(frame);
+        assert!(
+            text.chars().count() <= budget,
+            "{} characters exceeded budget {budget}",
+            text.chars().count()
+        );
+        let value = tool_value(frame);
+        if value["error"] == json!(rac_engine::budget::BUDGET_ERROR) {
+            continue;
+        }
+        let mapping = &value["provenance"]["overrides"][0];
+        assert_eq!(mapping["state"], json!(state));
+        assert_eq!(mapping["parent"]["source"], json!("acme/standards"));
+        assert_eq!(mapping["parent"]["id"], json!("STD-01JY4M8X2QZ7"));
+        assert_eq!(mapping["replacement"]["source"], json!("acme/app"));
+        assert_eq!(mapping["replacement"]["id"], json!("APP-01JY4M8X2QZ8"));
+        assert_eq!(mapping["rationale"]["source"], json!("acme/app"));
+        assert_eq!(mapping["rationale"]["id"], json!("APP-01JY4M8X2QZ9"));
+    }
+    fs::remove_dir_all(repository).expect("remove tight-budget override fixture");
+}
+
+#[test]
+fn stale_parent_blocks_the_next_request_instead_of_serving_the_old_generation() {
+    let repository = eval_fixture("stale-parent");
+    let corpus = repository.join("decisions");
+    let mut child = Command::new(env!("CARGO_BIN_EXE_decided-mcp"))
+        .arg("--root")
+        .arg(&corpus)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn long-lived decided-mcp");
+    let mut stdin = child.stdin.take().expect("server stdin");
+    let mut stdout = BufReader::new(child.stdout.take().expect("server stdout"));
+    let query = request(
+        1,
+        "search_artifacts",
+        json!({"query": "quantum ledger compaction"}),
+    );
+    writeln!(stdin, "{query}").expect("write first request");
+    stdin.flush().expect("flush first request");
+    let mut first_line = String::new();
+    stdout.read_line(&mut first_line).expect("read first response");
+    let first: Value = serde_json::from_str(first_line.trim()).expect("first response JSON");
+    assert_eq!(first["result"]["isError"], json!(false));
+
+    let parent_file = repository
+        .join("vendor/standards/decisions/quantum-ledger-compaction-anchor.md");
+    fs::write(&parent_file, "changed after verification\n").expect("mutate parent bytes");
+    let second = request(
+        2,
+        "search_artifacts",
+        json!({"query": "quantum ledger compaction"}),
+    );
+    writeln!(stdin, "{second}").expect("write second request");
+    stdin.flush().expect("flush second request");
+    let mut second_line = String::new();
+    stdout
+        .read_line(&mut second_line)
+        .expect("read second response");
+    let second: Value = serde_json::from_str(second_line.trim()).expect("second response JSON");
+    assert_eq!(second["result"]["isError"], json!(true));
+    assert!(tool_text(&second).contains("parent-corpus-digest-mismatch"));
+    assert!(!tool_text(&second).contains("FEDEVAL-000000000001"));
+
+    drop(stdin);
+    let output = child.wait_with_output().expect("wait for long-lived server");
+    assert!(
+        output.status.success(),
+        "server failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    fs::remove_dir_all(repository).expect("remove stale-parent fixture");
+}
+
+#[test]
+fn deleting_child_config_after_federation_is_seen_fails_closed() {
+    let repository = eval_fixture("deleted-config");
+    let corpus = repository.join("decisions");
+    let (child, mut stdin, mut stdout) = spawn_live(&corpus, &[]);
+
+    let first = live_call(
+        &mut stdin,
+        &mut stdout,
+        &request(1, "get_summary", json!({})),
+    );
+    assert_eq!(first["result"]["isError"], json!(false));
+
+    fs::remove_file(repository.join(".decided/config.yaml")).expect("remove child config");
+    let second = live_call(
+        &mut stdin,
+        &mut stdout,
+        &request(2, "get_summary", json!({})),
+    );
+    assert_eq!(second["result"]["isError"], json!(true));
+    assert!(tool_text(&second).contains("parent-corpus-child-config-missing"));
+    assert!(!tool_text(&second).contains("\"total\":41"));
+
+    finish_live(child, stdin, stdout);
+    fs::remove_dir_all(repository).expect("remove deleted-config fixture");
+}
+
+#[test]
+fn non_regular_or_dangling_manifest_never_falls_back_to_legacy() {
+    let repository = eval_fixture("non-file-manifest");
+    let corpus = repository.join("decisions");
+    let manifest = repository.join(".decided/corpus.md");
+    let (child, mut stdin, mut stdout) = spawn_live(&corpus, &["--no-cache"]);
+
+    let first = live_call(
+        &mut stdin,
+        &mut stdout,
+        &request(1, "get_summary", json!({})),
+    );
+    assert_eq!(first["result"]["isError"], json!(false));
+
+    fs::remove_file(&manifest).expect("remove manifest");
+    fs::create_dir(&manifest).expect("replace manifest with directory");
+    let directory_response = live_call(
+        &mut stdin,
+        &mut stdout,
+        &request(2, "get_summary", json!({})),
+    );
+    assert_eq!(directory_response["result"]["isError"], json!(true));
+    assert!(tool_text(&directory_response).contains("parent-corpus-symlink-traversal"));
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::symlink;
+        fs::remove_dir(&manifest).expect("remove manifest directory");
+        symlink("missing-corpus-manifest.md", &manifest).expect("create dangling manifest");
+        let dangling_response = live_call(
+            &mut stdin,
+            &mut stdout,
+            &request(3, "get_summary", json!({})),
+        );
+        assert_eq!(dangling_response["result"]["isError"], json!(true));
+        assert!(tool_text(&dangling_response).contains("parent-corpus-symlink-traversal"));
+    }
+
+    finish_live(child, stdin, stdout);
+    fs::remove_dir_all(repository).expect("remove non-file-manifest fixture");
+}
+
+#[test]
+fn a_manifest_added_to_a_live_server_activates_and_cannot_be_removed() {
+    let repository = eval_fixture("topology-add-remove");
+    let corpus = repository.join("decisions");
+    let manifest_path = repository.join(".decided/corpus.md");
+    let manifest = fs::read(&manifest_path).expect("read manifest before startup");
+    fs::remove_file(&manifest_path).expect("start without manifest");
+    let (child, mut stdin, mut stdout) = spawn_live(&corpus, &[]);
+
+    let legacy = live_call(
+        &mut stdin,
+        &mut stdout,
+        &request(
+            1,
+            "search_artifacts",
+            json!({"query": "quantum ledger compaction"}),
+        ),
+    );
+    assert_eq!(legacy["result"]["isError"], json!(false));
+    assert!(tool_value(&legacy)["matches"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .all(|item| item["id"] != json!("FEDEVAL-000000000001")));
+
+    fs::write(&manifest_path, &manifest).expect("add manifest");
+    let federated = live_call(
+        &mut stdin,
+        &mut stdout,
+        &request(
+            2,
+            "search_artifacts",
+            json!({"query": "quantum ledger compaction"}),
+        ),
+    );
+    assert_eq!(federated["result"]["isError"], json!(false));
+    assert_eq!(
+        tool_value(&federated)["matches"][0]["id"],
+        json!("FEDEVAL-000000000001")
+    );
+
+    fs::remove_file(&manifest_path).expect("remove observed manifest");
+    let removed = live_call(
+        &mut stdin,
+        &mut stdout,
+        &request(3, "get_summary", json!({})),
+    );
+    assert_eq!(removed["result"]["isError"], json!(true));
+    assert!(tool_text(&removed).contains("federation manifest disappeared"));
+    assert!(!tool_text(&removed).contains("FEDEVAL-000000000001"));
+
+    finish_live(child, stdin, stdout);
+    fs::remove_dir_all(repository).expect("remove topology fixture");
+}

--- a/rust/decided-mcp/tests/http_transport.rs
+++ b/rust/decided-mcp/tests/http_transport.rs
@@ -109,6 +109,80 @@ impl Server {
         panic!("HTTP server did not start");
     }
 
+    fn start_federated(tag: &str) -> Self {
+        let corpus = scratch(tag);
+        let parent = corpus.join("vendor/standards");
+        let audit_path = corpus.join("audit.jsonl");
+        std::fs::create_dir_all(corpus.join(".decided")).unwrap();
+        std::fs::create_dir_all(corpus.join("decisions")).unwrap();
+        std::fs::create_dir_all(parent.join(".decided")).unwrap();
+        std::fs::create_dir_all(parent.join("decisions")).unwrap();
+        std::fs::write(
+            corpus.join(".decided/config.yaml"),
+            format!(
+                "repository_key: APP\ncorpus:\n  source: acme/app\naudit:\n  enabled: true\n  path: {}\n",
+                audit_path.display()
+            ),
+        )
+        .unwrap();
+        std::fs::write(
+            parent.join(".decided/config.yaml"),
+            "repository_key: STD\ncorpus:\n  source: acme/standards\n",
+        )
+        .unwrap();
+        std::fs::write(
+            parent.join("decisions/parent.md"),
+            "---\nschema_version: 1\nid: STD-01JY4M8X2QZ7\ntype: decision\n---\n# Parent Audit Policy\n\n## Status\n\nAccepted\n\n## Context\n\nAudit parent context.\n\n## Decision\n\nKeep federation auditable.\n\n## Consequences\n\nFailures are recorded.\n",
+        )
+        .unwrap();
+        let digest = rac_engine::federation::calculate_parent_digest(&parent, "decisions")
+            .unwrap()
+            .digest;
+        std::fs::write(
+            corpus.join(".decided/corpus.md"),
+            format!(
+                "# Corpus\n\n## inherits\n\n```yaml\nversion: 1\nalias: standards\nsource: acme/standards\nroot: vendor/standards\ncorpus: decisions\ndigest: {digest}\n```\n"
+            ),
+        )
+        .unwrap();
+
+        let port = TcpListener::bind(("127.0.0.1", 0))
+            .unwrap()
+            .local_addr()
+            .unwrap()
+            .port();
+        let root = corpus.join("decisions").to_string_lossy().into_owned();
+        let port_text = port.to_string();
+        let child = Command::new(env!("CARGO_BIN_EXE_decided-mcp"))
+            .args([
+                "--root",
+                &root,
+                "--no-cache",
+                "--transport",
+                "http",
+                "--host",
+                "127.0.0.1",
+                "--port",
+                &port_text,
+            ])
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn federated HTTP server");
+        let server = Self {
+            child,
+            corpus,
+            port,
+        };
+        for _ in 0..100 {
+            if TcpStream::connect(("127.0.0.1", port)).is_ok() {
+                return server;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        panic!("federated HTTP server did not start");
+    }
+
     fn post(&self, body: &Value, method_header: &str, name: Option<&str>) -> (String, Value) {
         self.post_with_version_and_origin(body, method_header, name, CURRENT_VERSION, None)
     }
@@ -550,6 +624,53 @@ fn http_audit_records_every_result_collection() {
     assert!(returned[4].contains(&"RAC-111111111111".to_string()));
     assert!(returned[5].contains(&"RAC-111111111111".to_string()));
     assert!(returned[6].is_empty());
+}
+
+#[test]
+fn stale_parent_failure_is_audited_once_before_http_error_response() {
+    let _guard = serial_http_test();
+    let server = Server::start_federated("http-audit-stale-parent");
+    let arguments = json!({"query": "parent audit policy"});
+
+    let (first_status, first) = server.post_with_principal_headers(
+        &tool_call(1, "search_artifacts", arguments.clone()),
+        "tools/call",
+        Some("search_artifacts"),
+        &[("X-AsDecided-Principal", "alice@example.com")],
+    );
+    assert_eq!(first_status, "HTTP/1.1 200 OK");
+    assert_eq!(first["result"]["isError"], json!(false));
+
+    std::fs::write(
+        server.corpus.join("vendor/standards/decisions/parent.md"),
+        "changed after the verified generation\n",
+    )
+    .expect("mutate verified parent");
+    let before = server.audit_events().len();
+    let (second_status, second) = server.post_with_principal_headers(
+        &tool_call(2, "search_artifacts", arguments),
+        "tools/call",
+        Some("search_artifacts"),
+        &[("X-AsDecided-Principal", "alice@example.com")],
+    );
+    assert_eq!(second_status, "HTTP/1.1 200 OK");
+    assert_eq!(second["result"]["isError"], json!(true));
+    assert!(second["result"]["content"][0]["text"]
+        .as_str()
+        .unwrap()
+        .contains("parent-corpus-digest-mismatch"));
+
+    let events = server.audit_events();
+    assert_eq!(events.len(), before + 1, "failure records exactly one event");
+    let failure = events.last().unwrap();
+    assert_eq!(failure["tool"], json!("search_artifacts"));
+    assert_eq!(failure["query"], json!({
+        "query": "parent audit policy",
+        "type": null
+    }));
+    assert_eq!(failure["outcome"], json!("error"));
+    assert_eq!(failure["returned"], json!([]));
+    assert_eq!(failure["principal"], json!("alice@example.com"));
 }
 
 #[test]

--- a/rust/fixtures/eval/README.md
+++ b/rust/fixtures/eval/README.md
@@ -1,8 +1,8 @@
 # Grounding retrieval benchmark fixture (v0.23.0, WS1)
 
 This directory is the versioned fixture the `decided eval` grounding benchmark
-scores. It is a dev/CI surface, not a RAC artifact corpus — nothing here is part
-of the product knowledge under `rac/`.
+scores. It is a dev/CI surface, not an AsDecided artifact corpus — nothing here
+is part of the repository's product-knowledge corpus.
 
 ## Layout
 
@@ -27,14 +27,26 @@ of the product knowledge under `rac/`.
   category's `p_at_1` / `r_at_5`. Per-tool figures are diagnostic.
 - `baseline.json` — the committed `metrics` baseline, written by
   `decided eval --update-baseline` (human-only; CI never rebaselines).
+- `federation/` — the ADR-139 DecisionGrounding track. Its child inherits a
+  40-artifact standards parent containing a precise inherited match, six
+  lexical near-matches, and a 32-inbound-edge hard negative. The hard negative
+  has graph rank 1 but remains outside the top-five window because the v0.28
+  lexical floor clamps its graph contribution.
 
 ## Running
 
 ```sh
-rac eval                  # human-readable scorecard
-rac eval --json           # full scorecard JSON
-rac eval --check          # CI gate: exit 0 pass / 1 regression / 2 usage error
-rac eval --update-baseline  # human-only re-baseline
+decided eval                  # human-readable scorecard
+decided eval --json           # full scorecard JSON
+decided eval --check          # CI gate: exit 0 pass / 1 regression / 2 usage error
+decided eval --update-baseline  # human-only re-baseline
+
+# ADR-139 large-parent/hard-negative track
+decided eval --check \
+  --root rust/fixtures/eval/federation/child/decisions \
+  --queries rust/fixtures/eval/federation/queries.json \
+  --baseline rust/fixtures/eval/federation/baseline.json \
+  --config rust/fixtures/eval/federation/eval-config.json
 ```
 
 ## Calibration

--- a/rust/fixtures/eval/federation/baseline.json
+++ b/rust/fixtures/eval/federation/baseline.json
@@ -1,0 +1,23 @@
+{
+  "overall": {
+    "p_at_1": 1.0,
+    "p_at_3": 0.333333,
+    "p_at_5": 0.2,
+    "r_at_1": 1.0,
+    "r_at_3": 1.0,
+    "r_at_5": 1.0,
+    "negative_violations": 0
+  },
+  "by_category": {
+    "federated_large_parent": {
+      "p_at_1": 1.0,
+      "r_at_5": 1.0
+    }
+  },
+  "by_tool": {
+    "search_artifacts": {
+      "p_at_1": 1.0,
+      "r_at_5": 1.0
+    }
+  }
+}

--- a/rust/fixtures/eval/federation/child/.decided/config.yaml
+++ b/rust/fixtures/eval/federation/child/.decided/config.yaml
@@ -1,0 +1,4 @@
+repository_key: CHILD
+corpus:
+  source: eval/child
+

--- a/rust/fixtures/eval/federation/child/.decided/corpus.md
+++ b/rust/fixtures/eval/federation/child/.decided/corpus.md
@@ -1,0 +1,19 @@
+# DecisionGrounding federation fixture
+
+## inherits
+
+```yaml
+version: 1
+alias: standards
+source: eval/standards
+root: vendor/standards
+corpus: decisions
+digest: sha256:4657f93e3c7480636cc3d52907c45bfb3b1edf573e8975c2cda46a271672b624
+```
+
+## overrides
+
+```yaml
+version: 1
+items: []
+```

--- a/rust/fixtures/eval/federation/child/decisions/local-quantum-notes.md
+++ b/rust/fixtures/eval/federation/child/decisions/local-quantum-notes.md
@@ -1,0 +1,26 @@
+---
+schema_version: 1
+id: FEDEVAL-000000000003
+type: decision
+---
+# Local Quantum Ledger Notes
+
+## Status
+
+Accepted
+
+## Context
+
+The child application keeps operational notes for its quantum ledger client.
+
+## Decision
+
+Use the organisation standard whenever ledger compaction is configured.
+
+## Consequences
+
+The local repository does not redefine the parent compaction policy.
+
+## Category
+
+Technical

--- a/rust/fixtures/eval/federation/child/vendor/standards/.decided/config.yaml
+++ b/rust/fixtures/eval/federation/child/vendor/standards/.decided/config.yaml
@@ -1,0 +1,4 @@
+repository_key: STANDARDS
+corpus:
+  source: eval/standards
+

--- a/rust/fixtures/eval/federation/child/vendor/standards/decisions/compaction-decoy-01.md
+++ b/rust/fixtures/eval/federation/child/vendor/standards/decisions/compaction-decoy-01.md
@@ -1,0 +1,27 @@
+---
+schema_version: 1
+id: FEDEVAL-000000000101
+type: decision
+---
+# Quantum Ledger Compaction Planning
+
+## Status
+
+Accepted
+
+## Context
+
+This standard covers a neighbouring operational concern and uses anchor
+vocabulary, but does not select the signed checkpoint.
+
+## Decision
+
+Teams document their quantum ledger compaction planning procedure separately.
+
+## Consequences
+
+The document is a deliberate lexical near-match in the grounding benchmark.
+
+## Category
+
+Technical

--- a/rust/fixtures/eval/federation/child/vendor/standards/decisions/compaction-decoy-02.md
+++ b/rust/fixtures/eval/federation/child/vendor/standards/decisions/compaction-decoy-02.md
@@ -1,0 +1,27 @@
+---
+schema_version: 1
+id: FEDEVAL-000000000102
+type: decision
+---
+# Quantum Ledger Compaction Operations
+
+## Status
+
+Accepted
+
+## Context
+
+This standard covers a neighbouring operational concern and uses anchor
+vocabulary, but does not select the signed checkpoint.
+
+## Decision
+
+Teams document their quantum ledger compaction operations procedure separately.
+
+## Consequences
+
+The document is a deliberate lexical near-match in the grounding benchmark.
+
+## Category
+
+Technical

--- a/rust/fixtures/eval/federation/child/vendor/standards/decisions/compaction-decoy-03.md
+++ b/rust/fixtures/eval/federation/child/vendor/standards/decisions/compaction-decoy-03.md
@@ -1,0 +1,27 @@
+---
+schema_version: 1
+id: FEDEVAL-000000000103
+type: decision
+---
+# Quantum Ledger Compaction Observability
+
+## Status
+
+Accepted
+
+## Context
+
+This standard covers a neighbouring operational concern and uses anchor
+vocabulary, but does not select the signed checkpoint.
+
+## Decision
+
+Teams document their quantum ledger compaction observability procedure separately.
+
+## Consequences
+
+The document is a deliberate lexical near-match in the grounding benchmark.
+
+## Category
+
+Technical

--- a/rust/fixtures/eval/federation/child/vendor/standards/decisions/compaction-decoy-04.md
+++ b/rust/fixtures/eval/federation/child/vendor/standards/decisions/compaction-decoy-04.md
@@ -1,0 +1,27 @@
+---
+schema_version: 1
+id: FEDEVAL-000000000104
+type: decision
+---
+# Quantum Ledger Compaction Capacity
+
+## Status
+
+Accepted
+
+## Context
+
+This standard covers a neighbouring operational concern and uses anchor
+vocabulary, but does not select the signed checkpoint.
+
+## Decision
+
+Teams document their quantum ledger compaction capacity procedure separately.
+
+## Consequences
+
+The document is a deliberate lexical near-match in the grounding benchmark.
+
+## Category
+
+Technical

--- a/rust/fixtures/eval/federation/child/vendor/standards/decisions/compaction-decoy-05.md
+++ b/rust/fixtures/eval/federation/child/vendor/standards/decisions/compaction-decoy-05.md
@@ -1,0 +1,27 @@
+---
+schema_version: 1
+id: FEDEVAL-000000000105
+type: decision
+---
+# Quantum Ledger Compaction Scheduling
+
+## Status
+
+Accepted
+
+## Context
+
+This standard covers a neighbouring operational concern and uses anchor
+vocabulary, but does not select the signed checkpoint.
+
+## Decision
+
+Teams document their quantum ledger compaction scheduling procedure separately.
+
+## Consequences
+
+The document is a deliberate lexical near-match in the grounding benchmark.
+
+## Category
+
+Technical

--- a/rust/fixtures/eval/federation/child/vendor/standards/decisions/compaction-decoy-06.md
+++ b/rust/fixtures/eval/federation/child/vendor/standards/decisions/compaction-decoy-06.md
@@ -1,0 +1,27 @@
+---
+schema_version: 1
+id: FEDEVAL-000000000106
+type: decision
+---
+# Quantum Ledger Compaction Recovery
+
+## Status
+
+Accepted
+
+## Context
+
+This standard covers a neighbouring operational concern and uses anchor
+vocabulary, but does not select the signed checkpoint.
+
+## Decision
+
+Teams document their quantum ledger compaction recovery procedure separately.
+
+## Consequences
+
+The document is a deliberate lexical near-match in the grounding benchmark.
+
+## Category
+
+Technical

--- a/rust/fixtures/eval/federation/child/vendor/standards/decisions/ledger-reference-hub.md
+++ b/rust/fixtures/eval/federation/child/vendor/standards/decisions/ledger-reference-hub.md
@@ -1,0 +1,27 @@
+---
+schema_version: 1
+id: FEDEVAL-000000000002
+type: decision
+---
+# Ledger Reference Hub
+
+## Status
+
+Accepted
+
+## Context
+
+Many general standards link to this ledger reference index. Its glossary also
+mentions quantum compaction anchor terminology without setting that policy.
+
+## Decision
+
+Keep a stable ledger reference for broad portfolio navigation.
+
+## Consequences
+
+Relationship popularity alone does not make this the compaction policy.
+
+## Category
+
+Technical

--- a/rust/fixtures/eval/federation/child/vendor/standards/decisions/quantum-ledger-compaction-anchor.md
+++ b/rust/fixtures/eval/federation/child/vendor/standards/decisions/quantum-ledger-compaction-anchor.md
@@ -1,0 +1,26 @@
+---
+schema_version: 1
+id: FEDEVAL-000000000001
+type: decision
+---
+# Quantum Ledger Compaction Anchor
+
+## Status
+
+Accepted
+
+## Context
+
+Every child service needs one precise standard for quantum ledger compaction.
+
+## Decision
+
+Quantum ledger compaction MUST use the signed anchor checkpoint before pruning.
+
+## Consequences
+
+The exact inherited standard remains the strongest lexical grounding match.
+
+## Category
+
+Technical

--- a/rust/fixtures/eval/federation/child/vendor/standards/decisions/service-standard-001.md
+++ b/rust/fixtures/eval/federation/child/vendor/standards/decisions/service-standard-001.md
@@ -1,0 +1,30 @@
+---
+schema_version: 1
+id: FEDEVAL-000000001001
+type: decision
+---
+# Service Reliability Standard 001
+
+## Status
+
+Accepted
+
+## Context
+
+Portfolio service 001 needs a stable navigation reference for operational guidance.
+
+## Decision
+
+Service 001 records its reliability boundary and links to the shared reference hub.
+
+## Consequences
+
+The relationship makes the hub highly connected without adding query vocabulary.
+
+## Category
+
+Technical
+
+## Related Decisions
+
+- FEDEVAL-000000000002

--- a/rust/fixtures/eval/federation/child/vendor/standards/decisions/service-standard-002.md
+++ b/rust/fixtures/eval/federation/child/vendor/standards/decisions/service-standard-002.md
@@ -1,0 +1,30 @@
+---
+schema_version: 1
+id: FEDEVAL-000000001002
+type: decision
+---
+# Service Reliability Standard 002
+
+## Status
+
+Accepted
+
+## Context
+
+Portfolio service 002 needs a stable navigation reference for operational guidance.
+
+## Decision
+
+Service 002 records its reliability boundary and links to the shared reference hub.
+
+## Consequences
+
+The relationship makes the hub highly connected without adding query vocabulary.
+
+## Category
+
+Technical
+
+## Related Decisions
+
+- FEDEVAL-000000000002

--- a/rust/fixtures/eval/federation/child/vendor/standards/decisions/service-standard-003.md
+++ b/rust/fixtures/eval/federation/child/vendor/standards/decisions/service-standard-003.md
@@ -1,0 +1,30 @@
+---
+schema_version: 1
+id: FEDEVAL-000000001003
+type: decision
+---
+# Service Reliability Standard 003
+
+## Status
+
+Accepted
+
+## Context
+
+Portfolio service 003 needs a stable navigation reference for operational guidance.
+
+## Decision
+
+Service 003 records its reliability boundary and links to the shared reference hub.
+
+## Consequences
+
+The relationship makes the hub highly connected without adding query vocabulary.
+
+## Category
+
+Technical
+
+## Related Decisions
+
+- FEDEVAL-000000000002

--- a/rust/fixtures/eval/federation/child/vendor/standards/decisions/service-standard-004.md
+++ b/rust/fixtures/eval/federation/child/vendor/standards/decisions/service-standard-004.md
@@ -1,0 +1,30 @@
+---
+schema_version: 1
+id: FEDEVAL-000000001004
+type: decision
+---
+# Service Reliability Standard 004
+
+## Status
+
+Accepted
+
+## Context
+
+Portfolio service 004 needs a stable navigation reference for operational guidance.
+
+## Decision
+
+Service 004 records its reliability boundary and links to the shared reference hub.
+
+## Consequences
+
+The relationship makes the hub highly connected without adding query vocabulary.
+
+## Category
+
+Technical
+
+## Related Decisions
+
+- FEDEVAL-000000000002

--- a/rust/fixtures/eval/federation/child/vendor/standards/decisions/service-standard-005.md
+++ b/rust/fixtures/eval/federation/child/vendor/standards/decisions/service-standard-005.md
@@ -1,0 +1,30 @@
+---
+schema_version: 1
+id: FEDEVAL-000000001005
+type: decision
+---
+# Service Reliability Standard 005
+
+## Status
+
+Accepted
+
+## Context
+
+Portfolio service 005 needs a stable navigation reference for operational guidance.
+
+## Decision
+
+Service 005 records its reliability boundary and links to the shared reference hub.
+
+## Consequences
+
+The relationship makes the hub highly connected without adding query vocabulary.
+
+## Category
+
+Technical
+
+## Related Decisions
+
+- FEDEVAL-000000000002

--- a/rust/fixtures/eval/federation/child/vendor/standards/decisions/service-standard-006.md
+++ b/rust/fixtures/eval/federation/child/vendor/standards/decisions/service-standard-006.md
@@ -1,0 +1,30 @@
+---
+schema_version: 1
+id: FEDEVAL-000000001006
+type: decision
+---
+# Service Reliability Standard 006
+
+## Status
+
+Accepted
+
+## Context
+
+Portfolio service 006 needs a stable navigation reference for operational guidance.
+
+## Decision
+
+Service 006 records its reliability boundary and links to the shared reference hub.
+
+## Consequences
+
+The relationship makes the hub highly connected without adding query vocabulary.
+
+## Category
+
+Technical
+
+## Related Decisions
+
+- FEDEVAL-000000000002

--- a/rust/fixtures/eval/federation/child/vendor/standards/decisions/service-standard-007.md
+++ b/rust/fixtures/eval/federation/child/vendor/standards/decisions/service-standard-007.md
@@ -1,0 +1,30 @@
+---
+schema_version: 1
+id: FEDEVAL-000000001007
+type: decision
+---
+# Service Reliability Standard 007
+
+## Status
+
+Accepted
+
+## Context
+
+Portfolio service 007 needs a stable navigation reference for operational guidance.
+
+## Decision
+
+Service 007 records its reliability boundary and links to the shared reference hub.
+
+## Consequences
+
+The relationship makes the hub highly connected without adding query vocabulary.
+
+## Category
+
+Technical
+
+## Related Decisions
+
+- FEDEVAL-000000000002

--- a/rust/fixtures/eval/federation/child/vendor/standards/decisions/service-standard-008.md
+++ b/rust/fixtures/eval/federation/child/vendor/standards/decisions/service-standard-008.md
@@ -1,0 +1,30 @@
+---
+schema_version: 1
+id: FEDEVAL-000000001008
+type: decision
+---
+# Service Reliability Standard 008
+
+## Status
+
+Accepted
+
+## Context
+
+Portfolio service 008 needs a stable navigation reference for operational guidance.
+
+## Decision
+
+Service 008 records its reliability boundary and links to the shared reference hub.
+
+## Consequences
+
+The relationship makes the hub highly connected without adding query vocabulary.
+
+## Category
+
+Technical
+
+## Related Decisions
+
+- FEDEVAL-000000000002

--- a/rust/fixtures/eval/federation/child/vendor/standards/decisions/service-standard-009.md
+++ b/rust/fixtures/eval/federation/child/vendor/standards/decisions/service-standard-009.md
@@ -1,0 +1,30 @@
+---
+schema_version: 1
+id: FEDEVAL-000000001009
+type: decision
+---
+# Service Reliability Standard 009
+
+## Status
+
+Accepted
+
+## Context
+
+Portfolio service 009 needs a stable navigation reference for operational guidance.
+
+## Decision
+
+Service 009 records its reliability boundary and links to the shared reference hub.
+
+## Consequences
+
+The relationship makes the hub highly connected without adding query vocabulary.
+
+## Category
+
+Technical
+
+## Related Decisions
+
+- FEDEVAL-000000000002

--- a/rust/fixtures/eval/federation/child/vendor/standards/decisions/service-standard-010.md
+++ b/rust/fixtures/eval/federation/child/vendor/standards/decisions/service-standard-010.md
@@ -1,0 +1,30 @@
+---
+schema_version: 1
+id: FEDEVAL-000000001010
+type: decision
+---
+# Service Reliability Standard 010
+
+## Status
+
+Accepted
+
+## Context
+
+Portfolio service 010 needs a stable navigation reference for operational guidance.
+
+## Decision
+
+Service 010 records its reliability boundary and links to the shared reference hub.
+
+## Consequences
+
+The relationship makes the hub highly connected without adding query vocabulary.
+
+## Category
+
+Technical
+
+## Related Decisions
+
+- FEDEVAL-000000000002

--- a/rust/fixtures/eval/federation/child/vendor/standards/decisions/service-standard-011.md
+++ b/rust/fixtures/eval/federation/child/vendor/standards/decisions/service-standard-011.md
@@ -1,0 +1,30 @@
+---
+schema_version: 1
+id: FEDEVAL-000000001011
+type: decision
+---
+# Service Reliability Standard 011
+
+## Status
+
+Accepted
+
+## Context
+
+Portfolio service 011 needs a stable navigation reference for operational guidance.
+
+## Decision
+
+Service 011 records its reliability boundary and links to the shared reference hub.
+
+## Consequences
+
+The relationship makes the hub highly connected without adding query vocabulary.
+
+## Category
+
+Technical
+
+## Related Decisions
+
+- FEDEVAL-000000000002

--- a/rust/fixtures/eval/federation/child/vendor/standards/decisions/service-standard-012.md
+++ b/rust/fixtures/eval/federation/child/vendor/standards/decisions/service-standard-012.md
@@ -1,0 +1,30 @@
+---
+schema_version: 1
+id: FEDEVAL-000000001012
+type: decision
+---
+# Service Reliability Standard 012
+
+## Status
+
+Accepted
+
+## Context
+
+Portfolio service 012 needs a stable navigation reference for operational guidance.
+
+## Decision
+
+Service 012 records its reliability boundary and links to the shared reference hub.
+
+## Consequences
+
+The relationship makes the hub highly connected without adding query vocabulary.
+
+## Category
+
+Technical
+
+## Related Decisions
+
+- FEDEVAL-000000000002

--- a/rust/fixtures/eval/federation/child/vendor/standards/decisions/service-standard-013.md
+++ b/rust/fixtures/eval/federation/child/vendor/standards/decisions/service-standard-013.md
@@ -1,0 +1,30 @@
+---
+schema_version: 1
+id: FEDEVAL-000000001013
+type: decision
+---
+# Service Reliability Standard 013
+
+## Status
+
+Accepted
+
+## Context
+
+Portfolio service 013 needs a stable navigation reference for operational guidance.
+
+## Decision
+
+Service 013 records its reliability boundary and links to the shared reference hub.
+
+## Consequences
+
+The relationship makes the hub highly connected without adding query vocabulary.
+
+## Category
+
+Technical
+
+## Related Decisions
+
+- FEDEVAL-000000000002

--- a/rust/fixtures/eval/federation/child/vendor/standards/decisions/service-standard-014.md
+++ b/rust/fixtures/eval/federation/child/vendor/standards/decisions/service-standard-014.md
@@ -1,0 +1,30 @@
+---
+schema_version: 1
+id: FEDEVAL-000000001014
+type: decision
+---
+# Service Reliability Standard 014
+
+## Status
+
+Accepted
+
+## Context
+
+Portfolio service 014 needs a stable navigation reference for operational guidance.
+
+## Decision
+
+Service 014 records its reliability boundary and links to the shared reference hub.
+
+## Consequences
+
+The relationship makes the hub highly connected without adding query vocabulary.
+
+## Category
+
+Technical
+
+## Related Decisions
+
+- FEDEVAL-000000000002

--- a/rust/fixtures/eval/federation/child/vendor/standards/decisions/service-standard-015.md
+++ b/rust/fixtures/eval/federation/child/vendor/standards/decisions/service-standard-015.md
@@ -1,0 +1,30 @@
+---
+schema_version: 1
+id: FEDEVAL-000000001015
+type: decision
+---
+# Service Reliability Standard 015
+
+## Status
+
+Accepted
+
+## Context
+
+Portfolio service 015 needs a stable navigation reference for operational guidance.
+
+## Decision
+
+Service 015 records its reliability boundary and links to the shared reference hub.
+
+## Consequences
+
+The relationship makes the hub highly connected without adding query vocabulary.
+
+## Category
+
+Technical
+
+## Related Decisions
+
+- FEDEVAL-000000000002

--- a/rust/fixtures/eval/federation/child/vendor/standards/decisions/service-standard-016.md
+++ b/rust/fixtures/eval/federation/child/vendor/standards/decisions/service-standard-016.md
@@ -1,0 +1,30 @@
+---
+schema_version: 1
+id: FEDEVAL-000000001016
+type: decision
+---
+# Service Reliability Standard 016
+
+## Status
+
+Accepted
+
+## Context
+
+Portfolio service 016 needs a stable navigation reference for operational guidance.
+
+## Decision
+
+Service 016 records its reliability boundary and links to the shared reference hub.
+
+## Consequences
+
+The relationship makes the hub highly connected without adding query vocabulary.
+
+## Category
+
+Technical
+
+## Related Decisions
+
+- FEDEVAL-000000000002

--- a/rust/fixtures/eval/federation/child/vendor/standards/decisions/service-standard-017.md
+++ b/rust/fixtures/eval/federation/child/vendor/standards/decisions/service-standard-017.md
@@ -1,0 +1,30 @@
+---
+schema_version: 1
+id: FEDEVAL-000000001017
+type: decision
+---
+# Service Reliability Standard 017
+
+## Status
+
+Accepted
+
+## Context
+
+Portfolio service 017 needs a stable navigation reference for operational guidance.
+
+## Decision
+
+Service 017 records its reliability boundary and links to the shared reference hub.
+
+## Consequences
+
+The relationship makes the hub highly connected without adding query vocabulary.
+
+## Category
+
+Technical
+
+## Related Decisions
+
+- FEDEVAL-000000000002

--- a/rust/fixtures/eval/federation/child/vendor/standards/decisions/service-standard-018.md
+++ b/rust/fixtures/eval/federation/child/vendor/standards/decisions/service-standard-018.md
@@ -1,0 +1,30 @@
+---
+schema_version: 1
+id: FEDEVAL-000000001018
+type: decision
+---
+# Service Reliability Standard 018
+
+## Status
+
+Accepted
+
+## Context
+
+Portfolio service 018 needs a stable navigation reference for operational guidance.
+
+## Decision
+
+Service 018 records its reliability boundary and links to the shared reference hub.
+
+## Consequences
+
+The relationship makes the hub highly connected without adding query vocabulary.
+
+## Category
+
+Technical
+
+## Related Decisions
+
+- FEDEVAL-000000000002

--- a/rust/fixtures/eval/federation/child/vendor/standards/decisions/service-standard-019.md
+++ b/rust/fixtures/eval/federation/child/vendor/standards/decisions/service-standard-019.md
@@ -1,0 +1,30 @@
+---
+schema_version: 1
+id: FEDEVAL-000000001019
+type: decision
+---
+# Service Reliability Standard 019
+
+## Status
+
+Accepted
+
+## Context
+
+Portfolio service 019 needs a stable navigation reference for operational guidance.
+
+## Decision
+
+Service 019 records its reliability boundary and links to the shared reference hub.
+
+## Consequences
+
+The relationship makes the hub highly connected without adding query vocabulary.
+
+## Category
+
+Technical
+
+## Related Decisions
+
+- FEDEVAL-000000000002

--- a/rust/fixtures/eval/federation/child/vendor/standards/decisions/service-standard-020.md
+++ b/rust/fixtures/eval/federation/child/vendor/standards/decisions/service-standard-020.md
@@ -1,0 +1,30 @@
+---
+schema_version: 1
+id: FEDEVAL-000000001020
+type: decision
+---
+# Service Reliability Standard 020
+
+## Status
+
+Accepted
+
+## Context
+
+Portfolio service 020 needs a stable navigation reference for operational guidance.
+
+## Decision
+
+Service 020 records its reliability boundary and links to the shared reference hub.
+
+## Consequences
+
+The relationship makes the hub highly connected without adding query vocabulary.
+
+## Category
+
+Technical
+
+## Related Decisions
+
+- FEDEVAL-000000000002

--- a/rust/fixtures/eval/federation/child/vendor/standards/decisions/service-standard-021.md
+++ b/rust/fixtures/eval/federation/child/vendor/standards/decisions/service-standard-021.md
@@ -1,0 +1,30 @@
+---
+schema_version: 1
+id: FEDEVAL-000000001021
+type: decision
+---
+# Service Reliability Standard 021
+
+## Status
+
+Accepted
+
+## Context
+
+Portfolio service 021 needs a stable navigation reference for operational guidance.
+
+## Decision
+
+Service 021 records its reliability boundary and links to the shared reference hub.
+
+## Consequences
+
+The relationship makes the hub highly connected without adding query vocabulary.
+
+## Category
+
+Technical
+
+## Related Decisions
+
+- FEDEVAL-000000000002

--- a/rust/fixtures/eval/federation/child/vendor/standards/decisions/service-standard-022.md
+++ b/rust/fixtures/eval/federation/child/vendor/standards/decisions/service-standard-022.md
@@ -1,0 +1,30 @@
+---
+schema_version: 1
+id: FEDEVAL-000000001022
+type: decision
+---
+# Service Reliability Standard 022
+
+## Status
+
+Accepted
+
+## Context
+
+Portfolio service 022 needs a stable navigation reference for operational guidance.
+
+## Decision
+
+Service 022 records its reliability boundary and links to the shared reference hub.
+
+## Consequences
+
+The relationship makes the hub highly connected without adding query vocabulary.
+
+## Category
+
+Technical
+
+## Related Decisions
+
+- FEDEVAL-000000000002

--- a/rust/fixtures/eval/federation/child/vendor/standards/decisions/service-standard-023.md
+++ b/rust/fixtures/eval/federation/child/vendor/standards/decisions/service-standard-023.md
@@ -1,0 +1,30 @@
+---
+schema_version: 1
+id: FEDEVAL-000000001023
+type: decision
+---
+# Service Reliability Standard 023
+
+## Status
+
+Accepted
+
+## Context
+
+Portfolio service 023 needs a stable navigation reference for operational guidance.
+
+## Decision
+
+Service 023 records its reliability boundary and links to the shared reference hub.
+
+## Consequences
+
+The relationship makes the hub highly connected without adding query vocabulary.
+
+## Category
+
+Technical
+
+## Related Decisions
+
+- FEDEVAL-000000000002

--- a/rust/fixtures/eval/federation/child/vendor/standards/decisions/service-standard-024.md
+++ b/rust/fixtures/eval/federation/child/vendor/standards/decisions/service-standard-024.md
@@ -1,0 +1,30 @@
+---
+schema_version: 1
+id: FEDEVAL-000000001024
+type: decision
+---
+# Service Reliability Standard 024
+
+## Status
+
+Accepted
+
+## Context
+
+Portfolio service 024 needs a stable navigation reference for operational guidance.
+
+## Decision
+
+Service 024 records its reliability boundary and links to the shared reference hub.
+
+## Consequences
+
+The relationship makes the hub highly connected without adding query vocabulary.
+
+## Category
+
+Technical
+
+## Related Decisions
+
+- FEDEVAL-000000000002

--- a/rust/fixtures/eval/federation/child/vendor/standards/decisions/service-standard-025.md
+++ b/rust/fixtures/eval/federation/child/vendor/standards/decisions/service-standard-025.md
@@ -1,0 +1,30 @@
+---
+schema_version: 1
+id: FEDEVAL-000000001025
+type: decision
+---
+# Service Reliability Standard 025
+
+## Status
+
+Accepted
+
+## Context
+
+Portfolio service 025 needs a stable navigation reference for operational guidance.
+
+## Decision
+
+Service 025 records its reliability boundary and links to the shared reference hub.
+
+## Consequences
+
+The relationship makes the hub highly connected without adding query vocabulary.
+
+## Category
+
+Technical
+
+## Related Decisions
+
+- FEDEVAL-000000000002

--- a/rust/fixtures/eval/federation/child/vendor/standards/decisions/service-standard-026.md
+++ b/rust/fixtures/eval/federation/child/vendor/standards/decisions/service-standard-026.md
@@ -1,0 +1,30 @@
+---
+schema_version: 1
+id: FEDEVAL-000000001026
+type: decision
+---
+# Service Reliability Standard 026
+
+## Status
+
+Accepted
+
+## Context
+
+Portfolio service 026 needs a stable navigation reference for operational guidance.
+
+## Decision
+
+Service 026 records its reliability boundary and links to the shared reference hub.
+
+## Consequences
+
+The relationship makes the hub highly connected without adding query vocabulary.
+
+## Category
+
+Technical
+
+## Related Decisions
+
+- FEDEVAL-000000000002

--- a/rust/fixtures/eval/federation/child/vendor/standards/decisions/service-standard-027.md
+++ b/rust/fixtures/eval/federation/child/vendor/standards/decisions/service-standard-027.md
@@ -1,0 +1,30 @@
+---
+schema_version: 1
+id: FEDEVAL-000000001027
+type: decision
+---
+# Service Reliability Standard 027
+
+## Status
+
+Accepted
+
+## Context
+
+Portfolio service 027 needs a stable navigation reference for operational guidance.
+
+## Decision
+
+Service 027 records its reliability boundary and links to the shared reference hub.
+
+## Consequences
+
+The relationship makes the hub highly connected without adding query vocabulary.
+
+## Category
+
+Technical
+
+## Related Decisions
+
+- FEDEVAL-000000000002

--- a/rust/fixtures/eval/federation/child/vendor/standards/decisions/service-standard-028.md
+++ b/rust/fixtures/eval/federation/child/vendor/standards/decisions/service-standard-028.md
@@ -1,0 +1,30 @@
+---
+schema_version: 1
+id: FEDEVAL-000000001028
+type: decision
+---
+# Service Reliability Standard 028
+
+## Status
+
+Accepted
+
+## Context
+
+Portfolio service 028 needs a stable navigation reference for operational guidance.
+
+## Decision
+
+Service 028 records its reliability boundary and links to the shared reference hub.
+
+## Consequences
+
+The relationship makes the hub highly connected without adding query vocabulary.
+
+## Category
+
+Technical
+
+## Related Decisions
+
+- FEDEVAL-000000000002

--- a/rust/fixtures/eval/federation/child/vendor/standards/decisions/service-standard-029.md
+++ b/rust/fixtures/eval/federation/child/vendor/standards/decisions/service-standard-029.md
@@ -1,0 +1,30 @@
+---
+schema_version: 1
+id: FEDEVAL-000000001029
+type: decision
+---
+# Service Reliability Standard 029
+
+## Status
+
+Accepted
+
+## Context
+
+Portfolio service 029 needs a stable navigation reference for operational guidance.
+
+## Decision
+
+Service 029 records its reliability boundary and links to the shared reference hub.
+
+## Consequences
+
+The relationship makes the hub highly connected without adding query vocabulary.
+
+## Category
+
+Technical
+
+## Related Decisions
+
+- FEDEVAL-000000000002

--- a/rust/fixtures/eval/federation/child/vendor/standards/decisions/service-standard-030.md
+++ b/rust/fixtures/eval/federation/child/vendor/standards/decisions/service-standard-030.md
@@ -1,0 +1,30 @@
+---
+schema_version: 1
+id: FEDEVAL-000000001030
+type: decision
+---
+# Service Reliability Standard 030
+
+## Status
+
+Accepted
+
+## Context
+
+Portfolio service 030 needs a stable navigation reference for operational guidance.
+
+## Decision
+
+Service 030 records its reliability boundary and links to the shared reference hub.
+
+## Consequences
+
+The relationship makes the hub highly connected without adding query vocabulary.
+
+## Category
+
+Technical
+
+## Related Decisions
+
+- FEDEVAL-000000000002

--- a/rust/fixtures/eval/federation/child/vendor/standards/decisions/service-standard-031.md
+++ b/rust/fixtures/eval/federation/child/vendor/standards/decisions/service-standard-031.md
@@ -1,0 +1,30 @@
+---
+schema_version: 1
+id: FEDEVAL-000000001031
+type: decision
+---
+# Service Reliability Standard 031
+
+## Status
+
+Accepted
+
+## Context
+
+Portfolio service 031 needs a stable navigation reference for operational guidance.
+
+## Decision
+
+Service 031 records its reliability boundary and links to the shared reference hub.
+
+## Consequences
+
+The relationship makes the hub highly connected without adding query vocabulary.
+
+## Category
+
+Technical
+
+## Related Decisions
+
+- FEDEVAL-000000000002

--- a/rust/fixtures/eval/federation/child/vendor/standards/decisions/service-standard-032.md
+++ b/rust/fixtures/eval/federation/child/vendor/standards/decisions/service-standard-032.md
@@ -1,0 +1,30 @@
+---
+schema_version: 1
+id: FEDEVAL-000000001032
+type: decision
+---
+# Service Reliability Standard 032
+
+## Status
+
+Accepted
+
+## Context
+
+Portfolio service 032 needs a stable navigation reference for operational guidance.
+
+## Decision
+
+Service 032 records its reliability boundary and links to the shared reference hub.
+
+## Consequences
+
+The relationship makes the hub highly connected without adding query vocabulary.
+
+## Category
+
+Technical
+
+## Related Decisions
+
+- FEDEVAL-000000000002

--- a/rust/fixtures/eval/federation/eval-config.json
+++ b/rust/fixtures/eval/federation/eval-config.json
@@ -1,0 +1,14 @@
+{
+  "description": "Federated DecisionGrounding gate: preserve the precise inherited match and admit no hard negative in the top-five window.",
+  "tolerance": 0.02,
+  "floors": {
+    "negative_violations": 0,
+    "overall": {
+      "p_at_1": 0.9,
+      "r_at_5": 0.95
+    },
+    "by_category": {
+      "federated_large_parent": {"p_at_1": 0.9, "r_at_5": 0.95}
+    }
+  }
+}

--- a/rust/fixtures/eval/federation/queries.json
+++ b/rust/fixtures/eval/federation/queries.json
@@ -1,0 +1,21 @@
+{
+  "description": "DecisionGrounding federation track: one child, a large inherited parent, a highly connected lexical hard negative, and no source preference.",
+  "cases": [
+    {
+      "id": "FQ01",
+      "tool": "search_artifacts",
+      "category": "federated_large_parent",
+      "query": "quantum ledger compaction anchor",
+      "relevant": ["FEDEVAL-000000000001"],
+      "must_not_return": ["FEDEVAL-000000000002"]
+    },
+    {
+      "id": "FQ02",
+      "tool": "search_artifacts",
+      "category": "federated_large_parent",
+      "query": "signed anchor checkpoint pruning",
+      "relevant": ["FEDEVAL-000000000001"],
+      "must_not_return": ["FEDEVAL-000000000002", "FEDEVAL-000000000003"]
+    }
+  ]
+}

--- a/rust/rac-engine/src/budget.rs
+++ b/rust/rac-engine/src/budget.rs
@@ -364,8 +364,7 @@ fn truncate_optional_strategy(payload: &Value, budget: i64) -> (Value, bool) {
     // These fields are derived context, not the artifact identity itself. Drop
     // them in a fixed order only after whole-item collection truncation has
     // been exhausted. The marker tells the caller that context was omitted.
-    const OPTIONAL: [&str; 10] = [
-        "provenance",
+    const OPTIONAL: [&str; 9] = [
         "evidence",
         "outgoing",
         "incoming",
@@ -378,6 +377,51 @@ fn truncate_optional_strategy(payload: &Value, budget: i64) -> (Value, bool) {
     ];
     let mut candidate = object.clone();
     let mut changed = false;
+
+    let has_override_provenance = candidate
+        .get("provenance")
+        .and_then(Value::as_object)
+        .is_some_and(|provenance| provenance.contains_key("overrides"));
+    // An override record is one provenance fact: parent, replacement, and
+    // rationale must survive together. If that fixed record cannot fit after
+    // other reductions, `serialize` returns the explicit budget error.
+    if candidate.contains_key("provenance")
+        && !has_override_provenance
+        && length(&Value::Object(candidate.clone())) > budget
+    {
+        let protected = candidate
+            .get("provenance")
+            .and_then(Value::as_object)
+            .filter(|provenance| {
+                provenance.contains_key("source") && provenance.contains_key("layer")
+            })
+            .map(|provenance| {
+                let mut fixed = Map::new();
+                for key in ["source", "layer", "pin"] {
+                    if let Some(value) = provenance.get(key) {
+                        fixed.insert(key.to_string(), value.clone());
+                    }
+                }
+                Value::Object(fixed)
+            });
+        match protected {
+            Some(provenance) => {
+                if candidate.get("provenance") != Some(&provenance) {
+                    candidate.insert("provenance".to_string(), provenance);
+                    changed = true;
+                }
+            }
+            None => {
+                candidate.remove("provenance");
+                changed = true;
+            }
+        }
+        if changed {
+            candidate.insert(MARKER_TRUNCATED.to_string(), json!(true));
+            candidate.insert(MARKER_OMITTED.to_string(), json!(existing_omitted(payload)));
+            candidate.insert(MARKER_HINT.to_string(), json!(HINT_RELATED));
+        }
+    }
     for key in OPTIONAL {
         if candidate.contains_key(key) && length(&Value::Object(candidate.clone())) > budget {
             candidate.remove(key);
@@ -465,6 +509,77 @@ mod tests {
         assert!(char_len(&text) <= MIN_BUDGET);
         let value: Value = serde_json::from_str(&text).expect("budget error is JSON");
         assert_eq!(value["error"], json!(BUDGET_ERROR));
+    }
+
+    #[test]
+    fn federation_origin_survives_optional_context_truncation() {
+        let payload = json!({
+            "schema_version": "1",
+            "id": "ADR-001",
+            "content": "x".repeat(20_000),
+            "provenance": {
+                "source": "acme/standards",
+                "layer": "inherited",
+                "pin": "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+                "status": "Accepted",
+                "status_history": repeated("history", 32)
+            }
+        });
+        let text = serialize(&payload, 384);
+        assert!(char_len(&text) <= 384, "{} characters", char_len(&text));
+        let value: Value = serde_json::from_str(&text).expect("budget result is JSON");
+        assert_eq!(value["provenance"]["source"], json!("acme/standards"));
+        assert_eq!(value["provenance"]["layer"], json!("inherited"));
+        assert_eq!(
+            value["provenance"]["pin"],
+            json!("sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
+        );
+    }
+
+    fn assert_complete_override_or_budget_error(state: &str, source: &str) {
+        let payload = json!({
+            "schema_version": "1",
+            "id": "STD-01JY4M8X2QZ7",
+            "content": "x".repeat(20_000),
+            "provenance": {
+                "source": source,
+                "layer": if state == "overridden" { "inherited" } else { "local" },
+                "pin": "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+                "status": "Accepted",
+                "overrides": [{
+                    "state": state,
+                    "parent": {"source": "acme/standards", "id": "STD-01JY4M8X2QZ7"},
+                    "replacement": {"source": "acme/app", "id": "APP-01JY4M8X2QZ8"},
+                    "rationale": {"source": "acme/app", "id": "APP-01JY4M8X2QZ9"}
+                }]
+            }
+        });
+        for budget in [384, 512, 768] {
+            let text = serialize(&payload, budget);
+            assert!(char_len(&text) <= budget, "{} characters", char_len(&text));
+            let value: Value = serde_json::from_str(&text).expect("budget result is JSON");
+            if value["error"] == json!(BUDGET_ERROR) {
+                continue;
+            }
+            let mapping = &value["provenance"]["overrides"][0];
+            assert_eq!(mapping["state"], json!(state));
+            assert_eq!(mapping["parent"]["source"], json!("acme/standards"));
+            assert_eq!(mapping["parent"]["id"], json!("STD-01JY4M8X2QZ7"));
+            assert_eq!(mapping["replacement"]["source"], json!("acme/app"));
+            assert_eq!(mapping["replacement"]["id"], json!("APP-01JY4M8X2QZ8"));
+            assert_eq!(mapping["rationale"]["source"], json!("acme/app"));
+            assert_eq!(mapping["rationale"]["id"], json!("APP-01JY4M8X2QZ9"));
+        }
+    }
+
+    #[test]
+    fn tight_budget_preserves_overridden_parent_provenance_or_errors() {
+        assert_complete_override_or_budget_error("overridden", "acme/standards");
+    }
+
+    #[test]
+    fn tight_budget_preserves_replacement_provenance_or_errors() {
+        assert_complete_override_or_budget_error("replacement", "acme/app");
     }
 
     #[test]

--- a/rust/rac-engine/src/commands.rs
+++ b/rust/rac-engine/src/commands.rs
@@ -511,6 +511,23 @@ pub fn validate_stdin_against_corpus(
     }
 }
 
+fn validate_stdin_against_composed(
+    artifact: &Artifact,
+    corpus_dir: &str,
+    source_path: &str,
+    recursive: bool,
+    corpus: &crate::composition::ComposedCorpus,
+) -> StdinCorpusValidation {
+    let structural = validate_product(artifact, corpus_dir);
+    let relationships =
+        corpus.validate_proposed_document(artifact, source_path, corpus_dir, recursive);
+    StdinCorpusValidation {
+        source_path: source_path.to_string(),
+        structural_issues: structural,
+        relationship_issues: relationships.issues,
+    }
+}
+
 // ---------------------------------------------------------------------------
 // cmd_validate
 // ---------------------------------------------------------------------------
@@ -668,7 +685,17 @@ pub fn cmd_validate(args: &ValidateArgs) -> i32 {
         } else {
             py_path_str(&args.file)
         };
-        let result = validate_stdin_against_corpus(&artifact, corpus, &source_path, true);
+        let result = match load_composed_or_exit(corpus, true) {
+            Ok(Some(composed)) => validate_stdin_against_composed(
+                &artifact,
+                corpus,
+                &source_path,
+                true,
+                &composed,
+            ),
+            Ok(None) => validate_stdin_against_corpus(&artifact, corpus, &source_path, true),
+            Err(code) => return code,
+        };
         if args.json {
             emit(output::render_stdin_corpus_json(&result));
         } else {
@@ -915,7 +942,15 @@ pub fn cmd_relationships(args: &RelationshipsArgs) -> i32 {
 
     // Inspection arm (non --validate): always exit 0.
     let report = if is_dir {
-        build_relationship_report(&args.path, !args.top_level)
+        match load_composed_or_exit(&args.path, !args.top_level) {
+            Ok(Some(composed)) => crate::relationships::build_relationship_report_from_composed(
+                &args.path,
+                !args.top_level,
+                &composed,
+            ),
+            Ok(None) => build_relationship_report(&args.path, !args.top_level),
+            Err(code) => return code,
+        }
     } else {
         build_relationship_report_file(&args.path)
     };
@@ -940,7 +975,14 @@ pub fn cmd_stats(args: &StatsArgs) -> i32 {
     if !Path::new(&args.directory).is_dir() {
         return usage_error(&format!("not a directory: {}", args.directory));
     }
-    let stats = crate::stats::collect_stats(&args.directory);
+    let stats = match load_composed_or_exit(&args.directory, true) {
+        Ok(Some(composed)) => {
+            let items: Vec<_> = composed.effective().cloned().collect();
+            crate::stats::collect_stats_from_items(&args.directory, &items)
+        }
+        Ok(None) => crate::stats::collect_stats(&args.directory),
+        Err(code) => return code,
+    };
     if args.json {
         emit(output::render_stats_json(&stats));
     } else {
@@ -968,8 +1010,16 @@ pub fn cmd_portfolio(args: &PortfolioArgs) -> i32 {
         return usage_error(&format!("not a directory: {}", args.directory));
     }
     let recursive = !args.top_level;
-    let items = corpus_items(&args.directory, recursive);
-    let summary = crate::portfolio::portfolio_from_corpus(&args.directory, &items, recursive);
+    let summary = match load_composed_or_exit(&args.directory, recursive) {
+        Ok(Some(composed)) => {
+            crate::portfolio::portfolio_from_composed(&args.directory, &composed, recursive)
+        }
+        Ok(None) => {
+            let items = corpus_items(&args.directory, recursive);
+            crate::portfolio::portfolio_from_corpus(&args.directory, &items, recursive)
+        }
+        Err(code) => return code,
+    };
     if args.json {
         emit(output::render_portfolio_json(&summary));
     } else {
@@ -993,7 +1043,15 @@ pub fn cmd_index(args: &IndexArgs) -> i32 {
     if !Path::new(&args.directory).is_dir() {
         return usage_error(&format!("not a directory: {}", args.directory));
     }
-    let index = crate::index::build_repository_index(&args.directory, !args.top_level);
+    let recursive = !args.top_level;
+    let index = match load_composed_or_exit(&args.directory, recursive) {
+        Ok(Some(composed)) => {
+            let items: Vec<_> = composed.effective().cloned().collect();
+            crate::index::build_repository_index_from_items(&args.directory, &items, recursive)
+        }
+        Ok(None) => crate::index::build_repository_index(&args.directory, recursive),
+        Err(code) => return code,
+    };
     if args.json {
         emit(output::render_index_json(&index));
     } else {
@@ -1016,7 +1074,13 @@ pub fn cmd_coverage(args: &CoverageArgs) -> i32 {
     if !Path::new(&args.directory).is_dir() {
         return usage_error(&format!("not a directory: {}", args.directory));
     }
-    let report = crate::coverage::analyze_coverage(&args.directory);
+    let report = match load_composed_or_exit(&args.directory, true) {
+        Ok(Some(composed)) => {
+            crate::coverage::analyze_coverage_from_composed(&args.directory, &composed)
+        }
+        Ok(None) => crate::coverage::analyze_coverage(&args.directory),
+        Err(code) => return code,
+    };
     if args.json {
         emit(output::render_coverage_json(&report));
     } else {
@@ -1217,7 +1281,13 @@ pub fn cmd_herald(args: &HeraldArgs) -> i32 {
         Ok(text) => text.lines().map(str::trim).filter(|line| !line.is_empty()).map(str::to_string).collect::<Vec<_>>(),
         Err(error) => return usage_error(&format!("could not read paths file {}: {error}", args.paths_file)),
     };
-    let report = crate::herald::collect(&args.directory, &paths, !args.top_level);
+    let report = match load_composed_or_exit(&args.directory, !args.top_level) {
+        Ok(Some(composed)) => {
+            crate::herald::collect_from_composed(&args.directory, &paths, &composed)
+        }
+        Ok(None) => crate::herald::collect(&args.directory, &paths, !args.top_level),
+        Err(code) => return code,
+    };
     let body = crate::herald::render(&report, &args.link_base, args.max_inline);
     if let Err(error) = std::fs::write(&args.out, body) {
         return usage_error(&format!("could not write Herald output {}: {error}", args.out));
@@ -1330,8 +1400,17 @@ pub fn cmd_doctor(args: &DoctorArgs) -> i32 {
     if !Path::new(&args.directory).is_dir() {
         return usage_error(&format!("not a directory: {}", args.directory));
     }
-    let report =
-        crate::doctor::diagnose(&args.directory, !args.top_level, args.hub_threshold);
+    let recursive = !args.top_level;
+    let report = match load_composed_or_exit(&args.directory, recursive) {
+        Ok(Some(composed)) => crate::doctor::diagnose_composed(
+            &args.directory,
+            recursive,
+            args.hub_threshold,
+            &composed,
+        ),
+        Ok(None) => crate::doctor::diagnose(&args.directory, recursive, args.hub_threshold),
+        Err(code) => return code,
+    };
     if args.json {
         emit(output::render_doctor_json(&report));
     } else {
@@ -1366,7 +1445,17 @@ pub fn cmd_review(args: &ReviewArgs) -> i32 {
             return usage_error("--stale-after must be a non-negative number of days");
         }
     }
-    let report = crate::review::build_review(&args.directory, !args.top_level, args.stale_after);
+    let recursive = !args.top_level;
+    let report = match load_composed_or_exit(&args.directory, recursive) {
+        Ok(Some(composed)) => crate::review::build_review_composed(
+            &args.directory,
+            recursive,
+            args.stale_after,
+            &composed,
+        ),
+        Ok(None) => crate::review::build_review(&args.directory, recursive, args.stale_after),
+        Err(code) => return code,
+    };
     if args.sarif {
         emit(output::render_review_sarif(&report));
     } else if args.json {
@@ -1789,6 +1878,69 @@ pub fn annotate_search_recency(matches: &mut [crate::resolve::ResolvedArtifact],
     );
 }
 
+/// Join Git recency onto local matches from a composed corpus without ever
+/// attributing the child checkout's history to inherited artifacts.
+///
+/// Ranking has already completed when this runs. Inherited records retain a
+/// missing `recency` field; local records use their runtime-only physical
+/// locator while public paths remain owning-source-relative.
+pub fn annotate_composed_search_recency(
+    matches: &mut [crate::resolve::ResolvedArtifact],
+    directory: &str,
+    corpus: &crate::composition::ComposedCorpus,
+) {
+    use crate::corpus::Layer;
+    use crate::gitinfo;
+
+    let local: Vec<(usize, PathBuf)> = matches
+        .iter()
+        .enumerate()
+        .filter_map(|(index, artifact)| {
+            let key = artifact.key.as_ref()?;
+            let item = corpus.item(key)?;
+            (item.origin.layer == Layer::Local)
+                .then(|| (index, item.locator.path.clone()))
+        })
+        .collect();
+    if local.is_empty() {
+        return;
+    }
+    let local_count = local.len();
+
+    let timing_started = crate::timing::start();
+    let threshold = crate::validate::load_freshness_threshold(directory);
+    let reference = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_secs() as i64)
+        .unwrap_or(0);
+    let repo_root = gitinfo::repository_root(Path::new(directory));
+    let paths: Vec<PathBuf> = local.iter().map(|(_, path)| path.clone()).collect();
+    let committed = match &repo_root {
+        Some(root) => gitinfo::last_committed_for_paths_in_repo(root, &paths),
+        None => paths.into_iter().map(|path| (path, None)).collect(),
+    };
+    for ((index, _), (_, last)) in local.into_iter().zip(committed) {
+        let staleness = gitinfo::staleness(last.as_deref(), threshold, reference);
+        matches[index].recency = Some(crate::resolve::Recency {
+            last_committed: staleness
+                .last_committed
+                .as_deref()
+                .map(gitinfo::isoformat_roundtrip),
+            age_days: staleness.age_days,
+            stale: staleness.stale,
+        });
+    }
+    crate::timing::emit_since(
+        "git.recency_join",
+        timing_started,
+        &[
+            ("matches", matches.len() as u64),
+            ("local_matches", local_count as u64),
+            ("repository", u64::from(repo_root.is_some())),
+        ],
+    );
+}
+
 /// Serve `decided find` from the persistent index store (`_find_from_store`,
 /// ADR-112): a warm run against an unchanged corpus reads the mapped base;
 /// a cold run builds fresh, writes the store, and serves either the
@@ -1881,7 +2033,9 @@ pub fn cmd_find(args: &FindArgs) -> i32 {
             args.live,
         )
     };
-    if composed.is_none() {
+    if let Some(composed) = &composed {
+        annotate_composed_search_recency(&mut result.matches, &args.directory, composed);
+    } else {
         annotate_search_recency(&mut result.matches, &args.directory);
     }
     let render_started = crate::timing::start();

--- a/rust/rac-engine/src/composition.rs
+++ b/rust/rac-engine/src/composition.rs
@@ -16,7 +16,10 @@ use crate::relationships::{
     validation_row_from_item, CorpusItem, Relationship, RelationshipSummary,
     RelationshipValidation, ResolutionCandidate, ResolutionIndex, ValidationRow,
 };
-use crate::resolve::{entry_from_item, identity_entry_from_item, is_live_decision, IndexEntry};
+use crate::resolve::{
+    entry_from_item, identity_entry_from_item, is_live_decision, resolved_from_entry, IndexEntry,
+    ResolutionResult, OUTCOME_DUPLICATE, OUTCOME_NOT_FOUND, OUTCOME_RESOLVED,
+};
 
 pub const FINDING_CANONICAL_COLLISION: &str = "cross-corpus-canonical-id-collision";
 pub const FINDING_INVALID_OVERRIDE: &str = "cross-corpus-invalid-override";
@@ -668,6 +671,55 @@ impl ComposedCorpus {
         }
     }
 
+    /// Resolve one authored reference into the public exact-lookup shape.
+    ///
+    /// This adapter deliberately begins at [`Self::resolve`] rather than the
+    /// flattened identity projection. That preserves the canonical-only
+    /// contract for qualified parent references: a legacy or filename alias
+    /// containing `::` cannot bypass `validate_qualified_reference`.
+    /// Ambiguous paths include the owning source because two legal corpus
+    /// layers may carry the same corpus-relative path.
+    pub fn resolve_identity(&self, reference: &str) -> ResolutionResult {
+        match self.resolve(reference) {
+            Ok(item) => ResolutionResult {
+                artifact_id: reference.to_string(),
+                outcome: OUTCOME_RESOLVED,
+                artifact: Some(resolved_from_entry(&identity_entry_from_item(item))),
+                duplicate_paths: Vec::new(),
+            },
+            Err(LookupError::Ambiguous(keys)) => {
+                let mut paths: Vec<String> = keys
+                    .iter()
+                    .filter_map(|key| self.item(key))
+                    .map(|item| {
+                        format!(
+                            "{}::{}",
+                            item.artifact_path.source, item.artifact_path.relative_path
+                        )
+                    })
+                    .collect();
+                paths.sort();
+                paths.dedup();
+                ResolutionResult {
+                    artifact_id: reference.to_string(),
+                    outcome: OUTCOME_DUPLICATE,
+                    artifact: None,
+                    duplicate_paths: paths,
+                }
+            }
+            Err(
+                LookupError::NotFound
+                | LookupError::InvalidQualifiedReference
+                | LookupError::QualifiedCanonicalRequired,
+            ) => ResolutionResult {
+                artifact_id: reference.to_string(),
+                outcome: OUTCOME_NOT_FOUND,
+                artifact: None,
+                duplicate_paths: Vec::new(),
+            },
+        }
+    }
+
     fn validate_qualified_reference(&self, reference: &str) -> Result<(), LookupError> {
         let Some((alias, canonical_id)) = reference.split_once("::") else {
             return Err(LookupError::InvalidQualifiedReference);
@@ -710,6 +762,18 @@ impl ComposedCorpus {
         resolve_relationships(&self.effective_rows, &self.resolution_index)
     }
 
+    /// Child-declared edges resolved against the full composed identity
+    /// catalog. Diagnostics use this projection to keep their subjects local
+    /// without losing qualified parent and override resolution.
+    pub fn local_relationships(&self) -> Vec<Relationship> {
+        let rows: Vec<ValidationRow> = self
+            .local
+            .iter()
+            .map(|index| self.catalog_rows[*index].clone())
+            .collect();
+        resolve_relationships(&rows, &self.resolution_index)
+    }
+
     /// Resolve declared edges for every retained catalog record, including an
     /// overridden parent's immutable history. Export uses this projection;
     /// live reads and enforcement continue to use `relationships`.
@@ -738,6 +802,15 @@ impl ComposedCorpus {
         summary
     }
 
+    pub fn local_relationship_summary(&self) -> RelationshipSummary {
+        let rows: Vec<ValidationRow> = self
+            .local
+            .iter()
+            .map(|index| self.catalog_rows[*index].clone())
+            .collect();
+        crate::relationships::summary_from_rows_with_index(&rows, &self.resolution_index, true)
+    }
+
     /// Run the existing relationship validator over source-aware keys. The
     /// child repository root is intentionally supplied here so inherited
     /// filesystem scope is checked against child code.
@@ -762,6 +835,102 @@ impl ComposedCorpus {
             })
         });
         validation
+    }
+
+    pub fn validate_local_relationships(
+        &self,
+        child_directory: &str,
+        recursive: bool,
+    ) -> RelationshipValidation {
+        let rows: Vec<ValidationRow> = self
+            .local
+            .iter()
+            .map(|index| self.catalog_rows[*index].clone())
+            .collect();
+        validation_from_rows_with_index(
+            child_directory,
+            &rows,
+            &self.catalog_rows,
+            recursive,
+            &self.resolution_index,
+            false,
+            true,
+        )
+    }
+
+    /// Validate one proposed child document against the composed catalog.
+    /// Only proposal-owned findings are returned; an on-disk local artifact
+    /// with the same canonical id is treated as the document being replaced.
+    pub fn validate_proposed_document(
+        &self,
+        artifact: &crate::parse::Artifact,
+        source_path: &str,
+        child_directory: &str,
+        recursive: bool,
+    ) -> RelationshipValidation {
+        let source = self.child_source.clone().unwrap_or_else(|| {
+            crate::corpus::compatible_local_layer(child_directory).source
+        });
+        let origin = crate::corpus::CorpusLayer::local(source).origin();
+        let spec = crate::spec::spec_for(&crate::classify::classify(artifact).artifact_type);
+        let proposed = CorpusItem::new(
+            source_path.to_string(),
+            source_path.to_string(),
+            artifact.clone(),
+            spec,
+            origin,
+            crate::corpus::PhysicalArtifactLocator::new(
+                crate::corpus::PhysicalCorpusLocator::local(child_directory),
+                source_path,
+            ),
+        );
+        let canonical = py_casefold(&proposed.key.canonical_id);
+        let mut catalog_rows: Vec<ValidationRow> = self
+            .catalog_rows
+            .iter()
+            .filter(|row| {
+                !(row.origin.layer == Layer::Local
+                    && py_casefold(&row.key.canonical_id) == canonical)
+            })
+            .cloned()
+            .collect();
+        let mut effective_rows: Vec<ValidationRow> = self
+            .effective_rows
+            .iter()
+            .filter(|row| {
+                !(row.origin.layer == Layer::Local
+                    && py_casefold(&row.key.canonical_id) == canonical)
+            })
+            .cloned()
+            .collect();
+        let proposal_row = validation_row_from_item(&proposed);
+        catalog_rows.push(proposal_row.clone());
+        effective_rows.push(proposal_row.clone());
+        catalog_rows.sort_by(|left, right| {
+            left.artifact_path
+                .cmp(&right.artifact_path)
+                .then_with(|| left.key.cmp(&right.key))
+        });
+        effective_rows.sort_by(|left, right| {
+            left.artifact_path
+                .cmp(&right.artifact_path)
+                .then_with(|| left.key.cmp(&right.key))
+        });
+        let index = composed_resolution_index(
+            &catalog_rows,
+            &effective_rows,
+            self.parent.as_ref(),
+            &self.overrides,
+        );
+        validation_from_rows_with_index(
+            child_directory,
+            &[proposal_row],
+            &catalog_rows,
+            recursive,
+            &index,
+            false,
+            true,
+        )
     }
 }
 

--- a/rust/rac-engine/src/coverage.rs
+++ b/rust/rac-engine/src/coverage.rs
@@ -18,8 +18,9 @@
 
 use std::collections::{HashMap, HashSet};
 
+use crate::corpus::{ArtifactOrigin, ArtifactPath};
 use crate::identity::artifact_identifier;
-use crate::relationships::{corpus_items, relationships_from_corpus};
+use crate::relationships::{corpus_items, relationships_from_corpus, CorpusItem, Relationship};
 
 pub const GAP_UNSCHEDULED: &str = "unscheduled";
 pub const GAP_UNAPPLIED: &str = "unapplied";
@@ -38,6 +39,8 @@ fn missing_text(gap: &str) -> &'static str {
 #[derive(Debug)]
 pub struct CoverageGap {
     pub path: String,
+    pub artifact_path: Option<ArtifactPath>,
+    pub origin: Option<ArtifactOrigin>,
     pub id: String,
     pub artifact_type: String,
     pub gap: &'static str,
@@ -77,9 +80,31 @@ fn class_order(gap: &str) -> usize {
 /// `analyze_coverage(directory)` — always recursive, no writes, no git.
 pub fn analyze_coverage(directory: &str) -> CoverageReport {
     let items = corpus_items(directory, true);
+    let relationships = relationships_from_corpus(&items);
+    analyze_coverage_from_items(directory, &items, &relationships, false)
+}
+
+/// Coverage over one already-composed effective graph. Source-aware artifact
+/// paths prevent equal local/parent relative paths from collapsing into one
+/// node; public provenance is additive only on this federated seam.
+pub fn analyze_coverage_from_composed(
+    directory: &str,
+    corpus: &crate::composition::ComposedCorpus,
+) -> CoverageReport {
+    let items: Vec<CorpusItem> = corpus.effective().cloned().collect();
+    let relationships = corpus.relationships();
+    analyze_coverage_from_items(directory, &items, &relationships, true)
+}
+
+fn analyze_coverage_from_items(
+    directory: &str,
+    items: &[CorpusItem],
+    relationships: &[Relationship],
+    include_provenance: bool,
+) -> CoverageReport {
     // The identity index rows coverage reads: (path, id, type) per artifact,
     // unknown documents included with type "unknown" (they never gap).
-    let index: Vec<(String, String, String)> = items
+    let index: Vec<(String, ArtifactPath, ArtifactOrigin, String, String)> = items
         .iter()
         .map(|item| {
             let artifact_type = item
@@ -87,56 +112,64 @@ pub fn analyze_coverage(directory: &str) -> CoverageReport {
                 .map(|s| s.name.clone())
                 .unwrap_or_else(|| "unknown".to_string());
             let id = artifact_identifier(&item.artifact, item.spec, &item.path);
-            (item.path.clone(), id, artifact_type)
+            (
+                item.path.clone(),
+                item.artifact_path.clone(),
+                item.origin.clone(),
+                id,
+                artifact_type,
+            )
         })
         .collect();
-    let type_by_path: HashMap<&str, &str> = index
+    let type_by_path: HashMap<&ArtifactPath, &str> = index
         .iter()
-        .map(|(path, _, artifact_type)| (path.as_str(), artifact_type.as_str()))
+        .map(|(_, artifact_path, _, _, artifact_type)| (artifact_path, artifact_type.as_str()))
         .collect();
-    let relationships = relationships_from_corpus(&items);
 
     // Resolved incoming source types and resolved outgoing target types.
-    let mut incoming_types: HashMap<&str, HashSet<&str>> = index
+    let mut incoming_types: HashMap<&ArtifactPath, HashSet<&str>> = index
         .iter()
-        .map(|(path, _, _)| (path.as_str(), HashSet::new()))
+        .map(|(_, artifact_path, _, _, _)| (artifact_path, HashSet::new()))
         .collect();
-    let mut outgoing_types: HashMap<&str, HashSet<&str>> = index
+    let mut outgoing_types: HashMap<&ArtifactPath, HashSet<&str>> = index
         .iter()
-        .map(|(path, _, _)| (path.as_str(), HashSet::new()))
+        .map(|(_, artifact_path, _, _, _)| (artifact_path, HashSet::new()))
         .collect();
-    for rel in &relationships {
-        let Some(resolved) = rel.resolved_path.as_deref() else {
+    for rel in relationships {
+        let (Some(source), Some(resolved)) = (
+            rel.source_artifact.as_ref(),
+            rel.resolved_artifact.as_ref(),
+        ) else {
             continue;
         };
-        if resolved == rel.source_path {
+        if resolved == source {
             continue;
         }
-        let source_type = type_by_path.get(rel.source_path.as_str()).copied();
+        let source_type = type_by_path.get(source).copied();
         let target_type = type_by_path.get(resolved).copied();
         if let (Some(types), Some(source_type)) = (incoming_types.get_mut(resolved), source_type) {
             types.insert(source_type);
         }
-        if let (Some(types), Some(target_type)) =
-            (outgoing_types.get_mut(rel.source_path.as_str()), target_type)
-        {
+        if let (Some(types), Some(target_type)) = (outgoing_types.get_mut(source), target_type) {
             types.insert(target_type);
         }
     }
 
     let mut gaps: Vec<CoverageGap> = Vec::new();
-    for (path, id, artifact_type) in &index {
-        let incoming = &incoming_types[path.as_str()];
+    for (path, artifact_path, origin, id, artifact_type) in &index {
+        let incoming = &incoming_types[artifact_path];
         let gap = match artifact_type.as_str() {
             "requirement" if !incoming.contains("roadmap") => GAP_UNSCHEDULED,
             "decision" if !incoming.contains("requirement") && !incoming.contains("roadmap") => {
                 GAP_UNAPPLIED
             }
-            "roadmap" if !outgoing_types[path.as_str()].contains("requirement") => GAP_UNSCOPED,
+            "roadmap" if !outgoing_types[artifact_path].contains("requirement") => GAP_UNSCOPED,
             _ => continue,
         };
         gaps.push(CoverageGap {
             path: path.clone(),
+            artifact_path: include_provenance.then(|| artifact_path.clone()),
+            origin: include_provenance.then(|| origin.clone()),
             id: id.clone(),
             artifact_type: artifact_type.clone(),
             gap,
@@ -148,6 +181,7 @@ pub fn analyze_coverage(directory: &str) -> CoverageReport {
     gaps.sort_by(|a, b| {
         class_order(a.gap)
             .cmp(&class_order(b.gap))
+            .then_with(|| a.artifact_path.cmp(&b.artifact_path))
             .then_with(|| a.path.cmp(&b.path))
     });
     CoverageReport {

--- a/rust/rac-engine/src/derived_cache.rs
+++ b/rust/rac-engine/src/derived_cache.rs
@@ -902,25 +902,15 @@ impl FederatedCacheTracker<crate::composition::ComposedCorpus> {
             child_corpus,
             recursive,
             |generation| {
-                let Some(identity) = generation.identity() else {
-                    return Err(FederatedCacheError::InvalidModel {
+                let identity = generation.identity().ok_or_else(|| {
+                    FederatedCacheError::InvalidModel {
                         message: "composed cache reads require .decided/corpus.md".to_string(),
-                    });
-                };
+                    }
+                })?;
+                let composed = compose_logical_generation(child_corpus, generation)?;
                 let parent = generation
                     .verified_parent()
                     .expect("federated identity has a verified parent");
-                let child_files = generation
-                    .child_files()
-                    .expect("federated identity has captured child files");
-                let composed = crate::federated_corpus::compose_verified_generation_from_snapshot(
-                    child_corpus,
-                    parent,
-                    child_files,
-                )
-                .map_err(|error| {
-                    FederatedCacheError::composition(error.stable_code(), error.to_string())
-                })?;
                 let model = crate::derived::build_derived_index_from_composed(
                     &identity.child_corpus_path,
                     child_corpus,
@@ -933,6 +923,30 @@ impl FederatedCacheTracker<crate::composition::ComposedCorpus> {
             },
         )
     }
+}
+
+/// Compose the authoritative corpus from one already-captured logical
+/// generation. This is also the cache-disabled serving boundary: callers get
+/// the same verified bytes and overlay semantics without opening or writing a
+/// persistent store.
+pub fn compose_logical_generation(
+    child_corpus: &str,
+    generation: &LogicalGeneration,
+) -> Result<crate::composition::ComposedCorpus, FederatedCacheError> {
+    let parent = generation
+        .verified_parent()
+        .ok_or_else(|| FederatedCacheError::InvalidModel {
+            message: "composed generation requires .decided/corpus.md".to_string(),
+        })?;
+    let child_files = generation
+        .child_files()
+        .expect("federated identity has captured child files");
+    crate::federated_corpus::compose_verified_generation_from_snapshot(
+        child_corpus,
+        parent,
+        child_files,
+    )
+    .map_err(|error| FederatedCacheError::composition(error.stable_code(), error.to_string()))
 }
 
 fn stable_public_path(path: &str) -> bool {

--- a/rust/rac-engine/src/doctor.rs
+++ b/rust/rac-engine/src/doctor.rs
@@ -15,7 +15,8 @@ use crate::identity::path_stem;
 use crate::pycompat::{py_casefold, py_repr_str, py_strip};
 use crate::relationships::{
     corpus_items, relationship_severity, relationships_from_corpus, validate_relationships,
-    CorpusItem, RelationshipIssue, ISSUE_DUPLICATE_IDENTIFIER, ISSUE_RELATIONSHIP_CYCLE,
+    CorpusItem, Relationship, RelationshipIssue, RelationshipValidation,
+    ISSUE_DUPLICATE_IDENTIFIER, ISSUE_RELATIONSHIP_CYCLE,
 };
 use crate::resolve::{index_from_items, resolve_in_index, IndexEntry, OUTCOME_RESOLVED};
 use crate::review::{drift_problem, suspect_drift};
@@ -114,10 +115,63 @@ pub fn diagnose(directory: &str, recursive: bool, hub_threshold: i64) -> DoctorR
     }
 }
 
+/// Diagnose only writable child artifacts while resolving their graph through
+/// the authoritative composed catalog. Parent warnings and advisories are not
+/// copied into each child; parent load/validation failures have already
+/// stopped composition at the command boundary.
+pub fn diagnose_composed(
+    directory: &str,
+    recursive: bool,
+    hub_threshold: i64,
+    corpus: &crate::composition::ComposedCorpus,
+) -> DoctorReport {
+    let items: Vec<CorpusItem> = corpus.local_items().cloned().collect();
+    let relationships = corpus.relationships();
+    let validation = crate::commands::validate_directory_from_items(directory, recursive, &items);
+    let relationship_validation = corpus.validate_relationships(directory, recursive);
+    let identity_index = corpus.identity_index();
+    let mut findings = Vec::new();
+    findings.extend(validation_findings_from_result(&validation));
+    findings.extend(relationship_findings_from_result(
+        directory,
+        &relationship_validation,
+    ));
+    findings.extend(degree_findings_with_relationships(
+        &items,
+        &relationships,
+        hub_threshold,
+    ));
+    findings.extend(injection_findings(&items));
+    findings.extend(unlinked_reference_findings_with_index(
+        &items,
+        &identity_index,
+        &relationships,
+    ));
+    findings.extend(suspect_artifact_findings(directory, &items));
+    findings.sort_by(|a, b| {
+        severity_rank(a.severity)
+            .cmp(&severity_rank(b.severity))
+            .then_with(|| a.path.cmp(&b.path))
+            .then_with(|| a.code.cmp(b.code))
+            .then_with(|| a.problem.cmp(&b.problem))
+    });
+    DoctorReport {
+        directory: directory.to_string(),
+        hub_threshold,
+        findings,
+    }
+}
+
 /// One finding per structurally invalid artifact; the problem names the
 /// sorted, deduplicated error codes.
 fn validation_findings(directory: &str, recursive: bool) -> Vec<DoctorFinding> {
     let result = validate_directory(directory, recursive);
+    validation_findings_from_result(&result)
+}
+
+fn validation_findings_from_result(
+    result: &crate::commands::DirectoryValidation,
+) -> Vec<DoctorFinding> {
     let mut findings = Vec::new();
     for file in &result.files {
         if file.status != STATUS_INVALID {
@@ -184,6 +238,13 @@ fn issue_problem(issue: &RelationshipIssue) -> String {
 /// (`RELATIONSHIP_SEVERITY.get(code, SEVERITY_ERROR)`).
 fn relationship_findings(directory: &str, recursive: bool) -> Vec<DoctorFinding> {
     let result = validate_relationships(directory, recursive);
+    relationship_findings_from_result(directory, &result)
+}
+
+fn relationship_findings_from_result(
+    directory: &str,
+    result: &RelationshipValidation,
+) -> Vec<DoctorFinding> {
     result
         .issues
         .iter()
@@ -238,27 +299,43 @@ fn issue_code_static(code: &str) -> &'static str {
 /// over the resolved edges; the orphan definition matches the portfolio's
 /// "never a resolved target" count exactly.
 fn degree_findings(items: &[CorpusItem], hub_threshold: i64) -> Vec<DoctorFinding> {
+    let relationships = relationships_from_corpus(items);
+    degree_findings_with_relationships(items, &relationships, hub_threshold)
+}
+
+fn degree_findings_with_relationships(
+    items: &[CorpusItem],
+    relationships: &[Relationship],
+    hub_threshold: i64,
+) -> Vec<DoctorFinding> {
     let known: Vec<&CorpusItem> = items.iter().filter(|i| i.spec.is_some()).collect();
-    let mut inbound: std::collections::HashMap<&str, i64> =
-        known.iter().map(|i| (i.path.as_str(), 0)).collect();
-    let mut outbound: std::collections::HashMap<&str, i64> =
-        known.iter().map(|i| (i.path.as_str(), 0)).collect();
-    for rel in relationships_from_corpus(items) {
-        let Some(resolved) = &rel.resolved_path else {
+    let mut inbound: std::collections::HashMap<&crate::corpus::ArtifactPath, i64> = known
+        .iter()
+        .map(|item| (&item.artifact_path, 0))
+        .collect();
+    let mut outbound: std::collections::HashMap<&crate::corpus::ArtifactPath, i64> = known
+        .iter()
+        .map(|item| (&item.artifact_path, 0))
+        .collect();
+    for rel in relationships {
+        let (Some(source), Some(resolved)) = (
+            rel.source_artifact.as_ref(),
+            rel.resolved_artifact.as_ref(),
+        ) else {
             continue; // only resolved (unique, non-self) edges
         };
-        if let Some(count) = inbound.get_mut(resolved.as_str()) {
+        if let Some(count) = inbound.get_mut(resolved) {
             *count += 1;
         }
-        if let Some(count) = outbound.get_mut(rel.source_path.as_str()) {
+        if let Some(count) = outbound.get_mut(source) {
             *count += 1;
         }
     }
     let mut findings = Vec::new();
     for item in &known {
         let path = item.path.as_str();
-        let in_degree = *inbound.get(path).unwrap_or(&0);
-        let degree = in_degree + *outbound.get(path).unwrap_or(&0);
+        let in_degree = *inbound.get(&item.artifact_path).unwrap_or(&0);
+        let degree = in_degree + *outbound.get(&item.artifact_path).unwrap_or(&0);
         if in_degree == 0 {
             findings.push(DoctorFinding {
                 path: path.to_string(),
@@ -735,30 +812,46 @@ struct UnlinkedReference {
 /// one finding per (source, target), sorted by `(source_path, target_id)`.
 fn detect_unlinked_references(items: &[CorpusItem]) -> Vec<UnlinkedReference> {
     let index: Vec<IndexEntry> = index_from_items(items);
-    let by_path: std::collections::HashMap<&str, &IndexEntry> =
-        index.iter().map(|e| (e.path.as_str(), e)).collect();
+    let relationships = relationships_from_corpus(items);
+    detect_unlinked_references_with_index(items, &index, &relationships)
+}
 
-    let mut declared: std::collections::HashMap<&str, std::collections::HashSet<String>> =
-        std::collections::HashMap::new();
-    for rel in relationships_from_corpus(items) {
-        if let Some(resolved) = rel.resolved_path {
-            if let Some(item) = items.iter().find(|i| i.path == rel.source_path) {
-                declared
-                    .entry(item.path.as_str())
-                    .or_default()
-                    .insert(resolved);
-            }
+fn detect_unlinked_references_with_index(
+    items: &[CorpusItem],
+    identity_index: &[IndexEntry],
+    relationships: &[Relationship],
+) -> Vec<UnlinkedReference> {
+    let sources: Vec<IndexEntry> = index_from_items(items);
+    let by_key: std::collections::HashMap<&crate::corpus::ArtifactKey, &IndexEntry> = identity_index
+        .iter()
+        .filter_map(|entry| entry.key.as_ref().map(|key| (key, entry)))
+        .collect();
+
+    let mut declared: std::collections::HashMap<
+        crate::corpus::ArtifactPath,
+        std::collections::HashSet<crate::corpus::ArtifactPath>,
+    > = std::collections::HashMap::new();
+    for rel in relationships {
+        if let (Some(source), Some(resolved)) =
+            (&rel.source_artifact, &rel.resolved_artifact)
+        {
+            declared
+                .entry(source.clone())
+                .or_default()
+                .insert(resolved.clone());
         }
     }
 
     let mut findings: Vec<UnlinkedReference> = Vec::new();
-    for source in &index {
+    for source in &sources {
+        let Some(source_path) = source.artifact_path.as_ref() else {
+            continue;
+        };
         let self_aliases: std::collections::HashSet<String> =
             source.aliases.iter().map(|a| py_casefold(a)).collect();
         let empty = std::collections::HashSet::new();
-        let already = declared.get(source.path.as_str()).unwrap_or(&empty);
-        let mut seen_targets: std::collections::HashSet<String> =
-            std::collections::HashSet::new();
+        let already = declared.get(source_path).unwrap_or(&empty);
+        let mut seen_targets = std::collections::HashSet::new();
         for section in &source.search_sections {
             let heading = py_casefold(py_strip(&section.heading));
             if RELATIONSHIP_HEADINGS.contains(&heading.as_str()) {
@@ -769,18 +862,23 @@ fn detect_unlinked_references(items: &[CorpusItem]) -> Vec<UnlinkedReference> {
                     if self_aliases.contains(&py_casefold(&token)) {
                         continue; // self-reference
                     }
-                    let result = resolve_in_index(&index, &token);
+                    let result = resolve_in_index(identity_index, &token);
                     if result.outcome != OUTCOME_RESOLVED {
                         continue; // not a unique corpus artifact
                     }
                     let target = result.artifact.expect("resolved implies artifact");
-                    if target.path == source.path || already.contains(&target.path) {
+                    let (Some(target_key), Some(target_path)) =
+                        (target.key.as_ref(), target.artifact_path.as_ref())
+                    else {
+                        continue;
+                    };
+                    if source.key.as_ref() == Some(target_key) || already.contains(target_path) {
                         continue;
                     }
-                    if !seen_targets.insert(target.path.clone()) {
+                    if !seen_targets.insert(target_key.clone()) {
                         continue; // one finding per (source, target) pair
                     }
-                    let target_entry = by_path[target.path.as_str()];
+                    let target_entry = by_key[target_key];
                     findings.push(UnlinkedReference {
                         source_path: source.path.clone(),
                         target_id: target.id.clone(),
@@ -818,6 +916,30 @@ fn unlinked_reference_findings(items: &[CorpusItem]) -> Vec<DoctorFinding> {
                 "Add `{}` under `## {}` if the link is intended \u{2014} a suggestion to \
                  review; RAC writes no edge (ADR-082).",
                 r.suggested_line, r.related_section
+            ),
+        })
+        .collect()
+}
+
+fn unlinked_reference_findings_with_index(
+    items: &[CorpusItem],
+    identity_index: &[IndexEntry],
+    relationships: &[Relationship],
+) -> Vec<DoctorFinding> {
+    detect_unlinked_references_with_index(items, identity_index, relationships)
+        .into_iter()
+        .map(|record| DoctorFinding {
+            path: record.source_path,
+            code: CODE_UNLINKED_REFERENCE,
+            severity: SEVERITY_WARNING,
+            problem: format!(
+                "body references {} but declares no {} link to it",
+                record.matched_token, record.related_section
+            ),
+            fix: format!(
+                "Add `{}` under `## {}` if the link is intended — a suggestion to \
+                 review; RAC writes no edge (ADR-082).",
+                record.suggested_line, record.related_section
             ),
         })
         .collect()

--- a/rust/rac-engine/src/eval.rs
+++ b/rust/rac-engine/src/eval.rs
@@ -18,6 +18,8 @@ use std::path::Path;
 
 use serde_json::{Map, Value};
 
+use crate::composition::ComposedCorpus;
+use crate::corpus::ArtifactPath;
 use crate::pycompat::{py_repr_str, py_round};
 use crate::pyjson::py_float;
 use crate::relationships::{corpus_items, relationships_from_corpus, Relationship};
@@ -349,9 +351,60 @@ fn related_returned(root: &str, case: &QueryCase) -> EvalResult<Vec<String>> {
     Ok(incoming_ids(&relationships, &identity_by_path, &artifact.path))
 }
 
-fn returned_ids(root: &str, entries: &[IndexEntry], case: &QueryCase) -> EvalResult<Vec<String>> {
+fn related_returned_composed(
+    corpus: &ComposedCorpus,
+    root: &str,
+    case: &QueryCase,
+) -> EvalResult<Vec<String>> {
+    const MAX_RELATED_EDGES: usize = 1000;
+    let artifact = corpus.resolve(&case.query).map_err(|_| {
+        EvalUsageError(format!(
+            "get_related case {}: query {} did not resolve to an artifact in {}",
+            py_repr_str(&case.id),
+            py_repr_str(&case.query),
+            py_repr_str(root)
+        ))
+    })?;
+    let relationships = corpus.relationships();
+    let identity_by_path: HashMap<&ArtifactPath, &str> = corpus
+        .effective()
+        .map(|item| (&item.artifact_path, item.key.canonical_id.as_str()))
+        .collect();
+    let mut incoming = Vec::new();
+    for relationship in &relationships {
+        if relationship.resolved_artifact.as_ref() != Some(&artifact.artifact_path)
+            || relationship.source_artifact.as_ref() == Some(&artifact.artifact_path)
+        {
+            continue;
+        }
+        let Some(source_path) = relationship.source_artifact.as_ref() else {
+            continue;
+        };
+        let Some(id) = identity_by_path.get(source_path) else {
+            continue;
+        };
+        if incoming.len() < MAX_RELATED_EDGES {
+            incoming.push((
+                relationship_order(&relationship.relationship),
+                (*id).to_string(),
+                source_path.clone(),
+            ));
+        }
+    }
+    incoming.sort_by(|left, right| (left.0, &left.1, &left.2).cmp(&(right.0, &right.1, &right.2)));
+    Ok(incoming.into_iter().map(|(_, id, _)| id).collect())
+}
+
+fn returned_ids(
+    root: &str,
+    entries: &[IndexEntry],
+    composed: Option<&ComposedCorpus>,
+    case: &QueryCase,
+) -> EvalResult<Vec<String>> {
     if case.tool == TOOL_SEARCH {
         Ok(search_returned(entries, case))
+    } else if let Some(corpus) = composed {
+        related_returned_composed(corpus, root, case)
     } else {
         related_returned(root, case)
     }
@@ -452,6 +505,19 @@ pub fn corpus_hash(root: &str) -> String {
     format!("sha256:{}", digest.hexdigest())
 }
 
+fn composed_corpus_hash(corpus: &ComposedCorpus) -> String {
+    let mut digest = Sha256::new();
+    for item in corpus.catalog() {
+        digest.update(item.artifact_path.source.as_bytes());
+        digest.update(b"\0");
+        digest.update(item.artifact_path.relative_path.as_bytes());
+        digest.update(b"\0");
+        digest.update(corpus.content(&item.key).unwrap_or_default());
+        digest.update(b"\0");
+    }
+    format!("sha256:{}", digest.hexdigest())
+}
+
 /// `query_set_hash(path)` — `sha256:` over the raw file bytes.
 pub fn query_set_hash(path: &str) -> String {
     format!(
@@ -468,11 +534,16 @@ pub fn run_eval(root: &str, queries_path: &str) -> EvalResult<Scorecard> {
         return usage(format!("corpus not found or not a directory: {root}"));
     }
     let cases = load_query_set(queries_path)?;
-    let entries = build_index(root, true);
+    let composed = crate::federated_corpus::load_composed_corpus(root, true)
+        .map_err(|error| EvalUsageError(error.to_string()))?;
+    let entries = composed
+        .as_ref()
+        .map(ComposedCorpus::effective_index)
+        .unwrap_or_else(|| build_index(root, true));
 
     let mut results: Vec<CaseResult> = Vec::with_capacity(cases.len());
     for case in cases {
-        let returned = returned_ids(root, &entries, &case)?;
+        let returned = returned_ids(root, &entries, composed.as_ref(), &case)?;
         results.push(score_case(returned, case));
     }
     let n_queries = results.len() as i64;
@@ -491,7 +562,15 @@ pub fn run_eval(root: &str, queries_path: &str) -> EvalResult<Scorecard> {
         "lore_version".into(),
         Value::String(crate::output::rac_version()),
     );
-    metadata.insert("corpus_hash".into(), Value::String(corpus_hash(root)));
+    metadata.insert(
+        "corpus_hash".into(),
+        Value::String(
+            composed
+                .as_ref()
+                .map(composed_corpus_hash)
+                .unwrap_or_else(|| corpus_hash(root)),
+        ),
+    );
     metadata.insert(
         "query_set_hash".into(),
         Value::String(query_set_hash(queries_path)),

--- a/rust/rac-engine/src/herald.rs
+++ b/rust/rac-engine/src/herald.rs
@@ -2,13 +2,16 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
-use crate::retrieve::decisions_for_path;
+use crate::corpus::{ArtifactKey, ArtifactOrigin, Layer};
+use crate::retrieve::{decisions_for_path, decisions_for_path_with_rows, scope_rows_from_items};
 
 pub const MARKER: &str = "<!-- lore-decisions-on-pr -->";
 const PATHS_SHOWN: usize = 3;
 
 #[derive(Debug)]
 pub struct HeraldDecision {
+    pub key: Option<ArtifactKey>,
+    pub origin: Option<ArtifactOrigin>,
     pub id: String,
     pub title: String,
     pub status: String,
@@ -39,6 +42,8 @@ pub fn collect(corpus: &str, paths: &[String], recursive: bool) -> HeraldReport 
             let entry = merged
                 .entry(decision.id.clone())
                 .or_insert_with(|| HeraldDecision {
+                    key: decision.key,
+                    origin: None,
                     id: decision.id,
                     title: decision.title,
                     status: decision.status,
@@ -46,6 +51,45 @@ pub fn collect(corpus: &str, paths: &[String], recursive: bool) -> HeraldReport 
                     matching_entries: BTreeSet::new(),
                     changed_paths: BTreeSet::new(),
                 });
+            entry.matching_entries.insert(decision.matching_entry);
+            entry.changed_paths.insert(path.clone());
+        }
+    }
+    HeraldReport {
+        decisions: merged.into_values().collect(),
+    }
+}
+
+/// Herald collection over one effective composed scope projection. Stable
+/// ArtifactKey deduplication prevents equal canonical ids or relative paths
+/// in different sources from collapsing.
+pub fn collect_from_composed(
+    corpus_directory: &str,
+    paths: &[String],
+    corpus: &crate::composition::ComposedCorpus,
+) -> HeraldReport {
+    let items: Vec<_> = corpus.effective().cloned().collect();
+    let rows = scope_rows_from_items(&items);
+    let mut merged: BTreeMap<ArtifactKey, HeraldDecision> = BTreeMap::new();
+    let changed: BTreeSet<&String> = paths
+        .iter()
+        .filter(|path| !path.trim().is_empty())
+        .collect();
+    for path in changed {
+        for decision in decisions_for_path_with_rows(&rows, corpus_directory, path).decisions {
+            let Some(key) = decision.key.clone() else {
+                continue;
+            };
+            let entry = merged.entry(key.clone()).or_insert_with(|| HeraldDecision {
+                key: Some(key),
+                origin: decision.origin,
+                id: decision.id,
+                title: decision.title,
+                status: decision.status,
+                path: decision.path,
+                matching_entries: BTreeSet::new(),
+                changed_paths: BTreeSet::new(),
+            });
             entry.matching_entries.insert(decision.matching_entry);
             entry.changed_paths.insert(path.clone());
         }
@@ -78,9 +122,18 @@ fn bullet(decision: &HeraldDecision, link_base: &str) -> String {
     } else {
         format!("{}/{}", link_base.trim_end_matches('/'), decision.path)
     };
+    let label = if decision
+        .origin
+        .as_ref()
+        .is_some_and(|origin| origin.layer == Layer::Inherited)
+    {
+        format!("**{} — {}**", decision.id, decision.title)
+    } else {
+        format!("**[{} — {}]({link})**", decision.id, decision.title)
+    };
     format!(
-        "- **[{} — {}]({})** ({}) — applies to {} — changed: {}",
-        decision.id, decision.title, link, decision.status, scopes, changed
+        "- {label} ({}) — applies to {} — changed: {}",
+        decision.status, scopes, changed
     )
 }
 
@@ -136,6 +189,8 @@ mod tests {
 
     fn decision(id: &str) -> HeraldDecision {
         HeraldDecision {
+            key: None,
+            origin: None,
             id: id.to_string(),
             title: format!("{id} title"),
             status: "Accepted".to_string(),

--- a/rust/rac-engine/src/index.rs
+++ b/rust/rac-engine/src/index.rs
@@ -5,8 +5,9 @@
 //! writes the derived cache (spec/index-contracts.json `index-command`).
 
 use crate::classify::classify;
+use crate::corpus::ArtifactOrigin;
 use crate::identity::{artifact_identifier, artifact_identifiers};
-use crate::relationships::corpus_items;
+use crate::relationships::{corpus_items, CorpusItem};
 
 /// One row in the repository manifest: structural identity only.
 pub struct IndexEntry {
@@ -15,6 +16,8 @@ pub struct IndexEntry {
     pub title: Option<String>,
     pub path: String,
     pub aliases: Vec<String>,
+    /// Present only when the row came from an explicit composed projection.
+    pub origin: Option<ArtifactOrigin>,
 }
 
 /// Deterministic inventory of every artifact in a repository.
@@ -24,8 +27,12 @@ pub struct RepositoryIndex {
     pub artifacts: Vec<IndexEntry>,
 }
 
-pub fn build_repository_index(directory: &str, recursive: bool) -> RepositoryIndex {
-    let items = corpus_items(directory, recursive);
+fn repository_index_from_items(
+    directory: &str,
+    items: &[CorpusItem],
+    recursive: bool,
+    include_origin: bool,
+) -> RepositoryIndex {
     let artifacts = items
         .iter()
         .map(|it| IndexEntry {
@@ -34,6 +41,7 @@ pub fn build_repository_index(directory: &str, recursive: bool) -> RepositoryInd
             title: it.artifact.product.title.clone(),
             path: it.path.clone(),
             aliases: artifact_identifiers(&it.artifact, it.spec, &it.path),
+            origin: include_origin.then(|| it.origin.clone()),
         })
         .collect();
     RepositoryIndex {
@@ -41,4 +49,20 @@ pub fn build_repository_index(directory: &str, recursive: bool) -> RepositoryInd
         recursive,
         artifacts,
     }
+}
+
+/// Deterministic inventory over a caller-selected projection. Federation
+/// passes the effective items from its authoritative composition here; this
+/// adapter never walks or constructs an overlay independently.
+pub fn build_repository_index_from_items(
+    directory: &str,
+    items: &[CorpusItem],
+    recursive: bool,
+) -> RepositoryIndex {
+    repository_index_from_items(directory, items, recursive, true)
+}
+
+pub fn build_repository_index(directory: &str, recursive: bool) -> RepositoryIndex {
+    let items = corpus_items(directory, recursive);
+    repository_index_from_items(directory, &items, recursive, false)
 }

--- a/rust/rac-engine/src/output.rs
+++ b/rust/rac-engine/src/output.rs
@@ -697,6 +697,9 @@ pub fn render_relationships_json(report: &RelationshipReport) -> String {
             m.insert("path".into(), json!(artifact.path));
             m.insert("type".into(), json!(artifact.type_name));
             m.insert("relationships".into(), Value::Object(relationships));
+            if let Some(origin) = &artifact.origin {
+                m.insert("provenance".into(), artifact_origin_value(origin));
+            }
             Value::Object(m)
         })
         .collect();
@@ -727,7 +730,11 @@ pub fn render_relationships_human(report: &RelationshipReport) -> String {
 
     for artifact in &report.artifacts {
         lines.push(String::new());
-        lines.push(artifact.path.clone());
+        lines.push(format!(
+            "{}{}",
+            artifact.path,
+            human_origin_suffix(artifact.origin.as_ref())
+        ));
         for (section, refs) in &artifact.relationships {
             lines.push(format!("  {}:", relationship_label(section)));
             for reference in refs {
@@ -1559,14 +1566,31 @@ pub fn render_templates_json(names: &[&str]) -> String {
 
 const EMPTY_CORPUS_HINT: &str = "No artifacts yet — create your first with: decided quickstart";
 
-fn invalid_files_json(items: &[(&str, &[String])]) -> Value {
+fn human_origin_suffix(origin: Option<&crate::corpus::ArtifactOrigin>) -> String {
+    let Some(origin) = origin else {
+        return String::new();
+    };
+    let pin = origin
+        .pin
+        .as_ref()
+        .map(|pin| format!(" · {pin}"))
+        .unwrap_or_default();
+    format!("  [{} · {}{pin}]", origin.source, origin.layer.as_str())
+}
+
+fn invalid_files_json(
+    items: &[(&str, &[String], Option<&crate::corpus::ArtifactOrigin>)],
+) -> Value {
     Value::Array(
         items
             .iter()
-            .map(|(path, codes)| {
+            .map(|(path, codes, origin)| {
                 let mut m = Map::new();
                 m.insert("file".into(), json!(path));
                 m.insert("errors".into(), json!(codes));
+                if let Some(origin) = origin {
+                    m.insert("provenance".into(), artifact_origin_value(origin));
+                }
                 Value::Object(m)
             })
             .collect(),
@@ -1604,6 +1628,9 @@ pub fn render_stats_json(s: &PortfolioStats) -> String {
                 let mut m = Map::new();
                 m.insert("name".into(), json!(f.name));
                 m.insert("requirements".into(), json!(f.requirements));
+                if let Some(origin) = &f.origin {
+                    m.insert("provenance".into(), artifact_origin_value(origin));
+                }
                 Value::Object(m)
             }
             None => Value::Null,
@@ -1618,15 +1645,18 @@ pub fn render_stats_json(s: &PortfolioStats) -> String {
                     let mut m = Map::new();
                     m.insert("name".into(), json!(f.name));
                     m.insert("requirements".into(), json!(f.requirements));
+                    if let Some(origin) = &f.origin {
+                        m.insert("provenance".into(), artifact_origin_value(origin));
+                    }
                     Value::Object(m)
                 })
                 .collect(),
         ),
     );
-    let invalid: Vec<(&str, &[String])> = s
+    let invalid: Vec<(&str, &[String], Option<&crate::corpus::ArtifactOrigin>)> = s
         .invalid()
         .iter()
-        .map(|f| (f.path.as_str(), f.error_codes.as_slice()))
+        .map(|f| (f.path.as_str(), f.error_codes.as_slice(), f.origin.as_ref()))
         .collect();
     payload.insert("invalid".into(), invalid_files_json(&invalid));
 
@@ -1646,7 +1676,12 @@ pub fn render_stats_json(s: &PortfolioStats) -> String {
         payload.insert("decisions".into(), Value::Object(m));
     }
 
-    let mut family = |key: &str, count: usize, valid: usize, invalid: Vec<(&str, &[String])>| {
+    let mut family = |
+        key: &str,
+        count: usize,
+        valid: usize,
+        invalid: Vec<(&str, &[String], Option<&crate::corpus::ArtifactOrigin>)>,
+    | {
         let mut m = Map::new();
         m.insert("count".into(), json!(count));
         m.insert("valid".into(), json!(valid));
@@ -1655,26 +1690,26 @@ pub fn render_stats_json(s: &PortfolioStats) -> String {
     };
 
     if !s.roadmaps.is_empty() {
-        let invalid: Vec<(&str, &[String])> = s
+        let invalid: Vec<(&str, &[String], Option<&crate::corpus::ArtifactOrigin>)> = s
             .invalid_roadmaps()
             .iter()
-            .map(|r| (r.path.as_str(), r.error_codes.as_slice()))
+            .map(|r| (r.path.as_str(), r.error_codes.as_slice(), r.origin.as_ref()))
             .collect();
         family("roadmaps", s.roadmap_count(), s.valid_roadmaps(), invalid);
     }
     if !s.prompts.is_empty() {
-        let invalid: Vec<(&str, &[String])> = s
+        let invalid: Vec<(&str, &[String], Option<&crate::corpus::ArtifactOrigin>)> = s
             .invalid_prompts()
             .iter()
-            .map(|p| (p.path.as_str(), p.error_codes.as_slice()))
+            .map(|p| (p.path.as_str(), p.error_codes.as_slice(), p.origin.as_ref()))
             .collect();
         family("prompts", s.prompt_count(), s.valid_prompts(), invalid);
     }
     if !s.designs.is_empty() {
-        let invalid: Vec<(&str, &[String])> = s
+        let invalid: Vec<(&str, &[String], Option<&crate::corpus::ArtifactOrigin>)> = s
             .invalid_designs()
             .iter()
-            .map(|d| (d.path.as_str(), d.error_codes.as_slice()))
+            .map(|d| (d.path.as_str(), d.error_codes.as_slice(), d.origin.as_ref()))
             .collect();
         family("designs", s.design_count(), s.valid_designs(), invalid);
     }
@@ -1692,6 +1727,9 @@ pub fn render_stats_json(s: &PortfolioStats) -> String {
                         fm.insert("file".into(), json!(u.path));
                         fm.insert("name".into(), json!(u.name));
                         fm.insert("confidence".into(), crate::pyjson::py_float(py_round(u.confidence, 2)));
+                        if let Some(origin) = &u.origin {
+                            fm.insert("provenance".into(), artifact_origin_value(origin));
+                        }
                         Value::Object(fm)
                     })
                     .collect(),
@@ -1712,13 +1750,21 @@ pub fn render_stats_json(s: &PortfolioStats) -> String {
 }
 
 /// `  <red path> — <error codes | "unknown">` invalid-list line.
-fn invalid_reason_line(path: &str, error_codes: &[String]) -> String {
+fn invalid_reason_line(
+    path: &str,
+    error_codes: &[String],
+    origin: Option<&crate::corpus::ArtifactOrigin>,
+) -> String {
     let reasons = if error_codes.is_empty() {
         "unknown".to_string()
     } else {
         error_codes.join(", ")
     };
-    format!("  {} \u{2014} {reasons}", red(path))
+    format!(
+        "  {} \u{2014} {reasons}{}",
+        red(path),
+        human_origin_suffix(origin)
+    )
 }
 
 pub fn render_stats_human(s: &PortfolioStats) -> String {
@@ -1736,14 +1782,28 @@ pub fn render_stats_human(s: &PortfolioStats) -> String {
         String::new(),
     ];
 
-    let mut missing_block = |label: &str, names: &[&str]| {
-        lines.push(format!("{label}: {}", names.len()));
-        for name in names {
-            lines.push(format!("  - {name}"));
+    let mut missing_block = |label: &str, features: &[&crate::stats::FeatureStat]| {
+        lines.push(format!("{label}: {}", features.len()));
+        for feature in features {
+            lines.push(format!(
+                "  - {}{}",
+                feature.name,
+                human_origin_suffix(feature.origin.as_ref())
+            ));
         }
     };
-    missing_block("Features Missing Metrics", &s.missing_metrics());
-    missing_block("Features Missing Risks", &s.missing_risks());
+    let missing_metrics: Vec<_> = s
+        .features
+        .iter()
+        .filter(|feature| feature.success_metrics == 0)
+        .collect();
+    let missing_risks: Vec<_> = s
+        .features
+        .iter()
+        .filter(|feature| feature.risks == 0)
+        .collect();
+    missing_block("Features Missing Metrics", &missing_metrics);
+    missing_block("Features Missing Risks", &missing_risks);
     lines.push(format!(
         "Average Requirements Per Feature: {}",
         py_format_1f(s.average_requirements())
@@ -1751,8 +1811,10 @@ pub fn render_stats_human(s: &PortfolioStats) -> String {
 
     match s.largest_feature() {
         Some(f) => lines.push(format!(
-            "Largest Feature: {} ({} requirements)",
-            f.name, f.requirements
+            "Largest Feature: {} ({} requirements){}",
+            f.name,
+            f.requirements,
+            human_origin_suffix(f.origin.as_ref())
         )),
         None => lines.push("Largest Feature: (none)".to_string()),
     }
@@ -1765,7 +1827,12 @@ pub fn render_stats_human(s: &PortfolioStats) -> String {
     if !by_feature.is_empty() {
         let width = by_feature.iter().map(|f| f.name.chars().count()).max().unwrap_or(0) + 4;
         for f in &by_feature {
-            lines.push(format!("{}{}", ljust(&f.name, width), f.requirements));
+            lines.push(format!(
+                "{}{}{}",
+                ljust(&f.name, width),
+                f.requirements,
+                human_origin_suffix(f.origin.as_ref())
+            ));
         }
     } else {
         lines.push("(none)".to_string());
@@ -1776,7 +1843,11 @@ pub fn render_stats_human(s: &PortfolioStats) -> String {
         lines.push(String::new());
         lines.push(bold(&format!("Invalid Features ({})", invalid.len())));
         for f in &invalid {
-            lines.push(invalid_reason_line(&f.path, &f.error_codes));
+            lines.push(invalid_reason_line(
+                &f.path,
+                &f.error_codes,
+                f.origin.as_ref(),
+            ));
         }
     }
 
@@ -1812,7 +1883,11 @@ pub fn render_stats_human(s: &PortfolioStats) -> String {
             lines.push(String::new());
             lines.push(bold(&format!("{invalid_label} ({})", invalid.len())));
             for r in invalid {
-                lines.push(invalid_reason_line(&r.path, &r.error_codes));
+                lines.push(invalid_reason_line(
+                    &r.path,
+                    &r.error_codes,
+                    r.origin.as_ref(),
+                ));
             }
         }
     };
@@ -1838,7 +1913,11 @@ pub fn render_stats_human(s: &PortfolioStats) -> String {
             "{count} {noun} matched no known artifact schema (not errors — see ADR-010):"
         ));
         for u in &s.unrecognized {
-            lines.push(format!("  {}", u.path));
+            lines.push(format!(
+                "  {}{}",
+                u.path,
+                human_origin_suffix(u.origin.as_ref())
+            ));
         }
     }
 
@@ -1922,7 +2001,11 @@ pub fn render_portfolio_human(s: &PortfolioSummary) -> String {
             } else {
                 yellow("!")
             };
-            lines.push(format!("  {icon} {}", item.identifier));
+            lines.push(format!(
+                "  {icon} {}{}",
+                item.identifier,
+                human_origin_suffix(item.origin.as_ref())
+            ));
             lines.push(format!("      {}", item.message));
         }
     } else {
@@ -1980,11 +2063,12 @@ pub fn render_index_human(index: &crate::index::RepositoryIndex) -> String {
     let title_w = width(&|e| title_of(e).chars().count());
     for e in &index.artifacts {
         lines.push(format!(
-            "  {}  {}  {}  {}",
+            "  {}  {}  {}  {}{}",
             ljust(&e.id, id_w),
             ljust(&e.artifact_type, type_w),
             ljust(&title_of(e), title_w),
-            e.path
+            e.path,
+            human_origin_suffix(e.origin.as_ref())
         ));
     }
     lines.join("\n")
@@ -2003,6 +2087,9 @@ pub fn render_index_json(index: &crate::index::RepositoryIndex) -> String {
             m.insert("title".into(), json!(e.title));
             m.insert("path".into(), json!(e.path));
             m.insert("aliases".into(), json!(e.aliases));
+            if let Some(origin) = &e.origin {
+                m.insert("provenance".into(), artifact_origin_value(origin));
+            }
             Value::Object(m)
         })
         .collect();
@@ -2069,6 +2156,9 @@ pub fn portfolio_summary_value(s: &PortfolioSummary) -> Value {
             m.insert("severity".into(), json!(item.severity));
             m.insert("code".into(), json!(item.code));
             m.insert("message".into(), json!(item.message));
+            if let Some(origin) = &item.origin {
+                m.insert("provenance".into(), artifact_origin_value(origin));
+            }
             Value::Object(m)
         })
         .collect();
@@ -2124,7 +2214,12 @@ pub fn render_coverage_human(report: &CoverageReport) -> String {
         }
         lines.push(format!("{heading}: {}", members.len()));
         for gap in members {
-            lines.push(format!("  {}  {}", gap.id, gap.path));
+            lines.push(format!(
+                "  {}  {}{}",
+                gap.id,
+                gap.path,
+                human_origin_suffix(gap.origin.as_ref())
+            ));
         }
         lines.push(String::new());
     }
@@ -2154,6 +2249,9 @@ pub fn render_coverage_json(report: &CoverageReport) -> String {
             m.insert("type".into(), json!(g.artifact_type));
             m.insert("gap".into(), json!(g.gap));
             m.insert("missing".into(), json!(g.missing));
+            if let Some(origin) = &g.origin {
+                m.insert("provenance".into(), artifact_origin_value(origin));
+            }
             Value::Object(m)
         })
         .collect();

--- a/rust/rac-engine/src/portfolio.rs
+++ b/rust/rac-engine/src/portfolio.rs
@@ -32,6 +32,7 @@ pub struct AttentionItem {
     pub severity: String,
     pub code: String,
     pub message: String,
+    pub origin: Option<crate::corpus::ArtifactOrigin>,
 }
 
 #[derive(Debug)]
@@ -91,6 +92,7 @@ pub struct PortfolioRow {
     validate_issues: Vec<crate::parse::Issue>,
     recommended_slots: usize,
     missing_recommended: Vec<String>,
+    origin: crate::corpus::ArtifactOrigin,
 }
 
 pub fn portfolio_row(item: &CorpusItem) -> PortfolioRow {
@@ -109,6 +111,7 @@ pub fn portfolio_row(item: &CorpusItem) -> PortfolioRow {
             validate_issues: Vec::new(),
             recommended_slots: 0,
             missing_recommended: Vec::new(),
+            origin: item.origin.clone(),
         },
         Some(spec) => {
             let (_, missing_rec) = missing_sections(&item.artifact, spec);
@@ -122,6 +125,7 @@ pub fn portfolio_row(item: &CorpusItem) -> PortfolioRow {
                 validate_issues: validate(&item.artifact, None, Some(&artifact_type)),
                 recommended_slots: spec.recommended.len(),
                 missing_recommended: missing_rec,
+                origin: item.origin.clone(),
             }
         }
     }
@@ -159,6 +163,48 @@ pub fn portfolio_from_corpus(
     portfolio_from_rows(directory, &rows, recursive)
 }
 
+/// Portfolio over the authoritative composed effective view. Relationship
+/// metrics and validation come from the same source-aware resolver as lookup
+/// and enforcement rather than an items-only overlay.
+pub fn portfolio_from_composed(
+    directory: &str,
+    corpus: &crate::composition::ComposedCorpus,
+    recursive: bool,
+) -> PortfolioSummary {
+    let items: Vec<CorpusItem> = corpus.effective().cloned().collect();
+    let overrides = load_overrides(directory);
+    portfolio_from_corpus_with_analysis(
+        directory,
+        &items,
+        recursive,
+        &overrides,
+        corpus.relationship_summary(),
+        corpus.validate_relationships(directory, recursive).ok(),
+    )
+}
+
+/// Local-subject portfolio used by doctor/review. Child rows resolve through
+/// the composed catalog, while inherited warnings and advisories remain owned
+/// by the parent corpus.
+pub fn local_portfolio_from_composed(
+    directory: &str,
+    corpus: &crate::composition::ComposedCorpus,
+    recursive: bool,
+) -> PortfolioSummary {
+    let items: Vec<CorpusItem> = corpus.local_items().cloned().collect();
+    let overrides = load_overrides(directory);
+    portfolio_from_corpus_with_analysis(
+        directory,
+        &items,
+        recursive,
+        &overrides,
+        corpus.local_relationship_summary(),
+        corpus
+            .validate_local_relationships(directory, recursive)
+            .ok(),
+    )
+}
+
 pub fn portfolio_from_rows(
     directory: &str,
     rows: &[PortfolioRow],
@@ -176,12 +222,13 @@ pub fn portfolio_from_rows(
         &overrides,
         rel_summary,
         relationships_ok,
+        false,
     )
 }
 
 /// Build a portfolio from the central composed relationship projection and
 /// the exact child-config snapshot belonging to the generation.
-pub(crate) fn portfolio_from_corpus_with_analysis(
+pub fn portfolio_from_corpus_with_analysis(
     directory: &str,
     items: &[CorpusItem],
     recursive: bool,
@@ -189,7 +236,17 @@ pub(crate) fn portfolio_from_corpus_with_analysis(
     relationship_summary: RelationshipSummary,
     relationships_ok: bool,
 ) -> PortfolioSummary {
-    let rows: Vec<PortfolioRow> = items.iter().map(portfolio_row).collect();
+    let rows: Vec<PortfolioRow> = items
+        .iter()
+        .map(|item| {
+            let mut row = portfolio_row(item);
+            if item.origin.layer == crate::corpus::Layer::Inherited {
+                row.validate_issues.clear();
+                row.missing_recommended.clear();
+            }
+            row
+        })
+        .collect();
     portfolio_from_rows_with_analysis(
         directory,
         &rows,
@@ -197,6 +254,7 @@ pub(crate) fn portfolio_from_corpus_with_analysis(
         overrides,
         relationship_summary,
         relationships_ok,
+        true,
     )
 }
 
@@ -207,6 +265,7 @@ fn portfolio_from_rows_with_analysis(
     overrides: &SeverityOverrides,
     rel_summary: RelationshipSummary,
     relationships_ok: bool,
+    include_provenance: bool,
 ) -> PortfolioSummary {
 
     let mut by_type: Vec<(String, usize)> =
@@ -227,6 +286,10 @@ fn portfolio_from_rows_with_analysis(
     let mut unknown_paths: Vec<String> = Vec::new();
     let mut path_to_identifier: std::collections::HashMap<String, String> =
         std::collections::HashMap::new();
+    let mut artifact_path_to_identifier: std::collections::HashMap<
+        crate::corpus::ArtifactPath,
+        String,
+    > = std::collections::HashMap::new();
 
     for row in rows {
         bump(&mut by_type, &row.artifact_type);
@@ -235,6 +298,10 @@ fn portfolio_from_rows_with_analysis(
             continue;
         }
         path_to_identifier.insert(row.path.clone(), row.identifier.clone());
+        artifact_path_to_identifier.insert(
+            row.validation.artifact_path.clone(),
+            row.identifier.clone(),
+        );
 
         let issues = apply_overrides(row.validate_issues.clone(), &row.artifact_type, overrides);
         if has_errors(&issues) {
@@ -250,6 +317,7 @@ fn portfolio_from_rows_with_analysis(
                 severity: "error".to_string(),
                 code: ATTENTION_INVALID.to_string(),
                 message: format!("Validation errors: {}", error_codes.join(", ")),
+                origin: include_provenance.then(|| row.origin.clone()),
             });
         } else {
             valid_count += 1;
@@ -267,6 +335,7 @@ fn portfolio_from_rows_with_analysis(
                 severity: "warning".to_string(),
                 code: ATTENTION_MISSING_RECOMMENDED.to_string(),
                 message: format!("Missing recommended sections: {}", names.join(", ")),
+                origin: include_provenance.then(|| row.origin.clone()),
             });
         }
     }
@@ -275,10 +344,19 @@ fn portfolio_from_rows_with_analysis(
         let source = issue.source_path.clone().unwrap_or_default();
         let label = py_title(&issue.relationship.clone().unwrap_or_default().replace('_', " "));
         let phrase = rel_issue_phrase(&issue.code);
-        let identifier = path_to_identifier
-            .get(&source)
-            .cloned()
-            .unwrap_or_else(|| source.clone());
+        let identifier = if include_provenance {
+            issue
+                .source_artifact
+                .as_ref()
+                .and_then(|path| artifact_path_to_identifier.get(path))
+                .cloned()
+                .unwrap_or_else(|| source.clone())
+        } else {
+            path_to_identifier
+                .get(&source)
+                .cloned()
+                .unwrap_or_else(|| source.clone())
+        };
         attention.push(AttentionItem {
             path: source,
             identifier,
@@ -288,6 +366,11 @@ fn portfolio_from_rows_with_analysis(
                 "{label} {phrase}: {}",
                 issue.target.clone().unwrap_or_default()
             ),
+            origin: if include_provenance {
+                issue.origin.clone()
+            } else {
+                None
+            },
         });
     }
 

--- a/rust/rac-engine/src/relationships.rs
+++ b/rust/rac-engine/src/relationships.rs
@@ -989,6 +989,7 @@ pub(crate) fn validation_from_rows_with_index(
 pub struct ArtifactRelationships {
     pub path: String,
     pub type_name: String,
+    pub origin: Option<ArtifactOrigin>,
     /// `(snake_section, refs)` in `spec.optional` order.
     pub relationships: Vec<(String, Vec<String>)>,
 }
@@ -1101,11 +1102,71 @@ fn build_report(directory: &str, items: Vec<CorpusItem>, recursive: bool) -> Rel
             artifacts.push(ArtifactRelationships {
                 path: item.path.clone(),
                 type_name: spec.name.clone(),
+                origin: None,
                 relationships,
             });
         }
     }
     let labels = resolution_labels(&artifacts, &items);
+    RelationshipReport {
+        directory: directory.to_string(),
+        recursive,
+        total_files: items.len(),
+        artifacts,
+        labels,
+    }
+}
+
+/// Relationship inspection over the authoritative effective view. Labels
+/// resolve through `ComposedCorpus::resolve`, so qualified aliases and
+/// canonical override redirects match every other reader.
+pub fn build_relationship_report_from_composed(
+    directory: &str,
+    recursive: bool,
+    corpus: &crate::composition::ComposedCorpus,
+) -> RelationshipReport {
+    let items: Vec<&CorpusItem> = corpus.effective().collect();
+    let mut artifacts = Vec::new();
+    for item in &items {
+        let Some(spec) = item.spec else {
+            continue;
+        };
+        let relationships = extract_relationships_full(&item.artifact, spec);
+        if !relationships.is_empty() {
+            artifacts.push(ArtifactRelationships {
+                path: item.path.clone(),
+                type_name: spec.name.clone(),
+                origin: Some(item.origin.clone()),
+                relationships,
+            });
+        }
+    }
+    let mut labels = HashMap::new();
+    for artifact in &artifacts {
+        for (_, references) in &artifact.relationships {
+            for reference in references {
+                let folded = py_casefold(reference);
+                if labels.contains_key(&folded) {
+                    continue;
+                }
+                let Ok(item) = corpus.resolve(reference) else {
+                    continue;
+                };
+                let type_name = item.spec.map(|spec| spec.name.as_str()).unwrap_or("unknown");
+                let display = item
+                    .artifact
+                    .product
+                    .title
+                    .as_deref()
+                    .filter(|title| !title.is_empty())
+                    .unwrap_or(&item.key.canonical_id);
+                labels.insert(
+                    folded,
+                    format!("{display} ({type_name} · {})", item.key.canonical_id),
+                );
+            }
+        }
+    }
     RelationshipReport {
         directory: directory.to_string(),
         recursive,

--- a/rust/rac-engine/src/resolve.rs
+++ b/rust/rac-engine/src/resolve.rs
@@ -1148,7 +1148,7 @@ pub fn artifact_status(artifact: &Artifact) -> String {
 }
 
 /// `agent_rules.is_live_decision`: Accepted and not retired.
-pub(crate) fn is_live_decision(artifact: &Artifact) -> bool {
+pub fn is_live_decision(artifact: &Artifact) -> bool {
     let status = py_casefold(&artifact_status(artifact));
     if status != "accepted" {
         return false;

--- a/rust/rac-engine/src/review.rs
+++ b/rust/rac-engine/src/review.rs
@@ -120,6 +120,7 @@ pub fn review_from_portfolio(
             severity,
             code,
             message,
+            origin: _,
         } = item;
         let priority = attention_priority(code);
         let action = if code == ATTENTION_INVALID {
@@ -187,6 +188,39 @@ pub fn build_review(
     report
 }
 
+pub fn build_review_composed(
+    directory: &str,
+    recursive: bool,
+    stale_after_days: Option<i64>,
+    corpus: &crate::composition::ComposedCorpus,
+) -> ReviewReport {
+    let items: Vec<CorpusItem> = corpus.local_items().cloned().collect();
+    let portfolio = crate::portfolio::local_portfolio_from_composed(directory, corpus, recursive);
+    let mut report = review_from_portfolio(directory, portfolio, recursive);
+    let child_source = corpus.child_source();
+    let local_relationships: Vec<crate::relationships::Relationship> = corpus
+        .local_relationships()
+        .into_iter()
+        .filter(|relationship| {
+            relationship
+                .resolved_artifact
+                .as_ref()
+                .is_some_and(|path| Some(path.source.as_str()) == child_source)
+        })
+        .collect();
+    let mut advisories = drift_findings_from_relationships(directory, &local_relationships);
+    if let Some(window) = stale_after_days {
+        if let Some(finding) = cadence_finding(directory, &items, window) {
+            advisories.push(finding);
+        }
+    }
+    if !advisories.is_empty() {
+        report.issues.extend(advisories);
+        sort_issues(&mut report.issues);
+    }
+    report
+}
+
 // --- git-native drift --------------------------------------------------------
 
 pub(crate) struct DriftRecord {
@@ -205,13 +239,20 @@ pub(crate) fn suspect_drift(directory: &str, items: &[CorpusItem]) -> Vec<DriftR
         .into_iter()
         .filter(|r| r.resolved_path.is_some())
         .collect();
+    suspect_drift_from_relationships(directory, &resolved)
+}
+
+fn suspect_drift_from_relationships(
+    directory: &str,
+    resolved: &[crate::relationships::Relationship],
+) -> Vec<DriftRecord> {
     if resolved.is_empty() {
         return Vec::new();
     }
 
     let mut involved: Vec<PathBuf> = Vec::new();
     let mut seen_paths: std::collections::HashSet<String> = std::collections::HashSet::new();
-    for rel in &resolved {
+    for rel in resolved {
         for p in [&rel.source_path, rel.resolved_path.as_ref().unwrap()] {
             if seen_paths.insert(p.clone()) {
                 involved.push(PathBuf::from(p));
@@ -226,7 +267,7 @@ pub(crate) fn suspect_drift(directory: &str, items: &[CorpusItem]) -> Vec<DriftR
 
     let mut records: Vec<DriftRecord> = Vec::new();
     let mut seen: std::collections::HashSet<(String, String)> = std::collections::HashSet::new();
-    for rel in &resolved {
+    for rel in resolved {
         let target_path = rel.resolved_path.clone().unwrap();
         let source_when = committed.get(&rel.source_path).and_then(|v| v.clone());
         let target_when = committed.get(&target_path).and_then(|v| v.clone());
@@ -263,6 +304,25 @@ pub(crate) fn suspect_drift(directory: &str, items: &[CorpusItem]) -> Vec<DriftR
 
 fn drift_findings(directory: &str, items: &[CorpusItem]) -> Vec<ReviewIssue> {
     suspect_drift(directory, items)
+        .into_iter()
+        .map(|record| ReviewIssue {
+            priority: PRIORITY_SUSPECT_DRIFT,
+            severity: "warning".to_string(),
+            path: record.source_path.clone(),
+            identifier: crate::identity::path_stem(&record.source_path),
+            code: REVIEW_SUSPECT_ARTIFACT.to_string(),
+            message: drift_problem(&record),
+            action: format!("Run: decided doctor {directory}"),
+            impact: impact_for(REVIEW_SUSPECT_ARTIFACT).to_string(),
+        })
+        .collect()
+}
+
+fn drift_findings_from_relationships(
+    directory: &str,
+    relationships: &[crate::relationships::Relationship],
+) -> Vec<ReviewIssue> {
+    suspect_drift_from_relationships(directory, relationships)
         .into_iter()
         .map(|record| ReviewIssue {
             priority: PRIORITY_SUSPECT_DRIFT,

--- a/rust/rac-engine/src/stats.rs
+++ b/rust/rac-engine/src/stats.rs
@@ -5,9 +5,10 @@
 //! plus declared relationship-presence counts. Pure and deterministic.
 
 use crate::classify::classify;
+use crate::corpus::ArtifactOrigin;
 use crate::parse::Artifact;
 use crate::pycompat::first_nonempty_line;
-use crate::relationships::corpus_items;
+use crate::relationships::{corpus_items, CorpusItem};
 use crate::spec::{spec_for, ArtifactSpec, RELATIONSHIP_SECTIONS};
 use crate::validate::validate;
 
@@ -20,6 +21,8 @@ pub struct FeatureStat {
     pub requirements: usize,
     pub success_metrics: usize,
     pub risks: usize,
+    /// Present only when the row came from an explicit composed projection.
+    pub origin: Option<ArtifactOrigin>,
 }
 
 /// Per-file result for a Decision artifact.
@@ -28,6 +31,8 @@ pub struct DecisionStat {
     pub name: String,
     pub status: Option<String>,
     pub category: Option<String>,
+    /// Present only when the row came from an explicit composed projection.
+    pub origin: Option<ArtifactOrigin>,
 }
 
 /// Lightweight validity stat for roadmap/prompt/design.
@@ -36,6 +41,8 @@ pub struct ValidityStat {
     pub name: String,
     pub valid: bool,
     pub error_codes: Vec<String>,
+    /// Present only when the row came from an explicit composed projection.
+    pub origin: Option<ArtifactOrigin>,
 }
 
 /// Per-file result for a document that matched no known schema.
@@ -43,6 +50,8 @@ pub struct UnrecognizedStat {
     pub path: String,
     pub name: String,
     pub confidence: f64,
+    /// Present only when the row came from an explicit composed projection.
+    pub origin: Option<ArtifactOrigin>,
 }
 
 pub struct PortfolioStats {
@@ -319,8 +328,11 @@ fn decision_metadata(
     (status, category)
 }
 
-/// `collect_stats(directory)`.
-pub fn collect_stats(directory: &str) -> PortfolioStats {
+fn collect_stats_from_projection(
+    directory: &str,
+    items: &[CorpusItem],
+    include_origin: bool,
+) -> PortfolioStats {
     let mut stats = PortfolioStats {
         directory: directory.to_string(),
         features: Vec::new(),
@@ -335,9 +347,10 @@ pub fn collect_stats(directory: &str) -> PortfolioStats {
     // re-ordered canonically at the end.
     let mut rel_counts: Vec<(String, usize)> = Vec::new();
 
-    for item in corpus_items(directory, true) {
+    for item in items {
         let artifact = &item.artifact;
         let path = &item.path;
+        let origin = include_origin.then(|| item.origin.clone());
         let name = artifact_name(artifact, path);
         let classification = classify(artifact);
         let type_name = classification.artifact_type.as_str();
@@ -361,6 +374,7 @@ pub fn collect_stats(directory: &str) -> PortfolioStats {
                     name,
                     status,
                     category,
+                    origin,
                 });
             }
             "roadmap" => {
@@ -370,6 +384,7 @@ pub fn collect_stats(directory: &str) -> PortfolioStats {
                     name,
                     valid: codes.is_empty(),
                     error_codes: codes,
+                    origin,
                 });
             }
             "prompt" => {
@@ -379,6 +394,7 @@ pub fn collect_stats(directory: &str) -> PortfolioStats {
                     name,
                     valid: codes.is_empty(),
                     error_codes: codes,
+                    origin,
                 });
             }
             "design" => {
@@ -388,6 +404,7 @@ pub fn collect_stats(directory: &str) -> PortfolioStats {
                     name,
                     valid: codes.is_empty(),
                     error_codes: codes,
+                    origin,
                 });
             }
             "unknown" => {
@@ -395,6 +412,7 @@ pub fn collect_stats(directory: &str) -> PortfolioStats {
                     path: path.clone(),
                     name,
                     confidence: classification.confidence,
+                    origin,
                 });
             }
             _ => {
@@ -407,6 +425,7 @@ pub fn collect_stats(directory: &str) -> PortfolioStats {
                     requirements: artifact.product.requirements.len(),
                     success_metrics: artifact.product.success_metrics.len(),
                     risks: artifact.product.risks.len(),
+                    origin,
                 });
             }
         }
@@ -419,6 +438,19 @@ pub fn collect_stats(directory: &str) -> PortfolioStats {
         }
     }
     stats
+}
+
+/// Aggregate a caller-selected projection without performing another corpus
+/// walk. Federation passes its effective items here so counts and provenance
+/// describe the same authoritative overlay as other read consumers.
+pub fn collect_stats_from_items(directory: &str, items: &[CorpusItem]) -> PortfolioStats {
+    collect_stats_from_projection(directory, items, true)
+}
+
+/// `collect_stats(directory)`.
+pub fn collect_stats(directory: &str) -> PortfolioStats {
+    let items = corpus_items(directory, true);
+    collect_stats_from_projection(directory, &items, false)
 }
 
 #[cfg(test)]

--- a/rust/rac-engine/tests/composition.rs
+++ b/rust/rac-engine/tests/composition.rs
@@ -87,6 +87,37 @@ Composition needs one resolver.
     )
 }
 
+fn item_with_canonical_and_legacy(
+    relative_path: &str,
+    canonical_id: &str,
+    legacy_id: &str,
+) -> CorpusItem {
+    let text = format!(
+        "---\nschema_version: 1\nid: {canonical_id}\ntype: decision\n---\n# Qualified fixture\n\n## ID\n\n{legacy_id}\n\n## Status\n\nAccepted\n\n## Context\n\nComposition fixture.\n\n## Decision\n\nKeep qualification canonical.\n\n## Consequences\n\nAliases cannot bypass qualification.\n"
+    );
+    let origin = CorpusLayer::inherited(
+        PARENT_SOURCE,
+        PARENT_ALIAS,
+        "sha256:0123456789abcdef",
+    )
+    .origin();
+    let display = format!("/runtime/{PARENT_SOURCE}/{relative_path}");
+    CorpusItem::new(
+        display.clone(),
+        relative_path.to_string(),
+        parse_text(&text, &display),
+        spec_for("decision"),
+        origin,
+        PhysicalArtifactLocator::new(
+            PhysicalCorpusLocator::new(
+                format!("/runtime/{PARENT_SOURCE}"),
+                format!("/runtime/{PARENT_SOURCE}/decisions"),
+            ),
+            display,
+        ),
+    )
+}
+
 fn declaration(parent_id: &str, replacement: &str, rationale: &str) -> OverrideDeclaration {
     OverrideDeclaration::parse(
         &format!("{PARENT_ALIAS}::{parent_id}"),
@@ -178,6 +209,15 @@ fn aliases_are_unique_only_and_qualification_requires_a_canonical_id() {
         corpus.resolve("shared"),
         Err(LookupError::Ambiguous(keys)) if keys.len() == 2
     ));
+    let duplicate = corpus.resolve_identity("shared");
+    assert_eq!(duplicate.outcome, rac_engine::resolve::OUTCOME_DUPLICATE);
+    assert_eq!(
+        duplicate.duplicate_paths,
+        vec![
+            "acme/app::shared.md".to_string(),
+            "acme/standards::shared.md".to_string(),
+        ]
+    );
     assert_eq!(
         lookup_error(&corpus, "standards::shared"),
         LookupError::QualifiedCanonicalRequired
@@ -188,6 +228,33 @@ fn aliases_are_unique_only_and_qualification_requires_a_canonical_id() {
     );
     let resolved = corpus.resolve("standards::std-001").unwrap();
     assert_eq!(resolved.key, ArtifactKey::new(PARENT_SOURCE, "STD-001"));
+}
+
+#[test]
+fn qualified_resolution_rejects_legacy_and_unknown_aliases() {
+    let inherited = item_with_canonical_and_legacy(
+        "qualified.md",
+        "STD-KWJ4VMKVSS66",
+        "standards::legacy-name",
+    );
+    let corpus = ComposedCorpus::compose(Vec::new(), vec![inherited], parent(), Vec::new());
+
+    assert_eq!(
+        corpus.resolve_identity("standards::STD-KWJ4VMKVSS66").outcome,
+        rac_engine::resolve::OUTCOME_RESOLVED
+    );
+    for invalid in [
+        "standards::legacy-name",
+        "other::STD-KWJ4VMKVSS66",
+        "standards::UNKNOWN",
+        "standards::STD::CANONICAL",
+    ] {
+        assert_eq!(
+            corpus.resolve_identity(invalid).outcome,
+            rac_engine::resolve::OUTCOME_NOT_FOUND,
+            "{invalid} must not bypass qualified canonical validation"
+        );
+    }
 }
 
 #[test]

--- a/rust/rac-engine/tests/federated_cache.rs
+++ b/rust/rac-engine/tests/federated_cache.rs
@@ -37,7 +37,7 @@ The cache fixture is deterministic.
 
 ## Applies To
 
-- `src/**`
+- src/**
 "#;
 
 const PARENT_DECISION: &str = r#"---
@@ -65,7 +65,7 @@ The pin changes with these bytes.
 
 ## Applies To
 
-- `src/**`
+- src/**
 "#;
 
 fn scratch(tag: &str) -> PathBuf {
@@ -134,7 +134,7 @@ fn child_corpus(child: &Path) -> String {
 
 fn shared_decision(id: &str) -> String {
     format!(
-        "---\nschema_version: 1\nid: {id}\ntype: decision\n---\n# ADR-900: Shared Policy\n\n## Status\n\nAccepted\n\n## Context\n\nEqualmarker context.\n\n## Decision\n\nEqualmarker decision.\n\n## Consequences\n\nEqualmarker consequence.\n\n## Applies To\n\n- `src/**`\n"
+        "---\nschema_version: 1\nid: {id}\ntype: decision\n---\n# ADR-900: Shared Policy\n\n## Status\n\nAccepted\n\n## Context\n\nEqualmarker context.\n\n## Decision\n\nEqualmarker decision.\n\n## Consequences\n\nEqualmarker consequence.\n\n## Applies To\n\n- src/**\n"
     )
 }
 
@@ -596,4 +596,110 @@ fn no_manifest_keeps_the_single_corpus_content_key() {
     assert!(generation.identity().is_none());
     assert!(generation.verified_parent().is_none());
     fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn ancillary_readers_share_effective_and_local_composed_projections() {
+    let (child, _parent, _pin) = fixture("ancillary-readers");
+    let directory = child_corpus(&child);
+    let corpus = rac_engine::federated_corpus::load_composed_corpus(&directory, true)
+        .unwrap()
+        .unwrap();
+    let effective: Vec<_> = corpus.effective().cloned().collect();
+
+    let index = rac_engine::index::build_repository_index_from_items(&directory, &effective, true);
+    assert_eq!(index.artifacts.len(), 2);
+    assert!(index.artifacts.iter().all(|row| row.origin.is_some()));
+    let stats = rac_engine::stats::collect_stats_from_items(&directory, &effective);
+    assert_eq!(stats.decisions.len(), 2);
+    assert!(stats.decisions.iter().all(|row| row.origin.is_some()));
+
+    let portfolio = rac_engine::portfolio::portfolio_from_composed(&directory, &corpus, true);
+    assert_eq!(portfolio.total_artifacts(), 2);
+    let coverage = rac_engine::coverage::analyze_coverage_from_composed(&directory, &corpus);
+    assert_eq!(coverage.gaps.len(), 2);
+    assert!(coverage.gaps.iter().all(|gap| gap.origin.is_some()));
+    let relationships = rac_engine::relationships::build_relationship_report_from_composed(
+        &directory,
+        true,
+        &corpus,
+    );
+    assert_eq!(relationships.total_files, 2);
+    assert!(relationships
+        .artifacts
+        .iter()
+        .all(|artifact| artifact.origin.is_some()));
+
+    let doctor = rac_engine::doctor::diagnose_composed(&directory, true, 20, &corpus);
+    assert!(doctor
+        .findings
+        .iter()
+        .all(|finding| finding.path != "parent.md"));
+    let review = rac_engine::review::build_review_composed(&directory, true, None, &corpus);
+    assert_eq!(review.portfolio.total_artifacts(), 1);
+    assert!(review.issues.iter().all(|issue| issue.path != "parent.md"));
+
+    let herald = rac_engine::herald::collect_from_composed(
+        &directory,
+        &["src/main.rs".to_string()],
+        &corpus,
+    );
+    let scope_rows = rac_engine::retrieve::scope_rows_from_items(&effective);
+    assert_eq!(scope_rows.len(), 2);
+    assert_eq!(scope_rows[0].scope_entries, vec!["src/**".to_string()]);
+    assert_eq!(herald.decisions.len(), 2);
+    let body = rac_engine::herald::render(&herald, "https://example.test/child", 10);
+    assert!(body.contains("https://example.test/child/child.md"));
+    assert!(!body.contains("https://example.test/child/parent.md"));
+
+    let proposal = rac_engine::parse::parse_text(
+        &CHILD_DECISION.replace(
+            "## Consequences",
+            "## Related Decisions\n\n- standards::STD-KWJ4VMKVSS66\n\n## Consequences",
+        ),
+        "-",
+    );
+    let validation = corpus.validate_proposed_document(&proposal, "-", &directory, true);
+    assert!(validation.issues.is_empty());
+
+    fs::remove_dir_all(child).unwrap();
+}
+
+#[test]
+fn composed_portfolio_disambiguates_equal_relative_paths_by_source() {
+    let (child, parent, _pin) = fixture("portfolio-equal-paths");
+    fs::remove_file(child.join("decisions/child.md")).unwrap();
+    fs::remove_file(parent.join("decisions/parent.md")).unwrap();
+    fs::write(
+        child.join("decisions/shared.md"),
+        CHILD_DECISION.replace(
+            "## Consequences",
+            "## Related Decisions\n\n- APP-DOES-NOT-EXIST\n\n## Consequences",
+        ),
+    )
+    .unwrap();
+    fs::write(parent.join("decisions/shared.md"), PARENT_DECISION).unwrap();
+    let pin = calculate_parent_digest(&parent, "decisions")
+        .unwrap()
+        .digest;
+    write_manifest(&child, &pin, "equal-relative-paths");
+
+    let directory = child_corpus(&child);
+    let corpus = rac_engine::federated_corpus::load_composed_corpus(&directory, true)
+        .unwrap()
+        .unwrap();
+    let portfolio = rac_engine::portfolio::portfolio_from_composed(&directory, &corpus, true);
+    let relationship = portfolio
+        .attention
+        .iter()
+        .find(|item| item.code == rac_engine::portfolio::ATTENTION_BROKEN_RELATIONSHIP)
+        .expect("local broken relationship attention");
+    assert_eq!(relationship.path, "shared.md");
+    assert_eq!(relationship.identifier, "APP-KWJ4VMKVSS65");
+    assert_eq!(
+        relationship.origin.as_ref().map(|origin| origin.source.as_str()),
+        Some("acme/app")
+    );
+
+    fs::remove_dir_all(child).unwrap();
 }

--- a/rust/rac-engine/tests/source_aware_substrate.rs
+++ b/rust/rac-engine/tests/source_aware_substrate.rs
@@ -121,6 +121,7 @@ fn no_manifest_keeps_the_released_index_projection_byte_exact() {
                 title: item.artifact.product.title.clone(),
                 path: item.path.clone(),
                 aliases: artifact_identifiers(&item.artifact, item.spec, &item.path),
+                origin: None,
             })
             .collect(),
     };
@@ -155,6 +156,41 @@ fn no_manifest_keeps_the_released_index_projection_byte_exact() {
 
     // ADR-143 gates source-aware persisted rows behind an explicit layout.
     assert_eq!(rac_engine::index_store::STORE_LAYOUT_VERSION, "v2");
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn explicit_item_projections_add_index_and_stats_provenance() {
+    let root = scratch("read-projections");
+    fs::write(root.join("decisions/req-002.md"), REQUIREMENT).unwrap();
+    let directory = corpus_arg(&root);
+    let items = rac_engine::relationships::corpus_items(&directory, true);
+
+    let legacy_index = rac_engine::index::build_repository_index(&directory, true);
+    assert!(legacy_index.artifacts.iter().all(|row| row.origin.is_none()));
+    assert!(!rac_engine::output::render_index_json(&legacy_index).contains("provenance"));
+    let projected_index =
+        rac_engine::index::build_repository_index_from_items(&directory, &items, true);
+    assert_eq!(
+        projected_index.artifacts[0].origin.as_ref(),
+        Some(&items[0].origin)
+    );
+    assert!(rac_engine::output::render_index_json(&projected_index).contains("provenance"));
+    assert!(rac_engine::output::render_index_human(&projected_index).contains("acme/app · local"));
+
+    let legacy_stats = rac_engine::stats::collect_stats(&directory);
+    assert!(legacy_stats.features.iter().all(|row| row.origin.is_none()));
+    assert!(!rac_engine::output::render_stats_json(&legacy_stats).contains("provenance"));
+    let projected_stats = rac_engine::stats::collect_stats_from_items(&directory, &items);
+    let feature = projected_stats.features.first().expect("requirement feature");
+    let matching_item = items
+        .iter()
+        .find(|item| item.path == feature.path)
+        .expect("projected feature item");
+    assert_eq!(feature.origin.as_ref(), Some(&matching_item.origin));
+    assert!(rac_engine::output::render_stats_json(&projected_stats).contains("provenance"));
+    assert!(rac_engine::output::render_stats_human(&projected_stats).contains("acme/app · local"));
 
     let _ = fs::remove_dir_all(root);
 }


### PR DESCRIPTION
## Summary

- activate the central source-aware composition across remaining CLI read surfaces, local-subject diagnostics, Herald, and stdin proposal validation
- serve all six MCP tools from one freshly verified logical generation with cache-on/cache-off parity, qualified parent history, canonical override redirects, bounded provenance, and stale-parent refusal
- fail closed when federation topology, child config, manifest shape, source, or pin changes; audit preparation failures exactly once with no stale returned identity
- use the central composed resolver for both exact MCP tools, source-distinct ambiguity paths, canonical-only qualified references, and effective-vs-qualified-history graph projections
- retain source-aware identities through graph traversal, audit returned records, relationship findings, response budgets, summaries, and local Git recency without assigning child history to inherited artifacts
- extend the existing DecisionGrounding evaluation with a 40-artifact parent, lexical hard negatives, and a high-inbound graph decoy while preserving the v0.28 graph-floor invariant
- keep no-manifest repositories on the released single-corpus paths

## Stack

- depends on #458
- next: inherited export composition and Portal identity

Closes #270

## Validation

- `cargo test --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- MCP: 18 unit tests and 39 integration tests, including 8 federation and 14 HTTP tests
- composition: 9/9
- federated cache: 10/10
- `decided eval --check` federation track
- `decided validate decisions/`: 462 valid, 0 invalid, 12 skipped
- `decided relationships decisions/ --validate`: 2,931 checked, 0 issues
- `decided gate decisions/`: 0 blocking, 134 existing advisories
- `git diff --check`

All listed checks pass; one intentional differential test remains ignored.