### PR TITLE
feat(export): add point-in-time projections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ details, release history over commit history.
 
 ## Unreleased
 
+### Added
+
+- Added deterministic point-in-time JSON exports with `decided export --at
+  <revision>` for the viewer, documents, and graph projections. Historical
+  exports materialise the bounded configured corpus and federation closure so
+  identity and inherited records match that revision without changing `.git`.
+
 ## v0.29.0 — 2026-08-30
 
 ### Graph-complete corpus federation

--- a/decisions/requirements/rac-point-in-time-export.md
+++ b/decisions/requirements/rac-point-in-time-export.md
@@ -10,7 +10,7 @@ type: requirement
 Proposed
 
 Classification: `[internal]` — reproduce any historical corpus state from a
-commit SHA. Feature B of the `corpus-sync` programme: `rac export --at
+commit SHA. Feature B of the `corpus-sync` programme: `decided export --at
 <rev>` over the existing ADR-043 revision-materialisation seam.
 
 ## Problem
@@ -20,35 +20,46 @@ ADR-043 seam, but export cannot use it: there is no way to reproduce the
 corpus's consumption projections as of a named commit. Provenance-grade
 questions — "what did the corpus assert at release X?", "rebuild the index
 our auditors reviewed" — require checkout gymnastics outside the tool. A
-point-in-time export makes every projection a pure function of the
-repository content at a revision, which is the foundation the incremental
-change feed builds on.
+point-in-time export makes every projection a pure function of the repository
+content at a revision for a fixed producing CLI version, which is the
+foundation the incremental change feed builds on.
 
 ## Requirements
 
-- [REQ-001] An additive `rac export --at <rev>` option MUST apply to the three JSON payload modes — the default viewer JSON, `--documents`, and `--graph` — and emit the projection computed from the corpus path's content at git revision `<rev>`, materialised through the existing revision seam: read-only, offline, never mutating `.git` (ADR-043).
+- [REQ-001] An additive `decided export --at <rev>` option MUST apply to the three JSON payload modes — the default viewer JSON, `--documents`, and `--graph` — and emit the projection computed from the corpus path's content at git revision `<rev>`, materialised through the existing revision seam: read-only, offline, never mutating `.git` (ADR-043).
 - [REQ-002] Combining `--at` with `--html`, `--okf`, or `--agent-rules` MUST be rejected as a usage error; those modes write into the working tree and are out of point-in-time scope.
-- [REQ-003] Output MUST be a pure function of the repository content at `<rev>`, the corpus path, and the mode: byte-identical across runs, working directories, and clones of the same commit (ADR-002).
-- [REQ-004] Path fields and the corpus identity in `--at` output MUST be derived from the requested directory argument, never from the materialisation location, so an `--at HEAD` export over a clean working tree is byte-identical to the plain export.
+- [REQ-003] Output MUST be a pure function of the repository content at `<rev>`, the corpus path, the mode, and the producing CLI version: byte-identical across runs, working directories, and clones of the same commit when those inputs match, the required object closure is locally available, and the bounded snapshot admits it (ADR-002).
+- [REQ-004] Path fields and the corpus identity in `--at` output MUST be derived from the requested directory argument, never from the materialisation location, so an `--at HEAD` export is byte-identical to the plain export when worktree bytes match committed blobs, the required submodule object closure is locally available, and the corpus is within the documented snapshot safety limits.
 - [REQ-005] An unknown revision MUST exit non-zero with an actionable message naming the revision; a non-git directory MUST report that it is not a repository; a revision where the corpus path is absent MUST export an empty corpus as a valid result, matching the seam's fresh-adoption semantics.
 - [REQ-006] The viewer payload's tool-version field MUST remain the producing CLI's version — `--at` time-travels content, not the toolchain — and no field carrying wall-clock or environment data may be introduced (ADR-002, ADR-007).
+- [REQ-007] A configured or federated historical export MUST materialise only the requested corpus, governing config and manifest files, and recursively declared parent corpus paths. A submodule-backed path MUST be read offline from the already-local object database at the gitlink commit recorded by the selected revision; unavailable objects MUST fail actionably without fetching or observing the submodule worktree's current commit (ADR-043, ADR-134).
+- [REQ-008] The point-in-time seam MUST fail closed on archive, extraction, or object errors. Git archive attributes (`export-subst` or `export-ignore`) MUST NOT change or omit selected committed bytes; the seam MUST read exact blob objects or reject an affected path rather than violate byte parity.
+- [REQ-009] A governing `.decided/config.yaml` outside the containing Git repository MUST be rejected for `--at`, because that uncommitted ancestor cannot be reproduced from the selected revision.
+- [REQ-010] Revision reads MUST ignore local replace refs, disable lazy object fetching, and bound config/manifest discovery at the temporary snapshot root. The requested repository-relative corpus path MUST be derived from the argument rather than a current worktree symlink or checkout state.
 
 ## Acceptance Criteria
 
 - In a fixture repository with commits A and B where an artifact's body
-  changes between them, `rac export --documents --at <A>` carries the A
+  changes between them, `decided export --documents --at <A>` carries the A
   content and `--at <B>` the B content, each byte-stable across two runs.
-- With a clean working tree at B, `rac export --graph --at <B>` is
-  byte-identical to `rac export --graph`.
-- `rac export --at <unknown-sha>` exits non-zero naming the revision;
-  `rac export --okf --at <A>` exits with the usage error code.
+- With a working tree at B whose bytes match committed blobs and whose fixture
+  is within the snapshot safety limits, `decided export --graph --at <B>` is
+  byte-identical to `decided export --graph`.
+- `decided export --at <unknown-sha>` exits non-zero naming the revision;
+  `decided export --okf --at <A>` exits with the usage error code.
 - `git status` output is identical before and after `--at` runs: no `.git`
   mutation, no worktree registration, no leftover temp state.
+- A vendored parent and a submodule-backed parent whose recorded objects remain
+  local (including a deinitialised, custom-named checkout) each reproduce their
+  checked-out `--at HEAD` federation export byte-for-byte; changing the
+  submodule worktree after the selected superproject commit does not change the
+  historical output.
 
 ## Success Metrics
 
 - A consumer reproduces the exact export their pipeline ingested at a past
-  release from its commit SHA, byte-for-byte, on any clone.
+  release from its commit SHA, byte-for-byte, on any clone with the required
+  object closure available locally and within the snapshot safety limits.
 
 ## Risks
 
@@ -56,16 +67,23 @@ change feed builds on.
   payload and break parity with the plain export. Mitigation: REQ-004 pins
   parity as an acceptance criterion, not an implementation detail.
 - Large-repository materialisation is slow at export scale. Mitigation: the
-  seam archives only the corpus subpath, and the programme's evidence
-  initiative documents a performance floor.
+  read-only snapshot is short-lived and restricted to the corpus, governing
+  metadata, and declared parent closure; the programme's evidence initiative
+  documents a performance floor.
 
 ## Assumptions
 
-- The existing revision seam's semantics (read-only archive, empty corpus
-  for an absent subpath, typed errors for unknown revisions) are sufficient
-  without new git machinery (ADR-043).
+- The existing revision seam's semantics (read-only snapshot, empty corpus for
+  an absent subpath, typed errors for unknown revisions) are sufficient without
+  worktree or network machinery (ADR-043). Point-in-time export extends the
+  seam's selected path set to historical governing metadata and declared
+  parent paths, preserving the configured and federated closure without
+  materialising unrelated repository content.
 - Consumers address revisions by commit SHA or ref name; RAC resolves but
   does not invent revision identifiers.
+- The local Git object database is inside the trusted host boundary. RAC
+  rejects missing, malformed, or type/size-inconsistent objects, while Git
+  remains responsible for detecting hostile on-disk object-store tampering.
 
 ## Related Decisions
 
@@ -74,6 +92,7 @@ change feed builds on.
 - adr-011
 - adr-043
 - adr-080
+- adr-134
 
 ## Related Designs
 

--- a/decisions/roadmaps/corpus-sync.md
+++ b/decisions/roadmaps/corpus-sync.md
@@ -56,7 +56,7 @@ the engine.
   asserted.
 - Any historical corpus state is reproducible from a commit SHA: the
   projections become a pure function of (repository content at revision,
-  corpus path, mode).
+  corpus path, mode, producing CLI version).
 - A backend re-embeds only what changed between two SHAs, with a cursor the
   consumer owns; RAC persists nothing (ADR-080).
 - Consumers chunk at recorded, deterministic section boundaries while the
@@ -83,11 +83,13 @@ highest-leverage enterprise consumability win in the programme.
 ### Point-in-time export (`rac-point-in-time-export`)
 
 `decided export --at <rev>` for the three JSON payload modes, composing the
-ADR-043 revision-materialisation seam exactly as watchkeeper does. Output is
-a pure function of the repository content at the revision — byte-identical
-across runs, working directories, and clones — with paths and corpus
-identity derived from the requested directory, never the materialisation
-location.
+ADR-043 revision-materialisation seam over the bounded corpus, governing
+metadata, and declared parent paths so historical configuration and the
+verified federation closure remain coherent. At a fixed producing CLI version,
+output is a pure function of the repository content at the revision —
+byte-identical across runs, working directories, and clones that have the same
+required object closure available locally — with paths and corpus identity
+derived from the requested directory, never the materialisation location.
 
 ### Incremental change feed (`rac-export-change-feed`)
 
@@ -171,8 +173,10 @@ rather than duplicating them.
 - Every export mode is schema-validated in CI, and a drift test fails when
   the emitted shape and the packaged schema diverge in either direction.
 - `--at` and `--since` outputs are byte-stable across runs and clones of the
-  same commit, asserted by test; an `--at HEAD` export over a clean tree is
-  byte-identical to the plain export.
+  same commit when their required object closures are locally available and
+  within the documented safety limits, asserted by test; an `--at HEAD`
+  export is byte-identical to the plain export when worktree bytes match the
+  committed blobs.
 - The replay law holds in CI: base export plus feed reproduces the head
   export byte-for-byte.
 - A two-corpus merge fixture shows zero `(source, id)` collisions; repeated
@@ -189,7 +193,9 @@ rather than duplicating them.
 ## Assumptions
 
 - The ADR-043 seam is sufficient for read-only revision materialisation at
-  export scale; no new git machinery is needed.
+  export scale. Configured and federated exports extend its bounded path set to
+  governing metadata and the declared parent closure, including locally
+  available submodule commits; no worktree or network machinery is needed.
 - The documents and graph shapes fixed in `corpus-export-shape-contract`
   remain the wire baseline these features extend additively.
 - rac-connectors consumes the feed and anchors without contract changes

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -922,13 +922,14 @@ artifacts — existing output is overwritten.
 
 - **Input:** `decided export [directory]` — scanned recursively for `*.md` (default: current directory).
 - **Modes:** *(default)* viewer JSON to stdout · `--html` (self-contained Portal file) · `--okf` (OKF v0.2 Markdown bundle) · `--documents` (JSONL for memory/RAG backends) · `--graph` (typed node+edge JSON for graph backends) · `--schema <viewer|documents|graph>` (the packaged JSON Schema, without reading a corpus) · `--agent-rules` (per-client agent-context files; see its own behaviour)
-- **Options:** `--out <path>` (only `--html`/`--okf`/`--agent-rules`; the stdout modes are pipeable) · `--json` (no-op for the default mode) · `--local-only` (viewer/HTML, documents, and graph projections only)
-- **Exit codes:** `0` success · `2` not a directory, or `--out` given to a stdout mode
+- **Options:** `--out <path>` (only `--html`/`--okf`/`--agent-rules`; the stdout modes are pipeable) · `--json` (no-op for the default mode) · `--local-only` (viewer/HTML, documents, and graph projections only) · `--at <revision>` (read-only point-in-time viewer, documents, or graph export)
+- **Exit codes:** `0` success · `1` historical object, materialization, or federation validation failure · `2` not a directory, an unknown revision, a non-Git directory used with `--at`, an unsupported option combination, or `--out` given to a stdout mode
 
 ```bash
 decided export decisions/                      # viewer JSON to stdout
 decided export decisions/ --documents          # JSONL, one record per artifact
 decided export decisions/ --graph              # typed node+edge graph
+decided export decisions/ --documents --at v0.29.0 # historical JSONL
 decided export decisions/ --local-only         # writable child records only
 decided export --schema documents              # Draft 2020-12 record schema
 decided export decisions/ --html --out asdecided.html
@@ -940,6 +941,26 @@ their own source, layer, and verified-pin provenance; explicit overrides retain
 both the parent history and local replacement. `--local-only` is a human
 diagnostic/export projection of the writable child records. OKF bundles and
 generated agent rules remain local-only and do not accept the flag.
+
+`--at <revision>` reproduces any of the three JSON projections from a commit,
+tag, or other Git revision without checking it out or mutating `.git`. Only the
+requested corpus and its declared configuration, manifests, and materialised
+parent closure are copied from exact committed blobs. Local submodule objects
+are read at their recorded gitlink commits without fetching. The snapshot
+cannot inherit configuration from its temporary-directory ancestors. If the
+selected revision has no governing config, a currently governing config
+outside the Git repository is rejected because it cannot be reproduced.
+Output paths and corpus display identity still come from the requested
+directory.
+When worktree bytes match the committed blobs, the same submodule object
+closure is available locally, and the corpus is within the snapshot safety
+limits documented below, `--at HEAD` is byte-identical to a plain export.
+HTML, OKF, agent-rules, and schema modes do not accept `--at`.
+
+The bounded snapshot admits at most 50,000 Markdown files, 200,000 visited
+entries, 16 MiB per file, and 512 MiB of selected physical bytes. A selected
+path is limited to 64 components and 4,096 UTF-8 bytes. Exceeding a safety
+limit fails the export with exit code `1` rather than returning partial output.
 
 The three machine-readable payload contracts, compatibility rules, and direct
 schema links are documented on the [Export contracts](export-contracts.md)

--- a/docs/export-contracts.md
+++ b/docs/export-contracts.md
@@ -17,6 +17,24 @@ The emitted bytes are exactly the packaged resources:
 - [documents record v1](https://github.com/asdecided/core/blob/main/rust/rac-engine/assets/schemas/export-documents-v1.schema.json)
 - [graph export v1](https://github.com/asdecided/core/blob/main/rust/rac-engine/assets/schemas/export-graph-v1.schema.json)
 
+Each payload can also be reproduced at a Git revision:
+
+```sh
+decided export decisions/ --at <revision>
+decided export decisions/ --documents --at <revision>
+decided export decisions/ --graph --at <revision>
+```
+
+Point-in-time export is read-only and offline. It evaluates the corpus from a
+temporary, bounded snapshot of exact committed blobs for the corpus and
+declared federation paths at that revision, so historical governing
+configuration and inherited bytes travel together. An already-local submodule
+object database is read at its recorded gitlink commit; no fetch occurs. The
+temporary location, its ancestor configuration, and the revision name never
+enter the payload; paths and display identity retain the requested-directory
+spelling, and `rac_version` remains the version of the CLI producing the
+export.
+
 Those files are the machine-readable source of truth. CI validates exports of
 both a fixed fixture corpus and AsDecided's own decision corpus against them. A
 separate field-set guard also requires the producer and schema to name exactly

--- a/rust/decided/tests/point_in_time_export.rs
+++ b/rust/decided/tests/point_in_time_export.rs
@@ -1,0 +1,480 @@
+//! Black-box contract tests for `decided export --at <rev>`.
+
+use serde_json::Value;
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+static SCRATCH_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+fn scratch_suffix() -> String {
+    let sequence = SCRATCH_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock after epoch")
+        .as_nanos();
+    format!("{}-{nonce}-{sequence}", std::process::id())
+}
+
+struct TestRepo {
+    root: PathBuf,
+    runtime: PathBuf,
+}
+
+impl TestRepo {
+    fn new(label: &str) -> Self {
+        let suffix = scratch_suffix();
+        let root = std::env::temp_dir().join(format!("asdecided-at-{label}-{suffix}"));
+        let runtime = std::env::temp_dir().join(format!("asdecided-at-{label}-runtime-{suffix}"));
+        fs::create_dir_all(&root).expect("create point-in-time repository");
+        fs::create_dir_all(&runtime).expect("create point-in-time runtime directory");
+
+        let repo = Self { root, runtime };
+        repo.git(&["init", "--quiet"]);
+        repo.git(&["config", "user.name", "AsDecided Test"]);
+        repo.git(&["config", "user.email", "test@asdecided.invalid"]);
+        repo.git(&["config", "core.autocrlf", "false"]);
+        repo
+    }
+
+    fn path(&self, relative: &str) -> PathBuf {
+        self.root.join(relative)
+    }
+
+    fn write(&self, relative: &str, contents: &str) {
+        let path = self.path(relative);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("create fixture parent directory");
+        }
+        fs::write(path, contents).expect("write point-in-time fixture");
+    }
+
+    fn configure_corpus(&self) {
+        self.configure_corpus_source("tests/point-in-time");
+    }
+
+    fn configure_corpus_source(&self, source: &str) {
+        self.write(
+            ".decided/config.yaml",
+            &format!("repository_key: PIT\ncorpus:\n  source: {source}\n"),
+        );
+    }
+
+    fn git_output(&self, args: &[&str]) -> Output {
+        Command::new("git")
+            .args(args)
+            .current_dir(&self.root)
+            .env("GIT_CONFIG_NOSYSTEM", "1")
+            .output()
+            .expect("run git for point-in-time fixture")
+    }
+
+    fn git(&self, args: &[&str]) -> String {
+        let output = self.git_output(args);
+        assert!(
+            output.status.success(),
+            "git {args:?} failed with {:?}\nstdout:\n{}\nstderr:\n{}",
+            output.status.code(),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
+    }
+
+    fn commit_all(&self, message: &str) -> String {
+        self.git(&["add", "--all"]);
+        self.git(&["commit", "--quiet", "--message", message]);
+        self.git(&["rev-parse", "HEAD"])
+    }
+
+    fn run(&self, args: &[&str]) -> Output {
+        Command::new(env!("CARGO_BIN_EXE_decided"))
+            .args(args)
+            .current_dir(&self.root)
+            .env("DECIDED_CACHE_DIR", self.runtime.join("decided-cache"))
+            .env("XDG_CACHE_HOME", self.runtime.join("xdg-cache"))
+            .env("XDG_CONFIG_HOME", self.runtime.join("xdg-config"))
+            .env("XDG_STATE_HOME", self.runtime.join("xdg-state"))
+            .output()
+            .expect("run decided point-in-time export")
+    }
+
+    fn status(&self) -> Vec<u8> {
+        self.git_output(&["status", "--porcelain=v1", "--untracked-files=all"])
+            .stdout
+    }
+
+    fn worktree_snapshot(&self) -> BTreeMap<PathBuf, Vec<u8>> {
+        fn visit(root: &Path, directory: &Path, files: &mut BTreeMap<PathBuf, Vec<u8>>) {
+            let mut entries: Vec<_> = fs::read_dir(directory)
+                .expect("read point-in-time worktree")
+                .map(|entry| entry.expect("read point-in-time entry"))
+                .collect();
+            entries.sort_by_key(|entry| entry.file_name());
+            for entry in entries {
+                let path = entry.path();
+                if path == root.join(".git") {
+                    continue;
+                }
+                let file_type = entry.file_type().expect("inspect point-in-time entry");
+                if file_type.is_dir() {
+                    visit(root, &path, files);
+                } else if file_type.is_file() {
+                    files.insert(
+                        path.strip_prefix(root)
+                            .expect("fixture path is beneath root")
+                            .to_path_buf(),
+                        fs::read(path).expect("read point-in-time fixture file"),
+                    );
+                }
+            }
+        }
+
+        let mut files = BTreeMap::new();
+        visit(&self.root, &self.root, &mut files);
+        files
+    }
+}
+
+impl Drop for TestRepo {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.root);
+        let _ = fs::remove_dir_all(&self.runtime);
+    }
+}
+
+fn decision(marker: &str) -> String {
+    format!(
+        "---\nschema_version: 1\nid: PIT-01K000000001\ntype: decision\n---\n# Point-in-Time Decision\n\n## Context\n\nHistorical exports must be reproducible.\n\n## Decision\n\n{marker}\n\n## Consequences\n\nConsumers can recover the selected state.\n\n## Status\n\nAccepted\n"
+    )
+}
+
+fn assert_success(output: &Output, context: &str) {
+    assert!(
+        output.status.success(),
+        "{context} failed with {:?}\nstdout:\n{}\nstderr:\n{}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn documents_export_selects_a_or_b_byte_stably_without_mutating_git() {
+    let repo = TestRepo::new("documents");
+    repo.configure_corpus_source("tests/point-in-time-a");
+    repo.write("decisions/point-in-time.md", &decision("BODY AT COMMIT A"));
+    let commit_a = repo.commit_all("fixture: commit A");
+
+    repo.configure_corpus_source("tests/point-in-time-b");
+    repo.write("decisions/point-in-time.md", &decision("BODY AT COMMIT B"));
+    let commit_b = repo.commit_all("fixture: commit B");
+    let status_before = repo.status();
+
+    let at_a = repo.run(&["export", "decisions", "--documents", "--at", &commit_a]);
+    let at_a_again = repo.run(&["export", "decisions", "--documents", "--at", &commit_a]);
+    let at_b = repo.run(&["export", "decisions", "--documents", "--at", &commit_b]);
+    let at_b_again = repo.run(&["export", "decisions", "--documents", "--at", &commit_b]);
+
+    for (output, context) in [
+        (&at_a, "documents export at A"),
+        (&at_a_again, "repeated documents export at A"),
+        (&at_b, "documents export at B"),
+        (&at_b_again, "repeated documents export at B"),
+    ] {
+        assert_success(output, context);
+    }
+    assert_eq!(at_a.stdout, at_a_again.stdout);
+    assert_eq!(at_b.stdout, at_b_again.stdout);
+    assert_ne!(at_a.stdout, at_b.stdout);
+
+    let document_a: Value = serde_json::from_slice(&at_a.stdout).expect("documents JSONL at A");
+    let document_b: Value = serde_json::from_slice(&at_b.stdout).expect("documents JSONL at B");
+    assert!(document_a["text"]
+        .as_str()
+        .expect("document A text")
+        .contains("BODY AT COMMIT A"));
+    assert!(document_b["text"]
+        .as_str()
+        .expect("document B text")
+        .contains("BODY AT COMMIT B"));
+    assert_eq!(
+        document_a["metadata"]["source"], "tests/point-in-time-a",
+        "commit A must use commit A's corpus source"
+    );
+    assert_eq!(
+        document_b["metadata"]["source"], "tests/point-in-time-b",
+        "commit B must use commit B's corpus source"
+    );
+    assert_eq!(
+        repo.status(),
+        status_before,
+        "export must not mutate git state"
+    );
+}
+
+#[test]
+fn at_head_is_byte_identical_to_plain_viewer_documents_and_graph_exports() {
+    let repo = TestRepo::new("head-parity");
+    repo.configure_corpus();
+    repo.write("decisions/point-in-time.md", &decision("HEAD PARITY BODY"));
+    repo.commit_all("fixture: HEAD parity");
+
+    let absolute_decisions = repo.path("decisions").to_string_lossy().into_owned();
+    for directory in [".", "decisions", absolute_decisions.as_str()] {
+        for mode in [None, Some("--documents"), Some("--graph")] {
+            let mut plain_args = vec!["export", directory];
+            if let Some(mode) = mode {
+                plain_args.push(mode);
+            }
+            let plain = repo.run(&plain_args);
+
+            let mut historical_args = plain_args;
+            historical_args.push("--at=HEAD");
+            let historical = repo.run(&historical_args);
+
+            assert_success(&plain, &format!("plain {mode:?} export from {directory}"));
+            assert_success(
+                &historical,
+                &format!("historical {mode:?} export from {directory}"),
+            );
+            assert_eq!(
+                historical.stdout, plain.stdout,
+                "--at=HEAD changed the {mode:?} payload from {directory}"
+            );
+            assert_eq!(historical.stderr, plain.stderr);
+        }
+    }
+}
+
+#[test]
+fn unknown_revision_and_non_git_directory_are_actionable_usage_errors() {
+    let repo = TestRepo::new("errors");
+    repo.configure_corpus();
+    repo.write("decisions/point-in-time.md", &decision("ERROR FIXTURE"));
+    repo.commit_all("fixture: error surfaces");
+
+    let unknown_name = "definitely-not-a-revision";
+    let unknown = repo.run(&["export", "decisions", "--documents", "--at", unknown_name]);
+    assert_eq!(unknown.status.code(), Some(2));
+    let unknown_stderr = String::from_utf8_lossy(&unknown.stderr);
+    assert!(
+        unknown_stderr.contains(&format!("unknown revision: {unknown_name}")),
+        "stderr={unknown_stderr}"
+    );
+
+    let non_git = std::env::temp_dir().join(format!("asdecided-at-non-git-{}", scratch_suffix()));
+    fs::create_dir_all(&non_git).expect("create non-git directory");
+    fs::write(non_git.join("README.md"), "not a repository\n").expect("write non-git fixture");
+    let non_git_text = non_git.to_string_lossy().into_owned();
+    let output = Command::new(env!("CARGO_BIN_EXE_decided"))
+        .args(["export", &non_git_text, "--at", "HEAD"])
+        .current_dir(&non_git)
+        .output()
+        .expect("run decided outside git");
+    assert_eq!(output.status.code(), Some(2));
+    let non_git_stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        non_git_stderr.contains("not a git repository:"),
+        "stderr={non_git_stderr}"
+    );
+    assert!(
+        non_git_stderr.contains(&non_git_text),
+        "stderr={non_git_stderr}"
+    );
+    fs::remove_dir_all(non_git).expect("remove non-git fixture");
+}
+
+#[test]
+fn an_absent_historical_corpus_exports_as_an_empty_valid_payload() {
+    let repo = TestRepo::new("absent-corpus");
+    repo.configure_corpus();
+    repo.write("README.md", "The corpus is added later.\n");
+    let before_corpus = repo.commit_all("fixture: before corpus adoption");
+
+    repo.write("decisions/point-in-time.md", &decision("ADOPTED LATER"));
+    repo.commit_all("fixture: adopt corpus");
+
+    let output = repo.run(&["export", "decisions", "--at", &before_corpus]);
+    assert_success(&output, "empty historical viewer export");
+    let payload: Value = serde_json::from_slice(&output.stdout).expect("empty viewer JSON");
+    assert_eq!(payload["corpus"]["name"], "decisions");
+    assert_eq!(payload["corpus"]["source"], "tests/point-in-time");
+    assert_eq!(payload["corpus"]["artifact_count"], 0);
+    assert_eq!(payload["artifacts"], Value::Array(Vec::new()));
+    assert_eq!(payload["relationships"], Value::Array(Vec::new()));
+}
+
+#[test]
+fn historical_corpus_can_be_exported_after_its_live_path_is_deleted() {
+    let repo = TestRepo::new("deleted-live-path");
+    repo.configure_corpus();
+    repo.write(
+        "decisions/point-in-time.md",
+        &decision("HISTORICAL PATH BODY"),
+    );
+    let historical = repo.commit_all("fixture: corpus path exists");
+
+    fs::remove_dir_all(repo.path("decisions")).expect("remove live corpus path");
+    repo.commit_all("fixture: remove live corpus path");
+
+    let output = repo.run(&["export", "decisions", "--documents", "--at", &historical]);
+    assert_success(&output, "export deleted live corpus path from history");
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("HISTORICAL PATH BODY"),
+        "historical path was resolved through the current worktree: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn live_symlink_does_not_redirect_the_historical_repository_path() {
+    use std::os::unix::fs::symlink;
+
+    let repo = TestRepo::new("live-symlink-path");
+    repo.configure_corpus();
+    repo.write(
+        "decisions/point-in-time.md",
+        &decision("ORIGINAL DECISIONS BODY"),
+    );
+    let historical = repo.commit_all("fixture: original decisions path");
+
+    fs::rename(repo.path("decisions"), repo.path("archive")).expect("rename live corpus");
+    repo.write(
+        "archive/point-in-time.md",
+        &decision("CURRENT ARCHIVE BODY"),
+    );
+    symlink("archive", repo.path("decisions")).expect("redirect live decisions path");
+    repo.commit_all("fixture: redirect decisions through symlink");
+
+    let output = repo.run(&["export", "decisions", "--documents", "--at", &historical]);
+    assert_success(
+        &output,
+        "export lexical historical path through live symlink",
+    );
+    let body = String::from_utf8_lossy(&output.stdout);
+    assert!(body.contains("ORIGINAL DECISIONS BODY"), "stdout={body}");
+    assert!(!body.contains("CURRENT ARCHIVE BODY"), "stdout={body}");
+}
+
+#[cfg(unix)]
+#[test]
+fn external_live_symlink_cannot_switch_the_historical_repository() {
+    use std::os::unix::fs::symlink;
+
+    let repo = TestRepo::new("external-symlink-source");
+    repo.configure_corpus();
+    repo.write(
+        "alias/point-in-time.md",
+        &decision("SOURCE REPOSITORY BODY"),
+    );
+    let historical = repo.commit_all("fixture: source repository corpus");
+
+    let other = TestRepo::new("external-symlink-target");
+    other.configure_corpus_source("tests/other-repository");
+    other.write(
+        "decisions/point-in-time.md",
+        &decision("OTHER REPOSITORY BODY"),
+    );
+    other.commit_all("fixture: other repository corpus");
+
+    fs::remove_dir_all(repo.path("alias")).expect("remove live source corpus");
+    symlink(other.path("decisions"), repo.path("alias"))
+        .expect("redirect live corpus to another repository");
+
+    let requested = repo.path("alias").to_string_lossy().into_owned();
+    let output = repo.run(&["export", &requested, "--documents", "--at", &historical]);
+    assert_success(
+        &output,
+        "export lexical historical path despite external live symlink",
+    );
+    let body = String::from_utf8_lossy(&output.stdout);
+    assert!(body.contains("SOURCE REPOSITORY BODY"), "stdout={body}");
+    assert!(!body.contains("OTHER REPOSITORY BODY"), "stdout={body}");
+}
+
+#[cfg(unix)]
+#[test]
+fn symlinked_checkout_root_remains_a_valid_historical_repository_address() {
+    use std::os::unix::fs::symlink;
+
+    let repo = TestRepo::new("symlinked-checkout-root");
+    repo.configure_corpus();
+    repo.write(
+        "decisions/point-in-time.md",
+        &decision("SYMLINKED CHECKOUT BODY"),
+    );
+    repo.commit_all("fixture: symlinked checkout corpus");
+
+    let checkout_link = repo.runtime.join("checkout-link");
+    symlink(&repo.root, &checkout_link).expect("create checkout-root symlink");
+    let requested = checkout_link
+        .join("decisions")
+        .to_string_lossy()
+        .into_owned();
+    let output = repo.run(&["export", &requested, "--documents", "--at", "HEAD"]);
+    assert_success(&output, "export through symlinked checkout root");
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("SYMLINKED CHECKOUT BODY"),
+        "stdout={}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}
+
+#[test]
+fn at_rejects_write_and_schema_modes_before_writing_and_requires_a_value() {
+    let repo = TestRepo::new("usage");
+    repo.configure_corpus();
+    repo.write("decisions/point-in-time.md", &decision("USAGE FIXTURE"));
+    repo.commit_all("fixture: usage guards");
+    let worktree_before = repo.worktree_snapshot();
+    let status_before = repo.status();
+
+    for args in [
+        vec!["export", "decisions", "--html", "--at", "HEAD"],
+        vec!["export", "decisions", "--okf", "--at", "HEAD"],
+        vec!["export", "decisions", "--agent-rules", "--at", "HEAD"],
+        vec!["export", "decisions", "--schema", "viewer", "--at", "HEAD"],
+    ] {
+        let output = repo.run(&args);
+        assert_eq!(output.status.code(), Some(2), "args={args:?}");
+        assert!(
+            String::from_utf8_lossy(&output.stderr)
+                .contains("--at is available only for viewer, documents, and graph exports"),
+            "args={args:?}, stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    for args in [
+        vec!["export", "decisions", "--at"],
+        vec!["export", "decisions", "--at="],
+    ] {
+        let output = repo.run(&args);
+        assert_eq!(output.status.code(), Some(2), "args={args:?}");
+        assert!(
+            String::from_utf8_lossy(&output.stderr)
+                .contains("argument --at: expected one argument"),
+            "args={args:?}, stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    assert_eq!(
+        repo.worktree_snapshot(),
+        worktree_before,
+        "rejected --at modes wrote into the worktree"
+    );
+    assert_eq!(
+        repo.status(),
+        status_before,
+        "usage errors mutated git state"
+    );
+    assert!(!repo.path("lore-export.html").exists());
+    assert!(!repo.path("okf-bundle").exists());
+    assert!(!repo.path("AGENTS.md").exists());
+}

--- a/rust/decided/tests/point_in_time_federation.rs
+++ b/rust/decided/tests/point_in_time_federation.rs
@@ -1,0 +1,364 @@
+//! Black-box coverage for point-in-time exports of a committed federation graph.
+
+mod federation_graph_support;
+
+use federation_graph_support::{decision, GraphRepo, ParentEdge, ROOT_ID};
+use serde_json::Value;
+use std::process::{Command, Output};
+
+const PARENT_ID: &str = "STD-01K000000001";
+const PARENT_SOURCE: &str = "acme/standards";
+
+fn run(repo: &GraphRepo, args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_decided"))
+        .args(args)
+        .current_dir(repo.root())
+        .env("DECIDED_CACHE_DIR", repo.root().join(".decided/cache"))
+        .env("XDG_CACHE_HOME", repo.root().join(".xdg/cache"))
+        .env("XDG_CONFIG_HOME", repo.root().join(".xdg/config"))
+        .env("XDG_STATE_HOME", repo.root().join(".xdg/state"))
+        .output()
+        .expect("run decided point-in-time federation contract")
+}
+
+fn git(repo: &GraphRepo, args: &[&str]) -> Output {
+    Command::new("git")
+        .args(args)
+        .current_dir(repo.root())
+        .output()
+        .expect("run Git for point-in-time federation fixture")
+}
+
+fn assert_success(output: &Output, context: &str) {
+    assert!(
+        output.status.success(),
+        "{context} failed with {:?}\nstdout:\n{}\nstderr:\n{}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn commit_fixture(repo: &GraphRepo) {
+    for (context, args) in [
+        ("initialize fixture repository", &["init", "--quiet"][..]),
+        ("stage federation fixture", &["add", "--all"][..]),
+        (
+            "commit federation fixture",
+            &[
+                "-c",
+                "user.name=AsDecided Test",
+                "-c",
+                "user.email=tests@asdecided.dev",
+                "commit",
+                "--quiet",
+                "--message",
+                "test: commit v2 federation fixture",
+            ][..],
+        ),
+    ] {
+        assert_success(&git(repo, args), context);
+    }
+
+    let tree = git(repo, &["ls-tree", "-r", "--name-only", "HEAD"]);
+    assert_success(&tree, "list committed federation tree");
+    let paths = String::from_utf8_lossy(&tree.stdout);
+    for required in [
+        ".decided/config.yaml",
+        ".decided/corpus.md",
+        "decisions/root.md",
+        "vendor/standards/.decided/config.yaml",
+        "vendor/standards/decisions/standards.md",
+    ] {
+        assert!(
+            paths.lines().any(|path| path == required),
+            "committed federation tree omitted {required}:\n{paths}"
+        );
+    }
+}
+
+fn commit_all(repo: &GraphRepo, message: &str) {
+    assert_success(&git(repo, &["add", "--all"]), "stage fixture revision");
+    assert_success(
+        &git(
+            repo,
+            &[
+                "-c",
+                "user.name=AsDecided Test",
+                "-c",
+                "user.email=tests@asdecided.dev",
+                "commit",
+                "--quiet",
+                "--message",
+                message,
+            ],
+        ),
+        "commit fixture revision",
+    );
+}
+
+fn documents(output: &Output, context: &str) -> Vec<Value> {
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(|line| {
+            serde_json::from_str(line)
+                .unwrap_or_else(|error| panic!("{context} emitted invalid JSONL: {error}: {line}"))
+        })
+        .collect()
+}
+
+#[test]
+fn point_in_time_export_preserves_committed_v2_federation_and_local_only_projection() {
+    let repo = GraphRepo::new("point-in-time-export");
+    repo.create_node("vendor/standards", "STD", PARENT_SOURCE);
+    repo.write_node(
+        "vendor/standards",
+        "decisions/standards.md",
+        &decision(PARENT_ID, "Inherited Standards Policy", None),
+    );
+    let pin = repo.v2_digest("vendor/standards", PARENT_SOURCE);
+    repo.write_v2_manifest(
+        "",
+        &[ParentEdge::new(
+            "standards",
+            PARENT_SOURCE,
+            "vendor/standards",
+            pin.clone(),
+        )],
+        &[],
+    );
+    commit_fixture(&repo);
+
+    let current = run(&repo, &["export", "decisions", "--documents"]);
+    assert_success(&current, "export current v2 federation");
+    let historical = run(
+        &repo,
+        &["export", "decisions", "--documents", "--at", "HEAD"],
+    );
+    assert_success(&historical, "export committed v2 federation at HEAD");
+    assert_eq!(
+        historical.stdout, current.stdout,
+        "point-in-time documents bytes differ from the same checked-out revision"
+    );
+    assert_eq!(
+        historical.stderr, current.stderr,
+        "point-in-time export findings differ from the same checked-out revision"
+    );
+
+    let exported = documents(&historical, "historical federation export");
+    let inherited = exported
+        .iter()
+        .find(|document| document["id"].as_str() == Some(PARENT_ID))
+        .expect("historical export includes inherited parent content");
+    assert!(
+        inherited["text"]
+            .as_str()
+            .is_some_and(|text| text.contains("Inherited Standards Policy")),
+        "historical export omitted inherited parent body: {inherited}"
+    );
+    assert_eq!(
+        inherited["metadata"]["source"].as_str(),
+        Some(PARENT_SOURCE)
+    );
+    assert_eq!(
+        inherited["metadata"]["provenance"]["source"].as_str(),
+        Some(PARENT_SOURCE)
+    );
+    assert_eq!(
+        inherited["metadata"]["provenance"]["layer"].as_str(),
+        Some("inherited")
+    );
+    assert_eq!(
+        inherited["metadata"]["provenance"]["pin"].as_str(),
+        Some(pin.as_str())
+    );
+
+    let local = run(
+        &repo,
+        &[
+            "export",
+            "decisions",
+            "--documents",
+            "--local-only",
+            "--at",
+            "HEAD",
+        ],
+    );
+    assert_success(&local, "export historical local-only projection");
+    let local_documents = documents(&local, "historical local-only export");
+    assert_eq!(
+        local_documents.len(),
+        1,
+        "local-only export: {local_documents:?}"
+    );
+    assert_eq!(local_documents[0]["id"].as_str(), Some(ROOT_ID));
+    assert!(
+        local_documents
+            .iter()
+            .all(|document| document["metadata"]["source"].as_str() != Some(PARENT_SOURCE)),
+        "local-only historical export retained inherited provenance: {local_documents:?}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn historical_child_walk_prunes_nested_parent_roots_before_snapshot_validation() {
+    use std::os::unix::fs::symlink;
+
+    let repo = GraphRepo::new("point-in-time-parent-root-pruning");
+    repo.create_node("decisions/vendor/standards", "STD", PARENT_SOURCE);
+    repo.write_node(
+        "decisions/vendor/standards",
+        "decisions/standards.md",
+        &decision(PARENT_ID, "Inherited Standards Policy", None),
+    );
+    std::fs::create_dir_all(repo.path("decisions/vendor/standards/other"))
+        .expect("create unrelated parent content");
+    symlink(
+        "elsewhere",
+        repo.path("decisions/vendor/standards/other/unrelated.md"),
+    )
+    .expect("create unrelated committed symlink");
+    let pin = repo.v2_digest("decisions/vendor/standards", PARENT_SOURCE);
+    repo.write_v2_manifest(
+        "",
+        &[ParentEdge::new(
+            "standards",
+            PARENT_SOURCE,
+            "decisions/vendor/standards",
+            pin,
+        )],
+        &[],
+    );
+    assert_success(
+        &git(&repo, &["init", "--quiet"]),
+        "initialize parent-root pruning repository",
+    );
+    commit_all(&repo, "test: commit nested parent-root pruning fixture");
+
+    let current = run(&repo, &["export", "decisions", "--documents"]);
+    assert_success(&current, "export live graph with unrelated parent content");
+    let historical = run(
+        &repo,
+        &["export", "decisions", "--documents", "--at", "HEAD"],
+    );
+    assert_success(
+        &historical,
+        "export historical graph with nested parent root pruning",
+    );
+    assert_eq!(historical.stdout, current.stdout);
+    assert_eq!(historical.stderr, current.stderr);
+}
+
+#[test]
+fn absent_historical_child_corpus_is_empty_even_when_its_manifest_has_a_parent() {
+    let repo = GraphRepo::new("absent-historical-child");
+    std::fs::remove_dir_all(repo.path("decisions")).expect("remove the old child corpus path");
+    repo.create_node("vendor/standards", "STD", PARENT_SOURCE);
+    repo.write_node(
+        "vendor/standards",
+        "decisions/standards.md",
+        &decision(PARENT_ID, "Inherited Standards Policy", None),
+    );
+    let pin = repo.v2_digest("vendor/standards", PARENT_SOURCE);
+    repo.write_v2_manifest(
+        "",
+        &[ParentEdge::new(
+            "standards",
+            PARENT_SOURCE,
+            "vendor/standards",
+            pin,
+        )],
+        &[],
+    );
+
+    assert_success(
+        &git(&repo, &["init", "--quiet"]),
+        "initialize absent-corpus repository",
+    );
+    commit_all(&repo, "test: commit revision without child corpus");
+    let old_revision = git(&repo, &["rev-parse", "HEAD"]);
+    assert_success(&old_revision, "resolve absent-corpus revision");
+    let old_revision = String::from_utf8(old_revision.stdout)
+        .expect("Git revision is UTF-8")
+        .trim()
+        .to_string();
+
+    repo.write("decisions/root.md", &decision(ROOT_ID, "Root Policy", None));
+    commit_all(&repo, "test: add child corpus");
+    let current = run(&repo, &["export", "decisions", "--documents"]);
+    assert_success(&current, "export later federation revision");
+    assert!(
+        current
+            .stdout
+            .windows(ROOT_ID.len())
+            .any(|bytes| bytes == ROOT_ID.as_bytes())
+            && current
+                .stdout
+                .windows(PARENT_ID.len())
+                .any(|bytes| bytes == PARENT_ID.as_bytes()),
+        "later revision should prove both local and inherited records are exportable: {}",
+        String::from_utf8_lossy(&current.stdout)
+    );
+
+    let historical = run(
+        &repo,
+        &["export", "decisions", "--documents", "--at", &old_revision],
+    );
+    assert_success(
+        &historical,
+        "export revision where requested child corpus is absent",
+    );
+    assert!(
+        historical.stdout.is_empty(),
+        "an absent historical child corpus must not project inherited records: {}",
+        String::from_utf8_lossy(&historical.stdout)
+    );
+    assert!(
+        historical.stderr.is_empty(),
+        "an absent historical child corpus emitted findings: {}",
+        String::from_utf8_lossy(&historical.stderr)
+    );
+}
+
+#[test]
+fn absent_declared_parent_corpus_is_not_fabricated_as_an_empty_snapshot() {
+    let repo = GraphRepo::new("missing-historical-parent-corpus");
+    repo.create_node("vendor/standards", "STD", PARENT_SOURCE);
+    let empty_pin = repo.v2_digest("vendor/standards", PARENT_SOURCE);
+    std::fs::remove_dir_all(repo.path("vendor/standards/decisions"))
+        .expect("remove declared parent corpus before commit");
+    repo.write_v2_manifest(
+        "",
+        &[ParentEdge::new(
+            "standards",
+            PARENT_SOURCE,
+            "vendor/standards",
+            empty_pin,
+        )],
+        &[],
+    );
+    assert_success(
+        &git(&repo, &["init", "--quiet"]),
+        "initialize missing-parent repository",
+    );
+    commit_all(&repo, "test: commit missing declared parent corpus");
+
+    let historical = run(
+        &repo,
+        &["export", "decisions", "--documents", "--at", "HEAD"],
+    );
+    assert_eq!(
+        historical.status.code(),
+        Some(1),
+        "missing parent corpus must be a materialization failure\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&historical.stdout),
+        String::from_utf8_lossy(&historical.stderr)
+    );
+    assert!(historical.stdout.is_empty());
+    assert!(
+        String::from_utf8_lossy(&historical.stderr).contains("path does not exist at revision"),
+        "stderr={}",
+        String::from_utf8_lossy(&historical.stderr)
+    );
+}

--- a/rust/decided/tests/point_in_time_guards.rs
+++ b/rust/decided/tests/point_in_time_guards.rs
@@ -1,0 +1,355 @@
+//! Black-box guards for historical exports that cannot reproduce the
+//! governing configuration or committed bytes from the selected repository.
+
+use serde_json::Value;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+static SCRATCH_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+fn scratch_suffix() -> String {
+    let sequence = SCRATCH_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock after epoch")
+        .as_nanos();
+    format!("{}-{nonce}-{sequence}", std::process::id())
+}
+
+struct TestRepo {
+    scratch: PathBuf,
+    root: PathBuf,
+}
+
+impl TestRepo {
+    fn new(label: &str) -> Self {
+        Self::new_with_git_directory(label, false).0
+    }
+
+    fn new_with_external_git_directory(label: &str) -> (Self, PathBuf) {
+        Self::new_with_git_directory(label, true)
+    }
+
+    fn new_with_git_directory(label: &str, separate_git_directory: bool) -> (Self, PathBuf) {
+        let scratch =
+            std::env::temp_dir().join(format!("asdecided-at-guard-{label}-{}", scratch_suffix()));
+        let root = scratch.join("repository");
+        fs::create_dir_all(&root).expect("create point-in-time guard repository");
+
+        let repo = Self { scratch, root };
+        let resolved_git_directory = if separate_git_directory {
+            repo.scratch.join("external.git")
+        } else {
+            repo.root.join(".git")
+        };
+        if separate_git_directory {
+            let git_directory = resolved_git_directory.to_string_lossy().into_owned();
+            repo.git(&[
+                "init",
+                "--quiet",
+                "--separate-git-dir",
+                git_directory.as_str(),
+            ]);
+        } else {
+            repo.git(&["init", "--quiet"]);
+        }
+        repo.git(&["config", "user.name", "AsDecided Test"]);
+        repo.git(&["config", "user.email", "test@asdecided.invalid"]);
+        repo.git(&["config", "core.autocrlf", "false"]);
+        (repo, resolved_git_directory)
+    }
+
+    fn path(&self, relative: &str) -> PathBuf {
+        self.root.join(relative)
+    }
+
+    fn write(&self, relative: &str, contents: &str) {
+        let path = self.path(relative);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("create point-in-time guard fixture directory");
+        }
+        fs::write(path, contents).expect("write point-in-time guard fixture");
+    }
+
+    fn git(&self, args: &[&str]) -> String {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(&self.root)
+            .env("GIT_CONFIG_NOSYSTEM", "1")
+            .output()
+            .expect("run git for point-in-time guard fixture");
+        assert!(
+            output.status.success(),
+            "git {args:?} failed with {:?}\nstdout:\n{}\nstderr:\n{}",
+            output.status.code(),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
+    }
+
+    fn commit_all(&self) {
+        self.git(&["add", "--all"]);
+        self.git(&[
+            "commit",
+            "--quiet",
+            "--message",
+            "test: point-in-time materialization guard",
+        ]);
+    }
+
+    fn run(&self, corpus: &Path, revision: Option<&str>) -> Output {
+        self.run_with_temp(corpus, revision, None)
+    }
+
+    fn run_with_temp(&self, corpus: &Path, revision: Option<&str>, temp: Option<&Path>) -> Output {
+        let corpus = corpus.to_string_lossy().into_owned();
+        let mut args = vec!["export", corpus.as_str(), "--documents"];
+        if let Some(revision) = revision {
+            args.extend(["--at", revision]);
+        }
+        let mut command = Command::new(env!("CARGO_BIN_EXE_decided"));
+        command
+            .args(args)
+            .current_dir(&self.root)
+            .env("DECIDED_CACHE_DIR", self.scratch.join("cache"))
+            .env("XDG_CACHE_HOME", self.scratch.join("xdg-cache"))
+            .env("XDG_CONFIG_HOME", self.scratch.join("xdg-config"))
+            .env("XDG_STATE_HOME", self.scratch.join("xdg-state"));
+        if let Some(temp) = temp {
+            command.env("TMPDIR", temp);
+        }
+        command
+            .output()
+            .expect("run decided point-in-time guard fixture")
+    }
+}
+
+impl Drop for TestRepo {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.scratch);
+    }
+}
+
+fn decision(extra: &str) -> String {
+    format!(
+        "---\nschema_version: 1\nid: PIT-01K000000099\ntype: decision\n---\n# Guarded Historical Export\n\n## Context\n\nHistorical bytes must be exact.\n\n## Decision\n\nKeep materialization strict. {extra}\n\n## Consequences\n\nInexact snapshots fail closed.\n\n## Status\n\nAccepted\n"
+    )
+}
+
+fn assert_usage_error(output: &Output, expected: &[&str]) {
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "guard failure emitted a partial export: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    for fragment in expected {
+        assert!(
+            stderr.contains(fragment),
+            "missing {fragment:?} in actionable usage error: {stderr}"
+        );
+    }
+}
+
+#[test]
+fn governing_config_above_git_top_level_is_rejected() {
+    let repo = TestRepo::new("outside-governance");
+    fs::create_dir_all(repo.scratch.join(".decided")).expect("create governing config directory");
+    fs::write(
+        repo.scratch.join(".decided/config.yaml"),
+        "repository_key: OUT\ncorpus:\n  source: tests/outside-governance\n",
+    )
+    .expect("write governing config outside repository");
+    repo.write("decisions/decision.md", &decision(""));
+    repo.commit_all();
+
+    let output = repo.run(&repo.path("decisions"), Some("HEAD"));
+
+    assert_usage_error(&output, &[".decided/config.yaml", "outside", "repository"]);
+}
+
+#[test]
+fn historical_in_repository_config_wins_over_a_current_outside_ancestor() {
+    let repo = TestRepo::new("historical-in-repository-governance");
+    repo.write(
+        ".decided/config.yaml",
+        "repository_key: PIT\ncorpus:\n  source: tests/historical-governance\n",
+    );
+    repo.write("decisions/decision.md", &decision("HISTORICAL GOVERNANCE"));
+    repo.commit_all();
+    let historical = repo.git(&["rev-parse", "HEAD"]);
+
+    fs::remove_file(repo.path(".decided/config.yaml")).expect("remove current repository config");
+    fs::create_dir_all(repo.scratch.join(".decided")).expect("create outside config directory");
+    fs::write(
+        repo.scratch.join(".decided/config.yaml"),
+        "repository_key: OUT\ncorpus:\n  source: tests/outside-governance\n",
+    )
+    .expect("write outside current config");
+
+    let output = repo.run(&repo.path("decisions"), Some(&historical));
+    assert!(
+        output.status.success(),
+        "historical in-repository config was shadowed by current outside config: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("tests/historical-governance"),
+        "stdout={stdout}"
+    );
+    assert!(
+        !stdout.contains("tests/outside-governance"),
+        "stdout={stdout}"
+    );
+}
+
+#[test]
+fn temporary_directory_ancestor_config_cannot_inject_historical_identity() {
+    let repo = TestRepo::new("temporary-ancestor-boundary");
+    repo.write("decisions/decision.md", &decision("BOUNDED SNAPSHOT"));
+    repo.commit_all();
+    let ambient = repo.scratch.join("ambient-temp");
+    fs::create_dir_all(ambient.join(".decided")).expect("create ambient temp config directory");
+    fs::write(
+        ambient.join(".decided/config.yaml"),
+        "repository_key: AMBIENT\ncorpus:\n  source: tests/ambient-temp\n",
+    )
+    .expect("write ambient temp config");
+
+    let output = repo.run_with_temp(&repo.path("decisions"), Some("HEAD"), Some(&ambient));
+    assert!(
+        output.status.success(),
+        "ambient temp config disrupted historical export: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(!stdout.contains("tests/ambient-temp"), "stdout={stdout}");
+    let payload: Value = serde_json::from_slice(&output.stdout).expect("parse viewer export");
+    assert_eq!(
+        payload["metadata"]["source"], "decisions",
+        "stdout={stdout}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn snapshot_temp_base_inside_repository_is_rejected_before_any_write() {
+    let repo = TestRepo::new("repository-temp-boundary");
+    repo.write(
+        "decisions/decision.md",
+        &decision("NO REPOSITORY TEMP WRITE"),
+    );
+    repo.commit_all();
+
+    let output = repo.run_with_temp(&repo.path("decisions"), Some("HEAD"), Some(&repo.root));
+    assert_eq!(output.status.code(), Some(1));
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("revision snapshot base must be outside the selected repository"),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let leaked = fs::read_dir(&repo.root)
+        .expect("read repository root")
+        .filter_map(Result::ok)
+        .any(|entry| {
+            entry
+                .file_name()
+                .to_string_lossy()
+                .starts_with("decided-revision-")
+        });
+    assert!(
+        !leaked,
+        "snapshot temp directory was created inside repository"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn snapshot_temp_base_inside_external_git_directory_is_rejected_before_any_write() {
+    let (repo, git_directory) = TestRepo::new_with_external_git_directory("external-git-temp");
+    repo.write(
+        "decisions/decision.md",
+        &decision("NO EXTERNAL GIT TEMP WRITE"),
+    );
+    repo.commit_all();
+
+    let output = repo.run_with_temp(&repo.path("decisions"), Some("HEAD"), Some(&git_directory));
+    assert_eq!(output.status.code(), Some(1));
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("revision snapshot base must be outside the selected Git directory"),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let leaked = fs::read_dir(&git_directory)
+        .expect("read external Git directory")
+        .filter_map(Result::ok)
+        .any(|entry| {
+            entry
+                .file_name()
+                .to_string_lossy()
+                .starts_with("decided-revision-")
+        });
+    assert!(
+        !leaked,
+        "snapshot temp directory was created inside external Git directory"
+    );
+}
+
+fn assert_export_attribute_preserves_bytes(attribute: &str, extra: &str) {
+    let repo = TestRepo::new(attribute);
+    repo.write(
+        ".decided/config.yaml",
+        "repository_key: PIT\ncorpus:\n  source: tests/materialization-guards\n",
+    );
+    repo.write("decisions/decision.md", &decision(extra));
+    repo.write(
+        ".gitattributes",
+        &format!("decisions/decision.md {attribute}\n"),
+    );
+    repo.commit_all();
+
+    let plain = repo.run(&repo.path("decisions"), None);
+    let historical = repo.run(&repo.path("decisions"), Some("HEAD"));
+
+    for (output, context) in [(&plain, "plain export"), (&historical, "historical export")] {
+        assert!(
+            output.status.success(),
+            "{context} with {attribute} failed with {:?}\nstdout:\n{}\nstderr:\n{}",
+            output.status.code(),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    assert_eq!(
+        historical.stdout, plain.stdout,
+        "{attribute} changed committed bytes in the historical export"
+    );
+    assert!(
+        String::from_utf8_lossy(&historical.stdout).contains(extra),
+        "{attribute} export did not preserve the exact corpus marker {extra:?}"
+    );
+}
+
+#[test]
+fn export_ignore_on_a_corpus_path_does_not_omit_committed_bytes() {
+    assert_export_attribute_preserves_bytes("export-ignore", "EXPORT IGNORE BODY");
+}
+
+#[test]
+fn export_subst_on_a_corpus_path_does_not_rewrite_committed_bytes() {
+    assert_export_attribute_preserves_bytes("export-subst", "$Format:%H$");
+}

--- a/rust/decided/tests/point_in_time_submodule.rs
+++ b/rust/decided/tests/point_in_time_submodule.rs
@@ -1,0 +1,329 @@
+//! Black-box coverage for historical federation through a local Git submodule.
+
+mod federation_graph_support;
+
+use federation_graph_support::{decision, GraphRepo, ParentEdge};
+use serde_json::Value;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+const PARENT_ID: &str = "STD-01K000000001";
+const PARENT_SOURCE: &str = "acme/standards";
+const P1_TITLE: &str = "P1 Standards Policy";
+const P2_TITLE: &str = "P2 Standards Policy";
+
+struct ParentRepo {
+    root: PathBuf,
+}
+
+impl ParentRepo {
+    fn new(superproject: &GraphRepo) -> Self {
+        let name = superproject
+            .root()
+            .file_name()
+            .expect("superproject has a final path component")
+            .to_string_lossy();
+        let root = superproject
+            .root()
+            .with_file_name(format!("{name}-submodule-origin"));
+        fs::create_dir_all(root.join(".decided")).expect("create parent config directory");
+        fs::create_dir_all(root.join("decisions")).expect("create parent corpus");
+        fs::write(
+            root.join(".decided/config.yaml"),
+            format!("repository_key: STD\ncorpus:\n  source: {PARENT_SOURCE}\n"),
+        )
+        .expect("write parent config");
+
+        let parent = Self { root };
+        assert_success(
+            &git(&parent.root, &["init", "--quiet"]),
+            "initialize parent repository",
+        );
+        assert_success(
+            &git(&parent.root, &["config", "user.name", "AsDecided Test"]),
+            "configure parent author name",
+        );
+        assert_success(
+            &git(
+                &parent.root,
+                &["config", "user.email", "tests@asdecided.dev"],
+            ),
+            "configure parent author email",
+        );
+        assert_success(
+            &git(&parent.root, &["config", "core.autocrlf", "false"]),
+            "disable parent line-ending conversion",
+        );
+        parent.write_policy(P1_TITLE);
+        parent.commit("test: parent P1");
+        parent
+    }
+
+    fn write_policy(&self, title: &str) {
+        fs::write(
+            self.root.join("decisions/standards.md"),
+            decision(PARENT_ID, title, None),
+        )
+        .expect("write parent policy");
+    }
+
+    fn commit(&self, message: &str) -> String {
+        assert_success(&git(&self.root, &["add", "--all"]), "stage parent revision");
+        assert_success(
+            &git(&self.root, &["commit", "--quiet", "--message", message]),
+            "commit parent revision",
+        );
+        git_stdout(
+            &self.root,
+            &["rev-parse", "HEAD"],
+            "resolve parent revision",
+        )
+    }
+}
+
+impl Drop for ParentRepo {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.root);
+    }
+}
+
+fn git(directory: &Path, args: &[&str]) -> Output {
+    Command::new("git")
+        .args(args)
+        .current_dir(directory)
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .output()
+        .expect("run Git for submodule fixture")
+}
+
+fn git_stdout(directory: &Path, args: &[&str], context: &str) -> String {
+    let output = git(directory, args);
+    assert_success(&output, context);
+    String::from_utf8(output.stdout)
+        .expect("Git output is UTF-8")
+        .trim()
+        .to_string()
+}
+
+fn run(repo: &GraphRepo, args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_decided"))
+        .args(args)
+        .current_dir(repo.root())
+        .env("DECIDED_CACHE_DIR", repo.root().join(".decided/cache"))
+        .env("XDG_CACHE_HOME", repo.root().join(".xdg/cache"))
+        .env("XDG_CONFIG_HOME", repo.root().join(".xdg/config"))
+        .env("XDG_STATE_HOME", repo.root().join(".xdg/state"))
+        .output()
+        .expect("run decided submodule federation contract")
+}
+
+fn assert_success(output: &Output, context: &str) {
+    assert!(
+        output.status.success(),
+        "{context} failed with {:?}\nstdout:\n{}\nstderr:\n{}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn commit_superproject(repo: &GraphRepo, message: &str) -> String {
+    assert_success(&git(repo.root(), &["add", "--all"]), "stage superproject");
+    assert_success(
+        &git(
+            repo.root(),
+            &[
+                "-c",
+                "user.name=AsDecided Test",
+                "-c",
+                "user.email=tests@asdecided.dev",
+                "commit",
+                "--quiet",
+                "--message",
+                message,
+            ],
+        ),
+        "commit superproject",
+    );
+    git_stdout(
+        repo.root(),
+        &["rev-parse", "HEAD"],
+        "resolve superproject revision",
+    )
+}
+
+fn documents(output: &Output, context: &str) -> Vec<Value> {
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(|line| {
+            serde_json::from_str(line)
+                .unwrap_or_else(|error| panic!("{context} emitted invalid JSONL: {error}: {line}"))
+        })
+        .collect()
+}
+
+#[test]
+fn point_in_time_export_follows_recorded_submodule_commit_not_its_worktree() {
+    let repo = GraphRepo::new("point-in-time-submodule");
+    let parent = ParentRepo::new(&repo);
+    let p1 = git_stdout(&parent.root, &["rev-parse", "HEAD"], "resolve parent P1");
+
+    assert_success(
+        &git(repo.root(), &["init", "--quiet"]),
+        "initialize superproject",
+    );
+    let parent_url = parent.root.to_string_lossy().into_owned();
+    assert_success(
+        &git(
+            repo.root(),
+            &[
+                "-c",
+                "protocol.file.allow=always",
+                "submodule",
+                "add",
+                "--quiet",
+                &parent_url,
+                "vendor/standards",
+            ],
+        ),
+        "add local parent as a Git submodule",
+    );
+    let pin = repo.v2_digest("vendor/standards", PARENT_SOURCE);
+    repo.write_v2_manifest(
+        "",
+        &[ParentEdge::new(
+            "standards",
+            PARENT_SOURCE,
+            "vendor/standards",
+            pin.clone(),
+        )],
+        &[],
+    );
+    let super_revision = commit_superproject(&repo, "test: pin parent submodule at P1");
+
+    let recorded_gitlink = git_stdout(
+        repo.root(),
+        &["ls-tree", "HEAD", "vendor/standards"],
+        "read recorded submodule gitlink",
+    );
+    assert!(
+        recorded_gitlink.contains(&format!("commit {p1}\tvendor/standards")),
+        "superproject did not record P1 as its gitlink: {recorded_gitlink}"
+    );
+
+    let plain = run(&repo, &["export", "decisions", "--documents"]);
+    assert_success(&plain, "export checked-out submodule federation");
+    let historical = run(
+        &repo,
+        &[
+            "export",
+            "decisions",
+            "--documents",
+            "--at",
+            &super_revision,
+        ],
+    );
+    assert_success(&historical, "export historical submodule federation");
+    assert_eq!(
+        historical.stdout, plain.stdout,
+        "historical submodule export differs from the matching checkout"
+    );
+    assert_eq!(historical.stderr, plain.stderr);
+
+    let inherited = documents(&historical, "historical submodule export")
+        .into_iter()
+        .find(|document| document["id"].as_str() == Some(PARENT_ID))
+        .expect("historical export includes the inherited submodule policy");
+    assert!(
+        inherited["text"]
+            .as_str()
+            .is_some_and(|text| text.contains(P1_TITLE)),
+        "historical export omitted P1 content: {inherited}"
+    );
+    assert_eq!(
+        inherited["metadata"]["source"].as_str(),
+        Some(PARENT_SOURCE)
+    );
+    assert_eq!(
+        inherited["metadata"]["provenance"]["source"].as_str(),
+        Some(PARENT_SOURCE)
+    );
+    assert_eq!(
+        inherited["metadata"]["provenance"]["layer"].as_str(),
+        Some("inherited")
+    );
+    assert_eq!(
+        inherited["metadata"]["provenance"]["pin"].as_str(),
+        Some(pin.as_str())
+    );
+
+    parent.write_policy(P2_TITLE);
+    let p2 = parent.commit("test: parent P2");
+    assert_ne!(p2, p1, "parent P2 must advance beyond P1");
+    let submodule = repo.path("vendor/standards");
+    assert_success(
+        &git(
+            &submodule,
+            &[
+                "-c",
+                "protocol.file.allow=always",
+                "fetch",
+                "--quiet",
+                "origin",
+            ],
+        ),
+        "fetch P2 into the local submodule clone",
+    );
+    assert_success(
+        &git(&submodule, &["checkout", "--quiet", &p2]),
+        "advance the submodule worktree to P2",
+    );
+    assert_eq!(
+        git_stdout(
+            &submodule,
+            &["rev-parse", "HEAD"],
+            "read submodule worktree revision"
+        ),
+        p2,
+        "submodule worktree did not advance to P2"
+    );
+    assert_eq!(
+        git_stdout(
+            repo.root(),
+            &["rev-parse", "HEAD"],
+            "re-read superproject revision"
+        ),
+        super_revision,
+        "advancing the submodule worktree changed the superproject commit"
+    );
+
+    let historical_after_p2 = run(
+        &repo,
+        &[
+            "export",
+            "decisions",
+            "--documents",
+            "--at",
+            &super_revision,
+        ],
+    );
+    assert_success(
+        &historical_after_p2,
+        "re-export historical submodule federation after advancing its worktree",
+    );
+    assert_eq!(
+        historical_after_p2.stdout, historical.stdout,
+        "ambient submodule worktree state changed a point-in-time export"
+    );
+    assert_eq!(historical_after_p2.stderr, historical.stderr);
+    let rendered = String::from_utf8_lossy(&historical_after_p2.stdout);
+    assert!(
+        rendered.contains(P1_TITLE),
+        "historical export lost P1: {rendered}"
+    );
+    assert!(
+        !rendered.contains(P2_TITLE),
+        "historical export leaked P2 worktree bytes: {rendered}"
+    );
+}

--- a/rust/rac-engine/src/cli.rs
+++ b/rust/rac-engine/src/cli.rs
@@ -7,7 +7,7 @@
 use crate::commands::{
     cmd_corpus_digest, cmd_corpus_explain, cmd_corpus_status, cmd_coverage, cmd_decisions_for,
     cmd_diagnose, cmd_diff, cmd_doctor,
-    cmd_eval, cmd_export, cmd_find, cmd_gate, cmd_herald, cmd_hook, cmd_improve, cmd_index,
+    cmd_eval, cmd_export_at, cmd_find, cmd_gate, cmd_herald, cmd_hook, cmd_improve, cmd_index,
     cmd_init, cmd_inspect, cmd_mcp_stats, cmd_migrate, cmd_new, cmd_portfolio, cmd_quickstart,
     cmd_relationships, cmd_rename, cmd_resolve, cmd_retrieve, cmd_review, cmd_schema, cmd_sentry,
     cmd_skill, cmd_stats, cmd_telemetry, cmd_templates, cmd_usage, cmd_validate,
@@ -2306,6 +2306,7 @@ fn run_export(rest: &[&String]) -> u8 {
     let mut check = false;
     let mut client: Vec<String> = Vec::new();
     let mut out: Option<String> = None;
+    let mut at: Option<String> = None;
     let mut local_only = false;
     let mut extras: Vec<String> = Vec::new();
     let mut positional_only = false;
@@ -2445,6 +2446,13 @@ fn run_export(rest: &[&String]) -> u8 {
                     Err(code) => return code,
                 }
             }
+            other if other == "--at" || other.starts_with("--at=") => {
+                match take_opt_value(prog, "--at", other, rest, &mut i) {
+                    Ok(v) if !v.is_empty() => at = Some(v),
+                    Ok(_) => return argparse_error(prog, "argument --at: expected one argument"),
+                    Err(code) => return code,
+                }
+            }
             other => extras.push(other.to_string()),
         }
         i += 1;
@@ -2454,20 +2462,23 @@ fn run_export(rest: &[&String]) -> u8 {
         return unrecognized(&extras);
     }
 
-    cmd_export(&ExportArgs {
-        directory: directory.unwrap_or_else(|| ".".to_string()),
-        json,
-        schema,
-        graph,
-        documents,
-        html,
-        okf,
-        agent_rules,
-        check,
-        client,
-        out,
-        local_only,
-    }) as u8
+    cmd_export_at(
+        &ExportArgs {
+            directory: directory.unwrap_or_else(|| ".".to_string()),
+            json,
+            schema,
+            graph,
+            documents,
+            html,
+            okf,
+            agent_rules,
+            check,
+            client,
+            out,
+            local_only,
+        },
+        at.as_deref(),
+    ) as u8
 }
 
 fn is_client_choice(v: &str) -> bool {

--- a/rust/rac-engine/src/commands.rs
+++ b/rust/rac-engine/src/commands.rs
@@ -1,7 +1,8 @@
 //! Command orchestration: walk -> parse -> classify -> validate -> render.
 //! Output is order-deterministic.
 
-use std::path::{Path, PathBuf};
+use std::collections::{BTreeSet, VecDeque};
+use std::path::{Component, Path, PathBuf};
 
 use crate::corpus::{ArtifactOrigin, CorpusLayer};
 use crate::output;
@@ -258,7 +259,23 @@ fn load_composed_or_exit(
     directory: &str,
     recursive: bool,
 ) -> Result<Option<crate::composition::ComposedCorpus>, i32> {
-    match crate::federated_corpus::load_composed_corpus(directory, recursive) {
+    load_composed_or_exit_with_boundary(directory, recursive, None)
+}
+
+fn load_composed_or_exit_with_boundary(
+    directory: &str,
+    recursive: bool,
+    boundary: Option<&Path>,
+) -> Result<Option<crate::composition::ComposedCorpus>, i32> {
+    let loaded = match boundary {
+        Some(root) => crate::federated_corpus::load_composed_corpus_with_boundary(
+            directory,
+            recursive,
+            root,
+        ),
+        None => crate::federated_corpus::load_composed_corpus(directory, recursive),
+    };
+    match loaded {
         Ok(corpus) => Ok(corpus),
         Err(error) => {
             eprintln!("decided: {error}");
@@ -1597,14 +1614,393 @@ pub struct ExportArgs {
     pub local_only: bool,
 }
 
+struct HistoricalExportRevision {
+    /// Owns the temporary snapshot through rendering and emission.
+    _snapshot: crate::revisions::RevisionSnapshot,
+    boundary: PathBuf,
+    directory: String,
+    corpus_existed: bool,
+}
+
+enum HistoricalExportError {
+    Usage(String),
+    Materialization(String),
+}
+
+impl From<crate::revisions::RevisionError> for HistoricalExportError {
+    fn from(error: crate::revisions::RevisionError) -> Self {
+        match error {
+            crate::revisions::RevisionError::NotAGitRepository(message)
+            | crate::revisions::RevisionError::RevisionNotFound(message) => Self::Usage(message),
+        }
+    }
+}
+
+impl From<crate::revisions::RevisionSnapshotError> for HistoricalExportError {
+    fn from(error: crate::revisions::RevisionSnapshotError) -> Self {
+        match error {
+            crate::revisions::RevisionSnapshotError::NotAGitRepository(message)
+            | crate::revisions::RevisionSnapshotError::RevisionNotFound(message) => {
+                Self::Usage(message)
+            }
+            crate::revisions::RevisionSnapshotError::MaterializationFailed(message) => {
+                Self::Materialization(message)
+            }
+        }
+    }
+}
+
+fn lexical_absolute_path(directory: &str) -> Result<PathBuf, HistoricalExportError> {
+    let input = Path::new(directory);
+    let joined = if input.is_absolute() {
+        input.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .map_err(|error| {
+                HistoricalExportError::Usage(format!(
+                    "cannot resolve requested directory {directory}: {error}"
+                ))
+            })?
+            .join(input)
+    };
+    let mut normalized = PathBuf::new();
+    for component in joined.components() {
+        match component {
+            Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
+            Component::RootDir => normalized.push(std::path::MAIN_SEPARATOR_STR),
+            Component::CurDir => {}
+            Component::ParentDir => {
+                let _ = normalized.pop();
+            }
+            Component::Normal(value) => normalized.push(value),
+        }
+    }
+    Ok(normalized)
+}
+
+fn lexical_git_discovery_directory(requested: &Path) -> Option<PathBuf> {
+    let mut candidate = PathBuf::new();
+    let mut nearest_directory = None;
+    for component in requested.components() {
+        candidate.push(component.as_os_str());
+        match std::fs::symlink_metadata(&candidate) {
+            Ok(metadata) if metadata.file_type().is_symlink() => break,
+            Ok(metadata) if metadata.is_dir() => nearest_directory = Some(candidate.clone()),
+            Ok(_) | Err(_) => break,
+        }
+    }
+    nearest_directory
+}
+
+fn revision_repository_and_path(
+    directory: &str,
+) -> Result<(String, PathBuf, PathBuf), HistoricalExportError> {
+    let requested = lexical_absolute_path(directory)?;
+    let lexical_cwd = lexical_git_discovery_directory(&requested).ok_or_else(|| {
+        HistoricalExportError::Usage(format!("not a git repository: {directory}"))
+    })?;
+    let (repository_root, git_cwd) =
+        match crate::revisions::repository_root(&lexical_cwd.to_string_lossy()) {
+            Ok(repository_root) => (repository_root, lexical_cwd),
+            Err(_) => {
+                // A checkout itself may be addressed through a symlink. No
+                // lexical Git ancestor owns that path, so physical discovery
+                // is safe; an in-repository corpus symlink never reaches this
+                // fallback because its lexical repository wins above.
+                let mut physical_cwd = requested.clone();
+                while !physical_cwd.is_dir() {
+                    if !physical_cwd.pop() {
+                        return Err(HistoricalExportError::Usage(format!(
+                            "not a git repository: {directory}"
+                        )));
+                    }
+                }
+                let repository_root =
+                    crate::revisions::repository_root(&physical_cwd.to_string_lossy())?;
+                (repository_root, physical_cwd)
+            }
+        };
+    let repository_path = std::fs::canonicalize(&repository_root).map_err(|error| {
+        HistoricalExportError::Usage(format!(
+            "cannot resolve repository root {repository_root}: {error}"
+        ))
+    })?;
+    let relative = if let Ok(relative) = requested.strip_prefix(&repository_path) {
+        relative.to_path_buf()
+    } else {
+        let physical_cwd = std::fs::canonicalize(&git_cwd).map_err(|error| {
+            HistoricalExportError::Usage(format!(
+                "cannot resolve Git discovery directory {}: {error}",
+                git_cwd.display()
+            ))
+        })?;
+        let physical_prefix = physical_cwd.strip_prefix(&repository_path).map_err(|_| {
+            HistoricalExportError::Usage(format!(
+                "requested directory is outside Git repository: {directory}"
+            ))
+        })?;
+        let unresolved = requested.strip_prefix(&git_cwd).map_err(|_| {
+            HistoricalExportError::Usage(format!(
+                "cannot derive repository-relative path for {directory}"
+            ))
+        })?;
+        physical_prefix.join(unresolved)
+    };
+    Ok((repository_root, repository_path, relative))
+}
+
+fn node_path(node: &Path, relative: &str) -> PathBuf {
+    if node.as_os_str().is_empty() {
+        PathBuf::from(relative)
+    } else {
+        node.join(relative)
+    }
+}
+
+fn materialize_node_metadata(
+    snapshot: &mut crate::revisions::RevisionSnapshot,
+    node: &Path,
+) -> Result<(), HistoricalExportError> {
+    for relative in [
+        crate::federation::CONFIG_RELATIVE_PATH,
+        crate::federation::MANIFEST_RELATIVE_PATH,
+    ] {
+        snapshot
+            .materialize_path(
+                node_path(node, relative),
+                crate::revisions::MissingPathPolicy::Ignore,
+            )
+            .map_err(HistoricalExportError::from)?;
+    }
+    Ok(())
+}
+
+fn materialize_ancestor_metadata(
+    snapshot: &mut crate::revisions::RevisionSnapshot,
+    corpus: &Path,
+) -> Result<(), HistoricalExportError> {
+    let mut ancestor = corpus.to_path_buf();
+    loop {
+        materialize_node_metadata(snapshot, &ancestor)?;
+        if !ancestor.pop() {
+            return Ok(());
+        }
+    }
+}
+
+fn historical_composition_root(snapshot_root: &Path, corpus: &Path) -> PathBuf {
+    for ancestor in corpus.ancestors() {
+        if !ancestor.starts_with(snapshot_root) {
+            break;
+        }
+        let configured = ancestor
+            .join(crate::federation::CONFIG_RELATIVE_PATH)
+            .is_file();
+        let manifested = ancestor
+            .join(crate::federation::MANIFEST_RELATIVE_PATH)
+            .is_file();
+        if configured || manifested {
+            return ancestor
+                .strip_prefix(snapshot_root)
+                .unwrap_or_else(|_| Path::new(""))
+                .to_path_buf();
+        }
+    }
+    corpus
+        .strip_prefix(snapshot_root)
+        .unwrap_or_else(|_| Path::new(""))
+        .to_path_buf()
+}
+
+fn has_historical_governing_config(snapshot_root: &Path, corpus: &Path) -> bool {
+    corpus.ancestors().any(|ancestor| {
+        ancestor.starts_with(snapshot_root)
+            && ancestor
+                .join(crate::federation::CONFIG_RELATIVE_PATH)
+                .is_file()
+    })
+}
+
+fn historical_parent_declarations(
+    node: &Path,
+) -> Option<(Vec<crate::federation::ParentDeclaration>, bool)> {
+    match crate::federation::load_graph_manifest(node) {
+        Ok(Some(manifest)) => Some((manifest.parents, true)),
+        Ok(None) => match crate::federation::load_manifest(node) {
+            Ok(Some(manifest)) => Some((vec![manifest.inherits], false)),
+            Ok(None) | Err(_) => None,
+        },
+        Err(_) => None,
+    }
+}
+
+fn historical_parent_root_exclusions(
+    snapshot_root: &Path,
+    node: &Path,
+    corpus: &Path,
+) -> Vec<PathBuf> {
+    let absolute = snapshot_root.join(node);
+    let Some((parents, _)) = historical_parent_declarations(&absolute) else {
+        return Vec::new();
+    };
+    let mut exclusions: Vec<PathBuf> = parents
+        .into_iter()
+        .map(|parent| node_path(node, &parent.root))
+        .filter(|parent_root| parent_root.starts_with(corpus))
+        .collect();
+    exclusions.sort();
+    exclusions.dedup();
+    exclusions
+}
+
+fn historical_corpus_symlink_policy(
+    snapshot_root: &Path,
+    node: &Path,
+) -> crate::revisions::CorpusSymlinkPolicy {
+    match historical_parent_declarations(&snapshot_root.join(node)) {
+        Some((_, true)) => crate::revisions::CorpusSymlinkPolicy::RejectAll,
+        Some((_, false)) | None => crate::revisions::CorpusSymlinkPolicy::CorpusFilesOnly,
+    }
+}
+
+fn materialize_federation_closure(
+    snapshot: &mut crate::revisions::RevisionSnapshot,
+    root: PathBuf,
+) -> Result<(), HistoricalExportError> {
+    let mut queue = VecDeque::from([(root.clone(), 0usize)]);
+    let mut visited = BTreeSet::new();
+    let mut materialized_nodes = BTreeSet::from([root]);
+    let mut materialized_corpora = BTreeSet::new();
+    let mut edges = 0usize;
+
+    while let Some((node, depth)) = queue.pop_front() {
+        if !visited.insert(node.clone()) {
+            continue;
+        }
+        if depth > crate::federation::V2_MAX_INHERITANCE_DEPTH {
+            return Err(HistoricalExportError::Materialization(format!(
+                "historical federation exceeds maximum inheritance depth {}",
+                crate::federation::V2_MAX_INHERITANCE_DEPTH
+            )));
+        }
+        let absolute = snapshot.root().join(&node);
+        let Some((parents, recursive)) = historical_parent_declarations(&absolute) else {
+            // A malformed manifest is deliberately left for the established
+            // federation loader, which owns its stable validation diagnostic.
+            continue;
+        };
+        edges = edges.saturating_add(parents.len());
+        if edges > crate::federation::V2_MAX_EDGES {
+            return Err(HistoricalExportError::Materialization(format!(
+                "historical federation exceeds maximum edge count {}",
+                crate::federation::V2_MAX_EDGES
+            )));
+        }
+        for parent in parents {
+            let parent_root = node_path(&node, &parent.root);
+            if materialized_nodes.insert(parent_root.clone()) {
+                materialize_node_metadata(snapshot, &parent_root)?;
+            }
+            let parent_corpus = node_path(&parent_root, &parent.corpus);
+            if materialized_corpora.insert(parent_corpus.clone()) {
+                let exclusions = historical_parent_root_exclusions(
+                    snapshot.root(),
+                    &parent_root,
+                    &parent_corpus,
+                );
+                snapshot
+                    .materialize_corpus_with_options(
+                        parent_corpus,
+                        crate::revisions::MissingPathPolicy::Error,
+                        &exclusions,
+                        if recursive {
+                            crate::revisions::CorpusSymlinkPolicy::RejectAll
+                        } else {
+                            crate::revisions::CorpusSymlinkPolicy::CorpusFilesOnly
+                        },
+                    )
+                    .map_err(HistoricalExportError::from)?;
+            }
+            if recursive {
+                queue.push_back((parent_root, depth + 1));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn materialize_export_revision(
+    directory: &str,
+    revision: &str,
+) -> Result<HistoricalExportRevision, HistoricalExportError> {
+    let (repository_root, repository_path, relative) =
+        revision_repository_and_path(directory)?;
+    let mut snapshot = crate::revisions::RevisionSnapshot::open(&repository_root, revision)?;
+    materialize_ancestor_metadata(&mut snapshot, &relative)?;
+    let projected_corpus = snapshot.root().join(&relative);
+    let composition_root = historical_composition_root(snapshot.root(), &projected_corpus);
+    let exclusions = historical_parent_root_exclusions(
+        snapshot.root(),
+        &composition_root,
+        &relative,
+    );
+    let symlink_policy =
+        historical_corpus_symlink_policy(snapshot.root(), &composition_root);
+    let corpus = snapshot
+        .materialize_corpus_with_options(
+            &relative,
+            crate::revisions::MissingPathPolicy::EmptyDirectory,
+            &exclusions,
+            symlink_policy,
+        )
+        .map_err(HistoricalExportError::from)?;
+    if !has_historical_governing_config(snapshot.root(), &corpus.path) {
+        if let Some(config) = crate::validate::find_config_file(directory) {
+            let config = std::fs::canonicalize(&config).map_err(|error| {
+                HistoricalExportError::Usage(format!(
+                    "cannot resolve governing config {}: {error}",
+                    config.display()
+                ))
+            })?;
+            if !config.starts_with(&repository_path) {
+                return Err(HistoricalExportError::Usage(format!(
+                    "governing config {} is outside Git repository {} and cannot be reproduced by --at",
+                    config.display(),
+                    repository_path.display()
+                )));
+            }
+        }
+    }
+    if corpus.existed {
+        materialize_federation_closure(&mut snapshot, composition_root)?;
+    }
+    let boundary = snapshot.root().to_path_buf();
+    let directory = corpus.path.to_string_lossy().into_owned();
+    Ok(HistoricalExportRevision {
+        _snapshot: snapshot,
+        boundary,
+        directory,
+        corpus_existed: corpus.existed,
+    })
+}
+
 pub fn cmd_export(args: &ExportArgs) -> i32 {
-    if args.schema.is_none() && !Path::new(&args.directory).is_dir() {
+    cmd_export_at(args, None)
+}
+
+/// CLI-only revision projection, kept separate so adding `--at` does not
+/// change the released public [`ExportArgs`] construction contract.
+pub(crate) fn cmd_export_at(args: &ExportArgs, at: Option<&str>) -> i32 {
+    if args.schema.is_none() && at.is_none() && !Path::new(&args.directory).is_dir() {
         return usage_error(&format!("not a directory: {}", args.directory));
     }
     if args.local_only && (args.okf || args.agent_rules || args.schema.is_some()) {
         return usage_error(
             "--local-only is available only for viewer, documents, and graph exports",
         );
+    }
+    if at.is_some() && (args.html || args.okf || args.agent_rules || args.schema.is_some()) {
+        return usage_error("--at is available only for viewer, documents, and graph exports");
     }
     // Agent-rules is a distinct mode (ADR-067) owning --out/--client/--check
     // and --json; it dispatches before the export-payload guards.
@@ -1646,20 +2042,51 @@ pub fn cmd_export(args: &ExportArgs) -> i32 {
         emit_exact(schema);
         return EXIT_OK;
     }
-    let composed = match load_composed_or_exit(&args.directory, true) {
-        Ok(corpus) => corpus,
-        Err(code) => return code,
+    let historical = match at {
+        Some(revision) => match materialize_export_revision(&args.directory, revision) {
+            Ok(snapshot) => Some(snapshot),
+            Err(HistoricalExportError::Usage(message)) => return usage_error(&message),
+            Err(HistoricalExportError::Materialization(message)) => {
+                eprintln!("decided: {message}");
+                return EXIT_VALIDATION_FAILED;
+            }
+        },
+        None => None,
+    };
+    let export_directory = historical
+        .as_ref()
+        .map_or(args.directory.as_str(), |snapshot| snapshot.directory.as_str());
+    let identity_directory = args.directory.as_str();
+    let snapshot_boundary = historical
+        .as_ref()
+        .map(|snapshot| snapshot.boundary.as_path());
+    let historical_corpus_absent = historical
+        .as_ref()
+        .is_some_and(|snapshot| !snapshot.corpus_existed);
+    let composed = if historical_corpus_absent {
+        None
+    } else {
+        match load_composed_or_exit_with_boundary(export_directory, true, snapshot_boundary) {
+            Ok(corpus) => corpus,
+            Err(code) => return code,
+        }
     };
     if args.documents {
         let export = match composed.as_ref() {
-            Some(corpus) => crate::export::build_documents_export_from_composed(
-                &args.directory,
+            Some(corpus) => crate::export::build_documents_export_from_composed_for(
+                export_directory,
+                identity_directory,
                 corpus,
                 args.local_only,
+                snapshot_boundary,
             )
             .map_err(|error| error.message().to_string()),
-            None => crate::export::build_documents_export(&args.directory)
-                .map_err(|error| error.message().to_string()),
+            None => crate::export::build_documents_export_for(
+                export_directory,
+                identity_directory,
+                snapshot_boundary,
+            )
+            .map_err(|error| error.message().to_string()),
         };
         let export = match export {
             Ok(export) => export,
@@ -1668,19 +2095,30 @@ pub fn cmd_export(args: &ExportArgs) -> i32 {
                 return EXIT_VALIDATION_FAILED;
             }
         };
-        emit(output::render_documents_jsonl(&export));
+        let rendered = output::render_documents_jsonl(&export);
+        if historical_corpus_absent && rendered.is_empty() {
+            emit_exact("");
+        } else {
+            emit(rendered);
+        }
         return EXIT_OK;
     }
     if args.graph {
         let export = match composed.as_ref() {
-            Some(corpus) => crate::export::build_graph_export_from_composed(
-                &args.directory,
+            Some(corpus) => crate::export::build_graph_export_from_composed_for(
+                export_directory,
+                identity_directory,
                 corpus,
                 args.local_only,
+                snapshot_boundary,
             )
             .map_err(|error| error.message().to_string()),
-            None => crate::export::build_graph_export(&args.directory)
-                .map_err(|error| error.message().to_string()),
+            None => crate::export::build_graph_export_for(
+                export_directory,
+                identity_directory,
+                snapshot_boundary,
+            )
+            .map_err(|error| error.message().to_string()),
         };
         let export = match export {
             Ok(export) => export,
@@ -1748,14 +2186,21 @@ pub fn cmd_export(args: &ExportArgs) -> i32 {
         return EXIT_OK;
     }
     let export = match composed.as_ref() {
-        Some(corpus) => crate::export::build_corpus_export_from_composed(
-            &args.directory,
+        Some(corpus) => crate::export::build_corpus_export_from_composed_for(
+            export_directory,
+            identity_directory,
             output::rac_version(),
             corpus,
             args.local_only,
+            snapshot_boundary,
         )
         .map_err(|error| error.message().to_string()),
-        None => crate::export::build_corpus_export(&args.directory, output::rac_version())
+        None => crate::export::build_corpus_export_for(
+            export_directory,
+            identity_directory,
+            output::rac_version(),
+            snapshot_boundary,
+        )
             .map_err(|error| error.message().to_string()),
     };
     let export = match export {

--- a/rust/rac-engine/src/corpus.rs
+++ b/rust/rac-engine/src/corpus.rs
@@ -8,7 +8,7 @@ use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
-use crate::scaffold::{load_repository_identity, ScaffoldError};
+use crate::scaffold::{load_repository_identity_with_boundary, ScaffoldError};
 
 /// Whether an artifact belongs to the writable child or a read-only parent.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
@@ -187,9 +187,20 @@ impl PhysicalArtifactLocator {
 /// The exact non-federated source derivation shared by exports and the local
 /// source-aware layer: explicit `corpus.source`, then lower-case
 /// `repository_key`, then the released directory-basename fallback.
-pub fn compatible_corpus_source(directory: &str) -> Result<String, ScaffoldError> {
-    let Some(identity) = load_repository_identity(directory)? else {
-        return Ok(compatible_corpus_name(directory));
+pub fn compatible_corpus_source_with_fallback(
+    directory: &str,
+    fallback_directory: &str,
+) -> Result<String, ScaffoldError> {
+    compatible_corpus_source_with_fallback_and_boundary(directory, fallback_directory, None)
+}
+
+pub fn compatible_corpus_source_with_fallback_and_boundary(
+    directory: &str,
+    fallback_directory: &str,
+    boundary: Option<&Path>,
+) -> Result<String, ScaffoldError> {
+    let Some(identity) = load_repository_identity_with_boundary(directory, boundary)? else {
+        return Ok(compatible_corpus_name(fallback_directory));
     };
     if let Some(source) = identity.corpus_source {
         return Ok(source);
@@ -200,7 +211,11 @@ pub fn compatible_corpus_source(directory: &str) -> Result<String, ScaffoldError
             .unwrap_or(&repository_key)
             .to_ascii_lowercase());
     }
-    Ok(compatible_corpus_name(directory))
+    Ok(compatible_corpus_name(fallback_directory))
+}
+
+pub fn compatible_corpus_source(directory: &str) -> Result<String, ScaffoldError> {
+    compatible_corpus_source_with_fallback(directory, directory)
 }
 
 /// Build the dormant single local layer without making configuration errors

--- a/rust/rac-engine/src/export.rs
+++ b/rust/rac-engine/src/export.rs
@@ -3,6 +3,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
+use std::path::Path;
 
 use crate::composition::{ComposedCorpus, ComposedProvenance};
 use crate::corpus::{ArtifactKey, ArtifactOrigin, ArtifactPath, Layer};
@@ -14,7 +15,7 @@ use crate::pycompat::py_strip;
 use crate::relationships::{corpus_items, edge_spec, relationships_from_corpus, CorpusItem};
 use crate::scaffold::ScaffoldError;
 use crate::spec::ArtifactSpec;
-use crate::validate::load_ticketing_provider;
+use crate::validate::load_ticketing_provider_with_boundary;
 
 pub const EDGE_TYPE: &str = "relates-to";
 pub const STATUS_ABSENT: &str = "unknown";
@@ -58,6 +59,31 @@ pub fn export_schema(name: &str) -> Option<&'static str> {
 /// released directory-basename fallback (ADR-135).
 pub fn corpus_source(directory: &str) -> Result<String, ScaffoldError> {
     crate::corpus::compatible_corpus_source(directory)
+}
+
+fn corpus_source_with_fallback(
+    directory: &str,
+    fallback_directory: &str,
+    boundary: Option<&Path>,
+) -> Result<String, ScaffoldError> {
+    crate::corpus::compatible_corpus_source_with_fallback_and_boundary(
+        directory,
+        fallback_directory,
+        boundary,
+    )
+}
+
+fn logical_artifact_path(directory: &str, relative_path: &str) -> String {
+    let root = crate::walk::normalize_root(directory);
+    if root == "." {
+        relative_path.to_string()
+    } else if root == "/" {
+        format!("/{relative_path}")
+    } else if root.ends_with('/') {
+        format!("{root}{relative_path}")
+    } else {
+        format!("{root}/{relative_path}")
+    }
 }
 
 /// A deterministic failure while projecting an already-verified composed
@@ -448,6 +474,7 @@ impl CorpusExport {
 
 fn build_corpus_export_inner(
     directory: &str,
+    identity_directory: &str,
     rac_version: String,
     include_body_html: bool,
     corpus_source: String,
@@ -459,19 +486,21 @@ fn build_corpus_export_inner(
     for it in &items {
         let Some(spec) = it.spec else { continue };
         let canon = canonical[&it.path].clone();
+        let logical_path =
+            logical_artifact_path(identity_directory, &it.artifact_path.relative_path);
         let title = match &it.artifact.product.title {
             Some(t) if !t.is_empty() => t.clone(),
             _ => canon.clone(),
         };
         artifacts.push(ExportArtifact {
             id: canon,
-            aliases: artifact_identifiers(&it.artifact, it.spec, &it.path),
+            aliases: artifact_identifiers(&it.artifact, it.spec, &logical_path),
             artifact_type: spec.name.clone(),
             status: status(&it.artifact, spec),
             title,
-            path: it.path.clone(),
+            path: logical_path,
             body_html: if include_body_html {
-                crate::mdhtml::render(&body_markdown(&it.path))
+                crate::mdhtml::render(&body_markdown(&it.locator.path.to_string_lossy()))
             } else {
                 String::new()
             },
@@ -505,7 +534,7 @@ fn build_corpus_export_inner(
     edges.sort_by(|a, b| a.from.cmp(&b.from).then(a.to.cmp(&b.to)));
 
     CorpusExport {
-        corpus_name: corpus_name(directory),
+        corpus_name: corpus_name(identity_directory),
         corpus_source,
         rac_version,
         artifacts,
@@ -517,11 +546,21 @@ pub fn build_corpus_export(
     directory: &str,
     rac_version: String,
 ) -> Result<CorpusExport, ScaffoldError> {
+    build_corpus_export_for(directory, directory, rac_version, None)
+}
+
+pub fn build_corpus_export_for(
+    directory: &str,
+    identity_directory: &str,
+    rac_version: String,
+    boundary: Option<&Path>,
+) -> Result<CorpusExport, ScaffoldError> {
     Ok(build_corpus_export_inner(
         directory,
+        identity_directory,
         rac_version,
         true,
-        corpus_source(directory)?,
+        corpus_source_with_fallback(directory, identity_directory, boundary)?,
     ))
 }
 
@@ -534,8 +573,27 @@ pub fn build_corpus_export_from_composed(
     corpus: &ComposedCorpus,
     local_only: bool,
 ) -> Result<CorpusExport, FederatedExportError> {
+    build_corpus_export_from_composed_for(
+        directory,
+        directory,
+        rac_version,
+        corpus,
+        local_only,
+        None,
+    )
+}
+
+pub fn build_corpus_export_from_composed_for(
+    directory: &str,
+    identity_directory: &str,
+    rac_version: String,
+    corpus: &ComposedCorpus,
+    local_only: bool,
+    boundary: Option<&Path>,
+) -> Result<CorpusExport, FederatedExportError> {
     if !corpus.is_federated() {
-        return build_corpus_export(directory, rac_version).map_err(Into::into);
+        return build_corpus_export_for(directory, identity_directory, rac_version, boundary)
+            .map_err(Into::into);
     }
 
     let projected = projected_items(corpus, local_only)?;
@@ -612,7 +670,7 @@ pub fn build_corpus_export_from_composed(
                 .then(left.effective_terminal.cmp(&right.effective_terminal))
         });
         return Ok(CorpusExport {
-            corpus_name: corpus_name(directory),
+            corpus_name: corpus_name(identity_directory),
             corpus_source: composed_child_source(corpus)?,
             rac_version,
             artifacts,
@@ -651,7 +709,7 @@ pub fn build_corpus_export_from_composed(
     });
 
     Ok(CorpusExport {
-        corpus_name: corpus_name(directory),
+        corpus_name: corpus_name(identity_directory),
         corpus_source: composed_child_source(corpus)?,
         rac_version,
         artifacts,
@@ -662,7 +720,13 @@ pub fn build_corpus_export_from_composed(
 /// OKF consumes the source Markdown body directly. Avoid an irrelevant HTML
 /// render over the whole corpus on this path.
 pub fn build_okf_export(directory: &str, rac_version: String) -> CorpusExport {
-    build_corpus_export_inner(directory, rac_version, false, corpus_name(directory))
+    build_corpus_export_inner(
+        directory,
+        directory,
+        rac_version,
+        false,
+        corpus_name(directory),
+    )
 }
 
 /// Keep the first federation increment's OKF carrier local-only while using
@@ -763,12 +827,22 @@ pub struct DocumentsExport {
 }
 
 pub fn build_documents_export(directory: &str) -> Result<DocumentsExport, ScaffoldError> {
-    let source = corpus_source(directory)?;
+    build_documents_export_for(directory, directory, None)
+}
+
+pub fn build_documents_export_for(
+    directory: &str,
+    identity_directory: &str,
+    boundary: Option<&Path>,
+) -> Result<DocumentsExport, ScaffoldError> {
+    let source = corpus_source_with_fallback(directory, identity_directory, boundary)?;
     let items = corpus_items(directory, true);
     let mut documents: Vec<ExportDocument> = Vec::new();
     for it in &items {
         let Some(spec) = it.spec else { continue };
         let canon = artifact_identifier(&it.artifact, it.spec, &it.path);
+        let logical_path =
+            logical_artifact_path(identity_directory, &it.artifact_path.relative_path);
         let title = match &it.artifact.product.title {
             Some(t) if !t.is_empty() => t.clone(),
             _ => canon.clone(),
@@ -778,16 +852,16 @@ pub fn build_documents_export(directory: &str) -> Result<DocumentsExport, Scaffo
             artifact_type: spec.name.clone(),
             status: status(&it.artifact, spec),
             title,
-            text: body_markdown(&it.path),
-            aliases: artifact_identifiers(&it.artifact, it.spec, &it.path),
-            path: it.path.clone(),
+            text: body_markdown(&it.locator.path.to_string_lossy()),
+            aliases: artifact_identifiers(&it.artifact, it.spec, &logical_path),
+            path: logical_path,
             tags: tags_of(&it.artifact),
             provenance: None,
             graph_provenance: None,
         });
     }
     Ok(DocumentsExport {
-        corpus_name: corpus_name(directory),
+        corpus_name: corpus_name(identity_directory),
         corpus_source: source,
         documents,
     })
@@ -798,8 +872,19 @@ pub fn build_documents_export_from_composed(
     corpus: &ComposedCorpus,
     local_only: bool,
 ) -> Result<DocumentsExport, FederatedExportError> {
+    build_documents_export_from_composed_for(directory, directory, corpus, local_only, None)
+}
+
+pub fn build_documents_export_from_composed_for(
+    directory: &str,
+    identity_directory: &str,
+    corpus: &ComposedCorpus,
+    local_only: bool,
+    boundary: Option<&Path>,
+) -> Result<DocumentsExport, FederatedExportError> {
     if !corpus.is_federated() {
-        return build_documents_export(directory).map_err(Into::into);
+        return build_documents_export_for(directory, identity_directory, boundary)
+            .map_err(Into::into);
     }
 
     let projected = projected_items(corpus, local_only)?;
@@ -831,7 +916,7 @@ pub fn build_documents_export_from_composed(
         });
     }
     Ok(DocumentsExport {
-        corpus_name: corpus_name(directory),
+        corpus_name: corpus_name(identity_directory),
         corpus_source: composed_child_source(corpus)?,
         documents,
     })
@@ -873,9 +958,17 @@ pub struct GraphExport {
 }
 
 pub fn build_graph_export(directory: &str) -> Result<GraphExport, ScaffoldError> {
-    let source = corpus_source(directory)?;
+    build_graph_export_for(directory, directory, None)
+}
+
+pub fn build_graph_export_for(
+    directory: &str,
+    identity_directory: &str,
+    boundary: Option<&Path>,
+) -> Result<GraphExport, ScaffoldError> {
+    let source = corpus_source_with_fallback(directory, identity_directory, boundary)?;
     let items = corpus_items(directory, true);
-    let provider = load_ticketing_provider(directory);
+    let provider = load_ticketing_provider_with_boundary(directory, boundary);
     let canonical = canonical_by_path(&items);
 
     let mut nodes: Vec<GraphNode> = Vec::new();
@@ -933,7 +1026,7 @@ pub fn build_graph_export(directory: &str) -> Result<GraphExport, ScaffoldError>
     });
 
     Ok(GraphExport {
-        corpus_name: corpus_name(directory),
+        corpus_name: corpus_name(identity_directory),
         corpus_source: source,
         nodes,
         edges,
@@ -945,8 +1038,18 @@ pub fn build_graph_export_from_composed(
     corpus: &ComposedCorpus,
     local_only: bool,
 ) -> Result<GraphExport, FederatedExportError> {
+    build_graph_export_from_composed_for(directory, directory, corpus, local_only, None)
+}
+
+pub fn build_graph_export_from_composed_for(
+    directory: &str,
+    identity_directory: &str,
+    corpus: &ComposedCorpus,
+    local_only: bool,
+    boundary: Option<&Path>,
+) -> Result<GraphExport, FederatedExportError> {
     if !corpus.is_federated() {
-        return build_graph_export(directory).map_err(Into::into);
+        return build_graph_export_for(directory, identity_directory, boundary).map_err(Into::into);
     }
 
     let projected = projected_items(corpus, local_only)?;
@@ -972,7 +1075,7 @@ pub fn build_graph_export_from_composed(
 
     let included = included_keys(&projected);
     if let Some(graph) = corpus.graph() {
-        let provider = load_ticketing_provider(directory);
+        let provider = load_ticketing_provider_with_boundary(directory, boundary);
         let mut edges = Vec::new();
         for relationship in graph.catalog_relationships() {
             let source = graph.item(&relationship.source).ok_or_else(|| {
@@ -1025,7 +1128,7 @@ pub fn build_graph_export_from_composed(
                 .then(left.effective_terminal.cmp(&right.effective_terminal))
         });
         return Ok(GraphExport {
-            corpus_name: corpus_name(directory),
+            corpus_name: corpus_name(identity_directory),
             corpus_source: composed_child_source(corpus)?,
             nodes,
             edges,
@@ -1033,7 +1136,7 @@ pub fn build_graph_export_from_composed(
     }
 
     let by_path = item_by_artifact_path(corpus);
-    let provider = load_ticketing_provider(directory);
+    let provider = load_ticketing_provider_with_boundary(directory, boundary);
     let mut edges = Vec::new();
     for relationship in corpus.catalog_relationships() {
         let (source, target) = relationship_endpoints(&relationship, &by_path)?;
@@ -1073,7 +1176,7 @@ pub fn build_graph_export_from_composed(
     });
 
     Ok(GraphExport {
-        corpus_name: corpus_name(directory),
+        corpus_name: corpus_name(identity_directory),
         corpus_source: composed_child_source(corpus)?,
         nodes,
         edges,

--- a/rust/rac-engine/src/federated_corpus.rs
+++ b/rust/rac-engine/src/federated_corpus.rs
@@ -445,6 +445,13 @@ fn local_items_from_snapshot(
 /// disappeared. A present manifest is authoritative topology and must not be
 /// bypassed by falling back to a local-only corpus walk.
 fn composition_repository_root(directory: &str) -> PathBuf {
+    composition_repository_root_with_boundary(directory, None)
+}
+
+fn composition_repository_root_with_boundary(
+    directory: &str,
+    boundary: Option<&Path>,
+) -> PathBuf {
     let input = Path::new(directory);
     let absolute = if input.is_absolute() {
         input.to_path_buf()
@@ -455,6 +462,9 @@ fn composition_repository_root(directory: &str) -> PathBuf {
     };
     let search = std::fs::canonicalize(&absolute).unwrap_or(absolute);
     for ancestor in search.ancestors() {
+        if boundary.is_some_and(|root| !ancestor.starts_with(root)) {
+            break;
+        }
         let manifest = ancestor.join(crate::federation::MANIFEST_RELATIVE_PATH);
         let config = ancestor.join(crate::federation::CONFIG_RELATIVE_PATH);
         if std::fs::symlink_metadata(&manifest).is_ok()
@@ -462,6 +472,12 @@ fn composition_repository_root(directory: &str) -> PathBuf {
         {
             return ancestor.to_path_buf();
         }
+        if boundary.is_some_and(|root| ancestor == root) {
+            break;
+        }
+    }
+    if boundary.is_some() {
+        return search;
     }
     crate::validate::repository_root(directory)
 }
@@ -524,10 +540,26 @@ pub fn load_composed_corpus(
     directory: &str,
     recursive: bool,
 ) -> Result<Option<ComposedCorpus>, FederatedCorpusError> {
-    if let Some(corpus) = load_graph_composed_corpus(directory, recursive)? {
+    load_composed_corpus_with_optional_boundary(directory, recursive, None)
+}
+
+pub fn load_composed_corpus_with_boundary(
+    directory: &str,
+    recursive: bool,
+    boundary: &Path,
+) -> Result<Option<ComposedCorpus>, FederatedCorpusError> {
+    load_composed_corpus_with_optional_boundary(directory, recursive, Some(boundary))
+}
+
+fn load_composed_corpus_with_optional_boundary(
+    directory: &str,
+    recursive: bool,
+    boundary: Option<&Path>,
+) -> Result<Option<ComposedCorpus>, FederatedCorpusError> {
+    if let Some(corpus) = load_graph_composed_corpus_with_boundary(directory, boundary)? {
         return Ok(Some(corpus));
     }
-    let child_root = composition_repository_root(directory);
+    let child_root = composition_repository_root_with_boundary(directory, boundary);
     let Some(verified) = verify_parent(&child_root)? else {
         return Ok(None);
     };
@@ -543,7 +575,14 @@ pub fn load_graph_composed_corpus(
     directory: &str,
     _recursive: bool,
 ) -> Result<Option<ComposedCorpus>, FederatedCorpusError> {
-    load_verified_graph_corpus(directory)
+    load_graph_composed_corpus_with_boundary(directory, None)
+}
+
+fn load_graph_composed_corpus_with_boundary(
+    directory: &str,
+    boundary: Option<&Path>,
+) -> Result<Option<ComposedCorpus>, FederatedCorpusError> {
+    load_verified_graph_corpus_with_boundary(directory, boundary)
         .map(|corpus| corpus.map(VerifiedGraphCorpus::into_composed_corpus))
 }
 
@@ -556,7 +595,14 @@ pub fn load_graph_composed_corpus(
 pub fn load_verified_graph_corpus(
     directory: &str,
 ) -> Result<Option<VerifiedGraphCorpus>, FederatedCorpusError> {
-    let child_root = composition_repository_root(directory);
+    load_verified_graph_corpus_with_boundary(directory, None)
+}
+
+fn load_verified_graph_corpus_with_boundary(
+    directory: &str,
+    boundary: Option<&Path>,
+) -> Result<Option<VerifiedGraphCorpus>, FederatedCorpusError> {
+    let child_root = composition_repository_root_with_boundary(directory, boundary);
     if load_graph_manifest(&child_root)?.is_none() {
         return Ok(None);
     }

--- a/rust/rac-engine/src/revisions.rs
+++ b/rust/rac-engine/src/revisions.rs
@@ -1,11 +1,11 @@
 //! Git revision materialization (`decided.services.revisions`) — the only
-//! git-consuming module of the watchkeeper path (ADR-043). A revision name
-//! becomes a temporary directory holding the corpus subpath at that
-//! revision, via `git archive --format=tar` (never mutates `.git`: no
-//! worktree registration, no locks) piped through a minimal in-process tar
-//! reader (no tar binary, no new dependencies).
+//! git-consuming module of the watchkeeper and point-in-time export paths
+//! (ADR-043). The released watchkeeper seam retains its `git archive` parity
+//! contract. Point-in-time export uses the stricter [`RevisionSnapshot`]
+//! path, which reads bounded exact blob objects and declared submodule
+//! commits without fetching, checking out, or mutating `.git`.
 //!
-//! Contract mirrored from the oracle:
+//! Watchkeeper contract mirrored from the oracle:
 //! - `git rev-parse --show-toplevel` (cwd = the corpus directory) finds the
 //!   work-tree root; failure -> `not a git repository: <directory>`; a
 //!   missing git binary -> `git executable not found` (both exit 2 at the
@@ -20,13 +20,19 @@
 //!   when the materialization guard drops. Its path never appears in any
 //!   output surface (all reported paths are corpus-relative).
 
-use std::io;
-use std::path::{Path, PathBuf};
+use std::collections::BTreeMap;
+use std::io::{self, BufRead, BufReader, Read, Write};
+use std::path::{Component, Path, PathBuf};
 use std::process::{Command, Output, Stdio};
 use std::sync::atomic::{AtomicU64, Ordering};
 
-/// The two usage-error surfaces of revision resolution; `message()` is the
-/// text after the CLI's `decided: ` prefix.
+use crate::federation::{
+    V2_MAX_FILE_BYTES, V2_MAX_INHERITANCE_DEPTH, V2_MAX_INHERITED_FILES, V2_MAX_PATH_BYTES,
+    V2_MAX_PATH_COMPONENTS, V2_MAX_PHYSICAL_BYTES, V2_MAX_VISITED_ENTRIES,
+};
+
+/// The released watchkeeper revision errors. Keep this enum exhaustive-match
+/// compatible for downstream callers.
 #[derive(Debug)]
 pub enum RevisionError {
     /// `NotAGitRepository` — not inside a git work tree, or no git binary.
@@ -44,13 +50,43 @@ impl RevisionError {
     }
 }
 
+/// Errors from bounded, strict point-in-time snapshots.
+#[derive(Debug)]
+pub enum RevisionSnapshotError {
+    NotAGitRepository(String),
+    RevisionNotFound(String),
+    MaterializationFailed(String),
+}
+
+impl RevisionSnapshotError {
+    pub fn message(&self) -> &str {
+        match self {
+            RevisionSnapshotError::NotAGitRepository(message)
+            | RevisionSnapshotError::RevisionNotFound(message)
+            | RevisionSnapshotError::MaterializationFailed(message) => message,
+        }
+    }
+}
+
+impl From<RevisionError> for RevisionSnapshotError {
+    fn from(error: RevisionError) -> Self {
+        match error {
+            RevisionError::NotAGitRepository(message) => {
+                RevisionSnapshotError::NotAGitRepository(message)
+            }
+            RevisionError::RevisionNotFound(message) => {
+                RevisionSnapshotError::RevisionNotFound(message)
+            }
+        }
+    }
+}
+
 /// `_run_git(args, cwd)` — capture both streams, never check. Only a
 /// missing binary maps to `NotAGitRepository("git executable not found")`,
 /// like the oracle's `FileNotFoundError` arm.
 fn run_git(args: &[&str], cwd: &Path) -> Result<Output, RevisionError> {
-    Command::new("git")
-        .args(args)
-        .current_dir(cwd)
+    let mut command = git_command(args, cwd);
+    command
         .stdin(Stdio::null())
         .output()
         .map_err(|_| {
@@ -59,6 +95,30 @@ fn run_git(args: &[&str], cwd: &Path) -> Result<Output, RevisionError> {
             // user-facing class (PORT-CONTRACT decision 3).
             RevisionError::NotAGitRepository("git executable not found".to_string())
         })
+}
+
+/// Build a read-only Git command that cannot reinterpret objects through
+/// replacement refs or mutate a promisor repository by fetching objects.
+fn git_command(args: &[&str], cwd: &Path) -> Command {
+    let mut command = base_git_command(cwd);
+    command.args(args);
+    command
+}
+
+fn base_git_command(cwd: &Path) -> Command {
+    let mut command = Command::new("git");
+    command.current_dir(cwd);
+    for (variable, _) in std::env::vars_os() {
+        if variable.to_string_lossy().starts_with("GIT_") {
+            command.env_remove(variable);
+        }
+    }
+    command
+        .env("GIT_NO_REPLACE_OBJECTS", "1")
+        .env("GIT_NO_LAZY_FETCH", "1")
+        .env("GIT_OPTIONAL_LOCKS", "0")
+        .env("LC_ALL", "C");
+    command
 }
 
 /// `repository_root(directory)` — the work-tree root containing `directory`.
@@ -89,19 +149,1711 @@ impl Drop for MaterializedRevision {
 
 /// A fresh `decided-watchkeeper-` temp directory under the platform temp root
 /// (std honors TMPDIR like `tempfile` does).
-fn make_temp_dir() -> io::Result<PathBuf> {
+fn make_temp_dir(prefix: &str) -> io::Result<PathBuf> {
+    make_temp_dir_at(&std::env::temp_dir(), prefix)
+}
+
+fn make_temp_dir_at(base: &Path, prefix: &str) -> io::Result<PathBuf> {
     static COUNTER: AtomicU64 = AtomicU64::new(0);
-    let base = std::env::temp_dir();
     let pid = std::process::id();
     loop {
         let n = COUNTER.fetch_add(1, Ordering::Relaxed);
-        let candidate = base.join(format!("decided-watchkeeper-{pid}-{n}"));
-        match std::fs::create_dir(&candidate) {
+        let candidate = base.join(format!("{prefix}-{pid}-{n}"));
+        match create_private_dir(&candidate) {
             Ok(()) => return Ok(candidate),
             Err(e) if e.kind() == io::ErrorKind::AlreadyExists => continue,
             Err(e) => return Err(e),
         }
     }
+}
+
+#[cfg(unix)]
+fn create_private_dir(path: &Path) -> io::Result<()> {
+    use std::os::unix::fs::DirBuilderExt;
+
+    let mut builder = std::fs::DirBuilder::new();
+    builder.mode(0o700).create(path)
+}
+
+#[cfg(not(unix))]
+fn create_private_dir(path: &Path) -> io::Result<()> {
+    std::fs::create_dir(path)
+}
+
+/// Missing-path behavior for a selected path in a strict revision snapshot.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum MissingPathPolicy {
+    /// A missing selected path is a materialization error.
+    Error,
+    /// Report `existed = false` without creating a filesystem entry.
+    Ignore,
+    /// Create an empty directory and report `existed = false`.
+    ///
+    /// This is intentionally explicit and is used only for the historical
+    /// child corpus fresh-adoption case. Archive and extraction failures are
+    /// never converted into an empty directory.
+    EmptyDirectory,
+}
+
+/// Symlink validation mode for a historical corpus walk.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CorpusSymlinkPolicy {
+    /// Match the ordinary corpus walker: hidden and non-Markdown entries are
+    /// ignored, while a visible Markdown symlink is rejected.
+    CorpusFilesOnly,
+    /// Match the v2 federation verifier, which rejects every symlink inside a
+    /// selected node before hidden/extension filtering.
+    RejectAll,
+}
+
+/// The result of materializing one selected repository-relative path.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MaterializedPath {
+    /// The selected path underneath the snapshot root.
+    pub path: PathBuf,
+    /// Whether the selected path existed in the recorded revision.
+    pub existed: bool,
+}
+
+/// A bounded, strict snapshot of selected paths from one Git revision.
+///
+/// Callers open one guard and then add only the config, manifest, and corpus
+/// paths admitted by the federation graph. Exact paths are read from Git blob
+/// objects, so `export-ignore` and `export-subst` cannot alter provenance.
+/// Every Git command is read-only (`rev-parse`, `ls-tree`, `cat-file`, and
+/// `config --blob`), and no operation can fetch or check out data.
+pub struct RevisionSnapshot {
+    root: PathBuf,
+    repository_root: PathBuf,
+    revision: String,
+    commit: String,
+    limits: CorpusLimits,
+}
+
+impl Drop for RevisionSnapshot {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.root);
+    }
+}
+
+impl RevisionSnapshot {
+    /// Open a strict snapshot guard for `rev` without materializing any path.
+    pub fn open(repo_root: &str, rev: &str) -> Result<Self, RevisionSnapshotError> {
+        let repository_root = std::fs::canonicalize(repo_root).map_err(|error| {
+            RevisionSnapshotError::NotAGitRepository(format!("not a git repository: {error}"))
+        })?;
+        let verify = run_git(
+            &[
+                "rev-parse",
+                "--verify",
+                "--quiet",
+                &format!("{rev}^{{commit}}"),
+            ],
+            &repository_root,
+        )?;
+        if !verify.status.success() {
+            return Err(RevisionSnapshotError::RevisionNotFound(format!(
+                "unknown revision: {rev}"
+            )));
+        }
+        let commit = String::from_utf8_lossy(&verify.stdout).trim().to_string();
+        if commit.is_empty() {
+            return Err(RevisionSnapshotError::RevisionNotFound(format!(
+                "unknown revision: {rev}"
+            )));
+        }
+        let temp_base = std::fs::canonicalize(std::env::temp_dir()).map_err(|error| {
+            RevisionSnapshotError::MaterializationFailed(format!(
+                "cannot resolve revision snapshot base: {error}"
+            ))
+        })?;
+        let mut protected_roots = vec![("selected repository", repository_root.clone())];
+        if let Some(git_dir) = absolute_git_dir(&repository_root)? {
+            protected_roots.push(("selected Git directory", git_dir));
+        }
+        if let Some(common_dir) = absolute_git_common_dir(&repository_root)? {
+            protected_roots.push(("selected Git common directory", common_dir));
+        }
+        if let Some((boundary, _)) = protected_roots
+            .iter()
+            .find(|(_, protected)| temp_base.starts_with(protected))
+        {
+            return Err(RevisionSnapshotError::MaterializationFailed(format!(
+                "revision snapshot base must be outside the {boundary}: {}",
+                temp_base.display()
+            )));
+        }
+        let created_root = make_temp_dir_at(&temp_base, "decided-revision").map_err(|error| {
+            RevisionSnapshotError::MaterializationFailed(format!(
+                "cannot create revision snapshot: {error}"
+            ))
+        })?;
+        let root = std::fs::canonicalize(&created_root).map_err(|error| {
+            let _ = std::fs::remove_dir(&created_root);
+            RevisionSnapshotError::MaterializationFailed(format!(
+                "cannot resolve revision snapshot directory: {error}"
+            ))
+        })?;
+        Ok(Self {
+            root,
+            repository_root,
+            revision: rev.to_string(),
+            commit,
+            limits: CorpusLimits::default(),
+        })
+    }
+
+    /// Root of the temporary snapshot tree.
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// Strictly materialize one exact repository-relative file.
+    ///
+    /// Gitlink components are followed through already-local submodule object
+    /// databases using the commit recorded by the containing tree. This
+    /// repeats for nested gitlinks. A missing object database or recorded
+    /// commit is an error: the method never fetches and never substitutes
+    /// working-tree bytes for the recorded commit.
+    pub fn materialize_path(
+        &mut self,
+        repo_relative: impl AsRef<Path>,
+        missing: MissingPathPolicy,
+    ) -> Result<MaterializedPath, RevisionSnapshotError> {
+        let components = normalized_components(repo_relative.as_ref(), false)?;
+        validate_snapshot_path(&components)?;
+        let requested = components.join("/");
+        let destination = join_components(&self.root, &components);
+        let Some(resolved) = self.resolve_selection(&components)? else {
+            return self.handle_missing(&requested, destination, missing);
+        };
+        let Some(entry) = resolved.entry.as_ref() else {
+            return Err(materialization_error(format!(
+                "revision snapshot path must select a file, not a submodule root: {requested}"
+            )));
+        };
+        if entry.kind != "blob" {
+            return Err(materialization_error(format!(
+                "revision snapshot path must select a file: {requested}"
+            )));
+        }
+        let size = entry.size.ok_or_else(|| {
+            materialization_error(format!(
+                "git ls-tree did not report a blob size for {requested}"
+            ))
+        })?;
+        if size > V2_MAX_FILE_BYTES as u64 {
+            return Err(materialization_error(format!(
+                "revision snapshot file exceeds {V2_MAX_FILE_BYTES} bytes: {requested}"
+            )));
+        }
+        if !self.limits.admit(&requested, entry)? {
+            return Ok(MaterializedPath {
+                path: destination,
+                existed: true,
+            });
+        }
+        self.limits.physical_bytes = self
+            .limits
+            .physical_bytes
+            .checked_add(size)
+            .ok_or_else(|| materialization_error("revision snapshot byte count overflow".into()))?;
+        if self.limits.physical_bytes > V2_MAX_PHYSICAL_BYTES as u64 {
+            return Err(materialization_error(format!(
+                "revision snapshot exceeds physical byte limit {V2_MAX_PHYSICAL_BYTES}"
+            )));
+        }
+        materialize_blob(&resolved.repository, entry, &destination, &requested)?;
+        Ok(MaterializedPath {
+            path: destination,
+            existed: true,
+        })
+    }
+
+    /// Materialize only corpus-relevant Markdown entries under one selected
+    /// directory. A root corpus (`.`) is allowed here without archiving the
+    /// whole repository: hidden components and non-`.md` entries are omitted
+    /// with the same path semantics as the corpus walker.
+    ///
+    /// A missing non-root corpus becomes an empty directory with
+    /// `existed = false`, as required for historical fresh adoption.
+    pub fn materialize_corpus(
+        &mut self,
+        repo_relative: impl AsRef<Path>,
+    ) -> Result<MaterializedPath, RevisionSnapshotError> {
+        self.materialize_corpus_with_policy(repo_relative, MissingPathPolicy::EmptyDirectory)
+    }
+
+    /// Materialize corpus Markdown with an explicit missing-path policy.
+    ///
+    /// Historical child corpora use [`MissingPathPolicy::EmptyDirectory`] for
+    /// fresh adoption. Declared federation parents must use
+    /// [`MissingPathPolicy::Error`] so an unavailable parent cannot silently
+    /// become an empty corpus.
+    pub fn materialize_corpus_with_policy(
+        &mut self,
+        repo_relative: impl AsRef<Path>,
+        missing: MissingPathPolicy,
+    ) -> Result<MaterializedPath, RevisionSnapshotError> {
+        self.materialize_corpus_with_options(
+            repo_relative,
+            missing,
+            &[],
+            CorpusSymlinkPolicy::CorpusFilesOnly,
+        )
+    }
+
+    /// Materialize corpus Markdown while pruning repository-relative roots.
+    ///
+    /// The exclusions are declared federation parent roots. They are omitted
+    /// from the child walk so only each parent's explicitly selected corpus is
+    /// materialized by its later, required scan.
+    pub fn materialize_corpus_with_policy_and_exclusions(
+        &mut self,
+        repo_relative: impl AsRef<Path>,
+        missing: MissingPathPolicy,
+        excluded_repo_relative: &[PathBuf],
+    ) -> Result<MaterializedPath, RevisionSnapshotError> {
+        self.materialize_corpus_with_options(
+            repo_relative,
+            missing,
+            excluded_repo_relative,
+            CorpusSymlinkPolicy::RejectAll,
+        )
+    }
+
+    /// Materialize a corpus with explicit missing, exclusion, and symlink
+    /// semantics. This is the closure-first v2 federation entry point.
+    pub fn materialize_corpus_with_options(
+        &mut self,
+        repo_relative: impl AsRef<Path>,
+        missing: MissingPathPolicy,
+        excluded_repo_relative: &[PathBuf],
+        symlink_policy: CorpusSymlinkPolicy,
+    ) -> Result<MaterializedPath, RevisionSnapshotError> {
+        let components = normalized_components(repo_relative.as_ref(), true)?;
+        validate_snapshot_path(&components)?;
+        let mut excluded_roots = Vec::new();
+        for excluded in excluded_repo_relative {
+            let excluded = normalized_components(excluded, false)?;
+            validate_snapshot_path(&excluded)?;
+            if excluded.len() < components.len() || !excluded.starts_with(&components) {
+                return Err(materialization_error(format!(
+                    "revision snapshot corpus exclusion must equal or be nested under {}: {}",
+                    if components.is_empty() {
+                        ".".to_string()
+                    } else {
+                        components.join("/")
+                    },
+                    excluded.join("/")
+                )));
+            }
+            excluded_roots.push(excluded);
+        }
+        excluded_roots.sort();
+        excluded_roots.dedup();
+        let requested = if components.is_empty() {
+            ".".to_string()
+        } else {
+            components.join("/")
+        };
+        let destination = join_components(&self.root, &components);
+        let resolved = if components.is_empty() {
+            ResolvedSelection {
+                repository: self.repository_root.clone(),
+                commit: self.commit.clone(),
+                local_components: Vec::new(),
+                entry: None,
+            }
+        } else {
+            let Some(resolved) = self.resolve_selection(&components)? else {
+                return self.handle_missing(&requested, destination, missing);
+            };
+            resolved
+        };
+        if resolved
+            .entry
+            .as_ref()
+            .is_some_and(|entry| entry.kind != "tree")
+        {
+            return Err(materialization_error(format!(
+                "corpus path is not a directory at revision {}: {requested}",
+                self.revision
+            )));
+        }
+        std::fs::create_dir_all(&destination).map_err(|error| {
+            materialization_error(format!(
+                "cannot create snapshot corpus {requested}: {error}"
+            ))
+        })?;
+        if excluded_roots.iter().any(|excluded| excluded == &components) {
+            return Ok(MaterializedPath {
+                path: destination,
+                existed: true,
+            });
+        }
+
+        let mut batches: BTreeMap<(PathBuf, String), Vec<BlobTask>> = BTreeMap::new();
+        let mut directories = Vec::new();
+        collect_corpus_tasks(
+            &resolved.repository,
+            &resolved.commit,
+            &resolved.local_components,
+            &components,
+            &self.root,
+            0,
+            &mut self.limits,
+            &mut batches,
+            &mut directories,
+            &excluded_roots,
+            symlink_policy,
+        )?;
+        for directory in directories {
+            std::fs::create_dir_all(&directory).map_err(|error| {
+                materialization_error(format!(
+                    "cannot create Markdown-named corpus directory {}: {error}",
+                    directory.display()
+                ))
+            })?;
+        }
+        for ((repository, _commit), tasks) in batches {
+            materialize_blob_batch(&repository, &tasks)?;
+        }
+        Ok(MaterializedPath {
+            path: destination,
+            existed: true,
+        })
+    }
+
+    fn resolve_selection(
+        &self,
+        components: &[String],
+    ) -> Result<Option<ResolvedSelection>, RevisionSnapshotError> {
+        let mut repository = self.repository_root.clone();
+        let mut commit = self.commit.clone();
+        let mut component_start = 0usize;
+        let mut submodule_depth = 0usize;
+        loop {
+            let mut followed_gitlink = false;
+            for component_end in component_start + 1..=components.len() {
+                let local_components = components[component_start..component_end].to_vec();
+                let local_path = local_components.join("/");
+                let Some(entry) = tree_entry(&repository, &commit, &local_path)? else {
+                    return Ok(None);
+                };
+                if entry.mode == "160000" {
+                    submodule_depth = submodule_depth.saturating_add(1);
+                    if submodule_depth > V2_MAX_INHERITANCE_DEPTH {
+                        return Err(materialization_error(format!(
+                            "revision snapshot exceeds nested submodule depth limit {V2_MAX_INHERITANCE_DEPTH}"
+                        )));
+                    }
+                    if entry.kind != "commit" {
+                        return Err(materialization_error(format!(
+                            "invalid gitlink at {} in revision {}",
+                            components[..component_end].join("/"),
+                            self.revision
+                        )));
+                    }
+                    let global_gitlink = components[..component_end].join("/");
+                    let submodule = require_local_submodule(
+                        &repository,
+                        &commit,
+                        &local_components,
+                        &entry.object,
+                        &global_gitlink,
+                    )?;
+                    repository = submodule;
+                    commit = entry.object;
+                    component_start = component_end;
+                    followed_gitlink = true;
+                    if component_start == components.len() {
+                        return Ok(Some(ResolvedSelection {
+                            repository,
+                            commit,
+                            local_components: Vec::new(),
+                            entry: None,
+                        }));
+                    }
+                    break;
+                }
+                if component_end == components.len() {
+                    return Ok(Some(ResolvedSelection {
+                        repository,
+                        commit,
+                        local_components,
+                        entry: Some(entry),
+                    }));
+                }
+            }
+            if !followed_gitlink {
+                return Ok(None);
+            }
+        }
+    }
+
+    fn handle_missing(
+        &self,
+        requested: &str,
+        destination: PathBuf,
+        missing: MissingPathPolicy,
+    ) -> Result<MaterializedPath, RevisionSnapshotError> {
+        match missing {
+            MissingPathPolicy::Error => {
+                return Err(materialization_error(format!(
+                    "path does not exist at revision {}: {requested}",
+                    self.revision
+                )));
+            }
+            MissingPathPolicy::Ignore => {}
+            MissingPathPolicy::EmptyDirectory => {
+                std::fs::create_dir_all(&destination).map_err(|error| {
+                    materialization_error(format!(
+                        "cannot create empty snapshot path {requested}: {error}"
+                    ))
+                })?;
+            }
+        }
+        Ok(MaterializedPath {
+            path: destination,
+            existed: false,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct TreeEntry {
+    mode: String,
+    kind: String,
+    object: String,
+    size: Option<u64>,
+}
+
+struct ResolvedSelection {
+    repository: PathBuf,
+    commit: String,
+    local_components: Vec<String>,
+    /// `None` means the selected path is the root tree of a followed gitlink.
+    entry: Option<TreeEntry>,
+}
+
+#[derive(Debug)]
+struct BlobTask {
+    entry: TreeEntry,
+    destination: PathBuf,
+    display_path: String,
+}
+
+#[derive(Default)]
+struct CorpusLimits {
+    streamed: usize,
+    unkeyed_streamed: usize,
+    query_records: usize,
+    visited: usize,
+    files: usize,
+    physical_bytes: u64,
+    entries: BTreeMap<String, TreeEntry>,
+    streamed_entries: BTreeMap<String, TreeEntry>,
+}
+
+impl CorpusLimits {
+    fn charge_query(&mut self, context: &str) -> Result<(), RevisionSnapshotError> {
+        const MAX_QUERY_MULTIPLIER: usize = 4;
+
+        self.query_records = self.query_records.saturating_add(1);
+        if self.query_records
+            > V2_MAX_VISITED_ENTRIES.saturating_mul(MAX_QUERY_MULTIPLIER)
+        {
+            return Err(materialization_error(format!(
+                "revision snapshot exceeds bounded Git query overhead for {context}"
+            )));
+        }
+        Ok(())
+    }
+
+    fn charge_unkeyed_streamed(&mut self, context: &str) -> Result<(), RevisionSnapshotError> {
+        self.unkeyed_streamed = self.unkeyed_streamed.saturating_add(1);
+        if self.streamed.saturating_add(self.unkeyed_streamed) > V2_MAX_VISITED_ENTRIES {
+            return Err(materialization_error(format!(
+                "revision snapshot exceeds raw streamed entry limit {V2_MAX_VISITED_ENTRIES} for {context}"
+            )));
+        }
+        Ok(())
+    }
+
+    fn charge_streamed(
+        &mut self,
+        path: &str,
+        entry: &TreeEntry,
+    ) -> Result<(), RevisionSnapshotError> {
+        if let Some(previous) = self.streamed_entries.get(path) {
+            if previous == entry {
+                return Ok(());
+            }
+            return Err(materialization_error(format!(
+                "conflicting streamed Git entries target revision snapshot path {path}"
+            )));
+        }
+        self.streamed = self.streamed.saturating_add(1);
+        if self.streamed.saturating_add(self.unkeyed_streamed) > V2_MAX_VISITED_ENTRIES {
+            return Err(materialization_error(format!(
+                "revision snapshot exceeds raw streamed entry limit {V2_MAX_VISITED_ENTRIES} for {path}"
+            )));
+        }
+        self.streamed_entries
+            .insert(path.to_string(), entry.clone());
+        Ok(())
+    }
+
+    /// Admit one snapshot destination exactly once. A repeated traversal of
+    /// the same committed entry is free; a different source object attempting
+    /// to occupy that destination fails closed.
+    fn admit(&mut self, path: &str, entry: &TreeEntry) -> Result<bool, RevisionSnapshotError> {
+        if let Some(previous) = self.entries.get(path) {
+            if previous == entry {
+                return Ok(false);
+            }
+            return Err(materialization_error(format!(
+                "conflicting committed entries target revision snapshot path {path}"
+            )));
+        }
+        if self.visited >= V2_MAX_VISITED_ENTRIES {
+            return Err(materialization_error(format!(
+                "revision snapshot exceeds visited entry limit {V2_MAX_VISITED_ENTRIES}"
+            )));
+        }
+        self.entries.insert(path.to_string(), entry.clone());
+        self.visited += 1;
+        Ok(true)
+    }
+}
+
+fn materialization_error(message: String) -> RevisionSnapshotError {
+    RevisionSnapshotError::MaterializationFailed(message)
+}
+
+fn command_stderr(output: &Output) -> String {
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    if stderr.is_empty() {
+        format!("git exited with {}", output.status)
+    } else {
+        stderr
+    }
+}
+
+/// Convert a platform path to validated Git path components. Joining the
+/// result with `/` gives Git's required separator even on Windows.
+fn normalized_components(
+    path: &Path,
+    allow_root: bool,
+) -> Result<Vec<String>, RevisionSnapshotError> {
+    let mut out = Vec::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::Normal(value) => {
+                let value = value.to_str().ok_or_else(|| {
+                    materialization_error("revision snapshot paths must be valid UTF-8".to_string())
+                })?;
+                validate_portable_component(value, &path.display().to_string())?;
+                out.push(value.to_string());
+            }
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                return Err(materialization_error(format!(
+                    "revision snapshot path must be repository-relative: {}",
+                    path.display()
+                )));
+            }
+        }
+    }
+    if out.is_empty() && !allow_root {
+        return Err(materialization_error(
+            "revision snapshot path must select a bounded repository-relative path".to_string(),
+        ));
+    }
+    Ok(out)
+}
+
+fn validate_portable_component(
+    component: &str,
+    context: &str,
+) -> Result<(), RevisionSnapshotError> {
+    let bytes = component.as_bytes();
+    let windows_prefix = bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':';
+    if component.is_empty()
+        || component == "."
+        || component == ".."
+        || component.contains('/')
+        || component.contains('\\')
+        || windows_prefix
+    {
+        return Err(materialization_error(format!(
+            "unsafe revision snapshot path component {component:?} in {context}"
+        )));
+    }
+    Ok(())
+}
+
+fn join_components(root: &Path, components: &[String]) -> PathBuf {
+    let mut out = root.to_path_buf();
+    for component in components {
+        out.push(component);
+    }
+    out
+}
+
+fn strip_component_prefix<'a>(path: &'a [String], prefix: &[String]) -> Option<&'a [String]> {
+    if path.starts_with(prefix) {
+        Some(&path[prefix.len()..])
+    } else {
+        None
+    }
+}
+
+fn parse_tree_record(
+    record: &[u8],
+    context: &str,
+) -> Result<(Vec<String>, TreeEntry), RevisionSnapshotError> {
+    let Some(tab) = record.iter().position(|byte| *byte == b'\t') else {
+        return Err(materialization_error(format!(
+            "malformed git ls-tree output for {context}"
+        )));
+    };
+    let path = match std::str::from_utf8(&record[tab + 1..]) {
+        Ok(path) => path,
+        // The corpus walker excludes non-UTF-8 names and does not descend
+        // through a non-UTF-8 component, so callers discard this sentinel.
+        Err(_) => {
+            return Ok((
+                Vec::new(),
+                TreeEntry {
+                    mode: String::new(),
+                    kind: String::new(),
+                    object: String::new(),
+                    size: None,
+                },
+            ))
+        }
+    };
+    let header = std::str::from_utf8(&record[..tab]).map_err(|_| {
+        materialization_error(format!("malformed git ls-tree output for {context}"))
+    })?;
+    let fields: Vec<&str> = header.split_ascii_whitespace().collect();
+    if fields.len() != 3 && fields.len() != 4 {
+        return Err(materialization_error(format!(
+            "malformed git ls-tree output for {context}"
+        )));
+    }
+    let components: Vec<String> = path.split('/').map(str::to_string).collect();
+    for component in &components {
+        validate_portable_component(component, context)?;
+    }
+    Ok((
+        components,
+        TreeEntry {
+            mode: fields[0].to_string(),
+            kind: fields[1].to_string(),
+            object: fields[2].to_string(),
+            size: fields
+                .get(3)
+                .filter(|size| **size != "-")
+                .and_then(|size| size.parse().ok()),
+        },
+    ))
+}
+
+const MAX_LS_TREE_RECORD_BYTES: usize = V2_MAX_PATH_BYTES + 256;
+const MAX_GIT_STDERR_BYTES: u64 = 64 * 1024;
+
+fn drain_git_stderr(mut stderr: impl Read) -> io::Result<Vec<u8>> {
+    let mut retained = Vec::new();
+    let mut buffer = [0u8; 8 * 1024];
+    loop {
+        let read = stderr.read(&mut buffer)?;
+        if read == 0 {
+            return Ok(retained);
+        }
+        let remaining = (MAX_GIT_STDERR_BYTES as usize).saturating_sub(retained.len());
+        retained.extend_from_slice(&buffer[..read.min(remaining)]);
+    }
+}
+
+fn read_nul_record(
+    reader: &mut impl BufRead,
+    context: &str,
+) -> Result<Option<Vec<u8>>, RevisionSnapshotError> {
+    let mut record = Vec::new();
+    loop {
+        let buffer = reader.fill_buf().map_err(|error| {
+            materialization_error(format!("cannot read git ls-tree output for {context}: {error}"))
+        })?;
+        if buffer.is_empty() {
+            if record.is_empty() {
+                return Ok(None);
+            }
+            return Err(materialization_error(format!(
+                "unterminated git ls-tree record for {context}"
+            )));
+        }
+
+        let delimiter = buffer.iter().position(|byte| *byte == 0);
+        let take = delimiter.unwrap_or(buffer.len());
+        if record.len().saturating_add(take) > MAX_LS_TREE_RECORD_BYTES {
+            return Err(materialization_error(format!(
+                "git ls-tree record exceeds bounded path size for {context}"
+            )));
+        }
+        record.extend_from_slice(&buffer[..take]);
+        reader.consume(take + usize::from(delimiter.is_some()));
+        if delimiter.is_some() {
+            return Ok(Some(record));
+        }
+    }
+}
+
+fn visit_recursive_tree_records(
+    repository: &Path,
+    commit: &str,
+    selected: &[String],
+    visit: impl FnMut(&[u8]) -> Result<(), RevisionSnapshotError>,
+) -> Result<(), RevisionSnapshotError> {
+    let selected_path = selected.join("/");
+    let command = if selected.is_empty() {
+        git_command(&["ls-tree", "-r", "-t", "-l", "-z", commit], repository)
+    } else {
+        let literal = format!(":(literal){selected_path}");
+        git_command(
+            &["ls-tree", "-r", "-t", "-l", "-z", commit, "--", &literal],
+            repository,
+        )
+    };
+    let context = if selected.is_empty() {
+        "."
+    } else {
+        &selected_path
+    };
+    visit_tree_command(command, context, visit)
+}
+
+fn visit_tree_command(
+    mut command: Command,
+    context: &str,
+    mut visit: impl FnMut(&[u8]) -> Result<(), RevisionSnapshotError>,
+) -> Result<(), RevisionSnapshotError> {
+    let mut child = command
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|_| {
+            RevisionSnapshotError::NotAGitRepository("git executable not found".to_string())
+        })?;
+    let stdout = child.stdout.take().ok_or_else(|| {
+        materialization_error("git ls-tree stdout unavailable".to_string())
+    })?;
+    let stderr = child.stderr.take().ok_or_else(|| {
+        materialization_error("git ls-tree stderr unavailable".to_string())
+    })?;
+    let stderr_reader = std::thread::spawn(move || drain_git_stderr(stderr));
+
+    let mut stdout = BufReader::new(stdout);
+    let visit_result = (|| -> Result<(), RevisionSnapshotError> {
+        while let Some(record) = read_nul_record(&mut stdout, context)? {
+            if !record.is_empty() {
+                visit(&record)?;
+            }
+        }
+        Ok(())
+    })();
+    if visit_result.is_err() {
+        let _ = child.kill();
+    }
+    drop(stdout);
+    let status = child
+        .wait()
+        .map_err(|error| materialization_error(format!("cannot wait for git ls-tree: {error}")))?;
+    let stderr = stderr_reader
+        .join()
+        .map_err(|_| materialization_error("cannot join git ls-tree stderr reader".to_string()))?;
+    let stderr = stderr.map_err(|error| {
+        materialization_error(format!("cannot read git ls-tree stderr: {error}"))
+    })?;
+    visit_result?;
+    if !status.success() {
+        let stderr = String::from_utf8_lossy(&stderr);
+        return Err(materialization_error(format!(
+            "git ls-tree failed for {}: {}",
+            context,
+            if stderr.trim().is_empty() {
+                status.to_string()
+            } else {
+                stderr.trim().to_string()
+            }
+        )));
+    }
+    Ok(())
+}
+
+fn visit_tree_children(
+    repository: &Path,
+    commit: &str,
+    directory: &[String],
+    visit: impl FnMut(&[u8]) -> Result<(), RevisionSnapshotError>,
+) -> Result<(), RevisionSnapshotError> {
+    let directory_path = directory.join("/");
+    let command = if directory.is_empty() {
+        git_command(&["ls-tree", "-t", "-l", "-z", commit], repository)
+    } else {
+        let literal = format!(":(literal){directory_path}/");
+        git_command(
+            &["ls-tree", "-t", "-l", "-z", commit, "--", &literal],
+            repository,
+        )
+    };
+    visit_tree_command(
+        command,
+        if directory.is_empty() {
+            "."
+        } else {
+            &directory_path
+        },
+        visit,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn collect_included_frontier(
+    repository: &Path,
+    commit: &str,
+    directory: &[String],
+    selected_root: &[String],
+    global_prefix: &[String],
+    excluded: &[Vec<String>],
+    limits: &mut CorpusLimits,
+    traversed: &mut usize,
+    path_bytes: &mut usize,
+    included: &mut Vec<Vec<String>>,
+) -> Result<(), RevisionSnapshotError> {
+    let context = if directory.is_empty() {
+        ".".to_string()
+    } else {
+        directory.join("/")
+    };
+    visit_tree_children(repository, commit, directory, |record| {
+        limits.charge_query(&context)?;
+        let (path, entry) = parse_tree_record(record, &context)?;
+        if path.is_empty() {
+            limits.charge_unkeyed_streamed(&context)?;
+            return Ok(());
+        }
+        if let Some(relative) = strip_component_prefix(&path, selected_root) {
+            let global_path: Vec<String> = global_prefix
+                .iter()
+                .cloned()
+                .chain(relative.iter().cloned())
+                .collect();
+            let display_path = if global_path.is_empty() {
+                ".".to_string()
+            } else {
+                global_path.join("/")
+            };
+            limits.charge_streamed(&display_path, &entry)?;
+        }
+        if path == directory || directory.starts_with(&path) {
+            return Ok(());
+        }
+        let Some(relative) = strip_component_prefix(&path, directory) else {
+            return Err(materialization_error(format!(
+                "git ls-tree returned path {} outside frontier directory {context}",
+                path.join("/")
+            )));
+        };
+        if relative.len() != 1 {
+            return Err(materialization_error(format!(
+                "git ls-tree recursively entered {} while pruning {context}",
+                path.join("/")
+            )));
+        }
+        *traversed = traversed.saturating_add(1);
+        if *traversed > V2_MAX_VISITED_ENTRIES {
+            return Err(materialization_error(format!(
+                "revision snapshot exclusion frontier exceeds entry limit {V2_MAX_VISITED_ENTRIES}"
+            )));
+        }
+        if excluded.iter().any(|root| root == &path) {
+            return Ok(());
+        }
+        if excluded
+            .iter()
+            .any(|root| root.len() > path.len() && root.starts_with(&path))
+        {
+            if entry.kind == "commit" && entry.mode == "160000" {
+                let bytes = path.join("/").len();
+                *path_bytes = path_bytes.checked_add(bytes).ok_or_else(|| {
+                    materialization_error(
+                        "revision snapshot frontier byte count overflow".to_string(),
+                    )
+                })?;
+                if *path_bytes > V2_MAX_PHYSICAL_BYTES {
+                    return Err(materialization_error(format!(
+                        "revision snapshot exclusion frontier exceeds {V2_MAX_PHYSICAL_BYTES} path bytes"
+                    )));
+                }
+                // The superproject walk sees only the gitlink. Its normal
+                // processing follows the recorded local ODB, where the
+                // descendant exclusion is converted to submodule-local form
+                // and physically pruned by the recursive corpus scan.
+                included.push(path);
+                return Ok(());
+            }
+            if entry.kind != "tree" {
+                return Err(materialization_error(format!(
+                    "revision snapshot exclusion crosses non-tree path {}",
+                    path.join("/")
+                )));
+            }
+            return collect_included_frontier(
+                repository,
+                commit,
+                &path,
+                selected_root,
+                global_prefix,
+                excluded,
+                limits,
+                traversed,
+                path_bytes,
+                included,
+            );
+        }
+        let bytes = path.join("/").len();
+        *path_bytes = path_bytes.checked_add(bytes).ok_or_else(|| {
+            materialization_error("revision snapshot frontier byte count overflow".to_string())
+        })?;
+        if *path_bytes > V2_MAX_PHYSICAL_BYTES {
+            return Err(materialization_error(format!(
+                "revision snapshot exclusion frontier exceeds {V2_MAX_PHYSICAL_BYTES} path bytes"
+            )));
+        }
+        included.push(path);
+        Ok(())
+    })
+}
+
+fn visit_frontier_tree_records(
+    repository: &Path,
+    commit: &str,
+    selected: &[String],
+    included: &[Vec<String>],
+    mut visit: impl FnMut(&[u8]) -> Result<(), RevisionSnapshotError>,
+) -> Result<(), RevisionSnapshotError> {
+    const MAX_PATHSPEC_BATCH_BYTES: usize = 32 * 1024;
+    const MAX_PATHSPEC_BATCH_COUNT: usize = 256;
+
+    let context = if selected.is_empty() {
+        ".".to_string()
+    } else {
+        selected.join("/")
+    };
+    let mut start = 0usize;
+    while start < included.len() {
+        let mut command = base_git_command(repository);
+        command.args(["ls-tree", "-r", "-t", "-l", "-z", commit, "--"]);
+        let mut bytes = 0usize;
+        let mut end = start;
+        while end < included.len() && end - start < MAX_PATHSPEC_BATCH_COUNT {
+            let path = included[end].join("/");
+            let next_bytes = bytes.saturating_add(path.len() + 16);
+            if end > start && next_bytes > MAX_PATHSPEC_BATCH_BYTES {
+                break;
+            }
+            command.arg(format!(":(literal){path}"));
+            bytes = next_bytes;
+            end += 1;
+        }
+        visit_tree_command(command, &context, |record| visit(record))?;
+        start = end;
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn collect_corpus_tasks(
+    repository: &Path,
+    commit: &str,
+    selected: &[String],
+    global_prefix: &[String],
+    snapshot_root: &Path,
+    submodule_depth: usize,
+    limits: &mut CorpusLimits,
+    batches: &mut BTreeMap<(PathBuf, String), Vec<BlobTask>>,
+    directories: &mut Vec<PathBuf>,
+    excluded_roots: &[Vec<String>],
+    symlink_policy: CorpusSymlinkPolicy,
+) -> Result<(), RevisionSnapshotError> {
+    if submodule_depth > V2_MAX_INHERITANCE_DEPTH {
+        return Err(materialization_error(format!(
+            "revision snapshot exceeds nested submodule depth limit {V2_MAX_INHERITANCE_DEPTH}"
+        )));
+    }
+    let selected_path = selected.join("/");
+    let context = if selected.is_empty() {
+        "."
+    } else {
+        &selected_path
+    };
+    let mut local_exclusions = Vec::new();
+    for excluded in excluded_roots {
+        if excluded.len() > global_prefix.len() && excluded.starts_with(global_prefix) {
+            let mut local = selected.to_vec();
+            local.extend_from_slice(&excluded[global_prefix.len()..]);
+            local_exclusions.push(local);
+        }
+    }
+    local_exclusions.sort();
+    local_exclusions.dedup();
+
+    let included = if local_exclusions.is_empty() {
+        None
+    } else {
+        let mut included = Vec::new();
+        let mut traversed = 0usize;
+        let mut path_bytes = 0usize;
+        collect_included_frontier(
+            repository,
+            commit,
+            selected,
+            selected,
+            global_prefix,
+            &local_exclusions,
+            limits,
+            &mut traversed,
+            &mut path_bytes,
+            &mut included,
+        )?;
+        Some(included)
+    };
+
+    let mut visit_record = |record: &[u8]| {
+        limits.charge_query(context)?;
+        let (local_path, entry) = parse_tree_record(record, context)?;
+        if local_path.is_empty() {
+            limits.charge_unkeyed_streamed(context)?;
+            return Ok(());
+        }
+        let Some(relative) = strip_component_prefix(&local_path, selected) else {
+            // `ls-tree -t` reports the selected path's ancestor tree entries
+            // before the selected subtree. They are routing metadata, not
+            // corpus entries.
+            if selected.starts_with(&local_path) {
+                return Ok(());
+            }
+            return Err(materialization_error(format!(
+                "git ls-tree returned path {} outside selected corpus {}",
+                local_path.join("/"),
+                selected.join("/")
+            )));
+        };
+        if relative.is_empty() {
+            return Ok(());
+        }
+        let global_path: Vec<String> = global_prefix
+            .iter()
+            .cloned()
+            .chain(relative.iter().cloned())
+            .collect();
+        validate_snapshot_path(&global_path)?;
+        let display_path = global_path.join("/");
+        limits.charge_streamed(&display_path, &entry)?;
+        if excluded_roots
+            .iter()
+            .any(|excluded| global_path.starts_with(excluded))
+        {
+            return Ok(());
+        }
+        let hidden = relative.iter().any(|component| component.starts_with('.'));
+        let markdown_named = relative.last().is_some_and(|name| name.ends_with(".md"));
+        if entry.mode == "120000"
+            && (symlink_policy == CorpusSymlinkPolicy::RejectAll
+                || (!hidden && markdown_named))
+        {
+            return Err(materialization_error(format!(
+                "committed symlink is unsupported in revision snapshot corpus: {display_path}"
+            )));
+        }
+        if hidden {
+            return Ok(());
+        }
+        if !limits.admit(&display_path, &entry)? {
+            return Ok(());
+        }
+
+        match entry.kind.as_str() {
+            "commit" => {
+                let local_submodule = require_local_submodule(
+                    repository,
+                    commit,
+                    &local_path,
+                    &entry.object,
+                    &display_path,
+                )?;
+                if markdown_named {
+                    directories.push(join_components(snapshot_root, &global_path));
+                }
+                collect_corpus_tasks(
+                    &local_submodule,
+                    &entry.object,
+                    &[],
+                    &global_path,
+                    snapshot_root,
+                    submodule_depth + 1,
+                    limits,
+                    batches,
+                    directories,
+                    excluded_roots,
+                    symlink_policy,
+                )?;
+            }
+            "tree" if markdown_named => {
+                directories.push(join_components(snapshot_root, &global_path));
+            }
+            "tree" => {}
+            "blob" if markdown_named => {
+                if entry.mode == "120000" {
+                    return Err(materialization_error(format!(
+                        "committed symlink Markdown is unsupported in revision snapshots: {}",
+                        global_path.join("/")
+                    )));
+                }
+                let size = entry.size.ok_or_else(|| {
+                    materialization_error(format!(
+                        "git ls-tree did not report a blob size for {}",
+                        global_path.join("/")
+                    ))
+                })?;
+                if size > V2_MAX_FILE_BYTES as u64 {
+                    return Err(materialization_error(format!(
+                        "revision snapshot file exceeds {V2_MAX_FILE_BYTES} bytes: {}",
+                        global_path.join("/")
+                    )));
+                }
+                limits.files += 1;
+                if limits.files > V2_MAX_INHERITED_FILES {
+                    return Err(materialization_error(format!(
+                        "revision snapshot exceeds Markdown file limit {V2_MAX_INHERITED_FILES}"
+                    )));
+                }
+                limits.physical_bytes =
+                    limits.physical_bytes.checked_add(size).ok_or_else(|| {
+                        materialization_error("revision snapshot byte count overflow".into())
+                    })?;
+                if limits.physical_bytes > V2_MAX_PHYSICAL_BYTES as u64 {
+                    return Err(materialization_error(format!(
+                        "revision snapshot exceeds physical byte limit {V2_MAX_PHYSICAL_BYTES}"
+                    )));
+                }
+                batches
+                    .entry((repository.to_path_buf(), commit.to_string()))
+                    .or_default()
+                    .push(BlobTask {
+                        entry,
+                        destination: join_components(snapshot_root, &global_path),
+                        display_path,
+                    });
+            }
+            "blob" => {}
+            _ => {
+                return Err(materialization_error(format!(
+                    "unsupported Git tree entry for corpus path {}",
+                    global_path.join("/")
+                )));
+            }
+        }
+        Ok(())
+    };
+
+    if let Some(included) = included.as_deref() {
+        visit_frontier_tree_records(repository, commit, selected, included, &mut visit_record)
+    } else {
+        visit_recursive_tree_records(repository, commit, selected, &mut visit_record)
+    }
+}
+
+fn validate_snapshot_path(components: &[String]) -> Result<(), RevisionSnapshotError> {
+    if components.len() > V2_MAX_PATH_COMPONENTS {
+        return Err(materialization_error(format!(
+            "revision snapshot path exceeds {V2_MAX_PATH_COMPONENTS} components"
+        )));
+    }
+    let path = components.join("/");
+    for component in components {
+        validate_portable_component(component, &path)?;
+    }
+    if path.len() > V2_MAX_PATH_BYTES {
+        return Err(materialization_error(format!(
+            "revision snapshot path exceeds {V2_MAX_PATH_BYTES} UTF-8 bytes: {path}"
+        )));
+    }
+    Ok(())
+}
+
+fn materialize_blob_batch(
+    repository: &Path,
+    tasks: &[BlobTask],
+) -> Result<(), RevisionSnapshotError> {
+    if tasks.is_empty() {
+        return Ok(());
+    }
+    let mut command = git_command(&["cat-file", "--batch"], repository);
+    let mut child = command
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|_| {
+            RevisionSnapshotError::NotAGitRepository("git executable not found".to_string())
+        })?;
+    let stderr = child.stderr.take().ok_or_else(|| {
+        materialization_error("git cat-file stderr unavailable".to_string())
+    })?;
+    let stderr_reader = std::thread::spawn(move || drain_git_stderr(stderr));
+
+    let exchange_result =
+        (|| -> Result<(), RevisionSnapshotError> {
+            let mut stdin = child.stdin.take().ok_or_else(|| {
+                materialization_error("git cat-file stdin unavailable".to_string())
+            })?;
+            let stdout = child.stdout.take().ok_or_else(|| {
+                materialization_error("git cat-file stdout unavailable".to_string())
+            })?;
+            let mut stdout = BufReader::new(stdout);
+            for task in tasks {
+                stdin
+                    .write_all(task.entry.object.as_bytes())
+                    .and_then(|()| stdin.write_all(b"\n"))
+                    .and_then(|()| stdin.flush())
+                    .map_err(|error| {
+                        materialization_error(format!(
+                            "cannot request committed blob for {}: {error}",
+                            task.display_path
+                        ))
+                    })?;
+                read_blob_response(&mut stdout, task)?;
+            }
+            Ok(())
+        })();
+
+    if exchange_result.is_err() {
+        let _ = child.kill();
+    }
+
+    let status = child
+        .wait()
+        .map_err(|error| materialization_error(format!("cannot wait for git cat-file: {error}")))?;
+    let stderr = stderr_reader.join().map_err(|_| {
+        materialization_error("cannot join git cat-file stderr reader".to_string())
+    })?;
+    let stderr = stderr.map_err(|error| {
+        materialization_error(format!("cannot read git cat-file stderr: {error}"))
+    })?;
+    exchange_result?;
+    if !status.success() {
+        let stderr = String::from_utf8_lossy(&stderr);
+        return Err(materialization_error(format!(
+            "git cat-file --batch failed: {}",
+            if stderr.trim().is_empty() {
+                status.to_string()
+            } else {
+                stderr.trim().to_string()
+            }
+        )));
+    }
+    Ok(())
+}
+
+fn read_blob_response(
+    stdout: &mut impl BufRead,
+    task: &BlobTask,
+) -> Result<(), RevisionSnapshotError> {
+    let mut header = String::new();
+    stdout.read_line(&mut header).map_err(|error| {
+        materialization_error(format!(
+            "cannot read committed blob header for {}: {error}",
+            task.display_path
+        ))
+    })?;
+    let fields: Vec<&str> = header
+        .trim_end_matches('\n')
+        .split_ascii_whitespace()
+        .collect();
+    if fields.len() != 3 || fields[0] != task.entry.object || fields[1] != "blob" {
+        return Err(materialization_error(format!(
+            "git cat-file returned an invalid blob header for {}",
+            task.display_path
+        )));
+    }
+    let size: usize = fields[2].parse().map_err(|_| {
+        materialization_error(format!(
+            "git cat-file returned an invalid blob size for {}",
+            task.display_path
+        ))
+    })?;
+    if task.entry.size != Some(size as u64) || size > V2_MAX_FILE_BYTES {
+        return Err(materialization_error(format!(
+            "committed blob size changed while materializing {}",
+            task.display_path
+        )));
+    }
+    let mut bytes = vec![0; size];
+    stdout.read_exact(&mut bytes).map_err(|error| {
+        materialization_error(format!(
+            "cannot read committed blob for {}: {error}",
+            task.display_path
+        ))
+    })?;
+    let mut delimiter = [0u8; 1];
+    stdout.read_exact(&mut delimiter).map_err(|error| {
+        materialization_error(format!(
+            "cannot read blob delimiter for {}: {error}",
+            task.display_path
+        ))
+    })?;
+    if delimiter[0] != b'\n' {
+        return Err(materialization_error(format!(
+            "git cat-file returned a malformed blob for {}",
+            task.display_path
+        )));
+    }
+    write_regular_blob(&task.entry, &bytes, &task.destination, &task.display_path)?;
+    Ok(())
+}
+
+fn materialize_blob(
+    repository: &Path,
+    entry: &TreeEntry,
+    destination: &Path,
+    display_path: &str,
+) -> Result<(), RevisionSnapshotError> {
+    if entry.mode == "120000" {
+        return Err(materialization_error(format!(
+            "committed symlink is unsupported in revision snapshots: {display_path}"
+        )));
+    }
+    let blob = run_git(&["cat-file", "blob", &entry.object], repository)?;
+    if !blob.status.success() {
+        return Err(materialization_error(format!(
+            "cannot read committed blob for {display_path}: {}",
+            command_stderr(&blob)
+        )));
+    }
+    if entry.size != Some(blob.stdout.len() as u64) || blob.stdout.len() > V2_MAX_FILE_BYTES {
+        return Err(materialization_error(format!(
+            "committed blob size changed while materializing {display_path}"
+        )));
+    }
+    write_regular_blob(entry, &blob.stdout, destination, display_path)
+}
+
+fn write_regular_blob(
+    entry: &TreeEntry,
+    bytes: &[u8],
+    destination: &Path,
+    display_path: &str,
+) -> Result<(), RevisionSnapshotError> {
+    if entry.mode != "100644" && entry.mode != "100755" {
+        return Err(materialization_error(format!(
+            "unsupported Git blob mode {} for {display_path}",
+            entry.mode
+        )));
+    }
+    if let Some(parent) = destination.parent() {
+        std::fs::create_dir_all(parent).map_err(|error| {
+            materialization_error(format!(
+                "cannot create snapshot directory for {display_path}: {error}"
+            ))
+        })?;
+    }
+    if std::fs::symlink_metadata(destination)
+        .is_ok_and(|metadata| metadata.file_type().is_symlink())
+    {
+        std::fs::remove_file(destination).map_err(|error| {
+            materialization_error(format!(
+                "cannot replace snapshot symlink {display_path}: {error}"
+            ))
+        })?;
+    }
+    std::fs::write(destination, bytes).map_err(|error| {
+        materialization_error(format!(
+            "cannot write snapshot file {display_path}: {error}"
+        ))
+    })?;
+    #[cfg(unix)]
+    if entry.mode == "100755" {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(destination, std::fs::Permissions::from_mode(0o755)).map_err(
+            |error| {
+                materialization_error(format!(
+                    "cannot set snapshot permissions for {display_path}: {error}"
+                ))
+            },
+        )?;
+    }
+    Ok(())
+}
+
+fn tree_entry(
+    repository: &Path,
+    commit: &str,
+    path: &str,
+) -> Result<Option<TreeEntry>, RevisionSnapshotError> {
+    let literal_pathspec = format!(":(literal){path}");
+    let output = run_git(
+        &["ls-tree", "-l", "-z", commit, "--", &literal_pathspec],
+        repository,
+    )?;
+    if !output.status.success() {
+        return Err(materialization_error(format!(
+            "git ls-tree failed for {path}: {}",
+            command_stderr(&output)
+        )));
+    }
+    if output.stdout.is_empty() {
+        return Ok(None);
+    }
+    let mut records = output
+        .stdout
+        .split(|byte| *byte == 0)
+        .filter(|r| !r.is_empty());
+    let Some(record) = records.next() else {
+        return Ok(None);
+    };
+    if records.next().is_some() {
+        return Err(materialization_error(format!(
+            "git ls-tree returned multiple entries for literal path {path}"
+        )));
+    }
+    let Some(tab) = record.iter().position(|byte| *byte == b'\t') else {
+        return Err(materialization_error(format!(
+            "malformed git ls-tree output for {path}"
+        )));
+    };
+    if &record[tab + 1..] != path.as_bytes() {
+        return Err(materialization_error(format!(
+            "git ls-tree returned an unexpected path for {path}"
+        )));
+    }
+    let header = std::str::from_utf8(&record[..tab])
+        .map_err(|_| materialization_error(format!("malformed git ls-tree output for {path}")))?;
+    let fields: Vec<&str> = header.split_ascii_whitespace().collect();
+    if fields.len() != 4 {
+        return Err(materialization_error(format!(
+            "malformed git ls-tree output for {path}"
+        )));
+    }
+    Ok(Some(TreeEntry {
+        mode: fields[0].to_string(),
+        kind: fields[1].to_string(),
+        object: fields[2].to_string(),
+        size: if fields[3] == "-" {
+            None
+        } else {
+            Some(fields[3].parse().map_err(|_| {
+                materialization_error(format!("malformed git ls-tree size for {path}"))
+            })?)
+        },
+    }))
+}
+
+fn require_local_submodule(
+    parent_repository: &Path,
+    parent_commit: &str,
+    submodule_components: &[String],
+    commit: &str,
+    repo_relative: &str,
+) -> Result<PathBuf, RevisionSnapshotError> {
+    let parent_git_dir = absolute_git_common_dir(parent_repository)?.ok_or_else(|| {
+        materialization_error(format!(
+            "cannot locate parent Git object database for submodule: {repo_relative}"
+        ))
+    })?;
+    let module_components = submodule_name_for_path(
+        parent_repository,
+        parent_commit,
+        &submodule_components.join("/"),
+    )?
+    .unwrap_or_else(|| submodule_components.to_vec());
+    let module_candidate = join_components(&parent_git_dir.join("modules"), &module_components);
+    let mut found_repository = false;
+
+    if let Some(git_dir) = absolute_git_dir(&module_candidate)? {
+        found_repository = true;
+        if commit_is_available(&git_dir, commit)? {
+            return Ok(git_dir);
+        }
+    }
+
+    let worktree = run_git(&["rev-parse", "--show-toplevel"], parent_repository)?;
+    if worktree.status.success() {
+        let worktree = std::str::from_utf8(&worktree.stdout)
+            .map_err(|_| materialization_error("Git work-tree path is not UTF-8".to_string()))?
+            .trim();
+        if !worktree.is_empty() {
+            let checkout = join_components(Path::new(worktree), submodule_components);
+            if let Some(git_dir) = absolute_git_dir(&checkout)? {
+                found_repository = true;
+                if commit_is_available(&git_dir, commit)? {
+                    return Ok(git_dir);
+                }
+            }
+        }
+    }
+
+    if found_repository {
+        return Err(materialization_error(format!(
+            "recorded submodule commit is not available locally: {repo_relative} at {commit}"
+        )));
+    }
+    Err(materialization_error(format!(
+        "submodule object database is not available locally: {repo_relative}"
+    )))
+}
+
+fn submodule_name_for_path(
+    repository: &Path,
+    commit: &str,
+    submodule_path: &str,
+) -> Result<Option<Vec<String>>, RevisionSnapshotError> {
+    let Some(attributes) = tree_entry(repository, commit, ".gitmodules")? else {
+        return Ok(None);
+    };
+    if attributes.kind != "blob" || attributes.mode == "120000" {
+        return Err(materialization_error(
+            "committed .gitmodules must be a regular file".to_string(),
+        ));
+    }
+    let size = attributes.size.ok_or_else(|| {
+        materialization_error("git ls-tree did not report a .gitmodules size".to_string())
+    })?;
+    if size > V2_MAX_FILE_BYTES as u64 {
+        return Err(materialization_error(format!(
+            "committed .gitmodules exceeds {V2_MAX_FILE_BYTES} bytes"
+        )));
+    }
+
+    let blob = format!("--blob={commit}:.gitmodules");
+    let output = run_git(
+        &[
+            "config",
+            "--null",
+            "--no-includes",
+            &blob,
+            "--get-regexp",
+            "^submodule\\..*\\.path$",
+        ],
+        repository,
+    )?;
+    if !output.status.success() {
+        if output.status.code() == Some(1) {
+            return Ok(None);
+        }
+        return Err(materialization_error(format!(
+            "cannot read committed .gitmodules: {}",
+            command_stderr(&output)
+        )));
+    }
+    if output.stdout.len() > V2_MAX_FILE_BYTES {
+        return Err(materialization_error(format!(
+            "committed .gitmodules query exceeds {V2_MAX_FILE_BYTES} bytes"
+        )));
+    }
+
+    let mut matched: Option<Vec<String>> = None;
+    for record in output.stdout.split(|byte| *byte == 0) {
+        if record.is_empty() {
+            continue;
+        }
+        let record = std::str::from_utf8(record).map_err(|_| {
+            materialization_error("committed .gitmodules is not UTF-8".to_string())
+        })?;
+        let Some((key, value)) = record.split_once('\n') else {
+            return Err(materialization_error(
+                "malformed committed .gitmodules query result".to_string(),
+            ));
+        };
+        if value != submodule_path {
+            continue;
+        }
+        let Some(name) = key
+            .strip_prefix("submodule.")
+            .and_then(|key| key.strip_suffix(".path"))
+        else {
+            return Err(materialization_error(
+                "malformed committed .gitmodules key".to_string(),
+            ));
+        };
+        let components: Vec<String> = name.split('/').map(str::to_string).collect();
+        validate_snapshot_path(&components)?;
+        if matched.as_ref().is_some_and(|previous| previous != &components) {
+            return Err(materialization_error(format!(
+                "multiple committed submodule names select path {submodule_path}"
+            )));
+        }
+        matched = Some(components);
+    }
+    Ok(matched)
+}
+
+fn absolute_git_dir(repository: &Path) -> Result<Option<PathBuf>, RevisionSnapshotError> {
+    if !repository.is_dir() {
+        return Ok(None);
+    }
+    let output = run_git(&["rev-parse", "--absolute-git-dir"], repository)?;
+    if !output.status.success() {
+        return Ok(None);
+    }
+    let git_dir = std::str::from_utf8(&output.stdout)
+        .map_err(|_| materialization_error("Git object database path is not UTF-8".to_string()))?
+        .trim();
+    if git_dir.is_empty() {
+        return Ok(None);
+    }
+    let git_dir = std::fs::canonicalize(git_dir).map_err(|error| {
+        materialization_error(format!("cannot resolve local Git object database: {error}"))
+    })?;
+    Ok(Some(git_dir))
+}
+
+fn absolute_git_common_dir(repository: &Path) -> Result<Option<PathBuf>, RevisionSnapshotError> {
+    if !repository.is_dir() {
+        return Ok(None);
+    }
+    let output = run_git(&["rev-parse", "--git-common-dir"], repository)?;
+    if !output.status.success() {
+        return Ok(None);
+    }
+    let git_dir = std::str::from_utf8(&output.stdout)
+        .map_err(|_| materialization_error("Git common directory is not UTF-8".to_string()))?
+        .trim();
+    if git_dir.is_empty() {
+        return Ok(None);
+    }
+    let git_dir = Path::new(git_dir);
+    let git_dir = if git_dir.is_absolute() {
+        git_dir.to_path_buf()
+    } else {
+        repository.join(git_dir)
+    };
+    let git_dir = std::fs::canonicalize(git_dir).map_err(|error| {
+        materialization_error(format!("cannot resolve local Git common directory: {error}"))
+    })?;
+    Ok(Some(git_dir))
+}
+
+fn commit_is_available(repository: &Path, commit: &str) -> Result<bool, RevisionSnapshotError> {
+    let object = run_git(
+        &["cat-file", "-e", &format!("{commit}^{{commit}}")],
+        repository,
+    )?;
+    Ok(object.status.success())
 }
 
 /// `materialized_revision(repo_root, rev, subpath)` — verify the commit,
@@ -113,10 +1865,7 @@ pub fn materialize_revision(
     subpath: &str,
 ) -> Result<MaterializedRevision, RevisionError> {
     let root = Path::new(repo_root);
-    let verify = run_git(
-        &["rev-parse", "--verify", "--quiet", &format!("{rev}^{{commit}}")],
-        root,
-    )?;
+    let verify = run_git(&["rev-parse", "--verify", "--quiet", &format!("{rev}^{{commit}}")], root)?;
     if !verify.status.success() {
         return Err(RevisionError::RevisionNotFound(format!(
             "unknown revision: {rev}"
@@ -130,7 +1879,7 @@ pub fn materialize_revision(
     };
     let archive = run_git(&["archive", "--format=tar", rev, "--", pathspec], root)?;
 
-    let tmp = make_temp_dir().map_err(|e| {
+    let tmp = make_temp_dir("decided-watchkeeper").map_err(|e| {
         // No oracle-comparable surface exists for a failing temp root; the
         // closest degrade is the not-a-repository class (never hit by the
         // parity fixtures).

--- a/rust/rac-engine/src/scaffold.rs
+++ b/rust/rac-engine/src/scaffold.rs
@@ -23,7 +23,7 @@ use std::path::Path;
 use crate::pycompat::py_repr_str;
 use crate::relationships::CorpusItem;
 use crate::spec::available_schemas;
-use crate::validate::find_config_file;
+use crate::validate::{find_config_file, find_config_file_with_boundary};
 use crate::walk::py_join;
 
 // ---------------------------------------------------------------------------
@@ -372,7 +372,14 @@ fn read_config(config_path: &str) -> Result<RepositoryConfig, ScaffoldError> {
 pub fn load_repository_identity(
     start_dir: &str,
 ) -> Result<Option<RepositoryIdentityConfig>, ScaffoldError> {
-    match find_config_file(start_dir) {
+    load_repository_identity_with_boundary(start_dir, None)
+}
+
+pub fn load_repository_identity_with_boundary(
+    start_dir: &str,
+    boundary: Option<&Path>,
+) -> Result<Option<RepositoryIdentityConfig>, ScaffoldError> {
+    match find_config_file_with_boundary(start_dir, boundary) {
         Some(path) => read_identity_config(&path.to_string_lossy()).map(Some),
         None => Ok(None),
     }

--- a/rust/rac-engine/src/validate.rs
+++ b/rust/rac-engine/src/validate.rs
@@ -904,12 +904,26 @@ fn add_okf(
 /// `find_config_file(start_dir)`: the nearest `.decided/config.yaml` at or above
 /// the resolved `start_dir`.
 pub fn find_config_file(start_dir: &str) -> Option<PathBuf> {
+    find_config_file_with_boundary(start_dir, None)
+}
+
+/// Nearest config without walking above an optional trusted filesystem root.
+pub fn find_config_file_with_boundary(
+    start_dir: &str,
+    boundary: Option<&Path>,
+) -> Option<PathBuf> {
     let resolved = resolve_path(start_dir);
     let mut current: Option<&Path> = Some(resolved.as_path());
     while let Some(dir) = current {
+        if boundary.is_some_and(|root| !dir.starts_with(root)) {
+            return None;
+        }
         let candidate = dir.join(".decided").join("config.yaml");
         if candidate.is_file() {
             return Some(candidate);
+        }
+        if boundary.is_some_and(|root| dir == root) {
+            return None;
         }
         current = dir.parent();
     }
@@ -941,8 +955,11 @@ fn yaml_map_get<'a>(pairs: &'a [(Yaml, Yaml)], name: &str) -> Option<&'a Yaml> {
     })
 }
 
-fn load_config_mapping(start_dir: &str) -> Option<Vec<(Yaml, Yaml)>> {
-    let config_path = find_config_file(start_dir)?;
+fn load_config_mapping_with_boundary(
+    start_dir: &str,
+    boundary: Option<&Path>,
+) -> Option<Vec<(Yaml, Yaml)>> {
+    let config_path = find_config_file_with_boundary(start_dir, boundary)?;
     let text = std::fs::read_to_string(&config_path).ok()?;
     // The oracle uses full `yaml.safe_load`; the bounded frontmatter loader
     // covers the well-formed configs the parity corpus contains. (A config
@@ -950,6 +967,10 @@ fn load_config_mapping(start_dir: &str) -> Option<Vec<(Yaml, Yaml)>> {
     // fix here, not silently accept.)
     let (pairs, _issues) = load_frontmatter_mapping(&text);
     pairs
+}
+
+fn load_config_mapping(start_dir: &str) -> Option<Vec<(Yaml, Yaml)>> {
+    load_config_mapping_with_boundary(start_dir, None)
 }
 
 /// Coerce a YAML 1.1 severity value: bare `off` parses as Bool(false).
@@ -1035,7 +1056,14 @@ pub fn load_freshness_threshold(start_dir: &str) -> i64 {
 
 /// `load_ticketing_provider(start_dir)` (ADR-088).
 pub fn load_ticketing_provider(start_dir: &str) -> Option<String> {
-    let pairs = load_config_mapping(start_dir)?;
+    load_ticketing_provider_with_boundary(start_dir, None)
+}
+
+pub fn load_ticketing_provider_with_boundary(
+    start_dir: &str,
+    boundary: Option<&Path>,
+) -> Option<String> {
+    let pairs = load_config_mapping_with_boundary(start_dir, boundary)?;
     let Some(Yaml::Map(section)) = yaml_map_get(&pairs, "ticketing") else {
         return None;
     };

--- a/rust/rac-engine/tests/revision_snapshot.rs
+++ b/rust/rac-engine/tests/revision_snapshot.rs
@@ -1,0 +1,429 @@
+use rac_engine::revisions::{
+    materialize_revision, MissingPathPolicy, RevisionSnapshot, RevisionSnapshotError,
+};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+struct Scratch(PathBuf);
+
+impl Scratch {
+    fn new(label: &str) -> Self {
+        static NEXT: AtomicU64 = AtomicU64::new(0);
+        let path = std::env::temp_dir().join(format!(
+            "decided-revision-test-{label}-{}-{}",
+            std::process::id(),
+            NEXT.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::create_dir(&path).unwrap();
+        Self(path)
+    }
+
+    fn path(&self) -> &Path {
+        &self.0
+    }
+}
+
+impl Drop for Scratch {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+fn git(repo: &Path, args: &[&str]) -> String {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(repo)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+fn init(repo: &Path) {
+    git(repo, &["init", "-q"]);
+    git(repo, &["config", "user.name", "Revision Test"]);
+    git(repo, &["config", "user.email", "revision@example.invalid"]);
+}
+
+fn commit_all(repo: &Path, message: &str) -> String {
+    git(repo, &["add", "-A"]);
+    git(repo, &["commit", "-q", "-m", message]);
+    git(repo, &["rev-parse", "HEAD"])
+}
+
+#[test]
+fn root_corpus_materializes_only_exact_markdown_blobs() {
+    let scratch = Scratch::new("root-corpus");
+    let repo = scratch.path();
+    init(repo);
+    std::fs::create_dir_all(repo.join("nested")).unwrap();
+    std::fs::create_dir_all(repo.join(".hidden")).unwrap();
+    std::fs::write(repo.join("root.md"), "$Format:%H$\n").unwrap();
+    std::fs::write(repo.join("nested/keep.md"), "kept despite export-ignore\n").unwrap();
+    std::fs::write(repo.join("nested/ignore.txt"), "not corpus input\n").unwrap();
+    std::fs::write(repo.join(".hidden/skip.md"), "hidden\n").unwrap();
+    std::fs::write(
+        repo.join(".gitattributes"),
+        "root.md export-subst\nnested/keep.md export-ignore\n",
+    )
+    .unwrap();
+    let revision = commit_all(repo, "fixture");
+
+    let mut snapshot = RevisionSnapshot::open(repo.to_str().unwrap(), &revision).unwrap();
+    let corpus = snapshot.materialize_corpus(".").unwrap();
+    assert!(corpus.existed);
+    assert_eq!(
+        std::fs::read_to_string(corpus.path.join("root.md")).unwrap(),
+        "$Format:%H$\n"
+    );
+    assert_eq!(
+        std::fs::read_to_string(corpus.path.join("nested/keep.md")).unwrap(),
+        "kept despite export-ignore\n"
+    );
+    assert!(!corpus.path.join("nested/ignore.txt").exists());
+    assert!(!corpus.path.join(".hidden").exists());
+    assert!(!corpus.path.join(".gitattributes").exists());
+}
+
+#[test]
+fn missing_policies_distinguish_optional_file_and_empty_corpus() {
+    let scratch = Scratch::new("missing");
+    let repo = scratch.path();
+    init(repo);
+    std::fs::write(repo.join("README.md"), "fixture\n").unwrap();
+    let revision = commit_all(repo, "fixture");
+
+    let mut snapshot = RevisionSnapshot::open(repo.to_str().unwrap(), &revision).unwrap();
+    let optional = snapshot
+        .materialize_path(".decided/config.yaml", MissingPathPolicy::Ignore)
+        .unwrap();
+    assert!(!optional.existed);
+    assert!(!optional.path.exists());
+
+    let empty = snapshot.materialize_corpus("decisions").unwrap();
+    assert!(!empty.existed);
+    assert!(empty.path.is_dir());
+
+    let required = snapshot
+        .materialize_corpus_with_policy("parents/missing", MissingPathPolicy::Error)
+        .unwrap_err();
+    assert!(required.message().contains("path does not exist"));
+    assert!(!snapshot.root().join("parents/missing").exists());
+}
+
+#[test]
+fn replacement_refs_cannot_change_selected_revision_bytes() {
+    let scratch = Scratch::new("replace-ref");
+    let repo = scratch.path();
+    init(repo);
+    std::fs::create_dir(repo.join("decisions")).unwrap();
+    std::fs::write(repo.join("decisions/a.md"), "original\n").unwrap();
+    let original = commit_all(repo, "original");
+    std::fs::write(repo.join("decisions/a.md"), "replacement\n").unwrap();
+    let replacement = commit_all(repo, "replacement");
+    git(repo, &["replace", &original, &replacement]);
+    assert_eq!(
+        git(repo, &["show", &format!("{original}:decisions/a.md")]),
+        "replacement"
+    );
+
+    let mut snapshot = RevisionSnapshot::open(repo.to_str().unwrap(), &original).unwrap();
+    let corpus = snapshot.materialize_corpus("decisions").unwrap();
+    assert_eq!(
+        std::fs::read_to_string(corpus.path.join("a.md")).unwrap(),
+        "original\n"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn snapshot_and_legacy_temp_roots_are_private() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let scratch = Scratch::new("private-root");
+    let repo = scratch.path();
+    init(repo);
+    std::fs::write(repo.join("a.md"), "bytes\n").unwrap();
+    let revision = commit_all(repo, "fixture");
+
+    let snapshot = RevisionSnapshot::open(repo.to_str().unwrap(), &revision).unwrap();
+    assert_eq!(
+        std::fs::metadata(snapshot.root())
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777,
+        0o700
+    );
+    let legacy = materialize_revision(repo.to_str().unwrap(), &revision, ".").unwrap();
+    assert_eq!(
+        std::fs::metadata(&legacy.corpus)
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777,
+        0o700
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn unsafe_committed_tree_component_is_rejected_before_materialization() {
+    let scratch = Scratch::new("unsafe-tree-name");
+    let repo = scratch.path();
+    init(repo);
+    std::fs::create_dir(repo.join("decisions")).unwrap();
+    std::fs::write(repo.join("decisions/bad\\name.md"), "unsafe\n").unwrap();
+    let revision = commit_all(repo, "fixture");
+
+    let mut snapshot = RevisionSnapshot::open(repo.to_str().unwrap(), &revision).unwrap();
+    let error = snapshot.materialize_corpus("decisions").unwrap_err();
+    assert!(error
+        .message()
+        .contains("unsafe revision snapshot path component"));
+    assert!(!snapshot.root().join("decisions/bad/name.md").exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn symlink_policy_matches_plain_and_v2_corpus_semantics() {
+    use std::os::unix::fs::symlink;
+
+    let scratch = Scratch::new("corpus-symlink");
+    let repo = scratch.path();
+    init(repo);
+    std::fs::create_dir_all(repo.join("decisions/.hidden")).unwrap();
+    symlink("elsewhere", repo.join("decisions/non-markdown-link")).unwrap();
+    symlink("elsewhere", repo.join("decisions/.hidden/link.md")).unwrap();
+    let revision = commit_all(repo, "fixture");
+
+    let mut snapshot = RevisionSnapshot::open(repo.to_str().unwrap(), &revision).unwrap();
+    let ordinary = snapshot.materialize_corpus("decisions").unwrap();
+    assert!(!ordinary.path.join("non-markdown-link").exists());
+    assert!(!ordinary.path.join(".hidden").exists());
+
+    let mut v2_snapshot = RevisionSnapshot::open(repo.to_str().unwrap(), &revision).unwrap();
+    let error = v2_snapshot
+        .materialize_corpus_with_policy_and_exclusions("decisions", MissingPathPolicy::Error, &[])
+        .unwrap_err();
+    assert!(error.message().contains("committed symlink"));
+}
+
+#[cfg(unix)]
+#[test]
+fn child_corpus_excludes_declared_parent_root_before_validation() {
+    use std::os::unix::fs::symlink;
+
+    let scratch = Scratch::new("parent-root-exclusion");
+    let repo = scratch.path();
+    init(repo);
+    std::fs::create_dir_all(repo.join("decisions/vendor/p/policy")).unwrap();
+    std::fs::create_dir_all(repo.join("decisions/vendor/p/other")).unwrap();
+    std::fs::write(repo.join("decisions/child.md"), "child\n").unwrap();
+    std::fs::write(repo.join("decisions/vendor/p/policy/parent.md"), "parent\n").unwrap();
+    symlink(
+        "elsewhere",
+        repo.join("decisions/vendor/p/other/non-markdown-link"),
+    )
+    .unwrap();
+    let revision = commit_all(repo, "fixture");
+
+    let mut snapshot = RevisionSnapshot::open(repo.to_str().unwrap(), &revision).unwrap();
+    let child = snapshot
+        .materialize_corpus_with_policy_and_exclusions(
+            "decisions",
+            MissingPathPolicy::Error,
+            &[PathBuf::from("decisions/vendor/p")],
+        )
+        .unwrap();
+    assert_eq!(
+        std::fs::read_to_string(child.path.join("child.md")).unwrap(),
+        "child\n"
+    );
+    assert!(!child.path.join("vendor/p").exists());
+
+    let parent = snapshot
+        .materialize_corpus_with_policy("decisions/vendor/p/policy", MissingPathPolicy::Error)
+        .unwrap();
+    assert_eq!(
+        std::fs::read_to_string(parent.path.join("parent.md")).unwrap(),
+        "parent\n"
+    );
+    assert!(!snapshot
+        .root()
+        .join("decisions/vendor/p/other/non-markdown-link")
+        .exists());
+
+    let mut equality_snapshot = RevisionSnapshot::open(repo.to_str().unwrap(), &revision).unwrap();
+    let excluded_self = equality_snapshot
+        .materialize_corpus_with_policy_and_exclusions(
+            "decisions/vendor/p/policy",
+            MissingPathPolicy::Error,
+            &[PathBuf::from("decisions/vendor/p/policy")],
+        )
+        .unwrap();
+    assert!(excluded_self.existed);
+    assert!(excluded_self.path.is_dir());
+    assert!(!excluded_self.path.join("parent.md").exists());
+}
+
+#[test]
+fn nested_submodule_uses_the_historically_recorded_commit_offline() {
+    let scratch = Scratch::new("submodule");
+    let leaf = scratch.path().join("leaf-source");
+    let parent = scratch.path().join("parent");
+    std::fs::create_dir(&leaf).unwrap();
+    std::fs::create_dir(&parent).unwrap();
+    init(&leaf);
+    std::fs::create_dir_all(leaf.join("decisions")).unwrap();
+    std::fs::create_dir_all(leaf.join(".decided")).unwrap();
+    std::fs::write(leaf.join("decisions/leaf.md"), "historical bytes\n").unwrap();
+    std::fs::write(leaf.join(".decided/config.yaml"), "repository_key: LEAF\n").unwrap();
+    commit_all(&leaf, "leaf old");
+
+    init(&parent);
+    let leaf_arg = leaf.to_str().unwrap();
+    let output = Command::new("git")
+        .args([
+            "-c",
+            "protocol.file.allow=always",
+            "submodule",
+            "add",
+            "-q",
+            leaf_arg,
+            "decisions/vendor/leaf",
+        ])
+        .current_dir(&parent)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "submodule add failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let historical_parent = commit_all(&parent, "parent old");
+
+    let checkout = parent.join("decisions/vendor/leaf");
+    git(&checkout, &["config", "user.name", "Revision Test"]);
+    git(
+        &checkout,
+        &["config", "user.email", "revision@example.invalid"],
+    );
+    std::fs::write(
+        checkout.join("decisions/leaf.md"),
+        "working checkout is newer\n",
+    )
+    .unwrap();
+    commit_all(&checkout, "leaf new");
+    commit_all(&parent, "parent new pointer");
+    let head_before = git(&parent, &["rev-parse", "HEAD"]);
+    let status_before = git(&parent, &["status", "--porcelain=v1"]);
+
+    let mut snapshot =
+        RevisionSnapshot::open(parent.to_str().unwrap(), &historical_parent).unwrap();
+    let corpus = snapshot.materialize_corpus("decisions").unwrap();
+    assert_eq!(
+        std::fs::read_to_string(corpus.path.join("vendor/leaf/decisions/leaf.md")).unwrap(),
+        "historical bytes\n"
+    );
+    let config = snapshot
+        .materialize_path(
+            "decisions/vendor/leaf/.decided/config.yaml",
+            MissingPathPolicy::Error,
+        )
+        .unwrap();
+    assert_eq!(
+        std::fs::read_to_string(config.path).unwrap(),
+        "repository_key: LEAF\n"
+    );
+    assert_eq!(git(&parent, &["rev-parse", "HEAD"]), head_before);
+    assert_eq!(git(&parent, &["status", "--porcelain=v1"]), status_before);
+    assert_eq!(
+        std::fs::read_to_string(checkout.join("decisions/leaf.md")).unwrap(),
+        "working checkout is newer\n"
+    );
+}
+
+#[test]
+fn deinitialized_submodule_uses_the_remaining_local_object_database() {
+    let scratch = Scratch::new("deinitialized-submodule");
+    let leaf = scratch.path().join("leaf-source");
+    let parent = scratch.path().join("parent");
+    std::fs::create_dir(&leaf).unwrap();
+    std::fs::create_dir(&parent).unwrap();
+    init(&leaf);
+    std::fs::create_dir(leaf.join("decisions")).unwrap();
+    std::fs::write(leaf.join("decisions/leaf.md"), "local object bytes\n").unwrap();
+    commit_all(&leaf, "leaf");
+
+    init(&parent);
+    let output = Command::new("git")
+        .args([
+            "-c",
+            "protocol.file.allow=always",
+            "submodule",
+            "add",
+            "-q",
+            "--name",
+            "custom-leaf",
+            leaf.to_str().unwrap(),
+            "vendor/leaf",
+        ])
+        .current_dir(&parent)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "submodule add failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let revision = commit_all(&parent, "parent");
+    git(&parent, &["submodule", "deinit", "-f", "--", "vendor/leaf"]);
+    assert!(parent.join(".git/modules/custom-leaf/objects").is_dir());
+
+    let mut snapshot = RevisionSnapshot::open(parent.to_str().unwrap(), &revision).unwrap();
+    let corpus = snapshot
+        .materialize_corpus("vendor/leaf/decisions")
+        .unwrap();
+    assert_eq!(
+        std::fs::read_to_string(corpus.path.join("leaf.md")).unwrap(),
+        "local object bytes\n"
+    );
+}
+
+#[test]
+fn missing_blob_object_fails_closed() {
+    let scratch = Scratch::new("missing-object");
+    let repo = scratch.path();
+    init(repo);
+    std::fs::create_dir(repo.join("decisions")).unwrap();
+    std::fs::write(repo.join("decisions/a.md"), "bytes\n").unwrap();
+    let revision = commit_all(repo, "fixture");
+    let object = git(repo, &["rev-parse", "HEAD:decisions/a.md"]);
+    let mut snapshot = RevisionSnapshot::open(repo.to_str().unwrap(), &revision).unwrap();
+    std::fs::remove_file(
+        repo.join(".git/objects")
+            .join(&object[..2])
+            .join(&object[2..]),
+    )
+    .unwrap();
+
+    let error = snapshot.materialize_corpus("decisions").unwrap_err();
+    assert!(matches!(
+        error,
+        RevisionSnapshotError::MaterializationFailed(_)
+    ));
+    assert!(
+        error.message().contains("ls-tree")
+            || error.message().contains("invalid blob header")
+            || error.message().contains("cat-file"),
+        "unexpected error: {}",
+        error.message()
+    );
+    assert!(!snapshot.root().join("decisions/a.md").exists());
+}


### PR DESCRIPTION
## Summary

- adds `decided export --at <revision>` for viewer, documents, and graph projections
- reconstructs historical governing config and recursive federation/submodule closure from exact committed blobs using read-only, offline Git object access
- preserves requested-path identity and existing public Rust construction contracts while failing closed on missing objects, unsafe paths, and bounded snapshot limits
- prevents snapshot writes inside the worktree, Git directory, or Git common directory

## Verification

- `cargo clippy -p asdecided-core -p decided --all-targets -- -D warnings`
- 31 focused point-in-time tests: 10 engine snapshot tests and 21 CLI/federation/guard tests
- affected existing CLI, export, and federation regression suites
- release build: `cargo build --release --locked -p decided`
- corpus validation: 469/469 artifacts valid; relationships, review, and gate completed without blockers
- clean committed-tree byte parity for viewer, documents, and graph projections
- SurfaceCheck: 42 passed, 0 failed

A monolithic `cargo test --workspace --release` attempt exhausted the shared volume while LTO-linking integration binaries; it reported no code or test failure before storage exhaustion. The focused suites and release binary build completed successfully.

Closes #257