### PR TITLE
fix(release): restore crates.io trusted publishing

### DIFF
--- a/.github/workflows/crates-publish.yml
+++ b/.github/workflows/crates-publish.yml
@@ -1,12 +1,12 @@
 name: Publish crates.io packages
 
+# crates.io trusted publishing binds the OIDC claim to this workflow filename.
+# Keep publication in this top-level workflow rather than invoking it as a
+# reusable workflow from native-publish.yml.
 on:
-  workflow_call:
-    inputs:
-      version:
-        description: Exact workspace version to publish (X.Y.Z or vX.Y.Z)
-        required: true
-        type: string
+  workflow_run:
+    workflows: ["Publish native release"]
+    types: [completed]
   workflow_dispatch:
     inputs:
       version:
@@ -21,6 +21,11 @@ permissions:
 jobs:
   version:
     name: Resolve release version
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'release' &&
+       github.event.workflow_run.head_repository.full_name == github.repository)
     runs-on: ubuntu-latest
     outputs:
       number: ${{ steps.normalize.outputs.number }}
@@ -29,7 +34,7 @@ jobs:
       - name: Normalize and validate version
         id: normalize
         env:
-          REQUESTED_VERSION: ${{ inputs.version }}
+          REQUESTED_VERSION: ${{ github.event.workflow_run.head_branch || inputs.version }}
         run: |
           VERSION="$REQUESTED_VERSION"
           case "$VERSION" in

--- a/.github/workflows/native-publish.yml
+++ b/.github/workflows/native-publish.yml
@@ -219,16 +219,8 @@ jobs:
             cosign sign --yes "$reference"
           done
 
-  crates:
-    name: Publish crates.io packages
-    needs: [evidence, image]
-    permissions:
-      contents: read
-      id-token: write
-    uses: ./.github/workflows/crates-publish.yml
-    with:
-      version: ${{ github.event.release.tag_name }}
-
+  # crates-publish.yml follows this workflow through workflow_run so its OIDC
+  # token carries the filename registered with crates.io trusted publishing.
   mcp-registry:
     name: Publish to MCP Registry
     needs: [evidence, image]


### PR DESCRIPTION
## Why

The v0.28.0 native release produced its archives, images, attestations, SBOM, and MCP Registry record, but the crates.io stage failed during OIDC authentication. crates.io expected `crates-publish.yml`; the reusable call caused the JWT to identify `native-publish.yml` instead.

Failed run: https://github.com/asdecided/core/actions/runs/31315712199

## What changed

- Run `crates-publish.yml` as a top-level `workflow_run` only after a successful release-triggered native publication.
- Require the upstream run to come from this repository.
- Keep the existing manual dispatch recovery path.
- Remove the reusable crates.io call from `native-publish.yml`.

This preserves the release ordering while making the OIDC workflow filename match all three crates.io trusted-publisher records.

## Verification

- Both workflow files parse as YAML.
- The commit changes only the two release workflow files.
- The crates publisher remains idempotent for already-published versions.
- No tag, release, crate, image, registry record, or website deployment is created by this PR.