### PR TITLE
fix(release): dispatch trusted crates publisher

### DIFF
--- a/.github/workflows/crates-publish.yml
+++ b/.github/workflows/crates-publish.yml
@@ -1,12 +1,9 @@
 name: Publish crates.io packages
 
-# crates.io trusted publishing binds the OIDC claim to this workflow filename.
-# Keep publication in this top-level workflow rather than invoking it as a
-# reusable workflow from native-publish.yml.
+# crates.io trusted publishing binds the OIDC claim to this workflow filename
+# and rejects workflow_run events. native-publish.yml dispatches this top-level
+# workflow only after every native and Registry publication gate succeeds.
 on:
-  workflow_run:
-    workflows: ["Publish native release"]
-    types: [completed]
   workflow_dispatch:
     inputs:
       version:
@@ -21,11 +18,6 @@ permissions:
 jobs:
   version:
     name: Resolve release version
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.workflow_run.conclusion == 'success' &&
-       github.event.workflow_run.event == 'release' &&
-       github.event.workflow_run.head_repository.full_name == github.repository)
     runs-on: ubuntu-latest
     outputs:
       number: ${{ steps.normalize.outputs.number }}
@@ -34,7 +26,7 @@ jobs:
       - name: Normalize and validate version
         id: normalize
         env:
-          REQUESTED_VERSION: ${{ github.event.workflow_run.head_branch || inputs.version }}
+          REQUESTED_VERSION: ${{ inputs.version }}
         run: |
           VERSION="$REQUESTED_VERSION"
           case "$VERSION" in

--- a/.github/workflows/native-publish.yml
+++ b/.github/workflows/native-publish.yml
@@ -219,8 +219,6 @@ jobs:
             cosign sign --yes "$reference"
           done
 
-  # crates-publish.yml follows this workflow through workflow_run so its OIDC
-  # token carries the filename registered with crates.io trusted publishing.
   mcp-registry:
     name: Publish to MCP Registry
     needs: [evidence, image]
@@ -230,3 +228,21 @@ jobs:
     uses: ./.github/workflows/mcp-registry-publish.yml
     with:
       version: ${{ github.event.release.tag_name }}
+
+  crates:
+    name: Dispatch crates.io publication
+    needs: [mcp-registry]
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+    env:
+      GH_TOKEN: ${{ github.token }}
+      RELEASE_TAG: ${{ github.event.release.tag_name }}
+    steps:
+      - name: Dispatch trusted publisher workflow
+        run: >-
+          gh workflow run crates-publish.yml
+          --repo "$GITHUB_REPOSITORY"
+          --ref "${{ github.event.repository.default_branch }}"
+          -f version="$RELEASE_TAG"


### PR DESCRIPTION
## Summary

- remove the unsupported `workflow_run` trigger from the crates.io trusted-publishing workflow
- dispatch that top-level workflow with `workflow_dispatch` only after native evidence, signed images, and MCP Registry publication succeed
- retain the exact tag validation, full native release battery, dry runs, idempotent crate checks, and crates.io environment gate

## Why

The recovered v0.29.0 native release completed successfully, but its automatic crates follow-up failed before authentication because crates.io Trusted Publishing rejects OIDC tokens from the `workflow_run` event.

Failed automatic run: https://github.com/asdecided/core/actions/runs/33320762787

The existing `workflow_dispatch` path is accepted by crates.io. Its exact recovery run published all three v0.29.0 crates successfully:

https://github.com/asdecided/core/actions/runs/33321299297

## Verification

- both edited workflows parse as YAML
- `git diff --check`
- production recovery run passed the complete native battery and published `asdecided-core`, `decided`, and `decided-mcp` 0.29.0

This keeps crates publication in the filename registered with crates.io while restoring an automatic, fail-closed handoff for future releases.