### PR TITLE
fix(release): support Linux ARM64 builds

### DIFF
--- a/.github/workflows/rust-spike.yml
+++ b/.github/workflows/rust-spike.yml
@@ -31,6 +31,26 @@ on:
       - ".github/workflows/rust-spike.yml"
 
 jobs:
+  linux-arm64-build:
+    name: Linux ARM64 release build
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Install rust toolchain (pinned by rust/rust-toolchain.toml)
+        run: rustup show
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rust
+
+      - name: Build shipped native binaries
+        working-directory: rust
+        run: cargo build --release --locked -p decided -p decided-mcp
+
   windows-runtime:
     name: Windows native runtime smoke
     runs-on: windows-latest

--- a/rust/rac-engine/src/federation.rs
+++ b/rust/rac-engine/src/federation.rs
@@ -971,7 +971,7 @@ fn scan_yaml_events(yaml: &str) -> Result<RestrictedYamlScan, (Option<u64>, Stri
             } else {
                 // SAFETY: libyaml exposes a NUL-terminated problem string while
                 // the parser is alive.
-                unsafe { CStr::from_ptr(parser.0.problem) }
+                unsafe { CStr::from_ptr(parser.0.problem.cast()) }
                     .to_string_lossy()
                     .into_owned()
             };


### PR DESCRIPTION
## Summary

- cast libyaml's parser problem pointer to the target-native `c_char` type before passing it to `CStr::from_ptr`
- add a permanent `ubuntu-24.04-arm` release build gate for the shipped CLI and MCP binaries

## Why

The v0.29.0 release run exposed a Linux ARM64-only compile error because `c_char` is unsigned on that target while `unsafe-libyaml` exposes the field as `*const i8`. The cast preserves the existing bytes and lets `CStr` use the platform-native pointer type.

Failed release job: https://github.com/asdecided/core/actions/runs/33317160802/job/99273737990

## Verification

- `cargo +1.94.1 clippy -p asdecided-core --lib -- -D warnings`
- `cargo +1.94.1 test -p asdecided-core --lib` — 126 passed
- `cargo +1.94.1 build --release --locked -p decided -p decided-mcp`

The added ARM64 job will validate the exact PR head on a native runner.