### PR TITLE
feat(federation): activate verified corpus graphs

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -40,6 +40,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -47,6 +48,15 @@ name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bstr"
@@ -102,6 +112,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -127,11 +146,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "decided"
 version = "0.28.0"
 dependencies = [
  "asdecided-core",
  "serde_json",
+ "sha2",
 ]
 
 [[package]]
@@ -141,6 +171,7 @@ dependencies = [
  "asdecided-core",
  "serde",
  "serde_json",
+ "sha2",
 ]
 
 [[package]]
@@ -165,6 +196,16 @@ dependencies = [
  "quote",
  "rustc_version",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -196,6 +237,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
 
 [[package]]
 name = "globset"
@@ -524,6 +575,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -580,6 +642,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -617,6 +685,12 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "windows-link"

--- a/rust/decided-mcp/Cargo.toml
+++ b/rust/decided-mcp/Cargo.toml
@@ -16,3 +16,6 @@ publish = ["crates-io"]
 rac-engine = { package = "asdecided-core", version = "=0.28.0", path = "../rac-engine" }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
+
+[dev-dependencies]
+sha2 = "0.10"

--- a/rust/decided-mcp/src/graph.rs
+++ b/rust/decided-mcp/src/graph.rs
@@ -146,6 +146,14 @@ impl GraphView {
         )
     }
 
+    pub fn from_graph(corpus: &rac_engine::graph_composition::GraphComposition) -> Self {
+        Self::new_with_history(
+            corpus.identity_index(),
+            corpus.relationships(),
+            Some(corpus.catalog_relationships_compatible()),
+        )
+    }
+
     pub fn new(entries: Vec<IndexEntry>, relationships: Vec<Relationship>) -> Self {
         Self::new_with_history(entries, relationships, None)
     }
@@ -701,6 +709,34 @@ impl GraphCache {
             self.builds += 1;
         }
         self.view.as_ref().expect("federated graph view built")
+    }
+
+    pub fn view_for_graph(
+        &mut self,
+        generation: &str,
+        corpus: &rac_engine::graph_composition::GraphComposition,
+    ) -> &GraphView {
+        if self.federated_generation.as_deref() != Some(generation)
+            || self.generation.is_some()
+            || self.view.is_none()
+        {
+            let started = rac_engine::timing::start();
+            let replacement = GraphView::from_graph(corpus);
+            rac_engine::timing::emit_since(
+                "graph.view_build",
+                started,
+                &[
+                    ("entries", replacement.entry_count() as u64),
+                    ("relationships", replacement.relationship_count() as u64),
+                    ("payload_bytes", replacement.estimated_payload_bytes() as u64),
+                ],
+            );
+            self.view = Some(replacement);
+            self.generation = None;
+            self.federated_generation = Some(generation.to_string());
+            self.builds += 1;
+        }
+        self.view.as_ref().expect("graph federation view built")
     }
 
     #[cfg(test)]

--- a/rust/decided-mcp/src/main.rs
+++ b/rust/decided-mcp/src/main.rs
@@ -30,14 +30,24 @@ const TOOLS_LIST_RESULT: &str = include_str!("tools_list_result.json");
 
 pub(crate) struct ServerState {
     repository_root: PathBuf,
-    federation_seen: bool,
+    root_corpus_relative: String,
+    federation_mode: Option<FederationMode>,
+    persistent_cache: bool,
     tracker: Option<rac_engine::freshness::FreshnessTracker>,
     federated_tracker: Option<
         rac_engine::derived_cache::FederatedCacheTracker<
             rac_engine::composition::ComposedCorpus,
         >,
     >,
+    graph_tracker: rac_engine::derived_cache::GraphFederatedCacheTracker,
     graph_cache: graph::GraphCache,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum FederationMode {
+    Unknown,
+    V1,
+    V2,
 }
 
 enum RequestRead<'a> {
@@ -55,6 +65,7 @@ enum RequestRead<'a> {
         generation: rac_engine::derived_cache::LogicalGeneration,
         composed: Box<rac_engine::composition::ComposedCorpus>,
     },
+    Graph(rac_engine::derived_cache::GraphFederatedCacheRead<'a>),
 }
 
 impl RequestRead<'_> {
@@ -69,7 +80,7 @@ impl RequestRead<'_> {
         match self {
             Self::FederatedCached(read) => Some(read.composed),
             Self::FederatedFresh { composed, .. } => Some(composed),
-            Self::Legacy { .. } => None,
+            Self::Legacy { .. } | Self::Graph(_) => None,
         }
     }
 
@@ -84,7 +95,14 @@ impl RequestRead<'_> {
         match self {
             Self::FederatedCached(read) => Some(read.generation),
             Self::FederatedFresh { generation, .. } => Some(generation),
-            Self::Legacy { .. } => None,
+            Self::Legacy { .. } | Self::Graph(_) => None,
+        }
+    }
+
+    fn graph(&self) -> Option<&rac_engine::derived_cache::GraphFederatedCacheRead<'_>> {
+        match self {
+            Self::Graph(read) => Some(read),
+            _ => None,
         }
     }
 }
@@ -190,8 +208,8 @@ fn main() {
     if !std::path::Path::new(&root).is_dir() {
         usage_error(&format!("not a directory: {root}"));
     }
-    let mut federation_seen = false;
-    let topology = repository_topology(&root, None, &mut federation_seen)
+    let mut federation_mode = None;
+    let topology = repository_topology(&root, None, &mut federation_mode)
         .unwrap_or_else(|error| usage_error(&error));
     check_corpus(&root, &topology);
     // Server-lifetime freshness (ADR-105/118): one tracker per server keeps
@@ -215,9 +233,14 @@ fn main() {
     };
     let mut state = ServerState {
         repository_root: topology.repository_root,
-        federation_seen,
+        root_corpus_relative: topology.root_corpus_relative,
+        federation_mode,
+        persistent_cache: rac_engine::derived_cache::cache_enabled(cache),
         tracker,
         federated_tracker,
+        graph_tracker: rac_engine::derived_cache::GraphFederatedCacheTracker::new(
+            rac_engine::derived_cache::default_cache_dir(),
+        ),
         graph_cache: graph::GraphCache::default(),
     };
     // Audit recorder (ADR-084): built from the `.decided/config.yaml` audit stanza,
@@ -255,7 +278,19 @@ fn main() {
 
 /// Startup diagnostic (stderr only; declared-normalized in parity, §0).
 fn check_corpus(root: &str, topology: &RepositoryTopology) {
-    let has_artifacts = if topology.federated {
+    let has_artifacts = if topology.federation_mode == Some(FederationMode::V2) {
+        let verified = rac_engine::federation::verify_federation(
+            &topology.repository_root,
+            &topology.root_corpus_relative,
+        )
+        .unwrap_or_else(|error| usage_error(&error.to_string()))
+        .unwrap_or_else(|| usage_error("version-2 federation manifest disappeared"));
+        rac_engine::graph_federated_corpus::compose_verified_federation(verified)
+            .unwrap_or_else(|error| usage_error(&error.to_string()))
+            .composition
+            .effective()
+            .any(|item| item.spec.is_some())
+    } else if topology.federation_mode == Some(FederationMode::V1) {
         let generation = rac_engine::derived_cache::capture_logical_generation(
             &topology.repository_root,
             root,
@@ -284,7 +319,8 @@ a new repository. The server is running; get_summary will report the empty state
 
 struct RepositoryTopology {
     repository_root: PathBuf,
-    federated: bool,
+    root_corpus_relative: String,
+    federation_mode: Option<FederationMode>,
 }
 
 fn marker_present(path: &Path) -> Result<bool, String> {
@@ -309,16 +345,16 @@ fn marker_present(path: &Path) -> Result<bool, String> {
 fn repository_topology(
     root: &str,
     pinned_root: Option<&Path>,
-    federation_seen: &mut bool,
+    federation_mode: &mut Option<FederationMode>,
 ) -> Result<RepositoryTopology, String> {
+    let resolved_root = std::fs::canonicalize(root).map_err(|error| {
+        format!("cannot resolve MCP corpus root {}: {error}", Path::new(root).display())
+    })?;
     let repository_root = if let Some(pinned) = pinned_root {
         pinned.to_path_buf()
     } else {
-        let resolved = std::fs::canonicalize(root).map_err(|error| {
-            format!("cannot resolve MCP corpus root {}: {error}", Path::new(root).display())
-        })?;
         let mut selected = None;
-        for ancestor in resolved.ancestors() {
+        for ancestor in resolved_root.ancestors() {
             let config = ancestor.join(rac_engine::federation::CONFIG_RELATIVE_PATH);
             let manifest = ancestor.join(rac_engine::federation::MANIFEST_RELATIVE_PATH);
             if marker_present(&config)? || marker_present(&manifest)? {
@@ -326,26 +362,70 @@ fn repository_topology(
                 break;
             }
         }
-        selected.unwrap_or(resolved)
+        selected.unwrap_or_else(|| resolved_root.clone())
+    };
+    let relative = resolved_root.strip_prefix(&repository_root).map_err(|_| {
+        format!(
+            "parent-corpus-path-escape: MCP corpus root {} escaped pinned repository root {}",
+            resolved_root.display(),
+            repository_root.display()
+        )
+    })?;
+    let root_corpus_relative = if relative.as_os_str().is_empty() {
+        ".".to_string()
+    } else {
+        relative
+            .components()
+            .map(|component| component.as_os_str().to_string_lossy())
+            .collect::<Vec<_>>()
+            .join("/")
     };
 
     let manifest_path = repository_root.join(rac_engine::federation::MANIFEST_RELATIVE_PATH);
     let present = marker_present(&manifest_path)?;
-    if present {
-        // Presence itself is sticky. A malformed addition cannot be removed
-        // to make the next request fall back to a legacy corpus.
-        *federation_seen = true;
+    if present && federation_mode.is_none() {
+        // Presence becomes sticky before parsing. A malformed live addition
+        // therefore cannot be removed to regain a local-only fallback.
+        *federation_mode = Some(FederationMode::Unknown);
     }
-    let manifest = rac_engine::federation::load_manifest(&repository_root)
-        .map_err(|error| error.to_string())?;
-    let federated = manifest.is_some();
-    if *federation_seen && !federated {
+    if !present && federation_mode.is_some() {
         return Err(format!(
             "parent-corpus-malformed-manifest: federation manifest disappeared after this server observed federation: {}",
             manifest_path.display()
         ));
     }
-    if *federation_seen {
+    let observed = if present {
+        if rac_engine::federation::load_graph_manifest(&repository_root)
+            .map_err(|error| error.to_string())?
+            .is_some()
+        {
+            Some(FederationMode::V2)
+        } else if rac_engine::federation::load_manifest(&repository_root)
+            .map_err(|error| error.to_string())?
+            .is_some()
+        {
+            Some(FederationMode::V1)
+        } else {
+            return Err(format!(
+                "parent-corpus-malformed-manifest: federation manifest has no supported version: {}",
+                manifest_path.display()
+            ));
+        }
+    } else {
+        None
+    };
+    match (*federation_mode, observed) {
+        (Some(FederationMode::Unknown), Some(actual)) => *federation_mode = Some(actual),
+        (Some(expected), Some(actual)) if expected != actual => {
+            return Err(format!(
+                "parent-corpus-malformed-manifest: federation manifest version changed after this server pinned {expected:?}: {}",
+                manifest_path.display()
+            ));
+        }
+        (None, Some(actual)) => *federation_mode = Some(actual),
+        _ => {}
+    }
+    if federation_mode.is_some() {
         let config_path = repository_root.join(rac_engine::federation::CONFIG_RELATIVE_PATH);
         let metadata = std::fs::symlink_metadata(&config_path).map_err(|error| {
             format!(
@@ -368,7 +448,8 @@ fn repository_topology(
     }
     Ok(RepositoryTopology {
         repository_root,
-        federated,
+        root_corpus_relative,
+        federation_mode: *federation_mode,
     })
 }
 
@@ -614,23 +695,44 @@ fn a_bool(args: &[Arg], i: usize, default: bool) -> bool {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn read_request<'a>(
     root: &str,
     repository_root: &Path,
-    federation_seen: &mut bool,
+    root_corpus_relative: &str,
+    federation_mode: &mut Option<FederationMode>,
+    persistent_cache: bool,
     tracker: &'a mut Option<rac_engine::freshness::FreshnessTracker>,
     federated_tracker: &'a mut Option<
         rac_engine::derived_cache::FederatedCacheTracker<
             rac_engine::composition::ComposedCorpus,
         >,
     >,
+    graph_tracker: &'a mut rac_engine::derived_cache::GraphFederatedCacheTracker,
 ) -> Result<RequestRead<'a>, String> {
     // Every recognized tool enters the same strict topology boundary after
     // its allowlisted arguments have been normalized for audit. Cache-off
     // skips persistence only; it never skips topology, parent verification,
     // or exact-byte composition.
-    let topology = repository_topology(root, Some(repository_root), federation_seen)?;
-    if topology.federated {
+    let topology = repository_topology(root, Some(repository_root), federation_mode)?;
+    if topology.root_corpus_relative != root_corpus_relative {
+        return Err(format!(
+            "parent-corpus-path-escape: MCP corpus root changed after topology was pinned (expected {root_corpus_relative}, got {})",
+            topology.root_corpus_relative
+        ));
+    }
+    if topology.federation_mode == Some(FederationMode::V2) {
+        Ok(RequestRead::Graph(
+            graph_tracker
+                .read_graph(
+                    &topology.repository_root,
+                    root_corpus_relative,
+                    true,
+                    persistent_cache,
+                )
+                .map_err(|error| error.to_string())?,
+        ))
+    } else if topology.federation_mode == Some(FederationMode::V1) {
         match federated_tracker.as_mut() {
             Some(tracker) => Ok(RequestRead::FederatedCached(
                 tracker
@@ -694,9 +796,12 @@ fn dispatch(
     }
     let ServerState {
         repository_root,
-        federation_seen,
+        root_corpus_relative,
+        federation_mode,
+        persistent_cache,
         tracker,
         federated_tracker,
+        graph_tracker,
         graph_cache,
     } = state;
     // Audit args mirror server.py's per-tool `observed(...)` shapes exactly
@@ -719,12 +824,22 @@ fn dispatch(
                     let request = read_request(
                         root,
                         repository_root,
-                        federation_seen,
+                        root_corpus_relative,
+                        federation_mode,
+                        *persistent_cache,
                         tracker,
                         federated_tracker,
+                        graph_tracker,
                     )?;
                     let (_, model) = request.legacy();
-                    Ok(if let Some(corpus) = request.composed() {
+                    Ok(if let Some(read) = request.graph() {
+                        tools::get_artifact_graph(
+                            root,
+                            read.corpus,
+                            &a_str(&a, 0, ""),
+                            effective,
+                        )
+                    } else if let Some(corpus) = request.composed() {
                         tools::get_artifact_composed(
                             root,
                             corpus,
@@ -764,12 +879,26 @@ fn dispatch(
                     let request = read_request(
                         root,
                         repository_root,
-                        federation_seen,
+                        root_corpus_relative,
+                        federation_mode,
+                        *persistent_cache,
                         tracker,
                         federated_tracker,
+                        graph_tracker,
                     )?;
                     let (_, model) = request.legacy();
-                    Ok(if let Some(corpus) = request.composed() {
+                    Ok(if let Some(read) = request.graph() {
+                        tools::search_artifacts_graph(
+                            root,
+                            read.model,
+                            read.corpus,
+                            &query,
+                            artifact_type.as_deref(),
+                            &tags,
+                            live_only,
+                            server_budget,
+                        )
+                    } else if let Some(corpus) = request.composed() {
                         tools::search_artifacts_composed(
                             root,
                             request.cached_model(),
@@ -830,12 +959,25 @@ fn dispatch(
                     let request = read_request(
                         root,
                         repository_root,
-                        federation_seen,
+                        root_corpus_relative,
+                        federation_mode,
+                        *persistent_cache,
                         tracker,
                         federated_tracker,
+                        graph_tracker,
                     )?;
                     let (_, model) = request.legacy();
-                    Ok(if let Some(corpus) = request.composed() {
+                    Ok(if let Some(read) = request.graph() {
+                        tools::retrieve_grounding_graph(
+                            root,
+                            read.corpus,
+                            &task,
+                            &scope,
+                            top_k,
+                            effective,
+                            live_only,
+                        )
+                    } else if let Some(corpus) = request.composed() {
                         tools::retrieve_grounding_composed(
                             root, corpus, &task, &scope, top_k, effective, live_only,
                         )
@@ -866,12 +1008,24 @@ fn dispatch(
                     let request = read_request(
                         root,
                         repository_root,
-                        federation_seen,
+                        root_corpus_relative,
+                        federation_mode,
+                        *persistent_cache,
                         tracker,
                         federated_tracker,
+                        graph_tracker,
                     )?;
                     let (_, model) = request.legacy();
-                    Ok(if let Some(corpus) = request.composed() {
+                    Ok(if let Some(read) = request.graph() {
+                        tools::find_decisions_tool_graph(
+                            root,
+                            read.model,
+                            read.corpus,
+                            &topic,
+                            path.as_deref(),
+                            server_budget,
+                        )
+                    } else if let Some(corpus) = request.composed() {
                         tools::find_decisions_tool_composed(
                             root,
                             corpus,
@@ -905,13 +1059,18 @@ fn dispatch(
                     let request = read_request(
                         root,
                         repository_root,
-                        federation_seen,
+                        root_corpus_relative,
+                        federation_mode,
+                        *persistent_cache,
                         tracker,
                         federated_tracker,
+                        graph_tracker,
                     )?;
                     let (generation, model) = request.legacy();
                     let fresh_graph;
-                    let graph_view = if let (Some(corpus), Some(logical)) =
+                    let graph_view = if let Some(read) = request.graph() {
+                        graph_cache.view_for_graph(read.generation, &read.corpus.composition)
+                    } else if let (Some(corpus), Some(logical)) =
                         (request.composed(), request.logical_generation())
                     {
                         graph_cache.view_for_composed(logical.cache_key(), corpus)
@@ -926,7 +1085,15 @@ fn dispatch(
                             }
                         }
                     };
-                    Ok(if let Some(corpus) = request.composed() {
+                    Ok(if let Some(read) = request.graph() {
+                        tools::get_related_graph(
+                            graph_view,
+                            read.corpus,
+                            &id,
+                            depth,
+                            server_budget,
+                        )
+                    } else if let Some(corpus) = request.composed() {
                         tools::get_related_composed(
                             graph_view,
                             corpus,
@@ -949,12 +1116,17 @@ fn dispatch(
                     let request = read_request(
                         root,
                         repository_root,
-                        federation_seen,
+                        root_corpus_relative,
+                        federation_mode,
+                        *persistent_cache,
                         tracker,
                         federated_tracker,
+                        graph_tracker,
                     )?;
                     let (_, model) = request.legacy();
-                    Ok(if let (Some(corpus), Some(generation)) =
+                    Ok(if let Some(read) = request.graph() {
+                        tools::get_summary_graph(read.model, server_budget)
+                    } else if let (Some(corpus), Some(generation)) =
                         (request.composed(), request.logical_generation())
                     {
                         tools::get_summary_composed(
@@ -1019,13 +1191,18 @@ mod tests {
     fn unknown_tool_does_not_freshen_tracker() {
         let mut state = ServerState {
             repository_root: PathBuf::from("/definitely-not-a-decided-corpus"),
-            federation_seen: false,
+            root_corpus_relative: ".".to_string(),
+            federation_mode: None,
+            persistent_cache: true,
             tracker: Some(rac_engine::freshness::FreshnessTracker::new(
                 std::path::PathBuf::from("/definitely-not-a-decided-cache"),
                 "/definitely-not-a-decided-corpus",
                 None,
             )),
             federated_tracker: None,
+            graph_tracker: rac_engine::derived_cache::GraphFederatedCacheTracker::new(
+                PathBuf::from("/definitely-not-a-decided-cache"),
+            ),
             graph_cache: graph::GraphCache::default(),
         };
         let result = dispatch(
@@ -1050,13 +1227,18 @@ mod tests {
         let root = corpus.to_string_lossy().into_owned();
         let mut state = ServerState {
             repository_root: corpus.clone(),
-            federation_seen: false,
+            root_corpus_relative: ".".to_string(),
+            federation_mode: None,
+            persistent_cache: true,
             tracker: Some(rac_engine::freshness::FreshnessTracker::new(
                 cache.clone(),
                 &root,
                 Some(10),
             )),
             federated_tracker: None,
+            graph_tracker: rac_engine::derived_cache::GraphFederatedCacheTracker::new(
+                cache.clone(),
+            ),
             graph_cache: graph::GraphCache::default(),
         };
         let arguments = json!({"id": "FIX-0DEC1GRAPH00", "depth": 2});

--- a/rust/decided-mcp/src/tools.rs
+++ b/rust/decided-mcp/src/tools.rs
@@ -68,6 +68,33 @@ fn attach_composed_provenance(
     }
 }
 
+fn graph_provenance(
+    corpus: &rac_engine::graph_federated_corpus::VerifiedGraphCorpus,
+    key: Option<&rac_engine::corpus::ArtifactKey>,
+) -> Option<Map<String, Value>> {
+    let key = key?;
+    let item = corpus.composition.item(key)?;
+    rac_engine::output::graph_provenance_value(
+        &item.origin,
+        corpus.composition.provenance_for(key).unwrap_or(&[]),
+    )
+    .as_object()
+    .cloned()
+}
+
+fn attach_graph_provenance(
+    value: &mut Value,
+    corpus: &rac_engine::graph_federated_corpus::VerifiedGraphCorpus,
+    key: Option<&rac_engine::corpus::ArtifactKey>,
+) {
+    let Some(provenance) = graph_provenance(corpus, key) else {
+        return;
+    };
+    if let Some(record) = value.as_object_mut() {
+        record.insert("provenance".to_string(), Value::Object(provenance));
+    }
+}
+
 /// The additive empty-corpus guidance the server layers over the summary.
 const EMPTY_GUIDANCE: &str = "This repository has no AsDecided artifacts yet. The user can create the \
 first one with `decided quickstart`, or with `decided init` then \
@@ -126,6 +153,23 @@ fn composed_search_result_payload(
     {
         for (record, artifact) in matches.iter_mut().zip(&result.matches) {
             attach_composed_provenance(record, corpus, artifact.key.as_ref());
+        }
+    }
+    payload
+}
+
+fn graph_search_result_payload(
+    result: &SearchResult,
+    corpus: &rac_engine::graph_federated_corpus::VerifiedGraphCorpus,
+) -> Value {
+    let mut payload = output::search_result_value(result, true);
+    if let Some(matches) = payload
+        .as_object_mut()
+        .and_then(|object| object.get_mut("matches"))
+        .and_then(Value::as_array_mut)
+    {
+        for (record, artifact) in matches.iter_mut().zip(&result.matches) {
+            attach_graph_provenance(record, corpus, artifact.key.as_ref());
         }
     }
     payload
@@ -257,6 +301,58 @@ pub fn get_artifact_composed(
     serialize(&Value::Object(payload), budget)
 }
 
+pub fn get_artifact_graph(
+    root: &str,
+    corpus: &rac_engine::graph_federated_corpus::VerifiedGraphCorpus,
+    artifact_id: &str,
+    budget: i64,
+) -> String {
+    let result = corpus.composition.resolve_identity(artifact_id);
+    let Some(artifact) = result
+        .artifact
+        .as_ref()
+        .filter(|_| result.outcome == OUTCOME_RESOLVED)
+    else {
+        return serialize(&output::resolution_error_value(&result), budget);
+    };
+    let Some(key) = artifact.key.as_ref() else {
+        return serialize(&unreadable_payload(&artifact.id, &artifact.path), budget);
+    };
+    let Some(content) = corpus
+        .content(key)
+        .and_then(|bytes| String::from_utf8(bytes.to_vec()).ok())
+        .map(|text| text.replace("\r\n", "\n").replace('\r', "\n"))
+    else {
+        return serialize(&unreadable_payload(&artifact.id, &artifact.path), budget);
+    };
+    let mut payload = Map::new();
+    payload.insert("schema_version".to_string(), json!("1"));
+    for (name, value) in artifact_value(artifact) {
+        payload.insert(name, value);
+    }
+    payload.insert("content".to_string(), json!(content));
+
+    let mut provenance = graph_provenance(corpus, Some(key)).unwrap_or_default();
+    let status = corpus
+        .composition
+        .item(key)
+        .map(|item| artifact_status(&item.artifact))
+        .unwrap_or_default();
+    provenance.insert("status".to_string(), json!(status));
+    if let Some(item) = corpus
+        .composition
+        .item(key)
+        .filter(|item| item.origin.layer == rac_engine::corpus::Layer::Local)
+    {
+        let physical = item.locator.path.to_string_lossy();
+        for (name, value) in provenance::artifact_provenance(root, &physical) {
+            provenance.insert(name, value);
+        }
+    }
+    payload.insert("provenance".to_string(), Value::Object(provenance));
+    serialize(&Value::Object(payload), budget)
+}
+
 pub fn search_artifacts(
     root: &str,
     model: Option<&TrackerModel>,
@@ -332,6 +428,37 @@ pub fn search_artifacts_composed(
     };
     rac_engine::commands::annotate_composed_search_recency(&mut result.matches, root, corpus);
     serialize(&composed_search_result_payload(&result, corpus), budget)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn search_artifacts_graph(
+    root: &str,
+    model: &rac_engine::derived_cache::ReadModel,
+    corpus: &rac_engine::graph_federated_corpus::VerifiedGraphCorpus,
+    query: &str,
+    artifact_type: Option<&str>,
+    tags: &[String],
+    live_only: bool,
+    budget: i64,
+) -> String {
+    let mut result = match model {
+        rac_engine::derived_cache::ReadModel::View(reader) => rac_engine::read_model::store_search(
+            reader,
+            query,
+            artifact_type,
+            tags,
+            live_only,
+        ),
+        rac_engine::derived_cache::ReadModel::Fresh(derived) => search_index_filtered(
+            &derived.index_entries,
+            query,
+            artifact_type,
+            tags,
+            live_only,
+        ),
+    };
+    rac_engine::commands::annotate_graph_search_recency(&mut result.matches, root, corpus);
+    serialize(&graph_search_result_payload(&result, corpus), budget)
 }
 
 pub fn find_decisions_tool(
@@ -443,13 +570,62 @@ pub fn find_decisions_tool_composed(
     serialize(&payload, budget)
 }
 
+pub fn find_decisions_tool_graph(
+    root: &str,
+    model: &rac_engine::derived_cache::ReadModel,
+    corpus: &rac_engine::graph_federated_corpus::VerifiedGraphCorpus,
+    topic: &str,
+    path: Option<&str>,
+    budget: i64,
+) -> String {
+    if let Some(path) = path.filter(|path| !path.is_empty()) {
+        let rows = match model {
+            rac_engine::derived_cache::ReadModel::View(reader) => {
+                reader.scope_rows().unwrap_or_default()
+            }
+            rac_engine::derived_cache::ReadModel::Fresh(derived) => derived.scope_rows.clone(),
+        };
+        let result = rac_engine::retrieve::decisions_for_path_with_rows(&rows, root, path);
+        let mut payload = rac_engine::retrieve::scope_lookup_value_with_origin(&result, true);
+        if let Some(decisions) = payload
+            .get_mut("decisions")
+            .and_then(Value::as_array_mut)
+        {
+            for (value, decision) in decisions.iter_mut().zip(&result.decisions) {
+                attach_graph_provenance(value, corpus, decision.key.as_ref());
+            }
+        }
+        return serialize(&payload, budget);
+    }
+
+    let result = match model {
+        rac_engine::derived_cache::ReadModel::View(reader) => {
+            rac_engine::read_model::store_find_decisions(reader, topic)
+        }
+        rac_engine::derived_cache::ReadModel::Fresh(derived) => {
+            rac_engine::read_model::find_decisions_in_source_aware(
+                &derived.index_entries,
+                &derived.live_decision_keys,
+                &derived.live_decision_paths,
+                topic,
+            )
+        }
+    };
+    let mut payload = graph_search_result_payload(&result, corpus);
+    payload
+        .as_object_mut()
+        .expect("object")
+        .insert("filter".to_string(), json!("live-decisions"));
+    serialize(&payload, budget)
+}
+
 pub fn get_related(
     graph_view: &graph::GraphView,
     artifact_id: &str,
     depth: i64,
     budget: i64,
 ) -> String {
-    get_related_inner(graph_view, None, artifact_id, depth, budget)
+    get_related_inner(graph_view, None, None, artifact_id, depth, budget)
 }
 
 pub fn get_related_composed(
@@ -459,21 +635,35 @@ pub fn get_related_composed(
     depth: i64,
     budget: i64,
 ) -> String {
-    get_related_inner(graph_view, Some(corpus), artifact_id, depth, budget)
+    get_related_inner(graph_view, Some(corpus), None, artifact_id, depth, budget)
+}
+
+pub fn get_related_graph(
+    graph_view: &graph::GraphView,
+    corpus: &rac_engine::graph_federated_corpus::VerifiedGraphCorpus,
+    artifact_id: &str,
+    depth: i64,
+    budget: i64,
+) -> String {
+    get_related_inner(graph_view, None, Some(corpus), artifact_id, depth, budget)
 }
 
 fn get_related_inner(
     graph_view: &graph::GraphView,
     corpus: Option<&rac_engine::composition::ComposedCorpus>,
+    graph_corpus: Option<&rac_engine::graph_federated_corpus::VerifiedGraphCorpus>,
     artifact_id: &str,
     depth: i64,
     budget: i64,
 ) -> String {
     let graph_started = rac_engine::timing::start();
-    let result = corpus.map_or_else(
-        || graph_view.resolve(artifact_id),
-        |corpus| corpus.resolve_identity(artifact_id),
-    );
+    let result = if let Some(corpus) = graph_corpus {
+        corpus.composition.resolve_identity(artifact_id)
+    } else if let Some(corpus) = corpus {
+        corpus.resolve_identity(artifact_id)
+    } else {
+        graph_view.resolve(artifact_id)
+    };
     let Some(artifact) = result
         .artifact
         .as_ref()
@@ -482,12 +672,21 @@ fn get_related_inner(
         return serialize(&output::resolution_error_value(&result), budget);
     };
     let include_origin = graph_view.is_federated();
-    let historical = corpus.is_some_and(|corpus| {
-        artifact
-            .key
-            .as_ref()
-            .is_some_and(|key| corpus.is_overridden(key))
-    });
+    let historical = if let Some(corpus) = graph_corpus {
+        artifact.key.as_ref().is_some_and(|key| {
+            artifact_id
+                .split_once("::")
+                .is_some_and(|(qualifier, _)| qualifier == key.source)
+                && corpus.composition.terminal_redirects().contains_key(key)
+        })
+    } else {
+        corpus.is_some_and(|corpus| {
+            artifact
+                .key
+                .as_ref()
+                .is_some_and(|key| corpus.is_overridden(key))
+        })
+    };
     let outgoing = graph_view.outgoing(artifact, historical);
     let incoming_result = graph_view.incoming(artifact, historical);
     let incoming: Vec<Value> = incoming_result
@@ -508,6 +707,8 @@ fn get_related_inner(
             let mut value = Value::Object(m);
             if let Some(corpus) = corpus {
                 attach_composed_provenance(&mut value, corpus, r.key.as_ref());
+            } else if let Some(corpus) = graph_corpus {
+                attach_graph_provenance(&mut value, corpus, r.key.as_ref());
             } else {
                 attach_origin(&mut value, r.origin.as_ref(), include_origin);
             }
@@ -521,6 +722,7 @@ fn get_related_inner(
     }
     if let Some(provenance) = corpus
         .and_then(|corpus| composed_provenance(corpus, artifact.key.as_ref()))
+        .or_else(|| graph_corpus.and_then(|corpus| graph_provenance(corpus, artifact.key.as_ref())))
         .or_else(|| fixed_origin(artifact.origin.as_ref(), include_origin))
     {
         payload.insert("provenance".to_string(), Value::Object(provenance));
@@ -544,6 +746,8 @@ fn get_related_inner(
                 let mut value = Value::Object(m);
                 if let Some(corpus) = corpus {
                     attach_composed_provenance(&mut value, corpus, n.key.as_ref());
+                } else if let Some(corpus) = graph_corpus {
+                    attach_graph_provenance(&mut value, corpus, n.key.as_ref());
                 } else {
                     attach_origin(&mut value, n.origin.as_ref(), include_origin);
                 }
@@ -704,6 +908,32 @@ pub fn get_summary_composed(
     serialize(&payload, budget)
 }
 
+pub fn get_summary_graph(
+    model: &rac_engine::derived_cache::ReadModel,
+    budget: i64,
+) -> String {
+    let summary = match model {
+        rac_engine::derived_cache::ReadModel::View(reader) => {
+            reader.portfolio_summary().unwrap_or(Value::Null)
+        }
+        rac_engine::derived_cache::ReadModel::Fresh(derived) => {
+            derived.portfolio_summary.clone()
+        }
+    };
+    let mut payload = match summary {
+        Value::Object(payload) => payload,
+        _ => Map::new(),
+    };
+    if payload
+        .get("empty")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        payload.insert("guidance".to_string(), json!(EMPTY_GUIDANCE));
+    }
+    serialize(&Value::Object(payload), budget)
+}
+
 pub fn retrieve_grounding(
     root: &str,
     model: Option<&TrackerModel>,
@@ -754,6 +984,28 @@ pub fn retrieve_grounding_composed(
 ) -> String {
     let scope = if scope.is_empty() { None } else { Some(scope) };
     let payload = rac_engine::retrieve::retrieve_grounding_from_composed(
+        root,
+        task,
+        scope,
+        top_k,
+        effective,
+        live_only,
+        corpus,
+    );
+    serialize(&payload, effective)
+}
+
+pub fn retrieve_grounding_graph(
+    root: &str,
+    corpus: &rac_engine::graph_federated_corpus::VerifiedGraphCorpus,
+    task: &str,
+    scope: &str,
+    top_k: i64,
+    effective: i64,
+    live_only: bool,
+) -> String {
+    let scope = if scope.is_empty() { None } else { Some(scope) };
+    let payload = rac_engine::retrieve::retrieve_grounding_from_graph(
         root,
         task,
         scope,

--- a/rust/decided-mcp/tests/federation_graph.rs
+++ b/rust/decided-mcp/tests/federation_graph.rs
@@ -1,0 +1,500 @@
+//! MCP parity contract for the accepted corpus-federation graph design.
+//!
+//! Fixture pins are calculated independently of the engine. The same six
+//! public tools must consume one request-current graph with or without cache.
+
+#[path = "../../decided/tests/federation_graph_support/mod.rs"]
+mod federation_graph_support;
+
+use federation_graph_support::{
+    constrained_decision, decision, requirement, GraphRepo, OverrideEdge, ParentEdge,
+};
+use serde_json::{json, Value};
+use std::io::{BufRead, BufReader, Write};
+use std::path::Path;
+use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+
+fn request(id: usize, name: &str, arguments: Value) -> String {
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "method": "tools/call",
+        "params": {"name": name, "arguments": arguments}
+    })
+    .to_string()
+}
+
+fn run(root: &Path, extra: &[&str], requests: &[String]) -> Vec<Value> {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_decided-mcp"))
+        .arg("--root")
+        .arg(root)
+        .args(extra)
+        .env("DECIDED_CACHE_DIR", root.join("../.decided/cache"))
+        .env("XDG_CACHE_HOME", root.join("../.xdg/cache"))
+        .env("XDG_CONFIG_HOME", root.join("../.xdg/config"))
+        .env("XDG_STATE_HOME", root.join("../.xdg/state"))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn decided-mcp graph contract");
+    {
+        let stdin = child.stdin.as_mut().expect("MCP stdin");
+        for request in requests {
+            writeln!(stdin, "{request}").expect("write MCP request");
+        }
+    }
+    drop(child.stdin.take());
+    let output = child.wait_with_output().expect("wait for decided-mcp");
+    assert!(
+        output.status.success(),
+        "MCP graph server failed with {:?}: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout)
+        .expect("UTF-8 MCP frames")
+        .lines()
+        .map(|line| serde_json::from_str(line).expect("JSON-RPC response"))
+        .collect()
+}
+
+fn tool_text(frame: &Value) -> &str {
+    frame
+        .pointer("/result/content/0/text")
+        .and_then(Value::as_str)
+        .expect("MCP tool text")
+}
+
+fn graph_repo() -> GraphRepo {
+    let repo = GraphRepo::new("mcp-parity");
+    repo.create_node("vendor/standards", "STD", "acme/standards");
+    repo.write_node(
+        "vendor/standards",
+        "decisions/standard.md",
+        &constrained_decision(
+            "STD-01K000000001",
+            "Quantum Ledger Compaction Standard",
+            "forbidden_graph_marker",
+        ),
+    );
+    repo.create_node("vendor/product", "PRD", "acme/product");
+    repo.create_node("vendor/product/vendor/shared", "SHR", "acme/shared");
+    repo.write_node(
+        "vendor/product/vendor/shared",
+        "decisions/shared.md",
+        &decision("SHR-01K000000001", "Quantum Ledger Shared Guardrail", None),
+    );
+    repo.write_node(
+        "vendor/product",
+        "decisions/product.md",
+        &decision(
+            "PRD-01K000000001",
+            "Quantum Ledger Product Policy",
+            Some("shared::SHR-01K000000001"),
+        ),
+    );
+    repo.write_v2_manifest(
+        "vendor/product",
+        &[ParentEdge::new(
+            "shared",
+            "acme/shared",
+            "vendor/shared",
+            repo.v2_digest("vendor/product/vendor/shared", "acme/shared"),
+        )],
+        &[],
+    );
+    repo.write_v2_manifest(
+        "",
+        &[
+            ParentEdge::new(
+                "standards",
+                "acme/standards",
+                "vendor/standards",
+                repo.v2_digest("vendor/standards", "acme/standards"),
+            ),
+            ParentEdge::new(
+                "product",
+                "acme/product",
+                "vendor/product",
+                repo.v2_digest("vendor/product", "acme/product"),
+            ),
+        ],
+        &[],
+    );
+    repo
+}
+
+#[test]
+fn all_six_tools_have_cold_warm_and_cache_disabled_graph_parity() {
+    let repo = graph_repo();
+    let corpus = repo.root().join("decisions");
+    let requests = vec![
+        request(
+            1,
+            "get_artifact",
+            json!({"id": "acme/standards::STD-01K000000001"}),
+        ),
+        request(
+            2,
+            "search_artifacts",
+            json!({"query": "quantum ledger"}),
+        ),
+        request(
+            3,
+            "retrieve_grounding",
+            json!({"task": "quantum ledger compaction", "top_k": 5}),
+        ),
+        request(
+            4,
+            "find_decisions",
+            json!({"topic": "quantum ledger compaction"}),
+        ),
+        request(
+            5,
+            "get_related",
+            json!({"id": "acme/product::PRD-01K000000001", "depth": 2}),
+        ),
+        request(6, "get_summary", json!({})),
+        request(
+            7,
+            "find_decisions",
+            json!({"path": "src/guarded.rs"}),
+        ),
+    ];
+
+    let uncached = run(&corpus, &["--no-cache"], &requests);
+    let cold = run(&corpus, &[], &requests);
+    let warm = run(&corpus, &[], &requests);
+    assert_eq!(uncached.len(), 7);
+    assert_eq!(cold.len(), 7);
+    assert_eq!(warm.len(), 7);
+    assert_eq!(
+        uncached.iter().map(tool_text).collect::<Vec<_>>(),
+        cold.iter().map(tool_text).collect::<Vec<_>>(),
+        "cache-disabled and cold tools observed different graphs"
+    );
+    assert_eq!(
+        cold.iter().map(tool_text).collect::<Vec<_>>(),
+        warm.iter().map(tool_text).collect::<Vec<_>>(),
+        "cold and store-hit tools observed different graphs"
+    );
+
+    let joined = cold.iter().map(tool_text).collect::<Vec<_>>().join("\n");
+    for expected in [
+        "acme/standards",
+        "acme/product",
+        "acme/shared",
+        "sha256-v2:",
+    ] {
+        assert!(joined.contains(expected), "MCP output omitted {expected}");
+    }
+    assert!(
+        cold.iter()
+            .all(|frame| frame["result"]["isError"] == json!(false)),
+        "a graph-capable MCP tool rejected the shared closure: {cold:?}"
+    );
+}
+
+fn payload(frame: &Value) -> Value {
+    serde_json::from_str(tool_text(frame)).expect("tool payload JSON")
+}
+
+struct LiveServer {
+    child: Child,
+    stdin: ChildStdin,
+    stdout: BufReader<ChildStdout>,
+}
+
+impl LiveServer {
+    fn start(root: &Path) -> Self {
+        let mut child = Command::new(env!("CARGO_BIN_EXE_decided-mcp"))
+            .args(["--root", root.to_str().unwrap(), "--no-cache"])
+            .env("XDG_CACHE_HOME", root.join("../.xdg/cache"))
+            .env("XDG_CONFIG_HOME", root.join("../.xdg/config"))
+            .env("XDG_STATE_HOME", root.join("../.xdg/state"))
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn live MCP graph server");
+        let stdin = child.stdin.take().expect("live MCP stdin");
+        let stdout = BufReader::new(child.stdout.take().expect("live MCP stdout"));
+        Self { child, stdin, stdout }
+    }
+
+    fn send(&mut self, value: &Value) -> Value {
+        writeln!(self.stdin, "{value}").expect("write live MCP request");
+        self.stdin.flush().expect("flush live MCP request");
+        let mut line = String::new();
+        self.stdout.read_line(&mut line).expect("read live MCP frame");
+        assert!(!line.is_empty(), "live MCP process closed unexpectedly");
+        serde_json::from_str(&line).expect("live MCP JSON-RPC frame")
+    }
+}
+
+impl Drop for LiveServer {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+#[test]
+fn override_chain_is_atomic_and_historical_reads_are_explicit() {
+    let repo = GraphRepo::new("mcp-override-chain");
+    repo.create_node("vendor/mid", "MID", "acme/mid");
+    repo.create_node("vendor/mid/vendor/base", "BAS", "acme/base");
+    repo.write_node(
+        "vendor/mid/vendor/base",
+        "decisions/base.md",
+        &requirement("BAS-01K000000001", "Graph Chain Base", None),
+    );
+    repo.write_node(
+        "vendor/mid",
+        "decisions/replacement.md",
+        &requirement("MID-01K000000001", "Graph Chain Middle", None),
+    );
+    repo.write_node(
+        "vendor/mid",
+        "decisions/rationale.md",
+        &decision("MID-01K000000002", "Graph Chain Rationale", None),
+    );
+    repo.write_v2_manifest(
+        "vendor/mid",
+        &[ParentEdge::new(
+            "base",
+            "acme/base",
+            "vendor/base",
+            repo.v2_digest("vendor/mid/vendor/base", "acme/base"),
+        )],
+        &[OverrideEdge::new(
+            "acme/base::BAS-01K000000001",
+            "MID-01K000000001",
+            "MID-01K000000002",
+        )],
+    );
+    let oversized = format!(
+        "{}\n{}\n",
+        requirement("APP-01K000000010", "Graph Chain Terminal", None),
+        "terminal body ".repeat(600)
+    );
+    repo.write("decisions/replacement.md", &oversized);
+    repo.write(
+        "decisions/rationale.md",
+        &decision("APP-01K000000011", "Root Chain Rationale", None),
+    );
+    repo.write_v2_manifest(
+        "",
+        &[ParentEdge::new(
+            "mid",
+            "acme/mid",
+            "vendor/mid",
+            repo.v2_digest("vendor/mid", "acme/mid"),
+        )],
+        &[OverrideEdge::new(
+            "acme/mid::MID-01K000000001",
+            "APP-01K000000010",
+            "APP-01K000000011",
+        )],
+    );
+    let corpus = repo.root().join("decisions");
+    let frames = run(
+        &corpus,
+        &["--no-cache"],
+        &[
+            request(1, "get_artifact", json!({"id": "BAS-01K000000001"})),
+            request(
+                2,
+                "get_artifact",
+                json!({"id": "acme/base::BAS-01K000000001"}),
+            ),
+            request(
+                3,
+                "get_artifact",
+                json!({"id": "APP-01K000000010", "budget": 1024}),
+            ),
+        ],
+    );
+    let effective = payload(&frames[0]);
+    assert_eq!(effective["id"], json!("APP-01K000000010"));
+    assert_eq!(effective["provenance"]["overrides"].as_array().unwrap().len(), 2);
+    let historical = payload(&frames[1]);
+    assert_eq!(historical["id"], json!("BAS-01K000000001"));
+    assert_eq!(historical["provenance"]["source"], json!("acme/base"));
+    assert_eq!(historical["provenance"]["overrides"].as_array().unwrap().len(), 2);
+
+    let bounded = payload(&frames[2]);
+    if bounded.get("error").is_some() {
+        assert!(bounded.to_string().contains("response_budget_exceeded"));
+    } else {
+        assert_eq!(bounded["provenance"]["overrides"].as_array().unwrap().len(), 2);
+    }
+}
+
+#[test]
+fn diamond_equal_paths_and_equal_ids_remain_source_aware() {
+    const COMMON: &str = "COM-01K000000001";
+    let repo = GraphRepo::new("mcp-diamond-identity");
+    let mut parents = Vec::new();
+    for (branch, source, key) in [("a", "acme/a", "A01"), ("b", "acme/b", "B01")] {
+        let node = format!("vendor/{branch}");
+        let shared = format!("{node}/vendor/shared");
+        repo.create_node(&node, key, source);
+        repo.create_node(&shared, "SHR", "acme/shared");
+        repo.write_node(
+            &shared,
+            "decisions/shared.md",
+            &decision("SHR-01K000000001", "Diamond Shared Policy", None),
+        );
+        repo.write_node(
+            &node,
+            "decisions/equal.md",
+            &decision(COMMON, &format!("Equal Identity {branch}"), None),
+        );
+        repo.write_v2_manifest(
+            &node,
+            &[ParentEdge::new(
+                "shared",
+                "acme/shared",
+                "vendor/shared",
+                repo.v2_digest(&shared, "acme/shared"),
+            )],
+            &[],
+        );
+        parents.push(ParentEdge::new(
+            branch,
+            source,
+            &node,
+            repo.v2_digest(&node, source),
+        ));
+    }
+    repo.write_v2_manifest("", &parents, &[]);
+    let corpus = repo.root().join("decisions");
+    let frames = run(
+        &corpus,
+        &["--no-cache"],
+        &[
+            request(1, "search_artifacts", json!({"query": "equal identity"})),
+            request(2, "get_artifact", json!({"id": COMMON})),
+            request(3, "get_artifact", json!({"id": format!("acme/a::{COMMON}")})),
+            request(4, "get_artifact", json!({"id": format!("b::{COMMON}")})),
+            request(5, "get_artifact", json!({"id": "acme/shared::SHR-01K000000001"})),
+        ],
+    );
+    let matches = payload(&frames[0]);
+    let sources = matches["matches"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|item| item["provenance"]["source"].as_str().unwrap())
+        .collect::<std::collections::BTreeSet<_>>();
+    assert_eq!(sources, std::collections::BTreeSet::from(["acme/a", "acme/b"]));
+    assert!(matches["matches"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .all(|item| item.get("recency").is_none()
+            && item["provenance"]["layer"] == json!("inherited")
+            && item["provenance"]["pin"]
+                .as_str()
+                .is_some_and(|pin| pin.starts_with("sha256-v2:"))));
+    assert!(payload(&frames[1]).to_string().contains("ambiguous"));
+    assert_eq!(payload(&frames[2])["provenance"]["source"], json!("acme/a"));
+    assert_eq!(payload(&frames[3])["provenance"]["source"], json!("acme/b"));
+    assert_eq!(payload(&frames[4])["provenance"]["source"], json!("acme/shared"));
+}
+
+#[test]
+fn tamper_and_topology_changes_fail_closed_and_are_audited_once() {
+    let repo = GraphRepo::new("mcp-fail-closed");
+    let audit_path = repo.root().join("audit.jsonl");
+    repo.write(
+        ".decided/config.yaml",
+        &format!(
+            "repository_key: APP\ncorpus:\n  source: acme/root\naudit:\n  enabled: true\n  path: {}\n",
+            audit_path.display()
+        ),
+    );
+    repo.create_node("vendor/parent", "PAR", "acme/parent");
+    let parent_text = decision("PAR-01K000000001", "Fail Closed Parent", None);
+    repo.write_node("vendor/parent", "decisions/parent.md", &parent_text);
+    repo.write_v2_manifest(
+        "",
+        &[ParentEdge::new(
+            "parent",
+            "acme/parent",
+            "vendor/parent",
+            repo.v2_digest("vendor/parent", "acme/parent"),
+        )],
+        &[],
+    );
+    let mut server = LiveServer::start(&repo.root().join("decisions"));
+    let call = |id| {
+        json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": "tools/call",
+            "params": {"name": "search_artifacts", "arguments": {"query": "fail closed parent"}}
+        })
+    };
+
+    let first = server.send(&call(1));
+    assert_eq!(first["result"]["isError"], json!(false));
+    repo.write_node(
+        "vendor/parent",
+        "decisions/parent.md",
+        "changed after verification\n",
+    );
+    let stale = server.send(&call(2));
+    assert_eq!(stale["result"]["isError"], json!(true));
+    assert!(tool_text(&stale).contains("parent-corpus-digest-mismatch"));
+
+    repo.write_node("vendor/parent", "decisions/parent.md", &parent_text);
+    let restored = server.send(&call(3));
+    assert_eq!(restored["result"]["isError"], json!(false));
+    std::fs::remove_file(repo.root().join(".decided/corpus.md")).expect("remove manifest");
+    let topology = server.send(&call(4));
+    assert_eq!(topology["result"]["isError"], json!(true));
+    assert!(tool_text(&topology).contains("manifest disappeared"));
+
+    let list = server.send(&json!({"jsonrpc":"2.0","id":5,"method":"tools/list"}));
+    assert_eq!(list["result"]["tools"].as_array().unwrap().len(), 6);
+    let events = std::fs::read_to_string(&audit_path)
+        .expect("read graph audit")
+        .lines()
+        .map(|line| serde_json::from_str::<Value>(line).expect("audit JSON"))
+        .collect::<Vec<_>>();
+    assert_eq!(events.len(), 4, "one event per recognized tool call");
+    assert_eq!(events[0]["outcome"], json!("ok"));
+    assert_eq!(events[1]["outcome"], json!("error"));
+    assert_eq!(events[1]["returned"], json!([]));
+    assert_eq!(events[2]["outcome"], json!("ok"));
+    assert_eq!(events[3]["outcome"], json!("error"));
+    assert_eq!(events[3]["returned"], json!([]));
+}
+
+#[test]
+fn malformed_live_manifest_presence_is_sticky_before_version_selection() {
+    let repo = GraphRepo::new("mcp-malformed-sticky");
+    let mut server = LiveServer::start(&repo.root().join("decisions"));
+    let call = |id| {
+        json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": "tools/call",
+            "params": {"name": "get_summary", "arguments": {}}
+        })
+    };
+    assert_eq!(server.send(&call(1))["result"]["isError"], json!(false));
+    repo.write(
+        ".decided/corpus.md",
+        "# Corpus\n\n## inherits\n\n```yaml\nversion: 2\nparents: [\n```\n",
+    );
+    let malformed = server.send(&call(2));
+    assert_eq!(malformed["result"]["isError"], json!(true));
+    std::fs::remove_file(repo.root().join(".decided/corpus.md")).expect("remove malformed manifest");
+    let removed = server.send(&call(3));
+    assert_eq!(removed["result"]["isError"], json!(true));
+    assert!(tool_text(&removed).contains("manifest disappeared"));
+}

--- a/rust/decided/Cargo.toml
+++ b/rust/decided/Cargo.toml
@@ -17,3 +17,4 @@ rac-engine = { package = "asdecided-core", version = "=0.28.0", path = "../rac-e
 
 [dev-dependencies]
 serde_json = "1"
+sha2 = "0.10"

--- a/rust/decided/tests/federation_graph.rs
+++ b/rust/decided/tests/federation_graph.rs
@@ -1,0 +1,914 @@
+//! Black-box certification contract for accepted ADR-144 through ADR-148.
+//!
+//! The suite talks only to the public `decided` binary. It is expected to fail
+//! on the v0.28 engine and becomes the acceptance gate for the stacked v0.29
+//! graph implementation. Keep failures semantic; do not ignore these tests.
+
+mod federation_graph_support;
+
+use federation_graph_support::{
+    constrained_decision, decision, requirement, GraphRepo, OverrideEdge, ParentEdge, ROOT_ID,
+    ROOT_SOURCE, SHARED_ID, SHARED_SOURCE,
+};
+use serde_json::Value;
+use std::fs;
+use std::process::{Command, Output};
+
+const COMMON_ID: &str = "POL-01K000000001";
+const FORBIDDEN_MARKER: &str = "FORBIDDEN_GRAPH_MARKER";
+
+fn run(repo: &GraphRepo, args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_decided"))
+        .args(args)
+        .current_dir(repo.root())
+        .env("DECIDED_CACHE_DIR", repo.root().join(".decided/cache"))
+        .env("XDG_CACHE_HOME", repo.root().join(".xdg/cache"))
+        .env("XDG_CONFIG_HOME", repo.root().join(".xdg/config"))
+        .env("XDG_STATE_HOME", repo.root().join(".xdg/state"))
+        .output()
+        .expect("run decided graph contract")
+}
+
+fn stdout(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+fn stderr(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+fn rendered(output: &Output) -> String {
+    format!("{}{}", stdout(output), stderr(output))
+}
+
+fn assert_success(output: &Output, context: &str) {
+    assert!(
+        output.status.success(),
+        "{context} failed with {:?}\nstdout:\n{}\nstderr:\n{}",
+        output.status.code(),
+        stdout(output),
+        stderr(output)
+    );
+}
+
+fn assert_stable_failure(output: &Output, code: &str, context: &str) {
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "{context}\nstdout:\n{}\nstderr:\n{}",
+        stdout(output),
+        stderr(output)
+    );
+    assert!(
+        rendered(output).contains(code),
+        "{context} omitted stable code {code:?}:\n{}",
+        rendered(output)
+    );
+}
+
+fn json(output: &Output, context: &str) -> Value {
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "{context} did not emit JSON: {error}\nstdout:\n{}\nstderr:\n{}",
+            stdout(output),
+            stderr(output)
+        )
+    })
+}
+
+fn json_lines(output: &Output, context: &str) -> Vec<Value> {
+    stdout(output)
+        .lines()
+        .map(|line| {
+            serde_json::from_str(line)
+                .unwrap_or_else(|error| panic!("{context} emitted invalid JSONL: {error}: {line}"))
+        })
+        .collect()
+}
+
+fn count_id(records: &[Value], id: &str) -> usize {
+    records
+        .iter()
+        .filter(|record| record["id"].as_str() == Some(id))
+        .count()
+}
+
+fn direct_parent_repo(label: &str, sources: &[(&str, &str, &str)]) -> GraphRepo {
+    let repo = GraphRepo::new(label);
+    let mut parents = Vec::new();
+    for (index, (alias, source, id)) in sources.iter().enumerate() {
+        let node = format!("vendor/{alias}");
+        let key = format!("P{index:02}");
+        repo.create_node(&node, &key, source);
+        repo.write_node(
+            &node,
+            &format!("decisions/{alias}.md"),
+            &decision(id, &format!("{alias} inherited policy"), None),
+        );
+        parents.push(ParentEdge::new(
+            alias,
+            source,
+            &node,
+            repo.v2_digest(&node, source),
+        ));
+    }
+    repo.write_v2_manifest("", &parents, &[]);
+    repo
+}
+
+#[test]
+fn manifest_v2_digest_has_a_known_vector_and_binds_exact_bytes() {
+    let repo = GraphRepo::new("digest-vector");
+    repo.create_node("vendor/vector", "VEC", "acme/vector");
+    repo.write_node(
+        "vendor/vector",
+        "decisions/vector.md",
+        &decision("VEC-01K000000001", "Vector Policy", None),
+    );
+
+    let expected = repo.v2_digest("vendor/vector", "acme/vector");
+    assert_eq!(
+        expected, "sha256-v2:d6ca980630e9819dd079d68f639c705ec58244b0e2de7af26fcf6188d7419d45",
+        "the independent vector changed; review the exact framing before updating it"
+    );
+    repo.create_node("vendor/vector/vendor/leaf", "LEF", "acme/vector-leaf");
+    repo.write_node(
+        "vendor/vector/vendor/leaf",
+        "decisions/leaf.md",
+        &decision("LEF-01K000000001", "Vector Leaf", None),
+    );
+    repo.write_v2_manifest(
+        "vendor/vector",
+        &[ParentEdge::new(
+            "leaf",
+            "acme/vector-leaf",
+            "vendor/leaf",
+            repo.v2_digest("vendor/vector/vendor/leaf", "acme/vector-leaf"),
+        )],
+        &[],
+    );
+    let manifest_expected = repo.v2_digest("vendor/vector", "acme/vector");
+    assert_eq!(
+        manifest_expected,
+        "sha256-v2:577e8965b30513c36b74008df3b4521f206b2bf2f959b92036e0e3bda7e03c4a",
+        "the manifest-present vector changed; review the exact bytes before updating it"
+    );
+
+    fs::remove_file(repo.path("vendor/vector/.decided/corpus.md"))
+        .expect("temporarily restore the manifest-absent vector");
+    let absent_output = run(
+        &repo,
+        &[
+            "corpus",
+            "digest",
+            "--version",
+            "2",
+            "--root",
+            "vendor/vector",
+            "--corpus",
+            "decisions",
+        ],
+    );
+    assert_success(&absent_output, "calculate the manifest-absent v2 vector");
+    assert_eq!(stdout(&absent_output), format!("{expected}\n"));
+
+    repo.write_v2_manifest(
+        "vendor/vector",
+        &[ParentEdge::new(
+            "leaf",
+            "acme/vector-leaf",
+            "vendor/leaf",
+            repo.v2_digest("vendor/vector/vendor/leaf", "acme/vector-leaf"),
+        )],
+        &[],
+    );
+    let present_output = run(
+        &repo,
+        &[
+            "corpus",
+            "digest",
+            "--version",
+            "2",
+            "--root",
+            "vendor/vector",
+            "--corpus",
+            "decisions",
+        ],
+    );
+    assert_success(&present_output, "calculate the manifest-present v2 vector");
+    assert_eq!(stdout(&present_output), format!("{manifest_expected}\n"));
+
+    let manifest_path = repo.path("vendor/vector/.decided/corpus.md");
+    let mut commented = fs::read_to_string(&manifest_path).expect("read vector manifest");
+    commented.push_str("\n<!-- exact bytes are authenticated -->\n");
+    fs::write(manifest_path, commented).expect("write exact-byte vector change");
+    assert_ne!(
+        repo.v2_digest("vendor/vector", "acme/vector"),
+        manifest_expected
+    );
+}
+
+#[test]
+fn two_and_three_direct_parents_are_source_ordered_not_manifest_ordered() {
+    let repo = direct_parent_repo(
+        "direct-parents",
+        &[
+            ("security", "acme/security", "SEC-01K000000001"),
+            ("standards", "acme/standards", "STD-01K000000001"),
+            ("product", "acme/product", "PRD-01K000000001"),
+        ],
+    );
+    let first = run(&repo, &["export", "decisions", "--documents"]);
+    assert_success(&first, "export three direct parents");
+    for expected in [
+        ROOT_SOURCE,
+        "acme/security",
+        "acme/standards",
+        "acme/product",
+    ] {
+        assert!(stdout(&first).contains(expected), "missing {expected}");
+    }
+
+    let parents = [
+        ParentEdge::new(
+            "product",
+            "acme/product",
+            "vendor/product",
+            repo.v2_digest("vendor/product", "acme/product"),
+        ),
+        ParentEdge::new(
+            "security",
+            "acme/security",
+            "vendor/security",
+            repo.v2_digest("vendor/security", "acme/security"),
+        ),
+        ParentEdge::new(
+            "standards",
+            "acme/standards",
+            "vendor/standards",
+            repo.v2_digest("vendor/standards", "acme/standards"),
+        ),
+    ];
+    repo.write_v2_manifest("", &parents, &[]);
+    let permuted = run(&repo, &["export", "decisions", "--documents"]);
+    assert_success(&permuted, "export a permuted direct-parent list");
+    assert_eq!(
+        first.stdout, permuted.stdout,
+        "manifest order changed output"
+    );
+    assert_eq!(
+        first.stderr, permuted.stderr,
+        "manifest order changed findings"
+    );
+
+    repo.write_v2_manifest("", &parents[..2], &[]);
+    let two = run(&repo, &["validate", "decisions", "--json"]);
+    assert_success(&two, "validate two direct parents");
+}
+
+fn diamond_repo(label: &str) -> (GraphRepo, Vec<ParentEdge>) {
+    let repo = GraphRepo::new(label);
+    repo.create_node("vendor/a", "BRA", "acme/branch-a");
+    repo.create_node("vendor/a/vendor/shared", "SHR", SHARED_SOURCE);
+    repo.write_node(
+        "vendor/a/vendor/shared",
+        "decisions/shared.md",
+        &decision(SHARED_ID, "Shared Diamond Policy", None),
+    );
+    repo.create_node("vendor/b", "BRB", "acme/branch-b");
+    repo.copy_node("vendor/a/vendor/shared", "vendor/b/vendor/shared");
+
+    for (branch, source, alias) in [
+        ("vendor/a", "acme/branch-a", "shared-a"),
+        ("vendor/b", "acme/branch-b", "shared-b"),
+    ] {
+        repo.write_node(
+            branch,
+            "decisions/branch.md",
+            &decision(
+                if branch.ends_with('a') {
+                    "BRA-01K000000001"
+                } else {
+                    "BRB-01K000000001"
+                },
+                "Branch Policy",
+                None,
+            ),
+        );
+        let shared = format!("{branch}/vendor/shared");
+        repo.write_v2_manifest(
+            branch,
+            &[ParentEdge::new(
+                alias,
+                SHARED_SOURCE,
+                "vendor/shared",
+                repo.v2_digest(&shared, SHARED_SOURCE),
+            )],
+            &[],
+        );
+        assert!(repo.v2_digest(branch, source).starts_with("sha256-v2:"));
+    }
+    let parents = vec![
+        ParentEdge::new(
+            "a",
+            "acme/branch-a",
+            "vendor/a",
+            repo.v2_digest("vendor/a", "acme/branch-a"),
+        ),
+        ParentEdge::new(
+            "b",
+            "acme/branch-b",
+            "vendor/b",
+            repo.v2_digest("vendor/b", "acme/branch-b"),
+        ),
+    ];
+    repo.write_v2_manifest("", &parents, &[]);
+    (repo, parents)
+}
+
+#[test]
+fn transitive_diamond_dedupes_equal_pins_and_rejects_divergent_pins() {
+    let (repo, mut root_parents) = diamond_repo("diamond");
+    let valid = run(&repo, &["export", "decisions", "--documents"]);
+    assert_success(&valid, "compose a same-pin transitive diamond");
+    let documents = json_lines(&valid, "diamond documents export");
+    assert_eq!(
+        count_id(&documents, SHARED_ID),
+        1,
+        "a shared logical node must enter the catalog once"
+    );
+
+    repo.write_node(
+        "vendor/b/vendor/shared",
+        "decisions/shared.md",
+        &decision(SHARED_ID, "Divergent Shared Policy", None),
+    );
+    let divergent_shared = repo.v2_digest("vendor/b/vendor/shared", SHARED_SOURCE);
+    repo.write_v2_manifest(
+        "vendor/b",
+        &[ParentEdge::new(
+            "shared-b",
+            SHARED_SOURCE,
+            "vendor/shared",
+            divergent_shared,
+        )],
+        &[],
+    );
+    root_parents[1].digest = repo.v2_digest("vendor/b", "acme/branch-b");
+    repo.write_v2_manifest("", &root_parents, &[]);
+    let invalid = run(&repo, &["validate", "decisions", "--json"]);
+    assert_stable_failure(
+        &invalid,
+        "corpus-federation-divergent-pin",
+        "the same source with different canonical node digests must fail",
+    );
+    let invalid_payload = json(&invalid, "divergent-pin validation");
+    let provenance = &invalid_payload["files"][0]["provenance"];
+    assert_eq!(provenance["route_count"], 2);
+    assert_eq!(
+        provenance["source_route"],
+        serde_json::json!([ROOT_SOURCE, "acme/branch-a", SHARED_SOURCE])
+    );
+    assert_eq!(provenance["source"], ROOT_SOURCE);
+    assert_eq!(provenance["layer"], "local");
+    assert!(
+        provenance.get("pin").is_none(),
+        "root-owned composition findings must omit pin: {provenance}"
+    );
+}
+
+#[test]
+fn active_source_recurrence_is_reported_as_a_cycle_before_divergent_pin() {
+    let repo = GraphRepo::new("cycle");
+    repo.create_node("vendor/a", "A01", "acme/a");
+    repo.create_node("vendor/a/vendor/b", "B01", "acme/b");
+    repo.create_node("vendor/a/vendor/b/vendor/a-copy", "A02", "acme/a");
+    repo.write_node(
+        "vendor/a/vendor/b/vendor/a-copy",
+        "decisions/a-copy.md",
+        &decision("A02-01K000000001", "Repeated A Source", None),
+    );
+    let a_copy = repo.v2_digest("vendor/a/vendor/b/vendor/a-copy", "acme/a");
+    repo.write_v2_manifest(
+        "vendor/a/vendor/b",
+        &[ParentEdge::new(
+            "a-again",
+            "acme/a",
+            "vendor/a-copy",
+            a_copy,
+        )],
+        &[],
+    );
+    let b = repo.v2_digest("vendor/a/vendor/b", "acme/b");
+    repo.write_v2_manifest(
+        "vendor/a",
+        &[ParentEdge::new("b", "acme/b", "vendor/b", b)],
+        &[],
+    );
+    let a = repo.v2_digest("vendor/a", "acme/a");
+    repo.write_v2_manifest("", &[ParentEdge::new("a", "acme/a", "vendor/a", a)], &[]);
+
+    let output = run(&repo, &["validate", "decisions", "--json"]);
+    assert_stable_failure(
+        &output,
+        "corpus-federation-cycle",
+        "an active-ancestry source recurrence must be a cycle",
+    );
+    assert!(rendered(&output).contains("acme/a"));
+}
+
+#[test]
+fn global_qualification_equal_ids_and_contextual_aliases_share_one_resolver() {
+    let repo = GraphRepo::new("qualification");
+    let mut parents = Vec::new();
+    for (branch, branch_source, leaf_source, branch_id) in [
+        ("a", "acme/a", "acme/a-shared", "ARE-01K000000001"),
+        ("b", "acme/b", "acme/b-shared", "BRE-01K000000001"),
+        ("c", "acme/c", "acme/c-shared", "CRE-01K000000001"),
+    ] {
+        let node = format!("vendor/{branch}");
+        let leaf = format!("{node}/vendor/shared");
+        let branch_key = format!("BR{}", branch.to_uppercase());
+        repo.create_node(&node, &branch_key, branch_source);
+        repo.create_node(&leaf, "LEF", leaf_source);
+        repo.write_node(
+            &node,
+            "decisions/equal.md",
+            &decision(COMMON_ID, "Source Qualified Equal ID", None),
+        );
+        repo.write_node(
+            &leaf,
+            "decisions/leaf.md",
+            &decision(branch_id, "Contextual Leaf", None),
+        );
+        repo.write_node(
+            &node,
+            "decisions/reference.md",
+            &requirement(
+                &format!("BR{}-01K000000002", branch.to_uppercase()),
+                "Contextual Alias Reference",
+                Some(&format!("shared::{branch_id}")),
+            ),
+        );
+        repo.write_v2_manifest(
+            &node,
+            &[ParentEdge::new(
+                "shared",
+                leaf_source,
+                "vendor/shared",
+                repo.v2_digest(&leaf, leaf_source),
+            )],
+            &[],
+        );
+        parents.push(ParentEdge::new(
+            branch,
+            branch_source,
+            &node,
+            repo.v2_digest(&node, branch_source),
+        ));
+    }
+    repo.write_v2_manifest("", &parents, &[]);
+
+    let relationships = run(
+        &repo,
+        &["relationships", "decisions", "--validate", "--json"],
+    );
+    assert_success(
+        &relationships,
+        "the same nested alias spelling resolves in each owner context",
+    );
+    for source in ["acme/a", "acme/b", "acme/c"] {
+        let qualified = format!("{source}::{COMMON_ID}");
+        let output = run(&repo, &["resolve", &qualified, "decisions", "--json"]);
+        assert_success(&output, "globally qualify an equal canonical id");
+        assert!(stdout(&output).contains(source));
+    }
+    let ambiguous = run(&repo, &["resolve", COMMON_ID, "decisions", "--json"]);
+    assert_eq!(ambiguous.status.code(), Some(1));
+    let ambiguity = rendered(&ambiguous).to_lowercase();
+    assert!(ambiguity.contains("ambiguous"));
+    for source in ["acme/a", "acme/b", "acme/c"] {
+        assert!(ambiguity.contains(source));
+    }
+}
+
+#[test]
+fn override_chains_and_explicit_diamond_convergence_retain_lineage() {
+    let repo = GraphRepo::new("override-chain");
+    repo.create_node("vendor/mid", "MID", "acme/mid");
+    repo.create_node("vendor/mid/vendor/base", "BAS", "acme/base");
+    repo.write_node(
+        "vendor/mid/vendor/base",
+        "decisions/base.md",
+        &requirement("BAS-01K000000001", "Base Requirement", None),
+    );
+    repo.write_node(
+        "vendor/mid",
+        "decisions/replacement.md",
+        &requirement("MID-01K000000001", "Mid Replacement", None),
+    );
+    repo.write_node(
+        "vendor/mid",
+        "decisions/rationale.md",
+        &decision("MID-01K000000002", "Mid Rationale", None),
+    );
+    repo.write_v2_manifest(
+        "vendor/mid",
+        &[ParentEdge::new(
+            "base",
+            "acme/base",
+            "vendor/base",
+            repo.v2_digest("vendor/mid/vendor/base", "acme/base"),
+        )],
+        &[OverrideEdge::new(
+            "acme/base::BAS-01K000000001",
+            "MID-01K000000001",
+            "MID-01K000000002",
+        )],
+    );
+    repo.write(
+        "decisions/replacement.md",
+        &requirement("APP-01K000000010", "Root Replacement", None),
+    );
+    repo.write(
+        "decisions/rationale.md",
+        &decision("APP-01K000000011", "Root Rationale", None),
+    );
+    repo.write_v2_manifest(
+        "",
+        &[ParentEdge::new(
+            "mid",
+            "acme/mid",
+            "vendor/mid",
+            repo.v2_digest("vendor/mid", "acme/mid"),
+        )],
+        &[OverrideEdge::new(
+            "acme/mid::MID-01K000000001",
+            "APP-01K000000010",
+            "APP-01K000000011",
+        )],
+    );
+
+    let effective = run(
+        &repo,
+        &["resolve", "BAS-01K000000001", "decisions", "--json"],
+    );
+    assert_success(&effective, "resolve a two-hop override terminal");
+    assert_eq!(
+        json(&effective, "override terminal")["id"].as_str(),
+        Some("APP-01K000000010")
+    );
+    let historical = run(
+        &repo,
+        &[
+            "resolve",
+            "acme/base::BAS-01K000000001",
+            "decisions",
+            "--json",
+        ],
+    );
+    assert_success(&historical, "retain qualified override history");
+    assert_eq!(
+        json(&historical, "override history")["id"].as_str(),
+        Some("BAS-01K000000001")
+    );
+    let export = run(&repo, &["export", "decisions", "--documents"]);
+    assert_success(&export, "export complete override lineage");
+    for expected in [
+        "BAS-01K000000001",
+        "MID-01K000000001",
+        "APP-01K000000010",
+        "MID-01K000000002",
+        "APP-01K000000011",
+        "overridden",
+        "replacement",
+        "lineage",
+    ] {
+        assert!(stdout(&export).contains(expected), "missing {expected}");
+    }
+
+    let (diamond, root_parents) = diamond_repo("override-convergence");
+    for (branch, branch_source, replacement, rationale) in [
+        (
+            "vendor/a",
+            "acme/branch-a",
+            "BRA-01K000000010",
+            "BRA-01K000000011",
+        ),
+        (
+            "vendor/b",
+            "acme/branch-b",
+            "BRB-01K000000010",
+            "BRB-01K000000011",
+        ),
+    ] {
+        diamond.write_node(
+            branch,
+            "decisions/replacement.md",
+            &decision(replacement, "Branch Replacement", None),
+        );
+        diamond.write_node(
+            branch,
+            "decisions/rationale.md",
+            &decision(rationale, "Branch Rationale", None),
+        );
+        diamond.write_v2_manifest(
+            branch,
+            &[ParentEdge::new(
+                "shared",
+                SHARED_SOURCE,
+                "vendor/shared",
+                diamond.v2_digest(&format!("{branch}/vendor/shared"), SHARED_SOURCE),
+            )],
+            &[OverrideEdge::new(
+                &format!("{SHARED_SOURCE}::{SHARED_ID}"),
+                replacement,
+                rationale,
+            )],
+        );
+        assert!(diamond
+            .v2_digest(branch, branch_source)
+            .starts_with("sha256-v2:"));
+    }
+    diamond.write(
+        "decisions/converged.md",
+        &decision("APP-01K000000020", "Converged Policy", None),
+    );
+    diamond.write(
+        "decisions/convergence-rationale.md",
+        &decision("APP-01K000000021", "Convergence Rationale", None),
+    );
+    let refreshed = [
+        ParentEdge::new(
+            "a",
+            "acme/branch-a",
+            "vendor/a",
+            diamond.v2_digest("vendor/a", "acme/branch-a"),
+        ),
+        ParentEdge::new(
+            "b",
+            "acme/branch-b",
+            "vendor/b",
+            diamond.v2_digest("vendor/b", "acme/branch-b"),
+        ),
+    ];
+    assert_eq!(root_parents.len(), refreshed.len());
+    diamond.write_v2_manifest(
+        "",
+        &refreshed,
+        &[
+            OverrideEdge::new(
+                "acme/branch-a::BRA-01K000000010",
+                "APP-01K000000020",
+                "APP-01K000000021",
+            ),
+            OverrideEdge::new(
+                "acme/branch-b::BRB-01K000000010",
+                "APP-01K000000020",
+                "APP-01K000000021",
+            ),
+        ],
+    );
+    let converged = run(&diamond, &["validate", "decisions", "--json"]);
+    assert_success(
+        &converged,
+        "the joining corpus explicitly reconverges both live branch terminals",
+    );
+}
+
+#[test]
+fn transitive_inherited_decisions_enforce_against_root_code() {
+    let repo = GraphRepo::new("deep-enforcement");
+    repo.create_node("vendor/mid", "MID", "acme/mid");
+    repo.create_node("vendor/mid/vendor/guard", "GRD", "acme/guard");
+    repo.write_node(
+        "vendor/mid/vendor/guard",
+        "decisions/guard.md",
+        &constrained_decision("GRD-01K000000001", "Deep Guard", FORBIDDEN_MARKER),
+    );
+    repo.write_v2_manifest(
+        "vendor/mid",
+        &[ParentEdge::new(
+            "guard",
+            "acme/guard",
+            "vendor/guard",
+            repo.v2_digest("vendor/mid/vendor/guard", "acme/guard"),
+        )],
+        &[],
+    );
+    repo.write_v2_manifest(
+        "",
+        &[ParentEdge::new(
+            "mid",
+            "acme/mid",
+            "vendor/mid",
+            repo.v2_digest("vendor/mid", "acme/mid"),
+        )],
+        &[],
+    );
+
+    let scope = run(
+        &repo,
+        &["decisions-for", "src/guarded.rs", "decisions", "--json"],
+    );
+    assert_success(&scope, "route a transitive inherited Decision");
+    assert!(stdout(&scope).contains("GRD-01K000000001"));
+    repo.write(
+        "src/guarded.rs",
+        &format!("pub const MARKER: &str = \"{FORBIDDEN_MARKER}\";\n"),
+    );
+    let sentry = run(
+        &repo,
+        &[
+            "sentry",
+            "decisions",
+            "--repository",
+            ".",
+            "--full",
+            "--json",
+        ],
+    );
+    assert_eq!(
+        sentry.status.code(),
+        Some(1),
+        "deep rule must block root code"
+    );
+    for expected in ["GRD-01K000000001", "inherited-v2-guard", "src/guarded.rs"] {
+        assert!(stdout(&sentry).contains(expected), "missing {expected}");
+    }
+}
+
+#[test]
+fn cache_disabled_cold_warm_and_export_reads_share_one_graph_projection() {
+    let repo = direct_parent_repo(
+        "cache-export-parity",
+        &[
+            ("security", "acme/security", "SEC-01K000000001"),
+            ("standards", "acme/standards", "STD-01K000000001"),
+        ],
+    );
+    let uncached = run(
+        &repo,
+        &[
+            "find",
+            "inherited policy",
+            "decisions",
+            "--no-cache",
+            "--json",
+        ],
+    );
+    let graph_store_root = repo.root().join(".decided/cache/store/v3");
+    assert!(
+        !graph_store_root.exists(),
+        "--no-cache must not create the graph store/v3 layout"
+    );
+    let cold = run(&repo, &["find", "inherited policy", "decisions", "--json"]);
+    let generation_directories = || {
+        fs::read_dir(&graph_store_root)
+            .expect("read graph store/v3 root")
+            .map(|entry| entry.expect("read graph generation entry").path())
+            .filter(|path| path.is_dir())
+            .collect::<Vec<_>>()
+    };
+    let cold_generations = generation_directories();
+    assert_eq!(
+        cold_generations.len(),
+        1,
+        "the cold CLI process must persist exactly one graph generation"
+    );
+    for segment in ["entries.seg", "graph.seg"] {
+        assert!(
+            cold_generations[0].join(segment).is_file(),
+            "cold graph store omitted {segment}"
+        );
+    }
+    let warm = run(&repo, &["find", "inherited policy", "decisions", "--json"]);
+    let human = run(&repo, &["find", "inherited policy", "decisions"]);
+    for (name, output) in [("uncached", &uncached), ("cold", &cold), ("warm", &warm)] {
+        assert_success(output, &format!("{name} graph search"));
+    }
+    assert_success(&human, "human graph search");
+    let human_stdout = stdout(&human);
+    for expected in [
+        "source=acme/security layer=inherited pin=sha256-v2:",
+        "source=acme/standards layer=inherited pin=sha256-v2:",
+    ] {
+        assert!(
+            human_stdout.contains(expected),
+            "human graph search omitted {expected}: {human_stdout}"
+        );
+    }
+    assert_eq!(uncached.stdout, cold.stdout);
+    assert_eq!(cold.stdout, warm.stdout);
+    assert_eq!(uncached.stderr, cold.stderr);
+    assert_eq!(cold.stderr, warm.stderr);
+    assert_eq!(
+        generation_directories(),
+        cold_generations,
+        "the second CLI process must reuse the exact store/v3 generation"
+    );
+    let find_payload = json(&warm, "warm graph search");
+    let matches = find_payload["matches"]
+        .as_array()
+        .expect("graph search matches");
+    assert_eq!(matches.len(), 2);
+    for matched in matches {
+        let provenance = &matched["provenance"];
+        assert_eq!(provenance["layer"].as_str(), Some("inherited"));
+        assert!(
+            provenance["pin"]
+                .as_str()
+                .is_some_and(|pin| pin.starts_with("sha256-v2:")),
+            "inherited CLI find result omitted its v2 pin: {matched}"
+        );
+        assert!(
+            provenance["source"].as_str().is_some(),
+            "inherited CLI find result omitted its source: {matched}"
+        );
+        assert!(
+            matched.get("recency").is_none(),
+            "inherited CLI find must not derive recency from the root checkout: {matched}"
+        );
+    }
+
+    let documents = run(&repo, &["export", "decisions", "--documents"]);
+    let graph = run(&repo, &["export", "decisions", "--graph"]);
+    let viewer = run(&repo, &["export", "decisions"]);
+    for (name, output) in [
+        ("documents", &documents),
+        ("graph", &graph),
+        ("viewer", &viewer),
+    ] {
+        assert_success(output, &format!("{name} graph export"));
+        for source in [ROOT_SOURCE, "acme/security", "acme/standards"] {
+            assert!(stdout(output).contains(source), "{name} omitted {source}");
+        }
+    }
+    let local = run(
+        &repo,
+        &["export", "decisions", "--documents", "--local-only"],
+    );
+    assert_success(&local, "root-local diagnostic export");
+    assert!(stdout(&local).contains(ROOT_ID));
+    assert!(!stdout(&local).contains("acme/security"));
+    assert!(!stdout(&local).contains("acme/standards"));
+}
+
+#[test]
+fn no_manifest_and_manifest_v1_keep_the_released_observable_contract() {
+    let repo = GraphRepo::new("legacy-parity");
+    let before = run(&repo, &["resolve", ROOT_ID, "decisions", "--json"]);
+    assert_success(&before, "resolve without a manifest");
+    repo.create_node("vendor/unconfigured", "IGN", "acme/ignored");
+    repo.write_node(
+        "vendor/unconfigured",
+        "decisions/ignored.md",
+        &decision("IGN-01K000000001", "Ignored Physical Corpus", None),
+    );
+    let after = run(&repo, &["resolve", ROOT_ID, "decisions", "--json"]);
+    assert_success(&after, "resolve with an unconfigured physical corpus");
+    assert_eq!(before.stdout, after.stdout);
+    assert_eq!(before.stderr, after.stderr);
+
+    repo.create_node("vendor/v1", "VON", "acme/v1");
+    repo.write_node(
+        "vendor/v1",
+        "decisions/v1.md",
+        &decision("VON-01K000000001", "Version One Policy", None),
+    );
+    let digest = run(
+        &repo,
+        &[
+            "corpus",
+            "digest",
+            "--root",
+            "vendor/v1",
+            "--corpus",
+            "decisions",
+        ],
+    );
+    assert_success(&digest, "calculate an unchanged v1 digest");
+    let digest = stdout(&digest).trim().to_string();
+    assert!(digest.starts_with("sha256:"));
+    repo.write(
+        ".decided/corpus.md",
+        &format!(
+            "# Corpus\n\n## inherits\n\n```yaml\nversion: 1\nalias: legacy\nsource: acme/v1\nroot: vendor/v1\ncorpus: decisions\ndigest: {digest}\n```\n"
+        ),
+    );
+    let inherited = run(
+        &repo,
+        &["resolve", "legacy::VON-01K000000001", "decisions", "--json"],
+    );
+    assert_success(&inherited, "retain exact v1 qualification");
+    assert!(stdout(&inherited).contains("\"source\": \"acme/v1\""));
+    assert!(stdout(&inherited).contains(&digest));
+
+    let v1_multiple = fs::read_to_string(repo.root().join(".decided/corpus.md"))
+        .expect("read v1 manifest")
+        .replace("version: 1", "version: 1\nparents: []");
+    repo.write(".decided/corpus.md", &v1_multiple);
+    let failure = run(&repo, &["validate", "decisions", "--json"]);
+    assert_eq!(failure.status.code(), Some(1));
+    assert!(rendered(&failure).contains("parent-corpus"));
+}

--- a/rust/decided/tests/federation_graph_support/mod.rs
+++ b/rust/decided/tests/federation_graph_support/mod.rs
@@ -1,0 +1,285 @@
+//! Independent fixture construction for the manifest-v2 black-box contract.
+//!
+//! This module intentionally does not call the engine's federation APIs. The
+//! v2 pins are calculated with the public SHA-256 framing contract so a shared
+//! implementation defect cannot make both fixture and engine agree.
+
+#![allow(dead_code)]
+
+use sha2::{Digest, Sha256};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+static SCRATCH_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+pub const ROOT_SOURCE: &str = "acme/root";
+pub const SHARED_SOURCE: &str = "acme/shared";
+pub const SHARED_ID: &str = "SHR-01K000000001";
+pub const ROOT_ID: &str = "APP-01K000000001";
+
+#[derive(Clone, Debug)]
+pub struct ParentEdge {
+    pub alias: String,
+    pub source: String,
+    pub root: String,
+    pub corpus: String,
+    pub digest: String,
+}
+
+impl ParentEdge {
+    pub fn new(alias: &str, source: &str, root: &str, digest: String) -> Self {
+        Self {
+            alias: alias.to_string(),
+            source: source.to_string(),
+            root: root.to_string(),
+            corpus: "decisions".to_string(),
+            digest,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct OverrideEdge {
+    pub target: String,
+    pub replacement: String,
+    pub rationale: String,
+}
+
+impl OverrideEdge {
+    pub fn new(target: &str, replacement: &str, rationale: &str) -> Self {
+        Self {
+            target: target.to_string(),
+            replacement: replacement.to_string(),
+            rationale: rationale.to_string(),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct GraphRepo {
+    root: PathBuf,
+}
+
+impl GraphRepo {
+    pub fn new(label: &str) -> Self {
+        assert!(
+            label
+                .bytes()
+                .all(|byte| byte.is_ascii_lowercase() || byte == b'-'),
+            "fixture labels must stay portable"
+        );
+        let sequence = SCRATCH_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock after epoch")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "asdecided-federation-v2-{label}-{}-{nonce}-{sequence}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&root).expect("create graph fixture root");
+        let repo = Self { root };
+        repo.create_node("", "APP", ROOT_SOURCE);
+        repo.write("decisions/root.md", &decision(ROOT_ID, "Root Policy", None));
+        repo.write("src/guarded.rs", "pub fn guarded() {}\n");
+        repo
+    }
+
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    pub fn path(&self, relative: &str) -> PathBuf {
+        if relative.is_empty() {
+            self.root.clone()
+        } else {
+            self.root.join(relative)
+        }
+    }
+
+    pub fn create_node(&self, relative: &str, key: &str, source: &str) {
+        let node = self.path(relative);
+        fs::create_dir_all(node.join(".decided")).expect("create node config directory");
+        fs::create_dir_all(node.join("decisions")).expect("create node corpus");
+        fs::write(
+            node.join(".decided/config.yaml"),
+            format!("repository_key: {key}\ncorpus:\n  source: {source}\n"),
+        )
+        .expect("write node config");
+    }
+
+    pub fn write(&self, relative: &str, contents: &str) {
+        let relative = Path::new(relative);
+        assert!(!relative.is_absolute(), "fixture write must be relative");
+        assert!(
+            relative.components().all(|component| matches!(
+                component,
+                std::path::Component::Normal(_) | std::path::Component::CurDir
+            )),
+            "fixture write cannot escape its root"
+        );
+        let path = self.root.join(relative);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("create fixture directory");
+        }
+        fs::write(path, contents).expect("write fixture file");
+    }
+
+    pub fn write_node(&self, node: &str, relative: &str, contents: &str) {
+        let path = if node.is_empty() {
+            relative.to_string()
+        } else {
+            format!("{node}/{relative}")
+        };
+        self.write(&path, contents);
+    }
+
+    pub fn write_v2_manifest(
+        &self,
+        node: &str,
+        parents: &[ParentEdge],
+        overrides: &[OverrideEdge],
+    ) {
+        assert!(!parents.is_empty(), "v2 manifest needs at least one parent");
+        let mut manifest =
+            String::from("# Corpus\n\n## inherits\n\n```yaml\nversion: 2\nparents:\n");
+        for parent in parents {
+            manifest.push_str(&format!(
+                "  - alias: {}\n    source: {}\n    root: '{}'\n    corpus: '{}'\n    digest: {}\n",
+                parent.alias, parent.source, parent.root, parent.corpus, parent.digest
+            ));
+        }
+        manifest.push_str("```\n");
+        if !overrides.is_empty() {
+            manifest.push_str("\n## overrides\n\n```yaml\nversion: 2\nitems:\n");
+            for mapping in overrides {
+                manifest.push_str(&format!(
+                    "  - target: {}\n    with: {}\n    rationale: {}\n",
+                    mapping.target, mapping.replacement, mapping.rationale
+                ));
+            }
+            manifest.push_str("```\n");
+        }
+        self.write_node(node, ".decided/corpus.md", &manifest);
+    }
+
+    pub fn v2_digest(&self, node: &str, source: &str) -> String {
+        calculate_v2_digest(&self.path(node), "decisions", source)
+    }
+
+    pub fn copy_node(&self, source: &str, target: &str) {
+        copy_tree(&self.path(source), &self.path(target));
+    }
+}
+
+impl Drop for GraphRepo {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.root);
+    }
+}
+
+pub fn calculate_v2_digest(root: &Path, corpus: &str, source: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(b"asdecided-corpus-digest-v2\0");
+    frame(&mut hasher, 0x01, source.as_bytes());
+    frame(
+        &mut hasher,
+        0x02,
+        &fs::read(root.join(".decided/config.yaml")).expect("read digest config"),
+    );
+    let manifest = root.join(".decided/corpus.md");
+    if manifest.is_file() {
+        frame(&mut hasher, 0x03, &[1]);
+        frame(
+            &mut hasher,
+            0x04,
+            &fs::read(manifest).expect("read digest manifest"),
+        );
+    } else {
+        frame(&mut hasher, 0x03, &[0]);
+    }
+
+    let corpus_root = root.join(corpus);
+    let mut files = Vec::new();
+    collect_markdown(&corpus_root, &corpus_root, &mut files);
+    files.sort_by(|left, right| left.0.as_bytes().cmp(right.0.as_bytes()));
+    for (relative, bytes) in files {
+        frame(&mut hasher, 0x05, relative.as_bytes());
+        frame(&mut hasher, 0x06, &bytes);
+    }
+    format!("sha256-v2:{:x}", hasher.finalize())
+}
+
+fn frame(hasher: &mut Sha256, tag: u8, payload: &[u8]) {
+    hasher.update([tag]);
+    hasher.update((payload.len() as u64).to_be_bytes());
+    hasher.update(payload);
+}
+
+fn collect_markdown(root: &Path, current: &Path, files: &mut Vec<(String, Vec<u8>)>) {
+    let mut entries = fs::read_dir(current)
+        .unwrap_or_else(|error| panic!("read {}: {error}", current.display()))
+        .map(|entry| entry.expect("read corpus entry").path())
+        .collect::<Vec<_>>();
+    entries.sort();
+    for path in entries {
+        let metadata = fs::symlink_metadata(&path).expect("read corpus metadata");
+        if metadata.is_dir() {
+            collect_markdown(root, &path, files);
+        } else if metadata.is_file()
+            && path
+                .extension()
+                .is_some_and(|extension| extension.eq_ignore_ascii_case("md"))
+        {
+            let relative = path
+                .strip_prefix(root)
+                .expect("corpus file beneath root")
+                .to_string_lossy()
+                .replace('\\', "/");
+            files.push((relative, fs::read(path).expect("read corpus file")));
+        }
+    }
+}
+
+fn copy_tree(source: &Path, target: &Path) {
+    fs::create_dir_all(target).expect("create copied node");
+    for entry in fs::read_dir(source).expect("read copied node") {
+        let entry = entry.expect("read copied entry");
+        let destination = target.join(entry.file_name());
+        let file_type = entry.file_type().expect("copied entry type");
+        if file_type.is_dir() {
+            copy_tree(&entry.path(), &destination);
+        } else {
+            fs::copy(entry.path(), destination).expect("copy node file");
+        }
+    }
+}
+
+pub fn decision(id: &str, title: &str, related: Option<&str>) -> String {
+    let mut body = format!(
+        "---\nschema_version: 1\nid: {id}\ntype: decision\n---\n# {title}\n\n## Status\n\nAccepted\n\n## Category\n\nTechnical\n\n## Context\n\nThe graph fixture needs a reviewed policy.\n\n## Decision\n\nKeep source-aware graph behaviour deterministic.\n\n## Consequences\n\nThe public contract remains testable.\n"
+    );
+    if let Some(target) = related {
+        body.push_str(&format!("\n## Related Decisions\n\n- {target}\n"));
+    }
+    body
+}
+
+pub fn constrained_decision(id: &str, title: &str, marker: &str) -> String {
+    format!(
+        "{}\n## Applies To\n\n- src/**/*.rs\n\n## Code Constraints\n\n```yaml\nversion: 1\neligibility: eligible\nrules:\n  - id: inherited-v2-guard\n    kind: forbid_pattern\n    path_glob: \"src/**/*.rs\"\n    pattern: \"{marker}\"\n    message: \"Inherited graph policy forbids the marker.\"\n```\n",
+        decision(id, title, None)
+    )
+}
+
+pub fn requirement(id: &str, title: &str, related: Option<&str>) -> String {
+    let mut body = format!(
+        "---\nschema_version: 1\nid: {id}\ntype: requirement\n---\n# Requirement: {title}\n\n## Status\n\nProposed\n\n## Problem\n\nThe graph fixture needs a stable requirement.\n\n## Requirements\n\n- [REQ-001] The composed corpus MUST keep this requirement attributable.\n\n## Acceptance Criteria\n\n- Public reads expose the source-aware record.\n\n## Success Metrics\n\n- The contract assertion passes.\n\n## Risks\n\n- An independent overlay could lose provenance.\n\n## Assumptions\n\n- Every inherited source is already materialised.\n"
+    );
+    if let Some(target) = related {
+        body.push_str(&format!("\n## Related Decisions\n\n- {target}\n"));
+    }
+    body
+}

--- a/rust/decided/tests/federation_v2_runtime_guards.rs
+++ b/rust/decided/tests/federation_v2_runtime_guards.rs
@@ -1,0 +1,286 @@
+//! Black-box guards for graph-aware inspection and inherited write boundaries.
+
+mod federation_graph_support;
+
+use federation_graph_support::{decision, GraphRepo, ParentEdge};
+use serde_json::Value;
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Output};
+
+const PARENT_SOURCE: &str = "acme/runtime-parent";
+const PARENT_ID: &str = "PAR-01K000000001";
+
+fn runtime_repo(label: &str) -> GraphRepo {
+    let repo = GraphRepo::new(label);
+    repo.create_node("vendor/parent", "PAR", PARENT_SOURCE);
+    repo.write_node(
+        "vendor/parent",
+        "decisions/parent.md",
+        &decision(PARENT_ID, "Inherited Runtime Policy", None),
+    );
+    repo.write_v2_manifest(
+        "",
+        &[ParentEdge::new(
+            "parent",
+            PARENT_SOURCE,
+            "vendor/parent",
+            repo.v2_digest("vendor/parent", PARENT_SOURCE),
+        )],
+        &[],
+    );
+    repo
+}
+
+fn run(repo: &GraphRepo, args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_decided"))
+        .args(args)
+        .current_dir(repo.root())
+        .env("DECIDED_NO_CACHE", "1")
+        .env("XDG_CACHE_HOME", repo.path(".xdg/cache"))
+        .env("XDG_CONFIG_HOME", repo.path(".xdg/config"))
+        .env("XDG_STATE_HOME", repo.path(".xdg/state"))
+        .output()
+        .expect("run decided runtime guard contract")
+}
+
+fn assert_read_only_failure(output: &Output, context: &str) {
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "{context}\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr).to_lowercase();
+    assert!(
+        stderr.contains("refusing to write") && stderr.contains("read-only"),
+        "{context}: {stderr}"
+    );
+}
+
+fn file_bytes(root: &Path) -> BTreeMap<String, Vec<u8>> {
+    fn collect(root: &Path, current: &Path, files: &mut BTreeMap<String, Vec<u8>>) {
+        let mut entries = fs::read_dir(current)
+            .expect("read snapshot directory")
+            .map(|entry| entry.expect("read snapshot entry").path())
+            .collect::<Vec<_>>();
+        entries.sort();
+        for path in entries {
+            let metadata = fs::symlink_metadata(&path).expect("snapshot metadata");
+            if metadata.is_dir() {
+                collect(root, &path, files);
+            } else if metadata.is_file() {
+                files.insert(
+                    path.strip_prefix(root)
+                        .expect("snapshot path beneath root")
+                        .to_string_lossy()
+                        .replace('\\', "/"),
+                    fs::read(path).expect("snapshot bytes"),
+                );
+            }
+        }
+    }
+
+    let mut files = BTreeMap::new();
+    collect(root, root, &mut files);
+    files
+}
+
+#[test]
+fn inspect_verifies_the_graph_and_reports_only_root_local_files() {
+    let repo = runtime_repo("runtime-inspect-local");
+    let output = run(&repo, &["inspect", "decisions", "--json"]);
+    assert!(
+        output.status.success(),
+        "inspect failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value: Value = serde_json::from_slice(&output.stdout).expect("inspect JSON");
+    assert_eq!(value["summary"]["total_files"], 1);
+    assert_eq!(value["files"][0]["path"], "decisions/root.md");
+    assert!(!String::from_utf8_lossy(&output.stdout).contains(PARENT_ID));
+    assert!(!String::from_utf8_lossy(&output.stdout).contains("vendor/parent"));
+}
+
+#[test]
+fn inspect_fails_closed_when_an_inherited_pin_is_tampered() {
+    let repo = runtime_repo("runtime-inspect-tamper");
+    repo.write_node(
+        "vendor/parent",
+        "decisions/parent.md",
+        &decision(PARENT_ID, "Tampered Runtime Policy", None),
+    );
+    let output = run(&repo, &["inspect", "decisions", "--json"]);
+    assert_eq!(output.status.code(), Some(1));
+    assert!(output.stdout.is_empty());
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("parent-corpus-digest-mismatch"),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn inspect_refuses_direct_inherited_paths_before_a_parent_config_can_hide_the_graph() {
+    let repo = runtime_repo("runtime-inspect-direct-parent");
+    repo.write_node(
+        "vendor/parent",
+        "decisions/parent.md",
+        &decision(PARENT_ID, "Tampered Direct Parent", None),
+    );
+
+    for target in [
+        "vendor/parent/decisions",
+        "vendor/parent/decisions/parent.md",
+    ] {
+        let output = run(&repo, &["inspect", target, "--json"]);
+        assert_eq!(
+            output.status.code(),
+            Some(2),
+            "direct inherited inspect must be refused: {target}\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(output.stdout.is_empty());
+        assert!(
+            String::from_utf8_lossy(&output.stderr)
+                .contains("limited to root-local artifacts"),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+}
+
+#[test]
+fn named_write_surfaces_refuse_traversal_and_nonexistent_parent_suffixes_atomically() {
+    let repo = runtime_repo("runtime-write-surfaces");
+    fs::create_dir_all(repo.path("vendor/sibling")).expect("create traversal sibling");
+    fs::create_dir_all(repo.path("vendor/parent/.git")).expect("create inherited git dir");
+    repo.write("paths.txt", "src/guarded.rs\n");
+    let parent = repo.path("vendor/parent");
+    let before = file_bytes(&parent);
+
+    assert_read_only_failure(
+        &run(
+            &repo,
+            &[
+                "herald",
+                "decisions",
+                "--paths-file",
+                "paths.txt",
+                "--out",
+                "vendor/sibling/../parent/not-created/herald.md",
+            ],
+        ),
+        "Herald traversal output",
+    );
+    assert_read_only_failure(
+        &run(
+            &repo,
+            &[
+                "herald",
+                "decisions",
+                "--paths-file",
+                "paths.txt",
+                "--out",
+                "local-herald.md",
+                "--github-output",
+                "vendor/parent/not-created/github/output.txt",
+            ],
+        ),
+        "Herald GitHub output",
+    );
+    assert!(!repo.path("local-herald.md").exists());
+
+    assert_read_only_failure(
+        &run(
+            &repo,
+            &["skill", "install", "--dir", "vendor/parent", "--json"],
+        ),
+        "skill installation",
+    );
+    assert_read_only_failure(
+        &run(
+            &repo,
+            &["hook", "install", "--dir", "vendor/parent", "--json"],
+        ),
+        "hook installation",
+    );
+    assert_read_only_failure(
+        &run(
+            &repo,
+            &[
+                "eval",
+                "--update-baseline",
+                "--baseline",
+                "vendor/parent/not-created/deep/baseline.json",
+            ],
+        ),
+        "eval baseline update",
+    );
+
+    assert_eq!(file_bytes(&parent), before, "parent bytes changed");
+}
+
+#[cfg(unix)]
+#[test]
+fn concrete_multi_file_targets_refuse_symlink_routes_before_any_write() {
+    use std::os::unix::fs::symlink;
+
+    let repo = runtime_repo("runtime-write-symlinks");
+    let parent = repo.path("vendor/parent");
+    let before = file_bytes(&parent);
+
+    fs::create_dir_all(repo.path("generated")).expect("create agent-rules output root");
+    symlink(&parent, repo.path("generated/.github")).expect("link agent-rules subdirectory");
+    assert_read_only_failure(
+        &run(
+            &repo,
+            &[
+                "export",
+                "decisions",
+                "--agent-rules",
+                "--client",
+                "copilot",
+                "--out",
+                "generated",
+            ],
+        ),
+        "agent-rules symlink target",
+    );
+
+    fs::create_dir_all(repo.path("okf-out")).expect("create OKF output root");
+    symlink(
+        parent.join("decisions/parent.md"),
+        repo.path("okf-out/index.md"),
+    )
+    .expect("link OKF generated file");
+    assert_read_only_failure(
+        &run(
+            &repo,
+            &["export", "decisions", "--okf", "--out", "okf-out"],
+        ),
+        "OKF bundle symlink target",
+    );
+
+    fs::create_dir_all(repo.path("local-skill/.claude")).expect("create skill output root");
+    symlink(&parent, repo.path("local-skill/.claude/skills"))
+        .expect("link skill destination tree");
+    assert_read_only_failure(
+        &run(
+            &repo,
+            &[
+                "skill",
+                "install",
+                "decided-artifacts",
+                "--dir",
+                "local-skill",
+            ],
+        ),
+        "skill symlink target",
+    );
+
+    assert_eq!(file_bytes(&parent), before, "parent bytes changed");
+}

--- a/rust/decided/tests/federation_v2_write_boundary.rs
+++ b/rust/decided/tests/federation_v2_write_boundary.rs
@@ -1,0 +1,125 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static COUNTER: AtomicUsize = AtomicUsize::new(0);
+const V2_ZERO_DIGEST: &str =
+    "sha256-v2:0000000000000000000000000000000000000000000000000000000000000000";
+
+fn scratch(name: &str) -> PathBuf {
+    let sequence = COUNTER.fetch_add(1, Ordering::SeqCst);
+    let root = std::env::temp_dir().join(format!(
+        "asdecided-v2-write-boundary-{name}-{}-{sequence}",
+        std::process::id()
+    ));
+    fs::create_dir_all(root.join(".decided")).unwrap();
+    fs::create_dir_all(root.join("decisions")).unwrap();
+    fs::write(
+        root.join(".decided/config.yaml"),
+        "repository_key: APP\ncorpus:\n  source: acme/app\n",
+    )
+    .unwrap();
+    root
+}
+
+fn parent(root: &Path, source: &str) {
+    fs::create_dir_all(root.join(".decided")).unwrap();
+    fs::create_dir_all(root.join("decisions")).unwrap();
+    fs::write(
+        root.join(".decided/config.yaml"),
+        format!("repository_key: STD\ncorpus:\n  source: {source}\n"),
+    )
+    .unwrap();
+}
+
+fn activate_v2(root: &Path) {
+    let parents = [
+        ("one", "acme/one", "vendor/one"),
+        ("two", "acme/two", "vendor/two"),
+        ("three", "acme/three", "vendor/three"),
+    ];
+    for (_, source, path) in parents {
+        parent(&root.join(path), source);
+    }
+    parent(&root.join("vendor/one/vendor/leaf"), "acme/leaf");
+
+    let mut manifest = String::from("# Corpus\n\n## inherits\n\n```yaml\nversion: 2\nparents:\n");
+    for (alias, source, path) in parents {
+        manifest.push_str(&format!(
+            "  - alias: {alias}\n    source: {source}\n    root: {path}\n    corpus: decisions\n    digest: {V2_ZERO_DIGEST}\n"
+        ));
+    }
+    manifest.push_str("```\n\n## overrides\n\n```yaml\nversion: 2\nitems: []\n```\n");
+    fs::write(root.join(".decided/corpus.md"), manifest).unwrap();
+}
+
+fn run(root: &Path, args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_decided"))
+        .args(args)
+        .current_dir(root)
+        .env("DECIDED_NO_CACHE", "1")
+        .output()
+        .unwrap()
+}
+
+fn assert_refused(output: &Output, context: &str) {
+    assert_eq!(output.status.code(), Some(1), "{context}");
+    let stderr = String::from_utf8_lossy(&output.stderr).to_lowercase();
+    assert!(
+        stderr.contains("refusing to write") && stderr.contains("read-only"),
+        "{context}: {stderr}"
+    );
+}
+
+#[test]
+fn mutation_and_output_commands_refuse_all_v2_materialisation_routes() {
+    let root = scratch("commands");
+    activate_v2(&root);
+    let direct_mutation = root.join("vendor/two/decisions/forbidden.md");
+    let transitive_mutation = root.join("vendor/one/vendor/leaf/decisions/forbidden.md");
+    let output = root.join("vendor/three/forbidden.html");
+
+    assert_refused(
+        &run(
+            &root,
+            &[
+                "new",
+                "requirement",
+                "vendor/two/decisions/forbidden.md",
+                "--json",
+            ],
+        ),
+        "direct inherited mutation",
+    );
+    assert_refused(
+        &run(
+            &root,
+            &[
+                "new",
+                "requirement",
+                "vendor/one/vendor/leaf/decisions/forbidden.md",
+                "--json",
+            ],
+        ),
+        "transitive inherited mutation",
+    );
+    assert_refused(
+        &run(
+            &root,
+            &[
+                "export",
+                "decisions",
+                "--html",
+                "--out",
+                "vendor/three/forbidden.html",
+            ],
+        ),
+        "inherited output",
+    );
+
+    assert!(!direct_mutation.exists());
+    assert!(!transitive_mutation.exists());
+    assert!(!output.exists());
+    fs::remove_dir_all(root).unwrap();
+}

--- a/rust/rac-engine/Cargo.toml
+++ b/rust/rac-engine/Cargo.toml
@@ -24,6 +24,7 @@ markdown-it = { version = "0.6.1", default-features = false }
 globset = "0.4"
 regex = "1"
 serde_yaml = "0.9"
+unsafe-libyaml = "0.2"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 inotify = { version = "0.11", default-features = false }

--- a/rust/rac-engine/assets/schemas/export-documents-v1.schema.json
+++ b/rust/rac-engine/assets/schemas/export-documents-v1.schema.json
@@ -23,7 +23,6 @@
       "type": "object",
       "required": [
         "state",
-        "parent",
         "replacement",
         "rationale"
       ],
@@ -31,8 +30,15 @@
         "state": {
           "enum": [
             "overridden",
-            "replacement"
+            "replacement",
+            "lineage"
           ]
+        },
+        "owner_source": {
+          "type": "string"
+        },
+        "target": {
+          "$ref": "#/$defs/identity"
         },
         "parent": {
           "$ref": "#/$defs/identity"
@@ -44,6 +50,19 @@
           "$ref": "#/$defs/identity"
         }
       },
+      "anyOf": [
+        {
+          "required": [
+            "parent"
+          ]
+        },
+        {
+          "required": [
+            "owner_source",
+            "target"
+          ]
+        }
+      ],
       "additionalProperties": true
     },
     "provenance": {
@@ -64,7 +83,7 @@
         },
         "pin": {
           "type": "string",
-          "pattern": "^sha256:[0-9a-f]{64}$"
+          "pattern": "^sha256(?:-v2)?:[0-9a-f]{64}$"
         },
         "overrides": {
           "type": "array",

--- a/rust/rac-engine/assets/schemas/export-graph-v1.schema.json
+++ b/rust/rac-engine/assets/schemas/export-graph-v1.schema.json
@@ -23,7 +23,6 @@
       "type": "object",
       "required": [
         "state",
-        "parent",
         "replacement",
         "rationale"
       ],
@@ -31,8 +30,15 @@
         "state": {
           "enum": [
             "overridden",
-            "replacement"
+            "replacement",
+            "lineage"
           ]
+        },
+        "owner_source": {
+          "type": "string"
+        },
+        "target": {
+          "$ref": "#/$defs/identity"
         },
         "parent": {
           "$ref": "#/$defs/identity"
@@ -44,6 +50,19 @@
           "$ref": "#/$defs/identity"
         }
       },
+      "anyOf": [
+        {
+          "required": [
+            "parent"
+          ]
+        },
+        {
+          "required": [
+            "owner_source",
+            "target"
+          ]
+        }
+      ],
       "additionalProperties": true
     },
     "provenance": {
@@ -64,7 +83,7 @@
         },
         "pin": {
           "type": "string",
-          "pattern": "^sha256:[0-9a-f]{64}$"
+          "pattern": "^sha256(?:-v2)?:[0-9a-f]{64}$"
         },
         "overrides": {
           "type": "array",
@@ -195,6 +214,25 @@
             "$ref": "#/$defs/identity"
           },
           "target_identity": {
+            "oneOf": [
+              {
+                "$ref": "#/$defs/identity"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "authored_token": {
+            "type": "string"
+          },
+          "historical_candidates": {
+            "type": "array",
+            "items": {
+              "$ref": "#/$defs/identity"
+            }
+          },
+          "effective_terminal": {
             "oneOf": [
               {
                 "$ref": "#/$defs/identity"

--- a/rust/rac-engine/assets/schemas/export-viewer-v1.schema.json
+++ b/rust/rac-engine/assets/schemas/export-viewer-v1.schema.json
@@ -23,7 +23,6 @@
       "type": "object",
       "required": [
         "state",
-        "parent",
         "replacement",
         "rationale"
       ],
@@ -31,8 +30,15 @@
         "state": {
           "enum": [
             "overridden",
-            "replacement"
+            "replacement",
+            "lineage"
           ]
+        },
+        "owner_source": {
+          "type": "string"
+        },
+        "target": {
+          "$ref": "#/$defs/identity"
         },
         "parent": {
           "$ref": "#/$defs/identity"
@@ -44,6 +50,19 @@
           "$ref": "#/$defs/identity"
         }
       },
+      "anyOf": [
+        {
+          "required": [
+            "parent"
+          ]
+        },
+        {
+          "required": [
+            "owner_source",
+            "target"
+          ]
+        }
+      ],
       "additionalProperties": true
     },
     "provenance": {
@@ -64,7 +83,7 @@
         },
         "pin": {
           "type": "string",
-          "pattern": "^sha256:[0-9a-f]{64}$"
+          "pattern": "^sha256(?:-v2)?:[0-9a-f]{64}$"
         },
         "overrides": {
           "type": "array",
@@ -214,6 +233,25 @@
             "$ref": "#/$defs/identity"
           },
           "to_identity": {
+            "oneOf": [
+              {
+                "$ref": "#/$defs/identity"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "authored_token": {
+            "type": "string"
+          },
+          "historical_candidates": {
+            "type": "array",
+            "items": {
+              "$ref": "#/$defs/identity"
+            }
+          },
+          "effective_terminal": {
             "oneOf": [
               {
                 "$ref": "#/$defs/identity"

--- a/rust/rac-engine/src/agent_rules.rs
+++ b/rust/rac-engine/src/agent_rules.rs
@@ -52,6 +52,16 @@ fn targets_for(clients: &[String]) -> Vec<&'static AgentRulesTarget> {
         .collect()
 }
 
+/// Concrete output files selected for a generate run, in stable target order.
+/// Exposing the paths lets the command preflight the complete write set before
+/// the first managed block is created or updated.
+pub fn output_targets(root: &str, clients: &[String]) -> Vec<String> {
+    targets_for(clients)
+        .into_iter()
+        .map(|target| py_path_join(root, target.path))
+        .collect()
+}
+
 /// One distilled live-decision pointer.
 struct AgentRulesEntry {
     identifier: String,

--- a/rust/rac-engine/src/commands.rs
+++ b/rust/rac-engine/src/commands.rs
@@ -64,6 +64,11 @@ pub struct FileValidation {
     /// Released single-corpus validation leaves this absent so its rendered
     /// output remains byte-identical.
     pub origin: Option<ArtifactOrigin>,
+    /// Canonical source route for graph topology findings only. Ordinary
+    /// artifact validation and all released version-1 paths leave this absent.
+    pub source_route: Option<Vec<String>>,
+    /// Exact verified physical-route count represented by `source_route`.
+    pub route_count: Option<usize>,
 }
 
 pub struct DirectoryValidation {
@@ -132,6 +137,8 @@ pub fn validate_directory(directory: &str, recursive: bool) -> DirectoryValidati
                     status: STATUS_SKIPPED,
                     issues: Vec::new(),
                     origin: None,
+                    source_route: None,
+                    route_count: None,
                 };
             }
             let issues = apply_overrides(
@@ -150,6 +157,8 @@ pub fn validate_directory(directory: &str, recursive: bool) -> DirectoryValidati
                 status,
                 issues,
                 origin: None,
+                source_route: None,
+                route_count: None,
             }
         })
         .collect();
@@ -199,6 +208,8 @@ pub(crate) fn validate_directory_from_items(
                     status: STATUS_SKIPPED,
                     issues: Vec::new(),
                     origin: Some(item.origin.clone()),
+                    source_route: None,
+                    route_count: None,
                 };
             }
             let issues = if item.origin.layer == crate::corpus::Layer::Inherited {
@@ -221,6 +232,8 @@ pub(crate) fn validate_directory_from_items(
                 status,
                 issues,
                 origin: Some(item.origin.clone()),
+                source_route: None,
+                route_count: None,
             }
         })
         .collect();
@@ -268,6 +281,15 @@ fn refuse_read_only_target(path: &str) -> Option<i32> {
             Some(EXIT_VALIDATION_FAILED)
         }
     }
+}
+
+fn refuse_read_only_targets<'a>(paths: impl IntoIterator<Item = &'a str>) -> Option<i32> {
+    for path in paths {
+        if let Some(code) = refuse_read_only_target(path) {
+            return Some(code);
+        }
+    }
+    None
 }
 
 /// A fingerprint of the ancestor-walked `.decided/config.yaml` governing
@@ -458,6 +480,8 @@ pub fn validate_directory_incremental_in(
                 })
                 .collect(),
             origin: None,
+            source_route: None,
+            route_count: None,
         });
         let file_name = entry
             .display
@@ -633,7 +657,17 @@ pub fn cmd_validate(args: &ValidateArgs) -> i32 {
             }
             Ok(None) => validate_directory(&args.file, !args.top_level),
             Err(error) => {
-                let origin = manifest_failure_origin(&args.file);
+                let origin = error
+                    .validation_origin()
+                    .map(|origin| ArtifactOrigin {
+                        source: origin.source.clone(),
+                        layer: origin.layer,
+                        pin: origin.pin.clone(),
+                        alias: None,
+                    })
+                    .or_else(|| manifest_failure_origin(&args.file));
+                let source_route = error.source_route().map(<[String]>::to_vec);
+                let route_count = error.route_count();
                 DirectoryValidation {
                     directory: args.file.clone(),
                     recursive: !args.top_level,
@@ -648,6 +682,8 @@ pub fn cmd_validate(args: &ValidateArgs) -> i32 {
                             None,
                         )],
                         origin,
+                        source_route,
+                        route_count,
                     }],
                     okf: None,
                 }
@@ -820,10 +856,45 @@ pub struct InspectArgs {
 }
 
 pub fn cmd_inspect(args: &InspectArgs) -> i32 {
+    if args.file != "-" {
+        match crate::federated_corpus::is_read_only_graph_materialised_path(&args.file) {
+            Ok(true) => {
+                return usage_error(&format!(
+                    "inspect in a version-2 federation is limited to root-local artifacts: {}",
+                    args.file
+                ))
+            }
+            Ok(false) => {}
+            Err(error) => {
+                eprintln!("decided: {error}");
+                return EXIT_VALIDATION_FAILED;
+            }
+        }
+    }
     // Directory? Aggregate per-file results into type counts. (The directory
     // check precedes the .md extension guard — and never applies to `-`.)
     if args.file != "-" && Path::new(&args.file).is_dir() {
-        let result = crate::inspect::inspect_directory(&args.file, !args.top_level);
+        let result = match crate::federated_corpus::load_graph_composed_corpus(
+            &args.file,
+            !args.top_level,
+        ) {
+            Ok(Some(composed)) => {
+                let local = crate::federated_corpus::local_writable_projection(
+                    &args.file,
+                    &composed,
+                );
+                crate::inspect::inspect_directory_from_items(
+                    &args.file,
+                    !args.top_level,
+                    &local,
+                )
+            }
+            Ok(None) => crate::inspect::inspect_directory(&args.file, !args.top_level),
+            Err(error) => {
+                eprintln!("decided: {error}");
+                return EXIT_VALIDATION_FAILED;
+            }
+        };
         if args.json {
             emit(output::render_dir_inspect_json(&result));
         } else {
@@ -837,7 +908,38 @@ pub fn cmd_inspect(args: &InspectArgs) -> i32 {
         Ok(t) => t,
         Err(code) => return code,
     };
-    let artifact = parse_text(&text, "");
+    let graph_artifact = if args.file == "-" {
+        None
+    } else {
+        let target = match std::fs::canonicalize(&args.file) {
+            Ok(target) => target,
+            Err(error) => return usage_error(&format!("cannot read {}: {error}", args.file)),
+        };
+        let containing = Path::new(&args.file).parent().unwrap_or_else(|| Path::new("."));
+        match crate::federated_corpus::load_graph_composed_corpus(
+            &containing.to_string_lossy(),
+            true,
+        ) {
+            Ok(Some(composed)) => match composed
+                .local_items()
+                .find(|item| item.locator.path == target)
+            {
+                Some(item) => Some(item.artifact.clone()),
+                None => {
+                    return usage_error(&format!(
+                        "inspect in a version-2 federation is limited to root-local artifacts: {}",
+                        args.file
+                    ))
+                }
+            },
+            Ok(None) => None,
+            Err(error) => {
+                eprintln!("decided: {error}");
+                return EXIT_VALIDATION_FAILED;
+            }
+        }
+    };
+    let artifact = graph_artifact.unwrap_or_else(|| parse_text(&text, ""));
     let inspection = crate::inspect::build_inspection(&artifact);
     if args.verbose && !args.json {
         emit(output::render_inspect_verbose(
@@ -1224,14 +1326,14 @@ pub fn cmd_sentry(args: &SentryArgs) -> i32 {
         .map(|corpus| corpus.effective().cloned().collect())
         .unwrap_or_default();
     let report = match if let Some(composed) = &composed {
-        crate::sentry::analyze_with_items(
+        crate::sentry::analyze_with_items_excluding(
             &args.directory,
             &args.repository,
             args.base.as_deref(),
             args.full,
             &composed_items,
             true,
-            composed.read_only_root(),
+            composed.read_only_roots(),
         )
     } else {
         crate::sentry::analyze(
@@ -1276,6 +1378,11 @@ pub struct HeraldArgs {
 pub fn cmd_herald(args: &HeraldArgs) -> i32 {
     if !Path::new(&args.directory).is_dir() {
         return usage_error(&format!("not a directory: {}", args.directory));
+    }
+    if let Some(code) = refuse_read_only_targets(
+        std::iter::once(args.out.as_str()).chain(args.github_output.as_deref()),
+    ) {
+        return code;
     }
     let paths = match std::fs::read_to_string(&args.paths_file) {
         Ok(text) => text.lines().map(str::trim).filter(|line| !line.is_empty()).map(str::to_string).collect::<Vec<_>>(),
@@ -1516,6 +1623,20 @@ pub fn cmd_export(args: &ExportArgs) -> i32 {
     if args.out.is_some() && !(args.html || args.okf) {
         return usage_error("--out requires --html or --okf (--json writes to stdout)");
     }
+    // Classify explicit/default write targets before loading corpus content.
+    // A version-2 root deliberately does not enter the version-1 composition
+    // loader, but its inherited materialisations remain read-only even while
+    // graph command wiring is staged separately.
+    if args.html || args.okf {
+        let out = args.out.as_deref().unwrap_or(if args.okf {
+            "okf-bundle"
+        } else {
+            "lore-export.html"
+        });
+        if let Some(code) = refuse_read_only_target(out) {
+            return code;
+        }
+    }
     if let Some(name) = &args.schema {
         let Some(schema) = crate::export::export_schema(name) else {
             return usage_error(&format!(
@@ -1583,9 +1704,6 @@ pub fn cmd_export(args: &ExportArgs) -> i32 {
             None => crate::export::build_okf_export(&args.directory, output::rac_version()),
         };
         let out = args.out.as_deref().unwrap_or("okf-bundle");
-        if let Some(code) = refuse_read_only_target(out) {
-            return code;
-        }
         let recency = crate::okf::artifact_recency(&args.directory, &export);
         let bundle = match crate::okf::render_okf_bundle(&export, &recency, &args.directory) {
             Ok(bundle) => bundle,
@@ -1598,6 +1716,19 @@ pub fn cmd_export(args: &ExportArgs) -> i32 {
                 return EXIT_VALIDATION_FAILED;
             }
         };
+        let destinations: Vec<_> = bundle
+            .keys()
+            .map(|relative| std::path::Path::new(out).join(relative))
+            .collect();
+        let destination_text: Vec<_> = destinations
+            .iter()
+            .map(|path| path.to_string_lossy().into_owned())
+            .collect();
+        if let Some(code) =
+            refuse_read_only_targets(destination_text.iter().map(String::as_str))
+        {
+            return code;
+        }
         for (rel, content) in &bundle {
             let dest = std::path::Path::new(out).join(rel);
             let written = dest
@@ -1642,9 +1773,6 @@ pub fn cmd_export(args: &ExportArgs) -> i32 {
     }
 
     let out = args.out.as_deref().unwrap_or("lore-export.html");
-    if let Some(code) = refuse_read_only_target(out) {
-        return code;
-    }
     let html = match if composed.is_some() {
         crate::portal::render_federated_export_html(&export)
     } else {
@@ -1674,6 +1802,12 @@ fn cmd_agent_rules(args: &ExportArgs) -> i32 {
     let root = crate::agent_rules::agent_rules_root(&args.directory, args.out.as_deref());
     if let Some(code) = refuse_read_only_target(&root) {
         return code;
+    }
+    if !args.check {
+        let targets = crate::agent_rules::output_targets(&root, &args.client);
+        if let Some(code) = refuse_read_only_targets(targets.iter().map(String::as_str)) {
+            return code;
+        }
     }
     let result = if args.check {
         match crate::agent_rules::check_agent_rules(&args.directory, &root, &args.client) {
@@ -1807,7 +1941,11 @@ fn composed_resolution(
             paths.sort();
             Ok(crate::resolve::ResolutionResult {
                 artifact_id: artifact_id.to_string(),
-                outcome: crate::resolve::OUTCOME_DUPLICATE,
+                outcome: if corpus.is_graph() {
+                    crate::resolve::OUTCOME_AMBIGUOUS
+                } else {
+                    crate::resolve::OUTCOME_DUPLICATE
+                },
                 artifact: None,
                 duplicate_paths: paths,
             })
@@ -1855,17 +1993,20 @@ pub fn cmd_resolve(args: &ResolveArgs) -> i32 {
         } else {
             output::render_resolve_human(artifact)
         });
-    } else if result.outcome == crate::resolve::OUTCOME_DUPLICATE {
+    } else if result.outcome == crate::resolve::OUTCOME_DUPLICATE
+        || result.outcome == crate::resolve::OUTCOME_AMBIGUOUS
+    {
         let found: Vec<String> = result
             .duplicate_paths
             .iter()
             .map(|p| format!("- {p}"))
             .collect();
-        eprintln!(
-            "decided: duplicate artifact ID: {}\n\nFound in:\n{}",
-            args.id,
-            found.join("\n")
-        );
+        let label = if result.outcome == crate::resolve::OUTCOME_AMBIGUOUS {
+            "ambiguous artifact ID"
+        } else {
+            "duplicate artifact ID"
+        };
+        eprintln!("decided: {label}: {}\n\nFound in:\n{}", args.id, found.join("\n"));
     } else {
         eprintln!("decided: artifact not found: {}", args.id);
     }
@@ -2000,6 +2141,64 @@ pub fn annotate_composed_search_recency(
     );
 }
 
+/// Graph-v2 equivalent of [`annotate_composed_search_recency`]. Only records
+/// owned by the root source may use the root repository's Git history;
+/// inherited matches deliberately retain absent recency.
+pub fn annotate_graph_search_recency(
+    matches: &mut [crate::resolve::ResolvedArtifact],
+    directory: &str,
+    corpus: &crate::graph_federated_corpus::VerifiedGraphCorpus,
+) {
+    use crate::corpus::Layer;
+    use crate::gitinfo;
+
+    let local: Vec<(usize, PathBuf)> = matches
+        .iter()
+        .enumerate()
+        .filter_map(|(index, artifact)| {
+            let key = artifact.key.as_ref()?;
+            let item = corpus.composition.item(key)?;
+            (item.origin.layer == Layer::Local).then(|| (index, item.locator.path.clone()))
+        })
+        .collect();
+    if local.is_empty() {
+        return;
+    }
+    let local_count = local.len();
+    let timing_started = crate::timing::start();
+    let threshold = crate::validate::load_freshness_threshold(directory);
+    let reference = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_secs() as i64)
+        .unwrap_or(0);
+    let repo_root = gitinfo::repository_root(Path::new(directory));
+    let paths: Vec<PathBuf> = local.iter().map(|(_, path)| path.clone()).collect();
+    let committed = match &repo_root {
+        Some(root) => gitinfo::last_committed_for_paths_in_repo(root, &paths),
+        None => paths.into_iter().map(|path| (path, None)).collect(),
+    };
+    for ((index, _), (_, last)) in local.into_iter().zip(committed) {
+        let staleness = gitinfo::staleness(last.as_deref(), threshold, reference);
+        matches[index].recency = Some(crate::resolve::Recency {
+            last_committed: staleness
+                .last_committed
+                .as_deref()
+                .map(gitinfo::isoformat_roundtrip),
+            age_days: staleness.age_days,
+            stale: staleness.stale,
+        });
+    }
+    crate::timing::emit_since(
+        "git.recency_join",
+        timing_started,
+        &[
+            ("matches", matches.len() as u64),
+            ("local_matches", local_count as u64),
+            ("repository", u64::from(repo_root.is_some())),
+        ],
+    );
+}
+
 /// Serve `decided find` from the persistent index store (`_find_from_store`,
 /// ADR-112): a warm run against an unchanged corpus reads the mapped base;
 /// a cold run builds fresh, writes the store, and serves either the
@@ -2045,9 +2244,87 @@ fn find_from_store(args: &FindArgs) -> crate::resolve::SearchResult {
     }
 }
 
+fn cmd_find_graph(args: &FindArgs, repository_root: &Path, corpus_relative: &str) -> i32 {
+    use crate::derived_cache::{GraphFederatedCacheTracker, ReadModel};
+
+    let persistent_cache = crate::derived_cache::cache_enabled(args.cache);
+    let mut tracker = GraphFederatedCacheTracker::new(
+        crate::derived_cache::default_cache_dir(),
+    );
+    let read = match tracker.read_graph(
+        repository_root,
+        corpus_relative,
+        !args.top_level,
+        persistent_cache,
+    ) {
+        Ok(read) => read,
+        Err(error) => {
+            eprintln!("decided: {error}");
+            return EXIT_VALIDATION_FAILED;
+        }
+    };
+    let mut result = match read.model {
+        ReadModel::View(reader) => {
+            if args.decisions {
+                crate::read_model::store_find_decisions(reader, &args.query)
+            } else {
+                crate::read_model::store_search(
+                    reader,
+                    &args.query,
+                    args.artifact_type.as_deref(),
+                    &args.tags,
+                    args.live,
+                )
+            }
+        }
+        ReadModel::Fresh(derived) => {
+            if args.decisions {
+                crate::read_model::find_decisions_in_source_aware(
+                    &derived.index_entries,
+                    &derived.live_decision_keys,
+                    &derived.live_decision_paths,
+                    &args.query,
+                )
+            } else {
+                crate::resolve::search_index_filtered(
+                    &derived.index_entries,
+                    &args.query,
+                    args.artifact_type.as_deref(),
+                    &args.tags,
+                    args.live,
+                )
+            }
+        }
+    };
+    annotate_graph_search_recency(&mut result.matches, &args.directory, read.corpus);
+    let render_started = crate::timing::start();
+    let rendered = if args.json {
+        output::render_find_json_with_graph(&result, args.explain, read.corpus)
+    } else {
+        output::render_find_human_with_graph(&result, args.explain, read.corpus)
+    };
+    crate::timing::emit_since(
+        "cli.response_serialize",
+        render_started,
+        &[("matches", result.matches.len() as u64), ("bytes", rendered.len() as u64)],
+    );
+    emit(rendered);
+    EXIT_OK
+}
+
 pub fn cmd_find(args: &FindArgs) -> i32 {
     if !Path::new(&args.directory).is_dir() {
         return usage_error(&format!("not a directory: {}", args.directory));
+    }
+    let graph = match crate::federated_corpus::graph_cache_location(&args.directory) {
+        Ok(graph) => graph,
+        Err(error) => {
+            eprintln!("decided: {error}");
+            return EXIT_VALIDATION_FAILED;
+        }
+    };
+    if let Some((repository_root, corpus_relative)) = graph {
+        return cmd_find_graph(args, &repository_root, &corpus_relative);
     }
     let composed = match load_composed_or_exit(&args.directory, !args.top_level) {
         Ok(composed) => composed,
@@ -2056,15 +2333,20 @@ pub fn cmd_find(args: &FindArgs) -> i32 {
     let mut result = if let Some(composed) = &composed {
         let entries = composed.effective_index();
         if args.decisions {
-            let live_paths: Vec<String> = composed
+            let live_keys: Vec<crate::corpus::ArtifactKey> = composed
                 .effective()
                 .filter(|item| {
                     item.spec.map(|spec| spec.name.as_str()) == Some("decision")
                         && crate::resolve::is_live_decision(&item.artifact)
                 })
-                .map(|item| item.path.clone())
+                .map(|item| item.key.clone())
                 .collect();
-            crate::read_model::find_decisions_in(&entries, &live_paths, &args.query)
+            crate::read_model::find_decisions_in_source_aware(
+                &entries,
+                &live_keys,
+                &[],
+                &args.query,
+            )
         } else {
             crate::resolve::search_index_filtered(
                 &entries,
@@ -2332,7 +2614,7 @@ pub struct SkillArgs {
 /// bundled Claude Code agent skills. The `--dir` not-a-directory check runs
 /// BEFORE the unknown-name check (skill brief, landmine 5).
 pub fn cmd_skill(args: &SkillArgs) -> i32 {
-    use crate::skill::{install_skills, SkillInstallError};
+    use crate::skill::{install_skills, install_targets, SkillInstallError};
 
     if args.action == "list" {
         if args.name.is_some() {
@@ -2348,6 +2630,17 @@ pub fn cmd_skill(args: &SkillArgs) -> i32 {
 
     if !Path::new(&args.dir).is_dir() {
         return usage_error(&format!("not a directory: {}", args.dir));
+    }
+    let targets = match install_targets(&args.dir, args.name.as_deref()) {
+        Ok(targets) => targets,
+        Err(SkillInstallError::NotFound(message)) => return usage_error(&message),
+        Err(SkillInstallError::FileExists(message)) | Err(SkillInstallError::Io(message)) => {
+            eprintln!("decided: {message}");
+            return EXIT_VALIDATION_FAILED;
+        }
+    };
+    if let Some(code) = refuse_read_only_targets(targets.iter().map(String::as_str)) {
+        return code;
     }
     let installation = match install_skills(&args.dir, args.name.as_deref()) {
         Ok(installation) => installation,
@@ -2381,7 +2674,7 @@ pub struct HookArgs {
 /// install the bundled git hooks. `list` ignores `--style`/`--dir`; an
 /// invalid style never reaches here (argparse choices fire first).
 pub fn cmd_hook(args: &HookArgs) -> i32 {
-    use crate::hook::{install_hook, HookInstallError};
+    use crate::hook::{install_hook, install_target, HookInstallError};
 
     if args.action == "list" {
         if args.json {
@@ -2394,6 +2687,17 @@ pub fn cmd_hook(args: &HookArgs) -> i32 {
 
     if !Path::new(&args.dir).is_dir() {
         return usage_error(&format!("not a directory: {}", args.dir));
+    }
+    let target = match install_target(&args.dir, &args.style) {
+        Ok(target) => target,
+        Err(HookInstallError::NotAGitWorkTree(message)) => return usage_error(&message),
+        Err(HookInstallError::FileExists(message)) | Err(HookInstallError::Io(message)) => {
+            eprintln!("decided: {message}");
+            return EXIT_VALIDATION_FAILED;
+        }
+    };
+    if let Some(code) = refuse_read_only_target(&target) {
+        return code;
     }
     let installation = match install_hook(&args.dir, &args.style) {
         Ok(installation) => installation,
@@ -2434,6 +2738,11 @@ pub fn cmd_eval(args: &EvalArgs) -> i32 {
         eprintln!("decided eval: {}", err.0);
         EXIT_USAGE
     };
+    if args.update_baseline {
+        if let Some(code) = refuse_read_only_target(&args.baseline) {
+            return code;
+        }
+    }
     let scorecard = match eval::run_eval(&args.root, &args.queries) {
         Ok(scorecard) => scorecard,
         Err(err) => return fail(err),
@@ -3072,6 +3381,8 @@ mod validation_provenance_tests {
                     Some(3),
                 )],
                 origin,
+                source_route: None,
+                route_count: None,
             }],
             okf: None,
         }
@@ -3118,6 +3429,58 @@ mod validation_provenance_tests {
         assert_eq!(
             composed_sarif["runs"][0]["results"][0]["properties"],
             composed_json["files"][0]["provenance"]
+        );
+    }
+
+    #[test]
+    fn topology_validation_retains_route_context_in_every_renderer() {
+        let result = DirectoryValidation {
+            directory: "decisions".to_string(),
+            recursive: true,
+            files: vec![FileValidation {
+                path: crate::federation::MANIFEST_RELATIVE_PATH.to_string(),
+                artifact_type: "corpus-manifest".to_string(),
+                status: STATUS_INVALID,
+                issues: vec![Issue::new(
+                    "error",
+                    "corpus-federation-invalid-node",
+                    "shared inherited node is invalid".to_string(),
+                    None,
+                )],
+                origin: Some(ArtifactOrigin {
+                    source: "acme/shared".to_string(),
+                    layer: crate::corpus::Layer::Inherited,
+                    pin: Some(format!("sha256-v2:{}", "a".repeat(64))),
+                    alias: None,
+                }),
+                source_route: Some(vec![
+                    "acme/root".to_string(),
+                    "acme/left".to_string(),
+                    "acme/shared".to_string(),
+                ]),
+                route_count: Some(2),
+            }],
+            okf: None,
+        };
+
+        let human = output::render_validate_dir_human(&result);
+        assert!(human.contains(
+            "source route: acme/root -> acme/left -> acme/shared (2 verified physical routes)"
+        ));
+
+        let json: serde_json::Value =
+            serde_json::from_str(&output::render_validate_dir_json(&result)).unwrap();
+        assert_eq!(
+            json["files"][0]["provenance"]["source_route"],
+            serde_json::json!(["acme/root", "acme/left", "acme/shared"])
+        );
+        assert_eq!(json["files"][0]["provenance"]["route_count"], 2);
+
+        let sarif: serde_json::Value =
+            serde_json::from_str(&output::render_validate_sarif(&result)).unwrap();
+        assert_eq!(
+            sarif["runs"][0]["results"][0]["properties"],
+            json["files"][0]["provenance"]
         );
     }
 

--- a/rust/rac-engine/src/composition.rs
+++ b/rust/rac-engine/src/composition.rs
@@ -10,6 +10,7 @@ use std::fmt;
 use std::path::{Path, PathBuf};
 
 use crate::corpus::{ArtifactKey, ArtifactPath, Layer};
+use crate::graph_composition::{GraphComposition, GraphLookupError, GraphOverrideProvenance};
 use crate::pycompat::py_casefold;
 use crate::relationships::{
     resolution_index_from_rows, resolve_relationships, validation_from_rows_with_index,
@@ -271,9 +272,11 @@ pub enum LookupError {
 /// The one composed read model. `items` owns the catalog exactly once; local
 /// and effective corpora are stable ordered projections over it.
 pub struct ComposedCorpus {
+    graph: Option<GraphComposition>,
     items: Vec<CorpusItem>,
     child_source: Option<String>,
     read_only_root: Option<PathBuf>,
+    read_only_roots: Vec<PathBuf>,
     local: Vec<usize>,
     effective: Vec<usize>,
     parent: Option<ParentIdentity>,
@@ -284,6 +287,39 @@ pub struct ComposedCorpus {
     resolution_index: ResolutionIndex,
     item_by_key: HashMap<ArtifactKey, usize>,
     captured_content: HashMap<ArtifactKey, Vec<u8>>,
+}
+
+enum CorpusProjectionIter<'a> {
+    Direct(std::slice::Iter<'a, CorpusItem>),
+    Projected {
+        items: &'a [CorpusItem],
+        indices: std::slice::Iter<'a, usize>,
+    },
+}
+
+impl<'a> Iterator for CorpusProjectionIter<'a> {
+    type Item = &'a CorpusItem;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::Direct(items) => items.next(),
+            Self::Projected { items, indices } => indices.next().map(|index| &items[*index]),
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let length = self.len();
+        (length, Some(length))
+    }
+}
+
+impl ExactSizeIterator for CorpusProjectionIter<'_> {
+    fn len(&self) -> usize {
+        match self {
+            Self::Direct(items) => items.len(),
+            Self::Projected { indices, .. } => indices.len(),
+        }
+    }
 }
 
 impl ComposedCorpus {
@@ -385,6 +421,42 @@ impl ComposedCorpus {
         )
     }
 
+    /// Activate an already-verified version-2 graph behind the common read
+    /// facade. The graph remains the sole owner of catalog and projection
+    /// semantics; captured bytes and physical read-only roots stay runtime
+    /// data on this compatibility boundary.
+    pub fn from_graph(
+        graph: GraphComposition,
+        captured_content: impl IntoIterator<Item = (ArtifactKey, Vec<u8>)>,
+        read_only_roots: impl IntoIterator<Item = PathBuf>,
+    ) -> Self {
+        let child_source = graph.root_source().to_string();
+        let mut captured_content: HashMap<ArtifactKey, Vec<u8>> =
+            captured_content.into_iter().collect();
+        captured_content.retain(|key, _| graph.item(key).is_some());
+        let mut read_only_roots: Vec<PathBuf> = read_only_roots.into_iter().collect();
+        read_only_roots.sort();
+        read_only_roots.dedup();
+        let read_only_root = read_only_roots.first().cloned();
+        Self {
+            graph: Some(graph),
+            items: Vec::new(),
+            child_source: Some(child_source),
+            read_only_root,
+            read_only_roots,
+            local: Vec::new(),
+            effective: Vec::new(),
+            parent: None,
+            overrides: Vec::new(),
+            findings: Vec::new(),
+            catalog_rows: Vec::new(),
+            effective_rows: Vec::new(),
+            resolution_index: ResolutionIndex::new(),
+            item_by_key: HashMap::new(),
+            captured_content,
+        }
+    }
+
     fn build(
         items: Vec<CorpusItem>,
         child_source: Option<String>,
@@ -483,10 +555,13 @@ impl ComposedCorpus {
             .collect();
         captured_content.retain(|key, _| item_by_key.contains_key(key));
 
+        let read_only_roots = read_only_root.iter().cloned().collect();
         Self {
+            graph: None,
             items,
             child_source,
             read_only_root,
+            read_only_roots,
             local,
             effective,
             parent,
@@ -501,15 +576,36 @@ impl ComposedCorpus {
     }
 
     pub fn local_items(&self) -> impl ExactSizeIterator<Item = &CorpusItem> {
-        self.local.iter().map(|index| &self.items[*index])
+        match &self.graph {
+            Some(graph) => CorpusProjectionIter::Projected {
+                items: graph.catalog_slice(),
+                indices: graph.root_local_indices().iter(),
+            },
+            None => CorpusProjectionIter::Projected {
+                items: &self.items,
+                indices: self.local.iter(),
+            },
+        }
     }
 
     pub fn catalog(&self) -> impl ExactSizeIterator<Item = &CorpusItem> {
-        self.items.iter()
+        match &self.graph {
+            Some(graph) => CorpusProjectionIter::Direct(graph.catalog_slice().iter()),
+            None => CorpusProjectionIter::Direct(self.items.iter()),
+        }
     }
 
     pub fn effective(&self) -> impl ExactSizeIterator<Item = &CorpusItem> {
-        self.effective.iter().map(|index| &self.items[*index])
+        match &self.graph {
+            Some(graph) => CorpusProjectionIter::Projected {
+                items: graph.catalog_slice(),
+                indices: graph.effective_indices().iter(),
+            },
+            None => CorpusProjectionIter::Projected {
+                items: &self.items,
+                indices: self.effective.iter(),
+            },
+        }
     }
 
     pub fn parent(&self) -> Option<&ParentIdentity> {
@@ -520,8 +616,29 @@ impl ComposedCorpus {
         self.child_source.as_deref()
     }
 
+    /// V1's one read-only root. Graph-backed callers receive the first
+    /// bytewise-sorted root for source compatibility and must use
+    /// [`Self::read_only_roots`] for complete mutation/exclusion guards.
     pub fn read_only_root(&self) -> Option<&Path> {
         self.read_only_root.as_deref()
+    }
+
+    pub fn read_only_roots(&self) -> &[PathBuf] {
+        &self.read_only_roots
+    }
+
+    pub fn is_graph(&self) -> bool {
+        self.graph.is_some()
+    }
+
+    /// Whether this facade has any inherited layer, under either the v1
+    /// single-parent model or the v2 graph model.
+    pub fn is_federated(&self) -> bool {
+        self.graph.is_some() || self.parent.is_some()
+    }
+
+    pub fn graph(&self) -> Option<&GraphComposition> {
+        self.graph.as_ref()
     }
 
     pub fn overrides(&self) -> &[ValidatedOverride] {
@@ -532,6 +649,17 @@ impl ComposedCorpus {
     /// attach only to the retained parent and effective replacement; a
     /// rationale-only artifact is not itself marked as overridden.
     pub fn provenance_for(&self, key: &ArtifactKey) -> Option<ComposedProvenance> {
+        if let Some(graph) = &self.graph {
+            let item = graph.item(key)?;
+            let chain = graph.provenance_for(key)?;
+            // The v1 carrier cannot represent owner, lineage, or a complete
+            // multi-hop chain. Return fixed origin only when that is the whole
+            // truth; callers must use `graph_provenance_for` otherwise.
+            return chain.is_empty().then(|| ComposedProvenance {
+                origin: item.origin.clone(),
+                overrides: Vec::new(),
+            });
+        }
         let item = self.item(key)?;
         let mut overrides: Vec<_> = self
             .overrides
@@ -560,15 +688,28 @@ impl ComposedCorpus {
         })
     }
 
+    /// Complete version-2 provenance. No v1-shaped flattening or truncation
+    /// occurs; callers either receive the graph-native ordered chain or `None`
+    /// when this is a v1/no-manifest composition.
+    pub fn graph_provenance_for(&self, key: &ArtifactKey) -> Option<&[GraphOverrideProvenance]> {
+        self.graph.as_ref()?.provenance_for(key)
+    }
+
     pub fn findings(&self) -> &[CompositionFinding] {
         &self.findings
     }
 
     pub fn is_overridden(&self, key: &ArtifactKey) -> bool {
+        if let Some(graph) = &self.graph {
+            return graph.terminal_redirects().contains_key(key);
+        }
         self.overrides.iter().any(|mapping| &mapping.parent == key)
     }
 
     pub fn item(&self, key: &ArtifactKey) -> Option<&CorpusItem> {
+        if let Some(graph) = &self.graph {
+            return graph.item(key);
+        }
         self.item_by_key.get(key).map(|index| &self.items[*index])
     }
 
@@ -592,6 +733,9 @@ impl ComposedCorpus {
     /// counts come from this composition's source-aware resolver, including
     /// qualified cross-source edges and canonical override redirects.
     pub fn effective_index(&self) -> Vec<IndexEntry> {
+        if let Some(graph) = &self.graph {
+            return graph.effective_index();
+        }
         let key_by_path: HashMap<&ArtifactPath, &ArtifactKey> = self
             .items
             .iter()
@@ -616,6 +760,9 @@ impl ComposedCorpus {
     /// only its qualified canonical address, and replacement rows receive the
     /// explicitly authorized parent-canonical redirect.
     pub fn identity_index(&self) -> Vec<IndexEntry> {
+        if let Some(graph) = &self.graph {
+            return graph.identity_index();
+        }
         let effective: BTreeSet<&ArtifactKey> = self.effective().map(|item| &item.key).collect();
         let mut entries: Vec<IndexEntry> = self
             .catalog()
@@ -658,6 +805,26 @@ impl ComposedCorpus {
     /// Resolve against the effective unqualified view, or the retained parent
     /// catalog when the reference is explicitly qualified.
     pub fn resolve(&self, reference: &str) -> Result<&CorpusItem, LookupError> {
+        if let Some(graph) = &self.graph {
+            return match graph.resolve_public(reference) {
+                Ok(resolution) => graph
+                    .item(&resolution.selected)
+                    .ok_or(LookupError::NotFound),
+                Err(GraphLookupError::Ambiguous {
+                    historical_candidates,
+                    ..
+                }) => Err(LookupError::Ambiguous(historical_candidates)),
+                Err(GraphLookupError::InvalidQualifiedReference) => {
+                    Err(LookupError::InvalidQualifiedReference)
+                }
+                Err(GraphLookupError::QualifiedCanonicalRequired) => {
+                    Err(LookupError::QualifiedCanonicalRequired)
+                }
+                Err(GraphLookupError::UnknownContext | GraphLookupError::NotFound) => {
+                    Err(LookupError::NotFound)
+                }
+            };
+        }
         if reference.contains("::") {
             self.validate_qualified_reference(reference)?;
         }
@@ -680,6 +847,9 @@ impl ComposedCorpus {
     /// Ambiguous paths include the owning source because two legal corpus
     /// layers may carry the same corpus-relative path.
     pub fn resolve_identity(&self, reference: &str) -> ResolutionResult {
+        if let Some(graph) = &self.graph {
+            return graph.resolve_identity(reference);
+        }
         match self.resolve(reference) {
             Ok(item) => ResolutionResult {
                 artifact_id: reference.to_string(),
@@ -759,6 +929,9 @@ impl ComposedCorpus {
     /// Resolve all effective declared edges through the same index as exact
     /// lookup, retaining qualified access to overridden parent history.
     pub fn relationships(&self) -> Vec<Relationship> {
+        if let Some(graph) = &self.graph {
+            return graph.relationships();
+        }
         resolve_relationships(&self.effective_rows, &self.resolution_index)
     }
 
@@ -766,6 +939,9 @@ impl ComposedCorpus {
     /// catalog. Diagnostics use this projection to keep their subjects local
     /// without losing qualified parent and override resolution.
     pub fn local_relationships(&self) -> Vec<Relationship> {
+        if let Some(graph) = &self.graph {
+            return graph.root_local_relationships_compatible();
+        }
         let rows: Vec<ValidationRow> = self
             .local
             .iter()
@@ -778,6 +954,9 @@ impl ComposedCorpus {
     /// overridden parent's immutable history. Export uses this projection;
     /// live reads and enforcement continue to use `relationships`.
     pub fn catalog_relationships(&self) -> Vec<Relationship> {
+        if let Some(graph) = &self.graph {
+            return graph.catalog_relationships_compatible();
+        }
         resolve_relationships(&self.catalog_rows, &self.resolution_index)
     }
 
@@ -868,9 +1047,10 @@ impl ComposedCorpus {
         child_directory: &str,
         recursive: bool,
     ) -> RelationshipValidation {
-        let source = self.child_source.clone().unwrap_or_else(|| {
-            crate::corpus::compatible_local_layer(child_directory).source
-        });
+        let source = self
+            .child_source
+            .clone()
+            .unwrap_or_else(|| crate::corpus::compatible_local_layer(child_directory).source);
         let origin = crate::corpus::CorpusLayer::local(source).origin();
         let spec = crate::spec::spec_for(&crate::classify::classify(artifact).artifact_type);
         let proposed = CorpusItem::new(

--- a/rust/rac-engine/src/derived.rs
+++ b/rust/rac-engine/src/derived.rs
@@ -246,6 +246,82 @@ pub(crate) fn build_derived_index_from_composed(
     }
 }
 
+/// Build the one persistable graph projection from an authenticated semantic
+/// closure. Every row comes from `VerifiedGraphCorpus`; no filesystem walk or
+/// alternate overlay occurs at this cache boundary.
+pub(crate) fn build_derived_index_from_graph(
+    corpus: &crate::graph_federated_corpus::VerifiedGraphCorpus,
+    recursive: bool,
+) -> DerivedIndex {
+    let items: Vec<CorpusItem> = corpus.composition.effective().cloned().collect();
+    let index_entries = corpus.composition.effective_index();
+    let field_tokens: Vec<FieldTokens> = index_entries.iter().map(field_tokens_of).collect();
+    let source_artifacts: Vec<SourceAwareArtifact> = items
+        .iter()
+        .map(|item| SourceAwareArtifact {
+            key: item.key.clone(),
+            path: item.artifact_path.clone(),
+            origin: item.origin.clone(),
+            display_path: item.path.clone(),
+        })
+        .collect();
+    let live_decision_paths: Vec<String> = items
+        .iter()
+        .filter(|item| {
+            item.spec.map(|spec| spec.name == DECISION_TYPE).unwrap_or(false)
+                && is_live_decision(&item.artifact)
+        })
+        .map(|item| item.path.clone())
+        .collect();
+    let live_decision_keys: Vec<ArtifactKey> = items
+        .iter()
+        .filter(|item| {
+            item.spec.map(|spec| spec.name == DECISION_TYPE).unwrap_or(false)
+                && is_live_decision(&item.artifact)
+        })
+        .map(|item| item.key.clone())
+        .collect();
+    let relationships = corpus.composition.relationships();
+    let relationship_summary = corpus.composition.relationship_summary();
+    let overrides = crate::validate::overrides_from_config_bytes(
+        &corpus.federation.root_config_bytes,
+    );
+    let portfolio = crate::portfolio::portfolio_from_corpus_with_analysis(
+        &corpus.federation.root_corpus_path,
+        &items,
+        recursive,
+        &overrides,
+        relationship_summary,
+        true,
+    );
+    let canonical_redirects = corpus
+        .composition
+        .ordered_overrides()
+        .iter()
+        .map(|mapping| CanonicalRedirect {
+            parent: mapping.target.clone(),
+            replacement: mapping.replacement.clone(),
+            rationale: mapping.rationale.clone(),
+        })
+        .collect();
+
+    DerivedIndex {
+        layers: corpus.canonical_layers.values().cloned().collect(),
+        source_artifacts,
+        resolution: Box::new(ResolutionProjection {
+            entries: corpus.composition.identity_index(),
+            canonical_redirects,
+        }),
+        index_entries,
+        field_tokens,
+        relationships,
+        live_decision_keys,
+        live_decision_paths,
+        portfolio_summary: crate::output::portfolio_summary_value(&portfolio),
+        scope_rows: scope_rows_from_items(&items),
+    }
+}
+
 /// Build the derived structures fresh from one corpus walk (the miss path).
 pub fn build_derived_index(directory: &str, recursive: bool) -> DerivedIndex {
     let items = corpus_items(directory, recursive);

--- a/rust/rac-engine/src/derived_cache.rs
+++ b/rust/rac-engine/src/derived_cache.rs
@@ -13,8 +13,9 @@ use rayon::prelude::*;
 
 use crate::derived::{DerivedIndex, SCHEMA_VERSION};
 use crate::index_store::{
-    manifest_root_key, open_freshness_manifest, open_store, remove_store, store_dir,
-    write_freshness_manifest, write_store, FileState, MmapIndexReader,
+    manifest_root_key, open_freshness_manifest, open_graph_store, open_store,
+    remove_graph_store, remove_store, store_dir, write_freshness_manifest, write_graph_store,
+    write_store, FileState, GraphStoreMetadata, MmapIndexReader,
 };
 use crate::walk::find_markdown_files;
 
@@ -949,6 +950,564 @@ pub fn compose_logical_generation(
     .map_err(|error| FederatedCacheError::composition(error.stable_code(), error.to_string()))
 }
 
+// ---------------------------------------------------------------------------
+// Version-2 graph generations and request-boundary freshness (ADR-148).
+//
+// This is deliberately parallel to, rather than a modification of, the v1
+// `FederatedCacheTracker`. No-manifest and manifest-v1 callers therefore keep
+// their released generation, marker, and store/v2 paths byte-for-byte.
+// ---------------------------------------------------------------------------
+
+/// One successful graph read. The verified semantic corpus and its model are
+/// borrowed together, so a verification/composition failure cannot hand a
+/// caller the previously resident model.
+pub struct GraphFederatedCacheRead<'a> {
+    pub refresh: FederatedCacheRefresh,
+    pub model: &'a ReadModel,
+    pub generation: &'a str,
+    pub metadata: &'a GraphStoreMetadata,
+    pub corpus: &'a crate::graph_federated_corpus::VerifiedGraphCorpus,
+}
+
+impl GraphFederatedCacheRead<'_> {
+    /// Exact verification-time bytes for one stable graph artifact identity.
+    pub fn content(&self, key: &crate::corpus::ArtifactKey) -> Option<&[u8]> {
+        self.corpus.content(key)
+    }
+}
+
+/// Server-lifetime serving gate for manifest-v2 federation.
+///
+/// Every call first verifies and semantically adapts the complete closure.
+/// Only then may it compare a canonical `sha256-v3:` generation with resident
+/// state or open an exact-metadata `store/v3` generation. A changed generation
+/// always rebuilds the whole projection; no source-blind delta is applied.
+pub struct GraphFederatedCacheTracker {
+    cache_dir: PathBuf,
+    current_generation: Option<String>,
+    model: Option<ReadModel>,
+    metadata: Option<GraphStoreMetadata>,
+    corpus: Option<crate::graph_federated_corpus::VerifiedGraphCorpus>,
+}
+
+impl GraphFederatedCacheTracker {
+    pub fn new(cache_dir: PathBuf) -> Self {
+        Self {
+            cache_dir,
+            current_generation: None,
+            model: None,
+            metadata: None,
+            corpus: None,
+        }
+    }
+
+    fn invalidate(&mut self) {
+        self.current_generation = None;
+        self.model = None;
+        self.metadata = None;
+        self.corpus = None;
+    }
+
+    fn fail<T>(&mut self, error: FederatedCacheError) -> Result<T, FederatedCacheError> {
+        self.invalidate();
+        Err(error)
+    }
+
+    fn persist(
+        &self,
+        corpus: &crate::graph_federated_corpus::VerifiedGraphCorpus,
+        generation: &str,
+        derived: DerivedIndex,
+        metadata: &GraphStoreMetadata,
+    ) -> ReadModel {
+        if write_graph_store(
+            &self.cache_dir,
+            generation,
+            SCHEMA_VERSION,
+            &derived,
+            metadata,
+        ) {
+            if let Some(model) = open_validated_graph_store(
+                &self.cache_dir,
+                generation,
+                metadata,
+                corpus,
+            ) {
+                return ReadModel::View(model);
+            }
+            remove_graph_store(&self.cache_dir, generation);
+        }
+        ReadModel::Fresh(Box::new(derived))
+    }
+
+    /// Verify, adapt, and serve one manifest-v2 graph generation.
+    ///
+    /// `build` is invoked only when a complete derived projection is needed;
+    /// a cold exact-metadata store hit avoids rebuilding it. The closure must
+    /// derive solely from `corpus`, whose parser consumed the just-verified
+    /// byte snapshot without reopening inherited public paths.
+    pub(crate) fn read_or_recompose<F>(
+        &mut self,
+        repository_root: impl AsRef<Path>,
+        root_corpus_relative: &str,
+        recursive: bool,
+        persistent_cache: bool,
+        build: F,
+    ) -> Result<GraphFederatedCacheRead<'_>, FederatedCacheError>
+    where
+        F: FnOnce(
+            &crate::graph_federated_corpus::VerifiedGraphCorpus,
+        ) -> Result<DerivedIndex, FederatedCacheError>,
+    {
+        // Reverification precedes semantic adaptation, resident reuse, and
+        // store lookup on every request. Any failure drops the prior handle.
+        let verified = match crate::federation::verify_federation(
+            repository_root,
+            root_corpus_relative,
+        ) {
+            Ok(Some(verified)) => verified,
+            Ok(None) => {
+                return self.fail(FederatedCacheError::InvalidModel {
+                    message: "graph cache reads require a version-2 federation manifest"
+                        .to_string(),
+                });
+            }
+            Err(error) => return self.fail(error.into()),
+        };
+        let corpus = match crate::graph_federated_corpus::compose_verified_federation(verified) {
+            Ok(corpus) => corpus,
+            Err(error) => {
+                return self.fail(FederatedCacheError::composition(
+                    error.stable_code(),
+                    error.to_string(),
+                ));
+            }
+        };
+        let persistent_cache = persistent_cache
+            && crate::federated_corpus::write_target_within_roots(
+                &self.cache_dir,
+                &corpus.read_only_materialisation_roots,
+            )
+            .is_ok_and(|inside| !inside);
+        let generation = crate::federation_generation::closure_generation_from_verified(
+            &corpus.federation,
+            recursive,
+            &corpus.composition,
+        );
+        let layers = corpus.canonical_layers.values().cloned().collect();
+        let metadata = GraphStoreMetadata::from_composition(
+            generation.clone(),
+            layers,
+            &corpus.composition,
+        );
+
+        if self.current_generation.as_deref() == Some(generation.as_str())
+            && self.metadata.as_ref() == Some(&metadata)
+        {
+            // Replace the semantic handle with the request-current verified
+            // snapshot even when all generation inputs are byte-identical.
+            self.corpus = Some(corpus);
+            self.metadata = Some(metadata);
+            return Ok(GraphFederatedCacheRead {
+                refresh: FederatedCacheRefresh::WarmReuse,
+                model: self.model.as_ref().expect("current graph generation has a model"),
+                generation: self
+                    .current_generation
+                    .as_deref()
+                    .expect("current graph generation is installed"),
+                metadata: self.metadata.as_ref().expect("graph metadata installed"),
+                corpus: self.corpus.as_ref().expect("graph corpus installed"),
+            });
+        }
+
+        let cold = self.current_generation.is_none();
+        let (refresh, model) = if cold && persistent_cache {
+            match open_validated_graph_store(
+                &self.cache_dir,
+                &generation,
+                &metadata,
+                &corpus,
+            ) {
+                Some(model) => (FederatedCacheRefresh::StoreHit, ReadModel::View(model)),
+                None => {
+                    remove_graph_store(&self.cache_dir, &generation);
+                    let derived = match build(&corpus) {
+                        Ok(derived) => derived,
+                        Err(error) => return self.fail(error),
+                    };
+                    if let Err(error) = validate_graph_model(&corpus, &metadata, &derived) {
+                        return self.fail(FederatedCacheError::InvalidModel {
+                            message: error,
+                        });
+                    }
+                    (
+                        FederatedCacheRefresh::Recomposed,
+                        self.persist(&corpus, &generation, derived, &metadata),
+                    )
+                }
+            }
+        } else {
+            // A topology/input change always recomposes, even if an older
+            // process previously persisted this generation. `--no-cache`
+            // differs only by skipping store open/write.
+            let derived = match build(&corpus) {
+                Ok(derived) => derived,
+                Err(error) => return self.fail(error),
+            };
+            if let Err(error) = validate_graph_model(&corpus, &metadata, &derived) {
+                return self.fail(FederatedCacheError::InvalidModel {
+                    message: error,
+                });
+            }
+            let model = if persistent_cache {
+                self.persist(&corpus, &generation, derived, &metadata)
+            } else {
+                ReadModel::Fresh(Box::new(derived))
+            };
+            (FederatedCacheRefresh::Recomposed, model)
+        };
+
+        self.current_generation = Some(generation);
+        self.model = Some(model);
+        self.metadata = Some(metadata);
+        self.corpus = Some(corpus);
+        Ok(GraphFederatedCacheRead {
+            refresh,
+            model: self.model.as_ref().expect("graph model installed"),
+            generation: self
+                .current_generation
+                .as_deref()
+                .expect("graph generation installed"),
+            metadata: self.metadata.as_ref().expect("graph metadata installed"),
+            corpus: self.corpus.as_ref().expect("graph corpus installed"),
+        })
+    }
+
+    pub fn current_generation(&self) -> Option<&str> {
+        self.current_generation.as_deref()
+    }
+
+    /// Public graph serving boundary. Callers cannot inject an alternate or
+    /// partial projection: all persisted and resident models are produced by
+    /// the canonical verified-graph adapter.
+    pub fn read_graph(
+        &mut self,
+        repository_root: impl AsRef<Path>,
+        root_corpus_relative: &str,
+        recursive: bool,
+        persistent_cache: bool,
+    ) -> Result<GraphFederatedCacheRead<'_>, FederatedCacheError> {
+        self.read_or_recompose(
+            repository_root,
+            root_corpus_relative,
+            recursive,
+            persistent_cache,
+            |corpus| {
+                Ok(crate::derived::build_derived_index_from_graph(
+                    corpus, recursive,
+                ))
+            },
+        )
+    }
+}
+
+fn graph_key_projection_complete(
+    expected_effective: &[crate::corpus::ArtifactKey],
+    expected_catalog: &BTreeSet<crate::corpus::ArtifactKey>,
+    derived: &DerivedIndex,
+) -> bool {
+    let searchable = derived
+        .index_entries
+        .iter()
+        .filter_map(|entry| entry.key.clone())
+        .collect::<Vec<_>>();
+    let source_rows = derived
+        .source_artifacts
+        .iter()
+        .map(|artifact| artifact.key.clone())
+        .collect::<Vec<_>>();
+    let identities = derived
+        .resolution
+        .entries
+        .iter()
+        .filter_map(|entry| entry.key.clone())
+        .collect::<BTreeSet<_>>();
+    searchable == expected_effective
+        && source_rows == expected_effective
+        && identities == *expected_catalog
+        && derived.index_entries.len() == expected_effective.len()
+        && derived.source_artifacts.len() == expected_effective.len()
+        && derived.resolution.entries.len() == expected_catalog.len()
+}
+
+fn index_entries_equal(
+    left: &crate::resolve::IndexEntry,
+    right: &crate::resolve::IndexEntry,
+) -> bool {
+    left.key == right.key
+        && left.artifact_path == right.artifact_path
+        && left.origin == right.origin
+        && left.id == right.id
+        && left.artifact_type == right.artifact_type
+        && left.title == right.title
+        && left.path == right.path
+        && left.aliases == right.aliases
+        && left.search_sections == right.search_sections
+        && left.inbound_count == right.inbound_count
+        && left.tags == right.tags
+}
+
+/// Reject incomplete or alternate projections before either resident install
+/// or persistence. Graph metadata proves the stable layers/mappings; these
+/// checks additionally bind the complete effective/catalog identities and all
+/// endpoint-bearing read-model projections to the same semantic composition.
+fn validate_graph_model(
+    corpus: &crate::graph_federated_corpus::VerifiedGraphCorpus,
+    metadata: &GraphStoreMetadata,
+    derived: &DerivedIndex,
+) -> Result<(), String> {
+    if !metadata.matches_derived(derived) {
+        return Err("graph metadata does not match the derived projection".to_string());
+    }
+    let effective = corpus.composition.effective().collect::<Vec<_>>();
+    let expected_effective = effective
+        .iter()
+        .map(|item| item.key.clone())
+        .collect::<Vec<_>>();
+    let expected_catalog = corpus
+        .composition
+        .catalog()
+        .map(|item| item.key.clone())
+        .collect::<BTreeSet<_>>();
+    if !graph_key_projection_complete(&expected_effective, &expected_catalog, derived) {
+        return Err("graph projection omits or duplicates a catalog/effective identity".to_string());
+    }
+    let expected_entries = corpus.composition.effective_index();
+    let expected_identities = corpus.composition.identity_index();
+    if effective
+        .iter()
+        .zip(&derived.source_artifacts)
+        .any(|(item, source)| {
+            source.key != item.key
+                || source.path != item.artifact_path
+                || source.origin != item.origin
+                || source.display_path != item.path
+        })
+        || derived.index_entries.len() != expected_entries.len()
+        || derived
+            .index_entries
+            .iter()
+            .zip(&expected_entries)
+            .any(|(actual, expected)| !index_entries_equal(actual, expected))
+        || derived.resolution.entries.len() != expected_identities.len()
+        || derived
+            .resolution
+            .entries
+            .iter()
+            .zip(&expected_identities)
+            .any(|(actual, expected)| !index_entries_equal(actual, expected))
+    {
+        return Err("graph search projection does not match semantic artifact rows".to_string());
+    }
+    let expected_relationships = corpus
+        .composition
+        .relationships()
+        .into_iter()
+        .map(|row| {
+            (
+                row.source_artifact,
+                row.source_path,
+                row.relationship,
+                row.target,
+                row.resolved_artifact,
+                row.resolved_path,
+                row.issue,
+            )
+        })
+        .collect::<Vec<_>>();
+    let actual_relationships = derived
+        .relationships
+        .iter()
+        .map(|row| {
+            (
+                row.source_artifact.clone(),
+                row.source_path.clone(),
+                row.relationship.clone(),
+                row.target.clone(),
+                row.resolved_artifact.clone(),
+                row.resolved_path.clone(),
+                row.issue.clone(),
+            )
+        })
+        .collect::<Vec<_>>();
+    if actual_relationships != expected_relationships {
+        return Err("graph relationship projection differs from composition".to_string());
+    }
+    let expected_live = effective
+        .iter()
+        .filter(|item| {
+            item.spec
+                .is_some_and(|spec| spec.name == crate::derived::DECISION_TYPE)
+                && crate::resolve::is_live_decision(&item.artifact)
+        })
+        .map(|item| (item.key.clone(), item.path.clone()))
+        .collect::<Vec<_>>();
+    if derived.live_decision_keys.len() != expected_live.len()
+        || derived.live_decision_paths.len() != expected_live.len()
+        || derived
+            .live_decision_keys
+            .iter()
+            .zip(&derived.live_decision_paths)
+            .zip(expected_live.iter())
+            .any(|((key, path), expected)| (key, path) != (&expected.0, &expected.1))
+    {
+        return Err("graph liveness projection differs from composition".to_string());
+    }
+    let effective_items = effective.into_iter().cloned().collect::<Vec<_>>();
+    let expected_scope = crate::retrieve::scope_rows_from_items(&effective_items);
+    if derived.scope_rows.len() != expected_scope.len()
+        || derived.scope_rows.iter().zip(expected_scope).any(|(actual, expected)| {
+            actual.key != expected.key
+                || actual.artifact_path != expected.artifact_path
+                || actual.origin != expected.origin
+                || actual.id != expected.id
+                || actual.title != expected.title
+                || actual.status != expected.status
+                || actual.path != expected.path
+                || actual.scope_entries != expected.scope_entries
+        })
+    {
+        return Err("graph scope projection differs from composition".to_string());
+    }
+    Ok(())
+}
+
+fn validate_graph_store_view(
+    corpus: &crate::graph_federated_corpus::VerifiedGraphCorpus,
+    reader: &MmapIndexReader,
+) -> Result<(), String> {
+    let effective = corpus.composition.effective().collect::<Vec<_>>();
+    if reader.doc_count as usize != effective.len() {
+        return Err("stored graph omits an effective artifact".to_string());
+    }
+    let expected_entries = corpus.composition.effective_index();
+    for (docid, (item, expected)) in effective.iter().zip(&expected_entries).enumerate() {
+        let entry = reader
+            .full_entry(docid as u32)
+            .map_err(|error| error.to_string())?;
+        let source = reader
+            .source_artifact(docid as u32)
+            .map_err(|error| error.to_string())?;
+        if !index_entries_equal(&entry, expected)
+            || source.key != item.key
+            || source.path != item.artifact_path
+            || source.origin != item.origin
+            || source.display_path != item.path
+        {
+            return Err("stored graph search row differs from composition".to_string());
+        }
+    }
+    let expected_identities = corpus.composition.identity_index();
+    let identity_count = reader.identity_count().map_err(|error| error.to_string())?;
+    if identity_count as usize != expected_identities.len() {
+        return Err("stored graph omits or duplicates a catalog identity".to_string());
+    }
+    for (docid, expected) in expected_identities.iter().enumerate() {
+        let entry = reader
+            .identity_entry(docid as u32)
+            .map_err(|error| error.to_string())?;
+        if !index_entries_equal(&entry, expected) {
+            return Err("stored graph identity row differs from composition".to_string());
+        }
+    }
+    let expected_relationships = corpus
+        .composition
+        .relationships()
+        .into_iter()
+        .map(|row| {
+            (
+                row.source_artifact,
+                row.source_path,
+                row.relationship,
+                row.target,
+                row.resolved_artifact,
+                row.resolved_path,
+                row.issue,
+            )
+        })
+        .collect::<Vec<_>>();
+    let stored_relationships = reader
+        .relationships()
+        .map_err(|error| error.to_string())?
+        .into_iter()
+        .map(|row| {
+            (
+                row.source_artifact,
+                row.source_path,
+                row.relationship,
+                row.target,
+                row.resolved_artifact,
+                row.resolved_path,
+                row.issue,
+            )
+        })
+        .collect::<Vec<_>>();
+    if stored_relationships != expected_relationships {
+        return Err("stored graph relationships differ from composition".to_string());
+    }
+    let expected_live = effective
+        .iter()
+        .filter(|item| {
+            item.spec
+                .is_some_and(|spec| spec.name == crate::derived::DECISION_TYPE)
+                && crate::resolve::is_live_decision(&item.artifact)
+        })
+        .map(|item| (item.key.clone(), item.path.clone()))
+        .collect::<Vec<_>>();
+    let stored_live = reader
+        .live_decision_keys()
+        .map_err(|error| error.to_string())?
+        .into_iter()
+        .zip(
+            reader
+                .live_decision_paths()
+                .map_err(|error| error.to_string())?,
+        )
+        .collect::<Vec<_>>();
+    if stored_live != expected_live {
+        return Err("stored graph liveness differs from composition".to_string());
+    }
+    let effective_items = effective.into_iter().cloned().collect::<Vec<_>>();
+    let expected_scope = crate::retrieve::scope_rows_from_items(&effective_items);
+    let stored_scope = reader.scope_rows().map_err(|error| error.to_string())?;
+    if stored_scope.len() != expected_scope.len()
+        || stored_scope.iter().zip(expected_scope).any(|(actual, expected)| {
+            actual.key != expected.key
+                || actual.artifact_path != expected.artifact_path
+                || actual.origin != expected.origin
+                || actual.id != expected.id
+                || actual.title != expected.title
+                || actual.status != expected.status
+                || actual.path != expected.path
+                || actual.scope_entries != expected.scope_entries
+        })
+    {
+        return Err("stored graph scope rows differ from composition".to_string());
+    }
+    Ok(())
+}
+
+fn open_validated_graph_store(
+    cache_dir: &Path,
+    generation: &str,
+    metadata: &GraphStoreMetadata,
+    corpus: &crate::graph_federated_corpus::VerifiedGraphCorpus,
+) -> Option<MmapIndexReader> {
+    let view = open_graph_store(cache_dir, generation, SCHEMA_VERSION, metadata)?;
+    validate_graph_store_view(corpus, &view.model).ok()?;
+    Some(view.model)
+}
+
 fn stable_public_path(path: &str) -> bool {
     !path.is_empty()
         && !Path::new(path).is_absolute()
@@ -1140,5 +1699,16 @@ mod tests {
             corpus_hash_from_complete_manifest(&manifest),
             corpus_hash_from_complete_manifest(&stat_only_change)
         );
+    }
+
+    #[test]
+    fn graph_key_gate_rejects_a_partial_effective_and_catalog_overlay() {
+        let derived = crate::derived::build_derived_index_from_items("decisions", &[], true);
+        let key = crate::corpus::ArtifactKey::new("acme/root", "APP-KWJ4VMKVSS65");
+        assert!(!graph_key_projection_complete(
+            std::slice::from_ref(&key),
+            &BTreeSet::from([key.clone()]),
+            &derived,
+        ));
     }
 }

--- a/rust/rac-engine/src/export.rs
+++ b/rust/rac-engine/src/export.rs
@@ -5,7 +5,8 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 
 use crate::composition::{ComposedCorpus, ComposedProvenance};
-use crate::corpus::{ArtifactKey, ArtifactPath, Layer};
+use crate::corpus::{ArtifactKey, ArtifactOrigin, ArtifactPath, Layer};
+use crate::graph_composition::GraphOverrideProvenance;
 use crate::identity::{artifact_identifier, artifact_identifiers};
 use crate::markdown::split_frontmatter;
 use crate::parse::Artifact;
@@ -156,11 +157,21 @@ struct ProjectedItem<'a> {
 }
 
 fn full_sha256_pin(pin: &str) -> bool {
-    pin.len() == 71
-        && pin.starts_with("sha256:")
-        && pin[7..]
-            .bytes()
-            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    full_pin_with_prefix(pin, "sha256:")
+}
+
+fn full_graph_corpus_pin(pin: &str) -> bool {
+    full_sha256_pin(pin) || full_pin_with_prefix(pin, "sha256-v2:")
+}
+
+fn full_pin_with_prefix(pin: &str, prefix: &str) -> bool {
+    let hash = pin.strip_prefix(prefix);
+    hash.is_some_and(|hash| {
+        hash.len() == 64
+            && hash
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    })
 }
 
 fn snapshot_text(
@@ -211,7 +222,12 @@ fn projected_items<'a>(
                     item.key.source, item.key.canonical_id
                 )));
             };
-            if !full_sha256_pin(pin) {
+            let valid_pin = if corpus.is_graph() {
+                full_graph_corpus_pin(pin)
+            } else {
+                full_sha256_pin(pin)
+            };
+            if !valid_pin {
                 return Err(FederatedExportError::new(format!(
                     "{ERROR_MISSING_PIN}: inherited record {}::{} does not carry a full lowercase SHA-256 pin",
                     item.key.source, item.key.canonical_id
@@ -296,6 +312,45 @@ fn composed_provenance(
     })
 }
 
+/// Complete version-2 export provenance. The graph-native chain remains one
+/// ordered atomic value instead of being flattened into the v1 direct-mapping
+/// carrier.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GraphComposedProvenance {
+    pub origin: ArtifactOrigin,
+    pub overrides: Vec<GraphOverrideProvenance>,
+}
+
+fn graph_composed_provenance(
+    corpus: &ComposedCorpus,
+    item: &CorpusItem,
+) -> Result<GraphComposedProvenance, FederatedExportError> {
+    let overrides = corpus
+        .graph_provenance_for(&item.key)
+        .ok_or_else(|| {
+            FederatedExportError::new(format!(
+                "{ERROR_MISSING_PROVENANCE}: graph record {}::{} has no provenance",
+                item.key.source, item.key.canonical_id
+            ))
+        })?
+        .to_vec();
+    Ok(GraphComposedProvenance {
+        origin: item.origin.clone(),
+        overrides,
+    })
+}
+
+fn record_provenance(
+    corpus: &ComposedCorpus,
+    item: &CorpusItem,
+) -> Result<(Option<ComposedProvenance>, Option<GraphComposedProvenance>), FederatedExportError> {
+    if corpus.is_graph() {
+        Ok((None, Some(graph_composed_provenance(corpus, item)?)))
+    } else {
+        Ok((Some(composed_provenance(corpus, item)?), None))
+    }
+}
+
 fn composed_child_source(corpus: &ComposedCorpus) -> Result<String, FederatedExportError> {
     corpus.child_source().map(str::to_string).ok_or_else(|| {
         FederatedExportError::new(format!(
@@ -357,6 +412,9 @@ pub struct ExportArtifact {
     pub tags: Vec<String>,
     /// Present only when a federation manifest activated the composed model.
     pub provenance: Option<ComposedProvenance>,
+    /// Version-2 complete ordered provenance; mutually exclusive with the v1
+    /// `provenance` carrier.
+    pub graph_provenance: Option<GraphComposedProvenance>,
 }
 
 pub struct ExportRelationship {
@@ -366,6 +424,12 @@ pub struct ExportRelationship {
     pub from_identity: Option<ExportIdentity>,
     pub to_identity: Option<ExportIdentity>,
     pub provenance: Option<ComposedProvenance>,
+    pub graph_provenance: Option<GraphComposedProvenance>,
+    /// Version-2 catalog endpoint fields. `authored_token` being present is
+    /// the mode marker; the candidate set may be empty and the terminal null.
+    pub authored_token: Option<String>,
+    pub historical_candidates: Vec<ExportIdentity>,
+    pub effective_terminal: Option<ExportIdentity>,
 }
 
 pub struct CorpusExport {
@@ -413,6 +477,7 @@ fn build_corpus_export_inner(
             },
             tags: tags_of(&it.artifact),
             provenance: None,
+            graph_provenance: None,
         });
     }
 
@@ -430,6 +495,10 @@ fn build_corpus_export_inner(
                 from_identity: None,
                 to_identity: None,
                 provenance: None,
+                graph_provenance: None,
+                authored_token: None,
+                historical_candidates: Vec::new(),
+                effective_terminal: None,
             }
         })
         .collect();
@@ -465,7 +534,7 @@ pub fn build_corpus_export_from_composed(
     corpus: &ComposedCorpus,
     local_only: bool,
 ) -> Result<CorpusExport, FederatedExportError> {
-    if corpus.parent().is_none() {
+    if !corpus.is_federated() {
         return build_corpus_export(directory, rac_version).map_err(Into::into);
     }
 
@@ -474,6 +543,7 @@ pub fn build_corpus_export_from_composed(
     for projected_item in &projected {
         let item = projected_item.item;
         let Some(spec) = item.spec else { continue };
+        let (provenance, graph_provenance) = record_provenance(corpus, item)?;
         let id = item.key.canonical_id.clone();
         let title = match &item.artifact.product.title {
             Some(title) if !title.is_empty() => title.clone(),
@@ -492,11 +562,64 @@ pub fn build_corpus_export_from_composed(
             path: item.artifact_path.relative_path.clone(),
             body_html: crate::mdhtml::render(&projected_item.body_markdown),
             tags: tags_of(&item.artifact),
-            provenance: Some(composed_provenance(corpus, item)?),
+            provenance,
+            graph_provenance,
         });
     }
 
     let included = included_keys(&projected);
+    if let Some(graph) = corpus.graph() {
+        let mut relationships = Vec::new();
+        for relationship in graph.catalog_relationships() {
+            let source = graph.item(&relationship.source).ok_or_else(|| {
+                FederatedExportError::new(format!(
+                    "{ERROR_SNAPSHOT_MISSING}: relationship source has no graph artifact identity: {}::{}",
+                    relationship.source.source, relationship.source.canonical_id
+                ))
+            })?;
+            if !included.contains(&source.key) {
+                continue;
+            }
+            let (_, graph_provenance) = record_provenance(corpus, source)?;
+            let effective_key = relationship.effective_terminal.as_ref().map(|terminal| {
+                graph.terminal_redirects().get(terminal).unwrap_or(terminal)
+            });
+            let effective_terminal = effective_key.map(ExportIdentity::from);
+            relationships.push(ExportRelationship {
+                from: source.key.canonical_id.clone(),
+                to: effective_key
+                    .map(|key| key.canonical_id.clone())
+                    .unwrap_or_else(|| relationship.authored_token.clone()),
+                edge_type: EDGE_TYPE.to_string(),
+                from_identity: Some(ExportIdentity::from(&source.key)),
+                to_identity: effective_terminal.clone(),
+                provenance: None,
+                graph_provenance,
+                authored_token: Some(relationship.authored_token),
+                historical_candidates: relationship
+                    .historical_candidates
+                    .iter()
+                    .map(ExportIdentity::from)
+                    .collect(),
+                effective_terminal,
+            });
+        }
+        relationships.sort_by(|left, right| {
+            left.from_identity
+                .cmp(&right.from_identity)
+                .then(left.authored_token.cmp(&right.authored_token))
+                .then(left.historical_candidates.cmp(&right.historical_candidates))
+                .then(left.effective_terminal.cmp(&right.effective_terminal))
+        });
+        return Ok(CorpusExport {
+            corpus_name: corpus_name(directory),
+            corpus_source: composed_child_source(corpus)?,
+            rac_version,
+            artifacts,
+            relationships,
+        });
+    }
+
     let by_path = item_by_artifact_path(corpus);
     let mut relationships = Vec::new();
     for relationship in corpus.catalog_relationships() {
@@ -514,6 +637,10 @@ pub fn build_corpus_export_from_composed(
             from_identity: Some(ExportIdentity::from(&source.key)),
             to_identity: target.map(|item| ExportIdentity::from(&item.key)),
             provenance: Some(composed_provenance(corpus, source)?),
+            graph_provenance: None,
+            authored_token: None,
+            historical_candidates: Vec::new(),
+            effective_terminal: None,
         });
     }
     relationships.sort_by(|left, right| {
@@ -547,7 +674,7 @@ pub fn build_okf_export_from_composed(
     rac_version: String,
     corpus: &ComposedCorpus,
 ) -> CorpusExport {
-    if corpus.parent().is_none() {
+    if !corpus.is_federated() {
         return build_okf_export(directory, rac_version);
     }
 
@@ -571,6 +698,7 @@ pub fn build_okf_export_from_composed(
             body_html: String::new(),
             tags: tags_of(&item.artifact),
             provenance: None,
+            graph_provenance: None,
         });
     }
 
@@ -592,6 +720,10 @@ pub fn build_okf_export_from_composed(
             from_identity: None,
             to_identity: None,
             provenance: None,
+            graph_provenance: None,
+            authored_token: None,
+            historical_candidates: Vec::new(),
+            effective_terminal: None,
         });
     }
     relationships.sort_by(|left, right| {
@@ -621,6 +753,7 @@ pub struct ExportDocument {
     pub path: String,
     pub tags: Vec<String>,
     pub provenance: Option<ComposedProvenance>,
+    pub graph_provenance: Option<GraphComposedProvenance>,
 }
 
 pub struct DocumentsExport {
@@ -650,6 +783,7 @@ pub fn build_documents_export(directory: &str) -> Result<DocumentsExport, Scaffo
             path: it.path.clone(),
             tags: tags_of(&it.artifact),
             provenance: None,
+            graph_provenance: None,
         });
     }
     Ok(DocumentsExport {
@@ -664,7 +798,7 @@ pub fn build_documents_export_from_composed(
     corpus: &ComposedCorpus,
     local_only: bool,
 ) -> Result<DocumentsExport, FederatedExportError> {
-    if corpus.parent().is_none() {
+    if !corpus.is_federated() {
         return build_documents_export(directory).map_err(Into::into);
     }
 
@@ -673,6 +807,7 @@ pub fn build_documents_export_from_composed(
     for projected_item in projected {
         let item = projected_item.item;
         let Some(spec) = item.spec else { continue };
+        let (provenance, graph_provenance) = record_provenance(corpus, item)?;
         let id = item.key.canonical_id.clone();
         let title = match &item.artifact.product.title {
             Some(title) if !title.is_empty() => title.clone(),
@@ -691,7 +826,8 @@ pub fn build_documents_export_from_composed(
             ),
             path: item.artifact_path.relative_path.clone(),
             tags: tags_of(&item.artifact),
-            provenance: Some(composed_provenance(corpus, item)?),
+            provenance,
+            graph_provenance,
         });
     }
     Ok(DocumentsExport {
@@ -709,6 +845,7 @@ pub struct GraphNode {
     pub status: String,
     pub title: String,
     pub provenance: Option<ComposedProvenance>,
+    pub graph_provenance: Option<GraphComposedProvenance>,
 }
 
 pub struct GraphEdge {
@@ -722,6 +859,10 @@ pub struct GraphEdge {
     pub source_identity: Option<ExportIdentity>,
     pub target_identity: Option<ExportIdentity>,
     pub provenance: Option<ComposedProvenance>,
+    pub graph_provenance: Option<GraphComposedProvenance>,
+    pub authored_token: Option<String>,
+    pub historical_candidates: Vec<ExportIdentity>,
+    pub effective_terminal: Option<ExportIdentity>,
 }
 
 pub struct GraphExport {
@@ -751,6 +892,7 @@ pub fn build_graph_export(directory: &str) -> Result<GraphExport, ScaffoldError>
             status: status(&it.artifact, spec),
             title,
             provenance: None,
+            graph_provenance: None,
         });
     }
 
@@ -777,6 +919,10 @@ pub fn build_graph_export(directory: &str) -> Result<GraphExport, ScaffoldError>
             source_identity: None,
             target_identity: None,
             provenance: None,
+            graph_provenance: None,
+            authored_token: None,
+            historical_candidates: Vec::new(),
+            effective_terminal: None,
         });
     }
     edges.sort_by(|a, b| {
@@ -799,7 +945,7 @@ pub fn build_graph_export_from_composed(
     corpus: &ComposedCorpus,
     local_only: bool,
 ) -> Result<GraphExport, FederatedExportError> {
-    if corpus.parent().is_none() {
+    if !corpus.is_federated() {
         return build_graph_export(directory).map_err(Into::into);
     }
 
@@ -808,6 +954,7 @@ pub fn build_graph_export_from_composed(
     for projected_item in &projected {
         let item = projected_item.item;
         let Some(spec) = item.spec else { continue };
+        let (provenance, graph_provenance) = record_provenance(corpus, item)?;
         let id = item.key.canonical_id.clone();
         let title = match &item.artifact.product.title {
             Some(title) if !title.is_empty() => title.clone(),
@@ -818,11 +965,73 @@ pub fn build_graph_export_from_composed(
             artifact_type: spec.name.clone(),
             status: status(&item.artifact, spec),
             title,
-            provenance: Some(composed_provenance(corpus, item)?),
+            provenance,
+            graph_provenance,
         });
     }
 
     let included = included_keys(&projected);
+    if let Some(graph) = corpus.graph() {
+        let provider = load_ticketing_provider(directory);
+        let mut edges = Vec::new();
+        for relationship in graph.catalog_relationships() {
+            let source = graph.item(&relationship.source).ok_or_else(|| {
+                FederatedExportError::new(format!(
+                    "{ERROR_SNAPSHOT_MISSING}: relationship source has no graph artifact identity: {}::{}",
+                    relationship.source.source, relationship.source.canonical_id
+                ))
+            })?;
+            if !included.contains(&source.key) {
+                continue;
+            }
+            let (_, graph_provenance) = record_provenance(corpus, source)?;
+            let kind = edge_spec(&relationship.relationship);
+            let effective_key = relationship.effective_terminal.as_ref().map(|terminal| {
+                graph.terminal_redirects().get(terminal).unwrap_or(terminal)
+            });
+            let effective_terminal = effective_key.map(ExportIdentity::from);
+            edges.push(GraphEdge {
+                source: source.key.canonical_id.clone(),
+                target: effective_key
+                    .map(|key| key.canonical_id.clone())
+                    .unwrap_or_else(|| relationship.authored_token.clone()),
+                edge_type: relationship.relationship,
+                directed: kind.map(|spec| spec.directional).unwrap_or(false),
+                resolved: effective_key.is_some(),
+                external: relationship.external,
+                provider: match kind {
+                    Some(spec) if spec.external_provider => provider.clone(),
+                    _ => None,
+                },
+                source_identity: Some(ExportIdentity::from(&source.key)),
+                target_identity: effective_terminal.clone(),
+                provenance: None,
+                graph_provenance,
+                authored_token: Some(relationship.authored_token),
+                historical_candidates: relationship
+                    .historical_candidates
+                    .iter()
+                    .map(ExportIdentity::from)
+                    .collect(),
+                effective_terminal,
+            });
+        }
+        edges.sort_by(|left, right| {
+            left.source_identity
+                .cmp(&right.source_identity)
+                .then(left.edge_type.cmp(&right.edge_type))
+                .then(left.authored_token.cmp(&right.authored_token))
+                .then(left.historical_candidates.cmp(&right.historical_candidates))
+                .then(left.effective_terminal.cmp(&right.effective_terminal))
+        });
+        return Ok(GraphExport {
+            corpus_name: corpus_name(directory),
+            corpus_source: composed_child_source(corpus)?,
+            nodes,
+            edges,
+        });
+    }
+
     let by_path = item_by_artifact_path(corpus);
     let provider = load_ticketing_provider(directory);
     let mut edges = Vec::new();
@@ -849,6 +1058,10 @@ pub fn build_graph_export_from_composed(
             source_identity: Some(ExportIdentity::from(&source.key)),
             target_identity: target.map(|item| ExportIdentity::from(&item.key)),
             provenance: Some(composed_provenance(corpus, source)?),
+            graph_provenance: None,
+            authored_token: None,
+            historical_candidates: Vec::new(),
+            effective_terminal: None,
         });
     }
     edges.sort_by(|left, right| {

--- a/rust/rac-engine/src/federated_corpus.rs
+++ b/rust/rac-engine/src/federated_corpus.rs
@@ -17,7 +17,13 @@ use crate::composition::{
     FINDING_INVALID_OVERRIDE,
 };
 use crate::corpus::{CorpusLayer, PhysicalArtifactLocator, PhysicalCorpusLocator};
-use crate::federation::{verify_parent, ParentCorpusError, SnapshotFile, VerifiedParent};
+use crate::federation::{
+    direct_graph_materialisation_roots, load_graph_manifest, verify_federation, verify_parent,
+    ParentCorpusError, SnapshotFile, VerifiedParent,
+};
+use crate::graph_federated_corpus::{
+    compose_verified_federation, GraphFederatedCorpusError,
+};
 use crate::parse::parse_bytes;
 use crate::relationships::{
     relationship_severity, validation_from_rows, validation_row_from_item, CorpusItem,
@@ -35,6 +41,7 @@ pub const FEDERATED_WRITE_TARGET_RESOLUTION_FAILED: &str =
 #[derive(Debug)]
 pub enum FederatedCorpusError {
     Parent(ParentCorpusError),
+    Graph(GraphFederatedCorpusError),
     ParentInvalid {
         source: String,
         path: PathBuf,
@@ -59,6 +66,7 @@ impl FederatedCorpusError {
     pub fn stable_code(&self) -> &str {
         match self {
             Self::Parent(error) => error.stable_code(),
+            Self::Graph(error) => error.stable_code(),
             Self::ParentInvalid { .. } => PARENT_CORPUS_INVALID,
             Self::LocalSnapshot { .. } => FEDERATED_CORPUS_SNAPSHOT_FAILED,
             Self::WriteTarget { .. } => FEDERATED_WRITE_TARGET_RESOLUTION_FAILED,
@@ -69,8 +77,38 @@ impl FederatedCorpusError {
     pub fn path(&self) -> Option<&Path> {
         match self {
             Self::Parent(error) => error.path.as_deref(),
+            Self::Graph(error) => error.relative_path.as_deref().map(Path::new),
             Self::ParentInvalid { path, .. } | Self::Composition { path, .. } => Some(path),
             Self::LocalSnapshot { path, .. } | Self::WriteTarget { path, .. } => Some(path),
+        }
+    }
+
+    /// Stable source ownership for a graph-topology or inherited-node
+    /// validation failure. Version-1 failures which predate this carrier leave
+    /// it absent and retain their released rendering path.
+    pub fn validation_origin(&self) -> Option<&crate::federation::FederationValidationOrigin> {
+        match self {
+            Self::Parent(error) => error.validation_origin.as_deref(),
+            Self::Graph(error) => error.validation_origin.as_deref(),
+            _ => None,
+        }
+    }
+
+    /// Lexicographically minimal source route for a graph-topology finding.
+    pub fn source_route(&self) -> Option<&[String]> {
+        match self {
+            Self::Parent(error) => error.source_route.as_deref().map(Vec::as_slice),
+            Self::Graph(error) => error.source_route.as_deref().map(Vec::as_slice),
+            _ => None,
+        }
+    }
+
+    /// Exact number of verified physical routes represented by the finding.
+    pub fn route_count(&self) -> Option<usize> {
+        match self {
+            Self::Parent(error) => error.route_count.as_deref().copied(),
+            Self::Graph(error) => error.route_count.as_deref().copied(),
+            _ => None,
         }
     }
 }
@@ -92,6 +130,7 @@ impl fmt::Display for FederatedCorpusError {
                 }
                 write!(formatter, "{}: {message}", error.stable_code())
             }
+            Self::Graph(error) => write!(formatter, "{error}"),
             Self::ParentInvalid { source, detail, .. } => write!(
                 formatter,
                 "{PARENT_CORPUS_INVALID}: parent source '{source}' is invalid: {detail}"
@@ -116,6 +155,12 @@ impl std::error::Error for FederatedCorpusError {}
 impl From<ParentCorpusError> for FederatedCorpusError {
     fn from(error: ParentCorpusError) -> Self {
         Self::Parent(error)
+    }
+}
+
+impl From<GraphFederatedCorpusError> for FederatedCorpusError {
+    fn from(error: GraphFederatedCorpusError) -> Self {
+        Self::Graph(error)
     }
 }
 
@@ -396,6 +441,80 @@ fn local_items_from_snapshot(
     (items, contents)
 }
 
+/// Locate a configured repository even when its config is invalid or has
+/// disappeared. A present manifest is authoritative topology and must not be
+/// bypassed by falling back to a local-only corpus walk.
+fn composition_repository_root(directory: &str) -> PathBuf {
+    let input = Path::new(directory);
+    let absolute = if input.is_absolute() {
+        input.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .map(|current| current.join(input))
+            .unwrap_or_else(|_| input.to_path_buf())
+    };
+    let search = std::fs::canonicalize(&absolute).unwrap_or(absolute);
+    for ancestor in search.ancestors() {
+        let manifest = ancestor.join(crate::federation::MANIFEST_RELATIVE_PATH);
+        let config = ancestor.join(crate::federation::CONFIG_RELATIVE_PATH);
+        if std::fs::symlink_metadata(&manifest).is_ok()
+            || std::fs::symlink_metadata(&config).is_ok()
+        {
+            return ancestor.to_path_buf();
+        }
+    }
+    crate::validate::repository_root(directory)
+}
+
+fn graph_corpus_relative(
+    directory: &str,
+    repository_root: &Path,
+) -> Result<String, FederatedCorpusError> {
+    let corpus = std::fs::canonicalize(directory).map_err(|error| {
+        FederatedCorpusError::LocalSnapshot {
+            path: PathBuf::from(directory),
+            message: error.to_string(),
+        }
+    })?;
+    let root = std::fs::canonicalize(repository_root).map_err(|error| {
+        FederatedCorpusError::LocalSnapshot {
+            path: repository_root.to_path_buf(),
+            message: error.to_string(),
+        }
+    })?;
+    let relative = corpus.strip_prefix(&root).map_err(|_| {
+        FederatedCorpusError::LocalSnapshot {
+            path: PathBuf::from(directory),
+            message: "corpus path escapes the configured repository root".to_string(),
+        }
+    })?;
+    let text = relative.to_string_lossy().replace('\\', "/");
+    if text.is_empty() {
+        return Err(FederatedCorpusError::LocalSnapshot {
+            path: PathBuf::from(directory),
+            message: "version-2 federation requires a repository-relative corpus path"
+                .to_string(),
+        });
+    }
+    Ok(text)
+}
+
+/// Locate a configured version-2 graph for cache-backed read consumers.
+///
+/// `None` preserves the released no-manifest and manifest-v1 paths. A present
+/// malformed v2 manifest remains an error, and callers receive the exact
+/// repository/corpus pair consumed by [`verify_federation`].
+pub fn graph_cache_location(
+    directory: &str,
+) -> Result<Option<(PathBuf, String)>, FederatedCorpusError> {
+    let repository_root = composition_repository_root(directory);
+    if load_graph_manifest(&repository_root)?.is_none() {
+        return Ok(None);
+    }
+    let corpus_relative = graph_corpus_relative(directory, &repository_root)?;
+    Ok(Some((repository_root, corpus_relative)))
+}
+
 /// Load the central federated read model for `directory`.
 ///
 /// `Ok(None)` is the deliberate no-manifest compatibility result. Every
@@ -405,12 +524,39 @@ pub fn load_composed_corpus(
     directory: &str,
     recursive: bool,
 ) -> Result<Option<ComposedCorpus>, FederatedCorpusError> {
-    let child_root = crate::validate::repository_root(directory);
+    if let Some(corpus) = load_graph_composed_corpus(directory, recursive)? {
+        return Ok(Some(corpus));
+    }
+    let child_root = composition_repository_root(directory);
     let Some(verified) = verify_parent(&child_root)? else {
         return Ok(None);
     };
 
     compose_verified_generation(directory, recursive, &verified).map(Some)
+}
+
+/// Load only a version-2 graph composition. A version-1 or unconfigured
+/// repository returns `Ok(None)` without entering its verification path, so
+/// consumers which are additive only for graph federation can preserve the
+/// released version-1/no-manifest behaviour byte for byte.
+pub fn load_graph_composed_corpus(
+    directory: &str,
+    _recursive: bool,
+) -> Result<Option<ComposedCorpus>, FederatedCorpusError> {
+    let child_root = composition_repository_root(directory);
+    if load_graph_manifest(&child_root)?.is_none() {
+        return Ok(None);
+    }
+    let corpus_relative = graph_corpus_relative(directory, &child_root)?;
+    let verified = verify_federation(&child_root, &corpus_relative)?.ok_or_else(|| {
+        FederatedCorpusError::LocalSnapshot {
+            path: child_root.join(crate::federation::MANIFEST_RELATIVE_PATH),
+            message: "version-2 manifest changed during verification".to_string(),
+        }
+    })?;
+    compose_verified_federation(verified)
+        .map(|corpus| Some(corpus.into_composed_corpus()))
+        .map_err(Into::into)
 }
 
 /// Return the writable local layer for a configured corpus, or the released
@@ -533,12 +679,26 @@ fn lexical_normalize(path: &Path) -> PathBuf {
     normalized
 }
 
-fn manifest_root(path: &Path) -> Option<&Path> {
-    path.ancestors().find(|ancestor| {
-        ancestor
-            .join(crate::federation::MANIFEST_RELATIVE_PATH)
-            .is_file()
-    })
+fn manifest_roots(path: &Path) -> Result<Vec<PathBuf>, String> {
+    let mut roots = Vec::new();
+    let start = match std::fs::symlink_metadata(path) {
+        Ok(metadata) if !metadata.is_dir() => path.parent().unwrap_or(path),
+        _ => path,
+    };
+    for ancestor in start.ancestors() {
+        let manifest = ancestor.join(crate::federation::MANIFEST_RELATIVE_PATH);
+        match std::fs::symlink_metadata(&manifest) {
+            Ok(_) => roots.push(ancestor.to_path_buf()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(format!(
+                    "cannot inspect federation manifest {}: {error}",
+                    manifest.display()
+                ))
+            }
+        }
+    }
+    Ok(roots)
 }
 
 /// Resolve existing path components in traversal order so a symlink followed
@@ -584,6 +744,76 @@ fn resolve_write_target(path: &Path) -> Result<PathBuf, String> {
     Ok(resolved)
 }
 
+/// Traversal-safe containment for an output path against already-verified
+/// read-only roots. Ambiguous nonexistent `..` traversals are errors so cache
+/// callers can safely degrade to a non-persistent in-memory model.
+pub(crate) fn write_target_within_roots(
+    target: impl AsRef<Path>,
+    roots: &[PathBuf],
+) -> Result<bool, FederatedCorpusError> {
+    let target = target.as_ref();
+    let absolute = absolute_write_target(target)?;
+    let lexical = lexical_normalize(&absolute);
+    let resolved = resolve_write_target(&absolute).map_err(|message| {
+        FederatedCorpusError::WriteTarget {
+            path: target.to_path_buf(),
+            message,
+        }
+    })?;
+    Ok(roots.iter().any(|root| {
+        resolved == *root
+            || resolved.starts_with(root)
+            || lexical == *root
+            || lexical.starts_with(root)
+    }))
+}
+
+/// Whether a diagnostic target is inside any manifest-v2 materialisation.
+///
+/// Version 1 is deliberately excluded so its released physical `inspect`
+/// behaviour stays unchanged. In version 2, a nearer parent config must not
+/// hide the governing child graph when a user names `vendor/parent/...`
+/// directly.
+pub fn is_read_only_graph_materialised_path(
+    target: impl AsRef<Path>,
+) -> Result<bool, FederatedCorpusError> {
+    let target = target.as_ref();
+    let absolute = absolute_write_target(target)?;
+    let lexical = lexical_normalize(&absolute);
+    let resolved = resolve_write_target(&absolute).map_err(|message| {
+        FederatedCorpusError::WriteTarget {
+            path: target.to_path_buf(),
+            message,
+        }
+    })?;
+    let discover = |path: &Path| {
+        manifest_roots(path).map_err(|message| FederatedCorpusError::WriteTarget {
+            path: target.to_path_buf(),
+            message,
+        })
+    };
+    let mut child_roots = discover(&resolved)?;
+    for root in discover(&lexical)? {
+        if !child_roots.iter().any(|existing| existing == &root) {
+            child_roots.push(root);
+        }
+    }
+    for child_root in child_roots {
+        let Some(roots) = direct_graph_materialisation_roots(&child_root)? else {
+            continue;
+        };
+        if roots.iter().any(|root| {
+            resolved == *root
+                || resolved.starts_with(root)
+                || lexical == *root
+                || lexical.starts_with(root)
+        }) {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
 /// Whether a mutation target lies in a configured parent's read-only
 /// materialisation. Existing ancestors are canonicalized before containment
 /// is checked, and missing suffixes remain lexical, so neither `..` nor a
@@ -597,7 +827,13 @@ pub fn is_read_only_materialised_path(
     let resolved = match resolve_write_target(&absolute) {
         Ok(resolved) => resolved,
         Err(message) => {
-            if manifest_root(&lexical).is_none() {
+            let roots = manifest_roots(&lexical).map_err(|manifest_error| {
+                FederatedCorpusError::WriteTarget {
+                    path: target.to_path_buf(),
+                    message: manifest_error,
+                }
+            })?;
+            if roots.is_empty() {
                 return Ok(false);
             }
             return Err(FederatedCorpusError::WriteTarget {
@@ -606,11 +842,36 @@ pub fn is_read_only_materialised_path(
             });
         }
     };
-    let Some(child_root) = manifest_root(&resolved).or_else(|| manifest_root(&lexical)) else {
-        return Ok(false);
+    let discover = |path: &Path| {
+        manifest_roots(path).map_err(|message| FederatedCorpusError::WriteTarget {
+            path: target.to_path_buf(),
+            message,
+        })
     };
-    Ok(verify_parent(child_root)?.is_some_and(|verified| {
-        resolved == verified.materialisation_root
-            || resolved.starts_with(&verified.materialisation_root)
-    }))
+    let mut child_roots = discover(&resolved)?;
+    for root in discover(&lexical)? {
+        if !child_roots.iter().any(|existing| existing == &root) {
+            child_roots.push(root);
+        }
+    }
+    if child_roots.is_empty() {
+        return Ok(false);
+    }
+    let mut read_only = false;
+    for child_root in child_roots {
+        if let Some(roots) = direct_graph_materialisation_roots(&child_root)? {
+            read_only |= roots.iter().any(|root| {
+                resolved == *root
+                    || resolved.starts_with(root)
+                    || lexical == *root
+                    || lexical.starts_with(root)
+            });
+        } else if let Some(verified) = verify_parent(&child_root)? {
+            read_only |= resolved == verified.materialisation_root
+                || resolved.starts_with(&verified.materialisation_root)
+                || lexical == verified.materialisation_root
+                || lexical.starts_with(&verified.materialisation_root);
+        }
+    }
+    Ok(read_only)
 }

--- a/rust/rac-engine/src/federation.rs
+++ b/rust/rac-engine/src/federation.rs
@@ -7,7 +7,7 @@
 //! the exact config and Markdown bytes which were hashed, so later stages can
 //! parse the verified snapshot without re-reading mutable parent files.
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::path::{Component, Path, PathBuf};
@@ -59,7 +59,8 @@ pub const V2_MAX_VISITED_ENTRIES: usize = 200_000;
 /// unambiguous; locations, metadata, and timestamps never enter the preimage.
 pub const DIGEST_V1_DOMAIN: &[u8] = b"asdecided-corpus-digest-v1\0";
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
 pub enum ParentCorpusErrorCode {
     MalformedManifest,
     MultipleParents,
@@ -116,11 +117,26 @@ impl ParentCorpusErrorCode {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct ParentCorpusError {
     pub code: ParentCorpusErrorCode,
     pub message: String,
     pub path: Option<PathBuf>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub validation_origin: Option<Box<FederationValidationOrigin>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_route: Option<Box<Vec<String>>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub route_count: Option<Box<usize>>,
+}
+
+/// Stable ownership for a version-2 validation finding.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct FederationValidationOrigin {
+    pub source: String,
+    pub layer: crate::corpus::Layer,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pin: Option<String>,
 }
 
 impl ParentCorpusError {
@@ -129,6 +145,9 @@ impl ParentCorpusError {
             code,
             message: message.into(),
             path: None,
+            validation_origin: None,
+            source_route: None,
+            route_count: None,
         }
     }
 
@@ -141,7 +160,29 @@ impl ParentCorpusError {
             code,
             message: message.into(),
             path: Some(path.into()),
+            validation_origin: None,
+            source_route: None,
+            route_count: None,
         }
+    }
+
+    fn with_graph_context(
+        mut self,
+        validation_origin: FederationValidationOrigin,
+        source_route: Vec<String>,
+        route_count: usize,
+    ) -> Self {
+        debug_assert!(!source_route.is_empty());
+        debug_assert!(route_count >= 1);
+        self.validation_origin = Some(Box::new(validation_origin));
+        self.source_route = Some(Box::new(source_route));
+        self.route_count = Some(Box::new(route_count));
+        self
+    }
+
+    fn with_validation_origin(mut self, validation_origin: FederationValidationOrigin) -> Self {
+        self.validation_origin = Some(Box::new(validation_origin));
+        self
     }
 
     pub const fn stable_code(&self) -> &'static str {
@@ -296,6 +337,10 @@ pub struct VerifiedParent {
 pub struct VerifiedFederationNode {
     pub source: String,
     pub digest: String,
+    /// Lexicographically minimal verified root-to-node source route.
+    pub source_route: Vec<String>,
+    /// Exact number of verified physical routes represented by this node.
+    pub route_count: usize,
     pub config_path: PathBuf,
     pub config_bytes: Vec<u8>,
     pub manifest_path: PathBuf,
@@ -715,6 +760,13 @@ pub fn load_manifest(repository_root: &Path) -> Result<Option<CorpusManifest>, P
             ),
         )
     })?;
+    parse_manifest_v1_bytes(path, bytes).map(Some)
+}
+
+fn parse_manifest_v1_bytes(
+    path: PathBuf,
+    bytes: Vec<u8>,
+) -> Result<CorpusManifest, ParentCorpusError> {
     let raw = std::str::from_utf8(&bytes)
         .map_err(|_| malformed(&path, "manifest must be valid UTF-8"))?;
     let text = normalize_newlines(raw);
@@ -778,13 +830,13 @@ pub fn load_manifest(repository_root: &Path) -> Result<Option<CorpusManifest>, P
             (None, None)
         };
 
-    Ok(Some(CorpusManifest {
+    Ok(CorpusManifest {
         path,
         bytes,
         inherits,
         overrides,
         override_mapping_bytes,
-    }))
+    })
 }
 
 fn validate_v2_path(value: &str, field: &str) -> Result<(), String> {
@@ -858,53 +910,190 @@ fn validate_v2_path_limits(
     Ok(())
 }
 
-fn strict_yaml_lexical_check(path: &Path, yaml: &str) -> Result<(), ParentCorpusError> {
-    for (line_index, line) in yaml.lines().enumerate() {
-        let mut single = false;
-        let mut double = false;
-        let mut escaped = false;
-        let mut plain = String::new();
-        for character in line.chars() {
-            if escaped {
-                escaped = false;
-                continue;
-            }
-            if double && character == '\\' {
-                escaped = true;
-                continue;
-            }
-            if !double && character == '\'' {
-                single = !single;
-                continue;
-            }
-            if !single && character == '"' {
-                double = !double;
-                continue;
-            }
-            if !single && !double && character == '#' {
-                break;
-            }
-            if !single && !double {
-                plain.push(character);
-            }
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum YamlContainer {
+    Mapping { expects_key: bool },
+    Sequence,
+}
+
+#[derive(Debug, Default)]
+struct RestrictedYamlScan {
+    version: Option<u64>,
+    nodes: usize,
+    maximum_depth: usize,
+    forbidden_line: Option<usize>,
+}
+
+struct YamlParserGuard(unsafe_libyaml::yaml_parser_t);
+
+impl Drop for YamlParserGuard {
+    fn drop(&mut self) {
+        // SAFETY: the parser was initialized successfully and is deleted once.
+        unsafe { unsafe_libyaml::yaml_parser_delete(&mut self.0) };
+    }
+}
+
+fn scan_yaml_events(yaml: &str) -> Result<RestrictedYamlScan, (Option<u64>, String)> {
+    use std::ffi::CStr;
+    use std::mem::MaybeUninit;
+    use std::slice;
+    use unsafe_libyaml::yaml_event_type_t::{
+        YAML_ALIAS_EVENT, YAML_MAPPING_END_EVENT, YAML_MAPPING_START_EVENT, YAML_SCALAR_EVENT,
+        YAML_SEQUENCE_END_EVENT, YAML_SEQUENCE_START_EVENT, YAML_STREAM_END_EVENT,
+    };
+
+    let mut parser = MaybeUninit::<unsafe_libyaml::yaml_parser_t>::uninit();
+    // SAFETY: libyaml initializes the complete parser on success.
+    if unsafe { unsafe_libyaml::yaml_parser_initialize(parser.as_mut_ptr()) }.fail {
+        return Err((None, "YAML parser initialization failed".to_string()));
+    }
+    // SAFETY: initialization succeeded above.
+    let mut parser = YamlParserGuard(unsafe { parser.assume_init() });
+    // SAFETY: `yaml` remains alive for the parser's complete lifetime.
+    unsafe {
+        unsafe_libyaml::yaml_parser_set_input_string(
+            &mut parser.0,
+            yaml.as_ptr(),
+            yaml.len() as u64,
+        )
+    };
+
+    let mut scan = RestrictedYamlScan::default();
+    let mut containers = Vec::<YamlContainer>::new();
+    let mut root_key = None::<Vec<u8>>;
+    loop {
+        let mut event = MaybeUninit::<unsafe_libyaml::yaml_event_t>::uninit();
+        // SAFETY: the initialized parser owns its input and libyaml initializes
+        // the event completely on success.
+        if unsafe { unsafe_libyaml::yaml_parser_parse(&mut parser.0, event.as_mut_ptr()) }.fail {
+            let problem = if parser.0.problem.is_null() {
+                "invalid YAML".to_string()
+            } else {
+                // SAFETY: libyaml exposes a NUL-terminated problem string while
+                // the parser is alive.
+                unsafe { CStr::from_ptr(parser.0.problem) }
+                    .to_string_lossy()
+                    .into_owned()
+            };
+            return Err((scan.version, problem));
         }
-        let tokens = plain.split(|character: char| {
-            character.is_whitespace() || matches!(character, ':' | ',' | '[' | ']' | '{' | '}')
-        });
-        if tokens
-            .clone()
-            .any(|token| token.starts_with('&') || token.starts_with('*') || token.starts_with('!'))
-            || plain.trim_start().starts_with("<<:")
-            || plain.contains(" <<:")
-        {
-            return Err(malformed(
-                path,
-                format!(
-                    "version 2 YAML forbids anchors, aliases, custom tags, and merge keys (line {})",
-                    line_index + 1
-                ),
-            ));
+        // SAFETY: parsing succeeded above.
+        let mut event = unsafe { event.assume_init() };
+        let event_type = event.type_;
+        let line = event.start_mark.line as usize + 1;
+
+        match event_type {
+            YAML_ALIAS_EVENT => {
+                scan.nodes = scan.nodes.saturating_add(1);
+                scan.forbidden_line.get_or_insert(line);
+                if let Some(YamlContainer::Mapping { expects_key }) = containers.last_mut() {
+                    if !*expects_key {
+                        *expects_key = true;
+                    }
+                }
+            }
+            YAML_SCALAR_EVENT => {
+                scan.nodes = scan.nodes.saturating_add(1);
+                // SAFETY: scalar fields are valid for a scalar event and stay
+                // alive until yaml_event_delete below.
+                let scalar = unsafe { event.data.scalar };
+                let value = unsafe { slice::from_raw_parts(scalar.value, scalar.length as usize) };
+                if !scalar.anchor.is_null() || !scalar.tag.is_null() {
+                    scan.forbidden_line.get_or_insert(line);
+                }
+                let is_root_mapping = containers.len() == 1;
+                if let Some(YamlContainer::Mapping { expects_key }) = containers.last_mut() {
+                    if *expects_key {
+                        if value == b"<<" {
+                            scan.forbidden_line.get_or_insert(line);
+                        }
+                        if is_root_mapping {
+                            root_key = Some(value.to_vec());
+                        }
+                        *expects_key = false;
+                    } else {
+                        if is_root_mapping && root_key.as_deref() == Some(b"version") {
+                            scan.version = std::str::from_utf8(value)
+                                .ok()
+                                .and_then(|value| value.parse::<u64>().ok());
+                        }
+                        *expects_key = true;
+                    }
+                }
+            }
+            YAML_MAPPING_START_EVENT | YAML_SEQUENCE_START_EVENT => {
+                scan.nodes = scan.nodes.saturating_add(1);
+                if let Some(YamlContainer::Mapping { expects_key }) = containers.last_mut() {
+                    if !*expects_key {
+                        *expects_key = true;
+                    }
+                }
+                // SAFETY: the selected union field matches the event type.
+                let tagged_or_anchored = if event_type == YAML_MAPPING_START_EVENT {
+                    let start = unsafe { event.data.mapping_start };
+                    !start.anchor.is_null() || !start.tag.is_null()
+                } else {
+                    let start = unsafe { event.data.sequence_start };
+                    !start.anchor.is_null() || !start.tag.is_null()
+                };
+                if tagged_or_anchored {
+                    scan.forbidden_line.get_or_insert(line);
+                }
+                containers.push(if event_type == YAML_MAPPING_START_EVENT {
+                    YamlContainer::Mapping { expects_key: true }
+                } else {
+                    YamlContainer::Sequence
+                });
+                scan.maximum_depth = scan.maximum_depth.max(containers.len());
+            }
+            YAML_MAPPING_END_EVENT | YAML_SEQUENCE_END_EVENT => {
+                containers.pop();
+            }
+            _ => {}
         }
+        // SAFETY: this event was initialized by libyaml and is deleted once.
+        unsafe { unsafe_libyaml::yaml_event_delete(&mut event) };
+        if event_type == YAML_STREAM_END_EVENT {
+            break;
+        }
+    }
+    Ok(scan)
+}
+
+fn manifest_yaml_version(yaml: &str) -> Option<u64> {
+    match scan_yaml_events(yaml) {
+        Ok(scan) => scan.version,
+        Err((version, _)) => version,
+    }
+}
+
+fn restricted_yaml_event_check(path: &Path, yaml: &str) -> Result<(), ParentCorpusError> {
+    let scan = scan_yaml_events(yaml).map_err(|(_, reason)| {
+        malformed(path, format!("version 2 YAML is invalid: {reason}"))
+    })?;
+    if let Some(line) = scan.forbidden_line {
+        return Err(malformed(
+            path,
+            format!(
+                "version 2 YAML forbids anchors, aliases, custom tags, and merge keys (line {line})"
+            ),
+        ));
+    }
+    if scan.nodes > V2_MAX_YAML_NODES {
+        return Err(limit_error(
+            path,
+            "yaml-nodes",
+            V2_MAX_YAML_NODES,
+            scan.nodes,
+        ));
+    }
+    if scan.maximum_depth > V2_MAX_YAML_DEPTH {
+        return Err(limit_error(
+            path,
+            "yaml-depth",
+            V2_MAX_YAML_DEPTH,
+            scan.maximum_depth,
+        ));
     }
     Ok(())
 }
@@ -948,7 +1137,9 @@ fn parse_strict_v2_yaml(
     yaml: &str,
     section: &str,
 ) -> Result<serde_yaml::Value, ParentCorpusError> {
-    strict_yaml_lexical_check(path, yaml)?;
+    // The event pass applies the resource and restricted-syntax contract
+    // before serde constructs an owned YAML value.
+    restricted_yaml_event_check(path, yaml)?;
     let value: serde_yaml::Value = serde_yaml::from_str(yaml)
         .map_err(|error| malformed(path, format!("{section} YAML must be one mapping: {error}")))?;
     if !value.is_mapping() {
@@ -1064,7 +1255,7 @@ pub fn load_graph_manifest(
             ))
         }
     };
-    ensure_no_symlink_components(repository_root, &path)?;
+    ensure_no_reparse_components(repository_root, &path)?;
     if metadata.file_type().is_symlink() || !metadata.is_file() {
         return Err(ParentCorpusError::at(
             ParentCorpusErrorCode::SymlinkTraversal,
@@ -1075,7 +1266,35 @@ pub fn load_graph_manifest(
             ),
         ));
     }
-    if metadata.len() > V2_MAX_MANIFEST_BYTES as u64 {
+    // Capture one stable byte buffer before dispatch. Version 1 still returns
+    // to its established parser unchanged; version 2 never parses or compares
+    // a second path read.
+    let captured = capture_stable_regular(
+        &path,
+        usize::MAX,
+        "manifest-bytes",
+        false,
+        Some(directory_device(repository_root)?),
+    )?;
+    let Some(dispatch_version) = graph_manifest_version(&path, &captured.bytes) else {
+        // Anything not unambiguously selected as graph mode remains on the
+        // established v1 parser, including its exact diagnostics.
+        return Ok(None);
+    };
+    if dispatch_version == 1 {
+        return Ok(None);
+    }
+    if captured.identity.links != 1 {
+        return Err(ParentCorpusError::at(
+            ParentCorpusErrorCode::UnsupportedFilesystem,
+            &path,
+            format!(
+                "version 2 files must have exactly one hard link: {}",
+                path.display()
+            ),
+        ));
+    }
+    if captured.bytes.len() > V2_MAX_MANIFEST_BYTES {
         return Err(limit_error(
             &path,
             "manifest-bytes",
@@ -1083,16 +1302,28 @@ pub fn load_graph_manifest(
             V2_MAX_MANIFEST_BYTES + 1,
         ));
     }
-    let bytes = std::fs::read(&path).map_err(|error| {
-        ParentCorpusError::at(
-            ParentCorpusErrorCode::MalformedManifest,
-            &path,
-            format!(
-                "cannot read federation manifest {}: {error}",
-                path.display()
-            ),
-        )
-    })?;
+    parse_graph_manifest_bytes(path, captured.bytes).map(Some)
+}
+
+fn graph_manifest_version(path: &Path, bytes: &[u8]) -> Option<u64> {
+    let raw = std::str::from_utf8(bytes).ok()?;
+    let text = normalize_newlines(raw);
+    let inherits_sections = heading_sections(&text, "inherits");
+    let (start, end) = inherits_sections.first().copied()?;
+    if inherits_sections.len() != 1 {
+        return None;
+    }
+    let blocks = fenced_yaml_blocks(path, &text, start, end).ok()?;
+    if blocks.len() != 1 {
+        return None;
+    }
+    manifest_yaml_version(&blocks[0])
+}
+
+fn parse_graph_manifest_bytes(
+    path: PathBuf,
+    bytes: Vec<u8>,
+) -> Result<GraphCorpusManifest, ParentCorpusError> {
     let raw = std::str::from_utf8(&bytes)
         .map_err(|_| malformed(&path, "manifest must be valid UTF-8"))?;
     let text = normalize_newlines(raw);
@@ -1112,20 +1343,8 @@ pub fn load_graph_manifest(
             "## inherits must contain exactly one fenced yaml block",
         ));
     }
-    // Inspect only the version scalar before selecting the strict v2 mode.
-    let probe: serde_yaml::Value = serde_yaml::from_str(&blocks[0]).map_err(|error| {
-        malformed(
-            &path,
-            format!("## inherits YAML must be one mapping: {error}"),
-        )
-    })?;
-    let version = probe
-        .as_mapping()
-        .and_then(|mapping| mapping.get(serde_yaml::Value::String("version".to_string())))
-        .and_then(serde_yaml::Value::as_u64);
-    if version == Some(1) {
-        return Ok(None);
-    }
+    // The dispatch pass consumed events only. Restricted v2 scanning happens
+    // before this function constructs any serde YAML value.
     let value = parse_strict_v2_yaml(&path, &blocks[0], "## inherits")?;
     let raw: RawGraphManifest = serde_yaml::from_value(value).map_err(|error| {
         malformed(
@@ -1202,24 +1421,31 @@ pub fn load_graph_manifest(
                 ));
             }
             let value = parse_strict_v2_yaml(&path, &blocks[0], "## overrides")?;
-        let parsed: RawGraphOverrides = serde_yaml::from_value(value.clone()).map_err(|error| {
-            malformed(&path, format!("invalid version 2 override mapping: {error}"))
-        })?;
-        if parsed.version != 2 {
-            return Err(malformed(
-                &path,
-                "## overrides version must match ## inherits version 2",
-            ));
-        }
-        for item in &parsed.items {
-            if item.target.is_empty() || item.replacement.is_empty() || item.rationale.is_empty() {
+            let parsed: RawGraphOverrides =
+                serde_yaml::from_value(value.clone()).map_err(|error| {
+                    malformed(
+                        &path,
+                        format!("invalid version 2 override mapping: {error}"),
+                    )
+                })?;
+            if parsed.version != 2 {
                 return Err(malformed(
                     &path,
-                    "version 2 override operands must be non-empty canonical references",
+                    "## overrides version must match ## inherits version 2",
                 ));
             }
-        }
-        let item_count = parsed.items.len();
+            for item in &parsed.items {
+                if item.target.is_empty()
+                    || item.replacement.is_empty()
+                    || item.rationale.is_empty()
+                {
+                    return Err(malformed(
+                        &path,
+                        "version 2 override operands must be non-empty canonical references",
+                    ));
+                }
+            }
+            let item_count = parsed.items.len();
             if item_count > V2_MAX_OVERRIDES {
                 return Err(limit_error(
                     &path,
@@ -1233,13 +1459,70 @@ pub fn load_graph_manifest(
             (None, None)
         };
 
-    Ok(Some(GraphCorpusManifest {
+    Ok(GraphCorpusManifest {
         path,
         bytes,
         parents,
         overrides,
         override_mapping_bytes,
-    }))
+    })
+}
+
+/// Resolve every direct version-2 materialisation root for write-boundary
+/// classification without walking a corpus or verifying its content pin.
+///
+/// `None` preserves the version-1/no-manifest dispatch contract. A version-2
+/// manifest is parsed strictly and every declared root is independently
+/// confined beneath the declaring repository. Transitive materialisations are
+/// necessarily beneath one of these direct roots, so mutation guards do not
+/// need a corpus argument or a second graph overlay.
+pub fn direct_graph_materialisation_roots(
+    repository_root: &Path,
+) -> Result<Option<Vec<PathBuf>>, ParentCorpusError> {
+    let repository_root = std::fs::canonicalize(repository_root).map_err(|error| {
+        ParentCorpusError::at(
+            ParentCorpusErrorCode::PathEscape,
+            repository_root,
+            format!("repository root is unavailable: {error}"),
+        )
+    })?;
+    let Some(manifest) = load_graph_manifest(&repository_root)? else {
+        return Ok(None);
+    };
+    let mut roots: Vec<(PathBuf, &ParentDeclaration)> = Vec::new();
+    for declaration in &manifest.parents {
+        let candidate = checked_relative_join(&repository_root, &declaration.root, "root")?;
+        ensure_no_reparse_components(&repository_root, &candidate)?;
+        let root = canonical_confined(
+            &repository_root,
+            &candidate,
+            ParentCorpusErrorCode::MaterialisationMissing,
+            "materialisation",
+        )?;
+        if root == repository_root || !root.is_dir() {
+            return Err(ParentCorpusError::at(
+                ParentCorpusErrorCode::PathEscape,
+                &candidate,
+                "parent materialisation must be a directory strictly inside its declaring repository",
+            ));
+        }
+        ensure_no_mount_boundary(&repository_root, &root)?;
+        for (other_root, other) in &roots {
+            if root == *other_root || root.starts_with(other_root) || other_root.starts_with(&root)
+            {
+                return Err(ParentCorpusError::at(
+                    ParentCorpusErrorCode::OverlappingRoots,
+                    &root,
+                    format!(
+                        "sibling parent roots overlap for '{}' and '{}'",
+                        other.source, declaration.source
+                    ),
+                ));
+            }
+        }
+        roots.push((root, declaration));
+    }
+    Ok(Some(roots.into_iter().map(|(root, _)| root).collect()))
 }
 
 fn lexical_components(path: &Path) -> Result<Vec<&std::ffi::OsStr>, ()> {
@@ -1317,6 +1600,49 @@ fn ensure_no_symlink_components(boundary: &Path, target: &Path) -> Result<(), Pa
     Ok(())
 }
 
+fn ensure_no_reparse_components(boundary: &Path, target: &Path) -> Result<(), ParentCorpusError> {
+    ensure_no_symlink_components(boundary, target)?;
+    #[cfg(windows)]
+    {
+        let relative = target.strip_prefix(boundary).map_err(|_| {
+            ParentCorpusError::at(
+                ParentCorpusErrorCode::PathEscape,
+                target,
+                format!("parent path escapes repository boundary: {}", target.display()),
+            )
+        })?;
+        let mut current = boundary.to_path_buf();
+        for component in relative.components() {
+            let Component::Normal(value) = component else {
+                continue;
+            };
+            current.push(value);
+            match std::fs::symlink_metadata(&current) {
+                Ok(metadata) if is_symlink_or_reparse(&metadata) => {
+                    return Err(ParentCorpusError::at(
+                        ParentCorpusErrorCode::SymlinkTraversal,
+                        &current,
+                        format!(
+                            "parent path traverses a Windows reparse point: {}",
+                            current.display()
+                        ),
+                    ));
+                }
+                Ok(_) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+                Err(error) => {
+                    return Err(ParentCorpusError::at(
+                        ParentCorpusErrorCode::SnapshotFailed,
+                        &current,
+                        format!("cannot inspect parent path {}: {error}", current.display()),
+                    ));
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
 fn canonical_confined(
     boundary: &Path,
     candidate: &Path,
@@ -1359,7 +1685,11 @@ fn canonical_or_absolute(path: &Path) -> Option<PathBuf> {
 }
 
 #[cfg(target_os = "linux")]
-fn ensure_no_mount_boundary(boundary: &Path, target: &Path) -> Result<(), ParentCorpusError> {
+fn nested_mount_from_text(
+    mountinfo: &str,
+    boundary: &Path,
+    target: &Path,
+) -> Result<Option<PathBuf>, ()> {
     fn unescape_mount_path(value: &str) -> String {
         value
             .replace("\\040", " ")
@@ -1367,6 +1697,23 @@ fn ensure_no_mount_boundary(boundary: &Path, target: &Path) -> Result<(), Parent
             .replace("\\012", "\n")
             .replace("\\134", "\\")
     }
+    for line in mountinfo.lines() {
+        let Some(raw_mount) = line.split_whitespace().nth(4) else {
+            return Err(());
+        };
+        let mount = PathBuf::from(unescape_mount_path(raw_mount));
+        if mount != boundary
+            && mount.starts_with(boundary)
+            && (target == mount || target.starts_with(&mount))
+        {
+            return Ok(Some(mount));
+        }
+    }
+    Ok(None)
+}
+
+#[cfg(target_os = "linux")]
+fn ensure_no_mount_boundary(boundary: &Path, target: &Path) -> Result<(), ParentCorpusError> {
     let mountinfo = std::fs::read_to_string("/proc/self/mountinfo").map_err(|error| {
         ParentCorpusError::at(
             ParentCorpusErrorCode::UnsupportedFilesystem,
@@ -1374,28 +1721,22 @@ fn ensure_no_mount_boundary(boundary: &Path, target: &Path) -> Result<(), Parent
             format!("cannot inspect Linux mount identity: {error}"),
         )
     })?;
-    for line in mountinfo.lines() {
-        let Some(raw_mount) = line.split_whitespace().nth(4) else {
-            return Err(ParentCorpusError::at(
-                ParentCorpusErrorCode::UnsupportedFilesystem,
-                target,
-                "Linux mount identity record is malformed",
-            ));
-        };
-        let mount = PathBuf::from(unescape_mount_path(raw_mount));
-        if mount != boundary
-            && mount.starts_with(boundary)
-            && (target == mount || target.starts_with(&mount))
-        {
-            return Err(ParentCorpusError::at(
-                ParentCorpusErrorCode::UnsupportedFilesystem,
-                target,
-                format!(
-                    "federation path crosses mount boundary at {}",
-                    mount.display()
-                ),
-            ));
-        }
+    let nested = nested_mount_from_text(&mountinfo, boundary, target).map_err(|()| {
+        ParentCorpusError::at(
+            ParentCorpusErrorCode::UnsupportedFilesystem,
+            target,
+            "Linux mount identity record is malformed",
+        )
+    })?;
+    if let Some(mount) = nested {
+        return Err(ParentCorpusError::at(
+            ParentCorpusErrorCode::UnsupportedFilesystem,
+            target,
+            format!(
+                "federation path crosses mount boundary at {}",
+                mount.display()
+            ),
+        ));
     }
     Ok(())
 }
@@ -1405,6 +1746,58 @@ fn ensure_no_mount_boundary(_boundary: &Path, _target: &Path) -> Result<(), Pare
     // Stable device/volume identities are checked at every directory and file
     // on these platforms. Linux additionally exposes bind-mount identity.
     Ok(())
+}
+
+struct WalkMountBoundary {
+    boundary: PathBuf,
+    #[cfg(target_os = "linux")]
+    mountinfo: String,
+}
+
+impl WalkMountBoundary {
+    fn capture(boundary: &Path) -> Result<Self, ParentCorpusError> {
+        #[cfg(target_os = "linux")]
+        let mountinfo = std::fs::read_to_string("/proc/self/mountinfo").map_err(|error| {
+            ParentCorpusError::at(
+                ParentCorpusErrorCode::UnsupportedFilesystem,
+                boundary,
+                format!("cannot inspect Linux mount identity: {error}"),
+            )
+        })?;
+        Ok(Self {
+            boundary: boundary.to_path_buf(),
+            #[cfg(target_os = "linux")]
+            mountinfo,
+        })
+    }
+
+    fn check(&self, target: &Path) -> Result<(), ParentCorpusError> {
+        #[cfg(target_os = "linux")]
+        {
+            let nested = nested_mount_from_text(&self.mountinfo, &self.boundary, target).map_err(
+                |()| {
+                    ParentCorpusError::at(
+                        ParentCorpusErrorCode::UnsupportedFilesystem,
+                        target,
+                        "Linux mount identity record is malformed",
+                    )
+                },
+            )?;
+            if let Some(mount) = nested {
+                return Err(ParentCorpusError::at(
+                    ParentCorpusErrorCode::UnsupportedFilesystem,
+                    target,
+                    format!(
+                        "federation path crosses mount boundary at {}",
+                        mount.display()
+                    ),
+                ));
+            }
+        }
+        #[cfg(not(target_os = "linux"))]
+        let _ = target;
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1418,10 +1811,7 @@ struct StableFileIdentity {
 }
 
 #[cfg(unix)]
-fn stable_file_identity(
-    _path: &Path,
-    metadata: &std::fs::Metadata,
-) -> Result<StableFileIdentity, ()> {
+fn stable_metadata_identity(metadata: &std::fs::Metadata) -> Result<StableFileIdentity, ()> {
     use std::os::unix::fs::MetadataExt;
     Ok(StableFileIdentity {
         device: metadata.dev(),
@@ -1434,13 +1824,9 @@ fn stable_file_identity(
 }
 
 #[cfg(windows)]
-fn stable_file_identity(
-    path: &Path,
-    _metadata: &std::fs::Metadata,
-) -> Result<StableFileIdentity, ()> {
+fn opened_file_identity(file: &std::fs::File) -> Result<StableFileIdentity, ()> {
     use std::ffi::c_void;
     use std::mem::MaybeUninit;
-    use std::os::windows::fs::OpenOptionsExt;
     use std::os::windows::io::AsRawHandle;
 
     #[repr(C)]
@@ -1451,7 +1837,7 @@ fn stable_file_identity(
 
     #[repr(C)]
     struct ByHandleFileInformation {
-        _file_attributes: u32,
+        file_attributes: u32,
         _creation_time: FileTime,
         _last_access_time: FileTime,
         last_write_time: FileTime,
@@ -1471,12 +1857,6 @@ fn stable_file_identity(
         ) -> i32;
     }
 
-    const FILE_FLAG_BACKUP_SEMANTICS: u32 = 0x0200_0000;
-    let file = std::fs::OpenOptions::new()
-        .read(true)
-        .custom_flags(FILE_FLAG_BACKUP_SEMANTICS)
-        .open(path)
-        .map_err(|_| ())?;
     let mut information = MaybeUninit::<ByHandleFileInformation>::uninit();
     // SAFETY: `file` keeps a valid owned handle alive for the call and the
     // Win32 function initializes the complete output structure on success.
@@ -1491,6 +1871,10 @@ fn stable_file_identity(
     }
     // SAFETY: the successful Win32 call above initialized every field.
     let information = unsafe { information.assume_init() };
+    const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x0000_0400;
+    if information.file_attributes & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+        return Err(());
+    }
     let last_write = ((information.last_write_time.high as u64) << 32)
         | information.last_write_time.low as u64;
     Ok(StableFileIdentity {
@@ -1505,21 +1889,99 @@ fn stable_file_identity(
     })
 }
 
+#[cfg(unix)]
+fn opened_file_identity(file: &std::fs::File) -> Result<StableFileIdentity, ()> {
+    stable_metadata_identity(&file.metadata().map_err(|_| ())?)
+}
+
+#[cfg(unix)]
+fn open_no_follow(path: &Path, directory: bool) -> std::io::Result<std::fs::File> {
+    use std::os::unix::fs::OpenOptionsExt;
+    let flags = libc::O_NOFOLLOW | if directory { libc::O_DIRECTORY } else { 0 };
+    std::fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(flags)
+        .open(path)
+}
+
+#[cfg(windows)]
+fn open_no_follow(path: &Path, directory: bool) -> std::io::Result<std::fs::File> {
+    use std::os::windows::fs::OpenOptionsExt;
+    const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+    const FILE_FLAG_BACKUP_SEMANTICS: u32 = 0x0200_0000;
+    let flags = FILE_FLAG_OPEN_REPARSE_POINT
+        | if directory {
+            FILE_FLAG_BACKUP_SEMANTICS
+        } else {
+            0
+        };
+    std::fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(flags)
+        .open(path)
+}
+
 #[cfg(not(any(unix, windows)))]
-fn stable_file_identity(
+fn open_no_follow(_path: &Path, _directory: bool) -> std::io::Result<std::fs::File> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "no-follow opens are unavailable",
+    ))
+}
+
+#[cfg(windows)]
+fn stable_path_identity(
+    path: &Path,
+    _metadata: &std::fs::Metadata,
+    directory: bool,
+) -> Result<StableFileIdentity, ()> {
+    let file = open_no_follow(path, directory).map_err(|_| ())?;
+    opened_file_identity(&file)
+}
+
+#[cfg(unix)]
+fn stable_path_identity(
+    _path: &Path,
+    metadata: &std::fs::Metadata,
+    _directory: bool,
+) -> Result<StableFileIdentity, ()> {
+    stable_metadata_identity(metadata)
+}
+
+#[cfg(not(any(unix, windows)))]
+fn stable_path_identity(
     _path: &Path,
     _metadata: &std::fs::Metadata,
+    _directory: bool,
 ) -> Result<StableFileIdentity, ()> {
     Err(())
 }
 
-fn read_stable_regular(
+#[cfg(windows)]
+fn is_symlink_or_reparse(metadata: &std::fs::Metadata) -> bool {
+    use std::os::windows::fs::MetadataExt;
+    const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x0000_0400;
+    metadata.file_type().is_symlink()
+        || metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0
+}
+
+#[cfg(not(windows))]
+fn is_symlink_or_reparse(metadata: &std::fs::Metadata) -> bool {
+    metadata.file_type().is_symlink()
+}
+
+struct StableRegularCapture {
+    bytes: Vec<u8>,
+    identity: StableFileIdentity,
+}
+
+fn capture_stable_regular(
     path: &Path,
     maximum: usize,
     dimension: &str,
-    inherited: bool,
+    reject_hard_links: bool,
     expected_device: Option<u64>,
-) -> Result<Vec<u8>, ParentCorpusError> {
+) -> Result<StableRegularCapture, ParentCorpusError> {
     let before = std::fs::symlink_metadata(path).map_err(|error| {
         ParentCorpusError::at(
             ParentCorpusErrorCode::SnapshotFailed,
@@ -1530,7 +1992,7 @@ fn read_stable_regular(
             ),
         )
     })?;
-    if before.file_type().is_symlink() || !before.is_file() {
+    if is_symlink_or_reparse(&before) || !before.is_file() {
         return Err(ParentCorpusError::at(
             ParentCorpusErrorCode::SymlinkTraversal,
             path,
@@ -1540,19 +2002,19 @@ fn read_stable_regular(
             ),
         ));
     }
-    let before_identity = stable_file_identity(path, &before).map_err(|_| {
+    let before_identity = stable_path_identity(path, &before, false).map_err(|_| {
         ParentCorpusError::at(
             ParentCorpusErrorCode::UnsupportedFilesystem,
             path,
             format!("stable file identity is unavailable for {}", path.display()),
         )
     })?;
-    if inherited && before_identity.links != 1 {
+    if reject_hard_links && before_identity.links != 1 {
         return Err(ParentCorpusError::at(
             ParentCorpusErrorCode::UnsupportedFilesystem,
             path,
             format!(
-                "inherited files must have exactly one hard link: {}",
+                "version 2 files must have exactly one hard link: {}",
                 path.display()
             ),
         ));
@@ -1568,40 +2030,58 @@ fn read_stable_regular(
         ));
     }
     if before_identity.length > maximum as u64 {
-        return Err(limit_error(path, dimension, maximum, maximum + 1));
+        return Err(limit_error(
+            path,
+            dimension,
+            maximum,
+            maximum.saturating_add(1),
+        ));
     }
 
-    #[cfg(unix)]
-    let bytes = {
-        use std::io::Read;
-        use std::os::unix::fs::OpenOptionsExt;
-        let mut file = std::fs::OpenOptions::new()
-            .read(true)
-            .custom_flags(libc::O_NOFOLLOW)
-            .open(path)
-            .map_err(|error| {
-                ParentCorpusError::at(
-                    ParentCorpusErrorCode::SnapshotFailed,
-                    path,
-                    format!("cannot open federation input {}: {error}", path.display()),
-                )
-            })?;
-        let mut bytes = Vec::with_capacity(before_identity.length as usize);
-        file.read_to_end(&mut bytes).map_err(|error| {
-            ParentCorpusError::at(
-                ParentCorpusErrorCode::SnapshotFailed,
-                path,
-                format!("cannot read federation input {}: {error}", path.display()),
-            )
-        })?;
-        bytes
-    };
-    #[cfg(not(unix))]
-    let bytes = std::fs::read(path).map_err(|error| {
+    use std::io::Read;
+    let mut file = open_no_follow(path, false).map_err(|error| {
+        ParentCorpusError::at(
+            ParentCorpusErrorCode::SnapshotFailed,
+            path,
+            format!("cannot open federation input {}: {error}", path.display()),
+        )
+    })?;
+    let opened_identity = opened_file_identity(&file).map_err(|_| {
+        ParentCorpusError::at(
+            ParentCorpusErrorCode::UnsupportedFilesystem,
+            path,
+            format!(
+                "opened federation file identity is unavailable for {}",
+                path.display()
+            ),
+        )
+    })?;
+    if opened_identity != before_identity {
+        return Err(ParentCorpusError::at(
+            ParentCorpusErrorCode::SnapshotChanged,
+            path,
+            format!(
+                "federation input changed before its no-follow handle was opened: {}",
+                path.display()
+            ),
+        ));
+    }
+    let mut bytes = Vec::with_capacity(before_identity.length as usize);
+    file.read_to_end(&mut bytes).map_err(|error| {
         ParentCorpusError::at(
             ParentCorpusErrorCode::SnapshotFailed,
             path,
             format!("cannot read federation input {}: {error}", path.display()),
+        )
+    })?;
+    let opened_after = opened_file_identity(&file).map_err(|_| {
+        ParentCorpusError::at(
+            ParentCorpusErrorCode::UnsupportedFilesystem,
+            path,
+            format!(
+                "opened federation file identity is unavailable for {}",
+                path.display()
+            ),
         )
     })?;
 
@@ -1615,14 +2095,24 @@ fn read_stable_regular(
             ),
         )
     })?;
-    let after_identity = stable_file_identity(path, &after).map_err(|_| {
+    if is_symlink_or_reparse(&after) || !after.is_file() {
+        return Err(ParentCorpusError::at(
+            ParentCorpusErrorCode::SnapshotChanged,
+            path,
+            format!("federation input changed shape during capture: {}", path.display()),
+        ));
+    }
+    let after_identity = stable_path_identity(path, &after, false).map_err(|_| {
         ParentCorpusError::at(
             ParentCorpusErrorCode::UnsupportedFilesystem,
             path,
             format!("stable file identity is unavailable for {}", path.display()),
         )
     })?;
-    if before_identity != after_identity || bytes.len() as u64 != before_identity.length {
+    if before_identity != opened_after
+        || before_identity != after_identity
+        || bytes.len() as u64 != before_identity.length
+    {
         return Err(ParentCorpusError::at(
             ParentCorpusErrorCode::SnapshotChanged,
             path,
@@ -1632,7 +2122,109 @@ fn read_stable_regular(
             ),
         ));
     }
-    Ok(bytes)
+    Ok(StableRegularCapture {
+        bytes,
+        identity: before_identity,
+    })
+}
+
+fn read_stable_regular(
+    path: &Path,
+    maximum: usize,
+    dimension: &str,
+    reject_hard_links: bool,
+    expected_device: Option<u64>,
+) -> Result<Vec<u8>, ParentCorpusError> {
+    capture_stable_regular(
+        path,
+        maximum,
+        dimension,
+        reject_hard_links,
+        expected_device,
+    )
+    .map(|capture| capture.bytes)
+}
+
+fn validate_regular_entry(
+    path: &Path,
+    reject_hard_links: bool,
+    expected_device: u64,
+) -> Result<(), ParentCorpusError> {
+    let before = std::fs::symlink_metadata(path).map_err(|error| {
+        ParentCorpusError::at(
+            ParentCorpusErrorCode::SnapshotFailed,
+            path,
+            format!("cannot inspect federation entry {}: {error}", path.display()),
+        )
+    })?;
+    if is_symlink_or_reparse(&before) || !before.is_file() {
+        return Err(ParentCorpusError::at(
+            ParentCorpusErrorCode::SymlinkTraversal,
+            path,
+            format!("federation entry must be a real regular file: {}", path.display()),
+        ));
+    }
+    let before_identity = stable_path_identity(path, &before, false).map_err(|_| {
+        ParentCorpusError::at(
+            ParentCorpusErrorCode::UnsupportedFilesystem,
+            path,
+            format!("stable file identity is unavailable for {}", path.display()),
+        )
+    })?;
+    if reject_hard_links && before_identity.links != 1 {
+        return Err(ParentCorpusError::at(
+            ParentCorpusErrorCode::UnsupportedFilesystem,
+            path,
+            format!("version 2 files must have exactly one hard link: {}", path.display()),
+        ));
+    }
+    if before_identity.device != expected_device {
+        return Err(ParentCorpusError::at(
+            ParentCorpusErrorCode::UnsupportedFilesystem,
+            path,
+            format!("federation entry crosses a filesystem boundary: {}", path.display()),
+        ));
+    }
+    let file = open_no_follow(path, false).map_err(|error| {
+        ParentCorpusError::at(
+            ParentCorpusErrorCode::SnapshotFailed,
+            path,
+            format!("cannot open federation entry {}: {error}", path.display()),
+        )
+    })?;
+    let opened_identity = opened_file_identity(&file).map_err(|_| {
+        ParentCorpusError::at(
+            ParentCorpusErrorCode::UnsupportedFilesystem,
+            path,
+            format!("opened file identity is unavailable for {}", path.display()),
+        )
+    })?;
+    let after = std::fs::symlink_metadata(path).map_err(|error| {
+        ParentCorpusError::at(
+            ParentCorpusErrorCode::SnapshotChanged,
+            path,
+            format!("federation entry changed during inspection {}: {error}", path.display()),
+        )
+    })?;
+    let after_identity = stable_path_identity(path, &after, false).map_err(|_| {
+        ParentCorpusError::at(
+            ParentCorpusErrorCode::UnsupportedFilesystem,
+            path,
+            format!("stable file identity is unavailable for {}", path.display()),
+        )
+    })?;
+    if is_symlink_or_reparse(&after)
+        || !after.is_file()
+        || before_identity != opened_identity
+        || before_identity != after_identity
+    {
+        return Err(ParentCorpusError::at(
+            ParentCorpusErrorCode::SnapshotChanged,
+            path,
+            format!("federation entry changed during inspection: {}", path.display()),
+        ));
+    }
+    Ok(())
 }
 
 #[derive(Debug, Default)]
@@ -1671,7 +2263,7 @@ fn directory_device(path: &Path) -> Result<u64, ParentCorpusError> {
             ),
         )
     })?;
-    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+    if is_symlink_or_reparse(&metadata) || !metadata.is_dir() {
         return Err(ParentCorpusError::at(
             ParentCorpusErrorCode::SymlinkTraversal,
             path,
@@ -1681,28 +2273,52 @@ fn directory_device(path: &Path) -> Result<u64, ParentCorpusError> {
             ),
         ));
     }
-    stable_file_identity(path, &metadata)
-        .map(|identity| identity.device)
-        .map_err(|_| {
-            ParentCorpusError::at(
-                ParentCorpusErrorCode::UnsupportedFilesystem,
-                path,
-                format!(
-                    "stable filesystem identity is unavailable for {}",
-                    path.display()
-                ),
-            )
-        })
+    let before = stable_path_identity(path, &metadata, true).map_err(|_| {
+        ParentCorpusError::at(
+            ParentCorpusErrorCode::UnsupportedFilesystem,
+            path,
+            format!(
+                "stable filesystem identity is unavailable for {}",
+                path.display()
+            ),
+        )
+    })?;
+    let directory = open_no_follow(path, true).map_err(|error| {
+        ParentCorpusError::at(
+            ParentCorpusErrorCode::UnsupportedFilesystem,
+            path,
+            format!(
+                "cannot open federation directory without following links {}: {error}",
+                path.display()
+            ),
+        )
+    })?;
+    let opened = opened_file_identity(&directory).map_err(|_| {
+        ParentCorpusError::at(
+            ParentCorpusErrorCode::UnsupportedFilesystem,
+            path,
+            format!("opened directory identity is unavailable for {}", path.display()),
+        )
+    })?;
+    if before != opened {
+        return Err(ParentCorpusError::at(
+            ParentCorpusErrorCode::SnapshotChanged,
+            path,
+            format!("federation directory changed while opening: {}", path.display()),
+        ));
+    }
+    Ok(opened.device)
 }
 
 #[allow(clippy::too_many_arguments)] // The explicit bounds/context prevent accidental v1 reuse.
 fn snapshot_directory_v2(
     corpus_root: &Path,
+    mount_boundary: &WalkMountBoundary,
     directory: &Path,
     components: &mut Vec<String>,
     exclusions: &[PathBuf],
     expected_device: u64,
-    inherited_files: bool,
+    reject_hard_links: bool,
     charge_limits: bool,
     counters: &mut GraphCounters,
     output: &mut Vec<SnapshotFile>,
@@ -1717,7 +2333,14 @@ fn snapshot_directory_v2(
             ),
         )
     })?;
-    let directory_identity = stable_file_identity(directory, &directory_before).map_err(|_| {
+    if is_symlink_or_reparse(&directory_before) || !directory_before.is_dir() {
+        return Err(ParentCorpusError::at(
+            ParentCorpusErrorCode::SymlinkTraversal,
+            directory,
+            format!("inherited directory must be a real directory: {}", directory.display()),
+        ));
+    }
+    let directory_identity = stable_path_identity(directory, &directory_before, true).map_err(|_| {
         ParentCorpusError::at(
             ParentCorpusErrorCode::UnsupportedFilesystem,
             directory,
@@ -1727,6 +2350,30 @@ fn snapshot_directory_v2(
             ),
         )
     })?;
+    let directory_handle = open_no_follow(directory, true).map_err(|error| {
+        ParentCorpusError::at(
+            ParentCorpusErrorCode::SnapshotFailed,
+            directory,
+            format!(
+                "cannot open inherited directory without following links {}: {error}",
+                directory.display()
+            ),
+        )
+    })?;
+    let opened_directory_identity = opened_file_identity(&directory_handle).map_err(|_| {
+        ParentCorpusError::at(
+            ParentCorpusErrorCode::UnsupportedFilesystem,
+            directory,
+            format!("opened directory identity is unavailable for {}", directory.display()),
+        )
+    })?;
+    if directory_identity != opened_directory_identity {
+        return Err(ParentCorpusError::at(
+            ParentCorpusErrorCode::SnapshotChanged,
+            directory,
+            format!("inherited directory changed while opening: {}", directory.display()),
+        ));
+    }
     if directory_identity.device != expected_device {
         return Err(ParentCorpusError::at(
             ParentCorpusErrorCode::UnsupportedFilesystem,
@@ -1770,6 +2417,7 @@ fn snapshot_directory_v2(
             )?;
         }
         let path = entry.path();
+        mount_boundary.check(&path)?;
         if exclusions
             .iter()
             .any(|excluded| path == *excluded || path.starts_with(excluded))
@@ -1783,7 +2431,7 @@ fn snapshot_directory_v2(
                 format!("cannot inspect inherited entry {}: {error}", path.display()),
             )
         })?;
-        if metadata.file_type().is_symlink() {
+        if is_symlink_or_reparse(&metadata) {
             return Err(ParentCorpusError::at(
                 ParentCorpusErrorCode::SymlinkTraversal,
                 &path,
@@ -1793,7 +2441,14 @@ fn snapshot_directory_v2(
                 ),
             ));
         }
-        let Ok(name) = entry.file_name().into_string() else {
+        let file_name = entry.file_name();
+        let discovered_markdown = file_name
+            .to_str()
+            .is_some_and(|name| !name.starts_with('.') && name.ends_with(".md"));
+        if metadata.is_file() && !discovered_markdown {
+            validate_regular_entry(&path, reject_hard_links, expected_device)?;
+        }
+        let Ok(name) = file_name.into_string() else {
             continue;
         };
         if name.starts_with('.') {
@@ -1803,11 +2458,12 @@ fn snapshot_directory_v2(
         if metadata.is_dir() {
             snapshot_directory_v2(
                 corpus_root,
+                mount_boundary,
                 &path,
                 components,
                 exclusions,
                 expected_device,
-                inherited_files,
+                reject_hard_links,
                 charge_limits,
                 counters,
                 output,
@@ -1827,7 +2483,7 @@ fn snapshot_directory_v2(
                 &path,
                 V2_MAX_FILE_BYTES,
                 "file-bytes",
-                inherited_files,
+                reject_hard_links,
                 Some(expected_device),
             )?;
             if charge_limits {
@@ -1857,7 +2513,21 @@ fn snapshot_directory_v2(
             ),
         )
     })?;
-    let after_identity = stable_file_identity(directory, &directory_after).map_err(|_| {
+    if is_symlink_or_reparse(&directory_after) || !directory_after.is_dir() {
+        return Err(ParentCorpusError::at(
+            ParentCorpusErrorCode::SnapshotChanged,
+            directory,
+            format!("inherited directory changed shape during capture: {}", directory.display()),
+        ));
+    }
+    let opened_after_identity = opened_file_identity(&directory_handle).map_err(|_| {
+        ParentCorpusError::at(
+            ParentCorpusErrorCode::UnsupportedFilesystem,
+            directory,
+            format!("opened directory identity is unavailable for {}", directory.display()),
+        )
+    })?;
+    let after_identity = stable_path_identity(directory, &directory_after, true).map_err(|_| {
         ParentCorpusError::at(
             ParentCorpusErrorCode::UnsupportedFilesystem,
             directory,
@@ -1867,7 +2537,7 @@ fn snapshot_directory_v2(
             ),
         )
     })?;
-    if directory_identity != after_identity {
+    if directory_identity != opened_after_identity || directory_identity != after_identity {
         return Err(ParentCorpusError::at(
             ParentCorpusErrorCode::SnapshotChanged,
             directory,
@@ -2276,14 +2946,17 @@ struct CapturedNode {
     digest_v2: String,
 }
 
-fn captured_manifest(repository_root: &Path) -> Result<CapturedManifest, ParentCorpusError> {
-    if let Some(manifest) = load_graph_manifest(repository_root)? {
-        return Ok(CapturedManifest::V2(manifest));
+fn captured_manifest(
+    path: PathBuf,
+    bytes: Option<Vec<u8>>,
+) -> Result<CapturedManifest, ParentCorpusError> {
+    let Some(bytes) = bytes else {
+        return Ok(CapturedManifest::None);
+    };
+    if graph_manifest_version(&path, &bytes).is_some_and(|version| version != 1) {
+        return parse_graph_manifest_bytes(path, bytes).map(CapturedManifest::V2);
     }
-    match load_manifest(repository_root)? {
-        Some(manifest) => Ok(CapturedManifest::V1(manifest)),
-        None => Ok(CapturedManifest::None),
-    }
+    parse_manifest_v1_bytes(path, bytes).map(CapturedManifest::V1)
 }
 
 fn capture_v2_node(
@@ -2308,7 +2981,7 @@ fn capture_v2_node(
     }
     let device = directory_device(&repository_root)?;
     let config_candidate = repository_root.join(CONFIG_RELATIVE_PATH);
-    ensure_no_symlink_components(&repository_root, &config_candidate)?;
+    ensure_no_reparse_components(&repository_root, &config_candidate)?;
     let config_path = canonical_confined(
         &repository_root,
         &config_candidate,
@@ -2363,7 +3036,7 @@ fn capture_v2_node(
     }
 
     let manifest_path = repository_root.join(MANIFEST_RELATIVE_PATH);
-    ensure_no_symlink_components(&repository_root, &manifest_path)?;
+    ensure_no_reparse_components(&repository_root, &manifest_path)?;
     let manifest_bytes = match std::fs::symlink_metadata(&manifest_path) {
         Ok(_) => Some(read_stable_regular(
             &manifest_path,
@@ -2390,14 +3063,7 @@ fn capture_v2_node(
             &manifest_path,
         )?;
     }
-    let manifest = captured_manifest(&repository_root)?;
-    if manifest.bytes() != manifest_bytes.as_deref() {
-        return Err(ParentCorpusError::at(
-            ParentCorpusErrorCode::SnapshotChanged,
-            &manifest_path,
-            "federation manifest changed while it was parsed",
-        ));
-    }
+    let manifest = captured_manifest(manifest_path.clone(), manifest_bytes)?;
     add_limited(
         &mut counters.overrides,
         manifest.override_count(),
@@ -2407,6 +3073,7 @@ fn capture_v2_node(
     )?;
 
     let corpus_candidate = checked_relative_join(&repository_root, corpus_relative, "corpus")?;
+    ensure_no_reparse_components(&repository_root, &corpus_candidate)?;
     let corpus_root = canonical_confined(
         &repository_root,
         &corpus_candidate,
@@ -2426,9 +3093,11 @@ fn capture_v2_node(
         .iter()
         .filter_map(|parent| checked_relative_join(&repository_root, &parent.root, "root").ok())
         .collect::<Vec<_>>();
+    let walk_mount_boundary = WalkMountBoundary::capture(&repository_root)?;
     let mut files = Vec::new();
     snapshot_directory_v2(
         &corpus_root,
+        &walk_mount_boundary,
         &corpus_root,
         &mut Vec::new(),
         &exclusions,
@@ -2438,7 +3107,7 @@ fn capture_v2_node(
         counters,
         &mut files,
     )?;
-    let digest_v2 = digest_snapshot_v2(&source, &config_bytes, manifest_bytes.as_deref(), &files);
+    let digest_v2 = digest_snapshot_v2(&source, &config_bytes, manifest.bytes(), &files);
     Ok(CapturedNode {
         repository_root,
         source,
@@ -2489,6 +3158,7 @@ pub fn calculate_parent_digest_v2(
 
 struct GraphVerification {
     invocation_root: PathBuf,
+    root_source: String,
     counters: GraphCounters,
     physical_captures: BTreeMap<(PathBuf, String), CapturedNode>,
     expanded_physical: BTreeSet<(PathBuf, String)>,
@@ -2505,6 +3175,7 @@ impl GraphVerification {
         declaration: &ParentDeclaration,
     ) -> Result<PathBuf, ParentCorpusError> {
         let candidate = checked_relative_join(owner_root, &declaration.root, "root")?;
+        ensure_no_reparse_components(owner_root, &candidate)?;
         let root = canonical_confined(
             owner_root,
             &candidate,
@@ -2522,33 +3193,57 @@ impl GraphVerification {
         Ok(root)
     }
 
+    #[allow(clippy::too_many_arguments)] // Route ownership is explicit at every recursive edge.
     fn verify_edges(
         &mut self,
         owner_source: &str,
+        owner_pin: Option<&str>,
         owner_root: &Path,
         declarations: &[ParentDeclaration],
         depth: usize,
         active_sources: &mut Vec<String>,
         owner_is_v1: bool,
     ) -> Result<(), ParentCorpusError> {
+        let owner_origin = FederationValidationOrigin {
+            source: owner_source.to_string(),
+            layer: if owner_pin.is_some() {
+                crate::corpus::Layer::Inherited
+            } else {
+                crate::corpus::Layer::Local
+            },
+            pin: owner_pin.map(str::to_string),
+        };
         if depth > V2_MAX_INHERITANCE_DEPTH {
             return Err(limit_error(
                 owner_root,
                 "depth",
                 V2_MAX_INHERITANCE_DEPTH,
                 V2_MAX_INHERITANCE_DEPTH + 1,
-            ));
+            )
+            .with_graph_context(owner_origin, active_sources.clone(), 1));
         }
         let mut siblings: Vec<(PathBuf, &ParentDeclaration)> = Vec::new();
         for declaration in declarations {
+            let declared_route = active_sources
+                .iter()
+                .cloned()
+                .chain(std::iter::once(declaration.source.clone()))
+                .collect::<Vec<_>>();
             add_limited(
                 &mut self.counters.edges,
                 1,
                 V2_MAX_EDGES,
                 "edges",
                 owner_root,
-            )?;
-            let materialisation_root = self.resolve_materialisation(owner_root, declaration)?;
+            )
+            .map_err(|error| {
+                error.with_graph_context(owner_origin.clone(), declared_route.clone(), 1)
+            })?;
+            let materialisation_root = self
+                .resolve_materialisation(owner_root, declaration)
+                .map_err(|error| {
+                    error.with_graph_context(owner_origin.clone(), declared_route.clone(), 1)
+                })?;
             for (other_root, other) in &siblings {
                 let overlap = materialisation_root == *other_root
                     || materialisation_root.starts_with(other_root)
@@ -2565,7 +3260,8 @@ impl GraphVerification {
                             "sibling parent roots overlap for '{}' and '{}'",
                             other.source, declaration.source
                         ),
-                    ));
+                    )
+                    .with_graph_context(owner_origin.clone(), declared_route.clone(), 1));
                 }
             }
             siblings.push((materialisation_root.clone(), declaration));
@@ -2579,7 +3275,10 @@ impl GraphVerification {
                     &declaration.corpus,
                     &self.invocation_root,
                     &mut self.counters,
-                )?;
+                )
+                .map_err(|error| {
+                    error.with_graph_context(owner_origin.clone(), declared_route.clone(), 1)
+                })?;
                 self.physical_captures
                     .insert(physical_key.clone(), captured.clone());
                 captured
@@ -2592,7 +3291,8 @@ impl GraphVerification {
                         "manifest source '{}' does not match inherited corpus.source '{}'",
                         declaration.source, captured.source
                     ),
-                ));
+                )
+                .with_graph_context(owner_origin.clone(), declared_route.clone(), 1));
             }
             let verified_pin = if declaration.version == 1 {
                 digest_snapshot(&captured.source, &captured.config_bytes, &captured.files)
@@ -2607,7 +3307,8 @@ impl GraphVerification {
                         "declared parent digest '{}' does not match verified digest '{}'",
                         declaration.digest, verified_pin
                     ),
-                ));
+                )
+                .with_graph_context(owner_origin.clone(), declared_route.clone(), 1));
             }
             if owner_is_v1 && !matches!(captured.manifest, CapturedManifest::None) {
                 return Err(ParentCorpusError::at(
@@ -2617,7 +3318,8 @@ impl GraphVerification {
                         "version-1 parent source '{}' declares its own inheritance",
                         captured.source
                     ),
-                ));
+                )
+                .with_graph_context(owner_origin.clone(), declared_route.clone(), 1));
             }
             if active_sources
                 .iter()
@@ -2629,10 +3331,23 @@ impl GraphVerification {
                     ParentCorpusErrorCode::Cycle,
                     owner_root.join(MANIFEST_RELATIVE_PATH),
                     format!("federation source cycle: {}", route.join(" -> ")),
+                )
+                .with_graph_context(
+                    FederationValidationOrigin {
+                        source: self.root_source.clone(),
+                        layer: crate::corpus::Layer::Local,
+                        pin: None,
+                    },
+                    route,
+                    1,
                 ));
             }
             if let Some(existing) = self.logical_nodes.get(&captured.source) {
                 if existing.digest != captured.digest_v2 {
+                    let mut source_route = existing.source_route.clone();
+                    if declared_route < source_route {
+                        source_route = declared_route.clone();
+                    }
                     return Err(ParentCorpusError::at(
                         ParentCorpusErrorCode::DivergentPin,
                         owner_root.join(MANIFEST_RELATIVE_PATH),
@@ -2640,6 +3355,15 @@ impl GraphVerification {
                             "source '{}' verified with divergent pins '{}' and '{}'",
                             captured.source, existing.digest, captured.digest_v2
                         ),
+                    )
+                    .with_graph_context(
+                        FederationValidationOrigin {
+                            source: self.root_source.clone(),
+                            layer: crate::corpus::Layer::Local,
+                            pin: None,
+                        },
+                        source_route,
+                        existing.route_count + 1,
                     ));
                 }
             }
@@ -2665,6 +3389,7 @@ impl GraphVerification {
                     CapturedManifest::None => {}
                     CapturedManifest::V1(manifest) => self.verify_edges(
                         &captured.source,
+                        Some(&captured.digest_v2),
                         &captured.repository_root,
                         std::slice::from_ref(&manifest.inherits),
                         depth + 1,
@@ -2673,6 +3398,7 @@ impl GraphVerification {
                     )?,
                     CapturedManifest::V2(manifest) => self.verify_edges(
                         &captured.source,
+                        Some(&captured.digest_v2),
                         &captured.repository_root,
                         &manifest.parents,
                         depth + 1,
@@ -2684,14 +3410,25 @@ impl GraphVerification {
             }
             active_sources.pop();
 
-            if !self.logical_nodes.contains_key(&captured.source) {
+            if let Some(existing) = self.logical_nodes.get_mut(&captured.source) {
+                existing.route_count += 1;
+                if declared_route < existing.source_route {
+                    existing.source_route = declared_route;
+                }
+            } else {
+                let node_origin = FederationValidationOrigin {
+                    source: captured.source.clone(),
+                    layer: crate::corpus::Layer::Inherited,
+                    pin: Some(captured.digest_v2.clone()),
+                };
                 if self.logical_nodes.len() >= V2_MAX_INHERITED_SOURCES {
                     return Err(limit_error(
                         &captured.config_path,
                         "unique-inherited-sources",
                         V2_MAX_INHERITED_SOURCES,
                         V2_MAX_INHERITED_SOURCES + 1,
-                    ));
+                    )
+                    .with_graph_context(node_origin.clone(), declared_route.clone(), 1));
                 }
                 add_limited(
                     &mut self.counters.logical_files,
@@ -2699,7 +3436,10 @@ impl GraphVerification {
                     V2_MAX_INHERITED_FILES,
                     "inherited-files",
                     &captured.corpus_root,
-                )?;
+                )
+                .map_err(|error| {
+                    error.with_graph_context(node_origin.clone(), declared_route.clone(), 1)
+                })?;
                 let logical_bytes = captured.config_bytes.len()
                     + captured.manifest.bytes().map_or(0, <[u8]>::len)
                     + captured
@@ -2713,12 +3453,17 @@ impl GraphVerification {
                     V2_MAX_LOGICAL_BYTES,
                     "logical-bytes",
                     &captured.corpus_root,
-                )?;
+                )
+                .map_err(|error| {
+                    error.with_graph_context(node_origin, declared_route.clone(), 1)
+                })?;
                 self.logical_nodes.insert(
                     captured.source.clone(),
                     VerifiedFederationNode {
                         source: captured.source,
                         digest: captured.digest_v2,
+                        source_route: declared_route,
+                        route_count: 1,
                         config_path: captured.config_path,
                         config_bytes: captured.config_bytes,
                         manifest_path: captured.manifest_path,
@@ -2761,12 +3506,12 @@ pub fn verify_federation(
     validate_v2_path(root_corpus_relative, "corpus")
         .map_err(|reason| ParentCorpusError::new(ParentCorpusErrorCode::PathEscape, reason))?;
     let root_config_path = repository_root.join(CONFIG_RELATIVE_PATH);
-    ensure_no_symlink_components(&repository_root, &root_config_path)?;
+    ensure_no_reparse_components(&repository_root, &root_config_path)?;
     let root_config_bytes = read_stable_regular(
         &root_config_path,
         V2_MAX_CONFIG_BYTES,
         "config-bytes",
-        false,
+        true,
         Some(directory_device(&repository_root)?),
     )?;
     let config_text = std::str::from_utf8(&root_config_bytes).map_err(|_| {
@@ -2793,62 +3538,68 @@ pub fn verify_federation(
             "version 2 root config must declare corpus.source",
         )
     })?;
+    let root_origin = FederationValidationOrigin {
+        source: root_source.clone(),
+        layer: crate::corpus::Layer::Local,
+        pin: None,
+    };
     if root_source.len() > V2_MAX_SOURCE_BYTES {
         return Err(limit_error(
             &root_config_path,
             "source-bytes",
             V2_MAX_SOURCE_BYTES,
             V2_MAX_SOURCE_BYTES + 1,
-        ));
+        )
+        .with_validation_origin(root_origin.clone()));
     }
     let root_corpus_candidate =
-        checked_relative_join(&repository_root, root_corpus_relative, "corpus")?;
+        checked_relative_join(&repository_root, root_corpus_relative, "corpus")
+            .map_err(|error| error.with_validation_origin(root_origin.clone()))?;
+    ensure_no_reparse_components(&repository_root, &root_corpus_candidate)
+        .map_err(|error| error.with_validation_origin(root_origin.clone()))?;
     let root_corpus_root = canonical_confined(
         &repository_root,
         &root_corpus_candidate,
         ParentCorpusErrorCode::ParentCorpusMissing,
         "root corpus",
-    )?;
-    let root_device = directory_device(&repository_root)?;
-    if directory_device(&root_corpus_root)? != root_device {
+    )
+    .map_err(|error| error.with_validation_origin(root_origin.clone()))?;
+    let root_device = directory_device(&repository_root)
+        .map_err(|error| error.with_validation_origin(root_origin.clone()))?;
+    if directory_device(&root_corpus_root)
+        .map_err(|error| error.with_validation_origin(root_origin.clone()))?
+        != root_device
+    {
         return Err(ParentCorpusError::at(
             ParentCorpusErrorCode::UnsupportedFilesystem,
             &root_corpus_root,
             "root corpus crosses a filesystem boundary",
-        ));
+        )
+        .with_validation_origin(root_origin.clone()));
     }
     let root_exclusions = manifest
         .parents
         .iter()
         .map(|parent| checked_relative_join(&repository_root, &parent.root, "root"))
-        .collect::<Result<Vec<_>, _>>()?;
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| error.with_validation_origin(root_origin.clone()))?;
+    let root_mount_boundary = WalkMountBoundary::capture(&repository_root)
+        .map_err(|error| error.with_validation_origin(root_origin.clone()))?;
     let mut root_files = Vec::new();
     let mut root_snapshot_counters = GraphCounters::default();
     snapshot_directory_v2(
         &root_corpus_root,
+        &root_mount_boundary,
         &root_corpus_root,
         &mut Vec::new(),
         &root_exclusions,
         root_device,
-        false,
+        true,
         false,
         &mut root_snapshot_counters,
         &mut root_files,
-    )?;
-    let stable_manifest_bytes = read_stable_regular(
-        &manifest.path,
-        V2_MAX_MANIFEST_BYTES,
-        "manifest-bytes",
-        false,
-        Some(root_device),
-    )?;
-    if stable_manifest_bytes != manifest.bytes {
-        return Err(ParentCorpusError::at(
-            ParentCorpusErrorCode::SnapshotChanged,
-            &manifest.path,
-            "root federation manifest changed while it was parsed",
-        ));
-    }
+    )
+    .map_err(|error| error.with_validation_origin(root_origin))?;
     let root_override_count = manifest
         .overrides
         .as_ref()
@@ -2858,6 +3609,7 @@ pub fn verify_federation(
         .map_or(0, Vec::len);
     let mut verification = GraphVerification {
         invocation_root: repository_root.clone(),
+        root_source: root_source.clone(),
         counters: GraphCounters {
             overrides: root_override_count,
             ..GraphCounters::default()
@@ -2871,6 +3623,7 @@ pub fn verify_federation(
     };
     verification.verify_edges(
         &root_source,
+        None,
         &repository_root,
         &manifest.parents,
         1,
@@ -3300,5 +4053,50 @@ mod tests {
         let root = scratch("no-manifest");
         assert!(verify_parent(&root).unwrap().is_none());
         fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn captured_manifest_parser_never_reopens_its_path() {
+        let root = scratch("captured-manifest");
+        fs::create_dir_all(root.join(".decided")).unwrap();
+        let path = root.join(MANIFEST_RELATIVE_PATH);
+        let captured = format!(
+            "# Corpus\n\n## inherits\n\n```yaml\nversion: 2\nparents:\n  - alias: parent\n    source: acme/parent\n    root: vendor/parent\n    corpus: decisions\n    digest: {DIGEST_V2_PREFIX}{}\n```\n",
+            "0".repeat(64)
+        )
+        .into_bytes();
+        fs::write(&path, &captured).unwrap();
+        fs::write(&path, b"not the captured manifest\n").unwrap();
+        let parsed = parse_graph_manifest_bytes(path, captured).unwrap();
+        assert_eq!(parsed.parents[0].source, "acme/parent");
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn nested_mount_records_are_detected_for_every_walk_target() {
+        let mountinfo = concat!(
+            "1 0 8:1 / / rw - ext4 /dev/root rw\n",
+            "2 1 8:1 / /repo rw - ext4 /dev/root rw\n",
+            "3 2 8:1 / /repo/vendor\\040parent/decisions/nested rw - ext4 /dev/root rw\n",
+        );
+        assert_eq!(
+            nested_mount_from_text(
+                mountinfo,
+                Path::new("/repo/vendor parent"),
+                Path::new("/repo/vendor parent/decisions/nested/policy.md"),
+            )
+            .unwrap(),
+            Some(PathBuf::from("/repo/vendor parent/decisions/nested"))
+        );
+        assert_eq!(
+            nested_mount_from_text(
+                mountinfo,
+                Path::new("/repo/vendor parent"),
+                Path::new("/repo/vendor parent/decisions/policy.md"),
+            )
+            .unwrap(),
+            None
+        );
     }
 }

--- a/rust/rac-engine/src/gate.rs
+++ b/rust/rac-engine/src/gate.rs
@@ -518,14 +518,14 @@ fn build_gate_internal(
 
     if let Some(options) = code {
         let sentry = if let Some(corpus) = composed {
-            crate::sentry::analyze_with_items(
+            crate::sentry::analyze_with_items_excluding(
                 directory,
                 options.repository,
                 options.base,
                 options.full_tree,
                 &items,
                 true,
-                corpus.read_only_root(),
+                corpus.read_only_roots(),
             )
         } else {
             crate::sentry::analyze(

--- a/rust/rac-engine/src/graph_composition.rs
+++ b/rust/rac-engine/src/graph_composition.rs
@@ -12,12 +12,13 @@ use crate::corpus::{ArtifactKey, Layer};
 use crate::identity::artifact_identifiers;
 use crate::pycompat::py_casefold;
 use crate::relationships::{
-    edge_spec, extract_relationships_full, CorpusItem, Relationship, ISSUE_SELF_REFERENCE,
-    ISSUE_TARGET_AMBIGUOUS, ISSUE_TARGET_NOT_FOUND,
+    edge_spec, extract_relationships_full, relationship_severity, CorpusItem, Relationship,
+    RelationshipIssue, RelationshipSummary, ISSUE_SELF_REFERENCE, ISSUE_TARGET_AMBIGUOUS,
+    ISSUE_TARGET_NOT_FOUND,
 };
 use crate::resolve::{
     entry_from_item, identity_entry_from_item, is_live_decision, resolved_from_entry, IndexEntry,
-    ResolutionResult, OUTCOME_DUPLICATE, OUTCOME_NOT_FOUND, OUTCOME_RESOLVED,
+    ResolutionResult, OUTCOME_AMBIGUOUS, OUTCOME_NOT_FOUND, OUTCOME_RESOLVED,
 };
 
 pub const FINDING_INVALID_GRAPH: &str = "corpus-federation-invalid-graph";
@@ -662,6 +663,18 @@ impl GraphComposition {
         self.item_by_key.get(key).map(|index| &self.items[*index])
     }
 
+    pub(crate) fn catalog_slice(&self) -> &[CorpusItem] {
+        &self.items
+    }
+
+    pub(crate) fn effective_indices(&self) -> &[usize] {
+        &self.root_effective
+    }
+
+    pub(crate) fn root_local_indices(&self) -> &[usize] {
+        &self.root_local
+    }
+
     pub fn visibility(&self) -> &SourceVisibility {
         &self.visibility
     }
@@ -720,7 +733,7 @@ impl GraphComposition {
                 paths.dedup();
                 ResolutionResult {
                     artifact_id: reference.to_string(),
-                    outcome: OUTCOME_DUPLICATE,
+                    outcome: OUTCOME_AMBIGUOUS,
                     artifact: None,
                     duplicate_paths: paths,
                 }
@@ -771,6 +784,98 @@ impl GraphComposition {
             .into_iter()
             .map(|relationship| self.compatible_relationship(relationship))
             .collect()
+    }
+
+    /// Compatibility-only catalog projection for existing graph/export
+    /// consumers. Use [`Self::catalog_relationships`] whenever complete
+    /// historical candidate sets are required.
+    pub fn catalog_relationships_compatible(&self) -> Vec<Relationship> {
+        self.catalog_relationships()
+            .into_iter()
+            .map(|relationship| self.compatible_relationship(relationship))
+            .collect()
+    }
+
+    pub fn root_local_relationships_compatible(&self) -> Vec<Relationship> {
+        self.root_local()
+            .flat_map(|item| self.relationships_for(item, true))
+            .map(|relationship| self.compatible_relationship(relationship))
+            .collect()
+    }
+
+    /// Portfolio metrics over the same root-effective graph projection used
+    /// by lookup and enforcement. This avoids rebuilding a source-blind
+    /// resolver merely to persist the summary segment.
+    pub fn relationship_summary(&self) -> RelationshipSummary {
+        let relationships = self.effective_relationships();
+        let mut resolved_targets = BTreeSet::new();
+        let mut issues = Vec::new();
+        let mut total = 0usize;
+        for relationship in relationships.iter().filter(|row| !row.external) {
+            total += 1;
+            if let Some(target) = &relationship.effective_terminal {
+                resolved_targets.insert(target.clone());
+            }
+            let Some(issue) = relationship.issue else {
+                continue;
+            };
+            let item = self.item(&relationship.source);
+            let code = match issue {
+                GraphRelationshipIssue::TargetNotFound => ISSUE_TARGET_NOT_FOUND,
+                GraphRelationshipIssue::TargetAmbiguous => ISSUE_TARGET_AMBIGUOUS,
+                GraphRelationshipIssue::SelfReference => ISSUE_SELF_REFERENCE,
+            };
+            if item.is_some_and(|item| {
+                item.origin.layer == Layer::Inherited && relationship_severity(code) != "error"
+            }) {
+                continue;
+            }
+            issues.push(RelationshipIssue {
+                code: code.to_string(),
+                source_path: item.map(|item| item.path.clone()),
+                source_artifact: item.map(|item| item.artifact_path.clone()),
+                origin: item.map(|item| item.origin.clone()),
+                relationship: Some(relationship.relationship.clone()),
+                target: Some(relationship.authored_token.clone()),
+                identifier: None,
+                paths: None,
+            });
+        }
+        let known = self
+            .effective()
+            .filter(|item| item.spec.is_some())
+            .map(|item| item.key.clone())
+            .collect::<BTreeSet<_>>();
+        let orphaned = known
+            .iter()
+            .filter(|key| !resolved_targets.contains(*key))
+            .count();
+        let artifacts_with_relationships = self
+            .effective()
+            .filter(|item| {
+                item.spec.is_some_and(|spec| {
+                    extract_relationships_full(&item.artifact, spec)
+                        .into_iter()
+                        .any(|(_, references)| !references.is_empty())
+                })
+            })
+            .count();
+        let coverage = if known.is_empty() {
+            1.0
+        } else {
+            crate::pycompat::py_round(
+                artifacts_with_relationships as f64 / known.len() as f64,
+                4,
+            )
+        };
+        RelationshipSummary {
+            total,
+            valid: total - issues.len(),
+            broken: issues.len(),
+            orphaned,
+            coverage,
+            issues,
+        }
     }
 
     fn compatible_relationship(&self, relationship: GraphRelationship) -> Relationship {

--- a/rust/rac-engine/src/graph_federated_corpus.rs
+++ b/rust/rac-engine/src/graph_federated_corpus.rs
@@ -1,0 +1,985 @@
+//! Exact verified graph snapshots -> one source-aware semantic composition.
+//!
+//! This adapter is deliberately downstream of federation verification. It
+//! parses only captured byte buffers, never reopens a corpus path, and keeps
+//! version-1 roots on the established [`crate::federated_corpus`] path.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+use crate::classify::classify;
+use crate::composition::{ComposedCorpus, OverrideDeclaration, ParentIdentity};
+use crate::corpus::{
+    ArtifactKey, ArtifactOrigin, ArtifactPath, CorpusLayer, Layer, PhysicalArtifactLocator,
+    PhysicalCorpusLocator,
+};
+use crate::federation::{
+    FederationValidationOrigin, SnapshotFile, VerifiedFederation, VerifiedFederationNode,
+    MANIFEST_RELATIVE_PATH,
+};
+use crate::graph_composition::{
+    GraphComposition, GraphCompositionFinding, GraphCompositionInput, GraphOverrideDeclaration,
+    GraphRelationshipIssue, SourceNodeInput, SourceParentInput,
+};
+use crate::parse::parse_bytes;
+use crate::relationships::{
+    edge_spec, relationship_severity, CorpusItem, ISSUE_RELATIONSHIP_CYCLE, ISSUE_TARGET_AMBIGUOUS,
+    ISSUE_TARGET_NOT_FOUND, ISSUE_TARGET_TYPE_MISMATCH,
+};
+use crate::spec::spec_for;
+use crate::validate::{
+    apply_overrides, check_okf_conformance, resolve_severity, OkfEntry, SeverityOverrides,
+};
+
+pub const GRAPH_CORPUS_INVALID_NODE: &str = "corpus-federation-invalid-node";
+pub const GRAPH_CORPUS_INVALID_MANIFEST: &str = "corpus-federation-invalid-manifest";
+
+/// Exact captured content retained beside the parsed catalog.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CapturedGraphContent {
+    pub artifact_path: ArtifactPath,
+    pub bytes: Vec<u8>,
+}
+
+/// One deterministic failure at the verified-byte/semantic boundary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GraphFederatedCorpusError {
+    pub code: &'static str,
+    pub source: Option<String>,
+    pub relative_path: Option<String>,
+    pub message: String,
+    pub composition_findings: Box<Vec<GraphCompositionFinding>>,
+    pub validation_origin: Option<Box<FederationValidationOrigin>>,
+    pub source_route: Option<Box<Vec<String>>>,
+    pub route_count: Option<Box<usize>>,
+}
+
+impl GraphFederatedCorpusError {
+    pub fn stable_code(&self) -> &'static str {
+        self.code
+    }
+
+    fn sourced(
+        code: &'static str,
+        source: impl Into<String>,
+        relative_path: impl Into<String>,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            code,
+            source: Some(source.into()),
+            relative_path: Some(relative_path.into()),
+            message: message.into(),
+            composition_findings: Box::new(Vec::new()),
+            validation_origin: None,
+            source_route: None,
+            route_count: None,
+        }
+    }
+
+    fn composition(findings: Vec<GraphCompositionFinding>) -> Self {
+        let first = findings
+            .first()
+            .expect("graph composition reports at least one finding");
+        Self {
+            code: first.code,
+            source: first.owner_source.clone(),
+            relative_path: None,
+            message: first.message.clone(),
+            composition_findings: Box::new(findings),
+            validation_origin: None,
+            source_route: None,
+            route_count: None,
+        }
+    }
+
+    fn attach_federation_context(&mut self, federation: &VerifiedFederation) {
+        if !self.composition_findings.is_empty() {
+            self.validation_origin = Some(Box::new(FederationValidationOrigin {
+                source: federation.root_source.clone(),
+                layer: Layer::Local,
+                pin: None,
+            }));
+            self.source_route = Some(Box::new(vec![federation.root_source.clone()]));
+            self.route_count = Some(Box::new(1));
+            return;
+        }
+        let source = self.source.as_deref().unwrap_or(&federation.root_source);
+        if source == federation.root_source {
+            self.validation_origin = Some(Box::new(FederationValidationOrigin {
+                source: federation.root_source.clone(),
+                layer: Layer::Local,
+                pin: None,
+            }));
+        } else if let Some(node) = federation.node(source) {
+            self.validation_origin = Some(Box::new(FederationValidationOrigin {
+                source: node.source.clone(),
+                layer: Layer::Inherited,
+                pin: Some(node.digest.clone()),
+            }));
+            self.source_route = Some(Box::new(node.source_route.clone()));
+            self.route_count = Some(Box::new(node.route_count));
+        }
+    }
+}
+
+impl fmt::Display for GraphFederatedCorpusError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{}", self.code)?;
+        if let Some(source) = &self.source {
+            write!(formatter, ": source '{source}'")?;
+        }
+        if let Some(path) = &self.relative_path {
+            write!(formatter, " at {path}")?;
+        }
+        write!(formatter, ": {}", self.message)
+    }
+}
+
+impl std::error::Error for GraphFederatedCorpusError {}
+
+/// The semantic graph and every immutable input needed by later generations.
+///
+/// `federation` owns the exact config, manifest, Markdown, physical-route, and
+/// root records. The other fields are projections of those bytes; no consumer
+/// needs to reopen an inherited path to reconstruct them.
+pub struct VerifiedGraphCorpus {
+    pub federation: VerifiedFederation,
+    pub composition: GraphComposition,
+    pub captured_content: BTreeMap<ArtifactKey, CapturedGraphContent>,
+    pub canonical_layers: BTreeMap<String, CorpusLayer>,
+    pub read_only_materialisation_roots: Vec<PathBuf>,
+    pub read_only_corpus_roots: Vec<PathBuf>,
+}
+
+impl VerifiedGraphCorpus {
+    pub fn content(&self, key: &ArtifactKey) -> Option<&[u8]> {
+        self.captured_content
+            .get(key)
+            .map(|content| content.bytes.as_slice())
+    }
+
+    /// Move this verified semantic closure behind the shared read facade.
+    /// The facade owns the exact captured bytes and every read-only physical
+    /// root; no filesystem path is reopened during the conversion.
+    pub fn into_composed_corpus(self) -> ComposedCorpus {
+        ComposedCorpus::from_graph(
+            self.composition,
+            self.captured_content
+                .into_iter()
+                .map(|(key, content)| (key, content.bytes)),
+            self.read_only_materialisation_roots,
+        )
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawV2Overrides {
+    version: u32,
+    items: Vec<RawV2Override>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawV2Override {
+    target: String,
+    #[serde(rename = "with")]
+    replacement: String,
+    rationale: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawV1Overrides {
+    version: u32,
+    items: Vec<RawV1Override>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawV1Override {
+    parent: String,
+    #[serde(rename = "with")]
+    replacement: String,
+    rationale: String,
+}
+
+#[derive(Default)]
+struct LiftedOverrides {
+    graph: Vec<GraphOverrideDeclaration>,
+    v1: BTreeMap<String, Vec<OverrideDeclaration>>,
+}
+
+struct ParsedSnapshots {
+    items: Vec<CorpusItem>,
+    content: Vec<(ArtifactKey, CapturedGraphContent)>,
+    policies: BTreeMap<String, SeverityOverrides>,
+}
+
+type SemanticCompositionResult = (
+    GraphComposition,
+    BTreeMap<ArtifactKey, CapturedGraphContent>,
+    BTreeMap<String, CorpusLayer>,
+);
+
+/// Parse, intrinsically validate, and compose a verified version-2 closure.
+///
+/// This function consumes the verification result so the returned model owns
+/// all authenticated byte buffers and read-only roots. It performs no
+/// filesystem or network operation.
+pub fn compose_verified_federation(
+    federation: VerifiedFederation,
+) -> Result<VerifiedGraphCorpus, GraphFederatedCorpusError> {
+    let result: Result<SemanticCompositionResult, GraphFederatedCorpusError> = (|| {
+        let topology = topology(&federation);
+        let aliases = alias_tables(&topology);
+        let lifted = lift_overrides(&federation, &aliases)?;
+        let parsed = parse_and_validate_snapshots(&federation)?;
+
+        validate_nested_v1(
+            &federation,
+            &topology,
+            &parsed.items,
+            &lifted.v1,
+            &parsed.policies,
+        )?;
+
+        let composition = GraphComposition::compose(GraphCompositionInput::new(
+            federation.root_source.clone(),
+            topology,
+            parsed.items,
+            lifted.graph,
+        ))
+        .map_err(GraphFederatedCorpusError::composition)?;
+        validate_graph_relationships(&composition, &parsed.policies)?;
+
+        let captured_content = parsed.content.into_iter().collect();
+        let mut canonical_layers = BTreeMap::new();
+        canonical_layers.insert(
+            federation.root_source.clone(),
+            CorpusLayer::local(federation.root_source.clone()),
+        );
+        for node in &federation.nodes {
+            canonical_layers.insert(
+                node.source.clone(),
+                CorpusLayer {
+                    source: node.source.clone(),
+                    layer: Layer::Inherited,
+                    pin: Some(node.digest.clone()),
+                    alias: None,
+                },
+            );
+        }
+        Ok((composition, captured_content, canonical_layers))
+    })();
+    let (composition, captured_content, canonical_layers) = match result {
+        Ok(result) => result,
+        Err(mut error) => {
+            error.attach_federation_context(&federation);
+            return Err(error);
+        }
+    };
+
+    Ok(VerifiedGraphCorpus {
+        read_only_materialisation_roots: federation.materialisation_roots.clone(),
+        read_only_corpus_roots: federation.corpus_roots.clone(),
+        federation,
+        composition,
+        captured_content,
+        canonical_layers,
+    })
+}
+
+fn topology(federation: &VerifiedFederation) -> Vec<SourceNodeInput> {
+    let mut by_owner: BTreeMap<String, BTreeSet<SourceParentInput>> = BTreeMap::new();
+    for edge in &federation.edges {
+        by_owner
+            .entry(edge.owner_source.clone())
+            .or_default()
+            .insert(SourceParentInput::new(
+                edge.target_source.clone(),
+                edge.alias.clone(),
+            ));
+    }
+    let mut sources: BTreeSet<String> = federation
+        .nodes
+        .iter()
+        .map(|node| node.source.clone())
+        .collect();
+    sources.insert(federation.root_source.clone());
+    sources
+        .into_iter()
+        .map(|source| {
+            SourceNodeInput::new(
+                source.clone(),
+                by_owner
+                    .remove(&source)
+                    .unwrap_or_default()
+                    .into_iter()
+                    .collect(),
+            )
+        })
+        .collect()
+}
+
+fn alias_tables(topology: &[SourceNodeInput]) -> BTreeMap<String, BTreeMap<String, String>> {
+    topology
+        .iter()
+        .map(|node| {
+            (
+                node.source.clone(),
+                node.direct_parents
+                    .iter()
+                    .map(|parent| (parent.alias.clone(), parent.source.clone()))
+                    .collect(),
+            )
+        })
+        .collect()
+}
+
+fn lift_overrides(
+    federation: &VerifiedFederation,
+    aliases: &BTreeMap<String, BTreeMap<String, String>>,
+) -> Result<LiftedOverrides, GraphFederatedCorpusError> {
+    let mut lifted = LiftedOverrides::default();
+    lifted.graph.extend(parse_v2_overrides(
+        &federation.root_source,
+        federation.manifest.overrides.clone(),
+    )?);
+    for node in &federation.nodes {
+        match node.manifest_version {
+            None => {
+                if node.overrides.is_some() {
+                    return Err(invalid_manifest(
+                        &node.source,
+                        "a manifest-free node retained override declarations",
+                    ));
+                }
+            }
+            Some(1) => {
+                let (graph, v1) = parse_v1_overrides(
+                    &node.source,
+                    node.overrides.clone(),
+                    aliases.get(&node.source),
+                )?;
+                lifted.graph.extend(graph);
+                lifted.v1.insert(node.source.clone(), v1);
+            }
+            Some(2) => lifted
+                .graph
+                .extend(parse_v2_overrides(&node.source, node.overrides.clone())?),
+            Some(version) => {
+                return Err(invalid_manifest(
+                    &node.source,
+                    format!("unsupported retained manifest version {version}"),
+                ));
+            }
+        }
+    }
+    lifted.graph.sort();
+    Ok(lifted)
+}
+
+fn parse_v2_overrides(
+    owner: &str,
+    value: Option<serde_yaml::Value>,
+) -> Result<Vec<GraphOverrideDeclaration>, GraphFederatedCorpusError> {
+    let Some(value) = value else {
+        return Ok(Vec::new());
+    };
+    let raw: RawV2Overrides = serde_yaml::from_value(value).map_err(|error| {
+        invalid_manifest(owner, format!("version-2 overrides are malformed: {error}"))
+    })?;
+    if raw.version != 2 {
+        return Err(invalid_manifest(
+            owner,
+            format!(
+                "override version {} does not match manifest version 2",
+                raw.version
+            ),
+        ));
+    }
+    raw.items
+        .into_iter()
+        .map(|item| {
+            let (target_source, target_id) = global_target(&item.target).map_err(|message| {
+                invalid_manifest(
+                    owner,
+                    format!("override target '{}': {message}", item.target),
+                )
+            })?;
+            let replacement = local_operand(&item.replacement).map_err(|message| {
+                invalid_manifest(
+                    owner,
+                    format!("override replacement '{}': {message}", item.replacement),
+                )
+            })?;
+            let rationale = local_operand(&item.rationale).map_err(|message| {
+                invalid_manifest(
+                    owner,
+                    format!("override rationale '{}': {message}", item.rationale),
+                )
+            })?;
+            Ok(GraphOverrideDeclaration::new(
+                owner,
+                ArtifactKey::new(target_source, target_id),
+                ArtifactKey::new(owner, replacement),
+                ArtifactKey::new(owner, rationale),
+            ))
+        })
+        .collect()
+}
+
+fn parse_v1_overrides(
+    owner: &str,
+    value: Option<serde_yaml::Value>,
+    aliases: Option<&BTreeMap<String, String>>,
+) -> Result<(Vec<GraphOverrideDeclaration>, Vec<OverrideDeclaration>), GraphFederatedCorpusError> {
+    let Some(value) = value else {
+        return Ok((Vec::new(), Vec::new()));
+    };
+    let raw: RawV1Overrides = serde_yaml::from_value(value).map_err(|error| {
+        invalid_manifest(owner, format!("version-1 overrides are malformed: {error}"))
+    })?;
+    if raw.version != 1 {
+        return Err(invalid_manifest(
+            owner,
+            format!(
+                "override version {} does not match manifest version 1",
+                raw.version
+            ),
+        ));
+    }
+    let aliases =
+        aliases.ok_or_else(|| invalid_manifest(owner, "missing version-1 alias table"))?;
+    let mut graph = Vec::new();
+    let mut legacy = Vec::new();
+    for item in raw.items {
+        let declaration =
+            OverrideDeclaration::parse(&item.parent, &item.replacement, &item.rationale).map_err(
+                |error| {
+                    invalid_manifest(
+                        owner,
+                        format!("version-1 override target '{}': {error}", item.parent),
+                    )
+                },
+            )?;
+        let target_source = aliases.get(declaration.parent.alias()).ok_or_else(|| {
+            invalid_manifest(
+                owner,
+                format!(
+                    "version-1 override alias '{}' is not a direct parent",
+                    declaration.parent.alias()
+                ),
+            )
+        })?;
+        graph.push(GraphOverrideDeclaration::new(
+            owner,
+            ArtifactKey::new(target_source, declaration.parent.canonical_id().as_str()),
+            ArtifactKey::new(owner, declaration.replacement.as_str()),
+            ArtifactKey::new(owner, declaration.rationale.as_str()),
+        ));
+        legacy.push(declaration);
+    }
+    Ok((graph, legacy))
+}
+
+fn global_target(value: &str) -> Result<(&str, &str), &'static str> {
+    if value.trim() != value {
+        return Err("must be unpadded");
+    }
+    let Some((source, canonical_id)) = value.split_once("::") else {
+        return Err("must be globally source-qualified");
+    };
+    if source.is_empty()
+        || canonical_id.is_empty()
+        || source.trim() != source
+        || canonical_id.trim() != canonical_id
+        || canonical_id.contains("::")
+        || !source.contains('/')
+    {
+        return Err("must contain one source/canonical-id delimiter");
+    }
+    Ok((source, canonical_id))
+}
+
+fn local_operand(value: &str) -> Result<&str, &'static str> {
+    if value.is_empty() || value.trim() != value {
+        return Err("canonical id must be non-empty and unpadded");
+    }
+    if value.contains("::") {
+        return Err("local canonical id must not be qualified");
+    }
+    Ok(value)
+}
+
+fn invalid_manifest(source: &str, message: impl Into<String>) -> GraphFederatedCorpusError {
+    GraphFederatedCorpusError::sourced(
+        GRAPH_CORPUS_INVALID_MANIFEST,
+        source,
+        MANIFEST_RELATIVE_PATH,
+        message,
+    )
+}
+
+fn parse_and_validate_snapshots(
+    federation: &VerifiedFederation,
+) -> Result<ParsedSnapshots, GraphFederatedCorpusError> {
+    let mut parsed = ParsedSnapshots {
+        items: Vec::new(),
+        content: Vec::new(),
+        policies: BTreeMap::new(),
+    };
+    parse_source(
+        &federation.root_source,
+        CorpusLayer::local(&federation.root_source),
+        &federation.repository_root,
+        &federation.root_corpus_root,
+        &federation.root_files,
+        &federation.root_config_bytes,
+        &mut parsed,
+    )?;
+    for node in &federation.nodes {
+        let repository_root = repository_root_for_node(node).ok_or_else(|| {
+            GraphFederatedCorpusError::sourced(
+                GRAPH_CORPUS_INVALID_NODE,
+                &node.source,
+                ".decided/config.yaml",
+                "verified config path has no repository parent",
+            )
+        })?;
+        parse_source(
+            &node.source,
+            CorpusLayer {
+                source: node.source.clone(),
+                layer: Layer::Inherited,
+                pin: Some(node.digest.clone()),
+                alias: None,
+            },
+            repository_root,
+            &node.corpus_root,
+            &node.files,
+            &node.config_bytes,
+            &mut parsed,
+        )?;
+    }
+    Ok(parsed)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn parse_source(
+    source: &str,
+    layer: CorpusLayer,
+    repository_root: &Path,
+    corpus_root: &Path,
+    files: &[SnapshotFile],
+    config_bytes: &[u8],
+    parsed: &mut ParsedSnapshots,
+) -> Result<(), GraphFederatedCorpusError> {
+    let (provider, policy) = source_policy(config_bytes);
+    let locator = PhysicalCorpusLocator::new(repository_root, corpus_root);
+    let start = parsed.items.len();
+    for file in files {
+        let stable_path = file.relative_path.clone();
+        let artifact = parse_bytes(&file.bytes, &stable_path);
+        let artifact_type = classify(&artifact).artifact_type;
+        let spec = spec_for(&artifact_type);
+        let item = CorpusItem::new(
+            stable_path,
+            file.relative_path.clone(),
+            artifact,
+            spec,
+            layer.origin(),
+            PhysicalArtifactLocator::new(locator.clone(), file.absolute_path.clone()),
+        );
+        parsed.content.push((
+            item.key.clone(),
+            CapturedGraphContent {
+                artifact_path: item.artifact_path.clone(),
+                bytes: file.bytes.clone(),
+            },
+        ));
+        parsed.items.push(item);
+    }
+
+    let source_items = &parsed.items[start..];
+    for item in source_items {
+        let Some(spec) = item.spec else {
+            continue;
+        };
+        let issues = apply_overrides(
+            crate::validate::validate(&item.artifact, provider.as_deref(), Some(&spec.name)),
+            &spec.name,
+            &policy,
+        );
+        if let Some(issue) = issues.iter().find(|issue| issue.severity == "error") {
+            return Err(GraphFederatedCorpusError::sourced(
+                GRAPH_CORPUS_INVALID_NODE,
+                source,
+                &item.artifact_path.relative_path,
+                format!("structural error {}: {}", issue.code, issue.message),
+            ));
+        }
+    }
+    let entries: Vec<OkfEntry<'_>> = source_items
+        .iter()
+        .map(|item| OkfEntry {
+            path: &item.artifact_path.relative_path,
+            artifact_type: item.spec.map_or("unknown", |spec| spec.name.as_str()),
+            file_name: item
+                .artifact_path
+                .relative_path
+                .rsplit('/')
+                .next()
+                .unwrap_or(&item.artifact_path.relative_path),
+        })
+        .collect();
+    if let Some(finding) = check_okf_conformance(&entries, &policy)
+        .findings
+        .into_iter()
+        .find(|finding| finding.severity == "error")
+    {
+        return Err(GraphFederatedCorpusError::sourced(
+            GRAPH_CORPUS_INVALID_NODE,
+            source,
+            finding.path,
+            format!("OKF error {}: {}", finding.code, finding.message),
+        ));
+    }
+    parsed.policies.insert(source.to_string(), policy);
+    Ok(())
+}
+
+fn repository_root_for_node(node: &VerifiedFederationNode) -> Option<&Path> {
+    node.config_path.parent()?.parent()
+}
+
+fn yaml_string(value: &serde_yaml::Value) -> Option<String> {
+    value.as_str().map(str::to_string)
+}
+
+fn severity(value: &serde_yaml::Value) -> Option<String> {
+    match value {
+        serde_yaml::Value::Bool(false) => Some("off".to_string()),
+        serde_yaml::Value::Bool(true) => Some("on".to_string()),
+        _ => yaml_string(value),
+    }
+}
+
+fn source_policy(config: &[u8]) -> (Option<String>, SeverityOverrides) {
+    let Ok(value) = serde_yaml::from_slice::<serde_yaml::Value>(config) else {
+        return (None, SeverityOverrides::default());
+    };
+    let provider = value
+        .get("ticketing")
+        .and_then(|section| section.get("provider"))
+        .and_then(yaml_string);
+    let mut overrides = SeverityOverrides::default();
+    if let Some(rules) = value
+        .get("validation")
+        .and_then(|section| section.get("rules"))
+        .and_then(serde_yaml::Value::as_mapping)
+    {
+        for (key, value) in rules {
+            let (Some(key), Some(value)) = (key.as_str(), severity(value)) else {
+                continue;
+            };
+            if matches!(value.as_str(), "error" | "warning" | "off") {
+                overrides.rules.push((key.to_string(), value));
+            }
+        }
+    }
+    if let Some(types) = value
+        .get("validation")
+        .and_then(|section| section.get("types"))
+        .and_then(serde_yaml::Value::as_mapping)
+    {
+        for (key, value) in types {
+            let (Some(key), Some(value)) = (key.as_str(), severity(value)) else {
+                continue;
+            };
+            if matches!(value.as_str(), "error" | "warning") {
+                overrides.types.push((key.to_string(), value));
+            }
+        }
+    }
+    (provider, overrides)
+}
+
+fn validate_nested_v1(
+    federation: &VerifiedFederation,
+    topology: &[SourceNodeInput],
+    items: &[CorpusItem],
+    overrides: &BTreeMap<String, Vec<OverrideDeclaration>>,
+    policies: &BTreeMap<String, SeverityOverrides>,
+) -> Result<(), GraphFederatedCorpusError> {
+    for node in federation
+        .nodes
+        .iter()
+        .filter(|node| node.manifest_version == Some(1))
+    {
+        let graph_node = topology
+            .iter()
+            .find(|candidate| candidate.source == node.source)
+            .expect("verified graph node is present in topology");
+        let [parent] = graph_node.direct_parents.as_slice() else {
+            return Err(invalid_manifest(
+                &node.source,
+                "version-1 node must retain exactly one direct parent",
+            ));
+        };
+        let parent_node = federation.node(&parent.source).ok_or_else(|| {
+            invalid_manifest(
+                &node.source,
+                "version-1 direct parent is not in the verified closure",
+            )
+        })?;
+        let parent_identity = ParentIdentity::new(&parent.source, &parent.alias)
+            .map_err(|error| invalid_manifest(&node.source, error.to_string()))?;
+        let local = items
+            .iter()
+            .filter(|item| item.key.source == node.source)
+            .cloned()
+            .map(|item| reorigin_v1(item, Layer::Local, None, None))
+            .collect();
+        let inherited = items
+            .iter()
+            .filter(|item| item.key.source == parent.source)
+            .cloned()
+            .map(|item| {
+                reorigin_v1(
+                    item,
+                    Layer::Inherited,
+                    Some(parent_node.digest.clone()),
+                    Some(parent.alias.clone()),
+                )
+            })
+            .collect();
+        let composition = ComposedCorpus::compose(
+            local,
+            inherited,
+            parent_identity,
+            overrides.get(&node.source).cloned().unwrap_or_default(),
+        );
+        if let Some(finding) = composition.findings().first() {
+            return Err(GraphFederatedCorpusError::sourced(
+                finding.code,
+                &node.source,
+                MANIFEST_RELATIVE_PATH,
+                finding.message.clone(),
+            ));
+        }
+        let policy = policies
+            .get(&node.source)
+            .expect("source policy was parsed");
+        for relationship in composition.local_relationships() {
+            let source_path = relationship
+                .source_artifact
+                .as_ref()
+                .map(|path| path.relative_path.as_str())
+                .unwrap_or(relationship.source_path.as_str());
+            if let Some(code) = relationship.issue.as_deref() {
+                if relationship_blocks(policy, &composition, &relationship.source_artifact, code) {
+                    return Err(GraphFederatedCorpusError::sourced(
+                        GRAPH_CORPUS_INVALID_NODE,
+                        &node.source,
+                        source_path,
+                        format!("relationship error {code} for '{}'", relationship.target),
+                    ));
+                }
+            }
+            let Some(target_path) = &relationship.resolved_artifact else {
+                continue;
+            };
+            let Some(edge) = edge_spec(&relationship.relationship) else {
+                continue;
+            };
+            let target = composition
+                .catalog()
+                .find(|item| &item.artifact_path == target_path);
+            if target
+                .and_then(|item| item.spec)
+                .is_some_and(|spec| !edge.range.contains(&spec.name.as_str()))
+                && relationship_blocks(
+                    policy,
+                    &composition,
+                    &relationship.source_artifact,
+                    ISSUE_TARGET_TYPE_MISMATCH,
+                )
+            {
+                return Err(GraphFederatedCorpusError::sourced(
+                    GRAPH_CORPUS_INVALID_NODE,
+                    &node.source,
+                    source_path,
+                    format!(
+                        "relationship error {ISSUE_TARGET_TYPE_MISMATCH} for '{}'",
+                        relationship.target
+                    ),
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn reorigin_v1(
+    mut item: CorpusItem,
+    layer: Layer,
+    pin: Option<String>,
+    alias: Option<String>,
+) -> CorpusItem {
+    item.origin = ArtifactOrigin {
+        source: item.key.source.clone(),
+        layer,
+        pin,
+        alias,
+    };
+    item
+}
+
+fn relationship_blocks(
+    policy: &SeverityOverrides,
+    composition: &ComposedCorpus,
+    source_path: &Option<ArtifactPath>,
+    code: &str,
+) -> bool {
+    let artifact_type = source_path
+        .as_ref()
+        .and_then(|path| {
+            composition
+                .catalog()
+                .find(|item| item.artifact_path == *path)
+        })
+        .and_then(|item| item.spec)
+        .map_or("unknown", |spec| spec.name.as_str());
+    resolve_severity(relationship_severity(code), code, artifact_type, policy) == "error"
+}
+
+fn validate_graph_relationships(
+    composition: &GraphComposition,
+    policies: &BTreeMap<String, SeverityOverrides>,
+) -> Result<(), GraphFederatedCorpusError> {
+    let mut acyclic: BTreeMap<ArtifactKey, BTreeSet<ArtifactKey>> = BTreeMap::new();
+    for relationship in composition.catalog_relationships() {
+        let Some(source_item) = composition.item(&relationship.source) else {
+            continue;
+        };
+        let policy = policies
+            .get(&relationship.source.source)
+            .expect("every composition source has parsed policy");
+        let source_type = source_item
+            .spec
+            .map_or("unknown", |spec| spec.name.as_str());
+        let code = match relationship.issue {
+            Some(GraphRelationshipIssue::TargetNotFound) => Some(ISSUE_TARGET_NOT_FOUND),
+            Some(GraphRelationshipIssue::TargetAmbiguous) => Some(ISSUE_TARGET_AMBIGUOUS),
+            Some(GraphRelationshipIssue::SelfReference) | None => None,
+        };
+        if let Some(code) = code {
+            if resolve_severity(relationship_severity(code), code, source_type, policy) == "error" {
+                return Err(relationship_error(
+                    source_item,
+                    code,
+                    &relationship.authored_token,
+                ));
+            }
+        }
+        let Some(target_key) = relationship.effective_terminal else {
+            continue;
+        };
+        let Some(edge) = edge_spec(&relationship.relationship) else {
+            continue;
+        };
+        let target_type = composition
+            .item(&target_key)
+            .and_then(|item| item.spec)
+            .map(|spec| spec.name.as_str());
+        if target_type.is_some_and(|target_type| !edge.range.contains(&target_type))
+            && resolve_severity(
+                relationship_severity(ISSUE_TARGET_TYPE_MISMATCH),
+                ISSUE_TARGET_TYPE_MISMATCH,
+                source_type,
+                policy,
+            ) == "error"
+        {
+            return Err(relationship_error(
+                source_item,
+                ISSUE_TARGET_TYPE_MISMATCH,
+                &relationship.authored_token,
+            ));
+        }
+        if edge.acyclic && !relationship.external && target_key != relationship.source {
+            acyclic
+                .entry(relationship.source)
+                .or_default()
+                .insert(target_key);
+        }
+    }
+    if let Some(key) = cycle_source(&acyclic) {
+        let item = composition
+            .item(&key)
+            .expect("relationship cycle keys are catalog items");
+        let policy = policies
+            .get(&key.source)
+            .expect("cycle source has parsed policy");
+        let artifact_type = item.spec.map_or("unknown", |spec| spec.name.as_str());
+        if resolve_severity(
+            relationship_severity(ISSUE_RELATIONSHIP_CYCLE),
+            ISSUE_RELATIONSHIP_CYCLE,
+            artifact_type,
+            policy,
+        ) == "error"
+        {
+            return Err(relationship_error(item, ISSUE_RELATIONSHIP_CYCLE, "cycle"));
+        }
+    }
+    Ok(())
+}
+
+fn relationship_error(item: &CorpusItem, code: &str, target: &str) -> GraphFederatedCorpusError {
+    GraphFederatedCorpusError::sourced(
+        GRAPH_CORPUS_INVALID_NODE,
+        &item.key.source,
+        &item.artifact_path.relative_path,
+        format!("relationship error {code} for '{target}'"),
+    )
+}
+
+fn cycle_source(adjacency: &BTreeMap<ArtifactKey, BTreeSet<ArtifactKey>>) -> Option<ArtifactKey> {
+    fn visit(
+        node: &ArtifactKey,
+        adjacency: &BTreeMap<ArtifactKey, BTreeSet<ArtifactKey>>,
+        states: &mut BTreeMap<ArtifactKey, u8>,
+    ) -> Option<ArtifactKey> {
+        states.insert(node.clone(), 1);
+        if let Some(targets) = adjacency.get(node) {
+            for target in targets {
+                match states.get(target).copied().unwrap_or(0) {
+                    1 => return Some(node.clone()),
+                    0 => {
+                        if let Some(found) = visit(target, adjacency, states) {
+                            return Some(found);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+        states.insert(node.clone(), 2);
+        None
+    }
+
+    let mut states = BTreeMap::new();
+    for node in adjacency.keys() {
+        if states.get(node).copied().unwrap_or(0) == 0 {
+            if let Some(found) = visit(node, adjacency, &mut states) {
+                return Some(found);
+            }
+        }
+    }
+    None
+}

--- a/rust/rac-engine/src/hook.rs
+++ b/rust/rac-engine/src/hook.rs
@@ -70,6 +70,19 @@ pub enum HookInstallError {
     Io(String),
 }
 
+/// Resolve the concrete hook destination after applying the released `.git`
+/// directory check. The command layer uses this path for read-only federation
+/// preflight before installation creates a hooks directory or file.
+pub fn install_target(target_dir: &str, style: &str) -> Result<String, HookInstallError> {
+    let git_dir = Path::new(target_dir).join(".git");
+    if !git_dir.is_dir() {
+        return Err(HookInstallError::NotAGitWorkTree(format!(
+            "no .git directory in {target_dir}; run `decided hook install` from a git repository root"
+        )));
+    }
+    Ok(py_join(target_dir, &[".git", "hooks", style]))
+}
+
 /// `install_hook(target_dir, style)` — write the bundled `style` script to
 /// `<dir>/.git/hooks/<style>` and make it executable (git requires the exec
 /// bit; the oracle ORs `S_IXUSR|S_IXGRP|S_IXOTH` onto the fresh file's mode,
@@ -78,13 +91,7 @@ pub fn install_hook(target_dir: &str, style: &str) -> Result<InstalledHook, Hook
     let content = hook_bytes(style).expect("argparse-validated style");
 
     let git_dir = Path::new(target_dir).join(".git");
-    if !git_dir.is_dir() {
-        return Err(HookInstallError::NotAGitWorkTree(format!(
-            "no .git directory in {target_dir}; run `decided hook install` from a git repository root"
-        )));
-    }
-
-    let dest_display = py_join(target_dir, &[".git", "hooks", style]);
+    let dest_display = install_target(target_dir, style)?;
     let dest = Path::new(&dest_display);
     if dest.exists() {
         return Err(HookInstallError::FileExists(format!(

--- a/rust/rac-engine/src/index_store.rs
+++ b/rust/rac-engine/src/index_store.rs
@@ -731,6 +731,14 @@ impl GraphStoreMetadata {
                 .collect(),
         }
     }
+
+    /// Confirm that a fresh graph projection is the exact model described by
+    /// this metadata before it can become resident. Store opens perform the
+    /// same check after decoding; exposing the predicate keeps cache-disabled
+    /// graph reads on the identical fail-closed boundary.
+    pub fn matches_derived(&self, derived: &DerivedIndex) -> bool {
+        graph_metadata_matches_derived(self, derived)
+    }
 }
 
 /// Write one graph-federation generation under the isolated `store/v3`

--- a/rust/rac-engine/src/inspect.rs
+++ b/rust/rac-engine/src/inspect.rs
@@ -10,7 +10,7 @@
 use crate::classify::classify;
 use crate::parse::{parse_file, Artifact};
 use crate::pycompat::py_strip;
-use crate::relationships::extract_relationships;
+use crate::relationships::{extract_relationships, CorpusItem};
 use crate::spec::{canonical_value, spec_for, specs};
 use crate::walk::find_markdown_files;
 
@@ -149,6 +149,34 @@ pub fn inspect_directory(directory: &str, recursive: bool) -> DirectoryInspectio
                 path: entry.display,
                 artifact_type: c.artifact_type,
                 confidence: c.confidence,
+            }
+        })
+        .collect();
+    DirectoryInspection {
+        directory: directory.to_string(),
+        recursive,
+        files,
+    }
+}
+
+/// Inspect an already-verified writable projection without reopening its
+/// files. Graph federation uses this entry point so inherited materialisation
+/// paths never leak into a root-local directory inspection.
+pub fn inspect_directory_from_items(
+    directory: &str,
+    recursive: bool,
+    items: &[CorpusItem],
+) -> DirectoryInspection {
+    use rayon::prelude::*;
+    let files = items
+        .par_iter()
+        .filter(|item| recursive || !item.artifact_path.relative_path.contains('/'))
+        .map(|item| {
+            let classification = classify(&item.artifact);
+            FileInspection {
+                path: item.path.clone(),
+                artifact_type: classification.artifact_type,
+                confidence: classification.confidence,
             }
         })
         .collect();

--- a/rust/rac-engine/src/lib.rs
+++ b/rust/rac-engine/src/lib.rs
@@ -51,6 +51,7 @@ pub mod identity;
 pub mod corpus;
 pub mod composition;
 pub mod graph_composition;
+pub mod graph_federated_corpus;
 pub mod validate;
 pub mod relationships;
 pub mod diff;

--- a/rust/rac-engine/src/output.rs
+++ b/rust/rac-engine/src/output.rs
@@ -336,6 +336,14 @@ pub fn render_validate_dir_human(result: &DirectoryValidation) -> String {
                 &issue.message,
             );
         }
+        if let (Some(source_route), Some(route_count)) = (&f.source_route, f.route_count) {
+            lines.push(format!(
+                "    source route: {} ({} verified physical route{})",
+                source_route.join(" -> "),
+                route_count,
+                if route_count == 1 { "" } else { "s" }
+            ));
+        }
         lines.push(String::new());
     }
 
@@ -411,8 +419,19 @@ pub fn render_validate_dir_json(result: &DirectoryValidation) -> String {
                 "issues".into(),
                 Value::Array(f.issues.iter().map(issue_value).collect()),
             );
-            if let Some(origin) = &f.origin {
-                m.insert("provenance".into(), artifact_origin_value(origin));
+            if f.origin.is_some() || f.source_route.is_some() || f.route_count.is_some() {
+                let mut provenance = f
+                    .origin
+                    .as_ref()
+                    .and_then(|origin| artifact_origin_value(origin).as_object().cloned())
+                    .unwrap_or_default();
+                if let Some(source_route) = &f.source_route {
+                    provenance.insert("source_route".into(), json!(source_route));
+                }
+                if let Some(route_count) = f.route_count {
+                    provenance.insert("route_count".into(), json!(route_count));
+                }
+                m.insert("provenance".into(), Value::Object(provenance));
             }
             Value::Object(m)
         })
@@ -572,7 +591,25 @@ pub fn render_validate_sarif(result: &DirectoryValidation) -> String {
                 message: issue.message.clone(),
                 uri: quote_uri(&file.path),
                 line: issue.line,
-                properties: file.origin.as_ref().map(artifact_origin_value),
+                properties: if file.origin.is_some()
+                    || file.source_route.is_some()
+                    || file.route_count.is_some()
+                {
+                    let mut properties = file
+                        .origin
+                        .as_ref()
+                        .and_then(|origin| artifact_origin_value(origin).as_object().cloned())
+                        .unwrap_or_default();
+                    if let Some(source_route) = &file.source_route {
+                        properties.insert("source_route".into(), json!(source_route));
+                    }
+                    if let Some(route_count) = file.route_count {
+                        properties.insert("route_count".into(), json!(route_count));
+                    }
+                    Some(Value::Object(properties))
+                } else {
+                    None
+                },
             });
         }
     }
@@ -2894,7 +2931,12 @@ pub fn render_export_json(export: &CorpusExport) -> String {
             m.insert("title".into(), json!(a.title));
             m.insert("path".into(), json!(a.path));
             m.insert("body_html".into(), json!(a.body_html));
-            if let Some(provenance) = &a.provenance {
+            if let Some(provenance) = &a.graph_provenance {
+                m.insert(
+                    "provenance".into(),
+                    graph_composed_provenance_value(provenance),
+                );
+            } else if let Some(provenance) = &a.provenance {
                 m.insert("provenance".into(), composed_provenance_value(provenance));
             }
             Value::Object(m)
@@ -2914,10 +2956,34 @@ pub fn render_export_json(export: &CorpusExport) -> String {
             }
             if let Some(identity) = &e.to_identity {
                 m.insert("to_identity".into(), export_identity_value(identity));
-            } else if e.provenance.is_some() {
+            } else if e.provenance.is_some() || e.graph_provenance.is_some() {
                 m.insert("to_identity".into(), Value::Null);
             }
-            if let Some(provenance) = &e.provenance {
+            if let Some(authored_token) = &e.authored_token {
+                m.insert("authored_token".into(), json!(authored_token));
+                m.insert(
+                    "historical_candidates".into(),
+                    Value::Array(
+                        e.historical_candidates
+                            .iter()
+                            .map(export_identity_value)
+                            .collect(),
+                    ),
+                );
+                m.insert(
+                    "effective_terminal".into(),
+                    e.effective_terminal
+                        .as_ref()
+                        .map(export_identity_value)
+                        .unwrap_or(Value::Null),
+                );
+            }
+            if let Some(provenance) = &e.graph_provenance {
+                m.insert(
+                    "provenance".into(),
+                    graph_composed_provenance_value(provenance),
+                );
+            } else if let Some(provenance) = &e.provenance {
                 m.insert("provenance".into(), composed_provenance_value(provenance));
             }
             Value::Object(m)
@@ -3037,12 +3103,22 @@ pub fn render_documents_jsonl(export: &DocumentsExport) -> String {
             meta.insert("aliases".into(), json!(d.aliases));
             meta.insert("tags".into(), json!(d.tags));
             let source = d
-                .provenance
+                .graph_provenance
                 .as_ref()
                 .map(|provenance| provenance.origin.source.as_str())
+                .or_else(|| {
+                    d.provenance
+                        .as_ref()
+                        .map(|provenance| provenance.origin.source.as_str())
+                })
                 .unwrap_or(&export.corpus_source);
             meta.insert("source".into(), json!(source));
-            if let Some(provenance) = &d.provenance {
+            if let Some(provenance) = &d.graph_provenance {
+                meta.insert(
+                    "provenance".into(),
+                    graph_composed_provenance_value(provenance),
+                );
+            } else if let Some(provenance) = &d.provenance {
                 meta.insert("provenance".into(), composed_provenance_value(provenance));
             }
             let mut m = Map::new();
@@ -3069,7 +3145,12 @@ pub fn render_graph_json(export: &GraphExport) -> String {
             m.insert("type".into(), json!(n.artifact_type));
             m.insert("status".into(), json!(n.status));
             m.insert("title".into(), json!(n.title));
-            if let Some(provenance) = &n.provenance {
+            if let Some(provenance) = &n.graph_provenance {
+                m.insert(
+                    "provenance".into(),
+                    graph_composed_provenance_value(provenance),
+                );
+            } else if let Some(provenance) = &n.provenance {
                 m.insert("provenance".into(), composed_provenance_value(provenance));
             }
             Value::Object(m)
@@ -3092,10 +3173,34 @@ pub fn render_graph_json(export: &GraphExport) -> String {
             }
             if let Some(identity) = &e.target_identity {
                 m.insert("target_identity".into(), export_identity_value(identity));
-            } else if e.provenance.is_some() {
+            } else if e.provenance.is_some() || e.graph_provenance.is_some() {
                 m.insert("target_identity".into(), Value::Null);
             }
-            if let Some(provenance) = &e.provenance {
+            if let Some(authored_token) = &e.authored_token {
+                m.insert("authored_token".into(), json!(authored_token));
+                m.insert(
+                    "historical_candidates".into(),
+                    Value::Array(
+                        e.historical_candidates
+                            .iter()
+                            .map(export_identity_value)
+                            .collect(),
+                    ),
+                );
+                m.insert(
+                    "effective_terminal".into(),
+                    e.effective_terminal
+                        .as_ref()
+                        .map(export_identity_value)
+                        .unwrap_or(Value::Null),
+                );
+            }
+            if let Some(provenance) = &e.graph_provenance {
+                m.insert(
+                    "provenance".into(),
+                    graph_composed_provenance_value(provenance),
+                );
+            } else if let Some(provenance) = &e.provenance {
                 m.insert("provenance".into(), composed_provenance_value(provenance));
             }
             Value::Object(m)
@@ -3200,6 +3305,68 @@ pub fn composed_provenance_value(
     Value::Object(value)
 }
 
+/// Version-2 fixed origin plus the complete graph-native override chain. The
+/// chain is serialized as one value and is never projected through the v1
+/// direct-mapping carrier.
+pub fn graph_composed_provenance_value(
+    provenance: &crate::export::GraphComposedProvenance,
+) -> Value {
+    graph_provenance_value(&provenance.origin, &provenance.overrides)
+}
+
+/// Version-2 graph provenance. The complete ordered mapping chain is one
+/// indivisible response fact; budget truncation may remove optional content or
+/// a whole result record, but never an individual hop.
+pub fn graph_provenance_value(
+    origin: &crate::corpus::ArtifactOrigin,
+    overrides: &[crate::graph_composition::GraphOverrideProvenance],
+) -> Value {
+    let mut value = artifact_origin_value(origin)
+        .as_object()
+        .cloned()
+        .expect("artifact origin is an object");
+    if !overrides.is_empty() {
+        value.insert(
+            "overrides".into(),
+            Value::Array(
+                overrides
+                    .iter()
+                    .map(|mapping| {
+                        json!({
+                            "state": mapping.state.as_str(),
+                            "owner_source": mapping.owner_source,
+                            "target": artifact_key_value(&mapping.target),
+                            "replacement": artifact_key_value(&mapping.replacement),
+                            "rationale": artifact_key_value(&mapping.rationale),
+                        })
+                    })
+                    .collect(),
+            ),
+        );
+    }
+    Value::Object(value)
+}
+
+/// Lossless provenance for either federation manifest version. Version 2 is
+/// never projected through the single-hop version-1 carrier.
+pub fn composed_artifact_provenance_value(
+    corpus: &crate::composition::ComposedCorpus,
+    key: &crate::corpus::ArtifactKey,
+) -> Option<Value> {
+    if corpus.is_graph() {
+        let item = corpus.item(key)?;
+        let overrides = corpus.graph_provenance_for(key)?.to_vec();
+        return Some(graph_composed_provenance_value(
+            &crate::export::GraphComposedProvenance {
+                origin: item.origin.clone(),
+                overrides,
+            },
+        ));
+    }
+    corpus
+        .provenance_for(key)
+        .map(|provenance| composed_provenance_value(&provenance))
+}
 /// Federated resolution JSON with additive source/layer/pin provenance.
 pub fn render_resolve_json_with_origin(
     result: &ResolutionResult,
@@ -3242,12 +3409,9 @@ pub fn render_resolve_json_with_composed(
     if let Some(provenance) = artifact
         .key
         .as_ref()
-        .and_then(|key| corpus.provenance_for(key))
+        .and_then(|key| composed_artifact_provenance_value(corpus, key))
     {
-        value.insert(
-            "provenance".into(),
-            composed_provenance_value(&provenance),
-        );
+        value.insert("provenance".into(), provenance);
     }
     dumps_indent2(&Value::Object(value))
 }
@@ -3472,15 +3636,38 @@ pub fn render_find_json_with_composed(
             let Some(provenance) = artifact
                 .key
                 .as_ref()
-                .and_then(|key| corpus.provenance_for(key))
+                .and_then(|key| composed_artifact_provenance_value(corpus, key))
             else {
                 continue;
             };
             if let Some(object) = matched.as_object_mut() {
-                object.insert(
-                    "provenance".into(),
-                    composed_provenance_value(&provenance),
-                );
+                object.insert("provenance".into(), provenance);
+            }
+        }
+    }
+    dumps_indent2(&payload)
+}
+
+pub fn render_find_json_with_graph(
+    result: &SearchResult,
+    explain: bool,
+    corpus: &crate::graph_federated_corpus::VerifiedGraphCorpus,
+) -> String {
+    let mut payload = search_result_value_with_origin(result, explain, true);
+    if let Some(matches) = payload.get_mut("matches").and_then(Value::as_array_mut) {
+        for (matched, artifact) in matches.iter_mut().zip(&result.matches) {
+            let Some(key) = artifact.key.as_ref() else {
+                continue;
+            };
+            let Some(item) = corpus.composition.item(key) else {
+                continue;
+            };
+            let provenance = graph_provenance_value(
+                &item.origin,
+                corpus.composition.provenance_for(key).unwrap_or(&[]),
+            );
+            if let Some(object) = matched.as_object_mut() {
+                object.insert("provenance".into(), provenance);
             }
         }
     }
@@ -3575,6 +3762,37 @@ pub fn render_diagnosis_human(diagnosis: &SearchDiagnosis) -> String {
 /// `render_find_human` — aligned match rows, or a valid empty result
 /// (PORT-CONTRACT.d/06 §13). `{query!r}` is Python string repr.
 pub fn render_find_human(result: &SearchResult, explain: bool) -> String {
+    render_find_human_with_suffix(result, explain, |_| None)
+}
+
+/// Graph-v2 human search keeps the released table shape while naming the
+/// exact source, layer, and inherited pin for every returned record.
+pub fn render_find_human_with_graph(
+    result: &SearchResult,
+    explain: bool,
+    corpus: &crate::graph_federated_corpus::VerifiedGraphCorpus,
+) -> String {
+    render_find_human_with_suffix(result, explain, |artifact| {
+        let key = artifact.key.as_ref()?;
+        let origin = &corpus.composition.item(key)?.origin;
+        let mut suffix = format!(
+            "  [source={} layer={}",
+            origin.source,
+            origin.layer.as_str()
+        );
+        if let Some(pin) = &origin.pin {
+            suffix.push_str(&format!(" pin={pin}"));
+        }
+        suffix.push(']');
+        Some(suffix)
+    })
+}
+
+fn render_find_human_with_suffix(
+    result: &SearchResult,
+    explain: bool,
+    suffix_for: impl Fn(&ResolvedArtifact) -> Option<String>,
+) -> String {
     if result.matches.is_empty() {
         return format!("No artifacts match {}.", py_repr_str(&result.query));
     }
@@ -3607,6 +3825,9 @@ pub fn render_find_human(result: &SearchResult, explain: bool) -> String {
                 };
                 row.push_str(&yellow(&marker));
             }
+        }
+        if let Some(suffix) = suffix_for(m) {
+            row.push_str(&suffix);
         }
         lines.push(row);
         if let Some(snippet) = &m.snippet {

--- a/rust/rac-engine/src/portal.rs
+++ b/rust/rac-engine/src/portal.rs
@@ -17,6 +17,13 @@ pub const FEDERATED_SHELL: &str = include_str!("../assets/portal/asdecided-porta
 /// whitespace inside the element); the populated form replaces it verbatim.
 const SEAM: &str = r#"<script type="application/json" id="lore-export"></script>"#;
 
+// The v1 source-aware shell is also a frozen output. Version 2 patches only
+// its one direct-mapping property read at render time, leaving the packaged
+// v1 bytes and every v1 HTML export exact.
+const V1_OVERRIDE_TARGET_READ: &str = r#"T.state==="replacement"&&b(T.parent.id,$)"#;
+const V2_OVERRIDE_TARGET_READ: &str =
+    r#"T.state!=="overridden"&&b((T.target??T.parent).id,$)"#;
+
 /// `_escape_for_script(payload)` — make serialized JSON safe inside a
 /// `<script>` element with two valid JSON escapes, applied in the oracle's
 /// order: `</` → `<\/` first, then `<!--` → `<\u{0021}--` (both literal
@@ -51,7 +58,26 @@ pub fn render_export_html(export: &CorpusExport) -> Result<String, String> {
 }
 
 pub fn render_federated_export_html(export: &CorpusExport) -> Result<String, String> {
-    render_export_html_with_shell(export, FEDERATED_SHELL)
+    if export
+        .artifacts
+        .iter()
+        .any(|artifact| artifact.graph_provenance.is_some())
+    {
+        if FEDERATED_SHELL.matches(V1_OVERRIDE_TARGET_READ).count() != 1 {
+            return Err(
+                "packaged source-aware portal shell has no usable v1 override seam; re-vendor it"
+                    .to_string(),
+            );
+        }
+        let graph_shell = FEDERATED_SHELL.replacen(
+            V1_OVERRIDE_TARGET_READ,
+            V2_OVERRIDE_TARGET_READ,
+            1,
+        );
+        render_export_html_with_shell(export, &graph_shell)
+    } else {
+        render_export_html_with_shell(export, FEDERATED_SHELL)
+    }
 }
 
 #[cfg(test)]
@@ -63,6 +89,8 @@ mod tests {
         assert_eq!(SHELL.matches(SEAM).count(), 1);
         assert_eq!(FEDERATED_SHELL.matches(SEAM).count(), 1);
         assert_ne!(SHELL, FEDERATED_SHELL);
+        assert_eq!(FEDERATED_SHELL.matches(V1_OVERRIDE_TARGET_READ).count(), 1);
+        assert!(!FEDERATED_SHELL.contains(V2_OVERRIDE_TARGET_READ));
     }
 
     /// The two escapes in the oracle's order; the comment-open rewrite must

--- a/rust/rac-engine/src/resolve.rs
+++ b/rust/rac-engine/src/resolve.rs
@@ -32,6 +32,10 @@ use crate::spec::spec_for;
 pub const OUTCOME_RESOLVED: &str = "resolved";
 pub const OUTCOME_NOT_FOUND: &str = "not-found";
 pub const OUTCOME_DUPLICATE: &str = "duplicate";
+/// Version-2 federation keeps equal canonical ids as distinct source-owned
+/// records. A bare reference to several such records is an ambiguity, not a
+/// duplicate within one corpus.
+pub const OUTCOME_AMBIGUOUS: &str = "ambiguous";
 
 // Match-field tier ladder (ADR-037/038/109): id, title, tags, path, heading,
 // body — lower rank wins.

--- a/rust/rac-engine/src/retrieve.rs
+++ b/rust/rac-engine/src/retrieve.rs
@@ -534,15 +534,12 @@ pub fn scope_lookup_value_with_composed(
             let Some(provenance) = decision
                 .key
                 .as_ref()
-                .and_then(|key| corpus.provenance_for(key))
+                .and_then(|key| crate::output::composed_artifact_provenance_value(corpus, key))
             else {
                 continue;
             };
             if let Some(object) = value.as_object_mut() {
-                object.insert(
-                    "provenance".to_string(),
-                    crate::output::composed_provenance_value(&provenance),
-                );
+                object.insert("provenance".to_string(), provenance);
             }
         }
     }
@@ -909,8 +906,99 @@ pub fn retrieve_grounding_from_composed(
     live_only: bool,
     corpus: &crate::composition::ComposedCorpus,
 ) -> Value {
+    retrieve_grounding_from_source(
+        directory, task, scope, top_k, budget, live_only, corpus,
+    )
+}
+
+/// Grounding over the request-current verified graph closure. This shares the
+/// exact ranking and shaping path with v1 composition while sourcing content
+/// and complete ordered override provenance from the v2 snapshot.
+pub fn retrieve_grounding_from_graph(
+    directory: &str,
+    task: &str,
+    scope: Option<&str>,
+    top_k: i64,
+    budget: i64,
+    live_only: bool,
+    corpus: &crate::graph_federated_corpus::VerifiedGraphCorpus,
+) -> Value {
+    retrieve_grounding_from_source(
+        directory, task, scope, top_k, budget, live_only, corpus,
+    )
+}
+
+trait GroundingSource {
+    fn effective(&self) -> Vec<CorpusItem>;
+    fn effective_index(&self) -> Vec<IndexEntry>;
+    fn relationships(&self) -> Vec<crate::relationships::Relationship>;
+    fn content(&self, key: &ArtifactKey) -> Option<&[u8]>;
+    fn override_provenance(&self, key: &ArtifactKey) -> Option<Value>;
+}
+
+impl GroundingSource for crate::composition::ComposedCorpus {
+    fn effective(&self) -> Vec<CorpusItem> {
+        self.effective().cloned().collect()
+    }
+
+    fn effective_index(&self) -> Vec<IndexEntry> {
+        self.effective_index()
+    }
+
+    fn relationships(&self) -> Vec<crate::relationships::Relationship> {
+        self.relationships()
+    }
+
+    fn content(&self, key: &ArtifactKey) -> Option<&[u8]> {
+        self.content(key)
+    }
+
+    fn override_provenance(&self, key: &ArtifactKey) -> Option<Value> {
+        crate::output::composed_artifact_provenance_value(self, key)
+            .and_then(|provenance| provenance.get("overrides").cloned())
+    }
+}
+
+impl GroundingSource for crate::graph_federated_corpus::VerifiedGraphCorpus {
+    fn effective(&self) -> Vec<CorpusItem> {
+        self.composition.effective().cloned().collect()
+    }
+
+    fn effective_index(&self) -> Vec<IndexEntry> {
+        self.composition.effective_index()
+    }
+
+    fn relationships(&self) -> Vec<crate::relationships::Relationship> {
+        self.composition.relationships()
+    }
+
+    fn content(&self, key: &ArtifactKey) -> Option<&[u8]> {
+        self.content(key)
+    }
+
+    fn override_provenance(&self, key: &ArtifactKey) -> Option<Value> {
+        let item = self.composition.item(key)?;
+        crate::output::graph_provenance_value(
+            &item.origin,
+            self.composition.provenance_for(key).unwrap_or(&[]),
+        )
+        .get("overrides")
+        .cloned()
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn retrieve_grounding_from_source<C: GroundingSource>(
+    directory: &str,
+    task: &str,
+    scope: Option<&str>,
+    top_k: i64,
+    budget: i64,
+    live_only: bool,
+    corpus: &C,
+) -> Value {
     let top_k = top_k.max(1);
-    let effective: Vec<_> = corpus.effective().cloned().collect();
+    let effective = corpus.effective();
     let entries = corpus.effective_index();
     let keyword = search_index(&entries, task, None, &[]);
     let scope_rows = scope_rows_from_items(&effective);
@@ -1037,14 +1125,7 @@ pub fn retrieve_grounding_from_composed(
                 .and_then(|bytes| std::str::from_utf8(bytes).ok())
                 .map(|text| text.replace("\r\n", "\n").replace('\r', "\n"))
                 .unwrap_or_default();
-            if let Some(overrides) = corpus
-                .provenance_for(&item.key)
-                .and_then(|provenance| {
-                    crate::output::composed_provenance_value(&provenance)
-                        .get("overrides")
-                        .cloned()
-                })
-            {
+            if let Some(overrides) = corpus.override_provenance(&item.key) {
                 item.provenance.insert("overrides".to_string(), overrides);
             }
             let mut value = Map::new();

--- a/rust/rac-engine/src/sentry.rs
+++ b/rust/rac-engine/src/sentry.rs
@@ -398,7 +398,7 @@ fn invalid(
 fn collect_files(
     root: &Path,
     dir: &Path,
-    excluded: Option<&Path>,
+    excluded: &[PathBuf],
     output: &mut Vec<(String, PathBuf)>,
 ) {
     let Ok(entries) = std::fs::read_dir(dir) else {
@@ -408,10 +408,10 @@ fn collect_files(
     entries.sort_by_key(|entry| entry.file_name());
     for entry in entries {
         let path = entry.path();
-        if excluded.is_some_and(|excluded| {
-            std::fs::canonicalize(&path)
-                .ok()
-                .is_some_and(|path| path == excluded || path.starts_with(excluded))
+        if std::fs::canonicalize(&path).ok().is_some_and(|path| {
+            excluded
+                .iter()
+                .any(|excluded| path == *excluded || path.starts_with(excluded))
         }) {
             continue;
         }
@@ -530,9 +530,8 @@ pub fn analyze(
     analyze_with_items(corpus, repository, base, full_tree, &items, false, None)
 }
 
-/// Sentry over the effective items from one composed snapshot. `excluded`
-/// prevents code enumeration from entering the verified read-only parent
-/// materialisation.
+/// Compatibility entry point for one excluded read-only materialisation.
+/// Graph callers use [`analyze_with_items_excluding`].
 pub fn analyze_with_items(
     corpus: &str,
     repository: &str,
@@ -541,6 +540,29 @@ pub fn analyze_with_items(
     items: &[CorpusItem],
     include_origin: bool,
     excluded: Option<&Path>,
+) -> Result<SentryReport, String> {
+    let excluded: Vec<PathBuf> = excluded.into_iter().map(Path::to_path_buf).collect();
+    analyze_with_items_excluding(
+        corpus,
+        repository,
+        base,
+        full_tree,
+        items,
+        include_origin,
+        &excluded,
+    )
+}
+
+/// Multi-root composed Sentry entry point. Every verified direct, transitive,
+/// and duplicate-route materialisation root is excluded from code discovery.
+pub fn analyze_with_items_excluding(
+    corpus: &str,
+    repository: &str,
+    base: Option<&str>,
+    full_tree: bool,
+    items: &[CorpusItem],
+    include_origin: bool,
+    excluded: &[PathBuf],
 ) -> Result<SentryReport, String> {
     let repository_path = Path::new(repository);
     if !repository_path.is_dir() {
@@ -849,6 +871,97 @@ mod tests {
         assert_eq!(report.eligible_coverage_percent(), 100.0);
         assert_eq!(report.findings.len(), 1);
         assert_eq!(report.findings[0].code, CODE_VIOLATION);
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn composed_walk_excludes_every_read_only_materialisation_root() {
+        let root = std::env::temp_dir().join(format!(
+            "decided-sentry-multi-root-{}-{}",
+            std::process::id(),
+            std::thread::current().name().unwrap_or("test")
+        ));
+        let corpus = root.join("decisions");
+        let local_source = root.join("src");
+        let parent_a = root.join("vendor/parent-a");
+        let parent_b = root.join("vendor/parent-b");
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&corpus).unwrap();
+        fs::create_dir_all(&local_source).unwrap();
+        fs::create_dir_all(&parent_a).unwrap();
+        fs::create_dir_all(&parent_b).unwrap();
+        fs::write(
+            corpus.join("adr-001.md"),
+            "# ADR-001: Exclude materialised parents\n\n## Status\n\nAccepted\n\n## Context\n\nParent source trees are read-only inputs.\n\n## Decision\n\nSentry walks only the child code tree.\n\n## Consequences\n\nParent findings remain parent-owned.\n\n## Code Constraints\n\n```yaml\nversion: 1\nrules:\n  - id: no-forbidden-marker\n    kind: forbid_pattern\n    path_glob: \"**/*.rs\"\n    pattern: \"forbidden\"\n```\n",
+        )
+        .unwrap();
+        fs::write(local_source.join("safe.rs"), "fn safe() {}\n").unwrap();
+        fs::write(parent_a.join("code.rs"), "fn forbidden() {}\n").unwrap();
+        fs::write(parent_b.join("code.rs"), "fn forbidden() {}\n").unwrap();
+
+        let items = corpus_items(corpus.to_str().unwrap(), true);
+        let compatibility = analyze_with_items(
+            corpus.to_str().unwrap(),
+            root.to_str().unwrap(),
+            None,
+            true,
+            &items,
+            true,
+            None,
+        )
+        .unwrap();
+        let no_exclusions = analyze_with_items_excluding(
+            corpus.to_str().unwrap(),
+            root.to_str().unwrap(),
+            None,
+            true,
+            &items,
+            true,
+            &[],
+        )
+        .unwrap();
+        assert_eq!(compatibility.findings.len(), 2);
+        assert_eq!(no_exclusions.findings.len(), compatibility.findings.len());
+        assert_eq!(
+            no_exclusions
+                .findings
+                .iter()
+                .map(|finding| (&finding.path, finding.line, finding.code))
+                .collect::<Vec<_>>(),
+            compatibility
+                .findings
+                .iter()
+                .map(|finding| (&finding.path, finding.line, finding.code))
+                .collect::<Vec<_>>()
+        );
+
+        let parent_a = fs::canonicalize(parent_a).unwrap();
+        let parent_b = fs::canonicalize(parent_b).unwrap();
+        let one_exclusion = analyze_with_items_excluding(
+            corpus.to_str().unwrap(),
+            root.to_str().unwrap(),
+            None,
+            true,
+            &items,
+            true,
+            std::slice::from_ref(&parent_a),
+        )
+        .unwrap();
+        assert_eq!(one_exclusion.findings.len(), 1);
+        assert_eq!(one_exclusion.findings[0].path, "vendor/parent-b/code.rs");
+
+        let all_exclusions = analyze_with_items_excluding(
+            corpus.to_str().unwrap(),
+            root.to_str().unwrap(),
+            None,
+            true,
+            &items,
+            true,
+            &[parent_a, parent_b],
+        )
+        .unwrap();
+        assert!(all_exclusions.findings.is_empty());
 
         fs::remove_dir_all(root).unwrap();
     }

--- a/rust/rac-engine/src/skill.rs
+++ b/rust/rac-engine/src/skill.rs
@@ -84,18 +84,13 @@ pub enum SkillInstallError {
     Io(String),
 }
 
-/// `install_skills(target_dir, skill_name)` — write bundled skills into
-/// `<dir>/.claude/skills/<name>/SKILL.md`.
-///
-/// With no name every bundled skill is installed all-or-nothing: every
-/// target path is checked BEFORE any write, and one collision refuses the
-/// whole installation with nothing written (existing paths listed in
-/// registry order). Emitted paths are `str(Path(dir) / ...)` — the caller's
-/// `--dir` normalized by pathlib, never abspath'd (landmine 6).
-pub fn install_skills(
+/// Resolve every destination an installation would write, preserving the
+/// registry-order and unknown-name contract. Callers can preflight these
+/// concrete paths before the all-or-nothing write loop begins.
+pub fn install_targets(
     target_dir: &str,
     skill_name: Option<&str>,
-) -> Result<SkillInstallation, SkillInstallError> {
+) -> Result<Vec<String>, SkillInstallError> {
     if let Some(name) = skill_name {
         if skill_bytes(name).is_none() {
             return Err(SkillInstallError::NotFound(format!(
@@ -108,13 +103,32 @@ pub fn install_skills(
         Some(name) => vec![name],
         None => available_skills(),
     };
+    Ok(names
+        .iter()
+        .map(|name| py_join(target_dir, &[".claude", "skills", name, "SKILL.md"]))
+        .collect())
+}
+
+/// `install_skills(target_dir, skill_name)` — write bundled skills into
+/// `<dir>/.claude/skills/<name>/SKILL.md`.
+///
+/// With no name every bundled skill is installed all-or-nothing: every
+/// target path is checked BEFORE any write, and one collision refuses the
+/// whole installation with nothing written (existing paths listed in
+/// registry order). Emitted paths are `str(Path(dir) / ...)` — the caller's
+/// `--dir` normalized by pathlib, never abspath'd (landmine 6).
+pub fn install_skills(
+    target_dir: &str,
+    skill_name: Option<&str>,
+) -> Result<SkillInstallation, SkillInstallError> {
+    let names: Vec<&str> = match skill_name {
+        Some(name) => vec![name],
+        None => available_skills(),
+    };
 
     // Check every destination first, then write — a refusal never leaves a
     // partial installation behind.
-    let destinations: Vec<String> = names
-        .iter()
-        .map(|name| py_join(target_dir, &[".claude", "skills", name, "SKILL.md"]))
-        .collect();
+    let destinations = install_targets(target_dir, skill_name)?;
     let existing: Vec<&str> = destinations
         .iter()
         .filter(|dest| Path::new(dest.as_str()).exists())

--- a/rust/rac-engine/tests/composition_graph_facade.rs
+++ b/rust/rac-engine/tests/composition_graph_facade.rs
@@ -1,0 +1,251 @@
+use std::path::{Path, PathBuf};
+
+use rac_engine::composition::{ComposedCorpus, ParentIdentity};
+use rac_engine::corpus::{
+    ArtifactKey, CorpusLayer, PhysicalArtifactLocator, PhysicalCorpusLocator,
+};
+use rac_engine::graph_composition::{
+    GraphComposition, GraphCompositionInput, GraphOverrideDeclaration, GraphOverrideState,
+    SourceNodeInput, SourceParentInput,
+};
+use rac_engine::parse::parse_text;
+use rac_engine::relationships::CorpusItem;
+use rac_engine::resolve::OUTCOME_RESOLVED;
+use rac_engine::spec::spec_for;
+
+const ROOT: &str = "acme/app";
+const PARENT: &str = "acme/standards";
+
+fn key(source: &str, id: &str) -> ArtifactKey {
+    ArtifactKey::new(source, id)
+}
+
+fn item(
+    source: &str,
+    relative_path: &str,
+    id: &str,
+    artifact_type: &str,
+    relationships: &str,
+) -> CorpusItem {
+    let body = match artifact_type {
+        "decision" => {
+            "## Context\n\nFacade fixture.\n\n## Decision\n\nKeep graph reads central.\n\n## Consequences\n\nConsumers share one projection.\n"
+        }
+        "requirement" => {
+            "## Problem\n\nGraph activation needs a compatibility facade.\n\n## Requirements\n\n- [REQ-001] Reads MUST share one graph.\n"
+        }
+        other => panic!("unsupported fixture type {other}"),
+    };
+    let text = format!(
+        "---\nschema_version: 1\ntype: {artifact_type}\n---\n# {id}\n\n## ID\n\n{id}\n\n## Status\n\nAccepted\n\n{body}\n{relationships}"
+    );
+    let origin = if source == ROOT {
+        CorpusLayer::local(source).origin()
+    } else {
+        CorpusLayer::inherited(source, "standards", "sha256-v2:fixture").origin()
+    };
+    let display = format!("/runtime/{source}/{relative_path}");
+    CorpusItem::new(
+        display.clone(),
+        relative_path.to_string(),
+        parse_text(&text, &display),
+        spec_for(artifact_type),
+        origin,
+        PhysicalArtifactLocator::new(
+            PhysicalCorpusLocator::new(
+                format!("/runtime/{source}"),
+                format!("/runtime/{source}/decisions"),
+            ),
+            display,
+        ),
+    )
+}
+
+fn graph() -> GraphComposition {
+    GraphComposition::compose(GraphCompositionInput::new(
+        ROOT,
+        vec![
+            SourceNodeInput::new(ROOT, vec![SourceParentInput::new(PARENT, "standards")]),
+            SourceNodeInput::new(PARENT, Vec::new()),
+        ],
+        vec![
+            item(PARENT, "policy.md", "STD-POLICY", "requirement", ""),
+            item(
+                PARENT,
+                "consumer.md",
+                "STD-CONSUMER",
+                "requirement",
+                "## Related Requirements\n\n- STD-POLICY\n",
+            ),
+            item(ROOT, "replacement.md", "APP-POLICY", "requirement", ""),
+            item(ROOT, "rationale.md", "APP-ADR", "decision", ""),
+        ],
+        vec![GraphOverrideDeclaration::new(
+            ROOT,
+            key(PARENT, "STD-POLICY"),
+            key(ROOT, "APP-POLICY"),
+            key(ROOT, "APP-ADR"),
+        )],
+    ))
+    .unwrap()
+}
+
+#[test]
+fn v1_and_local_facades_keep_their_original_projection_contract() {
+    let local_item = item(ROOT, "local.md", "APP-LOCAL", "requirement", "");
+    let local = ComposedCorpus::local(vec![local_item]);
+    assert!(!local.is_graph());
+    assert!(!local.is_federated());
+    assert!(local.graph().is_none());
+    assert!(local.read_only_roots().is_empty());
+    assert!(local.read_only_root().is_none());
+    assert_eq!(local.catalog().len(), 1);
+    assert_eq!(local.effective().len(), 1);
+    assert_eq!(local.local_items().len(), 1);
+    assert_eq!(
+        local.resolve("APP-LOCAL").unwrap().key,
+        key(ROOT, "APP-LOCAL")
+    );
+    assert_eq!(
+        local.resolve_identity("APP-LOCAL").outcome,
+        OUTCOME_RESOLVED
+    );
+    assert_eq!(local.effective_index().len(), 1);
+    assert_eq!(local.identity_index().len(), 1);
+    assert!(local
+        .graph_provenance_for(&key(ROOT, "APP-LOCAL"))
+        .is_none());
+
+    let inherited = item(PARENT, "parent.md", "STD-PARENT", "requirement", "");
+    let expected_root = inherited.locator.corpus.repository_root.clone();
+    let v1 = ComposedCorpus::compose(
+        Vec::new(),
+        vec![inherited],
+        ParentIdentity::new(PARENT, "standards").unwrap(),
+        Vec::new(),
+    );
+    assert!(!v1.is_graph());
+    assert!(v1.is_federated());
+    assert_eq!(v1.read_only_root(), Some(expected_root.as_path()));
+    assert_eq!(v1.read_only_roots(), &[expected_root]);
+    assert_eq!(v1.catalog().len(), 1);
+    assert_eq!(v1.effective().len(), 1);
+}
+
+#[test]
+fn graph_facade_delegates_every_compatible_read_to_one_graph() {
+    let roots = vec![
+        PathBuf::from("/runtime/z-copy"),
+        PathBuf::from("/runtime/a-copy"),
+        PathBuf::from("/runtime/z-copy"),
+    ];
+    let corpus = ComposedCorpus::from_graph(
+        graph(),
+        vec![
+            (key(PARENT, "STD-POLICY"), b"verified parent".to_vec()),
+            (key(ROOT, "APP-POLICY"), b"captured root".to_vec()),
+            (key("unknown/source", "MISSING"), b"discard me".to_vec()),
+        ],
+        roots,
+    );
+
+    assert!(corpus.is_graph());
+    assert!(corpus.is_federated());
+    assert!(corpus.graph().is_some());
+    assert_eq!(corpus.child_source(), Some(ROOT));
+    assert_eq!(corpus.read_only_root(), Some(Path::new("/runtime/a-copy")));
+    assert_eq!(
+        corpus.read_only_roots(),
+        &[
+            PathBuf::from("/runtime/a-copy"),
+            PathBuf::from("/runtime/z-copy")
+        ]
+    );
+    assert_eq!(corpus.catalog().len(), 4);
+    assert_eq!(corpus.effective().len(), 3);
+    assert_eq!(corpus.local_items().len(), 2);
+    assert_eq!(
+        corpus
+            .effective()
+            .map(|item| item.key.clone())
+            .collect::<Vec<_>>(),
+        vec![
+            key(ROOT, "APP-ADR"),
+            key(ROOT, "APP-POLICY"),
+            key(PARENT, "STD-CONSUMER"),
+        ]
+    );
+
+    assert_eq!(
+        corpus.resolve("STD-POLICY").unwrap().key,
+        key(ROOT, "APP-POLICY")
+    );
+    assert_eq!(
+        corpus.resolve("acme/standards::STD-POLICY").unwrap().key,
+        key(PARENT, "STD-POLICY")
+    );
+    assert_eq!(
+        corpus.resolve_identity("STD-POLICY").outcome,
+        OUTCOME_RESOLVED
+    );
+    assert_eq!(corpus.effective_index().len(), 3);
+    assert_eq!(corpus.identity_index().len(), 4);
+    assert!(corpus.is_overridden(&key(PARENT, "STD-POLICY")));
+    assert_eq!(
+        corpus.content(&key(PARENT, "STD-POLICY")),
+        Some(b"verified parent".as_slice())
+    );
+    assert_eq!(corpus.captured_contents().count(), 2);
+
+    let live = corpus
+        .relationships()
+        .into_iter()
+        .find(|relationship| {
+            relationship
+                .source_artifact
+                .as_ref()
+                .is_some_and(|path| path.source == PARENT && path.relative_path == "consumer.md")
+        })
+        .unwrap();
+    assert_eq!(live.resolved_artifact.unwrap().source, ROOT);
+    let catalog = corpus
+        .catalog_relationships()
+        .into_iter()
+        .find(|relationship| {
+            relationship
+                .source_artifact
+                .as_ref()
+                .is_some_and(|path| path.source == PARENT && path.relative_path == "consumer.md")
+        })
+        .unwrap();
+    assert_eq!(catalog.resolved_artifact.unwrap().source, PARENT);
+    assert!(corpus.local_relationships().is_empty());
+}
+
+#[test]
+fn graph_chain_provenance_is_never_flattened_into_the_v1_carrier() {
+    let corpus = ComposedCorpus::from_graph(graph(), Vec::new(), Vec::new());
+    let historical = key(PARENT, "STD-POLICY");
+    let replacement = key(ROOT, "APP-POLICY");
+
+    let historical_chain = corpus.graph_provenance_for(&historical).unwrap();
+    assert_eq!(historical_chain.len(), 1);
+    assert_eq!(historical_chain[0].state, GraphOverrideState::Overridden);
+    let replacement_chain = corpus.graph_provenance_for(&replacement).unwrap();
+    assert_eq!(replacement_chain.len(), 1);
+    assert_eq!(replacement_chain[0].state, GraphOverrideState::Replacement);
+    let rendered = rac_engine::output::composed_artifact_provenance_value(&corpus, &replacement)
+        .expect("graph provenance serializes without a v1 projection");
+    assert_eq!(rendered["source"], ROOT);
+    assert_eq!(rendered["overrides"][0]["state"], "replacement");
+    assert_eq!(rendered["overrides"][0]["owner_source"], ROOT);
+    assert_eq!(rendered["overrides"][0]["target"]["source"], PARENT);
+    assert!(corpus.provenance_for(&historical).is_none());
+    assert!(corpus.provenance_for(&replacement).is_none());
+
+    let rationale = key(ROOT, "APP-ADR");
+    let fixed = corpus.provenance_for(&rationale).unwrap();
+    assert_eq!(fixed.origin.source, ROOT);
+    assert!(fixed.overrides.is_empty());
+    assert!(corpus.graph_provenance_for(&rationale).unwrap().is_empty());
+}

--- a/rust/rac-engine/tests/federated_export_emission.rs
+++ b/rust/rac-engine/tests/federated_export_emission.rs
@@ -5,19 +5,29 @@ use rac_engine::composition::{
     ArtifactOverrideProvenance, ComposedCorpus, ComposedProvenance, OverrideDeclaration,
     OverrideRole, ParentIdentity,
 };
-use rac_engine::corpus::{ArtifactKey, CorpusLayer, Layer};
+use rac_engine::corpus::{
+    ArtifactKey, CorpusLayer, Layer, PhysicalArtifactLocator, PhysicalCorpusLocator,
+};
 use rac_engine::export::{
     build_corpus_export, build_corpus_export_from_composed, build_documents_export,
     build_documents_export_from_composed, build_graph_export, build_graph_export_from_composed,
     build_okf_export_from_composed, export_schema, CorpusExport, DocumentsExport, ExportArtifact,
     ExportDocument, ExportIdentity, ExportRelationship, GraphEdge, GraphExport, GraphNode,
 };
+use rac_engine::graph_composition::{
+    GraphComposition, GraphCompositionInput, GraphOverrideDeclaration, SourceNodeInput,
+    SourceParentInput,
+};
 use rac_engine::output::{render_documents_jsonl, render_export_json, render_graph_json};
-use rac_engine::portal::{render_export_html, SHELL};
+use rac_engine::parse::parse_text;
+use rac_engine::portal::{render_export_html, render_federated_export_html, FEDERATED_SHELL, SHELL};
 use rac_engine::relationships::{corpus_items, CorpusItem};
+use rac_engine::spec::spec_for;
 use serde_json::Value;
 
 const PIN: &str = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+const GRAPH_PIN: &str =
+    "sha256-v2:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 
 const PARENT_POLICY: &str = r#"---
 schema_version: 1
@@ -231,6 +241,147 @@ fn overridden_provenance() -> ComposedProvenance {
     }
 }
 
+fn graph_item(
+    source: &str,
+    relative_path: &str,
+    id: &str,
+    artifact_type: &str,
+    relationships: &str,
+) -> (CorpusItem, Vec<u8>) {
+    let body = match artifact_type {
+        "decision" => {
+            "## Context\n\nExport fixture.\n\n## Decision\n\nRetain complete provenance.\n\n## Consequences\n\nPolicy history stays auditable.\n"
+        }
+        "requirement" => {
+            "## Problem\n\nGraph exports need stable identity.\n\n## Requirements\n\n- [REQ-001] Exports MUST retain source-aware history.\n"
+        }
+        other => panic!("unsupported fixture type {other}"),
+    };
+    let text = format!(
+        "---\nschema_version: 1\ntype: {artifact_type}\n---\n# {id}\n\n## ID\n\n{id}\n\n## Status\n\nAccepted\n\n{body}\n{relationships}"
+    );
+    let origin = if source == "acme/app" {
+        CorpusLayer::local(source).origin()
+    } else {
+        CorpusLayer::inherited(source, "runtime-only", GRAPH_PIN).origin()
+    };
+    let display = format!("/runtime/{source}/{relative_path}");
+    let item = CorpusItem::new(
+        display.clone(),
+        relative_path.to_string(),
+        parse_text(&text, &display),
+        spec_for(artifact_type),
+        origin,
+        PhysicalArtifactLocator::new(
+            PhysicalCorpusLocator::new(
+                format!("/runtime/{source}"),
+                format!("/runtime/{source}/decisions"),
+            ),
+            display,
+        ),
+    );
+    (item, text.into_bytes())
+}
+
+fn graph_corpus(
+    nodes: Vec<SourceNodeInput>,
+    fixtures: Vec<(CorpusItem, Vec<u8>)>,
+    overrides: Vec<GraphOverrideDeclaration>,
+) -> ComposedCorpus {
+    let (items, contents): (Vec<_>, Vec<_>) = fixtures
+        .into_iter()
+        .map(|(item, bytes)| {
+            let key = item.key.clone();
+            (item, (key, bytes))
+        })
+        .unzip();
+    let graph = GraphComposition::compose(GraphCompositionInput::new(
+        "acme/app",
+        nodes,
+        items,
+        overrides,
+    ))
+    .unwrap();
+    ComposedCorpus::from_graph(graph, contents, Vec::new())
+}
+
+fn graph_parent(source: &str, alias: &str) -> SourceParentInput {
+    SourceParentInput::new(source, alias)
+}
+
+fn graph_node(source: &str, parents: Vec<SourceParentInput>) -> SourceNodeInput {
+    SourceNodeInput::new(source, parents)
+}
+
+fn graph_mapping(
+    owner: &str,
+    target_source: &str,
+    target: &str,
+    replacement: &str,
+    rationale: &str,
+) -> GraphOverrideDeclaration {
+    GraphOverrideDeclaration::new(
+        owner,
+        key(target_source, target),
+        key(owner, replacement),
+        key(owner, rationale),
+    )
+}
+
+fn diamond_chain_corpus() -> ComposedCorpus {
+    let shared = "acme/shared";
+    let left = "acme/left";
+    let right = "acme/right";
+    graph_corpus(
+        vec![
+            graph_node(
+                "acme/app",
+                vec![graph_parent(left, "left"), graph_parent(right, "right")],
+            ),
+            graph_node(left, vec![graph_parent(shared, "base")]),
+            graph_node(right, vec![graph_parent(shared, "base")]),
+            graph_node(shared, Vec::new()),
+        ],
+        vec![
+            graph_item(shared, "policy.md", "POLICY", "requirement", ""),
+            graph_item(
+                shared,
+                "consumer.md",
+                "CONSUMER",
+                "requirement",
+                "## Related Requirements\n\n- POLICY\n",
+            ),
+            graph_item(left, "replacement.md", "LEFT-POLICY", "requirement", ""),
+            graph_item(left, "rationale.md", "LEFT-ADR", "decision", ""),
+            graph_item(
+                "acme/app",
+                "replacement.md",
+                "ROOT-POLICY",
+                "requirement",
+                "",
+            ),
+            graph_item("acme/app", "rationale.md", "ROOT-ADR", "decision", ""),
+        ],
+        vec![
+            graph_mapping(left, shared, "POLICY", "LEFT-POLICY", "LEFT-ADR"),
+            graph_mapping(
+                "acme/app",
+                left,
+                "LEFT-POLICY",
+                "ROOT-POLICY",
+                "ROOT-ADR",
+            ),
+            graph_mapping(
+                "acme/app",
+                shared,
+                "POLICY",
+                "ROOT-POLICY",
+                "ROOT-ADR",
+            ),
+        ],
+    )
+}
+
 #[test]
 fn viewer_emits_record_edge_endpoint_and_override_provenance() {
     let provenance = overridden_provenance();
@@ -248,6 +399,7 @@ fn viewer_emits_record_edge_endpoint_and_override_provenance() {
             body_html: "<p>Policy.</p>".to_string(),
             tags: Vec::new(),
             provenance: Some(provenance.clone()),
+            graph_provenance: None,
         }],
         relationships: vec![ExportRelationship {
             from: "STD-001".to_string(),
@@ -256,6 +408,10 @@ fn viewer_emits_record_edge_endpoint_and_override_provenance() {
             from_identity: Some(identity("acme/standards", "STD-001")),
             to_identity: Some(identity("acme/app", "APP-001")),
             provenance: Some(provenance),
+            graph_provenance: None,
+            authored_token: None,
+            historical_candidates: Vec::new(),
+            effective_terminal: None,
         }],
     };
 
@@ -301,6 +457,7 @@ fn documents_and_graph_emit_the_same_per_record_provenance() {
             path: "decisions/parent-policy.md".to_string(),
             tags: Vec::new(),
             provenance: Some(provenance.clone()),
+            graph_provenance: None,
         }],
     };
     let document: Value = serde_json::from_str(&render_documents_jsonl(&documents)).unwrap();
@@ -321,6 +478,7 @@ fn documents_and_graph_emit_the_same_per_record_provenance() {
             status: "Accepted".to_string(),
             title: "Parent policy".to_string(),
             provenance: Some(provenance.clone()),
+            graph_provenance: None,
         }],
         edges: vec![GraphEdge {
             source: "STD-001".to_string(),
@@ -333,6 +491,10 @@ fn documents_and_graph_emit_the_same_per_record_provenance() {
             source_identity: Some(identity("acme/standards", "STD-001")),
             target_identity: Some(identity("acme/app", "APP-001")),
             provenance: Some(provenance),
+            graph_provenance: None,
+            authored_token: None,
+            historical_candidates: Vec::new(),
+            effective_terminal: None,
         }],
     };
     let value: Value = serde_json::from_str(&render_graph_json(&graph)).unwrap();
@@ -357,6 +519,15 @@ fn packaged_schemas_declare_optional_federation_fields() {
     assert!(viewer_artifact["properties"]["provenance"].is_object());
     assert!(viewer_edge["properties"]["from_identity"].is_object());
     assert!(viewer_edge["properties"]["to_identity"].is_object());
+    assert!(viewer_edge["properties"]["authored_token"].is_object());
+    assert!(viewer_edge["properties"]["historical_candidates"].is_object());
+    assert!(viewer_edge["properties"]["effective_terminal"].is_object());
+    assert!(viewer["$defs"]["override"]["properties"]["owner_source"].is_object());
+    assert!(viewer["$defs"]["override"]["properties"]["state"]["enum"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|state| state == "lineage"));
     assert!(!viewer_artifact["required"]
         .as_array()
         .unwrap()
@@ -365,6 +536,7 @@ fn packaged_schemas_declare_optional_federation_fields() {
 
     let documents: Value = serde_json::from_str(export_schema("documents").unwrap()).unwrap();
     assert!(documents["properties"]["metadata"]["properties"]["provenance"].is_object());
+    assert!(documents["$defs"]["override"]["properties"]["owner_source"].is_object());
 
     let graph: Value = serde_json::from_str(export_schema("graph").unwrap()).unwrap();
     let graph_node = &graph["properties"]["nodes"]["items"];
@@ -372,14 +544,297 @@ fn packaged_schemas_declare_optional_federation_fields() {
     assert!(graph_node["properties"]["provenance"].is_object());
     assert!(graph_edge["properties"]["source_identity"].is_object());
     assert!(graph_edge["properties"]["target_identity"].is_object());
+    assert!(graph_edge["properties"]["authored_token"].is_object());
+    assert!(graph_edge["properties"]["historical_candidates"].is_object());
+    assert!(graph_edge["properties"]["effective_terminal"].is_object());
     assert_eq!(
         graph["$defs"]["provenance"]["properties"]["pin"]["pattern"],
-        "^sha256:[0-9a-f]{64}$"
+        "^sha256(?:-v2)?:[0-9a-f]{64}$"
     );
     assert_eq!(
         graph["$defs"]["provenance"]["allOf"][0]["then"]["required"][0],
         "pin"
     );
+}
+
+#[test]
+fn graph_exports_retain_reconciled_diamond_chain_and_endpoint_history() {
+    let root = scratch("graph-diamond-export");
+    let directory = corpus_path(&root, "child");
+    let corpus = diamond_chain_corpus();
+
+    let viewer =
+        build_corpus_export_from_composed(&directory, "test".to_string(), &corpus, false).unwrap();
+    assert_eq!(viewer.artifacts.len(), 6);
+    let terminal = viewer
+        .artifacts
+        .iter()
+        .find(|artifact| artifact.id == "ROOT-POLICY")
+        .unwrap();
+    assert!(terminal.provenance.is_none());
+    let terminal_provenance = terminal.graph_provenance.as_ref().unwrap();
+    assert_eq!(terminal_provenance.origin.source, "acme/app");
+    assert_eq!(terminal_provenance.origin.layer, Layer::Local);
+    assert_eq!(terminal_provenance.origin.pin, None);
+    assert_eq!(terminal_provenance.overrides.len(), 3);
+    assert_eq!(
+        terminal_provenance
+            .overrides
+            .iter()
+            .map(|mapping| (mapping.owner_source.as_str(), mapping.state.as_str()))
+            .collect::<Vec<_>>(),
+        vec![
+            ("acme/left", "lineage"),
+            ("acme/app", "replacement"),
+            ("acme/app", "replacement"),
+        ]
+    );
+    let history = viewer
+        .artifacts
+        .iter()
+        .find(|artifact| artifact.id == "POLICY")
+        .unwrap();
+    assert_eq!(
+        history.graph_provenance.as_ref().unwrap().origin.pin.as_deref(),
+        Some(GRAPH_PIN)
+    );
+
+    let relationship = viewer
+        .relationships
+        .iter()
+        .find(|relationship| relationship.from == "CONSUMER")
+        .unwrap();
+    assert_eq!(relationship.authored_token.as_deref(), Some("POLICY"));
+    assert_eq!(
+        relationship.historical_candidates,
+        vec![identity("acme/shared", "POLICY")]
+    );
+    assert_eq!(
+        relationship.effective_terminal,
+        Some(identity("acme/app", "ROOT-POLICY"))
+    );
+    assert_eq!(
+        relationship.to_identity,
+        Some(identity("acme/app", "ROOT-POLICY"))
+    );
+
+    let viewer_json: Value = serde_json::from_str(&render_export_json(&viewer)).unwrap();
+    let terminal_json = viewer_json["artifacts"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|artifact| artifact["id"] == "ROOT-POLICY")
+        .unwrap();
+    assert_eq!(
+        terminal_json["provenance"]["overrides"][0]["owner_source"],
+        "acme/left"
+    );
+    assert_eq!(
+        terminal_json["provenance"]["overrides"][0]["state"],
+        "lineage"
+    );
+    assert_eq!(
+        terminal_json["provenance"]["overrides"][0]["target"],
+        serde_json::json!({"source": "acme/shared", "id": "POLICY"})
+    );
+    assert!(terminal_json["provenance"]["overrides"][0]
+        .get("parent")
+        .is_none());
+    assert_eq!(
+        viewer_json["relationships"][0]["historical_candidates"],
+        serde_json::json!([{"source": "acme/shared", "id": "POLICY"}])
+    );
+    assert_eq!(
+        viewer_json["relationships"][0]["effective_terminal"],
+        serde_json::json!({"source": "acme/app", "id": "ROOT-POLICY"})
+    );
+
+    let documents = build_documents_export_from_composed(&directory, &corpus, false).unwrap();
+    assert_eq!(documents.documents.len(), 6);
+    let terminal_document = documents
+        .documents
+        .iter()
+        .find(|document| document.id == "ROOT-POLICY")
+        .unwrap();
+    assert_eq!(
+        terminal_document
+            .graph_provenance
+            .as_ref()
+            .unwrap()
+            .overrides,
+        terminal_provenance.overrides
+    );
+    let rendered_document: Value = render_documents_jsonl(&documents)
+        .lines()
+        .map(|line| serde_json::from_str::<Value>(line).unwrap())
+        .find(|document| document["id"] == "ROOT-POLICY")
+        .unwrap();
+    assert_eq!(
+        rendered_document["metadata"]["provenance"]["overrides"].as_array().unwrap().len(),
+        3
+    );
+
+    let graph = build_graph_export_from_composed(&directory, &corpus, false).unwrap();
+    assert_eq!(graph.nodes.len(), 6);
+    let edge = graph
+        .edges
+        .iter()
+        .find(|edge| edge.source == "CONSUMER")
+        .unwrap();
+    assert_eq!(edge.authored_token.as_deref(), Some("POLICY"));
+    assert_eq!(
+        edge.graph_provenance.as_ref().unwrap().origin.pin.as_deref(),
+        Some(GRAPH_PIN)
+    );
+    assert_eq!(
+        edge.historical_candidates,
+        vec![identity("acme/shared", "POLICY")]
+    );
+    assert_eq!(
+        edge.effective_terminal,
+        Some(identity("acme/app", "ROOT-POLICY"))
+    );
+    let graph_json: Value = serde_json::from_str(&render_graph_json(&graph)).unwrap();
+    let edge_json = graph_json["edges"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|edge| edge["source"] == "CONSUMER")
+        .unwrap();
+    assert_eq!(edge_json["authored_token"], "POLICY");
+    assert_eq!(
+        edge_json["effective_terminal"],
+        serde_json::json!({"source": "acme/app", "id": "ROOT-POLICY"})
+    );
+
+    let local_viewer =
+        build_corpus_export_from_composed(&directory, "test".to_string(), &corpus, true).unwrap();
+    assert_eq!(
+        local_viewer
+            .artifacts
+            .iter()
+            .map(|artifact| artifact.id.as_str())
+            .collect::<std::collections::BTreeSet<_>>(),
+        std::collections::BTreeSet::from(["ROOT-ADR", "ROOT-POLICY"])
+    );
+    assert!(local_viewer.artifacts.iter().all(|artifact| {
+        artifact
+            .graph_provenance
+            .as_ref()
+            .is_some_and(|provenance| provenance.origin.layer == Layer::Local)
+    }));
+    assert_eq!(
+        build_documents_export_from_composed(&directory, &corpus, true)
+            .unwrap()
+            .documents
+            .len(),
+        2
+    );
+    assert_eq!(
+        build_graph_export_from_composed(&directory, &corpus, true)
+            .unwrap()
+            .nodes
+            .len(),
+        2
+    );
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn graph_portal_keeps_three_equal_ids_independently_addressable() {
+    let root = scratch("graph-equal-id-portal");
+    let directory = corpus_path(&root, "child");
+    let shared = "acme/shared";
+    let left = "acme/left";
+    let right = "acme/right";
+    let corpus = graph_corpus(
+        vec![
+            graph_node(
+                "acme/app",
+                vec![graph_parent(left, "left"), graph_parent(right, "right")],
+            ),
+            graph_node(left, vec![graph_parent(shared, "base")]),
+            graph_node(right, vec![graph_parent(shared, "base")]),
+            graph_node(shared, Vec::new()),
+        ],
+        vec![
+            graph_item(shared, "shared.md", "SAME", "requirement", ""),
+            graph_item(left, "left.md", "SAME", "requirement", ""),
+            graph_item(right, "right.md", "SAME", "requirement", ""),
+            graph_item(
+                "acme/app",
+                "replacement.md",
+                "ROOT-SAME",
+                "requirement",
+                "",
+            ),
+            graph_item("acme/app", "rationale.md", "ROOT-ADR", "decision", ""),
+            graph_item(
+                "acme/app",
+                "consumer.md",
+                "ROOT-CONSUMER",
+                "requirement",
+                "## Related Requirements\n\n- SAME\n",
+            ),
+        ],
+        vec![
+            graph_mapping("acme/app", left, "SAME", "ROOT-SAME", "ROOT-ADR"),
+            graph_mapping("acme/app", right, "SAME", "ROOT-SAME", "ROOT-ADR"),
+            graph_mapping("acme/app", shared, "SAME", "ROOT-SAME", "ROOT-ADR"),
+        ],
+    );
+    let viewer =
+        build_corpus_export_from_composed(&directory, "test".to_string(), &corpus, false).unwrap();
+    assert_eq!(viewer.artifacts.len(), 6);
+    assert_eq!(
+        viewer
+            .artifacts
+            .iter()
+            .filter(|artifact| artifact.id == "SAME")
+            .map(|artifact| {
+                let provenance = artifact.graph_provenance.as_ref().unwrap();
+                format!("{}::{}", provenance.origin.source, artifact.id)
+            })
+            .collect::<std::collections::BTreeSet<_>>(),
+        std::collections::BTreeSet::from([
+            "acme/left::SAME".to_string(),
+            "acme/right::SAME".to_string(),
+            "acme/shared::SAME".to_string(),
+        ])
+    );
+    let relationship = viewer
+        .relationships
+        .iter()
+        .find(|relationship| relationship.from == "ROOT-CONSUMER")
+        .unwrap();
+    assert_eq!(relationship.authored_token.as_deref(), Some("SAME"));
+    assert_eq!(
+        relationship.historical_candidates,
+        vec![
+            identity(left, "SAME"),
+            identity(right, "SAME"),
+            identity(shared, "SAME"),
+        ]
+    );
+    assert_eq!(
+        relationship.effective_terminal,
+        Some(identity("acme/app", "ROOT-SAME"))
+    );
+
+    let html = render_federated_export_html(&viewer).unwrap();
+    for source in [left, right, shared] {
+        assert!(html.contains(&format!("\"source\": \"{source}\"")));
+    }
+    assert!(FEDERATED_SHELL.contains("function Ki(c){return`${c.source}::${c.id}`}"));
+    assert!(FEDERATED_SHELL.contains("#/artifact/${encodeURIComponent(J)}"));
+    assert!(FEDERATED_SHELL.contains("T.state===\"replacement\"&&b(T.parent.id,$)"));
+    assert!(!FEDERATED_SHELL.contains("T.state!==\"overridden\""));
+    assert!(html.contains(
+        "T.state!==\"overridden\"&&b((T.target??T.parent).id,$)"
+    ));
+
+    fs::remove_dir_all(root).unwrap();
 }
 
 #[test]
@@ -395,6 +850,9 @@ fn composed_exports_retain_parent_history_and_source_aware_edges() {
 
     let viewer =
         build_corpus_export_from_composed(&directory, "test".to_string(), &corpus, false).unwrap();
+    let v1_html = render_federated_export_html(&viewer).unwrap();
+    assert!(v1_html.contains("T.state===\"replacement\"&&b(T.parent.id,$)"));
+    assert!(!v1_html.contains("T.state!==\"overridden\""));
     assert_eq!(viewer.artifacts.len(), 4);
     let parent = viewer
         .artifacts

--- a/rust/rac-engine/tests/federation_graph_cache.rs
+++ b/rust/rac-engine/tests/federation_graph_cache.rs
@@ -1,0 +1,414 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use rac_engine::derived_cache::{
+    FederatedCacheError, FederatedCacheRefresh, GraphFederatedCacheTracker, ReadModel,
+};
+use rac_engine::derived::SCHEMA_VERSION;
+use rac_engine::federation::{calculate_parent_digest_v2, ParentCorpusErrorCode};
+use rac_engine::index_store::{graph_store_dir, open_graph_store, GRAPH_STORE_LAYOUT_VERSION};
+
+static COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+const ROOT_SOURCE: &str = "acme/root";
+const A_SOURCE: &str = "acme/a";
+const B_SOURCE: &str = "acme/b";
+const MID_SOURCE: &str = "acme/mid";
+const BASE_SOURCE: &str = "acme/base";
+
+#[derive(Clone)]
+struct Parent<'a> {
+    alias: &'a str,
+    source: &'a str,
+    root: &'a str,
+    digest: &'a str,
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let count = COUNTER.fetch_add(1, Ordering::SeqCst);
+    let root = std::env::temp_dir().join(format!(
+        "asdecided-graph-cache-{tag}-{}-{count}",
+        std::process::id()
+    ));
+    fs::create_dir_all(&root).unwrap();
+    root
+}
+
+fn decision(id: &str, label: &str) -> String {
+    format!(
+        "---\nschema_version: 1\nid: {id}\ntype: decision\n---\n# ADR-001: {label}\n\n## Status\n\nAccepted\n\n## Context\n\nThe graph cache fixture needs a valid decision.\n\n## Decision\n\nKeep {label} deterministic.\n\n## Consequences\n\nFreshness changes are observable.\n\n## Applies To\n\n- src/**\n"
+    )
+}
+
+fn write_node(root: &Path, repository_key: &str, source: &str, id: &str, label: &str) {
+    fs::create_dir_all(root.join(".decided")).unwrap();
+    fs::create_dir_all(root.join("decisions")).unwrap();
+    fs::write(
+        root.join(".decided/config.yaml"),
+        format!("repository_key: {repository_key}\ncorpus:\n  source: {source}\n"),
+    )
+    .unwrap();
+    fs::write(root.join("decisions/policy.md"), decision(id, label)).unwrap();
+}
+
+fn write_manifest(root: &Path, parents: &[Parent<'_>]) {
+    let mut text = String::from("# Corpus\n\n## inherits\n\n```yaml\nversion: 2\nparents:\n");
+    for parent in parents {
+        text.push_str(&format!(
+            "  - alias: {}\n    source: {}\n    root: {}\n    corpus: decisions\n    digest: {}\n",
+            parent.alias, parent.source, parent.root, parent.digest
+        ));
+    }
+    text.push_str("```\n\n## overrides\n\n```yaml\nversion: 2\nitems: []\n```\n");
+    fs::write(root.join(".decided/corpus.md"), text).unwrap();
+}
+
+fn pin(root: &Path) -> String {
+    calculate_parent_digest_v2(root, "decisions")
+        .unwrap()
+        .digest
+}
+
+fn direct_fixture(tag: &str) -> (PathBuf, String, String) {
+    let root = scratch(tag);
+    let a = root.join("vendor/a");
+    let b = root.join("vendor/b");
+    write_node(&root, "APP", ROOT_SOURCE, "APP-KWJ4VMKVSS65", "root policy");
+    write_node(&a, "AAA", A_SOURCE, "AAA-KWJ4VMKVSS66", "policy a");
+    write_node(&b, "BBB", B_SOURCE, "BBB-KWJ4VMKVSS67", "policy b");
+    let a_pin = pin(&a);
+    let b_pin = pin(&b);
+    write_manifest(
+        &root,
+        &[Parent {
+            alias: "a",
+            source: A_SOURCE,
+            root: "vendor/a",
+            digest: &a_pin,
+        }],
+    );
+    (root, a_pin, b_pin)
+}
+
+fn chain_fixture(tag: &str) -> (PathBuf, PathBuf) {
+    let root = scratch(tag);
+    let mid = root.join("vendor/mid");
+    let base = mid.join("vendor/base");
+    write_node(&root, "APP", ROOT_SOURCE, "APP-KWJ4VMKVSS65", "root policy");
+    write_node(&mid, "MID", MID_SOURCE, "MID-KWJ4VMKVSS68", "middle policy");
+    write_node(&base, "BAS", BASE_SOURCE, "BAS-KWJ4VMKVSS69", "base policy");
+    repin_chain(&root, &mid, &base);
+    (root, base)
+}
+
+fn repin_chain(root: &Path, mid: &Path, base: &Path) {
+    let base_pin = pin(base);
+    write_manifest(
+        mid,
+        &[Parent {
+            alias: "base",
+            source: BASE_SOURCE,
+            root: "vendor/base",
+            digest: &base_pin,
+        }],
+    );
+    let mid_pin = pin(mid);
+    write_manifest(
+        root,
+        &[Parent {
+            alias: "mid",
+            source: MID_SOURCE,
+            root: "vendor/mid",
+            digest: &mid_pin,
+        }],
+    );
+}
+
+#[test]
+fn cold_warm_and_cross_tracker_store_hit_use_one_exact_graph_generation() {
+    let (root, _a_pin, _b_pin) = direct_fixture("cold-warm-store");
+    let cache = scratch("cold-warm-store-cache");
+    let mut first = GraphFederatedCacheTracker::new(cache.clone());
+
+    let cold = first.read_graph(&root, "decisions", true, true).unwrap();
+    assert_eq!(cold.refresh, FederatedCacheRefresh::Recomposed);
+    assert!(cold.generation.starts_with("sha256-v3:"));
+    assert_eq!(cold.metadata.generation, cold.generation);
+    assert_eq!(cold.metadata.layers.len(), 2);
+    assert!(matches!(cold.model, ReadModel::View(_)));
+    let generation = cold.generation.to_string();
+    assert!(graph_store_dir(&cache, &generation).unwrap().is_dir());
+
+    let warm = first.read_graph(&root, "decisions", true, true).unwrap();
+    assert_eq!(warm.refresh, FederatedCacheRefresh::WarmReuse);
+    assert_eq!(warm.generation, generation);
+
+    let mut second = GraphFederatedCacheTracker::new(cache.clone());
+    {
+        let stored = second.read_graph(&root, "decisions", true, true).unwrap();
+        assert_eq!(stored.refresh, FederatedCacheRefresh::StoreHit);
+        assert_eq!(stored.generation, generation);
+        assert!(matches!(stored.model, ReadModel::View(_)));
+    }
+    let store = graph_store_dir(&cache, &generation).unwrap();
+    drop(second);
+
+    fs::write(store.join("graph.seg"), b"corrupt graph metadata").unwrap();
+    let mut repaired = GraphFederatedCacheTracker::new(cache.clone());
+    let repair = repaired.read_graph(&root, "decisions", true, true).unwrap();
+    assert_eq!(repair.refresh, FederatedCacheRefresh::Recomposed);
+    assert_eq!(repair.generation, generation);
+    drop(repaired);
+
+    let mut reopened = GraphFederatedCacheTracker::new(cache.clone());
+    let stored = reopened.read_graph(&root, "decisions", true, true).unwrap();
+    assert_eq!(stored.refresh, FederatedCacheRefresh::StoreHit);
+    assert_eq!(stored.generation, generation);
+
+    fs::remove_dir_all(root).unwrap();
+    fs::remove_dir_all(cache).unwrap();
+}
+
+fn replace_once_same_length(path: &Path, from: &[u8], to: &[u8]) {
+    assert_eq!(from.len(), to.len());
+    let mut bytes = fs::read(path).unwrap();
+    let offset = bytes
+        .windows(from.len())
+        .position(|window| window == from)
+        .unwrap_or_else(|| panic!("{} omitted the corruption target", path.display()));
+    bytes[offset..offset + from.len()].copy_from_slice(to);
+    fs::write(path, bytes).unwrap();
+}
+
+#[test]
+fn framing_valid_answer_corruption_is_removed_rebuilt_and_reopened() {
+    let (root, _a_pin, _b_pin) = direct_fixture("semantic-corruption");
+    let cache = scratch("semantic-corruption-cache");
+    let mut initial = GraphFederatedCacheTracker::new(cache.clone());
+    let (generation, metadata) = {
+        let read = initial.read_graph(&root, "decisions", true, true).unwrap();
+        assert_eq!(read.refresh, FederatedCacheRefresh::Recomposed);
+        (read.generation.to_string(), read.metadata.clone())
+    };
+    drop(initial);
+
+    let store = graph_store_dir(&cache, &generation).unwrap();
+    let entries = store.join("entries.seg");
+    replace_once_same_length(
+        &entries,
+        b"AAA-KWJ4VMKVSS66",
+        b"ZAA-KWJ4VMKVSS66",
+    );
+    assert!(
+        open_graph_store(&cache, &generation, SCHEMA_VERSION, &metadata).is_some(),
+        "same-length answer mutation should preserve segment framing and graph metadata"
+    );
+
+    let mut repairing = GraphFederatedCacheTracker::new(cache.clone());
+    let repaired = repairing
+        .read_graph(&root, "decisions", true, true)
+        .unwrap();
+    assert_eq!(repaired.refresh, FederatedCacheRefresh::Recomposed);
+    assert_eq!(repaired.generation, generation);
+    drop(repairing);
+
+    let repaired_entries = fs::read(&entries).unwrap();
+    assert!(repaired_entries
+        .windows(b"AAA-KWJ4VMKVSS66".len())
+        .any(|window| window == b"AAA-KWJ4VMKVSS66"));
+    assert!(!repaired_entries
+        .windows(b"ZAA-KWJ4VMKVSS66".len())
+        .any(|window| window == b"ZAA-KWJ4VMKVSS66"));
+
+    let mut reopened = GraphFederatedCacheTracker::new(cache.clone());
+    let stored = reopened.read_graph(&root, "decisions", true, true).unwrap();
+    assert_eq!(stored.refresh, FederatedCacheRefresh::StoreHit);
+    assert_eq!(stored.generation, generation);
+    assert!(matches!(stored.model, ReadModel::View(_)));
+
+    fs::remove_dir_all(root).unwrap();
+    fs::remove_dir_all(cache).unwrap();
+}
+
+#[test]
+fn cache_inside_read_only_materialisation_serves_fresh_without_writing() {
+    let (root, _a_pin, _b_pin) = direct_fixture("unsafe-cache-root");
+    let cache = root.join("vendor/a/.decided/cache");
+    let mut tracker = GraphFederatedCacheTracker::new(cache.clone());
+
+    let read = tracker.read_graph(&root, "decisions", true, true).unwrap();
+    assert_eq!(read.refresh, FederatedCacheRefresh::Recomposed);
+    assert!(matches!(read.model, ReadModel::Fresh(_)));
+    assert!(
+        !cache.exists(),
+        "a graph cache path inside a read-only materialisation must not be created"
+    );
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn ambiguous_nonexistent_parent_traversal_disables_graph_persistence() {
+    let (root, _a_pin, _b_pin) = direct_fixture("ambiguous-cache-root");
+    let cache = root.join("missing/../vendor/a/.decided/cache");
+    let mut tracker = GraphFederatedCacheTracker::new(cache.clone());
+
+    let read = tracker.read_graph(&root, "decisions", true, true).unwrap();
+    assert_eq!(read.refresh, FederatedCacheRefresh::Recomposed);
+    assert!(matches!(read.model, ReadModel::Fresh(_)));
+    assert!(!root.join("missing").exists());
+    assert!(!root.join("vendor/a/.decided/cache").exists());
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[cfg(unix)]
+#[test]
+fn symlink_ancestor_into_parent_disables_graph_persistence() {
+    use std::os::unix::fs::symlink;
+
+    let (root, _a_pin, _b_pin) = direct_fixture("symlink-cache-root");
+    let link = root.join("cache-link");
+    symlink(root.join("vendor/a/.decided"), &link).unwrap();
+    let cache = link.join("cache");
+    let mut tracker = GraphFederatedCacheTracker::new(cache.clone());
+
+    let read = tracker.read_graph(&root, "decisions", true, true).unwrap();
+    assert_eq!(read.refresh, FederatedCacheRefresh::Recomposed);
+    assert!(matches!(read.model, ReadModel::Fresh(_)));
+    assert!(!root.join("vendor/a/.decided/cache").exists());
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn parent_tamper_fails_closed_and_drops_the_resident_model() {
+    let (root, _a_pin, _b_pin) = direct_fixture("tamper");
+    let cache = scratch("tamper-cache");
+    let mut tracker = GraphFederatedCacheTracker::new(cache.clone());
+    tracker.read_graph(&root, "decisions", true, true).unwrap();
+
+    fs::write(
+        root.join("vendor/a/decisions/policy.md"),
+        decision("AAA-KWJ4VMKVSS66", "tampered policy a"),
+    )
+    .unwrap();
+    let error = match tracker.read_graph(&root, "decisions", true, true) {
+        Ok(_) => panic!("tampered closure must fail closed"),
+        Err(error) => error,
+    };
+    match error {
+        FederatedCacheError::Parent(error) => {
+            assert_eq!(error.code, ParentCorpusErrorCode::DigestMismatch)
+        }
+        other => panic!("expected digest mismatch, got {other}"),
+    }
+    assert_eq!(tracker.current_generation(), None);
+
+    fs::remove_dir_all(root).unwrap();
+    fs::remove_dir_all(cache).unwrap();
+}
+
+#[test]
+fn direct_parent_topology_and_manifest_permutation_fully_recompose() {
+    let (root, a_pin, b_pin) = direct_fixture("topology-permutation");
+    let cache = scratch("topology-permutation-cache");
+    let mut tracker = GraphFederatedCacheTracker::new(cache.clone());
+
+    let first_generation = tracker
+        .read_graph(&root, "decisions", true, true)
+        .unwrap()
+        .generation
+        .to_string();
+    write_manifest(
+        &root,
+        &[
+            Parent {
+                alias: "a",
+                source: A_SOURCE,
+                root: "vendor/a",
+                digest: &a_pin,
+            },
+            Parent {
+                alias: "b",
+                source: B_SOURCE,
+                root: "vendor/b",
+                digest: &b_pin,
+            },
+        ],
+    );
+    let topology = tracker.read_graph(&root, "decisions", true, true).unwrap();
+    assert_eq!(topology.refresh, FederatedCacheRefresh::Recomposed);
+    assert_ne!(topology.generation, first_generation);
+    assert_eq!(topology.metadata.layers.len(), 3);
+    let topology_generation = topology.generation.to_string();
+
+    write_manifest(
+        &root,
+        &[
+            Parent {
+                alias: "b",
+                source: B_SOURCE,
+                root: "vendor/b",
+                digest: &b_pin,
+            },
+            Parent {
+                alias: "a",
+                source: A_SOURCE,
+                root: "vendor/a",
+                digest: &a_pin,
+            },
+        ],
+    );
+    let permuted = tracker.read_graph(&root, "decisions", true, true).unwrap();
+    assert_eq!(permuted.refresh, FederatedCacheRefresh::Recomposed);
+    assert_ne!(permuted.generation, topology_generation);
+    assert_eq!(permuted.metadata.layers.len(), 3);
+
+    fs::remove_dir_all(root).unwrap();
+    fs::remove_dir_all(cache).unwrap();
+}
+
+#[test]
+fn transitive_leaf_change_reverified_and_repinned_through_the_whole_chain() {
+    let (root, base) = chain_fixture("chain");
+    let mid = root.join("vendor/mid");
+    let cache = scratch("chain-cache");
+    let mut tracker = GraphFederatedCacheTracker::new(cache.clone());
+    let first = tracker.read_graph(&root, "decisions", true, true).unwrap();
+    assert_eq!(first.metadata.layers.len(), 3);
+    let first_generation = first.generation.to_string();
+
+    fs::write(
+        base.join("decisions/policy.md"),
+        decision("BAS-KWJ4VMKVSS69", "updated base policy"),
+    )
+    .unwrap();
+    repin_chain(&root, &mid, &base);
+    let second = tracker.read_graph(&root, "decisions", true, true).unwrap();
+    assert_eq!(second.refresh, FederatedCacheRefresh::Recomposed);
+    assert_ne!(second.generation, first_generation);
+    assert_eq!(second.metadata.layers.len(), 3);
+
+    fs::remove_dir_all(root).unwrap();
+    fs::remove_dir_all(cache).unwrap();
+}
+
+#[test]
+fn cache_disabled_uses_the_same_verified_adapter_without_store_io() {
+    let (root, _a_pin, _b_pin) = direct_fixture("cache-disabled");
+    let cache = scratch("cache-disabled-cache");
+    let mut tracker = GraphFederatedCacheTracker::new(cache.clone());
+    let read = tracker.read_graph(&root, "decisions", true, false).unwrap();
+    assert_eq!(read.refresh, FederatedCacheRefresh::Recomposed);
+    assert!(matches!(read.model, ReadModel::Fresh(_)));
+    assert!(read.generation.starts_with("sha256-v3:"));
+    assert!(!cache
+        .join("store")
+        .join(GRAPH_STORE_LAYOUT_VERSION)
+        .exists());
+
+    fs::remove_dir_all(root).unwrap();
+    fs::remove_dir_all(cache).unwrap();
+}

--- a/rust/rac-engine/tests/federation_graph_loader.rs
+++ b/rust/rac-engine/tests/federation_graph_loader.rs
@@ -1,3 +1,4 @@
+use rac_engine::corpus::Layer;
 use rac_engine::federation::{
     calculate_parent_digest_v2, digest_snapshot_v2, load_graph_manifest, load_manifest,
     verify_federation, ParentCorpusErrorCode, SnapshotFile,
@@ -128,6 +129,12 @@ fn verifies_every_diamond_route_then_deduplicates_the_logical_source() {
     assert_eq!(closure.materialisation_roots.len(), 4);
     assert_eq!(closure.node("acme/a").unwrap().manifest_version, Some(2));
     assert!(closure.node("acme/a").unwrap().overrides.is_some());
+    let shared = closure.node("acme/shared").unwrap();
+    assert_eq!(
+        shared.source_route,
+        ["acme/root", "acme/a", "acme/shared"]
+    );
+    assert_eq!(shared.route_count, 2);
     assert_eq!(
         closure
             .root_files
@@ -160,10 +167,17 @@ fn a_tampered_second_diamond_route_fails_instead_of_trusting_the_first_copy() {
 fn same_source_with_distinct_verified_v2_digests_is_a_divergent_pin() {
     let root = scratch("divergent");
     diamond(&root, "different\n");
+    let error = verify_federation(&root, "decisions").unwrap_err();
+    assert_eq!(error.code, ParentCorpusErrorCode::DivergentPin);
     assert_eq!(
-        verify_federation(&root, "decisions").unwrap_err().code,
-        ParentCorpusErrorCode::DivergentPin
+        error.source_route.as_deref().unwrap(),
+        &["acme/root", "acme/a", "acme/shared"]
     );
+    assert_eq!(error.route_count.as_deref().copied(), Some(2));
+    let origin = error.validation_origin.unwrap();
+    assert_eq!(origin.source, "acme/root");
+    assert_eq!(origin.layer, Layer::Local);
+    assert_eq!(origin.pin, None);
     fs::remove_dir_all(root).unwrap();
 }
 
@@ -194,10 +208,14 @@ fn active_root_source_recurrence_is_a_cycle_after_pin_verification() {
         &root,
         &[("branch", "acme/branch", "vendor/branch", &branch_pin)],
     );
+    let error = verify_federation(&root, "decisions").unwrap_err();
+    assert_eq!(error.code, ParentCorpusErrorCode::Cycle);
     assert_eq!(
-        verify_federation(&root, "decisions").unwrap_err().code,
-        ParentCorpusErrorCode::Cycle
+        error.source_route.as_deref().unwrap(),
+        &["acme/root", "acme/branch", "acme/root"]
     );
+    assert_eq!(error.route_count.as_deref().copied(), Some(1));
+    assert_eq!(error.validation_origin.unwrap().source, "acme/root");
     fs::remove_dir_all(root).unwrap();
 }
 
@@ -261,6 +279,60 @@ fn version_one_stays_on_the_existing_loader_path() {
     fs::remove_dir_all(root).unwrap();
 }
 
+#[test]
+fn malformed_version_one_retains_the_exact_v1_diagnostic() {
+    let root = scratch("v1-diagnostic");
+    node(&root, "acme/root", "root\n");
+    fs::write(
+        root.join(".decided/corpus.md"),
+        "# Corpus\n\n## inherits\n\n```yaml\nversion: 1\n```\n\n```yaml\nversion: 1\n```\n",
+    )
+    .unwrap();
+    assert!(load_graph_manifest(&root).unwrap().is_none());
+    let first = load_manifest(&root).unwrap_err();
+    let second = load_manifest(&root).unwrap_err();
+    assert_eq!(first, second);
+    assert_eq!(first.code, ParentCorpusErrorCode::MultipleParents);
+    assert_eq!(
+        first.message,
+        "## inherits must contain exactly one fenced YAML mapping"
+    );
+    assert_eq!(first.validation_origin, None);
+    assert_eq!(first.source_route, None);
+    assert_eq!(first.route_count, None);
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn v2_restrictions_are_scanned_before_value_construction() {
+    let root = scratch("restricted-events");
+    node(&root, "acme/root", "root\n");
+    let digest = "sha256-v2:0000000000000000000000000000000000000000000000000000000000000000";
+    fs::write(
+        root.join(".decided/corpus.md"),
+        format!(
+            "# Corpus\n\n## inherits\n\n```yaml\nversion: &mode 2\nparents:\n  - alias: one\n    source: acme/shared\n    root: vendor/one\n    corpus: decisions\n    digest: {digest}\n```\n"
+        ),
+    )
+    .unwrap();
+    let error = load_graph_manifest(&root).unwrap_err();
+    assert_eq!(error.code, ParentCorpusErrorCode::MalformedManifest);
+    assert!(error.message.contains("forbids anchors"));
+
+    let nested = format!("{}0{}", "[".repeat(33), "]".repeat(33));
+    fs::write(
+        root.join(".decided/corpus.md"),
+        format!(
+            "# Corpus\n\n## inherits\n\n```yaml\nversion: 2\nparents:\n  - alias: one\n    source: acme/shared\n    root: vendor/one\n    corpus: decisions\n    digest: {digest}\nbomb: {nested}\n```\n"
+        ),
+    )
+    .unwrap();
+    let error = load_graph_manifest(&root).unwrap_err();
+    assert_eq!(error.code, ParentCorpusErrorCode::LimitExceeded);
+    assert!(error.message.contains("dimension=yaml-depth"));
+    fs::remove_dir_all(root).unwrap();
+}
+
 #[cfg(unix)]
 #[test]
 fn inherited_hard_links_fail_closed() {
@@ -285,4 +357,75 @@ fn inherited_hard_links_fail_closed() {
         ParentCorpusErrorCode::UnsupportedFilesystem
     );
     fs::remove_dir_all(root).unwrap();
+}
+
+#[cfg(unix)]
+#[test]
+fn every_inherited_regular_entry_is_checked_for_hard_links() {
+    for location in ["config", "manifest", "ignored"] {
+        let root = scratch(&format!("hard-link-{location}"));
+        node(&root, "acme/root", "root\n");
+        let parent = root.join("vendor/parent");
+        node(&parent, "acme/parent", "parent\n");
+        let target = match location {
+            "config" => parent.join(".decided/config.yaml"),
+            "manifest" => {
+                v2_manifest(&parent, &[("leaf", "acme/leaf", "vendor/leaf", "sha256-v2:0000000000000000000000000000000000000000000000000000000000000000")]);
+                parent.join(".decided/corpus.md")
+            }
+            _ => {
+                fs::write(parent.join("decisions/ignored.txt"), "ignored\n").unwrap();
+                parent.join("decisions/ignored.txt")
+            }
+        };
+        fs::hard_link(&target, target.with_extension("hardlink")).unwrap();
+        v2_manifest(
+            &root,
+            &[(
+                "parent",
+                "acme/parent",
+                "vendor/parent",
+                "sha256-v2:0000000000000000000000000000000000000000000000000000000000000000",
+            )],
+        );
+        let error = verify_federation(&root, "decisions").unwrap_err();
+        assert_eq!(error.code, ParentCorpusErrorCode::UnsupportedFilesystem);
+        assert_eq!(error.validation_origin.as_ref().unwrap().source, "acme/root");
+        assert_eq!(
+            error.source_route.as_deref().unwrap(),
+            &["acme/root", "acme/parent"]
+        );
+        assert_eq!(error.route_count.as_deref().copied(), Some(1));
+        fs::remove_dir_all(root).unwrap();
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn root_v2_regular_entries_are_also_checked_for_hard_links() {
+    for location in ["config", "manifest", "markdown", "ignored"] {
+        let root = scratch(&format!("root-hard-link-{location}"));
+        node(&root, "acme/root", "root\n");
+        let parent = root.join("vendor/parent");
+        node(&parent, "acme/parent", "parent\n");
+        let pin = calculate_parent_digest_v2(&parent, "decisions")
+            .unwrap()
+            .digest;
+        v2_manifest(&root, &[("parent", "acme/parent", "vendor/parent", &pin)]);
+        let target = match location {
+            "config" => root.join(".decided/config.yaml"),
+            "manifest" => root.join(".decided/corpus.md"),
+            "markdown" => root.join("decisions/policy.md"),
+            _ => {
+                fs::write(root.join("decisions/ignored.txt"), "ignored\n").unwrap();
+                root.join("decisions/ignored.txt")
+            }
+        };
+        fs::hard_link(&target, target.with_extension("hardlink")).unwrap();
+        assert_eq!(
+            verify_federation(&root, "decisions").unwrap_err().code,
+            ParentCorpusErrorCode::UnsupportedFilesystem
+        );
+        fs::remove_dir_all(root).unwrap();
+    }
 }

--- a/rust/rac-engine/tests/federation_loader.rs
+++ b/rust/rac-engine/tests/federation_loader.rs
@@ -1,12 +1,15 @@
+use rac_engine::federated_corpus::{is_read_only_materialised_path, load_composed_corpus};
 use rac_engine::federation::{
-    calculate_parent_digest, load_manifest, verify_parent, ParentCorpusErrorCode,
+    calculate_parent_digest, direct_graph_materialisation_roots, load_manifest, verify_parent,
+    ParentCorpusErrorCode,
 };
-use rac_engine::federated_corpus::is_read_only_materialised_path;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 static COUNTER: AtomicUsize = AtomicUsize::new(0);
+const V2_ZERO_DIGEST: &str =
+    "sha256-v2:0000000000000000000000000000000000000000000000000000000000000000";
 
 fn scratch(name: &str) -> PathBuf {
     let n = COUNTER.fetch_add(1, Ordering::SeqCst);
@@ -44,6 +47,221 @@ fn child_manifest(root: &Path, source: &str, pin: &str, parent_source: &str) {
         ),
     )
     .unwrap();
+}
+
+fn graph_manifest(root: &Path, source: &str, parents: &[(&str, &str, &str)]) {
+    fs::create_dir_all(root.join(".decided")).unwrap();
+    fs::write(
+        root.join(".decided/config.yaml"),
+        format!("repository_key: APP\ncorpus:\n  source: {source}\n"),
+    )
+    .unwrap();
+    let mut manifest = String::from("# Corpus\n\n## inherits\n\n```yaml\nversion: 2\nparents:\n");
+    for (alias, parent_source, parent_root) in parents {
+        manifest.push_str(&format!(
+            "  - alias: {alias}\n    source: {parent_source}\n    root: {parent_root}\n    corpus: decisions\n    digest: {V2_ZERO_DIGEST}\n"
+        ));
+    }
+    manifest.push_str("```\n\n## overrides\n\n```yaml\nversion: 2\nitems: []\n```\n");
+    fs::write(root.join(".decided/corpus.md"), manifest).unwrap();
+}
+
+#[test]
+fn nearest_config_starts_an_independent_repository_beneath_an_outer_graph() {
+    let outer = scratch("nested-independent-repository");
+    graph_manifest(
+        &outer,
+        "acme/outer",
+        &[("missing", "acme/missing", "vendor/missing")],
+    );
+
+    let nested = outer.join("tools/independent");
+    fs::create_dir_all(nested.join(".decided")).unwrap();
+    fs::create_dir_all(nested.join("decisions")).unwrap();
+    fs::write(
+        nested.join(".decided/config.yaml"),
+        b"repository_key: IND\ncorpus:\n  source: acme/independent\n",
+    )
+    .unwrap();
+
+    assert!(
+        load_composed_corpus(nested.join("decisions").to_str().unwrap(), true)
+            .unwrap()
+            .is_none(),
+        "the outer graph manifest must not govern a nearer configured repository"
+    );
+    fs::remove_dir_all(outer).unwrap();
+}
+
+#[test]
+fn every_direct_v2_parent_and_missing_suffix_is_read_only() {
+    let child = scratch("v2-three-parents");
+    for (root, source) in [
+        ("vendor/one", "acme/one"),
+        ("vendor/two", "acme/two"),
+        ("vendor/three", "acme/three"),
+    ] {
+        parent_at(&child.join(root), source);
+    }
+    graph_manifest(
+        &child,
+        "acme/app",
+        &[
+            ("one", "acme/one", "vendor/one"),
+            ("two", "acme/two", "vendor/two"),
+            ("three", "acme/three", "vendor/three"),
+        ],
+    );
+
+    let roots = direct_graph_materialisation_roots(&child).unwrap().unwrap();
+    assert_eq!(roots.len(), 3);
+    for target in [
+        child.join("vendor/one/decisions/new.md"),
+        child.join("vendor/two/new.html"),
+        child.join("vendor/three/new-okf/nested/file.json"),
+    ] {
+        assert!(
+            is_read_only_materialised_path(&target).unwrap(),
+            "{target:?}"
+        );
+    }
+    fs::remove_dir_all(child).unwrap();
+}
+
+#[test]
+fn transitive_node_local_and_nested_parent_paths_stay_read_only() {
+    let child = scratch("v2-transitive");
+    let branch = child.join("vendor/branch");
+    let leaf = branch.join("vendor/leaf");
+    parent_at(&branch, "acme/branch");
+    parent_at(&leaf, "acme/leaf");
+    graph_manifest(
+        &branch,
+        "acme/branch",
+        &[("leaf", "acme/leaf", "vendor/leaf")],
+    );
+    graph_manifest(
+        &child,
+        "acme/app",
+        &[("branch", "acme/branch", "vendor/branch")],
+    );
+
+    for target in [
+        branch.join("decisions/branch-new.md"),
+        leaf.join("decisions/leaf-new.md"),
+        leaf.join("not-created/deep/output.html"),
+    ] {
+        assert!(
+            is_read_only_materialised_path(&target).unwrap(),
+            "{target:?}"
+        );
+    }
+    fs::remove_dir_all(child).unwrap();
+}
+
+#[test]
+fn v2_siblings_parent_paths_and_traversal_do_not_cross_the_boundary() {
+    let child = scratch("v2-sibling-boundary");
+    let parent = child.join("vendor/standards");
+    parent_at(&parent, "acme/standards");
+    fs::create_dir_all(child.join("vendor/sibling")).unwrap();
+    fs::create_dir_all(child.join("decisions")).unwrap();
+    graph_manifest(
+        &child,
+        "acme/app",
+        &[("standards", "acme/standards", "vendor/standards")],
+    );
+
+    assert!(
+        is_read_only_materialised_path(child.join("vendor/sibling/../standards/new.html")).unwrap()
+    );
+    for target in [
+        child.join("vendor/sibling/new.html"),
+        child.join("decisions/new.md"),
+        child.join("../outside-new.md"),
+    ] {
+        assert!(
+            !is_read_only_materialised_path(&target).unwrap(),
+            "{target:?}"
+        );
+    }
+    fs::remove_dir_all(child).unwrap();
+}
+
+#[cfg(unix)]
+#[test]
+fn v2_symlink_ancestor_cannot_disguise_an_inherited_target() {
+    use std::os::unix::fs::symlink;
+
+    let child = scratch("v2-symlink-ancestor");
+    let parent = child.join("vendor/standards");
+    parent_at(&parent, "acme/standards");
+    graph_manifest(
+        &child,
+        "acme/app",
+        &[("standards", "acme/standards", "vendor/standards")],
+    );
+    symlink(
+        "standards/decisions",
+        child.join("vendor/parent-subdir-link"),
+    )
+    .unwrap();
+
+    let target = child.join("vendor/parent-subdir-link/../new.html");
+    assert!(is_read_only_materialised_path(&target).unwrap());
+    assert!(!target.exists());
+
+    let outside = scratch("v2-symlink-outside-target");
+    symlink(&outside, parent.join("outside-link")).unwrap();
+    let outward_target = parent.join("outside-link/forbidden.html");
+    assert!(is_read_only_materialised_path(&outward_target).unwrap());
+    assert!(!outside.join("forbidden.html").exists());
+    fs::remove_dir_all(outside).unwrap();
+    fs::remove_dir_all(child).unwrap();
+}
+
+#[test]
+fn malformed_v2_manifest_fails_closed_instead_of_using_v1_verification() {
+    let child = scratch("v2-malformed-write-boundary");
+    parent_at(&child.join("vendor/one"), "acme/one");
+    parent_at(&child.join("vendor/two"), "acme/two");
+    graph_manifest(
+        &child,
+        "acme/app",
+        &[
+            ("same", "acme/one", "vendor/one"),
+            ("same", "acme/two", "vendor/two"),
+        ],
+    );
+
+    let error = is_read_only_materialised_path(child.join("decisions/new.md")).unwrap_err();
+    assert_eq!(error.stable_code(), "corpus-federation-duplicate-parent");
+    fs::remove_dir_all(child).unwrap();
+
+    let directory_manifest = scratch("v2-directory-manifest-write-boundary");
+    fs::create_dir_all(directory_manifest.join(".decided/corpus.md")).unwrap();
+    let error = is_read_only_materialised_path(directory_manifest.join("new.md")).unwrap_err();
+    assert_eq!(error.stable_code(), "parent-corpus-symlink-traversal");
+    fs::remove_dir_all(directory_manifest).unwrap();
+}
+
+#[test]
+fn no_manifest_and_v1_write_boundary_behaviour_is_unchanged() {
+    let plain = scratch("write-boundary-no-manifest");
+    fs::create_dir_all(plain.join("decisions")).unwrap();
+    assert!(!is_read_only_materialised_path(plain.join("decisions/new.md")).unwrap());
+    fs::remove_dir_all(plain).unwrap();
+
+    let child = scratch("write-boundary-v1-parity");
+    let parent = child.join("vendor/standards");
+    parent_at(&parent, "acme/standards");
+    let pin = calculate_parent_digest(&parent, "decisions")
+        .unwrap()
+        .digest;
+    child_manifest(&child, "acme/app", &pin, "acme/standards");
+    assert!(is_read_only_materialised_path(parent.join("decisions/new.md")).unwrap());
+    assert!(!is_read_only_materialised_path(child.join("local-new.md")).unwrap());
+    fs::remove_dir_all(child).unwrap();
 }
 
 #[test]

--- a/rust/rac-engine/tests/graph_composition.rs
+++ b/rust/rac-engine/tests/graph_composition.rs
@@ -8,7 +8,7 @@ use rac_engine::graph_composition::{
 };
 use rac_engine::parse::parse_text;
 use rac_engine::relationships::CorpusItem;
-use rac_engine::resolve::{OUTCOME_DUPLICATE, OUTCOME_RESOLVED};
+use rac_engine::resolve::{OUTCOME_AMBIGUOUS, OUTCOME_RESOLVED};
 use rac_engine::spec::spec_for;
 
 const ROOT: &str = "acme/app";
@@ -182,7 +182,7 @@ fn equal_ids_are_legal_and_bare_lookup_is_deterministically_ambiguous() {
             effective_candidates: vec![key(LEFT, "SAME"), key(RIGHT, "SAME"), key(SHARED, "SAME"),],
         })
     );
-    assert_eq!(graph.resolve_identity("SAME").outcome, OUTCOME_DUPLICATE);
+    assert_eq!(graph.resolve_identity("SAME").outcome, OUTCOME_AMBIGUOUS);
     let qualified = graph.resolve_public("acme/shared::SAME").unwrap();
     assert!(qualified.qualified);
     assert_eq!(qualified.selected, key(SHARED, "SAME"));
@@ -585,6 +585,11 @@ fn self_relationship_remains_an_explicit_issue() {
         Some(GraphRelationshipIssue::SelfReference)
     );
     assert_eq!(relationship.effective_terminal, None);
+    let summary = graph.relationship_summary();
+    assert_eq!(summary.total, 1);
+    assert_eq!(summary.valid, 0);
+    assert_eq!(summary.broken, 1);
+    assert_eq!(summary.issues.len(), 1);
 }
 
 #[test]

--- a/rust/rac-engine/tests/graph_federated_corpus.rs
+++ b/rust/rac-engine/tests/graph_federated_corpus.rs
@@ -1,0 +1,341 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use rac_engine::corpus::{ArtifactKey, Layer};
+use rac_engine::federation::{
+    calculate_parent_digest, calculate_parent_digest_v2, verify_federation,
+};
+use rac_engine::graph_federated_corpus::{compose_verified_federation, GRAPH_CORPUS_INVALID_NODE};
+
+static COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+fn scratch(name: &str) -> PathBuf {
+    let sequence = COUNTER.fetch_add(1, Ordering::SeqCst);
+    let path = std::env::temp_dir().join(format!(
+        "asdecided-graph-semantic-{name}-{}-{sequence}",
+        std::process::id()
+    ));
+    fs::create_dir_all(&path).unwrap();
+    path
+}
+
+fn initialise_node(root: &Path, source: &str) {
+    fs::create_dir_all(root.join(".decided")).unwrap();
+    fs::create_dir_all(root.join("decisions")).unwrap();
+    fs::write(
+        root.join(".decided/config.yaml"),
+        format!("repository_key: TST\ncorpus:\n  source: {source}\n"),
+    )
+    .unwrap();
+}
+
+fn decision(id: &str, title: &str) -> String {
+    format!(
+        "---\nschema_version: 1\nid: {id}\ntype: decision\n---\n# {title}\n\n## Status\n\nAccepted\n\n## Context\n\nThe graph fixture needs a deterministic policy.\n\n## Decision\n\nKeep the verified snapshot authoritative.\n\n## Consequences\n\nEvery semantic record retains its source.\n"
+    )
+}
+
+fn write_decision(root: &Path, name: &str, id: &str) -> Vec<u8> {
+    let body = decision(id, name);
+    fs::write(root.join("decisions").join(format!("{name}.md")), &body).unwrap();
+    body.into_bytes()
+}
+
+fn v2_manifest(
+    root: &Path,
+    parents: &[(&str, &str, &str, &str)],
+    overrides: &[(&str, &str, &str)],
+) {
+    let mut manifest = String::from("# Corpus\n\n## inherits\n\n```yaml\nversion: 2\nparents:\n");
+    for (alias, source, parent_root, digest) in parents {
+        manifest.push_str(&format!(
+            "  - alias: {alias}\n    source: {source}\n    root: {parent_root}\n    corpus: decisions\n    digest: {digest}\n"
+        ));
+    }
+    manifest.push_str("```\n\n## overrides\n\n```yaml\nversion: 2\nitems:");
+    if overrides.is_empty() {
+        manifest.push_str(" []\n");
+    } else {
+        manifest.push('\n');
+        for (target, replacement, rationale) in overrides {
+            manifest.push_str(&format!(
+                "  - target: {target}\n    with: {replacement}\n    rationale: {rationale}\n"
+            ));
+        }
+    }
+    manifest.push_str("```\n");
+    fs::write(root.join(".decided/corpus.md"), manifest).unwrap();
+}
+
+fn v1_manifest(
+    root: &Path,
+    alias: &str,
+    source: &str,
+    parent_root: &str,
+    digest: &str,
+    overrides: &[(&str, &str, &str)],
+) {
+    let mut manifest = format!(
+        "# Corpus\n\n## inherits\n\n```yaml\nversion: 1\nalias: {alias}\nsource: {source}\nroot: {parent_root}\ncorpus: decisions\ndigest: {digest}\n```\n\n## overrides\n\n```yaml\nversion: 1\nitems:"
+    );
+    if overrides.is_empty() {
+        manifest.push_str(" []\n");
+    } else {
+        manifest.push('\n');
+        for (target, replacement, rationale) in overrides {
+            manifest.push_str(&format!(
+                "  - parent: {target}\n    with: {replacement}\n    rationale: {rationale}\n"
+            ));
+        }
+    }
+    manifest.push_str("```\n");
+    fs::write(root.join(".decided/corpus.md"), manifest).unwrap();
+}
+
+fn key(source: &str, id: &str) -> ArtifactKey {
+    ArtifactKey::new(source, id)
+}
+
+fn one_parent_graph(name: &str) -> PathBuf {
+    let root = scratch(name);
+    initialise_node(&root, "acme/root");
+    write_decision(&root, "root", "ROOT-KWJ4VMKVSS65");
+    let parent = root.join("vendor/standards");
+    initialise_node(&parent, "acme/standards");
+    write_decision(&parent, "policy", "STD-KWJ4VMKVSS65");
+    let pin = calculate_parent_digest_v2(&parent, "decisions")
+        .unwrap()
+        .digest;
+    v2_manifest(
+        &root,
+        &[("standards", "acme/standards", "vendor/standards", &pin)],
+        &[],
+    );
+    root
+}
+
+#[test]
+fn composes_multiple_nodes_from_captured_bytes_after_checkout_disappears() {
+    let root = scratch("multiple-nodes");
+    initialise_node(&root, "acme/root");
+    let root_bytes = write_decision(&root, "root", "ROOT-KWJ4VMKVSS65");
+
+    let left = root.join("vendor/left");
+    initialise_node(&left, "acme/left");
+    write_decision(&left, "left", "LEFT-KWJ4VMKVSS65");
+    let left_pin = calculate_parent_digest_v2(&left, "decisions")
+        .unwrap()
+        .digest;
+
+    let right = root.join("vendor/right");
+    initialise_node(&right, "acme/right");
+    write_decision(&right, "right", "RIGHT-KWJ4VMKVSS65");
+    let right_pin = calculate_parent_digest_v2(&right, "decisions")
+        .unwrap()
+        .digest;
+
+    v2_manifest(
+        &root,
+        &[
+            ("left", "acme/left", "vendor/left", &left_pin),
+            ("right", "acme/right", "vendor/right", &right_pin),
+        ],
+        &[],
+    );
+    let verified = verify_federation(&root, "decisions").unwrap().unwrap();
+    fs::remove_dir_all(&root).unwrap();
+
+    let graph = compose_verified_federation(verified).unwrap();
+    assert_eq!(graph.composition.catalog().len(), 3);
+    assert_eq!(graph.composition.effective().len(), 3);
+    assert_eq!(
+        graph.content(&key("acme/root", "ROOT-KWJ4VMKVSS65")),
+        Some(root_bytes.as_slice())
+    );
+    assert_eq!(graph.read_only_materialisation_roots.len(), 2);
+    assert_eq!(graph.read_only_corpus_roots.len(), 2);
+    assert_eq!(graph.canonical_layers["acme/root"].layer, Layer::Local);
+    assert_eq!(
+        graph.canonical_layers["acme/left"].pin.as_deref(),
+        Some(left_pin.as_str())
+    );
+    assert_eq!(graph.canonical_layers["acme/left"].alias, None);
+}
+
+#[test]
+fn semantic_paths_are_checkout_independent_and_never_absolute() {
+    let first_root = one_parent_graph("checkout-a");
+    let second_root = one_parent_graph("checkout-b");
+    let first = compose_verified_federation(
+        verify_federation(&first_root, "decisions")
+            .unwrap()
+            .unwrap(),
+    )
+    .unwrap();
+    let second = compose_verified_federation(
+        verify_federation(&second_root, "decisions")
+            .unwrap()
+            .unwrap(),
+    )
+    .unwrap();
+
+    let semantic_paths = |graph: &rac_engine::graph_federated_corpus::VerifiedGraphCorpus| {
+        graph
+            .composition
+            .catalog()
+            .map(|item| (item.key.clone(), item.path.clone()))
+            .collect::<Vec<_>>()
+    };
+    let first_paths = semantic_paths(&first);
+    assert_eq!(first_paths, semantic_paths(&second));
+    assert!(first_paths
+        .iter()
+        .all(|(_, path)| !Path::new(path).is_absolute()));
+    assert!(first_paths
+        .iter()
+        .all(|(_, path)| !path.contains(first_root.to_string_lossy().as_ref())));
+    assert!(first_paths
+        .iter()
+        .all(|(_, path)| !path.contains(second_root.to_string_lossy().as_ref())));
+
+    fs::remove_dir_all(first_root).unwrap();
+    fs::remove_dir_all(second_root).unwrap();
+}
+
+#[test]
+fn lifts_and_composes_a_root_v2_override() {
+    let root = scratch("v2-override");
+    initialise_node(&root, "acme/root");
+    write_decision(&root, "replacement", "ROOT-KWJ4VMKVSS65");
+    write_decision(&root, "rationale", "ROOT-KWJ4VMKVSS66");
+
+    let parent = root.join("vendor/standards");
+    initialise_node(&parent, "acme/standards");
+    write_decision(&parent, "policy", "STD-KWJ4VMKVSS65");
+    let pin = calculate_parent_digest_v2(&parent, "decisions")
+        .unwrap()
+        .digest;
+    v2_manifest(
+        &root,
+        &[("standards", "acme/standards", "vendor/standards", &pin)],
+        &[(
+            "acme/standards::STD-KWJ4VMKVSS65",
+            "ROOT-KWJ4VMKVSS65",
+            "ROOT-KWJ4VMKVSS66",
+        )],
+    );
+
+    let verified = verify_federation(&root, "decisions").unwrap().unwrap();
+    let graph = compose_verified_federation(verified).unwrap();
+    assert_eq!(graph.composition.catalog().len(), 3);
+    assert_eq!(graph.composition.effective().len(), 2);
+    let mapping = &graph.composition.ordered_overrides()[0];
+    assert_eq!(mapping.owner_source, "acme/root");
+    assert_eq!(mapping.target, key("acme/standards", "STD-KWJ4VMKVSS65"));
+    assert_eq!(
+        graph.composition.terminal_redirects().get(&mapping.target),
+        Some(&key("acme/root", "ROOT-KWJ4VMKVSS65"))
+    );
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn lifts_a_valid_nested_v1_override_into_the_graph() {
+    let root = scratch("nested-v1");
+    initialise_node(&root, "acme/root");
+    write_decision(&root, "root", "ROOT-KWJ4VMKVSS65");
+
+    let branch = root.join("vendor/branch");
+    initialise_node(&branch, "acme/branch");
+    write_decision(&branch, "replacement", "BRANCH-KWJ4VMKVSS65");
+    write_decision(&branch, "rationale", "BRANCH-KWJ4VMKVSS66");
+
+    let leaf = branch.join("vendor/leaf");
+    initialise_node(&leaf, "acme/leaf");
+    write_decision(&leaf, "policy", "LEAF-KWJ4VMKVSS65");
+    let leaf_v1_pin = calculate_parent_digest(&leaf, "decisions").unwrap().digest;
+    v1_manifest(
+        &branch,
+        "base",
+        "acme/leaf",
+        "vendor/leaf",
+        &leaf_v1_pin,
+        &[(
+            "base::LEAF-KWJ4VMKVSS65",
+            "BRANCH-KWJ4VMKVSS65",
+            "BRANCH-KWJ4VMKVSS66",
+        )],
+    );
+    let branch_pin = calculate_parent_digest_v2(&branch, "decisions")
+        .unwrap()
+        .digest;
+    v2_manifest(
+        &root,
+        &[("branch", "acme/branch", "vendor/branch", &branch_pin)],
+        &[],
+    );
+
+    let verified = verify_federation(&root, "decisions").unwrap().unwrap();
+    assert_eq!(
+        verified.node("acme/branch").unwrap().manifest_version,
+        Some(1)
+    );
+    let graph = compose_verified_federation(verified).unwrap();
+    assert_eq!(graph.composition.catalog().len(), 4);
+    let mapping = graph
+        .composition
+        .ordered_overrides()
+        .iter()
+        .find(|mapping| mapping.owner_source == "acme/branch")
+        .unwrap();
+    assert_eq!(mapping.target, key("acme/leaf", "LEAF-KWJ4VMKVSS65"));
+    assert_eq!(
+        mapping.replacement,
+        key("acme/branch", "BRANCH-KWJ4VMKVSS65")
+    );
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn invalid_parent_artifact_returns_a_stable_sourced_error() {
+    let root = scratch("invalid-parent");
+    initialise_node(&root, "acme/root");
+    write_decision(&root, "root", "ROOT-KWJ4VMKVSS65");
+
+    let parent = root.join("vendor/invalid");
+    initialise_node(&parent, "acme/invalid");
+    fs::write(
+        parent.join("decisions/broken.md"),
+        "---\nschema_version: 1\nid: BAD-KWJ4VMKVSS65\ntype: decision\n---\n# Broken\n\n## Status\n\nAccepted\n\n## Context\n\nMissing a required section.\n\n## Decision\n\nRemain invalid.\n",
+    )
+    .unwrap();
+    let pin = calculate_parent_digest_v2(&parent, "decisions")
+        .unwrap()
+        .digest;
+    v2_manifest(
+        &root,
+        &[("invalid", "acme/invalid", "vendor/invalid", &pin)],
+        &[],
+    );
+
+    let verified = verify_federation(&root, "decisions").unwrap().unwrap();
+    fs::remove_dir_all(&root).unwrap();
+    let error = match compose_verified_federation(verified) {
+        Ok(_) => panic!("invalid parent artifact must block graph composition"),
+        Err(error) => error,
+    };
+    assert_eq!(error.stable_code(), GRAPH_CORPUS_INVALID_NODE);
+    assert_eq!(error.source.as_deref(), Some("acme/invalid"));
+    assert_eq!(error.relative_path.as_deref(), Some("broken.md"));
+    assert!(error.message.contains("structural error"));
+    let origin = error.validation_origin.as_ref().unwrap();
+    assert_eq!(origin.source, "acme/invalid");
+    assert_eq!(origin.layer, Layer::Inherited);
+    assert!(origin.pin.as_deref().is_some_and(|pin| pin.starts_with("sha256-v2:")));
+    assert_eq!(
+        error.source_route.as_deref().unwrap(),
+        &["acme/root", "acme/invalid"]
+    );
+    assert_eq!(error.route_count.as_deref().copied(), Some(1));
+}

--- a/rust/rac-engine/tests/okf_v02.rs
+++ b/rust/rac-engine/tests/okf_v02.rs
@@ -23,6 +23,7 @@ fn artifact(path: String, id: &str, status: &str, title: &str, tags: &[&str]) ->
         body_html: String::new(),
         tags: tags.iter().map(|tag| (*tag).to_string()).collect(),
         provenance: None,
+        graph_provenance: None,
     }
 }
 
@@ -62,6 +63,10 @@ fn exports_truthful_okf_v02_carrier() {
             from_identity: None,
             to_identity: None,
             provenance: None,
+            graph_provenance: None,
+            authored_token: None,
+            historical_candidates: Vec::new(),
+            effective_terminal: None,
         }],
     };
     let recency = vec![


### PR DESCRIPTION
## Stack

1. #462 — ratify graph decisions
2. #463 — graph foundation
3. **This PR — activate the verified graph engine**
4. #465 — profile guidance and DecisionGrounding evidence

## What this implements

- manifest v2 with multiple direct parents and bounded recursive DAG composition
- independently verified physical routes, cycle/divergent-pin detection, and diamond deduplication
- global `corpus.source::canonical-id` resolution with source-contextual aliases
- equal cross-source IDs as deterministic ambiguity rather than precedence
- explicit Decision-backed override chains and diamond convergence
- one catalog/effective/root-local model across validation, resolution, retrieval, routing, gate, Sentry, exports, MCP, and audit
- closure generation v3 and isolated `store/v3` persistence with fail-closed freshness and corruption repair
- complete source/layer/pin, override-chain, and topology-route provenance
- read-only enforcement across every direct, transitive, and duplicate materialisation route
- additive viewer/documents/graph exports and source-aware Portal navigation
- exact v1 and no-manifest compatibility paths

## Hardening

The implementation uses stable captured bytes throughout digesting, parsing, validation, composition, persistence, and serving. It rejects unsafe YAML, symlink/reparse traversal, hard-linked inherited files, mount boundaries, path escapes, stale pins, invalid topology, and unsafe output/cache targets.

## Validation

- `cargo test --workspace --all-targets --locked --no-fail-fast` — passed
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — passed
- graph CLI contract — 9/9
- graph MCP contract — 5/5
- v1 federation CLI — 14/14
- v1 federation MCP — 8/8
- `decided validate decisions/` — 468 valid, 0 invalid, 12 skipped
- `decided relationships decisions/ --validate` — 3,055 checked, 0 issues
- `decided gate decisions/ --json` — 0 blocking, 134 existing advisories
- `decided review decisions/ --json` — 508 non-blocking issues, health 96
- agent-rules drift check — in sync
- Linux, Windows, and macOS cross-platform certification — passed

Review and merge after #462 and #463.

Closes #270
Closes #272