### PR TITLE
ci: define public release truth checks

### DIFF
--- a/surfacecheck.toml
+++ b/surfacecheck.toml
@@ -1,0 +1,78 @@
+[project]
+name = "AsDecided"
+version_source = "rust/Cargo.toml"
+repository = "https://github.com/asdecided/core"
+homepage = "https://asdecided.com"
+install = "brew install asdecided/tap/asdecided-core"
+release_url = "https://github.com/asdecided/core/releases/tag/v{version}"
+
+[[surface]]
+name = "README"
+kind = "markdown"
+path = "README.md"
+require = [
+  "{install}",
+  "cargo install decided",
+  "cargo install decided-mcp",
+  "https://asdecided.com/changelog",
+]
+
+[[surface]]
+name = "Repository changelog"
+kind = "markdown"
+path = "CHANGELOG.md"
+require = ["## v{version}"]
+
+[[surface]]
+name = "Homepage"
+kind = "url"
+url = "https://asdecided.com/"
+require = ["CURRENT / v{version}", "{install}"]
+canonical = "{homepage}"
+
+[[surface]]
+name = "Public changelog"
+kind = "url"
+url = "https://asdecided.com/changelog"
+require = ["v{version}", "/changelog/v{version}"]
+canonical = "https://asdecided.com/changelog"
+
+[[surface]]
+name = "Release record"
+kind = "url"
+url = "https://asdecided.com/changelog/v{version}"
+require = ["v{version}", "{release_url}"]
+canonical = "https://asdecided.com/changelog/v{version}"
+
+[[surface]]
+name = "Documentation"
+kind = "url"
+url = "https://asdecided.com/docs/"
+require = ["Current product release", "v{version}"]
+canonical = "https://asdecided.com/docs/"
+
+[[surface]]
+name = "Sitemap"
+kind = "sitemap"
+url = "https://asdecided.com/sitemap.xml"
+require = [
+  "https://asdecided.com/changelog/v{version}",
+  "https://asdecided.com/docs/vendor/core/federation/",
+  "https://asdecided.com/docs/vendor/core/export-contracts/",
+]
+
+[[surface]]
+name = "llms.txt"
+kind = "llms"
+url = "https://asdecided.com/llms.txt"
+require = [
+  "Current product release: v{version}",
+  "https://github.com/asdecided/core/releases/tag/v{version}",
+  "https://asdecided.com/docs/vendor/core/federation/",
+]
+
+[github]
+repository = "asdecided/core"
+homepage = "https://asdecided.com"
+description = "Native deterministic engine and read-only MCP server for engineering decisions."
+check_latest_release = true


### PR DESCRIPTION
## What changed

Add `surfacecheck.toml` as the explicit post-release truth contract for AsDecided Core.

It ties the Cargo workspace version to the repository changelog and install instructions, the public homepage and release record, canonical documentation, sitemap, `llms.txt`, GitHub About metadata, and the latest GitHub release. The v0.29 federation and export-contract documentation are required public surfaces.

## Dependency

Requires [tcballard/SurfaceCheck#2](https://github.com/tcballard/SurfaceCheck/pull/2), which adds Cargo workspace version support, templated surface URLs, and native certificate roots. Keep this PR draft until that dependency is available at a pinned ref or release.

## Current v0.29 audit

Against Core `bb4b785` and manifest version `0.29.0`:

- repository-local release facts: pass
- staged v0.29 website: **31 passed, 0 failed**
- live website and GitHub: **24 passed, 14 failed**

The 11 live-site failures are expected before the staged v0.29 site is published. GitHub contributes three remaining failures: latest release is still v0.28.0, the homepage still points to `https://docs.asdecided.com/core/`, and the description still uses the older requirements-as-code wording. The contract intentionally does not accept those stale values.

## Verification

- SurfaceCheck upstream format, clippy, test, and release build gates pass
- site production build and 16/16 rendered-surface tests pass
- site lint reports 0 errors (11 pre-existing `<img>` warnings)
- no tag, release, package, image, registry entry, or site deployment was created